### PR TITLE
[styles] Add missing classes prop to resulting hook of makeStyles

### DIFF
--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -11,6 +11,6 @@ import { StyleRules } from '@material-ui/styles/withStyles';
 // For TypeScript v3.5 Props has to extend {} instead of object
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
-export default function createStyles<ClassKey extends string, Props extends {} = any>(
+export default function createStyles<ClassKey extends string, Props extends {}>(
   styles: StyleRules<Props, ClassKey>
 ): StyleRules<Props, ClassKey>;

--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -11,6 +11,6 @@ import { StyleRules } from '@material-ui/styles/withStyles';
 // For TypeScript v3.5 Props has to extend {} instead of object
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
-export default function createStyles<ClassKey extends string, Props extends {}>(
+export default function createStyles<ClassKey extends string, Props extends {} = any>(
   styles: StyleRules<Props, ClassKey>
 ): StyleRules<Props, ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -7,10 +7,10 @@ import {
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
-export type MakeStylesHook<Props extends {} = {}, ClassKey extends string = string> = Extract<
-  keyof Props,
-  keyof Props
-> extends never
+export type MakeStylesHook<
+  Props extends {} = {},
+  ClassKey extends string = string
+> = keyof Props extends never
   ? (props?: Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>
   : (props: Props & Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>;
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -7,10 +7,10 @@ import {
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
-export type MakeStylesHook<
-  Props extends {} = any,
-  ClassKey extends string = string
-> = undefined extends Props
+export type MakeStylesHook<Props extends {} = {}, ClassKey extends string = string> = Extract<
+  keyof Props,
+  keyof Props
+> extends never
   ? (props?: Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>
   : (props: Props & Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>;
 
@@ -19,7 +19,7 @@ export type MakeStylesHook<
  */
 export default function makeStyles<
   Theme = DefaultTheme,
-  Props extends {} = any,
+  Props extends {} = {},
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -7,21 +7,21 @@ import {
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
+type MakeStylesHook<
+  Props extends {} = any,
+  ClassKey extends string = string
+> = undefined extends Props
+  ? (props?: Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>
+  : (props: Props & Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>;
+
 /**
- * `makeStyles` where the passed `styles` do not depend on props
- */
-export default function makeStyles<Theme = DefaultTheme, ClassKey extends string = string>(
-  style: Styles<Theme, {}, ClassKey>,
-  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props?: any) => ClassNameMap<ClassKey>;
-/**
- * `makeStyles` where the passed `styles` do depend on props
+ * `makeStyles` where the passed `styles` can depend on props
  */
 export default function makeStyles<
   Theme = DefaultTheme,
-  Props extends {} = {},
+  Props extends {} = any,
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,
-  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props: Props & Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>;
+  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
+): MakeStylesHook<Props, ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -1,8 +1,8 @@
 import {
   ClassNameMap,
-  PropsOfStyles,
   Styles,
   WithStylesOptions,
+  StyledComponentProps,
 } from '@material-ui/styles/withStyles';
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
@@ -24,4 +24,4 @@ export default function makeStyles<
 >(
   styles: Styles<Theme, Props, ClassKey>,
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props: Props) => ClassNameMap<ClassKey>;
+): (props: Props & Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -1,9 +1,4 @@
-import {
-  ClassNameMap,
-  Styles,
-  WithStylesOptions,
-  StyledComponentProps,
-} from '@material-ui/styles/withStyles';
+import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
@@ -11,8 +6,8 @@ export type MakeStylesHook<
   Props extends {} = {},
   ClassKey extends string = string
 > = keyof Props extends never
-  ? (props?: Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>
-  : (props: Props & Pick<StyledComponentProps<ClassKey>, 'classes'>) => ClassNameMap<ClassKey>;
+  ? (props?: { classes?: Partial<ClassNameMap<ClassKey>> }) => ClassNameMap<ClassKey>
+  : (props: Props & { classes?: Partial<ClassNameMap<ClassKey>> }) => ClassNameMap<ClassKey>;
 
 /**
  * `makeStyles` where the passed `styles` can depend on props

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -7,7 +7,7 @@ import {
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
-type MakeStylesHook<
+export type MakeStylesHook<
   Props extends {} = any,
   ClassKey extends string = string
 > = undefined extends Props
@@ -23,5 +23,5 @@ export default function makeStyles<
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,
-  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
+  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
 ): MakeStylesHook<Props, ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -10,7 +10,7 @@ export type MakeStylesHook<
   : (props: Props & { classes?: Partial<ClassNameMap<ClassKey>> }) => ClassNameMap<ClassKey>;
 
 /**
- * `makeStyles` where the passed `styles` can depend on props
+ * `makeStyles` where the passed `styles` do depend on props
  */
 export default function makeStyles<
   Theme = DefaultTheme,
@@ -20,3 +20,11 @@ export default function makeStyles<
   styles: Styles<Theme, Props, ClassKey>,
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
 ): MakeStylesHook<Props, ClassKey>;
+
+/**
+ * `makeStyles` where the passed `styles` do not depend on props
+ */
+export default function makeStyles<Theme = DefaultTheme, ClassKey extends string = string>(
+  styles: Styles<Theme, {}, ClassKey>,
+  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
+): MakeStylesHook<{}, ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -71,6 +71,7 @@ import { createStyles, makeStyles } from '@material-ui/styles';
   const NoPropsComponent = () => {
     const classes = useWithoutProps();
     const chartClasses = useChartClasses();
+    // $ExpectError
     const alsoClasses = useWithoutProps(5);
   };
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -89,6 +89,7 @@ import { createStyles, makeStyles } from '@material-ui/styles';
 
   const UnsafeProps = (props: StyleProps) => {
     // would be nice to have at least a compile time error because we forgot the argument
+    // $ExpectError
     const classes = useUnsafeProps(); // runtime: Can't read property color of undefined
     // but this would pass anyway
     const alsoClasses = useUnsafeProps(undefined); // runtime: Can't read property color of undefined

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -29,9 +29,9 @@ import { createStyles, makeStyles } from '@material-ui/styles';
     // $ExpectError
     const invalidClasses = useMyStyles({ colourTypo: 'red' });
     const extendedClasses = useMyStyles({ ...props, classes: { root: 'externalClassName' } });
-    // $ExpectError
     const invalidExtendedClasses = useMyStyles({
       ...props,
+      // $ExpectError
       classes: { toot: 'externalClassName' },
     });
     // $ExpectError

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -28,6 +28,9 @@ import { createStyles, makeStyles } from '@material-ui/styles';
     const classes = useMyStyles(props);
     // $ExpectError
     const invalidClasses = useMyStyles({ colourTypo: 'red' });
+    const extendedClasses = useMyStyles({ ...props, classes: { root: 'externalClassName' } });
+    // $ExpectError
+    const invalidExtendedClasses = useMyStyles({ ...props, classes: { toot: 'externalClassName' } });
     // $ExpectError
     const undefinedClassName = classes.toot;
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -30,7 +30,10 @@ import { createStyles, makeStyles } from '@material-ui/styles';
     const invalidClasses = useMyStyles({ colourTypo: 'red' });
     const extendedClasses = useMyStyles({ ...props, classes: { root: 'externalClassName' } });
     // $ExpectError
-    const invalidExtendedClasses = useMyStyles({ ...props, classes: { toot: 'externalClassName' } });
+    const invalidExtendedClasses = useMyStyles({
+      ...props,
+      classes: { toot: 'externalClassName' },
+    });
     // $ExpectError
     const undefinedClassName = classes.toot;
 


### PR DESCRIPTION
We can extend classes by passing external className to hook:
```ts
const useStyles = makeStyles({
  root: {
    width: ({ size }: SomeProps) => size,
  },
});

function component(props: FullProps) {
  const css = useStyles({ classes: { root: props.className }, size: props.size });
}
```
But without these changes we can't because `classes` prop is missing in hook. 