### PR TITLE
[docs] Fix table zebra customization demo

### DIFF
--- a/docs/src/pages/components/tables/CustomizedTables.js
+++ b/docs/src/pages/components/tables/CustomizedTables.js
@@ -21,8 +21,7 @@ const StyledTableCell = withStyles((theme) => ({
 const StyledTableRow = withStyles((theme) => ({
   root: {
     '&:nth-of-type(odd)': {
-      backgroundColor:
-        theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.16)',
+      backgroundColor: theme.palette.action.hover,
     },
   },
 }))(TableRow);

--- a/docs/src/pages/components/tables/CustomizedTables.js
+++ b/docs/src/pages/components/tables/CustomizedTables.js
@@ -20,7 +20,7 @@ const StyledTableCell = withStyles((theme) => ({
 
 const StyledTableRow = withStyles((theme) => ({
   root: {
-    '&:nth-of-type(odd)': {
+    '&:nth-child(even)': {
       backgroundColor: theme.palette.background.default,
     },
   },

--- a/docs/src/pages/components/tables/CustomizedTables.js
+++ b/docs/src/pages/components/tables/CustomizedTables.js
@@ -20,8 +20,8 @@ const StyledTableCell = withStyles((theme) => ({
 
 const StyledTableRow = withStyles((theme) => ({
   root: {
-    '&:nth-child(even)': {
-      backgroundColor: theme.palette.background.default,
+    '&:nth-of-type(odd)': {
+      backgroundColor: theme.palette.action.selected,
     },
   },
 }))(TableRow);

--- a/docs/src/pages/components/tables/CustomizedTables.js
+++ b/docs/src/pages/components/tables/CustomizedTables.js
@@ -21,7 +21,8 @@ const StyledTableCell = withStyles((theme) => ({
 const StyledTableRow = withStyles((theme) => ({
   root: {
     '&:nth-of-type(odd)': {
-      backgroundColor: theme.palette.action.selected,
+      backgroundColor:
+        theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.16)',
     },
   },
 }))(TableRow);

--- a/docs/src/pages/components/tables/CustomizedTables.tsx
+++ b/docs/src/pages/components/tables/CustomizedTables.tsx
@@ -24,8 +24,7 @@ const StyledTableRow = withStyles((theme: Theme) =>
   createStyles({
     root: {
       '&:nth-of-type(odd)': {
-        backgroundColor:
-          theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.16)',
+        backgroundColor: theme.palette.action.hover,
       },
     },
   }),

--- a/docs/src/pages/components/tables/CustomizedTables.tsx
+++ b/docs/src/pages/components/tables/CustomizedTables.tsx
@@ -24,7 +24,7 @@ const StyledTableRow = withStyles((theme: Theme) =>
   createStyles({
     root: {
       '&:nth-of-type(odd)': {
-        backgroundColor: theme.palette.background.default,
+        backgroundColor: theme.palette.action.selected,
       },
     },
   }),

--- a/docs/src/pages/components/tables/CustomizedTables.tsx
+++ b/docs/src/pages/components/tables/CustomizedTables.tsx
@@ -24,7 +24,8 @@ const StyledTableRow = withStyles((theme: Theme) =>
   createStyles({
     root: {
       '&:nth-of-type(odd)': {
-        backgroundColor: theme.palette.action.selected,
+        backgroundColor:
+          theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.16)',
       },
     },
   }),


### PR DESCRIPTION
The current "Custom Table" example in the documentation shows how to do a zebra pattern. However, when used with a table header it contains two dark rows next to each other. This resolves it by making even rows (counting the header) darker.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
