### PR TITLE
[docs] Label accessibility for native select

### DIFF
--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -80,16 +80,6 @@ That `id` needs to match the `labelId` of the `Select` e.g.
 </Select>
 ```
 
-For a [Native select](#native-select), you can mention a label like below by giving the value of the `id` attribute of the select element to the `InputLabel`'s `htmlFor` attribute,
-
-```jsx
-<InputLabel htmlFor="select">Age</InputLabel>
-<Select native id="select">
-  <option value="10">Ten</option>
-  <option value="20">Twenty</option>
-</Select>
-```
-
 Alternatively a `TextField` with an `id` and `label` creates the proper markup and
 ids for you:
 
@@ -98,4 +88,14 @@ ids for you:
   <MenuItem value="10">Ten</MenuItem>
   <MenuItem value="20">Twenty</MenuItem>
 </TextField>
+```
+
+For a [native select](#native-select), you should mention a label by giving the value of the `id` attribute of the select element to the `InputLabel`'s `htmlFor` attribute:
+
+```jsx
+<InputLabel htmlFor="select">Age</InputLabel>
+<NativeSelect id="select">
+  <option value="10">Ten</option>
+  <option value="20">Twenty</option>
+</NativeSelect>
 ```

--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -80,6 +80,16 @@ That `id` needs to match the `labelId` of the `Select` e.g.
 </Select>
 ```
 
+For a [Native select](#native-select), you can mention a label like below by giving the value of the `id` attribute of the select element to the `InputLabel`'s `htmlFor` attribute,
+
+```jsx
+<InputLabel htmlFor="select">Age</InputLabel>
+<Select native id="select">
+  <option value="10">Ten</option>
+  <option value="20">Twenty</option>
+</Select>
+```
+
 Alternatively a `TextField` with an `id` and `label` creates the proper markup and
 ids for you:
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Description**

- The ReadMe file of Selects is updated for the accessibility label of `<Select native/>`
- Found out that `<Select native/>` is detected in Chrome's lighthouse only when the `htmlFor` attribute is added to `<InputLabel/>`

**Declaration**
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
