### PR TITLE
[docs] Improve svgr documentation

### DIFF
--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -104,7 +104,7 @@ function HomeIcon(props) {
 
 ### Component prop
 
-You can use the `SvgIcon` wrapper even if your icons are saved the `.svg` format.
+You can use the `SvgIcon` wrapper even if your icons are saved in the `.svg` format.
 [svgr](https://github.com/smooth-code/svgr) has loaders to import svg files and use them as React components. For instance, with webpack:
 
 ```jsx

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -121,7 +121,7 @@ import StarIcon from './star.svg';
 ```
 
 It's also possible to use it with "url-loader" or "file-loader".
-For instance, it's the approach used by Create React App.
+It's the approach used by Create React App.
 
 ```jsx
 // webpack.config.js

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -107,15 +107,30 @@ function HomeIcon(props) {
 You can use the `SvgIcon` wrapper even if your icons are saved the `.svg` format.
 [svgr](https://github.com/smooth-code/svgr) has loaders to import svg files and use them as React components. For instance, with webpack:
 
-**webpack.config.js**
-```js
+```jsx
+// webpack.config.js
 {
   test: /\.svg$/,
   use: ['@svgr/webpack'],
 }
+
+// ---
+import StarIcon from './star.svg';
+
+<SvgIcon component={StarIcon} viewBox="0 0 600 476.6" />
 ```
 
+It's also possible to use it with "url-loader" or "file-loader".
+For instance, it's the approach used by Create React App.
+
 ```jsx
+// webpack.config.js
+{
+  test: /\.svg$/,
+  use: ['@svgr/webpack', 'url-loader'],
+}
+
+// ---
 import { ReactComponent as StarIcon } from './star.svg';
 
 <SvgIcon component={StarIcon} viewBox="0 0 600 476.6" />

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -105,7 +105,7 @@ function HomeIcon(props) {
 ### Component prop
 
 You can use the `SvgIcon` wrapper even if your icons are saved in the `.svg` format.
-[svgr](https://github.com/smooth-code/svgr) has loaders to import svg files and use them as React components. For instance, with webpack:
+[svgr](https://github.com/smooth-code/svgr) has loaders to import SVG files and use them as React components. For example, with webpack:
 
 ```jsx
 // webpack.config.js

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -116,7 +116,7 @@ You can use the `SvgIcon` wrapper even if your icons are saved the `.svg` format
 ```
 
 ```jsx
-import StarIcon from './star.svg';
+import { ReactComponent as StarIcon } from './star.svg';
 
 <SvgIcon component={StarIcon} viewBox="0 0 600 476.6" />
 ```


### PR DESCRIPTION
Using the `@svgr/webpack` loader it loads the svg files as a js module exporting a component named as ReactComponent and the source of the svg as the default export.
The example is invalid because it's adding at the component attribute the default export and that causes the error: 
```
Failed to execute 'createElement' on 'Document': The tag name provided
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
