### PR TITLE
[TrapFocus] Increase interval to be less noticeable

### DIFF
--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -585,7 +585,7 @@ describe('<Modal />', () => {
 
         setProps({ hideButton: true });
         expect(dialog).not.toHaveFocus();
-        clock.tick(500); // wait for the interval check to kick in.
+        clock.tick(250); // wait for the interval check to kick in.
         expect(dialog).toHaveFocus();
       });
 
@@ -645,7 +645,7 @@ describe('<Modal />', () => {
 
         getByTestId('foreign-input').focus();
         // wait for the `contain` interval check to kick in.
-        clock.tick(500);
+        clock.tick(250);
 
         expect(getByTestId('foreign-input')).toHaveFocus();
       });

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -117,7 +117,7 @@ function TrapFocus(props) {
     // https://html.spec.whatwg.org/multipage/interaction.html#focus-fixup-rule.
     const interval = setInterval(() => {
       contain();
-    }, 50);
+    }, 250);
 
     return () => {
       clearInterval(interval);


### PR DESCRIPTION
Tweak the interval duration to still be short enough for a user to recover his keyboard navigation when a focused DOM node is unmounted while being long enough not to create too much noise in the dev tools when investigating a performance issue.

**Before**
<img width="433" alt="Capture d’écran 2020-05-03 à 19 06 21" src="https://user-images.githubusercontent.com/3165635/80920829-a7d89a80-8d72-11ea-9d60-c3fdc1fd021f.png">

**After**
<img width="410" alt="Capture d’écran 2020-05-03 à 19 16 17" src="https://user-images.githubusercontent.com/3165635/80920828-a6a76d80-8d72-11ea-8bfa-7ba0d27b8944.png">

Related to #16585