### PR TITLE
[docs] Experimental layout

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -322,9 +322,13 @@ AppWrapper.propTypes = {
 export default function MyApp(props) {
   const { Component, pageProps } = props;
 
+  const { Layout = React.Fragment } = Component;
+
   return (
     <AppWrapper pageProps={pageProps}>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </AppWrapper>
   );
 }

--- a/docs/pages/components/about-the-lab.js
+++ b/docs/pages/components/about-the-lab.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import AppFrame from 'docs/src/modules/components/AppFrameLayout';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import { prepareMarkdown } from 'docs/src/modules/utils/parseMarkdown';
 
@@ -17,6 +18,8 @@ const requireRaw = require.context(
 export default function Page({ demos, docs }) {
   return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
 }
+
+Page.Layout = AppFrame;
 
 Page.getInitialProps = () => {
   const { demos, docs } = prepareMarkdown({ pageFilename, requireRaw });

--- a/docs/pages/components/alert.js
+++ b/docs/pages/components/alert.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import AppFrame from 'docs/src/modules/components/AppFrameLayout';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import { prepareMarkdown } from 'docs/src/modules/utils/parseMarkdown';
 
@@ -13,6 +14,8 @@ const requireRaw = require.context(
 export default function Page({ demos, docs }) {
   return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
 }
+
+Page.Layout = AppFrame;
 
 Page.getInitialProps = () => {
   const { demos, docs } = prepareMarkdown({ pageFilename, requireRaw });

--- a/docs/src/modules/components/AppFrameLayout.js
+++ b/docs/src/modules/components/AppFrameLayout.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import AppFrame from './AppFrame';
+
+export const Context = React.createContext(false);
+
+export default function AppFrameLayout({ children }) {
+  return (
+    <Context.Provider value>
+      <AppFrame>{children}</AppFrame>
+    </Context.Provider>
+  );
+}

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -21,6 +21,7 @@ import { SOURCE_CODE_ROOT_URL } from 'docs/src/modules/constants';
 import Demo from 'docs/src/modules/components/Demo';
 import AppTableOfContents from 'docs/src/modules/components/AppTableOfContents';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
+import { Context } from './AppFrameLayout';
 
 function flattenPages(pages, current = []) {
   return pages.reduce((items, item) => {
@@ -105,8 +106,10 @@ function MarkdownDocs(props) {
   const prevPage = pageList[currentPageNum - 1];
   const nextPage = pageList[currentPageNum + 1];
 
+  const Layout = React.useContext(Context) ? React.Fragment : AppFrame;
+
   return (
-    <AppFrame>
+    <Layout>
       <Head title={`${title} - Material-UI`} description={description} />
       {disableAd ? null : (
         <Portal
@@ -219,7 +222,7 @@ function MarkdownDocs(props) {
         </AppContainer>
       </div>
       {disableToc ? null : <AppTableOfContents items={toc} />}
-    </AppFrame>
+    </Layout>
   );
 }
 


### PR DESCRIPTION
Something I noticed doing https://github.com/mui-org/material-ui/pull/20903: We throw away too many UI on page transitions.

This isn't the final implementation. This isn't complete. It only works when transitioning from /components/alert to /components/about-the-lab. It's only noticeable (beyond perf) when the search-textbox has a value. The value is cleared normally but not when transitioning with the new layout pattern.

Opening this so I can profile the deploy and don't forget it after I finished other work.

Edit: Couldn't detect any noticeable differences (yet). Right now of the 130ms we need rendering a page 70ms is spent on the page, 50ms is spent on the AppDrawer and the rest is on the AppBar. Page and AppDrawer would need to re-render anyway. We can only gain in AppBar and the mount effects of AppFrame. But this opens up optimizations for the AppBar and potentially AppDrawer (only re-render the subtree where the active item changed). 

By not re-mounting MarkdownDocs we also avoid re-loading css vis `loadCSS`.