### PR TITLE
[system] Add csstype as dependency to material-ui-system

### DIFF
--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@material-ui/utils": "^4.9.6",
+    "csstype": "^2.5.2",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {},


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

When using yarn v2 with PnP, if I run `tsc`, it will complain:
```
../../.yarn/$$virtual/@material-ui-system-virtual-99565feeae/0/cache/@material-ui-system-npm-4.9.13-72f1b6da5b-3.zip/node_modules/@material-ui/system/index.d.ts:1:22 - error TS2307: Cannot find module 'csstype'.

1 import * as CSS from 'csstype';
```

This PR adds `csstype` to its dependencies. The version is the same as the one used by `material-ui-styles`