### PR TITLE
[core] Add support #rrggbbaa pattern in hexToRgb function

### DIFF
--- a/packages/material-ui/src/styles/colorManipulator.js
+++ b/packages/material-ui/src/styles/colorManipulator.js
@@ -37,9 +37,7 @@ export function hexToRgb(color) {
   return colors
     ? `rgb${colors.length === 4 ? 'a' : ''}(${colors
         .map((n, index) => {
-          return index < 3
-            ? parseInt(n, 16)
-            : parseFloat(parseInt((parseInt(n, 16) / 255) * 1000, 10) / 1000);
+          return index < 3 ? parseInt(n, 16) : Math.round((parseInt(n, 16) / 255) * 1000) / 1000;
         })
         .join(', ')})`
     : '';

--- a/packages/material-ui/src/styles/colorManipulator.js
+++ b/packages/material-ui/src/styles/colorManipulator.js
@@ -27,14 +27,22 @@ function clamp(value, min = 0, max = 1) {
 export function hexToRgb(color) {
   color = color.substr(1);
 
-  const re = new RegExp(`.{1,${color.length / 3}}`, 'g');
+  const re = new RegExp(`.{1,${color.length >= 6 ? 2 : 1}}`, 'g');
   let colors = color.match(re);
 
   if (colors && colors[0].length === 1) {
     colors = colors.map((n) => n + n);
   }
 
-  return colors ? `rgb(${colors.map((n) => parseInt(n, 16)).join(', ')})` : '';
+  return colors
+    ? `rgb${colors.length === 4 ? 'a' : ''}(${colors
+        .map((n, index) => {
+          return index < 3
+            ? parseInt(n, 16)
+            : parseFloat(parseInt((parseInt(n, 16) / 255) * 1000, 10) / 1000);
+        })
+        .join(', ')})`
+    : '';
 }
 
 function intToHex(int) {

--- a/packages/material-ui/src/styles/colorManipulator.test.js
+++ b/packages/material-ui/src/styles/colorManipulator.test.js
@@ -125,6 +125,14 @@ describe('utils/colorManipulator', () => {
       const output2 = decomposeColor(output1);
       expect(output1).to.deep.equal(output2);
     });
+
+    it('converts rgba hex', () => {
+      const decomposed = decomposeColor('#111111f8');
+      expect(decomposed).to.deep.equal({
+        type: 'rgba',
+        values: [17, 17, 17, 0.972],
+      });
+    });
   });
 
   describe('getContrastRatio', () => {

--- a/packages/material-ui/src/styles/colorManipulator.test.js
+++ b/packages/material-ui/src/styles/colorManipulator.test.js
@@ -69,6 +69,10 @@ describe('utils/colorManipulator', () => {
     it('converts a long hex color to an rgb color` ', () => {
       expect(hexToRgb('#a94fd3')).to.equal('rgb(169, 79, 211)');
     });
+
+    it('converts a long alpha hex color to an argb color` ', () => {
+      expect(hexToRgb('#111111f8')).to.equal('rgba(17, 17, 17, 0.973)');
+    });
   });
 
   describe('rgbToHex', () => {
@@ -130,7 +134,7 @@ describe('utils/colorManipulator', () => {
       const decomposed = decomposeColor('#111111f8');
       expect(decomposed).to.deep.equal({
         type: 'rgba',
-        values: [17, 17, 17, 0.972],
+        values: [17, 17, 17, 0.973],
       });
     });
   });


### PR DESCRIPTION
Fix #20497 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
