### PR TITLE
[test] Use actual element over document.activeElement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,6 +116,8 @@ module.exports = {
         // does not work with wildcard imports. Mistakes will throw at runtime anyway
         'import/named': 'off',
 
+        'material-ui/disallow-active-element-as-key-event-target': 'error',
+
         // upgraded level from recommended
         'mocha/no-exclusive-tests': 'error',
         'mocha/no-skipped-tests': 'error',

--- a/packages/eslint-plugin-material-ui/README.md
+++ b/packages/eslint-plugin-material-ui/README.md
@@ -4,9 +4,16 @@ Custom eslint rules for Material-UI.
 
 ## List of supported rules
 
+- `disallow-active-element-as-key-event-target`
 - `docgen-ignore-before-comment`
 - `no-hardcoded-labels`
 - `restricted-path-imports`
+
+### disallow-active-element-as-key-event-target
+
+Prevent `fireEvent.keyDown(document.activeElement)`. The implementation
+we use already verifies that the passed target can be the target of a
+`keydown` event. Passing the target explicitly (e.g. `fireEvent.keyDown(getByRole('tab', { selected: true }))`) makes the test more readable.
 
 ### docgen-ignore-before-comment
 

--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -8,6 +8,7 @@
     "emoji-regex": "^9.0.0"
   },
   "devDependencies": {
+    "@types/eslint": "^6.8.0",
     "babel-eslint": "^10.1.0"
   },
   "scripts": {

--- a/packages/eslint-plugin-material-ui/src/index.js
+++ b/packages/eslint-plugin-material-ui/src/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 module.exports.rules = {
+  'disallow-active-element-as-key-event-target': require('./rules/disallow-active-element-as-key-event-target'),
   'docgen-ignore-before-comment': require('./rules/docgen-ignore-before-comment'),
   'no-hardcoded-labels': require('./rules/no-hardcoded-labels'),
   'restricted-path-imports': require('./rules/restricted-path-imports'),

--- a/packages/eslint-plugin-material-ui/src/rules/disallow-active-element-as-key-event-target.js
+++ b/packages/eslint-plugin-material-ui/src/rules/disallow-active-element-as-key-event-target.js
@@ -1,0 +1,40 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const rule = {
+  meta: {
+    messages: {
+      'keyboard-target':
+        "Don't use document.activeElement as a target for keyboard events. Prefer the actual element.",
+    },
+  },
+  create(context) {
+    return {
+      /**
+       * @param {import('estree').CallExpression} node
+       */
+      CallExpression(node) {
+        const keyboardEventDispatchers = ['keyDown', 'keyUp'];
+        const {
+          arguments: [firstArgument],
+          callee,
+        } = node;
+        const isFireKeyboardEvent =
+          callee.type === 'MemberExpression' &&
+          keyboardEventDispatchers.indexOf(callee.property.name) !== -1 &&
+          callee.object.name === 'fireEvent';
+        const targetsDocumentActiveElement =
+          firstArgument !== undefined &&
+          firstArgument.type === 'MemberExpression' &&
+          firstArgument.object.name === 'document' &&
+          firstArgument.property.name === 'activeElement';
+
+        if (isFireKeyboardEvent && targetsDocumentActiveElement) {
+          context.report({ messageId: 'keyboard-target', node: firstArgument });
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/packages/eslint-plugin-material-ui/src/rules/disallow-active-elements-as-key-event-target.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/disallow-active-elements-as-key-event-target.test.js
@@ -1,0 +1,56 @@
+const eslint = require('eslint');
+const rule = require('./disallow-active-element-as-key-event-target');
+
+const ruleTester = new eslint.RuleTester({ parser: require.resolve('babel-eslint') });
+ruleTester.run('disallow-active-element-as-key-event-target', rule, {
+  valid: [
+    "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyDown(getByRole('button'), { key: ' ' })",
+    "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyDown(document.body, { key: 'Esc' })",
+    "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyUp(document.body, { key: 'Tab' })",
+  ],
+  invalid: [
+    {
+      code:
+        "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyUp(document.activeElement, { key: 'LeftArrow' })",
+      errors: [
+        {
+          message:
+            "Don't use document.activeElement as a target for keyboard events. Prefer the actual element.",
+          type: 'MemberExpression',
+        },
+      ],
+    },
+    {
+      code:
+        "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyDown(document.activeElement, { key: 'DownArrow' })",
+      errors: [
+        {
+          message:
+            "Don't use document.activeElement as a target for keyboard events. Prefer the actual element.",
+          type: 'MemberExpression',
+        },
+      ],
+    },
+    {
+      code:
+        "import { fireEvent } from 'any-path';\nfireEvent.keyDown(document.activeElement, { key: 'DownArrow' })",
+      errors: [
+        {
+          message:
+            "Don't use document.activeElement as a target for keyboard events. Prefer the actual element.",
+          type: 'MemberExpression',
+        },
+      ],
+    },
+    {
+      code: "fireEvent.keyDown(document.activeElement, { key: 'DownArrow' })",
+      errors: [
+        {
+          message:
+            "Don't use document.activeElement as a target for keyboard events. Prefer the actual element.",
+          type: 'MemberExpression',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -4,7 +4,7 @@ import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import consoleErrorMock, { consoleWarnMock } from 'test/utils/consoleErrorMock';
 import { spy } from 'sinon';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import { createFilterOptions } from '../useAutocomplete/useAutocomplete';
 import Autocomplete from './Autocomplete';
 import TextField from '@material-ui/core/TextField';
@@ -64,7 +64,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField autoFocus {...params} />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
       expect(document.querySelector(`.${classes.paper}`).textContent).to.equal('Loading…');
     });
   });
@@ -143,15 +143,16 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField autoFocus {...params} />}
         />,
       );
+      const textbox = getByRole('textbox');
 
       function checkHighlightIs(expected) {
         expect(getByRole('listbox').querySelector('li[data-focus]')).to.have.text(expected);
       }
 
       checkHighlightIs('one');
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       checkHighlightIs('two');
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
       checkHighlightIs('two');
     });
   });
@@ -208,14 +209,15 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
+      const textbox = getByRole('textbox');
 
       function checkHighlightIs(expected) {
         expect(getByRole('listbox').querySelector('li[data-focus]')).to.have.text(expected);
       }
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+      fireEvent.keyDown(textbox, { key: 'ArrowUp' });
       checkHighlightIs('three');
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' }); // selects the last option
+      fireEvent.keyDown(textbox, { key: 'Enter' }); // selects the last option
       const input = getByRole('textbox');
       input.blur();
       input.focus(); // opens the listbox again
@@ -227,7 +229,6 @@ describe('<Autocomplete />', () => {
     it('should not clear on blur when value does not match any option', () => {
       const handleChange = spy();
       const options = ['one', 'two'];
-
       render(
         <Autocomplete
           {...defaultProps}
@@ -238,10 +239,13 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField autoFocus {...params} />}
         />,
       );
-      fireEvent.change(document.activeElement, { target: { value: 'o' } });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.change(document.activeElement, { target: { value: 'oo' } });
-      document.activeElement.blur();
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.change(textbox, { target: { value: 'o' } });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.change(textbox, { target: { value: 'oo' } });
+      textbox.blur();
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal('oo');
     });
@@ -260,9 +264,12 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField autoFocus {...params} />}
         />,
       );
-      fireEvent.change(document.activeElement, { target: { value: 't' } });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      document.activeElement.blur();
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.change(textbox, { target: { value: 't' } });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      textbox.blur();
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal(options);
     });
@@ -322,7 +329,7 @@ describe('<Autocomplete />', () => {
     it('navigates between different tags', () => {
       const handleChange = spy();
       const options = ['one', 'two'];
-      const { getByRole } = render(
+      render(
         <Autocomplete
           {...defaultProps}
           defaultValue={options}
@@ -332,14 +339,22 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-      expect(document.activeElement).to.have.text('two');
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-      expect(document.activeElement).to.have.text('one');
-      fireEvent.keyDown(document.activeElement, { key: 'Backspace' });
+      const textbox = screen.getByRole('textbox');
+      const [firstSelectedValue, secondSelectedValue] = screen.getAllByRole('button');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
+
+      expect(secondSelectedValue).toHaveFocus();
+
+      fireEvent.keyDown(secondSelectedValue, { key: 'ArrowLeft' });
+
+      expect(firstSelectedValue).toHaveFocus();
+
+      fireEvent.keyDown(firstSelectedValue, { key: 'Backspace' });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal([options[1]]);
-      expect(document.activeElement).to.equal(getByRole('textbox'));
+      expect(textbox).toHaveFocus();
     });
   });
 
@@ -357,26 +372,40 @@ describe('<Autocomplete />', () => {
         renderInput={(props2) => <TextField {...props2} autoFocus />}
       />,
     );
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+    let textbox = screen.getByRole('textbox');
+
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
     expect(handleSubmit.callCount).to.equal(1);
 
-    fireEvent.change(document.activeElement, { target: { value: 'o' } });
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+    fireEvent.change(textbox, { target: { value: 'o' } });
+    fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
     expect(handleSubmit.callCount).to.equal(1);
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
     expect(handleSubmit.callCount).to.equal(2);
 
     setProps({ key: 'test-2', multiple: true, freeSolo: true });
-    fireEvent.change(document.activeElement, { target: { value: 'o' } });
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+    textbox = screen.getByRole('textbox');
+
+    fireEvent.change(textbox, { target: { value: 'o' } });
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
     expect(handleSubmit.callCount).to.equal(2);
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
     expect(handleSubmit.callCount).to.equal(3);
 
     setProps({ key: 'test-3', freeSolo: true });
-    fireEvent.change(document.activeElement, { target: { value: 'o' } });
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+    textbox = screen.getByRole('textbox');
+
+    fireEvent.change(textbox, { target: { value: 'o' } });
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
     expect(handleSubmit.callCount).to.equal(4);
   });
 
@@ -471,7 +500,7 @@ describe('<Autocomplete />', () => {
       expect(textbox, 'no option is focused when openened').not.to.have.attribute(
         'aria-activedescendant',
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
 
       const options = getAllByRole('option');
       expect(textbox).to.have.attribute('aria-activedescendant', options[0].getAttribute('id'));
@@ -521,7 +550,7 @@ describe('<Autocomplete />', () => {
     ['ArrowDown', 'ArrowUp'].forEach((key) => {
       it(`opens on ${key} when focus is on the textbox without moving focus`, () => {
         const handleOpen = spy();
-        const { getByRole } = render(
+        render(
           <Autocomplete
             {...defaultProps}
             open={false}
@@ -529,12 +558,13 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
+        const textbox = screen.getByRole('textbox');
 
-        fireEvent.keyDown(document.activeElement, { key });
+        fireEvent.keyDown(textbox, { key });
 
         // first from focus
         expect(handleOpen.callCount).to.equal(2);
-        expect(getByRole('textbox')).not.to.have.attribute('aria-activedescendant');
+        expect(textbox).not.to.have.attribute('aria-activedescendant');
       });
     });
 
@@ -551,7 +581,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
 
       expect(handleChange.callCount).to.equal(0);
     });
@@ -572,8 +602,8 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'Escape' });
-      fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
 
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal([]);
@@ -593,7 +623,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
 
       expect(handleClose.callCount).to.equal(1);
     });
@@ -607,7 +637,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
 
       expect(getByRole('textbox')).to.have.attribute(
         'aria-activedescendant',
@@ -624,7 +654,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
 
       const options = getAllByRole('option');
       expect(getByRole('textbox')).to.have.attribute(
@@ -678,34 +708,35 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowUp' });
 
       const options = getAllByRole('option');
-      expect(document.activeElement).toHaveFocus();
-      expect(document.activeElement).to.have.attribute(
+      expect(textbox).toHaveFocus();
+      expect(textbox).to.have.attribute(
         'aria-activedescendant',
         options[options.length - 1].getAttribute('id'),
       );
     });
 
     it('selects the first item if on the last item and pressing up by default', () => {
-      const { getAllByRole } = render(
+      render(
         <Autocomplete
           {...defaultProps}
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      const textbox = screen.getByRole('textbox');
 
-      const options = getAllByRole('option');
-      expect(document.activeElement).toHaveFocus();
-      expect(document.activeElement).to.have.attribute(
-        'aria-activedescendant',
-        options[0].getAttribute('id'),
-      );
+      fireEvent.keyDown(textbox, { key: 'ArrowUp' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
+      const options = screen.getAllByRole('option');
+      expect(textbox).toHaveFocus();
+      expect(textbox).to.have.attribute('aria-activedescendant', options[0].getAttribute('id'));
     });
 
     describe('prop: inlcudeInputInList', () => {
@@ -718,11 +749,13 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+        const textbox = screen.getByRole('textbox');
 
-        expect(document.activeElement).toHaveFocus();
-        expect(document.activeElement).not.to.have.attribute('aria-activedescendant');
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+        fireEvent.keyDown(textbox, { key: 'ArrowUp' });
+
+        expect(textbox).toHaveFocus();
+        expect(textbox).not.to.have.attribute('aria-activedescendant');
       });
 
       it('considers the textbox the successor of the last option when pressing Down', () => {
@@ -734,17 +767,19 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+        const textbox = screen.getByRole('textbox');
 
-        expect(document.activeElement).toHaveFocus();
-        expect(document.activeElement).not.to.have.attribute('aria-activedescendant');
+        fireEvent.keyDown(textbox, { key: 'ArrowUp' });
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
+        expect(textbox).toHaveFocus();
+        expect(textbox).not.to.have.attribute('aria-activedescendant');
       });
     });
 
     describe('prop: disableListWrap', () => {
       it('keeps focus on the first item if focus is on the first item and pressing Up', () => {
-        const { getAllByRole } = render(
+        render(
           <Autocomplete
             {...defaultProps}
             disableListWrap
@@ -752,18 +787,20 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+        const textbox = screen.getByRole('textbox');
 
-        expect(document.activeElement).toHaveFocus();
-        expect(document.activeElement).to.have.attribute(
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+        fireEvent.keyDown(textbox, { key: 'ArrowUp' });
+
+        expect(textbox).toHaveFocus();
+        expect(textbox).to.have.attribute(
           'aria-activedescendant',
-          getAllByRole('option')[0].getAttribute('id'),
+          screen.getAllByRole('option')[0].getAttribute('id'),
         );
       });
 
       it('focuses the last item when pressing Up when no option is active', () => {
-        const { getAllByRole, getByRole } = render(
+        render(
           <Autocomplete
             {...defaultProps}
             disableListWrap
@@ -771,11 +808,11 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
+        const textbox = screen.getByRole('textbox');
 
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+        fireEvent.keyDown(textbox, { key: 'ArrowUp' });
 
-        const textbox = getByRole('textbox');
-        const options = getAllByRole('option');
+        const options = screen.getAllByRole('option');
         expect(textbox).toHaveFocus();
         expect(textbox).to.have.attribute(
           'aria-activedescendant',
@@ -784,7 +821,7 @@ describe('<Autocomplete />', () => {
       });
 
       it('keeps focus on the last item if focus is on the last item and pressing Down', () => {
-        const { getAllByRole, getByRole } = render(
+        render(
           <Autocomplete
             {...defaultProps}
             disableListWrap
@@ -792,12 +829,13 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+        const textbox = screen.getByRole('textbox');
 
-        const textbox = getByRole('textbox');
-        const options = getAllByRole('option');
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
+        const options = screen.getAllByRole('option');
         expect(textbox).toHaveFocus();
         expect(textbox).to.have.attribute(
           'aria-activedescendant',
@@ -898,8 +936,10 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.change(document.activeElement, { target: { value: 'a' } });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.change(textbox, { target: { value: 'a' } });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal('a');
       expect(consoleErrorMock.callCount()).to.equal(2); // strict mode renders twice
@@ -930,9 +970,10 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
+      const textbox = screen.getByRole('textbox');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
 
       expect(consoleErrorMock.callCount()).to.equal(1); // strict mode renders twice
       expect(consoleErrorMock.messages()[0]).to.include(
@@ -989,16 +1030,18 @@ describe('<Autocomplete />', () => {
 
   describe('prop: options', () => {
     it('should keep focus on selected option and not reset to top option when options updated', () => {
-      const { getByRole, setProps } = render(
+      const { setProps } = render(
         <Autocomplete
           {...defaultProps}
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const listbox = getByRole('listbox');
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' }); // goes to 'one'
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' }); // goes to 'two'
+      const textbox = screen.getByRole('textbox');
+      const listbox = screen.getByRole('listbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // goes to 'one'
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // goes to 'two'
 
       function checkHighlightIs(expected) {
         expect(listbox.querySelector('li[data-focus]')).to.have.text(expected);
@@ -1011,7 +1054,7 @@ describe('<Autocomplete />', () => {
       checkHighlightIs('two');
 
       // user presses down, three should be highlighted
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       checkHighlightIs('three');
     });
 
@@ -1047,11 +1090,13 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal('one');
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
     });
 
@@ -1068,11 +1113,14 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
     });
   });
@@ -1087,13 +1135,20 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
+      const textbox = screen.getByRole('textbox');
+
       fireEvent.change(document.activeElement, { target: { value: 'O' } });
+
       expect(document.activeElement.value).to.equal('O');
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
       expect(document.activeElement.value).to.equal('one');
       expect(document.activeElement.selectionStart).to.equal(1);
       expect(document.activeElement.selectionEnd).to.equal(3);
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(document.activeElement.value).to.equal('one');
       expect(document.activeElement.selectionStart).to.equal(3);
       expect(document.activeElement.selectionEnd).to.equal(3);
@@ -1237,8 +1292,11 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleInputChange.calledBefore(handleChange)).to.equal(true);
     });
   });
@@ -1316,11 +1374,16 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal(options[0]);
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleChange.callCount).to.equal(1);
     });
 
@@ -1338,11 +1401,16 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      fireEvent.change(document.activeElement, { target: { value: 'three' } });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.change(textbox, { target: { value: 'three' } });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(container.querySelectorAll('[class*="MuiChip-root"]')).to.have.length(3);
-      fireEvent.change(document.activeElement, { target: { value: 'three' } });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+      fireEvent.change(textbox, { target: { value: 'three' } });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(container.querySelectorAll('[class*="MuiChip-root"]')).to.have.length(3);
     });
 
@@ -1356,11 +1424,16 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
+      const textbox = screen.getByRole('textbox');
+
       // Actual behavior when "あ" (Japanese) is entered on macOS/Safari with IME
-      fireEvent.change(document.activeElement, { target: { value: 'あ' } });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter', keyCode: 229 });
+      fireEvent.change(textbox, { target: { value: 'あ' } });
+      fireEvent.keyDown(textbox, { key: 'Enter', keyCode: 229 });
+
       expect(handleChange.callCount).to.equal(0);
-      fireEvent.keyDown(document.activeElement, { key: 'Enter', keyCode: 13 });
+
+      fireEvent.keyDown(textbox, { key: 'Enter', keyCode: 13 });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal('あ');
     });
@@ -1378,8 +1451,11 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.change(document.activeElement, { target: { value: options[2] } });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.change(textbox, { target: { value: options[2] } });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal(options[2]);
       expect(handleChange.args[0][2]).to.equal('create-option');
@@ -1396,9 +1472,12 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal(options[0]);
       expect(handleChange.args[0][2]).to.equal('select-option');
@@ -1417,7 +1496,10 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'Backspace' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'Backspace' });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal(options.slice(0, 2));
       expect(handleChange.args[0][2]).to.equal('remove-option');
@@ -1435,9 +1517,12 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      document.activeElement.blur();
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      textbox.blur();
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal(options[0]);
       expect(handleChange.args[0][2]).to.equal('blur');
@@ -1497,8 +1582,11 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+
       expect(handleInputChange.callCount).to.equal(1);
       expect(handleInputChange.args[0][1]).to.equal(options[0].name);
       expect(handleInputChange.args[0][2]).to.equal('reset');
@@ -1656,12 +1744,17 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField autoFocus {...params} />}
         />,
       );
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      const textbox = screen.getByRole('textbox');
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
       expect(handleChange.callCount).to.equal(2);
       expect(handleChange.args[1][0]).to.not.equal(undefined);
       expect(handleChange.args[1][1]).to.equal(options[0]);
       expect(handleChange.args[1][2]).to.equal('keyboard');
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
       expect(handleChange.callCount).to.equal(3);
       expect(handleChange.args[2][0]).to.not.equal(undefined);
       expect(handleChange.args[2][1]).to.equal(options[1]);
@@ -1690,7 +1783,7 @@ describe('<Autocomplete />', () => {
     it('should pass to onHighlightChange the correct value after filtering', () => {
       const handleChange = spy();
       const options = ['one', 'three', 'onetwo'];
-      const { queryAllByRole } = render(
+      render(
         <Autocomplete
           {...defaultProps}
           onHighlightChange={handleChange}
@@ -1698,10 +1791,15 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField autoFocus {...params} />}
         />,
       );
+      const textbox = screen.getByRole('textbox');
+
       fireEvent.change(document.activeElement, { target: { value: 'one' } });
-      expect(queryAllByRole('option').length).to.equal(2);
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+      expect(screen.getAllByRole('option').length).to.equal(2);
+
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
       expect(handleChange.args[handleChange.args.length - 1][1]).to.equal(options[2]);
     });
   });

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -3,7 +3,13 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
-import { act, createEvent, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import {
+  act,
+  createEvent,
+  createClientRender,
+  fireEvent,
+  screen,
+} from 'test/utils/createClientRender';
 import TreeItem from './TreeItem';
 import TreeView from '../TreeView';
 
@@ -150,17 +156,18 @@ describe('<TreeItem />', () => {
   it('should call onKeyDown when a key is pressed', () => {
     const handleKeyDown = spy();
 
-    const { getByTestId } = render(
+    render(
       <TreeView>
         <TreeItem nodeId="test" label="test" data-testid="test" onKeyDown={handleKeyDown} />
       </TreeView>,
     );
+    const treeitem = screen.getByRole('treeitem');
 
-    getByTestId('test').focus();
+    treeitem.focus();
 
-    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
-    fireEvent.keyDown(document.activeElement, { key: 'A' });
-    fireEvent.keyDown(document.activeElement, { key: ']' });
+    fireEvent.keyDown(treeitem, { key: 'Enter' });
+    fireEvent.keyDown(treeitem, { key: 'A' });
+    fireEvent.keyDown(treeitem, { key: ']' });
 
     expect(handleKeyDown.callCount).to.equal(3);
   });
@@ -295,7 +302,7 @@ describe('<TreeItem />', () => {
         getByTestId('start').focus();
         expect(getByTestId('start')).toHaveFocus();
 
-        fireEvent.keyDown(document.activeElement, { key: 'Tab' });
+        fireEvent.keyDown(getByTestId('start'), { key: 'Tab' });
         getByTestId('one').focus();
 
         expect(getByTestId('one')).toHaveFocus();
@@ -319,7 +326,7 @@ describe('<TreeItem />', () => {
         getByTestId('start').focus();
         expect(getByTestId('start')).toHaveFocus();
 
-        fireEvent.keyDown(document.activeElement, { key: 'Tab' });
+        fireEvent.keyDown(getByTestId('start'), { key: 'Tab' });
         getByTestId('two').focus();
 
         expect(getByTestId('two')).toHaveFocus();
@@ -357,8 +364,10 @@ describe('<TreeItem />', () => {
           );
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
+
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowRight' });
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           expect(getByTestId('one')).toHaveFocus();
         });
@@ -373,8 +382,10 @@ describe('<TreeItem />', () => {
           );
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowRight' });
+
           expect(getByTestId('two')).toHaveFocus();
         });
 
@@ -388,48 +399,60 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('two'));
+
           expect(getByTestId('two')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
+
+          fireEvent.keyDown(getByTestId('two'), { key: 'ArrowRight' });
+
           expect(getByTestId('two')).toHaveFocus();
         });
       });
 
       describe('left arrow interaction', () => {
         it('should close the node if focus is on an open node', () => {
-          const { getByTestId, getByText } = render(
+          render(
             <TreeView>
               <TreeItem nodeId="one" label="one" data-testid="one">
                 <TreeItem nodeId="two" label="two" />
               </TreeItem>
             </TreeView>,
           );
+          const [firstItem] = screen.getAllByRole('treeitem');
+          const firstItemLabel = screen.getByText('one');
 
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
-          getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
-          expect(getByTestId('one')).toHaveFocus();
+          fireEvent.click(firstItemLabel);
+
+          expect(firstItem).to.have.attribute('aria-expanded', 'true');
+
+          firstItem.focus();
+          fireEvent.keyDown(firstItem, { key: 'ArrowLeft' });
+
+          expect(firstItem).to.have.attribute('aria-expanded', 'false');
+          expect(firstItem).toHaveFocus();
         });
 
         it("should move focus to the node's parent node if focus is on a child node that is an end node", () => {
-          const { getByTestId, getByText } = render(
+          render(
             <TreeView defaultExpanded={['one']}>
               <TreeItem nodeId="one" label="one" data-testid="one">
                 <TreeItem nodeId="two" label="two" data-testid="two" />
               </TreeItem>
             </TreeView>,
           );
+          const [firstItem, secondItem] = screen.getAllByRole('treeitem');
+          const secondItemLabel = screen.getByText('two');
 
-          expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
-          fireEvent.click(getByText('two'));
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).toHaveFocus();
-          expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+          expect(firstItem).to.have.attribute('aria-expanded', 'true');
+
+          fireEvent.click(secondItemLabel);
+          fireEvent.keyDown(secondItem, { key: 'ArrowLeft' });
+
+          expect(firstItem).toHaveFocus();
+          expect(firstItem).to.have.attribute('aria-expanded', 'true');
         });
 
         it("should move focus to the node's parent node if focus is on a child node that is closed", () => {
-          const { getByTestId, getByText } = render(
+          render(
             <TreeView>
               <TreeItem nodeId="one" label="one" data-testid="one">
                 <TreeItem nodeId="two" label="two" data-testid="two">
@@ -439,15 +462,20 @@ describe('<TreeItem />', () => {
             </TreeView>,
           );
 
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+          fireEvent.click(screen.getByText('one'));
+
+          expect(screen.getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+
           // move focus to node two
-          fireEvent.click(getByText('two'));
-          fireEvent.click(getByText('two'));
-          expect(getByTestId('two')).to.have.attribute('aria-expanded', 'false');
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).toHaveFocus();
-          expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+          fireEvent.click(screen.getByText('two'));
+          fireEvent.click(screen.getByText('two'));
+
+          expect(screen.getByTestId('two')).to.have.attribute('aria-expanded', 'false');
+
+          fireEvent.keyDown(screen.getByTestId('two'), { key: 'ArrowLeft' });
+
+          expect(screen.getByTestId('one')).toHaveFocus();
+          expect(screen.getByTestId('one')).to.have.attribute('aria-expanded', 'true');
         });
 
         it('should do nothing if focus is on a root node that is closed', () => {
@@ -461,7 +489,7 @@ describe('<TreeItem />', () => {
 
           getByTestId('one').focus();
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowLeft' });
           expect(getByTestId('one')).toHaveFocus();
         });
 
@@ -473,7 +501,8 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowLeft' });
+
           expect(getByTestId('one')).toHaveFocus();
         });
       });
@@ -488,7 +517,8 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowDown' });
+
           expect(getByTestId('two')).toHaveFocus();
         });
 
@@ -502,8 +532,10 @@ describe('<TreeItem />', () => {
           );
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowDown' });
+
           expect(getByTestId('two')).toHaveFocus();
         });
 
@@ -541,7 +573,7 @@ describe('<TreeItem />', () => {
           expect(getByTestId('one')).not.to.equal(null);
 
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+          fireEvent.keyDown(getByTestId('one'), { key: 'ArrowDown' });
 
           expect(getByTestId('two')).toHaveFocus();
         });
@@ -557,9 +589,13 @@ describe('<TreeItem />', () => {
           );
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+
           fireEvent.click(getByText('two'));
+
           expect(getByTestId('two')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+          fireEvent.keyDown(getByTestId('two'), { key: 'ArrowDown' });
+
           expect(getByTestId('three')).toHaveFocus();
         });
       });
@@ -574,8 +610,11 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('two'));
+
           expect(getByTestId('two')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+          fireEvent.keyDown(getByTestId('two'), { key: 'ArrowUp' });
+
           expect(getByTestId('one')).toHaveFocus();
         });
 
@@ -589,9 +628,13 @@ describe('<TreeItem />', () => {
           );
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+
           fireEvent.click(getByText('two'));
+
           expect(getByTestId('two')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+          fireEvent.keyDown(getByTestId('two'), { key: 'ArrowUp' });
+
           expect(getByTestId('one')).toHaveFocus();
         });
 
@@ -606,9 +649,13 @@ describe('<TreeItem />', () => {
           );
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
+
           fireEvent.click(getByText('three'));
+
           expect(getByTestId('three')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowUp' });
+
           expect(getByTestId('two')).toHaveFocus();
         });
       });
@@ -625,8 +672,11 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('four'));
+
           expect(getByTestId('four')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'Home' });
+
+          fireEvent.keyDown(getByTestId('four'), { key: 'Home' });
+
           expect(getByTestId('one')).toHaveFocus();
         });
       });
@@ -643,8 +693,11 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'End' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: 'End' });
+
           expect(getByTestId('four')).toHaveFocus();
         });
 
@@ -663,8 +716,11 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'End' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: 'End' });
+
           expect(getByTestId('six')).toHaveFocus();
         });
       });
@@ -681,14 +737,19 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 't' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: 't' });
+
           expect(getByTestId('two')).toHaveFocus();
 
-          fireEvent.keyDown(document.activeElement, { key: 'f' });
+          fireEvent.keyDown(getByTestId('two'), { key: 'f' });
+
           expect(getByTestId('four')).toHaveFocus();
 
-          fireEvent.keyDown(document.activeElement, { key: 'o' });
+          fireEvent.keyDown(getByTestId('four'), { key: 'o' });
+
           expect(getByTestId('one')).toHaveFocus();
         });
 
@@ -703,14 +764,19 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 't' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: 't' });
+
           expect(getByTestId('two')).toHaveFocus();
 
-          fireEvent.keyDown(document.activeElement, { key: 't' });
+          fireEvent.keyDown(getByTestId('two'), { key: 't' });
+
           expect(getByTestId('three')).toHaveFocus();
 
-          fireEvent.keyDown(document.activeElement, { key: 't' });
+          fireEvent.keyDown(getByTestId('three'), { key: 't' });
+
           expect(getByTestId('two')).toHaveFocus();
         });
 
@@ -725,14 +791,19 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('apple').focus();
-          expect(getByTestId('apple')).toHaveFocus();
-          fireEvent.keyDown(document.activeElement, { key: 'v', ctrlKey: true });
+
           expect(getByTestId('apple')).toHaveFocus();
 
-          fireEvent.keyDown(document.activeElement, { key: 'v', metaKey: true });
+          fireEvent.keyDown(getByTestId('apple'), { key: 'v', ctrlKey: true });
+
           expect(getByTestId('apple')).toHaveFocus();
 
-          fireEvent.keyDown(document.activeElement, { key: 'v', shiftKey: true });
+          fireEvent.keyDown(getByTestId('apple'), { key: 'v', metaKey: true });
+
+          expect(getByTestId('apple')).toHaveFocus();
+
+          fireEvent.keyDown(getByTestId('apple'), { key: 'v', shiftKey: true });
+
           expect(getByTestId('apple')).toHaveFocus();
         });
 
@@ -787,10 +858,13 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
           expect(getByTestId('three')).to.have.attribute('aria-expanded', 'false');
           expect(getByTestId('five')).to.have.attribute('aria-expanded', 'false');
-          fireEvent.keyDown(document.activeElement, { key: '*' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: '*' });
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           expect(getByTestId('three')).to.have.attribute('aria-expanded', 'true');
           expect(getByTestId('five')).to.have.attribute('aria-expanded', 'true');
@@ -811,8 +885,11 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
-          fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: 'Enter' });
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
         });
 
@@ -826,8 +903,11 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('one'));
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
-          fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: 'Enter' });
+
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
         });
       });
@@ -843,8 +923,11 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).to.not.have.attribute('aria-selected');
-          fireEvent.keyDown(document.activeElement, { key: ' ' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: ' ' });
+
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('one')).to.have.class('Mui-selected');
         });
@@ -857,7 +940,8 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          fireEvent.keyDown(document.activeElement, { key: ' ' });
+          fireEvent.keyDown(getByTestId('one'), { key: ' ' });
+
           expect(getByTestId('one')).not.to.have.attribute('aria-selected');
         });
       });
@@ -902,23 +986,36 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('three'));
+
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowDown', shiftKey: true });
+
           expect(getByTestId('four')).toHaveFocus();
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(2);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('four'), { key: 'ArrowDown', shiftKey: true });
+
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('four')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(3);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('five'), { key: 'ArrowUp', shiftKey: true });
+
           expect(getByTestId('four')).toHaveFocus();
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(2);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('four'), { key: 'ArrowUp', shiftKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(1);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowUp', shiftKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(2);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('two'), { key: 'ArrowUp', shiftKey: true });
+
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
@@ -939,10 +1036,13 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('three'));
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowDown', shiftKey: true });
+
           expect(getByTestId('four')).toHaveFocus();
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('four'), { key: 'ArrowUp', shiftKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
         });
 
@@ -959,16 +1059,21 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('three'));
+
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowUp', shiftKey: true });
           fireEvent.click(getByText('six'), { ctrlKey: true });
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
+          fireEvent.keyDown(getByTestId('six'), { key: 'ArrowUp', shiftKey: true });
+          fireEvent.keyDown(getByTestId('five'), { key: 'ArrowUp', shiftKey: true });
+          fireEvent.keyDown(getByTestId('four'), { key: 'ArrowUp', shiftKey: true });
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowUp', shiftKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(5);
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
-          fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
+
+          fireEvent.keyDown(getByTestId('two'), { key: 'ArrowDown', shiftKey: true });
+          fireEvent.keyDown(getByTestId('three'), { key: 'ArrowDown', shiftKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(3);
         });
 
@@ -991,18 +1096,21 @@ describe('<TreeItem />', () => {
 
           fireEvent.click(getByText('five'));
           for (let i = 0; i < 5; i += 1) {
+            // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
             fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
           }
-          fireEvent.keyDown(document.activeElement, { key: ' ', shiftKey: true });
+          fireEvent.keyDown(screen.getByTestId('nine'), { key: ' ', shiftKey: true });
+
           expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('six')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('seven')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('eight')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('nine')).to.have.attribute('aria-selected', 'true');
           for (let i = 0; i < 9; i += 1) {
+            // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
             fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
           }
-          fireEvent.keyDown(document.activeElement, { key: ' ', shiftKey: true });
+          fireEvent.keyDown(screen.getByTestId('one'), { key: ' ', shiftKey: true });
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
@@ -1032,13 +1140,16 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('five').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'End', shiftKey: true, ctrlKey: true });
+          fireEvent.keyDown(getByTestId('five'), { key: 'End', shiftKey: true, ctrlKey: true });
+
           expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('six')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('seven')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('eight')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('nine')).to.have.attribute('aria-selected', 'true');
-          fireEvent.keyDown(document.activeElement, { key: 'Home', shiftKey: true, ctrlKey: true });
+
+          fireEvent.keyDown(getByTestId('nine'), { key: 'Home', shiftKey: true, ctrlKey: true });
+
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
@@ -1068,9 +1179,12 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('five').focus();
-          fireEvent.keyDown(document.activeElement, { key: 'End', shiftKey: true, ctrlKey: true });
+          fireEvent.keyDown(getByTestId('five'), { key: 'End', shiftKey: true, ctrlKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
-          fireEvent.keyDown(document.activeElement, { key: 'Home', shiftKey: true, ctrlKey: true });
+
+          fireEvent.keyDown(getByTestId('nine'), { key: 'Home', shiftKey: true, ctrlKey: true });
+
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
         });
 
@@ -1139,13 +1253,18 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
+
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          fireEvent.keyDown(document.activeElement, { key: ' ' });
+
+          fireEvent.keyDown(getByTestId('one'), { key: ' ' });
+
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
+
           getByTestId('two').focus();
-          fireEvent.keyDown(document.activeElement, { key: ' ', ctrlKey: true });
+          fireEvent.keyDown(getByTestId('two'), { key: ' ', ctrlKey: true });
+
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
         });
@@ -1199,7 +1318,8 @@ describe('<TreeItem />', () => {
         );
 
         getByTestId('one').focus();
-        fireEvent.keyDown(document.activeElement, { key: 'a', ctrlKey: true });
+        fireEvent.keyDown(getByTestId('one'), { key: 'a', ctrlKey: true });
+
         expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(5);
       });
 
@@ -1215,7 +1335,8 @@ describe('<TreeItem />', () => {
         );
 
         getByTestId('one').focus();
-        fireEvent.keyDown(document.activeElement, { key: 'a', ctrlKey: true });
+        fireEvent.keyDown(getByTestId('one'), { key: 'a', ctrlKey: true });
+
         expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
       });
     });

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -759,6 +759,7 @@ describe('<TreeItem />', () => {
           expect(navTreeItem).not.toHaveFocus();
 
           expect(() => {
+            getByTestId('keyDown').focus();
             fireEvent.keyDown(getByTestId('keyDown'), { key: 'a' });
           }).not.to.throw();
 

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -86,7 +86,7 @@ describe('<TreeView />', () => {
     expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
     fireEvent.click(getByText('one'));
     expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
-    fireEvent.keyDown(document.activeElement, { key: '*' });
+    fireEvent.keyDown(getByTestId('one'), { key: '*' });
     expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
   });
 
@@ -166,11 +166,11 @@ describe('<TreeView />', () => {
 
     fireEvent.click(getByText('one'));
     expect(getByTestId('one')).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(getByTestId('one'), { key: 'ArrowDown' });
     expect(getByTestId('two')).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(getByTestId('two'), { key: 'ArrowUp' });
     expect(getByTestId('one')).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(getByTestId('one'), { key: 'ArrowDown' });
     expect(getByTestId('two')).toHaveFocus();
   });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -122,31 +122,28 @@ describe('<ButtonBase />', () => {
 
   describe('event callbacks', () => {
     it('should fire event callbacks', () => {
-      const eventHandlerNames = [
-        'onClick',
-        'onFocus',
-        'onBlur',
-        'onKeyUp',
-        'onKeyDown',
-        'onMouseDown',
-        'onMouseLeave',
-        'onMouseUp',
-      ];
-
-      /**
-       * @type {Record<string, import('sinon').SinonSpy>}
-       */
-      const handlers = {};
-      eventHandlerNames.forEach((handlerName) => {
-        handlers[handlerName] = spy();
-      });
+      const onClick = spy();
+      const onBlur = spy();
+      const onFocus = spy();
+      const onKeyUp = spy();
+      const onKeyDown = spy();
+      const onMouseDown = spy();
+      const onMouseLeave = spy();
+      const onMouseUp = spy();
       const onDragEnd = spy();
       const onTouchStart = spy();
       const onTouchEnd = spy();
 
       const { getByText } = render(
         <ButtonBase
-          {...handlers}
+          onClick={onClick}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          onKeyUp={onKeyUp}
+          onKeyDown={onKeyDown}
+          onMouseDown={onMouseDown}
+          onMouseLeave={onMouseLeave}
+          onMouseUp={onMouseUp}
           onDragEnd={onDragEnd}
           onTouchEnd={onTouchEnd}
           onTouchStart={onTouchStart}
@@ -172,13 +169,29 @@ describe('<ButtonBase />', () => {
         expect(onDragEnd.callCount).to.equal(1);
       }
 
-      eventHandlerNames.forEach((n) => {
-        // onKeyDown -> keyDown
-        const eventType = n.charAt(2).toLowerCase() + n.slice(3);
-        // @ts-ignore eventType isn't a literal here, need const expression
-        fireEvent[eventType](button);
-        expect(handlers[n].callCount, `should have called the ${n} handler`).to.equal(1);
-      });
+      fireEvent.mouseDown(button);
+      expect(onMouseDown.callCount).to.equal(1);
+
+      fireEvent.mouseUp(button);
+      expect(onMouseUp.callCount).to.equal(1);
+
+      fireEvent.click(button);
+      expect(onClick.callCount).to.equal(1);
+
+      button.focus();
+      expect(onFocus.callCount).to.equal(1);
+
+      fireEvent.keyDown(button);
+      expect(onKeyDown.callCount).to.equal(1);
+
+      fireEvent.keyUp(button);
+      expect(onKeyUp.callCount).to.equal(1);
+
+      button.blur();
+      expect(onBlur.callCount).to.equal(1);
+
+      fireEvent.mouseLeave(button);
+      expect(onMouseLeave.callCount).to.equal(1);
     });
   });
 
@@ -685,7 +698,7 @@ describe('<ButtonBase />', () => {
     describe('prop: onKeyDown', () => {
       it('call it when keydown events are dispatched', () => {
         const onKeyDownSpy = spy();
-        const { getByText } = render(<ButtonBase onKeyDown={onKeyDownSpy}>Hello</ButtonBase>);
+        const { getByText } = render(<ButtonBase autoFocus onKeyDown={onKeyDownSpy}>Hello</ButtonBase>);
 
         fireEvent.keyDown(getByText('Hello'));
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -698,7 +698,11 @@ describe('<ButtonBase />', () => {
     describe('prop: onKeyDown', () => {
       it('call it when keydown events are dispatched', () => {
         const onKeyDownSpy = spy();
-        const { getByText } = render(<ButtonBase autoFocus onKeyDown={onKeyDownSpy}>Hello</ButtonBase>);
+        const { getByText } = render(
+          <ButtonBase autoFocus onKeyDown={onKeyDownSpy}>
+            Hello
+          </ButtonBase>,
+        );
 
         fireEvent.keyDown(getByText('Hello'));
 
@@ -834,7 +838,7 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
 
-        fireEvent.keyDown(document.activeElement, {
+        fireEvent.keyDown(document.querySelector('input'), {
           key: 'Enter',
         });
 
@@ -851,7 +855,7 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
 
-        fireEvent.keyUp(document.activeElement, {
+        fireEvent.keyUp(document.querySelector('input'), {
           key: ' ',
         });
 

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -313,7 +313,7 @@ describe('<Chip />', () => {
       const chip = getByRole('button');
       chip.focus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'p' });
+      fireEvent.keyDown(chip, { key: 'p' });
 
       expect(handleKeydown.callCount).to.equal(1);
       expect(handleKeydown.firstCall.returnValue).to.equal('p');
@@ -328,7 +328,7 @@ describe('<Chip />', () => {
       const chip = getByRole('button');
       chip.focus();
 
-      fireEvent.keyUp(document.activeElement, { key: 'Escape' });
+      fireEvent.keyUp(chip, { key: 'Escape' });
 
       expect(handleBlur.callCount).to.equal(1);
       expect(chip).not.toHaveFocus();
@@ -340,7 +340,7 @@ describe('<Chip />', () => {
       const chip = getByRole('button');
       chip.focus();
 
-      fireEvent.keyUp(document.activeElement, { key: ' ' });
+      fireEvent.keyUp(chip, { key: ' ' });
 
       expect(handleClick.callCount).to.equal(1);
     });
@@ -351,7 +351,7 @@ describe('<Chip />', () => {
       const chip = getByRole('button');
       chip.focus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(chip, { key: 'Enter' });
 
       expect(handleClick.callCount).to.equal(1);
     });
@@ -367,13 +367,13 @@ describe('<Chip />', () => {
           const chip = getAllByRole('button')[0];
           chip.focus();
 
-          fireEvent.keyDown(document.activeElement, { key });
+          fireEvent.keyDown(chip, { key });
 
           // defaultPrevented?
           expect(handleKeyDown.returnValues[0]).to.equal(true);
           expect(handleDelete.callCount).to.equal(0);
 
-          fireEvent.keyUp(document.activeElement, { key });
+          fireEvent.keyUp(chip, { key });
 
           expect(handleDelete.callCount).to.equal(1);
         });
@@ -384,7 +384,7 @@ describe('<Chip />', () => {
         const { container } = render(<Chip label={<input />} onKeyDown={handleKeyDown} />);
         const input = container.querySelector('input');
         input.focus();
-        fireEvent.keyDown(document.activeElement, { key: 'Backspace' });
+        fireEvent.keyDown(input, { key: 'Backspace' });
 
         // defaultPrevented?
         expect(handleKeyDown.returnValues[0]).to.equal(false);
@@ -403,7 +403,8 @@ describe('<Chip />', () => {
             />,
           );
 
-          fireEvent.keyUp(document.activeElement, { key });
+          fireEvent.keyUp(document.querySelector('input'), { key });
+
           expect(handleKeyUp.callCount).to.equal(1);
           expect(handleDelete.callCount).to.equal(0);
         });
@@ -419,7 +420,7 @@ describe('<Chip />', () => {
           />,
         );
 
-        fireEvent.keyUp(document.activeElement, { key: ' ' });
+        fireEvent.keyUp(document.querySelector('input'), { key: ' ' });
         expect(handleKeyUp.callCount).to.equal(1);
         expect(handleClick.callCount).to.equal(0);
       });
@@ -434,7 +435,7 @@ describe('<Chip />', () => {
           />,
         );
 
-        fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+        fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' });
         expect(handleKeyDown.callCount).to.equal(1);
         expect(handleClick.callCount).to.equal(0);
       });
@@ -449,7 +450,7 @@ describe('<Chip />', () => {
           />,
         );
 
-        fireEvent.keyUp(document.activeElement, { key: ' ' });
+        fireEvent.keyUp(document.querySelector('input'), { key: ' ' });
 
         expect(handleClick.callCount).to.equal(0);
         expect(handleKeyUp.callCount).to.equal(1);
@@ -465,7 +466,7 @@ describe('<Chip />', () => {
           />,
         );
 
-        fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+        fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' });
 
         expect(handleClick.callCount).to.equal(0);
         expect(handleKeyDown.callCount).to.equal(1);

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -100,7 +100,7 @@ describe('<Dialog />', () => {
     expect(dialog).not.to.equal(null);
 
     dialog.click();
-    fireEvent.keyDown(document.activeElement, { key: 'Esc' });
+    fireEvent.keyDown(document.querySelector('[data-mui-test="FakeBackdrop"]'), { key: 'Esc' });
     expect(onEscapeKeyDown.calledOnce).to.equal(true);
     expect(onClose.calledOnce).to.equal(true);
 
@@ -125,7 +125,7 @@ describe('<Dialog />', () => {
     expect(dialog).not.to.equal(null);
 
     dialog.click();
-    fireEvent.keyDown(document.activeElement, { key: 'Esc' });
+    fireEvent.keyDown(document.querySelector('[data-mui-test="FakeBackdrop"]'), { key: 'Esc' });
     expect(onClose.callCount).to.equal(0);
 
     clickBackdrop(document.body);

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -74,7 +74,7 @@ describe('<ExpansionPanelSummary />', () => {
     fireEvent.mouseDown(document.body); // pointer device
     const button = getByRole('button');
 
-    fireEvent.keyDown(document.activeElement, { key: 'Tab' }); // not actually focusing (yet)
+    fireEvent.keyDown(document.body, { key: 'Tab' }); // not actually focusing (yet)
     button.focus();
 
     expect(button).toHaveFocus();
@@ -84,7 +84,7 @@ describe('<ExpansionPanelSummary />', () => {
   it('blur should unset focused state', () => {
     const { getByRole } = render(<ExpansionPanelSummary />);
     fireEvent.mouseDown(document.body); // pointer device
-    fireEvent.keyDown(document.activeElement, { key: 'Tab' }); // not actually focusing (yet)
+    fireEvent.keyDown(document.body, { key: 'Tab' }); // not actually focusing (yet)
     const button = getByRole('button');
     button.focus();
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -129,13 +129,13 @@ describe('<InputBase />', () => {
     });
     expect(handleFocus.callCount).to.equal(1);
 
-    fireEvent.keyDown(document.activeElement, { key: 'a' });
+    fireEvent.keyDown(input, { key: 'a' });
     expect(handleKeyDown.callCount).to.equal(1);
 
     fireEvent.change(input, { target: { value: 'a' } });
     expect(handleChange.callCount).to.equal(1);
 
-    fireEvent.keyUp(document.activeElement, { key: 'a' });
+    fireEvent.keyUp(input, { key: 'a' });
     expect(handleKeyUp.callCount).to.equal(1);
 
     act(() => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { useFakeTimers, spy } from 'sinon';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createClientRender, fireEvent, within } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen, within } from 'test/utils/createClientRender';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { createMount } from '@material-ui/core/test-utils';
 import { ThemeProvider } from '@material-ui/styles';
@@ -526,17 +526,17 @@ describe('<Modal />', () => {
         </Modal>,
       );
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(screen.getByTestId('modal'), {
         keyCode: 13, // Enter
       });
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(screen.getByTestId('modal'), {
         keyCode: 9, // Tab
       });
 
       expect(document.querySelector('[data-test="sentinelStart"]')).toHaveFocus();
 
       initialFocus.focus();
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(screen.getByTestId('modal'), {
         keyCode: 9, // Tab
         shiftKey: true,
       });

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -255,8 +255,8 @@ describe('<Modal />', () => {
       const onEscapeKeyDownSpy = spy();
       const onCloseSpy = spy();
       const { getByTestId } = render(
-        <Modal data-testid="modal" open onEscapeKeyDown={onEscapeKeyDownSpy} onClose={onCloseSpy}>
-          <div />
+        <Modal open onEscapeKeyDown={onEscapeKeyDownSpy} onClose={onCloseSpy}>
+          <div data-testid="modal" tabIndex={-1} />
         </Modal>,
       );
       getByTestId('modal').focus();
@@ -275,8 +275,8 @@ describe('<Modal />', () => {
       const onCloseSpy = spy();
       const { getByTestId } = render(
         <div onKeyDown={handleKeyDown}>
-          <Modal data-testid="modal" open onEscapeKeyDown={onEscapeKeyDownSpy} onClose={onCloseSpy}>
-            <div />
+          <Modal open onEscapeKeyDown={onEscapeKeyDownSpy} onClose={onCloseSpy}>
+            <div data-testid="modal" tabIndex={-1} />
           </Modal>
         </div>,
       );
@@ -298,13 +298,12 @@ describe('<Modal />', () => {
       const { getByTestId } = render(
         <div onKeyDown={handleKeyDown}>
           <Modal
-            data-testid="modal"
             open
             disableEscapeKeyDown
             onEscapeKeyDown={onEscapeKeyDownSpy}
             onClose={onCloseSpy}
           >
-            <div />
+            <div data-testid="modal" tabIndex={-1} />
           </Modal>
         </div>,
       );

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import MenuItem from '../MenuItem';
 import Input from '../Input';
@@ -141,18 +141,19 @@ describe('<Select />', () => {
 
   [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach((key) => {
     it(`should open menu when pressed ${key} key on select`, () => {
-      const { getByRole } = render(
+      render(
         <Select value="">
           <MenuItem value="">none</MenuItem>
         </Select>,
       );
-      getByRole('button').focus();
+      const trigger = screen.getByRole('button');
+      trigger.focus();
 
-      fireEvent.keyDown(document.activeElement, { key });
-      expect(getByRole('listbox', { hidden: false })).not.to.equal(null);
+      fireEvent.keyDown(trigger, { key });
+      expect(screen.getByRole('listbox', { hidden: false })).not.to.equal(null);
 
-      fireEvent.keyUp(document.activeElement, { key });
-      expect(getByRole('listbox', { hidden: false })).not.to.equal(null);
+      fireEvent.keyUp(screen.getAllByRole('option')[0], { key });
+      expect(screen.getByRole('listbox', { hidden: false })).not.to.equal(null);
     });
   });
 
@@ -518,20 +519,21 @@ describe('<Select />', () => {
 
   describe('prop: readOnly', () => {
     it('should not trigger any event with readOnly', () => {
-      const { getByRole, queryByRole } = render(
+      render(
         <Select readOnly value="10">
           <MenuItem value={10}>Ten</MenuItem>
           <MenuItem value={20}>Twenty</MenuItem>
         </Select>,
         { baseElement: document.body },
       );
-      getByRole('button').focus();
+      const trigger = screen.getByRole('button');
+      trigger.focus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      expect(queryByRole('listbox')).to.equal(null);
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      expect(screen.queryByRole('listbox')).to.equal(null);
 
-      fireEvent.keyUp(document.activeElement, { key: 'ArrowDown' });
-      expect(queryByRole('listbox')).to.equal(null);
+      fireEvent.keyUp(trigger, { key: 'ArrowDown' });
+      expect(screen.queryByRole('listbox')).to.equal(null);
     });
   });
 
@@ -980,7 +982,7 @@ describe('<Select />', () => {
       </Select>,
     );
 
-    fireEvent.keyUp(document.activeElement, { key: ' ' });
+    fireEvent.keyUp(screen.getAllByRole('option')[0], { key: ' ' });
 
     expect(keyUpSpy.callCount).to.equal(1);
     expect(keyUpSpy.returnValues[0]).to.equal(true);

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -52,6 +52,7 @@ describe('<Slider />', () => {
     const { container, getByRole } = render(
       <Slider onChange={handleChange} onChangeCommitted={handleChangeCommitted} value={0} />,
     );
+    const slider = getByRole('slider');
 
     fireEvent.mouseDown(container.firstChild);
     fireEvent.mouseUp(document.body);
@@ -59,8 +60,8 @@ describe('<Slider />', () => {
     expect(handleChange.callCount).to.equal(1);
     expect(handleChangeCommitted.callCount).to.equal(1);
 
-    getByRole('slider').focus();
-    fireEvent.keyDown(document.activeElement, {
+    slider.focus();
+    fireEvent.keyDown(slider, {
       key: 'Home',
     });
     expect(handleChange.callCount).to.equal(2);
@@ -135,13 +136,13 @@ describe('<Slider />', () => {
       const [thumb1, thumb2] = getAllByRole('slider');
 
       thumb1.focus();
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb1, {
         key: 'ArrowRight',
       });
       expect(thumb1.getAttribute('aria-valuenow')).to.equal('21');
 
       thumb2.focus();
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb2, {
         key: 'ArrowLeft',
       });
       expect(thumb2.getAttribute('aria-valuenow')).to.equal('29');
@@ -209,12 +210,12 @@ describe('<Slider />', () => {
       expect(thumb).to.have.attribute('aria-valuenow', '20');
 
       thumb.focus();
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'ArrowUp',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '30');
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'ArrowDown',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '20');
@@ -247,27 +248,27 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'Home',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '0');
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'End',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '100');
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'PageDown',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '90');
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'Escape',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '90');
 
-      fireEvent.keyDown(document.activeElement, {
+      fireEvent.keyDown(thumb, {
         key: 'PageUp',
       });
       expect(thumb).to.have.attribute('aria-valuenow', '100');
@@ -285,10 +286,10 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '250');
 
-      fireEvent.keyDown(document.activeElement, moveLeftEvent);
+      fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '150');
     });
 
@@ -297,19 +298,19 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '96');
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '106');
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '108');
 
-      fireEvent.keyDown(document.activeElement, moveLeftEvent);
+      fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '96');
 
-      fireEvent.keyDown(document.activeElement, moveLeftEvent);
+      fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '86');
     });
 
@@ -318,13 +319,13 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveLeftEvent);
+      fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '6');
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '16');
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '26');
     });
 
@@ -333,7 +334,7 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '0.3');
     });
 
@@ -344,7 +345,7 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '3e-8');
     });
 
@@ -355,7 +356,7 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveLeftEvent);
+      fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '-3e-8');
     });
 
@@ -372,9 +373,9 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
       thumb.focus();
 
-      fireEvent.keyDown(document.activeElement, moveLeftEvent);
+      fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '31');
-      fireEvent.keyDown(document.activeElement, moveRightEvent);
+      fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '30');
     });
   });

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -48,7 +48,7 @@ describe('<Tab />', () => {
     fireEvent.pointerDown(document.body);
 
     act(() => {
-      fireEvent.keyDown(document.activeElement, { key: 'Tab' });
+      fireEvent.keyDown(document.body, { key: 'Tab' });
       // jsdom doesn't actually support tab focus, we need to do it manually
       getByRole('tab').focus();
     });
@@ -64,7 +64,7 @@ describe('<Tab />', () => {
     fireEvent.pointerDown(document.body);
 
     act(() => {
-      fireEvent.keyDown(document.activeElement, { key: 'Tab' });
+      fireEvent.keyDown(document.body, { key: 'Tab' });
       // jsdom doesn't actually support tab focus, we need to do it manually
       getByRole('tab').focus();
     });

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -5,7 +5,7 @@ import { useFakeTimers } from 'sinon';
 import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 
 const options = [
   'Show some love to Material-UI',
@@ -114,22 +114,22 @@ describe('<Menu /> integration', () => {
     button.click();
     const menuitems = getAllByRole('menuitem');
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' });
     expect(menuitems[0]).toHaveFocus();
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' });
     expect(menuitems[2]).toHaveFocus();
 
-    fireEvent.keyDown(document.activeElement, { key: 'Home' });
+    fireEvent.keyDown(menuitems[2], { key: 'Home' });
     expect(menuitems[0]).toHaveFocus();
 
-    fireEvent.keyDown(document.activeElement, { key: 'End' });
+    fireEvent.keyDown(menuitems[0], { key: 'End' });
     expect(menuitems[2]).toHaveFocus();
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
+    fireEvent.keyDown(menuitems[2], { key: 'ArrowRight' });
     expect(menuitems[2], 'no change on unassociated keys').toHaveFocus();
   });
 
@@ -314,16 +314,17 @@ describe('<Menu /> integration', () => {
   });
 
   it('closes the menu when Tabbing while the list is active', () => {
-    const { getByRole } = render(<ButtonMenu />);
+    render(<ButtonMenu />);
 
-    getByRole('button').focus();
-    getByRole('button').click();
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    trigger.click();
 
-    fireEvent.keyDown(document.activeElement, { key: 'Tab' });
+    fireEvent.keyDown(screen.getAllByRole('menuitem')[0], { key: 'Tab' });
     // react-transition-group uses one commit per state transition so we need to wait a bit
     clock.tick(0);
 
-    expect(getByRole('menu', { hidden: true })).toBeInaccessible();
+    expect(screen.getByRole('menu', { hidden: true })).toBeInaccessible();
   });
 
   it('closes the menu when the backdrop is clicked', () => {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 
 describe('<MenuList> integration', () => {
   const render = createClientRender();
@@ -64,8 +64,8 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
       const menuitems = getAllByRole('menuitem');
+      fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' });
 
       expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
@@ -82,8 +82,8 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
       const menuitems = getAllByRole('menuitem');
+      fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
 
       expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
@@ -100,9 +100,9 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
       const menuitems = getAllByRole('menuitem');
+      fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
+      fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' });
 
       expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
@@ -161,14 +161,14 @@ describe('<MenuList> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
 
       expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
 
       expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
@@ -208,7 +208,7 @@ describe('<MenuList> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
 
       expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
@@ -219,16 +219,16 @@ describe('<MenuList> integration', () => {
 
   describe('keyboard controls and tabIndex manipulation - preselected item, no item autoFocus', () => {
     it('should focus the first item if no item is focused when pressing ArrowDown', () => {
-      const { getAllByRole } = render(
+      render(
         <MenuList autoFocus>
           <MenuItem>Menu Item 1</MenuItem>
           <MenuItem selected>Menu Item 2</MenuItem>
           <MenuItem>Menu Item 3</MenuItem>
         </MenuList>,
       );
-      const menuitems = getAllByRole('menuitem');
+      const menuitems = screen.getAllByRole('menuitem');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
 
       expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
@@ -237,7 +237,7 @@ describe('<MenuList> integration', () => {
     });
 
     it('should focus the third item if no item is focused when pressing ArrowUp', () => {
-      const { getAllByRole } = render(
+      render(
         <MenuList autoFocus>
           <MenuItem>Menu Item 1</MenuItem>
           <MenuItem selected tabIndex={0}>
@@ -246,9 +246,9 @@ describe('<MenuList> integration', () => {
           <MenuItem>Menu Item 3</MenuItem>
         </MenuList>,
       );
-      const menuitems = getAllByRole('menuitem');
+      const menuitems = screen.getAllByRole('menuitem');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
 
       expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
@@ -288,7 +288,7 @@ describe('<MenuList> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+      fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' });
 
       expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
@@ -304,7 +304,7 @@ describe('<MenuList> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
 
       expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
@@ -313,7 +313,7 @@ describe('<MenuList> integration', () => {
   });
 
   it('should skip divider and disabled menu item', () => {
-    const { getAllByRole } = render(
+    render(
       <MenuList autoFocus>
         <MenuItem>Menu Item 1</MenuItem>
         <Divider component="li" />
@@ -322,30 +322,30 @@ describe('<MenuList> integration', () => {
         <MenuItem>Menu Item 4</MenuItem>
       </MenuList>,
     );
-    const menuitems = getAllByRole('menuitem');
+    const menuitems = screen.getAllByRole('menuitem');
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
     expect(menuitems[0]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
     expect(menuitems[3]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[3], { key: 'ArrowDown' });
     expect(menuitems[0]).toHaveFocus();
 
     // and ArrowUp again
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' });
     expect(menuitems[3]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[3], { key: 'ArrowUp' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' });
     expect(menuitems[0]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' });
     expect(menuitems[3]).toHaveFocus();
   });
 
   it('should stay on a single item if it is the only focusable one', () => {
-    const { getAllByRole } = render(
+    render(
       <MenuList autoFocus>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem>Menu Item 2</MenuItem>
@@ -353,17 +353,17 @@ describe('<MenuList> integration', () => {
         <MenuItem disabled>Menu Item 4</MenuItem>
       </MenuList>,
     );
-    const menuitems = getAllByRole('menuitem');
+    const menuitems = screen.getAllByRole('menuitem');
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' });
     expect(menuitems[1]).toHaveFocus();
   });
 
@@ -378,20 +378,20 @@ describe('<MenuList> integration', () => {
     );
     const menu = getByRole('menu');
 
-    fireEvent.keyDown(document.activeElement, { key: 'Home' });
+    fireEvent.keyDown(menu, { key: 'Home' });
     expect(menu).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menu, { key: 'ArrowDown' });
     expect(menu).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menu, { key: 'ArrowDown' });
     expect(menu).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'End' });
+    fireEvent.keyDown(menu, { key: 'End' });
     expect(menu).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menu, { key: 'ArrowUp' });
     expect(menu).toHaveFocus();
   });
 
   it('should allow focus on disabled items when disabledItemsFocusable=true', () => {
-    const { getAllByRole } = render(
+    render(
       <MenuList autoFocus disabledItemsFocusable>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
@@ -400,17 +400,17 @@ describe('<MenuList> integration', () => {
       </MenuList>,
     );
 
-    const menuitems = getAllByRole('menuitem');
+    const menuitems = screen.getAllByRole('menuitem');
 
-    fireEvent.keyDown(document.activeElement, { key: 'Home' });
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Home' });
     expect(menuitems[0]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowDown' });
     expect(menuitems[2]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'End' });
+    fireEvent.keyDown(menuitems[2], { key: 'End' });
     expect(menuitems[3]).toHaveFocus();
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(menuitems[3], { key: 'ArrowUp' });
     expect(menuitems[2]).toHaveFocus();
   });
 
@@ -430,9 +430,10 @@ describe('<MenuList> integration', () => {
           <MenuItem>Berizona</MenuItem>
         </MenuList>,
       );
-      getByRole('menu').focus();
+      const menu = getByRole('menu');
+      menu.focus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'a' });
+      fireEvent.keyDown(menu, { key: 'a' });
 
       expect(getByText('Arizona')).toHaveFocus();
     });
@@ -446,7 +447,7 @@ describe('<MenuList> integration', () => {
       );
       getByText('Arizona').focus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'a' });
+      fireEvent.keyDown(getByText('Arizona'), { key: 'a' });
 
       expect(getByText('Arcansas')).toHaveFocus();
     });
@@ -476,7 +477,7 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'c' });
+      fireEvent.keyDown(getByText('Arizona'), { key: 'c' });
 
       expect(getByText('Arizona')).toHaveFocus();
     });
@@ -489,11 +490,11 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'A' });
+      fireEvent.keyDown(getByText('Arizona'), { key: 'A' });
 
       expect(getByText('Arizona')).toHaveFocus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'r' });
+      fireEvent.keyDown(getByText('Arizona'), { key: 'r' });
 
       expect(getByText('Arizona')).toHaveFocus();
     });
@@ -510,38 +511,38 @@ describe('<MenuList> integration', () => {
       const button = getByText('Focusable Descendant');
       button.focus();
 
-      fireEvent.keyDown(document.activeElement, { key: 'z' });
+      fireEvent.keyDown(button, { key: 'z' });
 
       expect(button).toHaveFocus();
     });
 
     it('matches rapidly typed text', () => {
-      const { getByText } = render(
+      render(
         <MenuList autoFocus>
           <MenuItem>Worm</MenuItem>
           <MenuItem>Ordinary</MenuItem>
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'W' });
-      fireEvent.keyDown(document.activeElement, { key: 'o' });
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'W' });
+      fireEvent.keyDown(screen.getByText('Worm'), { key: 'o' });
 
-      expect(getByText('Worm')).toHaveFocus();
+      expect(screen.getByText('Worm')).toHaveFocus();
     });
 
     it('should reset the character buffer after 500ms', (done) => {
-      const { getByText } = render(
+      render(
         <MenuList autoFocus>
           <MenuItem>Worm</MenuItem>
           <MenuItem>Ordinary</MenuItem>
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'W' });
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'W' });
       setTimeout(() => {
-        fireEvent.keyDown(document.activeElement, { key: 'o' });
+        fireEvent.keyDown(screen.getByText('Worm'), { key: 'o' });
 
-        expect(getByText('Ordinary')).toHaveFocus();
+        expect(screen.getByText('Ordinary')).toHaveFocus();
         done();
       }, 500);
     });
@@ -552,7 +553,7 @@ describe('<MenuList> integration', () => {
         this.skip();
       }
 
-      const { getByText } = render(
+      render(
         <MenuList autoFocus>
           <MenuItem>
             W<span style={{ display: 'none' }}>Should not block type focus</span>orm
@@ -561,10 +562,10 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      fireEvent.keyDown(document.activeElement, { key: 'W' });
-      fireEvent.keyDown(document.activeElement, { key: 'o' });
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'W' });
+      fireEvent.keyDown(screen.getByText('Worm'), { key: 'o' });
 
-      expect(getByText('Worm')).toHaveFocus();
+      expect(screen.getByText('Worm')).toHaveFocus();
     });
   });
 });

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -127,7 +127,7 @@ describe('<Select> integration', () => {
 
       const trigger = getByRole('button');
       trigger.focus();
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(trigger, { key: 'Enter' });
 
       expect(getByTestId('label')).to.have.class('focused-label');
     });
@@ -147,16 +147,17 @@ describe('<Select> integration', () => {
           </Select>
         </FormControl>,
       );
+      const trigger = getByRole('button');
 
-      getByRole('button').focus();
-
-      expect(container.querySelector('[for="age-simple"]')).to.have.class('focused-label');
-
-      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      trigger.focus();
 
       expect(container.querySelector('[for="age-simple"]')).to.have.class('focused-label');
 
-      getByRole('button').blur();
+      fireEvent.keyDown(trigger, { key: 'Enter' });
+
+      expect(container.querySelector('[for="age-simple"]')).to.have.class('focused-label');
+
+      trigger.blur();
 
       expect(container.querySelector('[for="age-simple"]')).not.to.have.class('focused-label');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,6 +2375,14 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
+"@types/eslint@^6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-6.8.0.tgz#5f2289b9f01316da7cf31c9e63109a10602a23cb"
+  integrity sha512-hqzmggoxkOubpgTdcOltkfc5N8IftRJqU70d1jbOISjjZVPvjcr+CLi2CI70hx1SUIRkLgpglTy9w28nGe2Hsw==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
 "@types/estree@*", "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -2442,6 +2450,11 @@
     "@types/node" "*"
     "@types/parse5" "*"
     "@types/tough-cookie" "*"
+
+"@types/json-schema@*":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
 "@types/json2mq@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
While it's definitely a good idea to make sure the keyboard event target is the active element, it hurts readability in many cases. It's oftentimes not immediately clear what element is currently focused.

We now lint against `fireEvent.key*(document.activeElement)` while also ensuring that the target is focused. If it's not we throw and include the currently focused element.