### PR TITLE
[docs] Add missing spot do DiamondSponsors

### DIFF
--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -163,7 +163,7 @@ function AppDrawer(props) {
       </div>
       <Divider />
       <Box mx={3} my={2}>
-        <DiamondSponsors />
+        <DiamondSponsors spot="drawer" />
       </Box>
       {renderNavItems({ props, pages, activePage, depth: 0, t })}
     </PersistScroll>


### PR DESCRIPTION
Although we now only use it once we should keep the spot tracking in case we later use it somewhere else. We might forget to add it then.

Otherwise we should inline the component and add warning to add spot tracking once we export it again.