### PR TITLE
[docs] Reduce likelyhood of overflow in ToC

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
   },
   contents: {
     marginTop: theme.spacing(2),
-    paddingLeft: theme.spacing(1.5),
+    paddingLeft: theme.spacing(1),
   },
   ul: {
     padding: 0,
@@ -36,16 +36,17 @@ const useStyles = makeStyles((theme) => ({
   },
   item: {
     fontSize: 13,
-    padding: theme.spacing(0.5, 0, 0.5, 1),
-    borderLeft: '4px solid transparent',
-    boxSizing: 'content-box',
+    // paddingLeft: theme.spacing(1) where `border` is used as the "active" marker
+    paddingLeft: theme.spacing(0.5),
+    borderLeft: `${theme.spacing(0.5)}px solid transparent`,
+    boxSizing: 'border-box',
     '&:hover': {
-      borderLeft: `4px solid ${
+      borderLeft: `${theme.spacing(0.5)}px solid ${
         theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
       }`,
     },
     '&$active,&:active': {
-      borderLeft: `4px solid ${
+      borderLeft: `${theme.spacing(0.5)}px solid ${
         theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800]
       }`,
     },

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -35,18 +35,19 @@ const useStyles = makeStyles((theme) => ({
     listStyle: 'none',
   },
   item: {
-    fontSize: 13,
+    fontSize: '.8125rem',
+    lineHeight: 2,
     // paddingLeft: theme.spacing(1) where `border` is used as the "active" marker
-    paddingLeft: theme.spacing(0.5),
-    borderLeft: `${theme.spacing(0.5)}px solid transparent`,
+    paddingLeft: Math.max(0, theme.spacing(1) - 4),
+    borderLeft: `4px solid transparent`,
     boxSizing: 'border-box',
     '&:hover': {
-      borderLeft: `${theme.spacing(0.5)}px solid ${
+      borderLeft: `4px solid ${
         theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
       }`,
     },
     '&$active,&:active': {
-      borderLeft: `${theme.spacing(0.5)}px solid ${
+      borderLeft: `4px solid ${
         theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800]
       }`,
     },

--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -188,13 +188,18 @@ ${headers.components
               .trim();
             const hash = textToHash(headingText, headingHashes);
 
+            // enable splitting of long words from function name + first arg name
+            // Closing parens are less interesting since this would only allow breaking one character earlier.
+            // Applying the same mechanism would also allow breaking of non-function signatures like "Community help (free)".
+            // To detect that we enabled breaking of open/closing parens we'd need a context-sensitive parser.
+            const displayText = headingText.replace(/([^\s]\()/g, '$1&#8203;');
             /**
              * create a nested structure with 2 levels starting with level 2 e.g.
              * [{...level2, children: [level3, level3, level3]}, level2]
              */
             if (level === 2) {
               toc.push({
-                text: headingText,
+                text: displayText,
                 level,
                 hash,
                 children: [],
@@ -205,7 +210,7 @@ ${headers.components
               }
 
               toc[toc.length - 1].children.push({
-                text: headingText,
+                text: displayText,
                 level,
                 hash,
               });

--- a/docs/src/modules/utils/parseMarkdown.test.js
+++ b/docs/src/modules/utils/parseMarkdown.test.js
@@ -61,5 +61,48 @@ describe('parseMarkdown', () => {
         },
       ]);
     });
+
+    it('enables word-break for function signatures', () => {
+      const markdown = `
+# Theming
+## API
+### responsiveFontSizes(theme, options) => theme
+### createMuiTheme(options, ...args) => theme
+`;
+      // mock require.context
+      function requireRaw() {
+        return markdown;
+      }
+      requireRaw.keys = () => ['index.md'];
+
+      const {
+        docs: {
+          en: { toc },
+        },
+      } = prepareMarkdown({
+        pageFilename: 'test',
+        requireRaw,
+      });
+
+      expect(toc).to.have.deep.ordered.members([
+        {
+          children: [
+            {
+              hash: 'responsivefontsizes-theme-options-theme',
+              level: 3,
+              text: 'responsiveFontSizes(&#8203;theme, options) =&gt; theme',
+            },
+            {
+              hash: 'createmuitheme-options-args-theme',
+              level: 3,
+              text: 'createMuiTheme(&#8203;options, ...args) =&gt; theme',
+            },
+          ],
+          hash: 'api',
+          level: 2,
+          text: 'API',
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Especially function signatures are very likely to cause overflow since they can include two words that aren't breakable: `functionNameIsTheFirst(andTheFirstArgIsTheSecondName`. We now add a zero-width space after an opening paren that is from a function signature (i.e. a word that is followed by an opening paren).

This also aligns the ToC to the grid by using theme.spacing(1) instead of 1.5.

Before: https://material-ui.netlify.app/customization/theming/#theming
![Screenshot from 2020-05-09 14-51-06](https://user-images.githubusercontent.com/12292047/81474276-8f4e0180-9204-11ea-88ac-9463bbc990b4.png)

After: https://deploy-preview-20961--material-ui.netlify.app/customization/theming/#theming
![Screenshot from 2020-05-09 14-54-22](https://user-images.githubusercontent.com/12292047/81474323-fc619700-9204-11ea-9d8a-85555acadb88.png)
