### PR TITLE
[test] Improve assertion mismatch messages

### DIFF
--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -4,6 +4,14 @@ import { isInaccessible } from '@testing-library/dom';
 import { prettyDOM } from '@testing-library/react/pure';
 import { computeAccessibleName } from 'dom-accessibility-api';
 
+// chai#utils.elToString that looks like stringified elements in testing-library
+function elementToString(element) {
+  if (typeof element?.nodeType === 'number') {
+    return prettyDOM(element, undefined, { highlight: true, maxDepth: 1 });
+  }
+  return String(element);
+}
+
 chai.use(chaiDom);
 chai.use((chaiAPI, utils) => {
   // better diff view for expect(element).to.equal(document.activeElement)
@@ -12,10 +20,10 @@ chai.use((chaiAPI, utils) => {
 
     this.assert(
       element === document.activeElement,
-      'focus expected #{exp}, but #{act} was instead',
-      'unexpected focus on #{exp}',
-      element == null ? String(element) : prettyDOM(element),
-      prettyDOM(document.activeElement),
+      'expected element to have focus',
+      `expected element to NOT have focus \n${elementToString(element)}`,
+      elementToString(element),
+      elementToString(document.activeElement),
     );
   });
 
@@ -44,10 +52,10 @@ chai.use((chaiAPI, utils) => {
 
     this.assert(
       ariaHidden === true,
-      `expected ${utils.elToString(element)} to be aria-hidden\n${prettyDOM(previousNode)}`,
-      `expected ${utils.elToString(element)} to not be aria-hidden, but ${utils.elToString(
+      `expected \n${elementToString(element)} to be aria-hidden`,
+      `expected \n${elementToString(element)} to not be aria-hidden, but \n${elementToString(
         previousNode,
-      )} had aria-hidden="true" instead\n${prettyDOM(previousNode)}`,
+      )} had aria-hidden="true" instead`,
     );
   });
 
@@ -58,8 +66,8 @@ chai.use((chaiAPI, utils) => {
 
     this.assert(
       inaccessible === true,
-      `expected ${utils.elToString(element)} to be inaccessible but it was accessible`,
-      `expected ${utils.elToString(element)} to be accessible but it was inaccessible`,
+      `expected \n${elementToString(element)} to be inaccessible but it was accessible`,
+      `expected \n${elementToString(element)} to be accessible but it was inaccessible`,
     );
   });
 
@@ -128,10 +136,10 @@ chai.use((chaiAPI, utils) => {
 
     this.assert(
       actualName === expectedName,
-      `expected ${utils.elToString(
-        root,
-      )} to have accessible name '${expectedName}' but got '${actualName}' instead.`,
-      `expected ${utils.elToString(root)} not to have accessible name '${expectedName}'.`,
+      `expected \n${elementToString(root)} to have accessible name #{exp} but got #{act} instead.`,
+      `expected \n${elementToString(root)} not to have accessible name #{exp}.`,
+      expectedName,
+      actualName,
     );
   });
 


### PR DESCRIPTION
Realized by accident how to makes these useful. Previous messages were barely usable. This should be better:
- don't stringify element if we expect it but rather leverage chais `#{exp}` and `#{act}` placeholders
- hide the subtree of these elements. It is mostly noise in the message (apart from the accessible name) and is barely readably in the message. For debugging accessible name mismatches `debug()` is more appropriate since it'll also include referenced elements.

## toHaveFocus

Before
![Screenshot from 2020-05-09 20-56-10](https://user-images.githubusercontent.com/12292047/81482567-457f0e80-9238-11ea-9d0a-4cc631204c4e.png)

After
![Screenshot from 2020-05-09 20-55-11](https://user-images.githubusercontent.com/12292047/81482546-21bbc880-9238-11ea-86bd-425b7d0c7a0d.png)

## toBeInaccessible

Before
![Screenshot from 2020-05-09 20-56-25](https://user-images.githubusercontent.com/12292047/81482575-50d23a00-9238-11ea-8131-a8a1c112b6db.png)

After
![Screenshot from 2020-05-09 21-28-41](https://user-images.githubusercontent.com/12292047/81483134-166a9c00-923c-11ea-8958-1efd390ddcce.png)



## toHaveAccessibleName

Before
![Screenshot from 2020-05-09 20-56-31](https://user-images.githubusercontent.com/12292047/81482576-53cd2a80-9238-11ea-8de2-4179f01aeb00.png)

After
![Screenshot from 2020-05-09 21-29-09](https://user-images.githubusercontent.com/12292047/81483144-25514e80-923c-11ea-9635-d0786d93edd5.png)


## toBeAriaHidden

Before
![Screenshot from 2020-05-09 20-56-16](https://user-images.githubusercontent.com/12292047/81482571-4b74ef80-9238-11ea-9452-9803acb9b5e6.png)

After
![Screenshot from 2020-05-09 21-29-30](https://user-images.githubusercontent.com/12292047/81483153-313d1080-923c-11ea-8820-7b61a3e42fa1.png)

