### PR TITLE
[test] Prepare patch for `react@next`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,6 @@ workflows:
                 - l10n
                 - /dependabot\//
       - test_unit:
-          react-dist-tag: next
           requires:
             - checkout
       - test_static:
@@ -218,7 +217,6 @@ workflows:
           requires:
             - checkout
       - test_browser:
-          react-dist-tag: next
           requires:
             - checkout
       - test_regressions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,7 @@ workflows:
                 - l10n
                 - /dependabot\//
       - test_unit:
+          react-dist-tag: next
           requires:
             - checkout
       - test_static:
@@ -217,6 +218,7 @@ workflows:
           requires:
             - checkout
       - test_browser:
+          react-dist-tag: next
           requires:
             - checkout
       - test_regressions:

--- a/scripts/react-next.diff
+++ b/scripts/react-next.diff
@@ -1,0 +1,112 @@
+diff --git a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+index 0bfa7e1be..94ea402c2 100644
+--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
++++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+@@ -994,7 +994,7 @@ describe('<Autocomplete />', () => {
+         />,
+       );
+ 
+-      expect(consoleWarnMock.callCount()).to.equal(4);
++      expect(consoleWarnMock.callCount()).to.equal(2);
+       expect(consoleWarnMock.messages()[0]).to.include(
+         'None of the options match with `"not a good value"`',
+       );
+@@ -1023,7 +1023,7 @@ describe('<Autocomplete />', () => {
+       const options = getAllByRole('option').map((el) => el.textContent);
+       expect(options).to.have.length(7);
+       expect(options).to.deep.equal(['A', 'D', 'E', 'B', 'G', 'F', 'C']);
+-      expect(consoleWarnMock.callCount()).to.equal(2);
++      expect(consoleWarnMock.callCount()).to.equal(1);
+       expect(consoleWarnMock.messages()[0]).to.include('returns duplicated headers');
+     });
+   });
+diff --git a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+index 973ae7024..73b52cdfe 100644
+--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
++++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+@@ -145,7 +145,7 @@ describe('ThemeProvider', () => {
+           <div />
+         </ThemeProvider>,
+       );
+-      expect(consoleErrorMock.callCount()).to.equal(2); // twice in strict mode
++      expect(consoleErrorMock.callCount()).to.equal(1);
+       expect(consoleErrorMock.messages()[0]).to.include('However, no outer theme is present.');
+     });
+ 
+@@ -158,7 +158,7 @@ describe('ThemeProvider', () => {
+           ,
+         </ThemeProvider>,
+       );
+-      expect(consoleErrorMock.callCount()).to.equal(2);
++      expect(consoleErrorMock.callCount()).to.equal(1);
+       expect(consoleErrorMock.messages()[0]).to.include(
+         'Material-UI: You should return an object from your theme function',
+       );
+diff --git a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+index a8a9544a3..a43b6033c 100644
+--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
++++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+@@ -103,7 +103,7 @@ describe('<Breadcrumbs />', () => {
+       );
+       expect(getAllByRole('listitem', { hidden: false })).to.have.length(4);
+       expect(getByRole('list')).to.have.text('first/second/third/fourth');
+-      expect(consoleErrorMock.callCount()).to.equal(2); // strict mode renders twice
++      expect(consoleErrorMock.callCount()).to.equal(1);
+       expect(consoleErrorMock.messages()[0]).to.include(
+         'Material-UI: You have provided an invalid combination of props to the Breadcrumbs.\nitemsAfterCollapse={2} + itemsBeforeCollapse={2} >= maxItems={3}',
+       );
+diff --git a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+index 9f4873a08..d1b6e6aeb 100644
+--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
++++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+@@ -254,7 +254,7 @@ describe('<TextareaAutosize />', () => {
+         wrapper.setProps();
+         wrapper.update();
+ 
+-        expect(consoleErrorMock.callCount()).to.equal(3);
++        expect(consoleErrorMock.callCount()).to.equal(1);
+         expect(consoleErrorMock.messages()[0]).to.include('Material-UI: Too many re-renders.');
+       });
+     });
+diff --git a/packages/material-ui/src/internal/SwitchBase.test.js b/packages/material-ui/src/internal/SwitchBase.test.js
+index c925204ac..2fccd80fe 100644
+--- a/packages/material-ui/src/internal/SwitchBase.test.js
++++ b/packages/material-ui/src/internal/SwitchBase.test.js
+@@ -374,7 +374,7 @@ describe('<SwitchBase />', () => {
+         wrapper.setProps({ checked: true });
+         expect(consoleErrorMock.callCount()).to.equal(2);
+         expect(consoleErrorMock.messages()[0]).to.include(
+-          'Warning: A component is changing an uncontrolled input of type checkbox to be controlled.',
++          'Warning: A component is changing an uncontrolled input to be controlled.',
+         );
+         expect(consoleErrorMock.messages()[1]).to.include(
+           'Material-UI: A component is changing the uncontrolled checked state of SwitchBase to be controlled.',
+@@ -393,7 +393,7 @@ describe('<SwitchBase />', () => {
+         setProps({ checked: undefined });
+         expect(consoleErrorMock.callCount()).to.equal(2);
+         expect(consoleErrorMock.messages()[0]).to.include(
+-          'Warning: A component is changing a controlled input of type checkbox to be uncontrolled.',
++          'Warning: A component is changing a controlled input to be uncontrolled.',
+         );
+         expect(consoleErrorMock.messages()[1]).to.include(
+           'Material-UI: A component is changing the controlled checked state of SwitchBase to be uncontrolled.',
+diff --git a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+index 68b0a4a5c..e31152c44 100644
+--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
++++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+@@ -284,14 +284,10 @@ describe('useMediaQuery', () => {
+       }
+ 
+       render(<MyComponent />);
+-      // logs warning twice in StrictMode
+-      expect(consoleErrorMock.callCount()).to.equal(2);
++      expect(consoleErrorMock.callCount()).to.equal(1);
+       expect(consoleErrorMock.messages()[0]).to.include(
+         'Material-UI: The `query` argument provided is invalid',
+       );
+-      expect(consoleErrorMock.messages()[1]).to.include(
+-        'Material-UI: The `query` argument provided is invalid',
+-      );
+     });
+   });
+ });

--- a/scripts/use-react-dist-tag.js
+++ b/scripts/use-react-dist-tag.js
@@ -50,6 +50,15 @@ async function main(distTag) {
 
   // add newline for clean diff
   fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
+
+  try {
+    await exec(`git apply ${path.resolve(__dirname, `./react-${distTag}.diff`)}`);
+  } catch (error) {
+    // ignore if the patch doesn't exist
+    if (error.code !== 128) {
+      throw error;
+    }
+  }
 }
 
 main(process.env.REACT_DIST_TAG).catch((error) => {


### PR DESCRIPTION
Includes a patch in the main branch that fixes CI when using `react@next`.

This way we can prepare for `react@next` when we have the time or address issues as soon as they arise (instead of addressing all at once on release day). Once we have patch the makes CI go green when testing `react@next` the repo checks will no longer be marked as "failing" between the scheduled `react@next` test and the first build on the main branch.

changes in `react@next` addressed:
- React monkey patches console methods in StrictMode so that you don't have to assert on double render invokations. This means that assertions relying the number of console.* invokations are now stable between StrictMode and no StrictMode.