### PR TITLE
[core] Batch small changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Big thanks to the 27 contributors who made this release possible.
 
 Here are some highlights ✨:
 
-- 💎 A new diamond sponsor: [Sencha](https://www.creative-tim.com/), thank you!
+- 💎 A new diamond sponsor: [Sencha](https://sencha.com/), thank you!
 - ⚛️ More tests migrated from enzyme to testing-library @marcosvega91.
 - And many more 🐛 bug fixes and 📚 improvements.
 

--- a/docs/pages/discover-more/backers.js
+++ b/docs/pages/discover-more/backers.js
@@ -11,7 +11,7 @@ const requireRaw = require.context(
 );
 
 export default function Page({ demos, docs }) {
-  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} disableAd />;
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/discover-more/showcase.js
+++ b/docs/pages/discover-more/showcase.js
@@ -11,7 +11,7 @@ const requireRaw = require.context(
 );
 
 export default function Page({ demos, docs }) {
-  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} disableToc />;
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/getting-started/templates.js
+++ b/docs/pages/getting-started/templates.js
@@ -15,7 +15,7 @@ const requireRaw = require.context(
 );
 
 export default function Page({ demos, docs }) {
-  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} disableToc />;
 }
 
 Page.getInitialProps = () => {

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
   },
   contents: {
     marginTop: theme.spacing(2),
-    paddingLeft: 8,
+    paddingLeft: theme.spacing(1),
   },
   ul: {
     padding: 0,
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
   },
   item: {
     fontSize: '.8125rem',
-    padding: `4px 0 4px 5px`,
+    padding: theme.spacing(0.5, 0, 0.5, `${Math.max(0, theme.spacing(1) - 3)}px`),
     borderLeft: `3px solid transparent`,
     boxSizing: 'border-box',
     '&:hover': {

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
   },
   contents: {
     marginTop: theme.spacing(2),
-    paddingLeft: theme.spacing(1),
+    paddingLeft: 8,
   },
   ul: {
     padding: 0,
@@ -36,20 +36,16 @@ const useStyles = makeStyles((theme) => ({
   },
   item: {
     fontSize: '.8125rem',
-    lineHeight: 2,
-    // paddingLeft: theme.spacing(1) where `border` is used as the "active" marker
-    paddingLeft: Math.max(0, theme.spacing(1) - 4),
-    borderLeft: `4px solid transparent`,
+    padding: `4px 0 4px 5px`,
+    borderLeft: `3px solid transparent`,
     boxSizing: 'border-box',
     '&:hover': {
-      borderLeft: `4px solid ${
-        theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
-      }`,
+      borderLeftColor:
+        theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900],
     },
     '&$active,&:active': {
-      borderLeft: `4px solid ${
-        theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800]
-      }`,
+      borderLeftColor:
+        theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
     },
   },
   secondaryItem: {

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -638,9 +638,6 @@ const useStyles = makeStyles(
       [theme.breakpoints.up('sm')]: {
         borderRadius: theme.shape.borderRadius,
       },
-      '&:focus': {
-        outline: `2px dashed ${theme.palette.text.primary}`,
-      },
     },
     /* Isolate the demo with an outline. */
     demoBgOutlined: {

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -679,7 +679,7 @@ const useStyles = makeStyles(
       '& pre': {
         overflow: 'auto',
         lineHeight: 1.5,
-        margin: '0px !important',
+        margin: '0 !important',
         maxHeight: 1000,
       },
     },

--- a/docs/src/modules/constants.js
+++ b/docs/src/modules/constants.js
@@ -15,7 +15,7 @@ const LANGUAGES = ['en', 'zh', 'ru', 'pt', 'es', 'fr', 'de', 'ja', 'aa'];
 const LANGUAGES_SSR = ['en', 'zh', 'ru', 'pt', 'es'];
 
 // Work in progress
-const LANGUAGES_IN_PROGRESS = [...LANGUAGES];
+const LANGUAGES_IN_PROGRESS = LANGUAGES.slice();
 
 // Valid languages to use in production
 const LANGUAGES_LABEL = [

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -144,7 +144,7 @@ const useDialogStyles = makeStyles((theme) => ({
     color: theme.palette.primary.dark,
     backgroundSize: '30px 30px',
     backgroundColor: '#fff',
-    backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0px',
+    backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0',
     backgroundImage:
       'linear-gradient(45deg, #f4f4f4 25%, transparent 25%), linear-gradient(-45deg, #f4f4f4 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f4f4f4 75%), linear-gradient(-45deg, transparent 75%, #f4f4f4 75%)',
   },

--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -141,9 +141,9 @@ const AirbnbSlider = withStyles({
     border: '1px solid currentColor',
     marginTop: -12,
     marginLeft: -13,
-    boxShadow: '#ebebeb 0px 2px 2px',
+    boxShadow: '#ebebeb 0 2px 2px',
     '&:focus, &:hover, &$active': {
-      boxShadow: '#ccc 0px 2px 3px 1px',
+      boxShadow: '#ccc 0 2px 3px 1px',
     },
     '& .bar': {
       // display: inline-block !important;

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -142,9 +142,9 @@ const AirbnbSlider = withStyles({
     border: '1px solid currentColor',
     marginTop: -12,
     marginLeft: -13,
-    boxShadow: '#ebebeb 0px 2px 2px',
+    boxShadow: '#ebebeb 0 2px 2px',
     '&:focus, &:hover, &$active': {
-      boxShadow: '#ccc 0px 2px 3px 1px',
+      boxShadow: '#ccc 0 2px 3px 1px',
     },
     '& .bar': {
       // display: inline-block !important;

--- a/docs/src/pages/components/tables/ReactVirtualizedTable.js
+++ b/docs/src/pages/components/tables/ReactVirtualizedTable.js
@@ -17,7 +17,7 @@ const styles = (theme) => ({
     // https://github.com/bvaughn/react-virtualized/issues/454
     '& .ReactVirtualized__Table__headerRow': {
       flip: false,
-      paddingRight: theme.direction === 'rtl' ? '0px !important' : undefined,
+      paddingRight: theme.direction === 'rtl' ? '0 !important' : undefined,
     },
   },
   tableRow: {

--- a/docs/src/pages/components/tables/ReactVirtualizedTable.tsx
+++ b/docs/src/pages/components/tables/ReactVirtualizedTable.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
       // https://github.com/bvaughn/react-virtualized/issues/454
       '& .ReactVirtualized__Table__headerRow': {
         flip: false,
-        paddingRight: theme.direction === 'rtl' ? '0px !important' : undefined,
+        paddingRight: theme.direction === 'rtl' ? '0 !important' : undefined,
       },
     },
     tableRow: {

--- a/docs/src/pages/components/tabs/tabs.md
+++ b/docs/src/pages/components/tabs/tabs.md
@@ -71,7 +71,7 @@ Here is an example of customizing the component. You can learn more about this i
 
 {{"demo": "pages/components/tabs/CustomizedTabs.js", "bg": true}}
 
-👑 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://deprecate.mui-treasury.com/components/tabs).
+👑 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/styles/tabs/).
 
 ## Vertical tabs
 

--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -220,4 +220,4 @@ function App() {
     </React.StrictMode>,
   );
 }
-````
+```

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -169,7 +169,7 @@ export const styles = (theme) => ({
   listbox: {
     listStyle: 'none',
     margin: 0,
-    padding: '8px 0px',
+    padding: '8px 0',
     maxHeight: '40vh',
     overflow: 'auto',
   },

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -58,10 +58,10 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButton(props, ref) {
     let newValue;
 
     if (value && index >= 0) {
-      newValue = [...value];
+      newValue = value.slice();
       newValue.splice(index, 1);
     } else {
-      newValue = value ? [...value, buttonValue] : [buttonValue];
+      newValue = value ? value.concat(buttonValue) : [buttonValue];
     }
 
     onChange(event, newValue);

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import TreeViewContext from './TreeViewContext';
 import { withStyles } from '@material-ui/core/styles';
 import { useControlled } from '@material-ui/core/utils';
+import TreeViewContext from './TreeViewContext';
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -196,7 +196,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
         return oldTabbable;
       });
     } else {
-      newExpanded = [value, ...expanded];
+      newExpanded = [value].concat(expanded);
     }
 
     if (onNodeToggle) {
@@ -217,7 +217,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
       const topLevelNodes = nodeMap.current[-1].children;
       diff = topLevelNodes.filter((node) => !isExpanded(node));
     }
-    const newExpanded = [...expanded, ...diff];
+    const newExpanded = expanded.concat(diff);
 
     if (diff.length > 0) {
       setExpandedState(newExpanded);
@@ -295,7 +295,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
     if (selected.indexOf(value) !== -1) {
       newSelected = selected.filter((id) => id !== value);
     } else {
-      newSelected = [value, ...selected];
+      newSelected = [value].concat(selected);
     }
 
     if (onNodeSelect) {
@@ -411,9 +411,9 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
     if (map) {
       nodes.push(id);
       if (map.children) {
-        nodes.push(...map.children);
+        nodes.concat(map.children);
         map.children.forEach((node) => {
-          nodes.push(...getNodesToRemove(node));
+          nodes.concat(getNodesToRemove(node));
         });
       }
     }

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -500,7 +500,7 @@ export default function useAutocomplete(props) {
     let newValue = option;
 
     if (multiple) {
-      newValue = Array.isArray(value) ? [...value] : [];
+      newValue = Array.isArray(value) ? value.slice() : [];
 
       if (process.env.NODE_ENV !== 'production') {
         const matches = newValue.filter((val) => getOptionSelected(option, val));
@@ -716,7 +716,7 @@ export default function useAutocomplete(props) {
       case 'Backspace':
         if (multiple && inputValue === '' && value.length > 0) {
           const index = focusedTag === -1 ? value.length - 1 : focusedTag;
-          const newValue = [...value];
+          const newValue = value.slice();
           newValue.splice(index, 1);
           handleValue(event, newValue, 'remove-option', {
             option: value[index],
@@ -805,7 +805,7 @@ export default function useAutocomplete(props) {
   };
 
   const handleTagDelete = (index) => (event) => {
-    const newValue = [...value];
+    const newValue = value.slice();
     newValue.splice(index, 1);
     handleValue(event, newValue, 'remove-option', {
       option: value[index],

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -57,7 +57,7 @@ describe('withStyles', () => {
 
       const ref = React.createRef();
       mount(<StyledTarget ref={ref} />);
-      expect(ref.current instanceof TargetComponent).to.equal(true);
+      expect(ref.current).to.be.instanceof(TargetComponent);
     });
 
     it('forwards refs to React.forwardRef types', () => {

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -1,4 +1,4 @@
-import { expect, assert } from 'chai';
+import { expect } from 'chai';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { stub } from 'sinon';

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -57,7 +57,7 @@ describe('withStyles', () => {
 
       const ref = React.createRef();
       mount(<StyledTarget ref={ref} />);
-      assert.instanceOf(ref.current, TargetComponent);
+      expect(ref.current instanceof TargetComponent).to.equal(true);
     });
 
     it('forwards refs to React.forwardRef types', () => {
@@ -69,33 +69,6 @@ describe('withStyles', () => {
       mount(<StyledTarget ref={ref} />);
       expect(ref.current.nodeName).to.equal('DIV');
     });
-
-    // describe('innerRef', () => {
-    //   beforeEach(() => {
-    //     consoleErrorMock.spy();
-    //     PropTypes.resetWarningCache();
-    //   });
-
-    //   afterEach(() => {
-    //     consoleErrorMock.reset();
-    //   });
-
-    //   it('is deprecated', () => {
-    //     const ThemedDiv = withStyles({})('div');
-
-    //     mount(
-    //       <React.Fragment>
-    //         <ThemedDiv innerRef={React.createRef()} />
-    //       </React.Fragment>,
-    //     );
-
-    //     assert.strictEqual(consoleErrorMock.callCount(), 1);
-    //     assert.include(
-    //       consoleErrorMock.messages()[0],
-    //       'Warning: Failed prop type: Material-UI: The `innerRef` prop is deprecated',
-    //     );
-    //   });
-    // });
   });
 
   it('should forward the props', () => {

--- a/packages/material-ui-system/src/spacing.test.js
+++ b/packages/material-ui-system/src/spacing.test.js
@@ -142,20 +142,6 @@ describe('spacing', () => {
         padding: 16,
       },
     });
-
-    // const output3 = spacing({
-    //   theme: {},
-    //   p: 1,
-    //   sm: {
-    //     p: 2,
-    //   },
-    // });
-    // assert.deepEqual(output3, {
-    //   padding: 8,
-    //   '@media (min-width:600px)': {
-    //     padding: 16,
-    //   },
-    // });
   });
 
   it('should support full version', () => {

--- a/packages/material-ui-system/src/style.test.js
+++ b/packages/material-ui-system/src/style.test.js
@@ -47,20 +47,6 @@ describe('style', () => {
         backgroundColor: 'red',
       },
     });
-
-    // const output3 = bgcolor({
-    //   theme: {},
-    //   bgcolor: 'blue',
-    //   sm: {
-    //     bgcolor: 'red',
-    //   },
-    // });
-    // assert.deepEqual(output3, {
-    //   backgroundColor: 'blue',
-    //   '@media (min-width:600px)': {
-    //     backgroundColor: 'red',
-    //   },
-    // });
   });
 
   const boxShadow = style({

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -57,13 +57,13 @@ export const styles = (theme) => {
     dashedColorPrimary: {
       backgroundImage: `radial-gradient(${backgroundPrimary} 0%, ${backgroundPrimary} 16%, transparent 42%)`,
       backgroundSize: '10px 10px',
-      backgroundPosition: '0px -23px',
+      backgroundPosition: '0 -23px',
     },
     /* Styles applied to the additional bar element if `variant="buffer"` and `color="secondary"`. */
     dashedColorSecondary: {
       backgroundImage: `radial-gradient(${backgroundSecondary} 0%, ${backgroundSecondary} 16%, transparent 42%)`,
       backgroundSize: '10px 10px',
-      backgroundPosition: '0px -23px',
+      backgroundPosition: '0 -23px',
     },
     /* Styles applied to the layered bar1 and bar2 elements. */
     bar: {
@@ -145,11 +145,11 @@ export const styles = (theme) => {
     '@keyframes buffer': {
       '0%': {
         opacity: 1,
-        backgroundPosition: '0px -23px',
+        backgroundPosition: '0 -23px',
       },
       '50%': {
         opacity: 0,
-        backgroundPosition: '0px -23px',
+        backgroundPosition: '0 -23px',
       },
       '100%': {
         opacity: 1,

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -465,12 +465,6 @@ describe('<Popover />', () => {
         'Warning: Failed prop type: Invalid prop `PaperProps.component` supplied to `MockedPopover`. Expected an element type that can hold a ref.',
       );
     });
-
-    // it('should warn if anchorEl is not visible', () => {
-    //   mount(<Popover open anchorEl={document.createElement('div')} />);
-    //   assert.strictEqual(consoleErrorMock.callCount(), 1);
-    //   assert.include(consoleErrorMock.messages()[0], 'The node element should be visible');
-    // });
   });
 
   describe('prop anchorReference="anchorPosition"', () => {

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -345,7 +345,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
           className,
         )}
         ref={setDisplayNode}
-        data-mui-test="SelectDisplay"
         tabIndex={tabIndex}
         role="button"
         aria-disabled={disabled ? 'true' : undefined}

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -149,7 +149,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     let newValue;
 
     if (multiple) {
-      newValue = Array.isArray(value) ? [...value] : [];
+      newValue = Array.isArray(value) ? value.slice() : [];
       const itemIndex = value.indexOf(child.props.value);
       if (itemIndex === -1) {
         newValue.push(child.props.value);

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -90,7 +90,7 @@ function setValueIndex({ values, source, newValue, index }) {
     return source;
   }
 
-  const output = [...values];
+  const output = values.slice();
   output[index] = newValue;
   return output;
 }
@@ -386,7 +386,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
 
   const range = Array.isArray(valueDerived);
   const instanceRef = React.useRef();
-  let values = range ? [...valueDerived].sort(asc) : [valueDerived];
+  let values = range ? valueDerived.slice().sort(asc) : [valueDerived];
   values = values.map((value) => clamp(value, min, max));
   const marks =
     marksProp === true && step !== null

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -48,7 +48,7 @@ export const styles = (theme) => ({
     },
     '&$paddingCheckbox': {
       width: 24, // prevent the checkbox column from growing
-      padding: '0px 12px 0 16px',
+      padding: '0 12px 0 16px',
       '&:last-child': {
         paddingLeft: 12,
         paddingRight: 16,

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -43,7 +43,7 @@ describe('<Tabs />', () => {
   // The test fails on Safari with just:
   //
   // container.scrollLeft = 200;
-  // assert.strictEqual(container.scrollLeft, 200); 💥
+  // expect(container.scrollLeft).to.equal(200); 💥
   if (isSafari) {
     return;
   }

--- a/packages/material-ui/src/internal/animate.test.js
+++ b/packages/material-ui/src/internal/animate.test.js
@@ -11,7 +11,7 @@ describe('animate', () => {
       // The test fails on Safari with just:
       //
       // container.scrollLeft = 200;
-      // assert.strictEqual(container.scrollLeft, 200); 💥
+      // expect(container.scrollLeft).to.equal(200); 💥
 
       // in JSDOM the test prevents mocha from exiting
       this.skip();

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -110,7 +110,7 @@ function describeRef(element, getOptions) {
       const { inheritComponent, mount, refInstanceof } = getOptions();
 
       testRef(element, mount, (instance, wrapper) => {
-        expect(instance instanceof refInstanceof).to.equal(true);
+        expect(instance).to.be.instanceof(refInstanceof);
 
         if (inheritComponent && instance.nodeType === 1) {
           const rootHost = findOutermostIntrinsic(wrapper);

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import * as React from 'react';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 import ReactTestRenderer from 'react-test-renderer';
@@ -47,8 +47,9 @@ function testClassName(element, getOptions) {
 
     const wrapper = mount(React.cloneElement(element, { className }));
 
-    assert.strictEqual(
-      findOutermostIntrinsic(wrapper).hasClass(className),
+    expect(
+      findOutermostIntrinsic(wrapper).hasClass(className)
+    ).to.equal(
       true,
       'does have a custom `className`',
     );
@@ -69,7 +70,7 @@ function testComponentProp(element, getOptions) {
 
       const wrapper = mount(React.cloneElement(element, { component }));
 
-      assert.strictEqual(findRootComponent(wrapper, { classes, component }).exists(), true);
+      expect(findRootComponent(wrapper, { classes, component }).exists()).to.equal(true);
     });
   });
 }
@@ -91,7 +92,7 @@ function testPropsSpread(element, getOptions) {
     const wrapper = mount(React.cloneElement(element, { [testProp]: value }));
     const root = findRootComponent(wrapper, { classes, component: inheritComponent });
 
-    assert.strictEqual(root.props()[testProp], value);
+    expect(root.props()[testProp]).to.equal(value);
   });
 }
 
@@ -111,11 +112,11 @@ function describeRef(element, getOptions) {
       const { inheritComponent, mount, refInstanceof } = getOptions();
 
       testRef(element, mount, (instance, wrapper) => {
-        assert.instanceOf(instance, refInstanceof);
+        expect(instance instanceof refInstanceof).to.equal(true);
 
         if (inheritComponent && instance.nodeType === 1) {
           const rootHost = findOutermostIntrinsic(wrapper);
-          assert.strictEqual(instance, rootHost.instance());
+          expect(instance).to.equal(rootHost.instance());
         }
       });
     });
@@ -142,8 +143,8 @@ function testRootClass(element, getOptions) {
     // jump to the host component because some components pass the `root` class
     // to the `classes` prop of the root component.
     // https://github.com/mui-org/material-ui/blob/f9896bcd129a1209153106296b3d2487547ba205/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L101
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.root), true);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(className), true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(classes.root)).to.equal(true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(className)).to.equal(true);
   });
 }
 

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -47,9 +47,7 @@ function testClassName(element, getOptions) {
 
     const wrapper = mount(React.cloneElement(element, { className }));
 
-    expect(
-      findOutermostIntrinsic(wrapper).hasClass(className)
-    ).to.equal(
+    expect(findOutermostIntrinsic(wrapper).hasClass(className)).to.equal(
       true,
       'does have a custom `className`',
     );

--- a/packages/material-ui/src/test-utils/testRef.js
+++ b/packages/material-ui/src/test-utils/testRef.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 
 function assertDOMNode(node) {
   // duck typing a DOM node
-  assert.ok(node.nodeName);
+  expect(typeof node.nodeName).to.equal('string');
 }
 
 /**

--- a/packages/material-ui/src/test-utils/until.test.js
+++ b/packages/material-ui/src/test-utils/until.test.js
@@ -57,7 +57,7 @@ describe('until', () => {
     ).to.equal(true);
   });
 
-  it('throws when assert.strictEqual called on an empty wrapper', () => {
+  it('throws when until called on an empty wrapper', () => {
     expect(() => {
       until.call(shallow(<Div />).find('Foo'), 'div');
     }).to.throw(Error);

--- a/packages/material-ui/src/withWidth/withWidth.js
+++ b/packages/material-ui/src/withWidth/withWidth.js
@@ -51,7 +51,7 @@ const withWidth = (options = {}) => (Component) => {
      *            |-------|-------|-------|-------|------>
      * width      |  xs   |  sm   |  md   |  lg   |  xl
      */
-    const keys = [...theme.breakpoints.keys].reverse();
+    const keys = theme.breakpoints.keys.slice().reverse();
     const widthComputed = keys.reduce((output, key) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const matches = useMediaQuery(theme.breakpoints.up(key));

--- a/test/utils/consoleErrorMock.test.js
+++ b/test/utils/consoleErrorMock.test.js
@@ -12,8 +12,7 @@ describe('consoleErrorMock()', () => {
 
   describe('args', () => {
     it('was removed but throws a descriptive error', () => {
-      expect(
-        () => consoleErrorMock.args()).to.throw(
+      expect(() => consoleErrorMock.args()).to.throw(
         'args() was removed in favor of messages(). Use messages() to match against the actual error message that will be displayed in the console.',
       );
     });

--- a/test/utils/consoleErrorMock.test.js
+++ b/test/utils/consoleErrorMock.test.js
@@ -1,19 +1,19 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import consoleErrorMock from './consoleErrorMock';
 
 describe('consoleErrorMock()', () => {
   describe('callCount()', () => {
     it('should throw error when calling callCount() before spy()', () => {
-      assert.throws(() => {
+      expect(() => {
         consoleErrorMock.callCount();
-      }, 'Requested call count before spy() was called');
+      }).to.throw('Requested call count before spy() was called');
     });
   });
 
   describe('args', () => {
     it('was removed but throws a descriptive error', () => {
-      assert.throws(
-        () => consoleErrorMock.args(),
+      expect(
+        () => consoleErrorMock.args()).to.throw(
         'args() was removed in favor of messages(). Use messages() to match against the actual error message that will be displayed in the console.',
       );
     });
@@ -22,9 +22,9 @@ describe('consoleErrorMock()', () => {
   describe('messages()', () => {
     describe('when not spying', () => {
       it('should throw error', () => {
-        assert.throws(() => {
+        expect(() => {
           consoleErrorMock.messages();
-        }, 'Requested call count before spy() was called');
+        }).to.throw('Requested call count before spy() was called');
       });
     });
 
@@ -40,7 +40,7 @@ describe('consoleErrorMock()', () => {
       it('returns the formatted output', () => {
         console.error('expected %s but got %s', '1', 2);
 
-        assert.strictEqual(consoleErrorMock.messages()[0], 'expected 1 but got 2');
+        expect(consoleErrorMock.messages()[0]).to.equal('expected 1 but got 2');
       });
     });
   });
@@ -48,15 +48,15 @@ describe('consoleErrorMock()', () => {
   describe('spy()', () => {
     it('should place a spy in console.error', () => {
       consoleErrorMock.spy();
-      assert.strictEqual(console.error.hasOwnProperty('isSinonProxy'), true);
+      expect(console.error.hasOwnProperty('isSinonProxy')).to.equal(true);
       consoleErrorMock.reset();
-      assert.strictEqual(console.error.hasOwnProperty('isSinonProxy'), false);
+      expect(console.error.hasOwnProperty('isSinonProxy')).to.equal(false);
     });
 
     it('should keep the call count', () => {
       consoleErrorMock.spy();
       console.error();
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      expect(consoleErrorMock.callCount()).to.equal(1);
       consoleErrorMock.reset();
     });
   });


### PR DESCRIPTION
- [test] Remove legacy data-mui-test ec9858d: the fewer, the better.
- [docs] Update mui-treasury link 68279a4.
- [docs] Fix wrong link 38db8e2.
- [docs] Add lost flags from #20601 d5958d8: spotted working at the sponsor page.
- [docs] Remove leftover from #20724 ad9e3eb: spotted testing the demos in IE 11.
- [test] Remove all assert.x API a528ab4: we were missing a few. I believe we are 100% done now.
- [core] Avoid over-transpiling 4a42017: Raised in #20896 (comment). I'm curious about the bundle size reduction, it seems to be [interesting](https://babeljs.io/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYewdgzgLgBGCmB3AagQwDYFd4RgXhgG0A6UgNw2wgF1iIQAnKACgEoBuIA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Ces2015%2Creact%2Cstage-2%2Cenv&prettier=false&targets=&version=7.9.6&externalPlugins=).
- [core] Use shorthand unit when possible f5de90f53b1b2d299d8937e1d0035fb4f3766f50.
- [docs] Better visually group tocs items b1499053889149d138549d6abcb00dfade39089c.
- [docs] Fix Crowdin parsing 02b430a.