### PR TITLE
[core] Add missing args to createMuiStrictModeTheme

### DIFF
--- a/packages/material-ui/src/styles/createMuiStrictModeTheme.js
+++ b/packages/material-ui/src/styles/createMuiStrictModeTheme.js
@@ -1,7 +1,7 @@
 import { deepmerge } from '@material-ui/utils';
 import createMuiTheme from './createMuiTheme';
 
-export default function createMuiStrictModeTheme(options) {
+export default function createMuiStrictModeTheme(options, ...args) {
   return createMuiTheme(
     deepmerge(
       {
@@ -9,5 +9,6 @@ export default function createMuiStrictModeTheme(options) {
       },
       options,
     ),
+    ...args,
   );
 }


### PR DESCRIPTION
- Added ...args that are present in createMuiTheme, but were missing in createMuiStrictModeTheme.  As they share the same typescript signature, (as seen in packages/material-ui/src/styles/index.d.ts) and as createMuiStrictModeTheme is supposed to extend createMuiTheme, I figured the ...args should be added in.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
