### PR TITLE
[ClickAwayListener] Refactor click-away detection

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -73,19 +73,7 @@ function ClickAwayListener(props) {
       return;
     }
 
-    let insideDOM;
-
-    // If not enough, can use https://github.com/DieterHolvoet/event-propagation-path/blob/master/propagationPath.js
-    if (event.composedPath) {
-      insideDOM = event.composedPath().indexOf(nodeRef.current) > -1;
-    } else {
-      // TODO v6 remove dead logic https://caniuse.com/#search=composedPath.
-      const doc = ownerDocument(nodeRef.current);
-      insideDOM =
-        !doc.documentElement.contains(event.target) || nodeRef.current.contains(event.target);
-    }
-
-    if (!insideDOM && (disableReactTree || !insideReactTree)) {
+    if (!nodeRef.current.contains(event.target) && (disableReactTree || !insideReactTree)) {
       onClickAway(event);
     }
   });

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -248,11 +248,9 @@ describe('<ClickAwayListener />', () => {
         const [buttonShown, hideButton] = React.useReducer(() => false, true);
 
         return (
-          <React.Fragment>
-            <ClickAwayListener onClickAway={handleClickAway}>
-              <div>{buttonShown && <button {...{ [eventName]: hideButton }} type="button" />}</div>
-            </ClickAwayListener>
-          </React.Fragment>
+          <ClickAwayListener onClickAway={handleClickAway}>
+            <div>{buttonShown && <button {...{ [eventName]: hideButton }} type="button" />}</div>
+          </ClickAwayListener>
         );
       }
       render(<Test />);

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import Portal from '../Portal';
 import ClickAwayListener from './ClickAwayListener';
 
@@ -217,6 +217,47 @@ describe('<ClickAwayListener />', () => {
       </ClickAwayListener>,
     );
     fireEvent.click(document.body);
+    expect(handleClickAway.callCount).to.equal(0);
+  });
+
+  it('triggers onClickAway if an outside target is removed', () => {
+    const handleClickAway = spy();
+    function Test() {
+      const [buttonShown, hideButton] = React.useReducer(() => false, true);
+
+      return (
+        <React.Fragment>
+          {buttonShown && <button onClick={hideButton} type="button" />}
+          <ClickAwayListener onClickAway={handleClickAway}>
+            <div />
+          </ClickAwayListener>
+        </React.Fragment>
+      );
+    }
+    render(<Test />);
+
+    screen.getByRole('button').click();
+
+    expect(handleClickAway.callCount).to.equal(1);
+  });
+
+  it('does not trigger onClickAway if an inside target is removed', () => {
+    const handleClickAway = spy();
+    function Test() {
+      const [buttonShown, hideButton] = React.useReducer(() => false, true);
+
+      return (
+        <React.Fragment>
+          <ClickAwayListener onClickAway={handleClickAway}>
+            <div>{buttonShown && <button onClick={hideButton} type="button" />}</div>
+          </ClickAwayListener>
+        </React.Fragment>
+      );
+    }
+    render(<Test />);
+
+    screen.getByRole('button').click();
+
     expect(handleClickAway.callCount).to.equal(0);
   });
 });

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -220,44 +220,46 @@ describe('<ClickAwayListener />', () => {
     expect(handleClickAway.callCount).to.equal(0);
   });
 
-  it('triggers onClickAway if an outside target is removed', () => {
-    const handleClickAway = spy();
-    function Test() {
-      const [buttonShown, hideButton] = React.useReducer(() => false, true);
+  ['onClick', 'onClickCapture'].forEach((eventName) => {
+    it(`${eventName} triggers onClickAway if an outside target is removed`, () => {
+      const handleClickAway = spy();
+      function Test() {
+        const [buttonShown, hideButton] = React.useReducer(() => false, true);
 
-      return (
-        <React.Fragment>
-          {buttonShown && <button onClick={hideButton} type="button" />}
-          <ClickAwayListener onClickAway={handleClickAway}>
-            <div />
-          </ClickAwayListener>
-        </React.Fragment>
-      );
-    }
-    render(<Test />);
+        return (
+          <React.Fragment>
+            {buttonShown && <button {...{ [eventName]: hideButton }} type="button" />}
+            <ClickAwayListener onClickAway={handleClickAway}>
+              <div />
+            </ClickAwayListener>
+          </React.Fragment>
+        );
+      }
+      render(<Test />);
 
-    screen.getByRole('button').click();
+      screen.getByRole('button').click();
 
-    expect(handleClickAway.callCount).to.equal(1);
-  });
+      expect(handleClickAway.callCount).to.equal(1);
+    });
 
-  it('does not trigger onClickAway if an inside target is removed', () => {
-    const handleClickAway = spy();
-    function Test() {
-      const [buttonShown, hideButton] = React.useReducer(() => false, true);
+    it(`${eventName} does not trigger onClickAway if an inside target is removed`, () => {
+      const handleClickAway = spy();
+      function Test() {
+        const [buttonShown, hideButton] = React.useReducer(() => false, true);
 
-      return (
-        <React.Fragment>
-          <ClickAwayListener onClickAway={handleClickAway}>
-            <div>{buttonShown && <button onClick={hideButton} type="button" />}</div>
-          </ClickAwayListener>
-        </React.Fragment>
-      );
-    }
-    render(<Test />);
+        return (
+          <React.Fragment>
+            <ClickAwayListener onClickAway={handleClickAway}>
+              <div>{buttonShown && <button {...{ [eventName]: hideButton }} type="button" />}</div>
+            </ClickAwayListener>
+          </React.Fragment>
+        );
+      }
+      render(<Test />);
 
-    screen.getByRole('button').click();
+      screen.getByRole('button').click();
 
-    expect(handleClickAway.callCount).to.equal(0);
+      expect(handleClickAway.callCount).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
Initial plan was adding a test for #20409

I originally thought we should rather check `node.isConnected` instead of looping through the composed path and realized that `documentElement.contains` isn't a meaningful check since it can only be false if:

1. event.target is not in the same frame as nodeRef.current
2. event.target is not connected?

Point 1 is impossible since the event handler is attached to the ownerDocument of nodeRef.current. 

Point 2 is only an assumption from #20409. I need to check if the new test was failing prior to #20409 and obviously verify the new build on the sandbox in #20197

Edit:
- Still passes #20197: https://codesandbox.io/s/icy-waterfall-oxede?file=/src/Demo.js