### PR TITLE
[styles] Increase counter only for non global styles

### DIFF
--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.js
@@ -31,7 +31,7 @@ export default function createGenerateClassName(options = {}) {
   const seedPrefix = seed === '' ? '' : `${seed}-`;
   let ruleCounter = 0;
 
-  return (rule, styleSheet) => {
+  const getNextCounterId = () => {
     ruleCounter += 1;
     if (process.env.NODE_ENV !== 'production') {
       if (ruleCounter >= 1e10) {
@@ -43,7 +43,10 @@ export default function createGenerateClassName(options = {}) {
         );
       }
     }
+    return ruleCounter;
+  };
 
+  return (rule, styleSheet) => {
     const name = styleSheet.options.name;
 
     // Is a global static MUI style?
@@ -59,14 +62,14 @@ export default function createGenerateClassName(options = {}) {
         return prefix;
       }
 
-      return `${prefix}-${ruleCounter}`;
+      return `${prefix}-${getNextCounterId()}`;
     }
 
     if (process.env.NODE_ENV === 'production') {
-      return `${seedPrefix}${productionPrefix}${ruleCounter}`;
+      return `${seedPrefix}${productionPrefix}${getNextCounterId()}`;
     }
 
-    const suffix = `${rule.key}-${ruleCounter}`;
+    const suffix = `${rule.key}-${getNextCounterId()}`;
 
     // Help with debuggability.
     if (styleSheet.options.classNamePrefix) {

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
@@ -89,6 +89,19 @@ describe('createGenerateClassName', () => {
     ).to.equal('MuiButton-root-1');
     expect(
       generateClassName(
+        { key: 'root' },
+        {
+          options: {
+            name: 'MuiButton',
+            theme: {
+              [nested]: true,
+            },
+          },
+        },
+      ),
+    ).to.equal('MuiButton-root-2');
+    expect(
+      generateClassName(
         { key: 'disabled' },
         {
           options: {

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
@@ -86,7 +86,7 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-    ).to.equal('MuiButton-root-2');
+    ).to.equal('MuiButton-root-1');
     expect(
       generateClassName(
         { key: 'disabled' },


### PR DESCRIPTION
I have an idea to reduce the `ruleCounter` amount but maybe I didn't fully understand the idea behind increasing the `ruleCounter`.

Right now all styles also those which are not using the `ruleCounter` are increasing the counter.  

This PR increases the counter only once it is used.