### PR TITLE
[docs] Improve custom progress bar demo

### DIFF
--- a/docs/src/pages/components/progress/CustomizedProgressBars.js
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.js
@@ -52,11 +52,11 @@ function FacebookProgress(props) {
     <div className={classes.root}>
       <CircularProgress
         variant="determinate"
-        value={100}
         className={classes.top}
         size={24}
         thickness={4}
         {...props}
+        value={100}
       />
       <CircularProgress
         variant="indeterminate"

--- a/docs/src/pages/components/progress/CustomizedProgressBars.tsx
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.tsx
@@ -51,7 +51,7 @@ function FacebookProgress(props: CircularProgressProps) {
   return (
     <div className={classes.root}>
       <CircularProgress
-        variant="determinate"        
+        variant="determinate"
         className={classes.top}
         size={24}
         thickness={4}

--- a/docs/src/pages/components/progress/CustomizedProgressBars.tsx
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.tsx
@@ -51,12 +51,12 @@ function FacebookProgress(props: CircularProgressProps) {
   return (
     <div className={classes.root}>
       <CircularProgress
-        variant="determinate"
-        value={100}
+        variant="determinate"        
         className={classes.top}
         size={24}
         thickness={4}
         {...props}
+        value={100}
       />
       <CircularProgress
         variant="indeterminate"


### PR DESCRIPTION
Since this component has to display background behind a "real" progress, the `100` value has to be overridden, otherwise it won't be displayed since their values are the same.

```javascript
<Progress variant="static" color="secondary" value={progress} />
```
before:
![image](https://user-images.githubusercontent.com/5864772/81713322-633db500-947e-11ea-9786-75ce3bdd3898.png)

after:
![image](https://user-images.githubusercontent.com/5864772/81713276-528d3f00-947e-11ea-91f8-10036c825843.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

