### PR TITLE
[core] Explicitly declare children

### DIFF
--- a/packages/material-ui-lab/src/AlertTitle/AlertTitle.d.ts
+++ b/packages/material-ui-lab/src/AlertTitle/AlertTitle.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
 
 export interface AlertTitleProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, AlertTitleClassKey> {}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, AlertTitleClassKey> {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+}
 
 export type AlertTitleClassKey = 'root';
 

--- a/packages/material-ui-lab/src/TabContext/TabContext.d.ts
+++ b/packages/material-ui-lab/src/TabContext/TabContext.d.ts
@@ -6,6 +6,9 @@ export interface TabContextValue {
 }
 
 export interface TabContextProps {
+  /**
+   * The content of the component.
+   */
   children?: React.ReactNode;
   /**
    * The value of the currently selected `Tab`.

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.d.ts
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.d.ts
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
-import { BoxProps } from '@material-ui/core/Box';
 
 export type TabPanelClassKey = 'root';
 
-export interface TabPanelProps extends StandardProps<BoxProps, TabPanelClassKey> {
+export interface TabPanelProps
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TabPanelClassKey> {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
   /**
    * The `value` of the corresponding `Tab`. Must use the index of the `Tab` when
    * no `value` was passed to `Tab`.

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
@@ -5,6 +5,10 @@ import { TransitionProps } from '@material-ui/core/transitions';
 export interface TreeItemProps
   extends StandardProps<React.HTMLAttributes<HTMLLIElement>, TreeItemClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * The icon used to collapse the node.
    */
   collapseIcon?: React.ReactNode;

--- a/packages/material-ui-lab/src/TreeView/TreeView.d.ts
+++ b/packages/material-ui-lab/src/TreeView/TreeView.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '@material-ui/core';
 export interface TreeViewPropsBase
   extends StandardProps<React.HTMLAttributes<HTMLUListElement>, TreeViewClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * The default icon used to collapse the node.
    */
   defaultCollapseIcon?: React.ReactNode;

--- a/packages/material-ui/src/Backdrop/Backdrop.d.ts
+++ b/packages/material-ui/src/Backdrop/Backdrop.d.ts
@@ -9,6 +9,10 @@ export interface BackdropProps
     BackdropClassKey
   > {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * If `true`, the backdrop is invisible.
    * It can be used when rendering a popover or a custom select component.
    */

--- a/packages/material-ui/src/CardActions/CardActions.d.ts
+++ b/packages/material-ui/src/CardActions/CardActions.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface CardActionsProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardActionsClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * If `true`, the actions do not have additional margin.
    */
   disableSpacing?: boolean;

--- a/packages/material-ui/src/DialogActions/DialogActions.d.ts
+++ b/packages/material-ui/src/DialogActions/DialogActions.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface DialogActionsProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogActionsClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * If `true`, the actions do not have additional margin.
    */
   disableSpacing?: boolean;

--- a/packages/material-ui/src/DialogContent/DialogContent.d.ts
+++ b/packages/material-ui/src/DialogContent/DialogContent.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface DialogContentProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogContentClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * Display the top and bottom dividers.
    */
   dividers?: boolean;

--- a/packages/material-ui/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface DialogTitleProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogTitleClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * If `true`, the children won't be wrapped by a typography component.
    * For instance, this can be useful to render an h4 instead of the default h2.
    */

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.d.ts
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface ExpansionPanelActionsProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ExpansionPanelActionsClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * If `true`, the actions do not have additional margin.
    */
   disableSpacing?: boolean;

--- a/packages/material-ui/src/FormGroup/FormGroup.d.ts
+++ b/packages/material-ui/src/FormGroup/FormGroup.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface FormGroupProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, FormGroupClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * Display group of elements in a compact row.
    */
   row?: boolean;

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '..';
 export interface PaperProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, PaperClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
    */

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.d.ts
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.d.ts
@@ -4,7 +4,12 @@ import { StandardProps } from '..';
 export type ScopedCssBaselineClassKey = 'root';
 
 export interface ScopedCssBaselineProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ScopedCssBaselineClassKey> {}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ScopedCssBaselineClassKey> {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+}
 
 /**
  *

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.d.ts
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.d.ts
@@ -4,6 +4,10 @@ import { StandardProps } from '@material-ui/core';
 export interface TabScrollButtonProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TabScrollButtonClassKey> {
   /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
    * Which direction should the button indicate?
    */
   direction: 'left' | 'right';

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -106,10 +106,6 @@ const prettierConfig = prettier.resolveConfig.sync(process.cwd(), {
   config: path.join(__dirname, '../prettier.config.js'),
 });
 
-function isExternalProp(prop: ttp.PropTypeNode, component: ttp.ComponentNode): boolean {
-  return Array.from(prop.filenames).some((filename) => filename !== component.propsFilename);
-}
-
 async function generateProptypes(
   tsFile: string,
   jsFile: string,

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -42,13 +42,6 @@ const useExternalPropsFromInputBase = [
 ];
 
 /**
- * TODO: RESOLVE_BEFORE_MERGE
- * Stop special casing `children`. They have to be implemented by each
- * component individually and need a sensible description. There's no such thing
- * as a default implementation for `children`.
- */
-
-/**
  * A map of components and their props that should be documented
  * but are not used directly in their implementation.
  *
@@ -128,8 +121,6 @@ async function generateProptypes(
     component.types.forEach((prop) => {
       if (prop.name === 'classes' && prop.jsDoc) {
         prop.jsDoc += '\nSee [CSS API](#css) below for more details.';
-      } else if (prop.name === 'children' && !prop.jsDoc) {
-        prop.jsDoc = 'The content of the component.';
       } else if (
         !prop.jsDoc ||
         (ignoreExternalDocumentation[component.name] &&


### PR DESCRIPTION
- so that collaborators think about what the children of their component do
- so that the documentation appears in IntelliSense as well