### PR TITLE
[core] Narrow type definition for useControlled hook

### DIFF
--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -18,4 +18,6 @@ export interface UseControlledProps<T = any> {
   state?: string;
 }
 
-export default function useControlled<T = any>(props: UseControlledProps<T>): [T, (newValue: T) => void];
+export default function useControlled<T = any>(
+  props: UseControlledProps<T>
+): [T, (newValue: T) => void];

--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -1,4 +1,4 @@
-export interface UseControlledProps<T = any> {
+export interface UseControlledProps<T = unknown> {
   /**
    * This prop contains the component value when it's controlled.
    */

--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -18,6 +18,6 @@ export interface UseControlledProps<T = unknown> {
   state?: string;
 }
 
-export default function useControlled<T = any>(
+export default function useControlled<T = unknown>(
   props: UseControlledProps<T>
 ): [T, (newValue: T) => void];

--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -1,16 +1,21 @@
-export interface UseControlledProps {
+export interface UseControlledProps<T = any> {
   /**
    * This prop contains the component value when it's controlled.
    */
-  controlled: any;
+  controlled: T | undefined;
   /**
-   * The default value.
+   * The default value when uncontrolled.
    */
-  default: any;
+  default: T | undefined;
   /**
    * The component name displayed in warnings.
    */
   name: string;
+
+  /**
+   * The name of the state variable displayed in warnings.
+   */
+  state?: string;
 }
 
-export default function useControlled(props: UseControlledProps): [any, () => void];
+export default function useControlled<T = any>(props: UseControlledProps<T>): [T, (newValue: T) => void];


### PR DESCRIPTION
- Add missing `newValue` parameter to set function returned by the useControlled hook.
- Made the UseControlledProps interface generic along with the hook itself.
  - This way, the returned value can be correctly typed.
  - A default type of `any` was given to make the type change non-breaking.
- Added missing `state` property to the UseControlledProps interface.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
