### PR TITLE
[test] Improve isolation of tests using mount()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,6 +115,20 @@ module.exports = {
       rules: {
         // does not work with wildcard imports. Mistakes will throw at runtime anyway
         'import/named': 'off',
+        //
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: '@material-ui/core/test-utils',
+                importNames: ['createMount'],
+                message:
+                  "Please use `import createMount from 'test/utils/createMount'` instead. `createMount` from /core has cleanup issues that require breaking changes.",
+              },
+            ],
+          },
+        ],
 
         'material-ui/disallow-active-element-as-key-event-target': 'error',
 

--- a/packages/material-ui-lab/src/Alert/Alert.test.js
+++ b/packages/material-ui-lab/src/Alert/Alert.test.js
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Alert from './Alert';
 import Paper from '@material-ui/core/Paper';
 
 describe('<Alert />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Alert />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Alert />, () => ({

--- a/packages/material-ui-lab/src/AlertTitle/AlertTitle.test.js
+++ b/packages/material-ui-lab/src/AlertTitle/AlertTitle.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import AlertTitle from './AlertTitle';
 
 describe('<AlertTitle />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<AlertTitle />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<AlertTitle />, () => ({

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import consoleErrorMock, { consoleWarnMock } from 'test/utils/consoleErrorMock';
 import { spy } from 'sinon';
@@ -10,7 +11,7 @@ import Autocomplete from './Autocomplete';
 import TextField from '@material-ui/core/TextField';
 
 describe('<Autocomplete />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   const defaultProps = {
@@ -20,7 +21,6 @@ describe('<Autocomplete />', () => {
 
   before(() => {
     classes = getClasses(<Autocomplete {...defaultProps} renderInput={() => null} />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Autocomplete {...defaultProps} renderInput={() => null} />, () => ({
@@ -29,7 +29,6 @@ describe('<Autocomplete />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'div',
-    after: () => mount.cleanUp(),
   }));
 
   describe('combobox', () => {

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import AvatarGroup from './AvatarGroup';
 import { Avatar } from '@material-ui/core';
 
 describe('<AvatarGroup />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<AvatarGroup />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<AvatarGroup />, () => ({

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Pagination from './Pagination';
@@ -9,11 +10,10 @@ import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 
 describe('<Pagination />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Pagination />);
   });
 
@@ -22,7 +22,7 @@ describe('<Pagination />', () => {
     inheritComponent: 'nav',
     mount,
     refInstanceof: window.HTMLElement,
-    after: () => mount.cleanUp(),
+
     skip: ['componentProp'],
   }));
 

--- a/packages/material-ui-lab/src/PaginationItem/PaginationItem.test.js
+++ b/packages/material-ui-lab/src/PaginationItem/PaginationItem.test.js
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import PaginationItem from './PaginationItem';
 
 describe('<PaginationItem />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<PaginationItem />);
   });
 
@@ -20,7 +20,6 @@ describe('<PaginationItem />', () => {
     inheritComponent: 'button',
     mount,
     refInstanceof: window.HTMLButtonElement,
-    after: () => mount.cleanUp(),
   }));
 
   it('should render', () => {

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub, spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Rating from './Rating';
 
 describe('<Rating />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
   const defaultProps = {
@@ -16,12 +17,7 @@ describe('<Rating />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Rating {...defaultProps} />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Rating {...defaultProps} />, () => ({

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Skeleton from './Skeleton';
 
 describe('<Skeleton />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Skeleton />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Skeleton />, () => ({

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
-  createMount,
   findOutermostIntrinsic,
   getClasses,
   wrapsIntrinsicElement,
 } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Icon from '@material-ui/core/Icon';
 import Fab from '@material-ui/core/Fab';
@@ -14,7 +14,8 @@ import SpeedDial from './SpeedDial';
 import SpeedDialAction from '../SpeedDialAction';
 
 describe('<SpeedDial />', () => {
-  let mount;
+  // StrictModeViolation: uses Zoom
+  const mount = createMount({ strict: false });
   let classes;
 
   const icon = <Icon>font_icon</Icon>;
@@ -26,17 +27,11 @@ describe('<SpeedDial />', () => {
   };
 
   before(() => {
-    // StrictModeViolation: uses Zoom
-    mount = createMount({ strict: false });
     classes = getClasses(
       <SpeedDial {...defaultProps}>
         <div />
       </SpeedDial>,
     );
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<SpeedDial {...defaultProps} />, () => ({
@@ -112,22 +107,21 @@ describe('<SpeedDial />', () => {
   });
 
   describe('prop: direction', () => {
-    const testDirection = (direction) => {
-      const className = `direction${direction}`;
-      const wrapper = mount(
-        <SpeedDial {...defaultProps} direction={direction.toLowerCase()}>
-          <SpeedDialAction icon={icon} tooltipTitle="action1" />
-          <SpeedDialAction icon={icon} tooltipTitle="action2" />
-        </SpeedDial>,
-      );
-      expect(findOutermostIntrinsic(wrapper).hasClass(classes[className])).to.equal(true);
-    };
-
-    it('should place actions in correct position', () => {
-      testDirection('Up');
-      testDirection('Down');
-      testDirection('Left');
-      testDirection('Right');
+    [
+      ['up', 'directionUp'],
+      ['down', 'directionDown'],
+      ['left', 'directionLeft'],
+      ['right', 'directionRight'],
+    ].forEach(([direction, className]) => {
+      it(`should place actions in the correct position when direction=${direction}`, () => {
+        const wrapper = mount(
+          <SpeedDial {...defaultProps} direction={direction.toLowerCase()}>
+            <SpeedDialAction icon={icon} tooltipTitle="action1" />
+            <SpeedDialAction icon={icon} tooltipTitle="action2" />
+          </SpeedDial>,
+        );
+        expect(findOutermostIntrinsic(wrapper).hasClass(classes[className])).to.equal(true);
+      });
     });
   });
 

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
 import Fab from '@material-ui/core/Fab';
@@ -8,7 +9,8 @@ import SpeedDialAction from './SpeedDialAction';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 
 describe('<SpeedDialAction />', () => {
-  let mount;
+  // StrictModeViolation: uses Tooltip
+  const mount = createMount({ strict: false });
   let classes;
   const icon = <Icon>add</Icon>;
   const defaultProps = {
@@ -17,13 +19,7 @@ describe('<SpeedDialAction />', () => {
   };
 
   before(() => {
-    // StrictModeViolation: uses Tooltip
-    mount = createMount({ strict: false });
     classes = getClasses(<SpeedDialAction {...defaultProps} />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<SpeedDialAction {...defaultProps} />, () => ({

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import { getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import Icon from '@material-ui/core/Icon';
 import SpeedDialIcon from './SpeedDialIcon';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 
 describe('<SpeedDialIcon />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const icon = <Icon>font_icon</Icon>;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<SpeedDialIcon />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<SpeedDialIcon />, () => ({

--- a/packages/material-ui-lab/src/TabList/TabList.test.js
+++ b/packages/material-ui-lab/src/TabList/TabList.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
@@ -9,13 +10,12 @@ import TabList from './TabList';
 import TabContext from '../TabContext';
 
 describe('<TabList />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<Tabs />);
-    mount = createMount({ strict: true });
   });
 
   function mountInContext(node) {
@@ -30,7 +30,6 @@ describe('<TabList />', () => {
     refInstanceof: window.HTMLDivElement,
     // TODO: no idea why reactTestRenderer fails
     skip: ['reactTestRenderer'],
-    after: () => mount.cleanUp(),
   }));
 
   // outside of TabContext pass every test in Tabs

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.test.js
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.test.js
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import TabPanel from './TabPanel';
 import TabContext from '../TabContext';
 
 describe('<TabPanel />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<TabPanel value={0} />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<TabPanel value="0" />, () => ({
@@ -22,7 +22,6 @@ describe('<TabPanel />', () => {
     mount: (element) => mount(<TabContext value="0">{element}</TabContext>),
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'reactTestRenderer'],
-    after: () => mount.cleanUp(),
   }));
 
   it('renders a [role="tabpanel"]', () => {

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -3,23 +3,22 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createClientRender } from 'test/utils/createClientRender';
 import createServerRender from 'test/utils/createServerRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ToggleButton from './ToggleButton';
 
 describe('<ToggleButton />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<ToggleButton value="classes">Hello World</ToggleButton>);
   });
 
   describeConformance(<ToggleButton value="X">Hello, World!</ToggleButton>, () => ({
-    after: () => mount.cleanUp(),
     classes,
     inheritComponent: ButtonBase,
     mount,

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import ToggleButtonGroup from './ToggleButtonGroup';
 import ToggleButton from '../ToggleButton';
 
 describe('<ToggleButtonGroup />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(
       <ToggleButtonGroup>
         <ToggleButton value="hello" />
@@ -22,7 +22,6 @@ describe('<ToggleButtonGroup />', () => {
   });
 
   describeConformance(<ToggleButtonGroup />, () => ({
-    after: () => mount.cleanUp(),
     classes,
     inheritComponent: 'div',
     mount,

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import {
   act,
@@ -15,12 +16,11 @@ import TreeView from '../TreeView';
 
 describe('<TreeItem />', () => {
   let classes;
-  let mount;
+  // StrictModeViolation: uses Collapse
+  const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
 
   before(() => {
-    // StrictModeViolation: uses Collapse
-    mount = createMount({ strict: false });
     classes = getClasses(<TreeItem nodeId="one" label="one" />);
   });
 
@@ -30,7 +30,6 @@ describe('<TreeItem />', () => {
     mount,
     refInstanceof: window.HTMLLIElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should call onClick when clicked', () => {

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -3,19 +3,19 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import TreeView from './TreeView';
 import TreeItem from '../TreeItem';
 
 describe('<TreeView />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   // StrictModeViolation: test uses TreeItem
   const render = createClientRender({ strict: false });
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TreeView />);
   });
 
@@ -25,7 +25,6 @@ describe('<TreeView />', () => {
     mount,
     refInstanceof: window.HTMLUListElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   describe('warnings', () => {

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
 import { create, SheetsRegistry } from 'jss';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import StylesProvider, { StylesContext } from './StylesProvider';
 import makeStyles from '../makeStyles';
 import createGenerateClassName from '../createGenerateClassName';
@@ -18,19 +18,11 @@ function getOptions(wrapper) {
 }
 
 describe('StylesProvider', () => {
-  let mount;
+  const mount = createMount();
   let generateClassName;
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
 
   beforeEach(() => {
     generateClassName = createGenerateClassName();
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   it('should provide the options', () => {

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender } from 'test/utils/createClientRender';
 import makeStyles from '../makeStyles';
@@ -8,16 +8,8 @@ import useTheme from '../useTheme';
 import ThemeProvider from './ThemeProvider';
 
 describe('ThemeProvider', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   it('should provide the theme', () => {
     const ref = React.createRef();

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { SheetsRegistry } from 'jss';
 import { act } from 'react-dom/test-utils';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createMuiTheme } from '@material-ui/core/styles';
 import createGenerateClassName from '../createGenerateClassName';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -13,7 +13,7 @@ import StylesProvider from '../StylesProvider';
 import ThemeProvider from '../ThemeProvider';
 
 describe('makeStyles', () => {
-  let mount;
+  const mount = createMount({ strict: null });
 
   /**
    * returns a function that given the props for the styles object will return
@@ -38,16 +38,8 @@ describe('makeStyles', () => {
 
   let generateClassName;
 
-  before(() => {
-    mount = createMount({ strict: undefined });
-  });
-
   beforeEach(() => {
     generateClassName = createGenerateClassName();
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   it('should accept a classes prop', () => {

--- a/packages/material-ui-styles/src/styled/styled.test.js
+++ b/packages/material-ui-styles/src/styled/styled.test.js
@@ -3,18 +3,17 @@ import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import styled from './styled';
 import { SheetsRegistry } from 'jss';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createGenerateClassName } from '@material-ui/styles';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import StylesProvider from '../StylesProvider';
 
 describe('styled', () => {
-  let mount;
+  // StrictModeViolation: uses makeStyles
+  const mount = createMount({ strict: false });
   let StyledButton;
 
   before(() => {
-    // StrictModeViolation: uses makeStyles
-    mount = createMount({ strict: false });
     StyledButton = styled('button')({
       background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
       borderRadius: 3,
@@ -24,10 +23,6 @@ describe('styled', () => {
       padding: '0 30px',
       boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
     });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   it('should work as expected', () => {
@@ -47,7 +42,7 @@ describe('styled', () => {
   describe('prop: clone', () => {
     let wrapper;
 
-    before(() => {
+    beforeEach(() => {
       wrapper = mount(
         <StyledButton clone data-test="enzyme">
           <div>Styled Components</div>

--- a/packages/material-ui-styles/src/useTheme/useTheme.test.js
+++ b/packages/material-ui-styles/src/useTheme/useTheme.test.js
@@ -1,19 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import useTheme from './useTheme';
 import ThemeProvider from '../ThemeProvider';
 
 describe('useTheme', () => {
-  let mount;
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  const mount = createMount();
 
   it('should use the theme', () => {
     const ref = React.createRef();

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { stub } from 'sinon';
 import { SheetsRegistry } from 'jss';
 import { Input } from '@material-ui/core';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { isMuiElement } from '@material-ui/core/utils';
 import { createMuiTheme } from '@material-ui/core/styles';
 // import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -14,20 +14,12 @@ import ThemeProvider from '../ThemeProvider';
 import withStyles from './withStyles';
 
 describe('withStyles', () => {
-  let mount;
+  // StrictModeViolation: uses makeStyles
+  const mount = createMount({ strict: false });
   let generateClassName;
-
-  before(() => {
-    // StrictModeViolation: uses makeStyles
-    mount = createMount({ strict: false });
-  });
 
   beforeEach(() => {
     generateClassName = createGenerateClassName();
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   it('hoist statics', () => {

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { Input } from '@material-ui/core';
 import { isMuiElement } from '@material-ui/core/utils';
 import PropTypes from 'prop-types';
@@ -9,15 +9,7 @@ import withTheme from './withTheme';
 import ThemeProvider from '../ThemeProvider';
 
 describe('withTheme', () => {
-  let mount;
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  const mount = createMount();
 
   it('should inject the theme', () => {
     const ref = React.createRef();

--- a/packages/material-ui-utils/src/elementAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementAcceptingRef.test.js
@@ -3,13 +3,10 @@ import { expect } from 'chai';
 import * as PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createMount } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import elementAcceptingRef from './elementAcceptingRef';
 
 describe('elementAcceptingRef', () => {
-  let mount;
-
   function checkPropType(element, required = false) {
     PropTypes.checkPropTypes(
       { children: required ? elementAcceptingRef.isRequired : elementAcceptingRef },
@@ -18,14 +15,6 @@ describe('elementAcceptingRef', () => {
       'DummyComponent',
     );
   }
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   beforeEach(() => {
     consoleErrorMock.spy();

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
@@ -3,13 +3,10 @@ import { expect } from 'chai';
 import * as PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createMount } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import elementTypeAcceptingRef from './elementTypeAcceptingRef';
 
 describe('elementTypeAcceptingRef', () => {
-  let mount;
-
   function checkPropType(elementType) {
     PropTypes.checkPropTypes(
       { component: elementTypeAcceptingRef },
@@ -18,14 +15,6 @@ describe('elementTypeAcceptingRef', () => {
       'DummyComponent',
     );
   }
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   beforeEach(() => {
     consoleErrorMock.spy();

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import AppBar from './AppBar';
 import Paper from '../Paper';
 
 describe('<AppBar />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<AppBar>Hello World</AppBar>);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<AppBar>Conformance?</AppBar>, () => ({

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -1,24 +1,20 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { spy } from 'sinon';
 import CancelIcon from '../internal/svg-icons/Cancel';
 import describeConformance from '../test-utils/describeConformance';
 import Avatar from './Avatar';
 
 describe('<Avatar />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Avatar />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Avatar />, () => ({

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Backdrop from './Backdrop';
 import Fade from '../Fade';
 
 describe('<Backdrop />', () => {
-  let mount;
+  // StrictModeViolation: uses Fade
+  const mount = createMount({ strict: false });
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses Fade
-    mount = createMount({ strict: false });
     classes = getClasses(<Backdrop open />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Backdrop open />, () => ({

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Badge from './Badge';
@@ -10,7 +11,7 @@ function findBadge(container) {
 }
 
 describe('<Badge />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   const defaultProps = {
@@ -23,12 +24,7 @@ describe('<Badge />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Badge {...defaultProps} />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import BottomNavigationAction from '../BottomNavigationAction';
@@ -9,7 +10,7 @@ import Icon from '../Icon';
 import BottomNavigation from './BottomNavigation';
 
 describe('<BottomNavigation />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   let actionClasses;
   const render = createClientRender();
@@ -23,11 +24,6 @@ describe('<BottomNavigation />', () => {
       </BottomNavigation>,
     );
     actionClasses = getClasses(<BottomNavigationAction icon={icon} />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender, within } from 'test/utils/createClientRender';
 import ButtonBase from '../ButtonBase';
 import BottomNavigationAction from './BottomNavigationAction';
 
 describe('<BottomNavigationAction />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<BottomNavigationAction />);
   });
 
@@ -23,7 +23,6 @@ describe('<BottomNavigationAction />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('adds a `selected` class when selected', () => {

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,20 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Box from './Box';
 
 describe('<Box />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   describeConformance(<Box />, () => ({
     mount,

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Breadcrumbs from './Breadcrumbs';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender } from 'test/utils/createClientRender';
 
 describe('<Breadcrumbs />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(
       <Breadcrumbs>
         <span>Hello World</span>
@@ -26,7 +26,6 @@ describe('<Breadcrumbs />', () => {
     mount,
     refInstanceof: window.HTMLElement,
     testComponentPropWith: 'div',
-    after: () => mount.cleanUp(),
   }));
 
   it('should render inaccessible seperators between each listitem', () => {

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import createServerRender from 'test/utils/createServerRender';
@@ -8,12 +9,11 @@ import Button from './Button';
 import ButtonBase from '../ButtonBase';
 
 describe('<Button />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Button>Hello World</Button>);
   });
 
@@ -23,7 +23,6 @@ describe('<Button />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render with the root & text classes but no others', () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import TouchRipple from './TouchRipple';
 import ButtonBase from './ButtonBase';
@@ -32,7 +33,7 @@ describe('<ButtonBase />', () => {
   /**
    * @type {ReturnType<typeof createMount>}
    */
-  let mount;
+  const mount = createMount();
   /**
    * @type {Record<string, string>}
    */
@@ -41,7 +42,6 @@ describe('<ButtonBase />', () => {
   let canFireDragEvents = true;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<ButtonBase />);
     // browser testing config
     try {
@@ -59,7 +59,6 @@ describe('<ButtonBase />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'a',
-    after: () => mount.cleanUp(),
   }));
 
   describe('root node', () => {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
@@ -10,7 +11,7 @@ const cb = () => {};
 
 describe('<TouchRipple />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   /**
@@ -48,11 +49,6 @@ describe('<TouchRipple />', () => {
 
   before(() => {
     classes = getClasses(<TouchRipple />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<TouchRipple />, () => ({

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Button from '../Button';
@@ -8,20 +9,15 @@ import ButtonGroup from './ButtonGroup';
 
 describe('<ButtonGroup />', () => {
   const render = createClientRender();
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(
       <ButtonGroup>
         <Button>Hello World</Button>
       </ButtonGroup>,
     );
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/Card/Card.test.js
+++ b/packages/material-ui/src/Card/Card.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Card from './Card';
 import Paper from '../Paper';
 
 describe('<Card />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Card />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Card />, () => ({

--- a/packages/material-ui/src/CardActionArea/CardActionArea.test.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.test.js
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ButtonBase from '../ButtonBase';
 import CardActionArea from './CardActionArea';
 
 describe('<CardActionArea />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<CardActionArea />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<CardActionArea />, () => ({

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import CardActions from './CardActions';
 
 describe('<CardActions />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<CardActions />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<CardActions />, () => ({

--- a/packages/material-ui/src/CardContent/CardContent.test.js
+++ b/packages/material-ui/src/CardContent/CardContent.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import CardContent from './CardContent';
 
 describe('<CardContent />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<CardContent />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<CardContent />, () => ({

--- a/packages/material-ui/src/CardHeader/CardHeader.test.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import CardHeader from './CardHeader';
 import Typography from '../Typography';
 
 describe('<CardHeader />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   const typographyClasses = getClasses(<Typography />);
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<CardHeader />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<CardHeader />, () => ({

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import CardMedia from './CardMedia';
@@ -8,16 +9,11 @@ import consoleErrorMock from 'test/utils/consoleErrorMock';
 import PropTypes from 'prop-types';
 
 describe('<CardMedia />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<CardMedia image="/foo.jpg" />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<CardMedia image="/foo.jpg" />, () => ({

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Checkbox from './Checkbox';
@@ -11,11 +12,10 @@ import IconButton from '../IconButton';
 describe('<Checkbox />', () => {
   const render = createClientRender();
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     classes = getClasses(<Checkbox />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Checkbox checked />, () => ({
@@ -24,7 +24,6 @@ describe('<Checkbox />', () => {
     mount,
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should have the classes required for Checkbox', () => {

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import CheckBox from '../internal/svg-icons/CheckBox';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Avatar from '../Avatar';
@@ -10,12 +11,11 @@ import Chip from './Chip';
 
 describe('<Chip />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<Chip />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Chip />, () => ({
@@ -24,7 +24,6 @@ describe('<Chip />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    after: () => mount.cleanUp(),
   }));
 
   describe('text only', () => {

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import CircularProgress from './CircularProgress';
 
 describe('<CircularProgress />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<CircularProgress />);
   });
 
@@ -21,7 +21,6 @@ describe('<CircularProgress />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render with the primary color by default', () => {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Collapse from './Collapse';
 import {
@@ -13,7 +14,8 @@ import {
 import { Transition } from 'react-transition-group';
 
 describe('<Collapse />', () => {
-  let mount;
+  // StrictModeViolation: uses react-transition-group
+  const mount = createMount({ strict: false });
   let classes;
   const defaultProps = {
     in: true,
@@ -22,8 +24,6 @@ describe('<Collapse />', () => {
   const render = createClientRender({ strict: false });
 
   before(() => {
-    // StrictModeViolation: uses react-transition-group
-    mount = createMount({ strict: false });
     classes = getClasses(<Collapse {...defaultProps} />);
   });
 
@@ -33,7 +33,6 @@ describe('<Collapse />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    after: () => mount.cleanUp(),
   }));
 
   it('should render a container around the wrapper', () => {

--- a/packages/material-ui/src/Container/Container.test.js
+++ b/packages/material-ui/src/Container/Container.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import { findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Container from './Container';
 
 describe('<Container />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const defaultProps = {
     children: <div />,
   };
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Container {...defaultProps} />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Container {...defaultProps} />, () => ({

--- a/packages/material-ui/src/CssBaseline/CssBaseline.test.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.test.js
@@ -1,20 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import CssBaseline from './CssBaseline';
 
 describe('<CssBaseline />', () => {
-  let mount;
-
-  before(() => {
-    // StrictModeViolation: makeStyles will retain the styles in the head in strict mode
-    // which becomes an issue for global styles
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  // StrictModeViolation: makeStyles will retain the styles in the head in strict mode
+  // which becomes an issue for global styles
+  const mount = createMount({ strict: false });
 
   it('renders its children', () => {
     const wrapper = mount(

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Modal from '../Modal';
@@ -32,13 +33,12 @@ function clickBackdrop(container) {
 
 describe('<Dialog />', () => {
   let clock;
-  let mount;
+  // StrictModeViolation: uses Fade
+  const mount = createMount({ strict: false });
   let classes;
   const render = createClientRender({ strict: false });
 
   before(() => {
-    // StrictModeViolation: uses Fade
-    mount = createMount({ strict: false });
     classes = getClasses(<Dialog>foo</Dialog>);
   });
 
@@ -60,7 +60,6 @@ describe('<Dialog />', () => {
       // react-transition-group issue
       'reactTestRenderer',
     ],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render with a TransitionComponent', () => {

--- a/packages/material-ui/src/DialogActions/DialogActions.test.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import DialogActions from './DialogActions';
 
 describe('<DialogActions />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<DialogActions />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<DialogActions />, () => ({

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import DialogContent from './DialogContent';
 
 describe('<DialogContent />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<DialogContent />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<DialogContent />, () => ({

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '../test-utils';
-import describeConformance from '../test-utils/describeConformance';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import describeConformance from '@material-ui/core/test-utils/describeConformance';
+import createMount from 'test/utils/createMount';
 import DialogContentText from './DialogContentText';
 import Typography from '../Typography';
 
 describe('<DialogContentText />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<DialogContentText />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<DialogContentText>foo</DialogContentText>, () => ({

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import DialogTitle from './DialogTitle';
 
 describe('<DialogTitle />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<DialogTitle>foo</DialogTitle>);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<DialogTitle>foo</DialogTitle>, () => ({

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Divider from './Divider';
 
 describe('<Divider />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Divider />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Divider />, () => ({

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import { findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '../test-utils/describeConformance';
 import Slide from '../Slide';
@@ -10,22 +11,17 @@ import Drawer, { getAnchor, isHorizontal } from './Drawer';
 import { createClientRender } from 'test/utils/createClientRender';
 
 describe('<Drawer />', () => {
-  let mount;
+  // StrictModeViolation: uses Slide
+  const mount = createMount({ strict: false });
   let classes;
   const render = createClientRender({ strict: false });
 
   before(() => {
-    // StrictModeViolation: uses Slide
-    mount = createMount({ strict: false });
     classes = getClasses(
       <Drawer>
         <div />
       </Drawer>,
     );
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import { getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Paper from '../Paper';
@@ -11,18 +12,13 @@ import ExpansionPanelSummary from '../ExpansionPanelSummary';
 import Collapse from '../Collapse';
 
 describe('<ExpansionPanel />', () => {
-  let mount;
+  // StrictModeViolation: uses Collapse
+  const mount = createMount({ strict: false });
   let classes;
   const minimalChildren = [<ExpansionPanelSummary key="header" />];
 
   before(() => {
-    // StrictModeViolation: uses Collapse
-    mount = createMount({ strict: false });
     classes = getClasses(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ExpansionPanel>{minimalChildren}</ExpansionPanel>, () => ({

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.test.js
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ExpansionPanelActions from './ExpansionPanelActions';
 
 describe('<ExpansionPanelActions />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<ExpansionPanelActions>foo</ExpansionPanelActions>);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ExpansionPanelActions>Conformance</ExpansionPanelActions>, () => ({

--- a/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.test.js
+++ b/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ExpansionPanelDetails from './ExpansionPanelDetails';
 
 describe('<ExpansionPanelDetails />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<ExpansionPanelDetails>foo</ExpansionPanelDetails>);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ExpansionPanelDetails>Conformance</ExpansionPanelDetails>, () => ({

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import ExpansionPanel from '../ExpansionPanel';
@@ -9,13 +10,12 @@ import ExpansionPanelSummary from './ExpansionPanelSummary';
 import ButtonBase from '../ButtonBase';
 
 describe('<ExpansionPanelSummary />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
     // requires mocking the TransitionComponent of `ExpansionPanel`
-    mount = createMount({ strict: true });
     classes = getClasses(<ExpansionPanelSummary />);
   });
 
@@ -25,7 +25,6 @@ describe('<ExpansionPanelSummary />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('renders the children inside the .content element', () => {

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '../test-utils';
-import describeConformance from '../test-utils/describeConformance';
+import { getClasses } from '@material-ui/core/test-utils';
+import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
+import createMount from 'test/utils/createMount';
 import createServerRender from 'test/utils/createServerRender';
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';
 
 describe('<Fab />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender({ strict: false });
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Fab>Fab</Fab>);
   });
 
@@ -24,7 +24,6 @@ describe('<Fab />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render with the root class but no others', () => {

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -5,27 +5,19 @@ import {
   ThemeProvider,
   unstable_createMuiStrictModeTheme as createMuiStrictModeTheme,
 } from '@material-ui/core/styles';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Fade from './Fade';
 import { Transition } from 'react-transition-group';
 
 describe('<Fade />', () => {
-  let mount;
+  // StrictModeViolation: uses react-transition-group
+  const mount = createMount({ strict: false });
 
   const defaultProps = {
     in: true,
     children: <div />,
   };
-
-  before(() => {
-    // StrictModeViolation: uses react-transition-group
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   describeConformance(<Fade {...defaultProps} />, () => ({
     classes: {},

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FilledInput from './FilledInput';
@@ -8,11 +9,10 @@ import InputBase from '../InputBase';
 
 describe('<FilledInput />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<FilledInput />);
   });
 
@@ -22,7 +22,6 @@ describe('<FilledInput />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should have the underline class', () => {

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { act, createClientRender } from 'test/utils/createClientRender';
 import Input from '../Input';
@@ -10,7 +11,7 @@ import FormControl from './FormControl';
 import useFormControl from './useFormControl';
 
 describe('<FormControl />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
@@ -23,12 +24,7 @@ describe('<FormControl />', () => {
   }
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<FormControl />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<FormControl />, () => ({

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Checkbox from '../Checkbox';
@@ -8,12 +9,11 @@ import FormControlLabel from './FormControlLabel';
 import FormControl from '../FormControl';
 
 describe('<FormControlLabel />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender({ strict: false });
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<FormControlLabel label="Pizza" control={<div />} />);
   });
 
@@ -23,7 +23,6 @@ describe('<FormControlLabel />', () => {
     mount,
     refInstanceof: window.HTMLLabelElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render the label text inside an additional element', () => {

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import FormGroup from './FormGroup';
 
 describe('<FormGroup />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<FormGroup />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<FormGroup />, () => ({

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FormHelperText from './FormHelperText';
 import FormControl from '../FormControl';
 
 describe('<FormHelperText />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<FormHelperText />);
   });
 
@@ -22,7 +22,6 @@ describe('<FormHelperText />', () => {
     mount,
     refInstanceof: window.HTMLParagraphElement,
     testComponentPropWith: 'div',
-    after: () => mount.cleanUp(),
   }));
 
   describe('prop: error', () => {

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FormLabel from './FormLabel';
 import FormControl, { useFormControl } from '../FormControl';
 
 describe('<FormLabel />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<FormLabel />);
   });
 
@@ -23,7 +23,6 @@ describe('<FormLabel />', () => {
     mount,
     refInstanceof: window.HTMLLabelElement,
     testComponentPropWith: 'div',
-    after: () => mount.cleanUp(),
   }));
 
   describe('prop: required', () => {

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '../test-utils/describeConformance';
 import Grid, { styles } from './Grid';
 
 describe('<Grid />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Grid />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Grid />, () => ({

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import GridList from './GridList';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -20,17 +21,12 @@ const tilesData = [
 
 describe('<GridList />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   let shallow;
 
   before(() => {
     classes = getClasses(<GridList />);
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -1,21 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import GridListTile from './GridListTile';
 
 describe('<GridListTile />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<GridListTile />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<GridListTile />, () => ({

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import GridListTileBar from './GridListTileBar';
 
 describe('<GridListTileBar />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   let shallow;
 
   before(() => {
     classes = getClasses(<GridListTileBar title="classes" />);
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<GridListTileBar title="conform?" />, () => ({

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Grow from './Grow';
 import {
@@ -13,20 +13,12 @@ import { Transition } from 'react-transition-group';
 import useForkRef from '../utils/useForkRef';
 
 describe('<Grow />', () => {
-  let mount;
+  // StrictModeViolation: uses react-transition-group
+  const mount = createMount({ strict: false });
   const defaultProps = {
     in: true,
     children: <div />,
   };
-
-  before(() => {
-    // StrictModeViolation: uses react-transition-group
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   describeConformance(
     <Grow in>
@@ -45,7 +37,7 @@ describe('<Grow />', () => {
     }),
   );
 
-  describe('transition lifecycle', () => {
+  describe('calls the appropriate callbacks for each transition', () => {
     let clock;
 
     before(() => {

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import HiddenCss from './HiddenCss';
 import { createMuiTheme, MuiThemeProvider } from '../styles';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -11,22 +12,17 @@ describe('<HiddenCss />', () => {
   /**
    * @type {ReturnType<typeof createMount>}
    */
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ untilSelector: 'div' });
     classes = getClasses(
       <HiddenCss>
         <div />
       </HiddenCss>,
     );
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describe('the generated class names', () => {

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Icon from './Icon';
 
 describe('<Icon />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Icon />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Icon>account_circle</Icon>, () => ({

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -11,11 +12,10 @@ import IconButton from './IconButton';
 
 describe('<IconButton />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender({ strict: false });
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<IconButton />);
   });
 
@@ -25,7 +25,6 @@ describe('<IconButton />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render an inner label span (bloody safari)', () => {

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Input from './Input';
 import InputBase from '../InputBase';
 
 describe('<Input />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     classes = getClasses(<Input />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Input />, () => ({

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -11,12 +12,11 @@ import FormControl from '../FormControl';
 import Input from '../Input';
 
 describe('<InputAdornment />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<InputAdornment position="start">foo</InputAdornment>);
   });
 
@@ -26,7 +26,6 @@ describe('<InputAdornment />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    after: () => mount.cleanUp(),
   }));
 
   it('should wrap text children in a Typography', () => {

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -15,11 +16,10 @@ import Select from '../Select';
 
 describe('<InputBase />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<InputBase />);
   });
 
@@ -29,7 +29,6 @@ describe('<InputBase />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render an <input /> inside the div', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
@@ -10,12 +11,11 @@ import InputLabel from './InputLabel';
 import FormLabel from '../FormLabel';
 
 describe('<InputLabel />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<InputLabel />);
   });
 
@@ -25,7 +25,6 @@ describe('<InputLabel />', () => {
     mount,
     refInstanceof: window.HTMLLabelElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render a label with text', () => {

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import LinearProgress from './LinearProgress';
 
 describe('<LinearProgress />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<LinearProgress />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<LinearProgress />, () => ({

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Link from './Link';
 import Typography from '../Typography';
@@ -13,18 +14,13 @@ function focusVisible(element) {
 }
 
 describe('<Link />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Link href="/">Home</Link>);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Link href="/">Home</Link>, () => ({

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import { findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ListSubheader from '../ListSubheader';
 import List from './List';
 import ListItem from '../ListItem';
 
 describe('<List />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<List />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<List />, () => ({

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { act, createClientRender, fireEvent, queries } from 'test/utils/createClientRender';
@@ -15,13 +16,12 @@ const NoContent = React.forwardRef(() => {
 });
 
 describe('<ListItem />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
     classes = getClasses(<ListItem />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<ListItem />, () => ({
@@ -29,7 +29,6 @@ describe('<ListItem />', () => {
     inheritComponent: 'li',
     mount,
     refInstanceof: window.HTMLLIElement,
-    after: () => mount.cleanUp(),
   }));
 
   it('should render with gutters classes', () => {

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import ListItemAvatar from './ListItemAvatar';
 
 describe('<ListItemAvatar />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(
       <ListItemAvatar>
         <div />
       </ListItemAvatar>,
     );
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ListItemIcon from './ListItemIcon';
 
 describe('<ListItemIcon />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(
       <ListItemIcon>
         <span />
       </ListItemIcon>,
     );
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ListItemSecondaryAction from './ListItemSecondaryAction';
 
 describe('<ListItemSecondaryAction />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<ListItemSecondaryAction />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ListItemSecondaryAction />, () => ({

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -1,21 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import { getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from '../Typography';
 import ListItemText from './ListItemText';
 
 describe('<ListItemText />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<ListItemText />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ListItemText />, () => ({

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ListSubheader from './ListSubheader';
 
 describe('<ListSubheader />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<ListSubheader />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ListSubheader />, () => ({

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Popover from '../Popover';
 import Menu from './Menu';
@@ -12,7 +13,8 @@ const MENU_LIST_HEIGHT = 100;
 
 describe('<Menu />', () => {
   let classes;
-  let mount;
+  // StrictModeViolation: uses Popover
+  const mount = createMount({ strict: false });
   const defaultProps = {
     open: false,
     anchorEl: () => document.createElement('div'),
@@ -20,12 +22,6 @@ describe('<Menu />', () => {
 
   before(() => {
     classes = getClasses(<Menu {...defaultProps} />);
-    // StrictModeViolation: uses Popover
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Menu {...defaultProps} open />, () => ({
@@ -133,13 +129,8 @@ describe('<Menu />', () => {
   });
 
   describe('list node', () => {
-    let wrapper;
-
-    before(() => {
-      wrapper = mount(<Menu {...defaultProps} className="test-class" data-test="hi" open />);
-    });
-
     it('should render a MenuList inside the Popover', () => {
+      const wrapper = mount(<Menu {...defaultProps} className="test-class" data-test="hi" open />);
       expect(wrapper.find(Popover).find(MenuList).exists()).to.equal(true);
     });
   });

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, getClasses, createMount } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import ListItem from '../ListItem';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
@@ -10,16 +11,11 @@ import MenuItem from './MenuItem';
 describe('<MenuItem />', () => {
   let shallow;
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<MenuItem />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<MenuItem />, () => ({

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import MenuList from './MenuList';
@@ -19,12 +19,8 @@ function setStyleWidthForJsdomOrBrowser(style, width) {
 }
 
 describe('<MenuList />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
 
   describeConformance(<MenuList />, () => ({
     classes: {},
@@ -32,7 +28,6 @@ describe('<MenuList />', () => {
     mount,
     refInstanceof: window.HTMLUListElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   describe('prop: children', () => {

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import { getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
@@ -10,7 +11,7 @@ import LinearProgress from '../LinearProgress';
 import MobileStepper from './MobileStepper';
 
 describe('<MobileStepper />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const defaultProps = {
     steps: 2,
@@ -29,12 +30,7 @@ describe('<MobileStepper />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<MobileStepper {...defaultProps} />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<MobileStepper {...defaultProps} />, () => ({

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender, fireEvent, screen, within } from 'test/utils/createClientRender';
 import { createMuiTheme } from '@material-ui/core/styles';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { ThemeProvider } from '@material-ui/styles';
 import describeConformance from '../test-utils/describeConformance';
 import Fade from '../Fade';
@@ -14,7 +14,8 @@ import Backdrop from '../Backdrop';
 import Modal from './Modal';
 
 describe('<Modal />', () => {
-  let mount;
+  // StrictModeViolation: uses Backdrop
+  const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
   let savedBodyStyle;
 
@@ -23,13 +24,7 @@ describe('<Modal />', () => {
   });
 
   beforeEach(() => {
-    // StrictModeViolation: uses Backdrop
-    mount = createMount({ strict: false });
     document.body.setAttribute('style', savedBodyStyle);
-  });
-
-  afterEach(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Input from '../Input';
 import NativeSelect from './NativeSelect';
 
 describe('<NativeSelect />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const defaultProps = {
     input: <Input />,
     children: [
@@ -22,11 +23,6 @@ describe('<NativeSelect />', () => {
 
   before(() => {
     classes = getClasses(<NativeSelect {...defaultProps} />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<NativeSelect {...defaultProps} />, () => ({

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { createShallow } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import NativeSelectInput from './NativeSelectInput';
 
 describe('<NativeSelectInput />', () => {
   let shallow;
-  let mount;
+  const mount = createMount();
   const defaultProps = {
     classes: { select: 'select' },
     value: 10,
@@ -27,11 +28,6 @@ describe('<NativeSelectInput />', () => {
 
   before(() => {
     shallow = createShallow();
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<NativeSelectInput {...defaultProps} onChange={() => {}} />, () => ({

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -1,20 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import createServerRender from 'test/utils/createServerRender';
 import NoSsr from './NoSsr';
 
 describe('<NoSsr />', () => {
-  let mount;
+  const mount = createMount();
   const serverRender = createServerRender();
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   describe('server-side rendering', () => {
     it('should not render the children as the width is unknown', () => {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import OutlinedInput from './OutlinedInput';
@@ -8,12 +9,11 @@ import InputBase from '../InputBase';
 
 describe('<OutlinedInput />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<OutlinedInput />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<OutlinedInput labelWidth={0} />, () => ({
@@ -22,7 +22,6 @@ describe('<OutlinedInput />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('should render a NotchedOutline', () => {

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import * as PropTypes from 'prop-types';
 import describeConformance from '../test-utils/describeConformance';
 import Paper from './Paper';
@@ -8,18 +9,13 @@ import { createMuiTheme, ThemeProvider } from '../styles';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 describe('<Paper />', () => {
-  let mount;
+  const mount = createMount();
   let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Paper />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Paper />, () => ({

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
@@ -12,7 +12,7 @@ import Grow from '../Grow';
 import Popper from './Popper';
 
 describe('<Popper />', () => {
-  let mount;
+  const mount = createMount();
   let rtlTheme;
   const render = createClientRender();
   const defaultProps = {
@@ -22,7 +22,6 @@ describe('<Popper />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
     rtlTheme = createMuiTheme({
       direction: 'rtl',
     });
@@ -38,7 +37,6 @@ describe('<Popper />', () => {
       // https://github.com/facebook/react/issues/11565
       'reactTestRenderer',
     ],
-    after: () => mount.cleanUp(),
   }));
 
   describe('prop: placement', () => {

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
@@ -10,11 +11,10 @@ import Radio from './Radio';
 describe('<Radio />', () => {
   const render = createClientRender();
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     classes = getClasses(<Radio />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Radio />, () => ({
@@ -23,7 +23,6 @@ describe('<Radio />', () => {
     mount,
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   describe('styleSheet', () => {

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import * as PropTypes from 'prop-types';
-import { createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import { findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FormGroup from '../FormGroup';
@@ -12,17 +13,9 @@ import consoleErrorMock from 'test/utils/consoleErrorMock';
 import useRadioGroup from './useRadioGroup';
 
 describe('<RadioGroup />', () => {
-  let mount;
+  // StrictModeViolation: test uses #simulate
+  const mount = createMount({ strict: false });
   const render = createClientRender({ strict: true });
-
-  before(() => {
-    // StrictModeViolation: test uses #simulate
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   function findRadio(wrapper, value) {
     return wrapper.find(`input[value="${value}"]`).first();

--- a/packages/material-ui/src/RootRef/RootRef.test.js
+++ b/packages/material-ui/src/RootRef/RootRef.test.js
@@ -2,22 +2,14 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import RootRef from './RootRef';
 
 const Fn = () => <div />;
 
 describe('<RootRef />', () => {
-  let mount;
-
-  before(() => {
-    // StrictModeViolation: uses findDOMNode
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  // StrictModeViolation: uses findDOMNode
+  const mount = createMount({ strict: false });
 
   it('call rootRef function on mount and unmount', () => {
     const rootRef = spy();

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import ScopedCssBaseline from './ScopedCssBaseline';
 import describeConformance from '../test-utils/describeConformance';
 
 describe('<ScopedCssBaseline />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<ScopedCssBaseline />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<ScopedCssBaseline />, () => ({

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -12,13 +13,12 @@ import { spy, stub, useFakeTimers } from 'sinon';
 
 describe('<Select />', () => {
   let classes;
-  let mount;
+  // StrictModeViolation: uses Menu
+  const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
 
   before(() => {
     classes = getClasses(<Select />);
-    // StrictModeViolation: uses Menu
-    mount = createMount({ strict: false });
   });
 
   describeConformance(<Select value="" />, () => ({
@@ -27,7 +27,6 @@ describe('<Select />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'rootClass'],
-    after: () => mount.cleanUp(),
   }));
 
   describe('prop: inputProps', () => {

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Slide, { setTranslateValue } from './Slide';
 import {
@@ -13,20 +13,12 @@ import { Transition } from 'react-transition-group';
 import { useForkRef } from '../utils';
 
 describe('<Slide />', () => {
-  let mount;
+  const mount = createMount();
   const defaultProps = {
     in: true,
     children: <div id="testChild" />,
     direction: 'down',
   };
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   describeConformance(
     <Slide in>

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
@@ -27,13 +28,12 @@ describe('<Slider />', () => {
     return;
   }
 
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<Slider value={0} />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Slider value={0} />, () => ({
@@ -42,7 +42,6 @@ describe('<Slider />', () => {
     mount,
     refInstanceof: window.HTMLSpanElement,
     testComponentPropWith: 'span',
-    after: () => mount.cleanUp(),
   }));
 
   it('should call handlers', () => {

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -1,25 +1,21 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Snackbar from './Snackbar';
 import Grow from '../Grow';
 
 describe('<Snackbar />', () => {
-  let mount;
+  // StrictModeViolation: uses Slide
+  const mount = createMount({ strict: false });
   let classes;
   const render = createClientRender({ strict: false });
 
   before(() => {
     classes = getClasses(<Snackbar open />);
-    // StrictModeViolation: uses Slide
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Snackbar open message="message" />, () => ({

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Paper from '../Paper';
 import SnackbarContent from './SnackbarContent';
 
 describe('<SnackbarContent />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<SnackbarContent message="message" />);
   });
 
@@ -22,7 +22,6 @@ describe('<SnackbarContent />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   describe('prop: action', () => {

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender, within } from 'test/utils/createClientRender';
 import Step from './Step';
@@ -56,13 +57,12 @@ StepChildDiv.propTypes = {
 
 describe('<Step />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
 
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<Step />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Step />, () => ({
@@ -71,7 +71,6 @@ describe('<Step />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   it('merges styles and other props into the root node', () => {

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import StepButton from './StepButton';
@@ -19,15 +20,7 @@ describe('<StepButton />', () => {
   });
 
   describe('internals', () => {
-    let mount;
-
-    before(() => {
-      mount = createMount({ strict: true });
-    });
-
-    after(() => {
-      mount.cleanUp();
-    });
+    const mount = createMount();
 
     describeConformance(<StepButton />, () => ({
       classes,

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import StepConnector from './StepConnector';
 
 describe('<StepConnector />', () => {
   let shallow;
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<StepConnector />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<StepConnector />, () => ({

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Collapse from '../Collapse';
 import StepContent from './StepContent';
@@ -8,7 +9,8 @@ import StepContent from './StepContent';
 describe('<StepContent />', () => {
   let classes;
   let shallow;
-  let mount;
+  // StrictModeViolation: uses Collapse
+  const mount = createMount({ strict: false });
   const defaultProps = {
     orientation: 'vertical',
   };
@@ -16,12 +18,6 @@ describe('<StepContent />', () => {
   before(() => {
     classes = getClasses(<StepContent />);
     shallow = createShallow({ dive: true });
-    // StrictModeViolation: uses Collapse
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<StepContent {...defaultProps} />, () => ({

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -1,21 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { createShallow } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import StepIcon from './StepIcon';
 import SvgIcon from '../SvgIcon';
 
 describe('<StepIcon />', () => {
   let shallow;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<StepIcon icon={1} />, () => ({

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from '../Typography';
 import StepIcon from '../StepIcon';
@@ -9,16 +10,11 @@ import StepLabel from './StepLabel';
 describe('<StepLabel />', () => {
   let shallow;
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<StepLabel />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<StepLabel />, () => ({

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import CheckCircle from '../internal/svg-icons/CheckCircle';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Paper from '../Paper';
 import Step from '../Step';
@@ -13,17 +14,12 @@ import Stepper from './Stepper';
 describe('<Stepper />', () => {
   let classes;
   let shallow;
-  let mount;
+  // StrictModeViolation: test uses StepContent
+  const mount = createMount({ strict: false });
 
   before(() => {
     classes = getClasses(<Stepper />);
     shallow = createShallow({ dive: true });
-    // StrictModeViolation: test uses StepContent
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -1,24 +1,20 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import SvgIcon from './SvgIcon';
 
 describe('<SvgIcon />', () => {
   let shallow;
-  let mount;
+  const mount = createMount();
   let classes;
   let path;
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
     classes = getClasses(<SvgIcon>foo</SvgIcon>);
     path = <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />;
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import PropTypes, { checkPropTypes } from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -88,16 +88,8 @@ const NullPaper = React.forwardRef(function NullPaper(props, ref) {
 });
 
 describe('<SwipeableDrawer />', () => {
-  let mount;
-
-  before(() => {
-    // test are mostly asserting on implementation details
-    mount = createMount({ strict: undefined });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  // test are mostly asserting on implementation details
+  const mount = createMount({ strict: null });
 
   describeConformance(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />, () => ({
     classes: {},

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
 import Switch from './Switch';
 
 describe('<Switch />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Switch />);
   });
 
@@ -20,7 +20,6 @@ describe('<Switch />', () => {
     mount,
     only: ['refForwarding'],
     refInstanceof: window.HTMLSpanElement,
-    after: () => mount.cleanUp(),
   }));
 
   /* TODO Switch violates root component

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Tab from './Tab';
@@ -10,11 +11,10 @@ import ButtonBase from '../ButtonBase';
 const render = createClientRender();
 
 describe('<Tab />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Tab textColor="inherit" />);
   });
 
@@ -23,7 +23,6 @@ describe('<Tab />', () => {
     inheritComponent: ButtonBase,
     mount,
     refInstanceof: window.HTMLButtonElement,
-    after: () => mount.cleanUp(),
   }));
 
   it('should have a ripple by default', () => {

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import TabScrollButton from './TabScrollButton';
 import describeConformance from '../test-utils/describeConformance';
@@ -12,10 +13,9 @@ describe('<TabScrollButton />', () => {
   };
   const render = createClientRender();
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TabScrollButton {...defaultProps} />);
   });
 
@@ -24,7 +24,6 @@ describe('<TabScrollButton />', () => {
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    after: () => mount.cleanUp(),
   }));
 
   it('should render as a button with the root class', () => {

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Table from './Table';
 import TableContext from './TableContext';
 
 describe('<Table />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Table>foo</Table>);
   });
 
@@ -27,7 +27,6 @@ describe('<Table />', () => {
       refInstanceof: window.HTMLTableElement,
       // can't test another component with tbody as a child
       testComponentPropWith: 'table',
-      after: () => mount.cleanUp(),
     }),
   );
 

--- a/packages/material-ui/src/TableBody/TableBody.test.js
+++ b/packages/material-ui/src/TableBody/TableBody.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import TableBody from './TableBody';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 
 describe('<TableBody />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
@@ -16,8 +17,6 @@ describe('<TableBody />', () => {
   }
 
   before(() => {
-    mount = createMount({ strict: true });
-
     classes = getClasses(<TableBody />);
   });
 
@@ -28,7 +27,7 @@ describe('<TableBody />', () => {
       const wrapper = mount(<table>{node}</table>);
       return wrapper.find('table').childAt(0);
     },
-    after: () => mount.cleanUp(),
+
     refInstanceof: window.HTMLTableSectionElement,
     // can't test with custom `component` with `renderInTable`
     testComponentPropWith: 'tbody',

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import TableCell from './TableCell';
 
 describe('<TableCell />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   function renderInTable(node) {
@@ -20,7 +21,6 @@ describe('<TableCell />', () => {
   }
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TableCell />);
   });
 
@@ -37,7 +37,7 @@ describe('<TableCell />', () => {
       );
       return wrapper.find('tr').childAt(0);
     },
-    after: () => mount.cleanUp(),
+
     refInstanceof: window.HTMLTableCellElement,
     // invalid nesting otherwise
     testComponentPropWith: 'td',

--- a/packages/material-ui/src/TableContainer/TableContainer.test.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.test.js
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import TableContainer from './TableContainer';
 
 describe('<TableContainer />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TableContainer />);
   });
 
@@ -18,6 +18,5 @@ describe('<TableContainer />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    after: () => mount.cleanUp(),
   }));
 });

--- a/packages/material-ui/src/TableFooter/TableFooter.test.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import TableFooter from './TableFooter';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 
 describe('<TableFooter />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
@@ -16,7 +17,6 @@ describe('<TableFooter />', () => {
   }
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TableFooter />);
   });
 
@@ -27,7 +27,7 @@ describe('<TableFooter />', () => {
       const wrapper = mount(<table>{node}</table>);
       return wrapper.find('table').childAt(0);
     },
-    after: () => mount.cleanUp(),
+
     refInstanceof: window.HTMLTableSectionElement,
     testComponentPropWith: 'thead',
   }));

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import TableHead from './TableHead';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 
 describe('<TableHead />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
   function renderInTable(node) {
@@ -15,7 +16,6 @@ describe('<TableHead />', () => {
   }
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TableHead>foo</TableHead>);
   });
 
@@ -26,7 +26,7 @@ describe('<TableHead />', () => {
       const wrapper = mount(<table>{node}</table>);
       return wrapper.find('table').childAt(0);
     },
-    after: () => mount.cleanUp(),
+
     refInstanceof: window.HTMLTableSectionElement,
     testComponentPropWith: 'tbody',
   }));

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { fireEvent, createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -13,11 +14,10 @@ import TablePagination from './TablePagination';
 describe('<TablePagination />', () => {
   const noop = () => {};
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(
       <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={10} />,
     );
@@ -38,7 +38,7 @@ describe('<TablePagination />', () => {
         );
         return wrapper.find('tr').childAt(0);
       },
-      after: () => mount.cleanUp(),
+
       refInstanceof: window.HTMLTableCellElement,
       // can only use `td` in a tr so we just fake a different component
       testComponentPropWith: (props) => <td {...props} />,

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import TableRow from './TableRow';
 
 describe('<TableRow />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
@@ -19,7 +20,6 @@ describe('<TableRow />', () => {
   }
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TableRow />);
   });
 
@@ -34,7 +34,7 @@ describe('<TableRow />', () => {
       );
       return wrapper.find('tbody').childAt(0);
     },
-    after: () => mount.cleanUp(),
+
     refInstanceof: window.HTMLTableRowElement,
     testComponentPropWith: 'tr',
   }));

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import TableSortLabel from './TableSortLabel';
 import ButtonBase from '../ButtonBase';
 import Sort from '@material-ui/icons/Sort';
 
 describe('<TableSortLabel />', () => {
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<TableSortLabel />);
   });
 
@@ -21,7 +21,7 @@ describe('<TableSortLabel />', () => {
     classes,
     inheritComponent: ButtonBase,
     mount,
-    after: () => mount.cleanUp(),
+
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],
   }));

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import createServerRender from 'test/utils/createServerRender';
 import describeConformance from '../test-utils/describeConformance';
@@ -48,13 +49,12 @@ describe('<Tabs />', () => {
     return;
   }
 
-  let mount;
+  const mount = createMount();
   let classes;
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<Tabs value={0} />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<Tabs value={0} />, () => ({
@@ -62,7 +62,6 @@ describe('<Tabs />', () => {
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    after: () => mount.cleanUp(),
   }));
 
   it('can be named via `aria-label`', () => {

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
@@ -11,12 +12,11 @@ import MenuItem from '../MenuItem';
 
 describe('<TextField />', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<TextField />);
-    mount = createMount({ strict: true });
   });
 
   describeConformance(<TextField />, () => ({
@@ -25,7 +25,6 @@ describe('<TextField />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
-    after: () => mount.cleanUp(),
   }));
 
   describe('structure', () => {

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub, useFakeTimers } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import TextareaAutosize from './TextareaAutosize';
@@ -11,15 +11,7 @@ function getStyle(wrapper) {
 }
 
 describe('<TextareaAutosize />', () => {
-  let mount;
-
-  before(() => {
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  const mount = createMount();
 
   describeConformance(<TextareaAutosize />, () => ({
     inheritComponent: 'textarea',

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Toolbar from './Toolbar';
 
 describe('<Toolbar />', () => {
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<Toolbar>foo</Toolbar>);
   });
 
@@ -20,7 +20,6 @@ describe('<Toolbar />', () => {
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    after: () => mount.cleanUp(),
   }));
 
   it('should render with gutters class', () => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -3,7 +3,8 @@ import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Popper from '../Popper';
@@ -30,7 +31,8 @@ function simulatePointerDevice() {
 }
 
 describe('<Tooltip />', () => {
-  let mount;
+  // StrictModeViolation: uses Grow and tests a lot of impl details
+  const mount = createMount({ strict: null });
   let classes;
   const render = createClientRender({ strict: false });
   let clock;
@@ -51,13 +53,10 @@ describe('<Tooltip />', () => {
   beforeEach(() => {
     testReset();
     clock = useFakeTimers();
-    // StrictModeViolation: uses Grow and tests a lot of impl details
-    mount = createMount({ strict: undefined });
   });
 
   afterEach(() => {
     clock.restore();
-    mount.cleanUp();
   });
 
   describeConformance(<Tooltip {...defaultProps} />, () => ({

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -1,7 +1,8 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from './Typography';
 
@@ -9,7 +10,7 @@ describe('<Typography />', () => {
   /**
    * @type {ReturnType<typeof createMount>}
    */
-  let mount;
+  const mount = createMount();
   /**
    * @type {ReturnType<typeof createShallow>}
    */
@@ -22,13 +23,8 @@ describe('<Typography />', () => {
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Typography />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Typography />, () => ({

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import {
   unstable_createMuiStrictModeTheme as createMuiStrictModeTheme,
@@ -11,16 +11,8 @@ import { Transition } from 'react-transition-group';
 import Zoom from './Zoom';
 
 describe('<Zoom />', () => {
-  let mount;
-
-  before(() => {
-    // StrictModeViolation: uses react-transition-group
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
+  // StrictModeViolation: uses react-transition-group
+  const mount = createMount({ strict: false });
 
   describeConformance(
     <Zoom in>

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -20,11 +21,10 @@ const shouldSuccessOnce = (name) => (func) => () => {
 
 describe('<SwitchBase />', () => {
   const render = createClientRender();
-  let mount;
+  const mount = createMount();
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
     classes = getClasses(<SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />);
   });
 
@@ -36,7 +36,6 @@ describe('<SwitchBase />', () => {
       mount,
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
-      after: () => mount.cleanUp(),
     }),
   );
 

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import createMount from './createMount';
+import createMount from 'test/utils/createMount';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 
 describe('findOutermostIntrinsic', () => {
-  let mount;
+  const mount = createMount({ strict: null });
   const expectIntrinsic = (node, expected) => {
     const wrapper = mount(node);
     const outermostIntrinsic = findOutermostIntrinsic(wrapper);
@@ -19,14 +19,6 @@ describe('findOutermostIntrinsic', () => {
     }
   };
   const Headless = ({ children }) => children;
-
-  before(() => {
-    mount = createMount({ strict: undefined });
-  });
-
-  after(() => {
-    mount.cleanUp();
-  });
 
   it('returns immediate DOM nodes', () => {
     expectIntrinsic(<div>Hello, World!</div>, 'div');

--- a/packages/material-ui/src/utils/focusVisible.test.js
+++ b/packages/material-ui/src/utils/focusVisible.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { createMount } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import useIsFocusVisible, { teardown as teardownFocusVisible } from './useIsFocusVisible';
 import useForkRef from './useForkRef';
 
@@ -49,16 +49,11 @@ const SimpleButton = React.forwardRef(function SimpleButton(props, ref) {
 });
 
 describe('focus-visible polyfill', () => {
-  let mount;
+  const mount = createMount();
 
   before(() => {
     // isolate test from previous component test that use the polyfill in the document scope
     teardownFocusVisible(document);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describe('focus inside shadowRoot', () => {

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { createMount, createShallow } from '@material-ui/core/test-utils';
+import { createShallow } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import mediaQuery from 'css-mediaquery';
 import withWidth, { isWidthDown, isWidthUp } from './withWidth';
 import createMuiTheme from '../styles/createMuiTheme';
@@ -38,11 +39,10 @@ const EmptyWithWidth = withWidth()(Empty);
 describe('withWidth', () => {
   let matchMediaInstances;
   let shallow;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     shallow = createShallow({ disableLifecycleMethods: true });
-    mount = createMount({ strict: true });
   });
 
   beforeEach(() => {
@@ -62,10 +62,6 @@ describe('withWidth', () => {
 
   afterEach(() => {
     window.matchMedia.restore();
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describe('server-side rendering', () => {

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import { findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
 import TableCell from '@material-ui/core/TableCell';
 import TableFooter from '@material-ui/core/TableFooter';
@@ -9,7 +10,7 @@ import TableBody from '@material-ui/core/TableBody';
 
 describe('<TableRow> integration', () => {
   let classes;
-  let mount;
+  const mount = createMount();
   const render = createClientRender();
   function mountInTable(node, Variant) {
     const wrapper = mount(
@@ -24,11 +25,6 @@ describe('<TableRow> integration', () => {
 
   before(() => {
     classes = getClasses(<TableCell />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   it('should render a th with the head class when in the context of a table head', () => {

--- a/packages/material-ui/test/integration/TableRow.test.js
+++ b/packages/material-ui/test/integration/TableRow.test.js
@@ -1,21 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import createMount from 'test/utils/createMount';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 
 describe('<TableRow> integration', () => {
   let classes;
-  let mount;
+  const mount = createMount();
 
   before(() => {
     classes = getClasses(<TableRow />);
-    mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   it('should render with the head class when in the context of a table head', () => {

--- a/test/utils/createMount.js
+++ b/test/utils/createMount.js
@@ -1,0 +1,93 @@
+/* eslint-env mocha */
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as PropTypes from 'prop-types';
+import { mount as enzymeMount } from 'enzyme';
+
+// fork of `@material-ui/core/test-utils`
+// with strict isolation of DOM between tests
+
+/**
+ * Can't just mount <React.Fragment>{node}</React.Fragment>
+ * because that swallows wrapper.setProps
+ *
+ * why class component:
+ * https://github.com/airbnb/enzyme/issues/2043
+ */
+// eslint-disable-next-line react/prefer-stateless-function
+class Mode extends React.Component {
+  static propTypes = {
+    /**
+     * this is essentially children. However we can't use children because then
+     * using `wrapper.setProps({ children })` would work differently if this component
+     * would be the root.
+     */
+    __element: PropTypes.element.isRequired,
+    __strict: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    // Excess props will come from e.g. enzyme setProps
+    const { __element, __strict, ...other } = this.props;
+    const Component = __strict ? React.StrictMode : React.Fragment;
+
+    return <Component>{React.cloneElement(__element, other)}</Component>;
+  }
+}
+
+// Generate an enhanced mount function.
+export default function createMount(options = {}) {
+  const { mount = enzymeMount, strict: globalStrict = true, ...globalEnzymeOptions } = options;
+
+  let container = null;
+
+  /**
+   * @param {import('mocha').Test | undefined} test
+   */
+  function computeTestName(test) {
+    /**
+     * @type {import('mocha').Test | import('mocha').Suite | undefined}
+     */
+    let current = test;
+    const titles = [];
+    while (current != null) {
+      titles.push(current.title);
+      current = current.parent;
+    }
+
+    return titles.filter(Boolean).reverse().join(' -> ');
+  }
+
+  beforeEach(function beforeEachMountTest() {
+    container = document.createElement('div');
+    container.setAttribute('data-test', computeTestName(this.currentTest));
+    document.body.insertBefore(container, document.body.firstChild);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.parentElement.removeChild(container);
+    container = null;
+  });
+
+  const mountWithContext = function mountWithContext(node, localOptions = {}) {
+    const { strict = globalStrict, ...localEnzymeOptions } = localOptions;
+
+    if (container === null) {
+      throw new Error(
+        `Tried to mount without setup. Mounting inside before() is not allowed. Try mounting in beforeEach or better: in each test`,
+      );
+    }
+    ReactDOM.unmountComponentAtNode(container);
+
+    // some tests require that no other components are in the tree
+    // e.g. when doing .instance(), .state() etc.
+    return mount(strict == null ? node : <Mode __element={node} __strict={Boolean(strict)} />, {
+      attachTo: container,
+      ...globalEnzymeOptions,
+      ...localEnzymeOptions,
+    });
+  };
+
+  return mountWithContext;
+}


### PR DESCRIPTION
- disallow usage of `@material-ui/core/test-utils#createMount`
- adds a fork of `@material-ui/core/test-utils#createMount` that automatically cleans up tests
  It's too easy to get this wrong manually. Even worse is that missing cleanup can be unnoticed until a leak becomes obvious due to e.g. `getAll*`
  - new `createMount` uses StrictMode by default
  - will throw if called outside of `beforeEach` or a test
  - cleans up between each test