### PR TITLE
[Snackbar] Fix double click issue on demos

### DIFF
--- a/docs/src/pages/components/snackbars/DirectionSnackbar.js
+++ b/docs/src/pages/components/snackbars/DirectionSnackbar.js
@@ -43,6 +43,7 @@ export default function DirectionSnackbar() {
         onClose={handleClose}
         TransitionComponent={transition}
         message="I love snacks"
+        key={transition ? transition.name : ''}
       />
     </div>
   );

--- a/docs/src/pages/components/snackbars/DirectionSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/DirectionSnackbar.tsx
@@ -47,6 +47,7 @@ export default function DirectionSnackbar() {
         onClose={handleClose}
         TransitionComponent={transition}
         message="I love snacks"
+        key={transition ? transition.name : ''}
       />
     </div>
   );

--- a/docs/src/pages/components/snackbars/TransitionsSnackbar.js
+++ b/docs/src/pages/components/snackbars/TransitionsSnackbar.js
@@ -43,6 +43,7 @@ export default function TransitionsSnackbar() {
         onClose={handleClose}
         TransitionComponent={state.Transition}
         message="I love snacks"
+        key={state.Transition.name}
       />
     </div>
   );

--- a/docs/src/pages/components/snackbars/TransitionsSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/TransitionsSnackbar.tsx
@@ -49,6 +49,7 @@ export default function TransitionsSnackbar() {
         onClose={handleClose}
         TransitionComponent={state.Transition}
         message="I love snacks"
+        key={state.Transition.name}
       />
     </div>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Might not be an issue but if you look at these demos:

- https://material-ui.com/components/snackbars/#change-transition
- https://material-ui.com/components/snackbars/#control-slide-direction

Clicking the different options requires two clicks between them. This is different for the other examples.