### PR TITLE
[Autocomplete] Fix iOS double tap

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -16,8 +16,14 @@ export { createFilterOptions };
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
-    '&:hover $clearIndicatorDirty, &$focused $clearIndicatorDirty': {
+    '&$focused $clearIndicatorDirty': {
       visibility: 'visible',
+    },
+    /* Avoid double tap issue on iOS */
+    '@media (pointer: fine)': {
+      '&:hover $clearIndicatorDirty': {
+        visibility: 'visible',
+      },
     },
   },
   /* Styles applied to the root element if `fullWidth={true}`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes #21049 - [AutoComplete] Requires two clicks to open on mobile ios after state is set 
Based on code by @oliviertassinari, thanks for the help!