### PR TITLE
[AppBar] Fix z-index issue on Firefox

### DIFF
--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -48,7 +48,6 @@ export const styles = (theme) => {
     /* Styles applied to the root element if `position="static"`. */
     positionStatic: {
       position: 'static',
-      transform: 'translateZ(0)', // Make sure we can see the elevation.
     },
     /* Styles applied to the root element if `position="relative"`. */
     positionRelative: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Removed  transform: 'translateZ(0)' from AppBar styles.

Closes #20963