### PR TITLE
[core] Small changes

### DIFF
--- a/docs/pages/api-docs/click-away-listener.md
+++ b/docs/pages/api-docs/click-away-listener.md
@@ -28,7 +28,7 @@ For instance, if you need to hide a menu when people click anywhere else on your
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The wrapped element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
-| <span class="prop-name">disableReactTree</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | The mouse event to listen to. You can disable the listener by providing `false`. |
+| <span class="prop-name">disableReactTree</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the React tree is ignored and only the DOM tree is considered. This prop changes how portaled elements are handled. |
 | <span class="prop-name">mouseEvent</span> | <span class="prop-type">'onClick'<br>&#124;&nbsp;'onMouseDown'<br>&#124;&nbsp;'onMouseUp'<br>&#124;&nbsp;false</span> | <span class="prop-default">'onClick'</span> | The mouse event to listen to. You can disable the listener by providing `false`. |
 | <span class="prop-name required">onClickAway&nbsp;*</span> | <span class="prop-type">func</span> |  | Callback fired when a "click away" event is detected. |
 | <span class="prop-name">touchEvent</span> | <span class="prop-type">'onTouchEnd'<br>&#124;&nbsp;'onTouchStart'<br>&#124;&nbsp;false</span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -98,7 +98,7 @@ const useDemoToolbarStyles = makeStyles(
         margin: '8px 0',
       },
       toggleButton: {
-        height: 32,
+        padding: '4px 9px',
       },
       tooltip: {
         zIndex: theme.zIndex.appBar - 1,

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -43,24 +43,26 @@ export default function DiamondSponsors(props) {
       <Typography variant="caption" color="textSecondary" display="block" gutterBottom>
         {t('diamondSponsors')}
       </Typography>
-      <a
-        data-ga-event-category="sponsor"
-        data-ga-event-action={spot}
-        data-ga-event-label="sencha"
-        href="https://www.sencha.com/products/extreact/extreact-for-material-ui/?utm_source=materialui&utm_medium=referral&utm_content=product-200429-extreactmaterialui"
-        rel="noopener noreferrer sponsored"
-        target="_blank"
-        style={{ marginLeft: 8, width: 125, height: 35 }}
-      >
-        <img
-          width="125"
-          height="35"
-          src="/static/in-house/sencha-125x35.svg"
-          alt="sencha"
-          title="UI Components for Productive Dev Teams"
-          loading="lazy"
-        />
-      </a>
+      {t && !t ? (
+        <a
+          data-ga-event-category="sponsor"
+          data-ga-event-action={spot}
+          data-ga-event-label="sencha"
+          href="https://www.sencha.com/products/extreact/extreact-for-material-ui/?utm_source=materialui&utm_medium=referral&utm_content=product-200429-extreactmaterialui"
+          rel="noopener noreferrer sponsored"
+          target="_blank"
+          style={{ marginLeft: 8, width: 125, height: 35 }}
+        >
+          <img
+            width="125"
+            height="35"
+            src="/static/in-house/sencha-125x35.svg"
+            alt="sencha"
+            title="UI Components for Productive Dev Teams"
+            loading="lazy"
+          />
+        </a>
+      ) : null}
       <a
         style={{ marginTop: 8 }}
         aria-label={t('diamondSponsors')}

--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -195,7 +195,7 @@ const pages = [
   },
   {
     pathname: 'https://material-ui.com/store/',
-    title: 'Store',
+    title: 'Premium themes',
     linkProps: {
       'data-ga-event-category': 'store',
       'data-ga-event-action': 'click',

--- a/docs/src/pages/components/tabs/AccessibleTabs.js
+++ b/docs/src/pages/components/tabs/AccessibleTabs.js
@@ -14,8 +14,8 @@ function TabPanel(props) {
     <div
       role="tabpanel"
       hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
+      id={`a11y-tabpanel-${index}`}
+      aria-labelledby={`a11y-tab-${index}`}
       {...other}
     >
       {value === index && (
@@ -44,9 +44,9 @@ function DemoTabs(props) {
         selectionFollowsFocus={selectionFollowsFocus}
         value={value}
       >
-        <Tab label="Item One" aria-controls="simple-tabpanel-0" id="simple-tab-0" />
-        <Tab label="Item Two" aria-controls="simple-tabpanel-1" id="simple-tab-1" />
-        <Tab label="Item Three" aria-controls="simple-tabpanel-2" id="simple-tab-2" />
+        <Tab label="Item One" aria-controls="a11y-tabpanel-0" id="a11y-tab-0" />
+        <Tab label="Item Two" aria-controls="a11y-tabpanel-1" id="a11y-tab-1" />
+        <Tab label="Item Three" aria-controls="a11y-tabpanel-2" id="a11y-tab-2" />
       </Tabs>
     </AppBar>
   );

--- a/docs/src/pages/components/tabs/AccessibleTabs.tsx
+++ b/docs/src/pages/components/tabs/AccessibleTabs.tsx
@@ -19,8 +19,8 @@ function TabPanel(props: TabPanelProps) {
     <div
       role="tabpanel"
       hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
+      id={`a11y-tabpanel-${index}`}
+      aria-labelledby={`a11y-tab-${index}`}
       {...other}
     >
       {value === index && (
@@ -49,9 +49,9 @@ function DemoTabs(props: DemoTabsProps) {
         selectionFollowsFocus={selectionFollowsFocus}
         value={value}
       >
-        <Tab label="Item One" aria-controls="simple-tabpanel-0" id="simple-tab-0" />
-        <Tab label="Item Two" aria-controls="simple-tabpanel-1" id="simple-tab-1" />
-        <Tab label="Item Three" aria-controls="simple-tabpanel-2" id="simple-tab-2" />
+        <Tab label="Item One" aria-controls="a11y-tabpanel-0" id="a11y-tab-0" />
+        <Tab label="Item Two" aria-controls="a11y-tabpanel-1" id="a11y-tab-1" />
+        <Tab label="Item Three" aria-controls="a11y-tabpanel-2" id="a11y-tab-2" />
       </Tabs>
     </AppBar>
   );

--- a/docs/src/pages/components/tabs/CustomizedTabs.js
+++ b/docs/src/pages/components/tabs/CustomizedTabs.js
@@ -51,7 +51,7 @@ const StyledTabs = withStyles({
     display: 'flex',
     justifyContent: 'center',
     backgroundColor: 'transparent',
-    '& > div': {
+    '& > span': {
       maxWidth: 40,
       width: '100%',
       backgroundColor: '#635ee7',

--- a/docs/src/pages/components/tabs/CustomizedTabs.js
+++ b/docs/src/pages/components/tabs/CustomizedTabs.js
@@ -57,7 +57,7 @@ const StyledTabs = withStyles({
       backgroundColor: '#635ee7',
     },
   },
-})((props) => <Tabs {...props} TabIndicatorProps={{ children: <div /> }} />);
+})((props) => <Tabs {...props} TabIndicatorProps={{ children: <span /> }} />);
 
 const StyledTab = withStyles((theme) => ({
   root: {

--- a/docs/src/pages/components/tabs/CustomizedTabs.tsx
+++ b/docs/src/pages/components/tabs/CustomizedTabs.tsx
@@ -64,7 +64,7 @@ const StyledTabs = withStyles({
       backgroundColor: '#635ee7',
     },
   },
-})((props: StyledTabsProps) => <Tabs {...props} TabIndicatorProps={{ children: <div /> }} />);
+})((props: StyledTabsProps) => <Tabs {...props} TabIndicatorProps={{ children: <span /> }} />);
 
 interface StyledTabProps {
   label: string;

--- a/docs/src/pages/components/tabs/CustomizedTabs.tsx
+++ b/docs/src/pages/components/tabs/CustomizedTabs.tsx
@@ -58,7 +58,7 @@ const StyledTabs = withStyles({
     display: 'flex',
     justifyContent: 'center',
     backgroundColor: 'transparent',
-    '& > div': {
+    '& > span': {
       maxWidth: 40,
       width: '100%',
       backgroundColor: '#635ee7',

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -226,7 +226,7 @@
     "/styles": "Styles",
     "/styles/basics": "Basics",
     "/styles/advanced": "Advanced",
-    "https://material-ui.com/store/": "Store",
+    "https://material-ui.com/store/": "Premium themes",
     "/components/material-icons": "Material Icons",
     "/components/textarea-autosize": "Textarea Autosize",
     "/components/rating": "Rating",

--- a/packages/material-ui-lab/src/Pagination/Pagination.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.js
@@ -35,7 +35,7 @@ const Pagination = React.forwardRef(function Pagination(props, ref) {
     count,
     defaultPage,
     disabled,
-    getItemAriaLabel: getAriaLabel = defaultGetAriaLabel,
+    getItemAriaLabel = defaultGetAriaLabel,
     hideNextButton,
     hidePrevButton,
     onChange,
@@ -65,7 +65,7 @@ const Pagination = React.forwardRef(function Pagination(props, ref) {
             {renderItem({
               ...item,
               color,
-              'aria-label': getAriaLabel(item.type, item.page, item.selected),
+              'aria-label': getItemAriaLabel(item.type, item.page, item.selected),
               shape,
               size,
               variant,

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.d.ts
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.d.ts
@@ -6,7 +6,8 @@ export interface ClickAwayListenerProps {
    */
   children: React.ReactNode;
   /**
-   * The mouse event to listen to. You can disable the listener by providing `false`.
+   * If `true`, the React tree is ignored and only the DOM tree is considered.
+   * This prop changes how portaled elements are handled.
    */
   disableReactTree?: boolean;
   /**

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -159,7 +159,8 @@ ClickAwayListener.propTypes = {
    */
   children: elementAcceptingRef.isRequired,
   /**
-   * The mouse event to listen to. You can disable the listener by providing `false`.
+   * If `true`, the React tree is ignored and only the DOM tree is considered.
+   * This prop changes how portaled elements are handled.
    */
   disableReactTree: PropTypes.bool,
   /**

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -226,7 +226,7 @@ describe('<ClickAwayListener />', () => {
     ['onClickCapture', false],
     ['onClickCapture', true],
   ].forEach(([eventName, disableReactTree]) => {
-    it(`when 'disableRectTree=${disableReactTree}' ${eventName} triggers onClickAway if an outside target is removed`, () => {
+    it(`when 'disableRectTree=${disableReactTree}' ${eventName} triggers onClickAway if an outside target is removed`, function test() {
       if (!new Event('click').composedPath) {
         this.skip();
       }
@@ -251,7 +251,7 @@ describe('<ClickAwayListener />', () => {
       expect(handleClickAway.callCount).to.equal(1);
     });
 
-    it(`when 'disableRectTree=${disableReactTree}' ${eventName} does not trigger onClickAway if an inside target is removed`, () => {
+    it(`when 'disableRectTree=${disableReactTree}' ${eventName} does not trigger onClickAway if an inside target is removed`, function test() {
       if (!new Event('click').composedPath) {
         this.skip();
       }

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import Portal from '../Portal';
 import ClickAwayListener from './ClickAwayListener';
 
@@ -218,5 +218,60 @@ describe('<ClickAwayListener />', () => {
     );
     fireEvent.click(document.body);
     expect(handleClickAway.callCount).to.equal(0);
+  });
+
+  [
+    ['onClick', false],
+    ['onClick', true],
+    ['onClickCapture', false],
+    ['onClickCapture', true],
+  ].forEach(([eventName, disableReactTree]) => {
+    it(`when 'disableRectTree=${disableReactTree}' ${eventName} triggers onClickAway if an outside target is removed`, () => {
+      if (!new Event('click').composedPath) {
+        this.skip();
+      }
+
+      const handleClickAway = spy();
+      function Test() {
+        const [buttonShown, hideButton] = React.useReducer(() => false, true);
+
+        return (
+          <React.Fragment>
+            {buttonShown && <button {...{ [eventName]: hideButton }} type="button" />}
+            <ClickAwayListener onClickAway={handleClickAway} disableReactTree={disableReactTree}>
+              <div />
+            </ClickAwayListener>
+          </React.Fragment>
+        );
+      }
+      render(<Test />);
+
+      screen.getByRole('button').click();
+
+      expect(handleClickAway.callCount).to.equal(1);
+    });
+
+    it(`when 'disableRectTree=${disableReactTree}' ${eventName} does not trigger onClickAway if an inside target is removed`, () => {
+      if (!new Event('click').composedPath) {
+        this.skip();
+      }
+
+      const handleClickAway = spy();
+
+      function Test() {
+        const [buttonShown, hideButton] = React.useReducer(() => false, true);
+
+        return (
+          <ClickAwayListener onClickAway={handleClickAway} disableReactTree={disableReactTree}>
+            <div>{buttonShown && <button {...{ [eventName]: hideButton }} type="button" />}</div>
+          </ClickAwayListener>
+        );
+      }
+      render(<Test />);
+
+      screen.getByRole('button').click();
+
+      expect(handleClickAway.callCount).to.equal(0);
+    });
   });
 });

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -385,7 +385,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   });
 
   const range = Array.isArray(valueDerived);
-  const instanceRef = React.useRef();
   let values = range ? valueDerived.slice().sort(asc) : [valueDerived];
   values = values.map((value) => clamp(value, min, max));
   const marks =
@@ -394,10 +393,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
           value: min + step * index,
         }))
       : marksProp || [];
-
-  instanceRef.current = {
-    source: valueDerived, // Keep track of the input value to leverage immutable state comparison.
-  };
 
   const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
   const [focusVisible, setFocusVisible] = React.useState(-1);

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -116,8 +116,7 @@ function findNativeHandler({ domTreeShapes, start, current, anchor }) {
   });
 }
 
-const disableSwipeToOpenDefault =
-  typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
+const iOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
 const transitionDurationDefault = { enter: duration.enteringScreen, exit: duration.leavingScreen };
 
 const useEnhancedEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
@@ -129,7 +128,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
     anchor = 'left',
     disableBackdropTransition = false,
     disableDiscovery = false,
-    disableSwipeToOpen = disableSwipeToOpenDefault,
+    disableSwipeToOpen = iOS,
     hideBackdrop,
     hysteresis = 0.52,
     minFlingVelocity = 450,

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -184,7 +184,7 @@ describe('<Tooltip />', () => {
     expect(handleRequestOpen.callCount).to.equal(1);
     expect(handleClose.callCount).to.equal(0);
     fireEvent.mouseLeave(getByRole('button'));
-    clock.tick(10);
+    clock.tick(0);
     expect(handleRequestOpen.callCount).to.equal(1);
     expect(handleClose.callCount).to.equal(1);
   });

--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -11,7 +11,6 @@ export interface UseControlledProps<T = unknown> {
    * The component name displayed in warnings.
    */
   name: string;
-
   /**
    * The name of the state variable displayed in warnings.
    */

--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -5,6 +5,7 @@ const whitelist = [
   // required for fake getComputedStyle
   'CSSStyleDeclaration',
   'Element',
+  'Event',
   'Image',
   'HTMLElement',
   'HTMLInputElement',


### PR DESCRIPTION
- [SwipeableDrawer] Rename prop to add more information and match docs ea3e04f
- [docs] Restore the correct padding on JS/TS toggle fafcd5a: 

<img width="138" alt="Capture d’écran 2020-05-17 à 00 17 02" src="https://user-images.githubusercontent.com/3165635/82131275-c3f92480-97d3-11ea-90ec-2e0edebbe2a5.png">

- [Slider] Remove dead code 0b891cb
- [core] Remove blank line 50aa48f
- [Tooltip] No need to wait 10ms 1699663
- [Pagination] No need to rename the prop 8c4a23b
- [docs] Store is too broad 189a0e9: feedback from one of the author, Bootlab.
- [ClickAwayListener] Fix wrong `disableReactTree` description 9199935: Follow-up on #20994
- [ClickAwayListener] Add more tests 92a314c: Follow-up on #20994
- [Tabs] Fix a few HTML warnings 1651c11: https://validator.w3.org/nu/?showsource=yes&showoutline=yes&showimagereport=yes&doc=https%3A%2F%2Fmaster--material-ui.netlify.app%2Fcomponents%2Ftabs%2F
- [docs] Re-enable Sencha next month 812ac78