### PR TITLE
[docs] Add CssBaseline to auto dark mode example

### DIFF
--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -156,6 +156,7 @@ For instance, you can enable the dark mode automatically:
 import React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -172,6 +173,7 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
+      <CssBaseline/>
       <Routes />
     </ThemeProvider>
   );


### PR DESCRIPTION
The updated code example that enables dark mode automatically, will now alter the page background to make the newly coloured text readable.

Summary of changes.

I introduce the CssBaseline import, and add the CssBaseline Component within ThemeProvider.

This is previewed, and tested for proper syntax and result.

Please see https://github.com/mui-org/material-ui/issues/21092 for more.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #21092 