### PR TITLE
Add issue template for material design issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/3.material-design.md
+++ b/.github/ISSUE_TEMPLATE/3.material-design.md
@@ -1,5 +1,5 @@
 ---
 name: Material design issue
 about: An issue with one of our components regarding the Material design guidelines.
-labels: 'status: needs triage', 'material design system'
+labels: 'status: needs triage, material design system'
 ---

--- a/.github/ISSUE_TEMPLATE/3.material-design.md
+++ b/.github/ISSUE_TEMPLATE/3.material-design.md
@@ -1,0 +1,5 @@
+---
+name: Material design issue
+about: An issue with one of our components regarding the Material design guidelines.
+labels: 'status: needs triage', 'material design system'
+---


### PR DESCRIPTION
This will primarily be used by the material design team to create issues. Since we don't know the volume yet they're opened with a new status label `status: needs triage`. 

I want to try out github projects for these issues. Could a repo admin enable these please (@oliviertassinari). We'll see how that goes.