### PR TITLE
[test] Reduce SkeletonChildren flakyness

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -75,6 +75,7 @@ const blacklist = [
   'docs-components-selects/GroupedSelect.png', // Needs interaction
   'docs-components-skeleton/Animations.png', // Animation disabled
   'docs-components-skeleton/Facebook.png', // Flaky image loading
+  'docs-components-skeleton/SkeletonChildren.png', // flaky image loading
   'docs-components-skeleton/YouTube.png', // Flaky image loading
   'docs-components-snackbars/ConsecutiveSnackbars.png', // Needs interaction
   'docs-components-snackbars/CustomizedSnackbars.png', // Redundant

--- a/test/regressions/tests/Skeleton/SkeletonChildren.js
+++ b/test/regressions/tests/Skeleton/SkeletonChildren.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Typography from '@material-ui/core/Typography';
+import Avatar from '@material-ui/core/Avatar';
+import Skeleton from '@material-ui/lab/Skeleton';
+
+export default function SkeletonChildren() {
+  return (
+    <React.Fragment>
+      <CssBaseline />
+      <div style={{ alignItems: 'center', display: 'flex', width: '200px' }}>
+        <div style={{ margin: '8px' }}>
+          <Skeleton variant="circle">
+            <Avatar />
+          </Skeleton>
+        </div>
+        <div style={{ width: '100%' }}>
+          <Skeleton width="100%">
+            <Typography>.</Typography>
+          </Skeleton>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
Extracts the parts of `docs/src/pages/components/skeleton/SkeletonTypography.js` that do not depend on external resources. They're not relevant for the regression test.