### PR TITLE
[Skeleton] Improve contrast on light themes

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -7,7 +7,7 @@ export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
     display: 'block',
-    // create a "on paper" color with sufficient contrast
+    // Create a "on paper" color with sufficient contrast.
     backgroundColor: fade(theme.palette.text.primary, 0.16),
     height: '1.2em',
   },

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { fade, withStyles } from '@material-ui/core/styles';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
     display: 'block',
-    backgroundColor: theme.palette.action.hover,
+    // create a "on paper" color with sufficient contrast
+    backgroundColor: fade(theme.palette.text.primary, 0.16),
     height: '1.2em',
   },
   /* Styles applied to the root element if `variant="text"`. */


### PR DESCRIPTION
Breaking Change: Skeleton no longer reuses `theme.palette.action.hover` for its background color but fades to 16% of the primary text color.

I cannot see the Skeleton in light mode on one of my monitors. Might be I'm getting old (even more reason to fix it), or my monitor is bad (also a reason a to fix it) but it's also using a color that is used for different purposes just because it had the same color: `:hover` is not necessarily a good semantic for placeholder UIs. 

In absence of a material design guide I'm fading the "on paper" color to 16%. Ideally the material guidelines would have values for these "loading"-states for primary/secondary and background color so that we could apply a systematic approach to `Skeleton`, `CircularProgress` and `LinearProgress`. 
