### PR TITLE
[SvgIcon] Add displayName in react-devtools

### DIFF
--- a/packages/material-ui/src/utils/createSvgIcon.js
+++ b/packages/material-ui/src/utils/createSvgIcon.js
@@ -12,6 +12,8 @@ export default function createSvgIcon(path, displayName) {
   );
 
   if (process.env.NODE_ENV !== 'production') {
+    // Need to set `displayName` on the inner component for React.memo.
+    // React prior to 16.14 ignores `displayName` on the wrapper.
     Component.displayName = `${displayName}Icon`;
   }
 

--- a/packages/material-ui/src/utils/createSvgIcon.js
+++ b/packages/material-ui/src/utils/createSvgIcon.js
@@ -5,12 +5,10 @@ import SvgIcon from '../SvgIcon';
  * Private module reserved for @material-ui/x packages.
  */
 export default function createSvgIcon(path, displayName) {
-  const Component = React.memo(
-    React.forwardRef((props, ref) => (
-      <SvgIcon data-mui-test={`${displayName}Icon`} ref={ref} {...props}>
-        {path}
-      </SvgIcon>
-    )),
+  const Component = (props, ref) => (
+    <SvgIcon data-mui-test={`${displayName}Icon`} ref={ref} {...props}>
+      {path}
+    </SvgIcon>
   );
 
   if (process.env.NODE_ENV !== 'production') {
@@ -19,5 +17,5 @@ export default function createSvgIcon(path, displayName) {
 
   Component.muiName = SvgIcon.muiName;
 
-  return Component;
+  return React.memo(React.forwardRef(Component));
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

I checked in  the devtool I cannot see Icon display name.

Before

![Screen Shot 2020-05-21 at 10 48 20](https://user-images.githubusercontent.com/17973301/82522131-b2f14000-9b52-11ea-8852-af881d71d9da.png)

After

![Screen Shot 2020-05-21 at 10 49 38](https://user-images.githubusercontent.com/17973301/82522155-bedd0200-9b52-11ea-95fc-bf5b652002b4.png)

Not sure if it related to the PR here https://github.com/facebook/react/pull/17274
