### PR TITLE
Add component props to ComponentCreator types

### DIFF
--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -20,7 +20,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
 >(
   styles:
     | CreateCSSProperties<Props>
-    | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
+    | ((props: { theme: Theme } & Props & React.ComponentProps<Component>) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>
 ) => React.ComponentType<
   Omit<


### PR DESCRIPTION
Injected styled component props to `styles` argument of `ComponentCreator` when used as `function`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
