### PR TITLE
[Avatar] Fix group positioning

### DIFF
--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -20,6 +20,9 @@ export const styles = (theme) => ({
   avatar: {
     border: `2px solid ${theme.palette.background.default}`,
     marginLeft: -8,
+    '&:first-child': {
+      marginLeft: 0,
+    },
   },
 });
 
@@ -51,6 +54,8 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
 
   const extraAvatars = children.length > clampedMax ? children.length - clampedMax + 1 : 0;
 
+  const marginLeft = spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing;
+
   return (
     <div className={clsx(classes.root, className)} ref={ref} {...other}>
       {children.slice(0, children.length - extraAvatars).map((child, index) => {
@@ -58,7 +63,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className: clsx(child.props.className, classes.avatar),
           style: {
             zIndex: children.length - index,
-            marginLeft: spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing,
+            marginLeft: index === 0 ? undefined : marginLeft,
             ...child.props.style,
           },
         });
@@ -68,7 +73,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className={classes.avatar}
           style={{
             zIndex: 0,
-            marginLeft: spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing,
+            marginLeft,
           }}
         >
           +{extraAvatars}


### PR DESCRIPTION
Screenshot from docs:
![Screen Shot 2020-05-21 at 7 31 26 PM](https://user-images.githubusercontent.com/932566/82618812-b956da80-9b99-11ea-975e-32ac967ae6ce.png)

Easily fixed by not applying negative margin to first child

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
