### PR TITLE
[docs] Replace typefaces with fontsource

### DIFF
--- a/docs/src/pages/components/typography/typography.md
+++ b/docs/src/pages/components/typography/typography.md
@@ -26,20 +26,20 @@ Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 ## Install with npm
 
-You can [install it](https://www.npmjs.com/package/typeface-roboto) by typing the below command in your terminal:
+You can [install it](https://www.npmjs.com/package/fontsource-roboto) by typing the below command in your terminal:
 
-`npm install typeface-roboto --save`
+`npm install fontsource-roboto`
 
 Then, you can import it in your entry-point.
 
 ```js
-import 'typeface-roboto';
+import 'fontsource-roboto';
 ```
 
-For more info check out the [typeface](https://github.com/KyleAMathews/typefaces/tree/master/packages/roboto) project.
+For more info check out [Fontsource](https://github.com/DecliningLotus/fontsource/blob/master/packages/roboto/README.md).
 
 ⚠️ Be careful when using this approach.
-Make sure your bundler doesn't eager load all the font variations (100/300/400/500/700/900, italic/regular, SVG/woff).
+Make sure your bundler doesn't eager load all the font variations (100/300/400/500/700/900, italic/regular, SVG/woff). Fontsource can be configured to load specific subsets, weights and styles.
 Inlining all the font files can significantly increase the size of your bundle.
 Material-UI default typography configuration only relies on 300, 400, 500, and 700 font weights.
 


### PR DESCRIPTION
Replaced the ageing Typefaces project with a link to Fontsource, a newly actively maintained Open Source NPM font packager. Link : https://github.com/DecliningLotus/fontsource

The Typefaces project has somewhat been neglected over the years and has a long list of issues and pull requests that have left it outdated. Although very understandable, as I can imagine Kyle is very busy developing for Gatsby.

Fontsource is a major rebuild of this project, with added features such as the ability to choose subsets, weights and styles. It also clears up all the bugs from the previous project, checks for updates on Google Fonts on a weekly basis via Github Actions, has far more in-depth documentation and is also adding a lot more Open Source fonts that haven't been added by the original Typefaces project.

Let me know if there are any concerns and thoughts toward this!