### PR TITLE
[Transition] Prevent passing undefined argument to callbacks

### DIFF
--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -83,7 +83,12 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      callback(node, isAppearing);
+      const isExitCallback = isAppearing === undefined;
+      if (isExitCallback) {
+        callback(node);
+      } else {
+        callback(node, isAppearing);
+      }
     }
   };
 

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -83,8 +83,9 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      const isExitCallback = isAppearing === undefined;
-      if (isExitCallback) {
+
+      // onEnterXxx and onExitXxx callbacks have a different arguments.length value.
+      if (isAppearing === undefined) {
         callback(node);
       } else {
         callback(node, isAppearing);

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -53,7 +53,12 @@ const Fade = React.forwardRef(function Fade(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      callback(node, isAppearing);
+      const isExitCallback = isAppearing === undefined;
+      if (isExitCallback) {
+        callback(node);
+      } else {
+        callback(node, isAppearing);
+      }
     }
   };
 

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -53,8 +53,9 @@ const Fade = React.forwardRef(function Fade(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      const isExitCallback = isAppearing === undefined;
-      if (isExitCallback) {
+
+      // onEnterXxx and onExitXxx callbacks have a different arguments.length value.
+      if (isAppearing === undefined) {
         callback(node);
       } else {
         callback(node, isAppearing);

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -56,8 +56,9 @@ const Grow = React.forwardRef(function Grow(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      const isExitCallback = isAppearing === undefined;
-      if (isExitCallback) {
+
+      // onEnterXxx and onExitXxx callbacks have a different arguments.length value.
+      if (isAppearing === undefined) {
         callback(node);
       } else {
         callback(node, isAppearing);

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -101,7 +101,12 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
   const normalizedTransitionCallback = (callback) => (isAppearing) => {
     if (callback) {
-      callback(childrenRef.current, isAppearing);
+      const isExitCallback = isAppearing === undefined;
+      if (isExitCallback) {
+        callback(childrenRef.current);
+      } else {
+        callback(childrenRef.current, isAppearing);
+      }
     }
   };
 

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -101,8 +101,8 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
   const normalizedTransitionCallback = (callback) => (isAppearing) => {
     if (callback) {
-      const isExitCallback = isAppearing === undefined;
-      if (isExitCallback) {
+      // onEnterXxx and onExitXxx callbacks have a different arguments.length value.
+      if (isAppearing === undefined) {
         callback(childrenRef.current);
       } else {
         callback(childrenRef.current, isAppearing);

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -55,7 +55,12 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      callback(node, isAppearing);
+      const isExitCallback = isAppearing === undefined;
+      if (isExitCallback) {
+        callback(node);
+      } else {
+        callback(node, isAppearing);
+      }
     }
   };
 

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -55,8 +55,9 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
       const [node, isAppearing] = enableStrictModeCompat
         ? [nodeRef.current, nodeOrAppearing]
         : [nodeOrAppearing, maybeAppearing];
-      const isExitCallback = isAppearing === undefined;
-      if (isExitCallback) {
+
+      // onEnterXxx and onExitXxx callbacks have a different arguments.length value.
+      if (isAppearing === undefined) {
         callback(node);
       } else {
         callback(node, isAppearing);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

**Fixes:** https://github.com/mui-org/material-ui/issues/21091

This PR applies changes so we have a consistent logic for normalising transition callbacks.

So the existing logic in `Grow` component:
https://github.com/mui-org/material-ui/blob/dd9280e753eb8dc3444a26e85fe4f800b759cad2/packages/material-ui/src/Grow/Grow.js#L54-L66

is copy-pasted for other `Transition` components.