### PR TITLE
Adapt CONTRIBUTING.md for https instead of SSH git clone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ git checkout -b my-topic-branch
 6. Make changes, commit and push to your fork:
 
 ```sh
+git push --set-upstream origin my-topic-branch
 git push -u
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,9 @@ When in doubt, keep your Pull Requests small. To give a Pull Request the best ch
 2. Clone the fork to your local machine and add upstream remote:
 
 ```sh
-git clone git@github.com:<yourname>/material-ui.git
+git clone https://github.com/<your username>/material-ui.git
 cd material-ui
-git remote add upstream git@github.com:mui-org/material-ui.git
+git remote add upstream https://github.com/mui-org/material-ui.git
 ```
 
 3. Synchronize your local `master` branch with the upstream one:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

I followed the instructions on CONTRIBUTING.md but got stuck because I don't have an SSH key. Therefore I adapted the instructions, so it can be followed for people with and without SSH key.