### PR TITLE
[LinearProgress] Set aria-valuemin and aria-valuemax

### DIFF
--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -184,6 +184,8 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
   if (variant === 'determinate' || variant === 'buffer') {
     if (value !== undefined) {
       rootProps['aria-valuenow'] = Math.round(value);
+      rootProps['aria-valuemin'] = 0;
+      rootProps['aria-valuemax'] = 100;
       let transform = value - 100;
       if (theme.direction === 'rtl') {
         transform = -transform;

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -82,7 +82,6 @@ describe('<LinearProgress />', () => {
     const progressbar = screen.getByRole('progressbar');
 
     expect(progressbar.children[0]).to.have.nested.property('style.transform', 'translateX(-23%)');
-    expect(progressbar).to.have.attribute('aria-valuenow', '77');
   });
 
   it('should render with buffer classes for the primary color by default', () => {
@@ -140,6 +139,13 @@ describe('<LinearProgress />', () => {
     expect(progressbar.children[0]).to.have.class(classes.barColorPrimary);
     expect(progressbar.children[1]).to.have.class(classes.barColorPrimary);
     expect(progressbar.children[1]).to.have.class(classes.bar2Indeterminate);
+  });
+
+  it('exposes the current value to screen readers when determinate', () => {
+    render(<LinearProgress variant="determinate" value={77} />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).to.have.attribute('aria-valuenow', '77');
   });
 
   describe('prop: value', () => {

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import { createClientRender, screen } from 'test/utils/createClientRender';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import LinearProgress from './LinearProgress';
 
 describe('<LinearProgress />', () => {
   const mount = createMount();
-  let shallow;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<LinearProgress />);
   });
 
@@ -25,110 +25,121 @@ describe('<LinearProgress />', () => {
   }));
 
   it('should render indeterminate variant by default', () => {
-    const wrapper = shallow(<LinearProgress />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.hasClass(classes.indeterminate)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.bar1Indeterminate)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.bar2Indeterminate)).to.equal(true);
+    render(<LinearProgress />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).to.have.class(classes.root);
+    expect(progressbar).to.have.class(classes.indeterminate);
+    expect(progressbar.children[0]).to.have.class(classes.bar1Indeterminate);
+    expect(progressbar.children[1]).to.have.class(classes.bar2Indeterminate);
   });
 
-  it('should render for the primary color', () => {
-    const wrapper = shallow(<LinearProgress color="primary" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
+  it('should render for the primary color by default', () => {
+    render(<LinearProgress />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar.children[0]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.barColorPrimary);
   });
 
   it('should render for the secondary color', () => {
-    const wrapper = shallow(<LinearProgress color="secondary" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorSecondary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorSecondary)).to.equal(true);
+    render(<LinearProgress color="secondary" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar.children[0]).to.have.class(classes.barColorSecondary);
+    expect(progressbar.children[1]).to.have.class(classes.barColorSecondary);
   });
 
   it('should render with determinate classes for the primary color by default', () => {
-    const wrapper = shallow(<LinearProgress value={1} variant="determinate" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.bar1Determinate)).to.equal(true);
+    render(<LinearProgress value={1} variant="determinate" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).to.have.class(classes.determinate);
+    expect(progressbar.children[0]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[0]).to.have.class(classes.bar1Determinate);
   });
 
   it('should render with determinate classes for the primary color', () => {
-    const wrapper = shallow(<LinearProgress color="primary" value={1} variant="determinate" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.bar1Determinate)).to.equal(true);
+    render(<LinearProgress color="primary" value={1} variant="determinate" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).to.have.class(classes.determinate);
+    expect(progressbar.children[0]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[0]).to.have.class(classes.bar1Determinate);
   });
 
   it('should render with determinate classes for the secondary color', () => {
-    const wrapper = shallow(<LinearProgress color="secondary" value={1} variant="determinate" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorSecondary)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.bar1Determinate)).to.equal(true);
+    render(<LinearProgress color="secondary" value={1} variant="determinate" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).to.have.class(classes.determinate);
+    expect(progressbar.children[0]).to.have.class(classes.barColorSecondary);
+    expect(progressbar.children[0]).to.have.class(classes.bar1Determinate);
   });
 
   it('should set width of bar1 on determinate variant', () => {
-    const wrapper = shallow(<LinearProgress variant="determinate" value={77} />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
-    expect(wrapper.childAt(0).props().style.transform).to.equal('translateX(-23%)');
-    expect(wrapper.props()['aria-valuenow']).to.equal(77);
+    render(<LinearProgress variant="determinate" value={77} />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar.children[0]).to.have.nested.property('style.transform', 'translateX(-23%)');
+    expect(progressbar).to.have.attribute('aria-valuenow', '77');
   });
 
   it('should render with buffer classes for the primary color by default', () => {
-    const wrapper = shallow(<LinearProgress value={1} valueBuffer={1} variant="buffer" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.dashedColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.bar1Buffer)).to.equal(true);
-    expect(wrapper.childAt(2).hasClass(classes.colorPrimary)).to.equal(true);
-    expect(wrapper.childAt(2).hasClass(classes.bar2Buffer)).to.equal(true);
+    render(<LinearProgress value={1} valueBuffer={1} variant="buffer" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar.children[0]).to.have.class(classes.dashedColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.bar1Buffer);
+    expect(progressbar.children[2]).to.have.class(classes.colorPrimary);
+    expect(progressbar.children[2]).to.have.class(classes.bar2Buffer);
   });
 
   it('should render with buffer classes for the primary color', () => {
-    const wrapper = shallow(
-      <LinearProgress value={1} valueBuffer={1} color="primary" variant="buffer" />,
-    );
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.dashedColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.bar1Buffer)).to.equal(true);
-    expect(wrapper.childAt(2).hasClass(classes.colorPrimary)).to.equal(true);
-    expect(wrapper.childAt(2).hasClass(classes.bar2Buffer)).to.equal(true);
+    render(<LinearProgress value={1} valueBuffer={1} color="primary" variant="buffer" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar.children[0]).to.have.class(classes.dashedColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.bar1Buffer);
+    expect(progressbar.children[2]).to.have.class(classes.colorPrimary);
+    expect(progressbar.children[2]).to.have.class(classes.bar2Buffer);
   });
 
   it('should render with buffer classes for the secondary color', () => {
-    const wrapper = shallow(
-      <LinearProgress value={1} valueBuffer={1} color="secondary" variant="buffer" />,
-    );
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.dashedColorSecondary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorSecondary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.bar1Buffer)).to.equal(true);
-    expect(wrapper.childAt(2).hasClass(classes.colorSecondary)).to.equal(true);
-    expect(wrapper.childAt(2).hasClass(classes.bar2Buffer)).to.equal(true);
+    render(<LinearProgress value={1} valueBuffer={1} color="secondary" variant="buffer" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar.children[0]).to.have.class(classes.dashedColorSecondary);
+    expect(progressbar.children[1]).to.have.class(classes.barColorSecondary);
+    expect(progressbar.children[1]).to.have.class(classes.bar1Buffer);
+    expect(progressbar.children[2]).to.have.class(classes.colorSecondary);
+    expect(progressbar.children[2]).to.have.class(classes.bar2Buffer);
   });
 
   it('should set width of bar1 and bar2 on buffer variant', () => {
-    const wrapper = shallow(<LinearProgress variant="buffer" value={77} valueBuffer={85} />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.childAt(1).props().style.transform).to.equal('translateX(-23%)');
-    expect(wrapper.childAt(2).props().style.transform).to.equal('translateX(-15%)');
+    render(<LinearProgress variant="buffer" value={77} valueBuffer={85} />);
+
+    expect(document.querySelector(`.${classes.bar1Buffer}`)).to.have.nested.property(
+      'style.transform',
+      'translateX(-23%)',
+    );
+    expect(document.querySelector(`.${classes.bar2Buffer}`)).to.have.nested.property(
+      'style.transform',
+      'translateX(-15%)',
+    );
   });
 
   it('should render with query classes', () => {
-    const wrapper = shallow(<LinearProgress variant="query" />);
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
-    expect(wrapper.hasClass(classes.query)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(0).hasClass(classes.bar1Indeterminate)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
-    expect(wrapper.childAt(1).hasClass(classes.bar2Indeterminate)).to.equal(true);
+    render(<LinearProgress variant="query" />);
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).to.have.class(classes.query);
+    expect(progressbar.children[0]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[0]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.barColorPrimary);
+    expect(progressbar.children[1]).to.have.class(classes.bar2Indeterminate);
   });
 
   describe('prop: value', () => {
@@ -141,12 +152,15 @@ describe('<LinearProgress />', () => {
     });
 
     it('should warn when not used as expected', () => {
-      shallow(<LinearProgress variant="determinate" value={undefined} />);
+      const { rerender } = render(<LinearProgress variant="determinate" value={undefined} />);
+
       expect(consoleErrorMock.callCount()).to.equal(1);
       expect(consoleErrorMock.messages()[0]).to.match(
         /Material-UI: You need to provide a value prop/,
       );
-      shallow(<LinearProgress variant="buffer" value={undefined} />);
+
+      rerender(<LinearProgress variant="buffer" value={undefined} />);
+
       expect(consoleErrorMock.callCount()).to.equal(3);
       expect(consoleErrorMock.messages()[1]).to.match(
         /Material-UI: You need to provide a value prop/,

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -141,11 +141,13 @@ describe('<LinearProgress />', () => {
     expect(progressbar.children[1]).to.have.class(classes.bar2Indeterminate);
   });
 
-  it('exposes the current value to screen readers when determinate', () => {
+  it('exposes the current, min and max value to screen readers when determinate', () => {
     render(<LinearProgress variant="determinate" value={77} />);
     const progressbar = screen.getByRole('progressbar');
 
     expect(progressbar).to.have.attribute('aria-valuenow', '77');
+    expect(progressbar).to.have.attribute('aria-valuemin', '0');
+    expect(progressbar).to.have.attribute('aria-valuemax', '100');
   });
 
   describe('prop: value', () => {


### PR DESCRIPTION
[`aria-valuemin` and `aria-valuemax` should be set if they are known](https://www.w3.org/TR/wai-aria-1.1/#aria-valuenow). `LinearProgress` always assumes `value` to be in the 0-100 range:

> The value of the progress indicator for the determinate and buffer variants. Value between 0 and 100.

https://material-ui.com/api/linear-progress/#props

Used this opportunity to port to testing-library


