### PR TITLE
[docs] Update minimum TypeScript version to 3.2

### DIFF
--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -36,3 +36,7 @@ It's a must-do for static pages, but it needs to be put in balance with not doin
 
 Material-UI supports the most recent versions of React, starting with ^16.8.0 (the one with the hooks).
 Have a look at the older [versions](https://material-ui.com/versions/) for backward compatibility.
+
+## TypeScript
+
+Material-UI requires a minimum version of TypeScript 3.2.

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -2,7 +2,7 @@
 
 <p class="description">You can add static typing to JavaScript to improve developer productivity and code quality thanks to TypeScript.</p>
 
-Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example. A minimum version of TypeScript 2.8 is required.
+Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example. A minimum version of TypeScript 3.2 is required.
 
 In order for types to work, you have to at least have the following options enabled
 in your `tsconfig.json`:

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -2,7 +2,9 @@
 
 <p class="description">You can add static typing to JavaScript to improve developer productivity and code quality thanks to TypeScript.</p>
 
-Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example. A minimum version of TypeScript 3.2 is required.
+Material-UI requires a minimum version of TypeScript 3.2.
+
+Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example.
 
 In order for types to work, you have to at least have the following options enabled
 in your `tsconfig.json`:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

We might want to consider bumping the minimum version in MUI v5 again because https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0 no longer supports TypeScript 3.2. It would also allow us to use trailing commas for better diffs and revert https://github.com/mui-org/material-ui/pull/20443

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
