### PR TITLE
[docs] Track pixel ratio

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -128,6 +128,11 @@ function usePersistCodeVariant() {
   return codeVariant;
 }
 
+/**
+ * basically just a `useAnalytics` hook.
+ * However, it needs the redux store which is created
+ * in the same component this "hook" is used.
+ */
 function Analytics() {
   React.useEffect(() => {
     loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
@@ -170,6 +175,8 @@ function Analytics() {
       matchMedia = null;
     };
   }, []);
+
+  return null;
 }
 
 // Inspired by

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -143,6 +143,33 @@ function Analytics() {
   React.useEffect(() => {
     window.ga('set', 'dimension2', options.userLanguage);
   }, [options.userLanguage]);
+
+  React.useEffect(() => {
+    /**
+     * @type {null | MediaQueryList}
+     */
+    let matchMedia = null;
+
+    /**
+     * Based on https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#Monitoring_screen_resolution_or_zoom_level_changes
+     * Adjusted to track 3 or more different ratios
+     */
+    function trackDevicePixelRation() {
+      window.ga('set', 'dimension3', window.devicePixelRatio);
+
+      matchMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+      // Need to setup again.
+      // Otherwise we track only changes from the initial ratio to another.
+      // It would not track 3 or more different monitors/zoom stages
+      matchMedia.addListener(trackDevicePixelRation);
+    }
+
+    trackDevicePixelRation();
+
+    return () => {
+      matchMedia = null;
+    };
+  }, []);
 }
 
 // Inspired by
@@ -293,7 +320,6 @@ function AppWrapper(props) {
       'https://fonts.googleapis.com/css?family=Roboto+Condensed:700|Work+Sans:300,400&display=swap',
     ];
   }
-
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Helps for decisions when we might want to add special hints for different screen ratios. If we have a big spread of ratios we should include them, otherwise not so much.

Also helpful if creating srcSets for 2x displays is useful.

Used the opportunity to refactor our `PersistState` which is really an "Analytics"-component.