### PR TITLE
[core] Ensure <SelectInput> is correctly focused by 3rd party form libraries

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -66,7 +66,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     name: 'Select',
   });
 
-  const inputRef = React.useRef(null);
+  const [inputRef, setInputRef] = React.useState(null);
   const [displayNode, setDisplayNode] = React.useState(null);
   const { current: isOpenControlled } = React.useRef(openProp != null);
   const [menuMinWidthState, setMenuMinWidthState] = React.useState();
@@ -79,11 +79,20 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       focus: () => {
         displayNode.focus();
       },
-      node: inputRef.current,
+      node: inputRef,
       value,
     }),
-    [displayNode, value],
+    [inputRef, displayNode, value],
   );
+
+  React.useLayoutEffect(() => {
+    if (inputRef) {
+      // Ensure that libraries attempting to focus the hidden input focus the displayNode instead
+      inputRef.focus = function focus() {
+        displayNode.focus();
+      };
+    }
+  }, [inputRef, displayNode]);
 
   React.useEffect(() => {
     if (autoFocus && displayNode) {
@@ -371,7 +380,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       <input
         value={Array.isArray(value) ? value.join(',') : value}
         name={name}
-        ref={inputRef}
+        ref={setInputRef}
         type="hidden"
         autoFocus={autoFocus}
         {...other}

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -162,4 +162,24 @@ describe('<Select> integration', () => {
       expect(container.querySelector('[for="age-simple"]')).not.to.have.class('focused-label');
     });
   });
+
+  describe('hidden input', () => {
+    it('focuses the display node when a 3rd party library attempts to focus the hidden input', () => {
+      const { container, getByRole } = render(
+        <FormControl>
+          <InputLabel id="label">Age</InputLabel>
+          <Select id="input" labelId="label" value="10">
+            <MenuItem value="">none</MenuItem>
+            <MenuItem value="10">Ten</MenuItem>
+          </Select>
+        </FormControl>,
+      );
+
+      // Some 3rd party libraries attemt to call .focus() on the hidden input even though
+      // This won't actually result in a focus event so we test the .focus() method itself
+      container.querySelector('input').focus();
+
+      expect(getByRole('button')).toHaveFocus();
+    });
+  });
 });


### PR DESCRIPTION
Some 3rd party libraries like final-form-focus attempt to focus invalid inputs by calling `.focus()` on the `<input>` of that name.

However for `<SelectInput>` the `<input>` is a hidden input and focusing it does not result in the `<SelectInput>` gaining focus. Additionally the `<input>` does not contain any information that could be used to deduce the correct element to focus.

To deal with this we can replace the input's focus method with one that focuses the correct node. This will ensure that if a 3rd party library tries to focus the SelectInput from the dom the SelectInput actually gains focus.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
