### PR TITLE
[test] Track size of `@material-ui/utils`

### DIFF
--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -87,6 +87,11 @@ async function getSizeLimitBundles() {
       webpack: true,
       path: 'packages/material-ui/build/esm/useScrollTrigger/index.js',
     },
+    {
+      name: '@material-ui/utils',
+      webpack: true,
+      path: 'packages/material-ui-utils/build/esm/index.js',
+    },
   ];
 }
 


### PR DESCRIPTION
> While they kind of forgot about tracking `@material-ui/utils` and its size, `@material-ui/utils` certainly haven't forgotten about them

Motivated by #21214