### PR TITLE
[docs] List all the Tab components under the API section

### DIFF
--- a/docs/pages/api-docs/tab-context.md
+++ b/docs/pages/api-docs/tab-context.md
@@ -33,3 +33,7 @@ The component cannot hold a ref.
 
 Any other props supplied will be provided to the root element (native element).
 
+## Demos
+
+- [Tabs](/components/tabs/)
+

--- a/docs/pages/api-docs/tab-list.md
+++ b/docs/pages/api-docs/tab-list.md
@@ -37,3 +37,7 @@ Any other props supplied will be provided to the root element ([Tabs](/api/tabs/
 The props of the [Tabs](/api/tabs/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Demos
+
+- [Tabs](/components/tabs/)
+

--- a/docs/pages/api-docs/tab-panel.md
+++ b/docs/pages/api-docs/tab-panel.md
@@ -50,3 +50,7 @@ You can override the style of the component thanks to one of these customization
 
 If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TabPanel/TabPanel.js) for more detail.
 
+## Demos
+
+- [Tabs](/components/tabs/)
+

--- a/docs/src/pages/components/tabs/SimpleTabs.js
+++ b/docs/src/pages/components/tabs/SimpleTabs.js
@@ -18,9 +18,10 @@ function TabPanel(props) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-		  <Box p={3} display={value === index ? 'block' : 'none'}>
-	  		<Typography>{children}</Typography>
-  		</Box>
+      {value === index && (
+        <Box p={3}>
+          <Typography>{children}</Typography>
+        </Box>
       )}
     </div>
   );

--- a/docs/src/pages/components/tabs/SimpleTabs.js
+++ b/docs/src/pages/components/tabs/SimpleTabs.js
@@ -18,10 +18,9 @@ function TabPanel(props) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-      {value === index && (
-        <Box p={3}>
-          <Typography>{children}</Typography>
-        </Box>
+		  <Box p={3} display={value === index ? 'block' : 'none'}>
+	  		<Typography>{children}</Typography>
+  		</Box>
       )}
     </div>
   );

--- a/docs/src/pages/components/tabs/tabs.md
+++ b/docs/src/pages/components/tabs/tabs.md
@@ -1,6 +1,6 @@
 ---
 title: Tabs React component
-components: Tabs, Tab, TabScrollButton
+components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel
 ---
 
 # Tabs

--- a/packages/material-ui-lab/src/TabContext/TabContext.d.ts
+++ b/packages/material-ui-lab/src/TabContext/TabContext.d.ts
@@ -17,6 +17,10 @@ export interface TabContextProps {
 }
 /**
  *
+ * Demos:
+ *
+ * - [Tabs](https://material-ui.com/components/tabs/)
+ *
  * API:
  *
  * - [TabContext API](https://material-ui.com/api/tab-context/)

--- a/packages/material-ui-lab/src/TabList/TabList.d.ts
+++ b/packages/material-ui-lab/src/TabList/TabList.d.ts
@@ -13,6 +13,10 @@ export interface TabListTypeMap<
 }
 /**
  *
+ * Demos:
+ *
+ * - [Tabs](https://material-ui.com/components/tabs/)
+ *
  * API:
  *
  * - [TabList API](https://material-ui.com/api/tab-list/)

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.d.ts
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.d.ts
@@ -18,6 +18,10 @@ export interface TabPanelProps
 
 /**
  *
+ * Demos:
+ *
+ * - [Tabs](https://material-ui.com/components/tabs/)
+ *
  * API:
  *
  * - [TabPanel API](https://material-ui.com/api/tab-panel/)


### PR DESCRIPTION
to avoid re-render of tab sub-components on every select of tabs, instead of creating tab sub-components, their visibility can be modified.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
