### PR TITLE
[docs] Fix typo in default palette value

### DIFF
--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -30,7 +30,7 @@ If any of the [`palette.primary`](/customization/default-theme/?expand-path=$.pa
 [`palette.error`](/customization/default-theme/?expand-path=$.palette.error),
 [`palette.warning`](/customization/default-theme/?expand-path=$.palette.warning),
 [`palette.info`](/customization/default-theme/?expand-path=$.palette.info) or
-[`palette.successs`](/customization/default-theme/?expand-path=$.palette.successs)
+[`palette.success`](/customization/default-theme/?expand-path=$.palette.success)
 'intention' objects are provided, they will replace the defaults.
 
 The intention value can either be a [color](/customization/color/) object, or an object with one or more of the keys specified by the following TypeScript interface:


### PR DESCRIPTION
Just a simple typo fix 👍 

"successs" -> "success"

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
