### PR TITLE
[docs] Improve ad display

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -139,7 +139,7 @@ function Ad(props) {
     if (carbonOut || codeFundOut) {
       children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
       minHeight = 'auto';
-    } else if (randomSplit < 0.5) {
+    } else if (randomSplit < 0.4) {
       children = <AdCodeFund />;
     } else {
       children = <AdCarbon />;

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -1,31 +1,41 @@
 import React from 'react';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
+import { capitalize } from '@material-ui/core/utils';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import AdCodeFund from 'docs/src/modules/components/AdCodeFund';
 import AdCarbon from 'docs/src/modules/components/AdCarbon';
 import AdInHouse from 'docs/src/modules/components/AdInHouse';
+import { AdContext, adPlacement } from 'docs/src/modules/components/AdManager';
 
 const styles = (theme) => ({
   root: {
     position: 'relative',
-    minHeight: 124,
-    maxWidth: '30ch',
     display: 'block',
-    marginTop: theme.spacing(4),
-    marginBottom: theme.spacing(3),
+  },
+  placementBody: {
+    fontSize: theme.typography.body1.fontSize,
+    maxWidth: '56ch',
+    margin: theme.spacing(4, 1, 3),
+    minHeight: 126,
+  },
+  'placementTocs-top': {
+    minHeight: 240,
+  },
+  'placementTocs-bottom': {
+    minHeight: 240,
   },
   paper: {
     padding: theme.spacing(1.5),
     border: `2px solid ${theme.palette.primary.main}`,
-    backgroundColor: theme.palette.background.level2,
     display: 'block',
   },
 });
 
-function Adblock(props) {
+function PleaseDisableAdblock(props) {
   const t = useSelector((state) => state.options.t);
 
   return (
@@ -47,13 +57,12 @@ function Adblock(props) {
 }
 
 const disable = process.env.NODE_ENV !== 'production' && process.env.ENABLE_AD !== 'true';
-
 const inHouseAds = [
   {
     name: 'scaffoldhub',
     link: 'https://scaffoldhub.io/?partner=1',
     img: '/static/in-house/scaffoldhub.png',
-    description: '<b>Scaffold</b><br />Automate building your full-stack Material-UI web-app.',
+    description: '<b>Scaffold</b>. Automate building your full-stack Material-UI web-app.',
   },
   {
     name: 'templates',
@@ -61,7 +70,7 @@ const inHouseAds = [
       'https://material-ui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-templates',
     img: '/static/in-house/themes-2.jpg',
     description:
-      '<b>Premium Templates</b><br />Start your project with the best templates for admins, dashboards and more.',
+      '<b>Premium Templates</b>. Start your project with the best templates for admins, dashboards and more.',
   },
   {
     name: 'themes',
@@ -69,7 +78,7 @@ const inHouseAds = [
       'https://material-ui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-themes',
     img: '/static/in-house/themes.png',
     description:
-      '<b>Premium Themes</b><br />Kickstart your application development with a ready-made theme.',
+      '<b>Premium Themes</b>. Kickstart your application development with a ready-made theme.',
   },
   {
     name: 'tidelift',
@@ -77,15 +86,14 @@ const inHouseAds = [
       'https://tidelift.com/subscription/pkg/npm-material-ui?utm_source=npm-material-ui&utm_medium=referral&utm_campaign=enterprise&utm_content=ad',
     img: '/static/in-house/tidelift.png',
     description:
-      '<b>Material-UI for enterprise</b><br />Save time and reduce risk. Managed open source — backed by maintainers.',
+      '<b>Material-UI for enterprise</b>. Save time and reduce risk. Managed open source — backed by maintainers.',
   },
   {
     name: 'sketch',
     link:
       'https://material-ui.com/store/items/sketch-react/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-sketch',
     img: '/static/in-house/sketch.png',
-    description:
-      '<b>Sketch</b><br />A large UI kit with over 600 handcrafted Material-UI symbols 💎.',
+    description: '<b>Sketch</b>. A large UI kit with over 600 handcrafted Material-UI symbols 💎.',
   },
   {
     name: 'figma',
@@ -93,20 +101,78 @@ const inHouseAds = [
       'https://material-ui.com/store/items/figma-react/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-figma',
     img: '/static/in-house/figma.png',
     description:
-      '<b>Figma</b><br />A large UI kit with over 600 handcrafted Material-UI components 🎨.',
+      '<b>Figma</b>. A large UI kit with over 600 handcrafted Material-UI components 🎨.',
   },
 ];
 
 function Ad(props) {
-  const { classes } = props;
+  const { placement, classes } = props;
 
-  const timerAdblock = React.useRef();
-  const { current: randomSplit } = React.useRef(Math.random());
-  const { current: randomInHouse } = React.useRef(Math.random());
-  const { current: randomAdblock } = React.useRef(Math.random());
   const [adblock, setAdblock] = React.useState(null);
   const [carbonOut, setCarbonOut] = React.useState(null);
   const [codeFundOut, setCodeFundOut] = React.useState(null);
+
+  let children;
+
+  // Hide the content to google bot.
+  if (/Googlebot/.test(navigator.userAgent) || disable) {
+    children = <span />;
+  }
+
+  const { current: randomAdblock } = React.useRef(Math.random());
+  const { current: randomInHouse } = React.useRef(Math.random());
+  let minHeight;
+
+  if (!children && adblock) {
+    minHeight = 'auto';
+
+    if (randomAdblock < 0.2) {
+      children = <PleaseDisableAdblock className={classes.paper} />;
+    } else {
+      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
+    }
+  }
+
+  const { current: randomSplit } = React.useRef(Math.random());
+
+  if (!children) {
+    if (carbonOut || codeFundOut) {
+      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
+      minHeight = 'auto';
+    } else if (randomSplit < 0.5) {
+      children = <AdCodeFund />;
+    } else {
+      children = <AdCarbon />;
+    }
+  }
+
+  const getEventLabel = () => {
+    let label;
+
+    if (children.type === AdCodeFund) {
+      label = 'codefund';
+    } else if (children.type === AdCarbon) {
+      label = 'carbon';
+    } else if (children.type === AdInHouse) {
+      if (!adblock && codeFundOut) {
+        label = 'in-house-codefund';
+      } else if (!adblock && carbonOut) {
+        label = 'in-house-carbon';
+      } else {
+        label = 'in-house';
+      }
+    } else if (children.type === PleaseDisableAdblock) {
+      label = 'in-house-adblock';
+    }
+
+    return label;
+  };
+
+  const ad = React.useContext(AdContext);
+  const eventLabel = getEventLabel();
+  const eventValue = adPlacement === 'body' ? ad.portal.placement : adPlacement;
+
+  const timerAdblock = React.useRef();
 
   const checkAdblock = React.useCallback(
     (attempt = 1) => {
@@ -164,59 +230,14 @@ function Ad(props) {
     };
   }, []);
 
-  let children;
-  let minHeight;
-
-  // Hide the content to google bot.
-  if (/Googlebot/.test(navigator.userAgent) || disable) {
-    children = <span />;
-  }
-
-  if (!children && adblock) {
-    minHeight = 'auto';
-
-    if (randomAdblock < 0.2) {
-      children = <Adblock className={classes.paper} />;
-    } else {
-      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
-    }
-  }
-
-  if (!children) {
-    if (carbonOut || codeFundOut) {
-      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
-      minHeight = 'auto';
-    } else if (randomSplit < 0.5) {
-      children = <AdCodeFund />;
-    } else {
-      children = <AdCarbon />;
-    }
-  }
-
   React.useEffect(() => {
-    // Avoid a flood of events.
+    // Avoid an exceed on the Google Analytics quotas.
     if (Math.random() < 0.9) {
       return undefined;
     }
 
     const delay = setTimeout(() => {
-      let type;
-
-      if (children.type === AdCodeFund) {
-        type = 'codefund';
-      } else if (children.type === AdCarbon) {
-        type = 'carbon';
-      } else if (children.type === AdInHouse) {
-        if (!adblock && codeFundOut) {
-          type = 'in-house-codefund';
-        } else if (!adblock && carbonOut) {
-          type = 'in-house-carbon';
-        } else {
-          type = 'in-house';
-        }
-      } else if (children.type === Adblock) {
-        type = 'in-house-adblock';
-      } else {
+      if (!eventLabel) {
         return;
       }
 
@@ -224,15 +245,17 @@ function Ad(props) {
         hitType: 'event',
         eventCategory: 'ad',
         eventAction: 'display',
-        eventLabel: type,
+        eventLabel,
+        eventValue,
       });
 
-      if (type.indexOf('in-house') === 0) {
+      if (eventLabel.indexOf('in-house') === 0) {
         window.ga('send', {
           hitType: 'event',
           eventCategory: 'in-house-ad',
           eventAction: 'display',
           eventLabel: children.props.ad.name,
+          eventValue,
         });
       }
     }, 2500);
@@ -240,17 +263,42 @@ function Ad(props) {
     return () => {
       clearTimeout(delay);
     };
-  }, [children.type, children.props.ad, codeFundOut, carbonOut, adblock]);
+  }, [eventLabel, children.props.ad, eventValue]);
+
+  // Refresh the ad after 1m30.
+  // An approximation to trigger when coming back to the window tab "after a while".
+  const [key, setKey] = React.useState(0);
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setKey((currentKey) => currentKey + 1);
+    }, 90000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (adPlacement !== placement) {
+    return null;
+  }
 
   return (
-    <span className={classes.root} style={{ minHeight }}>
-      {children}
+    <span
+      className={clsx(classes.root, classes[`placement${capitalize(adPlacement)}`])}
+      style={{ minHeight: adPlacement === 'body' ? minHeight : null }}
+      data-ga-event-category="ad"
+      data-ga-event-action="click"
+      data-ga-event-label={eventLabel}
+      data-ga-event-value={eventValue}
+    >
+      {React.cloneElement(children, { key })}
     </span>
   );
 }
 
 Ad.propTypes = {
   classes: PropTypes.object.isRequired,
+  placement: PropTypes.oneOf(['body', 'tocs-top', 'tocs-bottom']).isRequired,
 };
 
 export default React.memo(withStyles(styles)(Ad));

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -3,29 +3,32 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
-import { capitalize } from '@material-ui/core/utils';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import AdCodeFund from 'docs/src/modules/components/AdCodeFund';
 import AdCarbon from 'docs/src/modules/components/AdCarbon';
 import AdInHouse from 'docs/src/modules/components/AdInHouse';
-import { AdContext, adPlacement } from 'docs/src/modules/components/AdManager';
+import { AdContext, adPlacement, adShape } from 'docs/src/modules/components/AdManager';
 
 const styles = (theme) => ({
   root: {
     position: 'relative',
     display: 'block',
   },
-  placementBody: {
-    fontSize: theme.typography.body1.fontSize,
-    maxWidth: '56ch',
+  'placement-body-image': {
     margin: theme.spacing(4, 1, 3),
     minHeight: 126,
   },
-  'placementTocs-top': {
+  'placement-body-inline': {
+    margin: theme.spacing(4, 0, 3),
+    minHeight: 126,
+    display: 'flex',
+    alignItems: 'flex-end',
+  },
+  'placement-tocs-top-image': {
     minHeight: 240,
   },
-  'placementTocs-bottom': {
+  'placement-tocs-bottom-image': {
     minHeight: 240,
   },
   paper: {
@@ -170,7 +173,7 @@ function Ad(props) {
 
   const ad = React.useContext(AdContext);
   const eventLabel = getEventLabel();
-  const eventValue = adPlacement === 'body' ? ad.portal.placement : adPlacement;
+  const eventValue = `${adPlacement === 'body' ? ad.portal.placement : adPlacement}-${adShape}`;
 
   const timerAdblock = React.useRef();
 
@@ -284,11 +287,13 @@ function Ad(props) {
 
   return (
     <span
-      className={clsx(classes.root, classes[`placement${capitalize(adPlacement)}`])}
+      className={clsx(classes.root, classes[`placement-${adPlacement}-${adShape}`])}
       style={{ minHeight: adPlacement === 'body' ? minHeight : null }}
       data-ga-event-category="ad"
       data-ga-event-action="click"
+      /* advertiser network */
       data-ga-event-label={eventLabel}
+      /* docs placement */
       data-ga-event-value={eventValue}
     >
       {React.cloneElement(children, { key })}

--- a/docs/src/modules/components/AdCarbon.js
+++ b/docs/src/modules/components/AdCarbon.js
@@ -1,62 +1,36 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import loadScript from 'docs/src/modules/utils/loadScript';
+import adStyles from 'docs/src/modules/components/ad.styles';
 
-const styles = (theme) => ({
-  '@global': {
-    '#carbonads': {
-      display: 'block',
-      overflow: 'hidden',
-      backgroundColor: theme.palette.background.level2,
-      padding: `${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${
-        theme.spacing(1.5) + 130
-      }px`,
-      borderRadius: theme.shape.borderRadius,
-      '& .carbon-img': {
-        float: 'left',
-        marginLeft: -130,
-        width: 130,
-        height: 100,
-        marginRight: theme.spacing(1.5),
-      },
-      '& img': {
-        verticalAlign: 'middle',
-      },
-      '& a, & a:hover': {
-        color: theme.palette.text.primary,
-        textDecoration: 'none',
-      },
-      '& .carbon-text': {
-        ...theme.typography.body2,
-        display: 'block',
-      },
-      '& .carbon-poweredby': {
-        ...theme.typography.caption,
-        color: theme.palette.text.secondary,
-        marginTop: theme.spacing(0.5),
-        display: 'block',
+const useStyles = makeStyles((theme) => {
+  const styles = adStyles(theme);
+
+  return {
+    '@global': {
+      '#carbonads': {
+        ...styles.root,
+        '& .carbon-img': styles.imgWrapper,
+        '& img': styles.img,
+        '& a, & a:hover': styles.a,
+        '& .carbon-text': styles.description,
+        '& .carbon-poweredby': styles.poweredby,
       },
     },
-  },
+  };
 });
 
-function AdCarbon() {
+export default function AdCarbon() {
+  useStyles();
+  const ref = React.useRef(null);
+
   React.useEffect(() => {
-    const scriptSlot = document.querySelector('#carbon-ad');
-
-    // Concurrence issues
-    if (!scriptSlot) {
-      return;
-    }
-
     const script = loadScript(
       'https://cdn.carbonads.com/carbon.js?serve=CKYIL27L&placement=material-uicom',
-      scriptSlot,
+      ref.current,
     );
     script.id = '_carbonads_js';
   }, []);
 
-  return <span id="carbon-ad" data-ga-event-category="ad" data-ga-event-action="click" />;
+  return <span ref={ref} />;
 }
-
-export default withStyles(styles)(AdCarbon);

--- a/docs/src/modules/components/AdCodeFund.js
+++ b/docs/src/modules/components/AdCodeFund.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import loadScript from 'docs/src/modules/utils/loadScript';
 import adStyles from 'docs/src/modules/components/ad.styles';
+import { adShape } from 'docs/src/modules/components/AdManager';
 
 const useStyles = makeStyles((theme) => {
   const styles = adStyles(theme);
@@ -20,6 +21,7 @@ const useStyles = makeStyles((theme) => {
             fontStyle: 'normal',
           },
         },
+        '& .cf-cta': styles.link,
       },
     },
   };
@@ -30,7 +32,12 @@ export default function AdCodeFund() {
   const ref = React.useRef(null);
 
   React.useEffect(() => {
-    loadScript('https://codefund.io/properties/137/funder.js?theme=unstyled', ref.current);
+    loadScript(
+      `https://codefund.io/properties/137/funder.js?theme=unstyled${
+        adShape === 'inline' ? '&template=horizontal' : ''
+      }`,
+      ref.current,
+    );
   }, []);
 
   return (

--- a/docs/src/modules/components/AdCodeFund.js
+++ b/docs/src/modules/components/AdCodeFund.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => {
         '& .cf-powered-by.cf-powered-by': {
           ...styles.poweredby,
           '& em': {
-            display: 'none',
+            fontStyle: 'normal',
           },
         },
       },

--- a/docs/src/modules/components/AdCodeFund.js
+++ b/docs/src/modules/components/AdCodeFund.js
@@ -1,66 +1,42 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import loadScript from 'docs/src/modules/utils/loadScript';
+import adStyles from 'docs/src/modules/components/ad.styles';
 
-const styles = (theme) => ({
-  '@global': {
-    '#cf': {
-      display: 'block',
-      overflow: 'hidden',
-      backgroundColor: theme.palette.background.level2,
-      padding: `${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${
-        theme.spacing(1.5) + 130
-      }px`,
-      borderRadius: theme.shape.borderRadius,
-      '& .cf-img-wrapper.cf-img-wrapper': {
-        float: 'left',
-        marginLeft: -130,
-        width: 130,
-        height: 100,
-        marginRight: theme.spacing(1.5),
-      },
-      '& img': {
-        verticalAlign: 'middle',
-      },
-      '& a, & a:hover': {
-        color: theme.palette.text.primary,
-        textDecoration: 'none',
-      },
-      '& .cf-text.cf-text': {
-        ...theme.typography.body2,
-        display: 'block',
-      },
-      '& .cf-powered-by.cf-powered-by': {
-        ...theme.typography.caption,
-        color: theme.palette.text.secondary,
-        marginTop: theme.spacing(0.5),
-        display: 'block',
-        '& em': {
-          display: 'none',
+const useStyles = makeStyles((theme) => {
+  const styles = adStyles(theme);
+
+  return {
+    '@global': {
+      '#cf': {
+        ...styles.root,
+        '& .cf-img-wrapper.cf-img-wrapper': styles.imgWrapper,
+        '& img': styles.img,
+        '& a, & a:hover': styles.a,
+        '& .cf-text.cf-text': styles.description,
+        '& .cf-powered-by.cf-powered-by': {
+          ...styles.poweredby,
+          '& em': {
+            display: 'none',
+          },
         },
       },
     },
-  },
+  };
 });
 
-function AdCodeFund() {
+export default function AdCodeFund() {
+  useStyles();
+  const ref = React.useRef(null);
+
   React.useEffect(() => {
-    const scriptSlot = document.querySelector('#code-fund-script-slot');
-
-    // Concurrence issues
-    if (!scriptSlot) {
-      return;
-    }
-
-    loadScript('https://codefund.io/properties/137/funder.js?theme=unstyled', scriptSlot);
+    loadScript('https://codefund.io/properties/137/funder.js?theme=unstyled', ref.current);
   }, []);
 
   return (
     <React.Fragment>
-      <span id="code-fund-script-slot" />
-      <span id="codefund" data-ga-event-category="ad" data-ga-event-action="click" />
+      <span ref={ref} />
+      <span id="codefund" />
     </React.Fragment>
   );
 }
-
-export default withStyles(styles)(AdCodeFund);

--- a/docs/src/modules/components/AdGuest.js
+++ b/docs/src/modules/components/AdGuest.js
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Portal from '@material-ui/core/Portal';
+import { AdContext } from 'docs/src/modules/components/AdManager';
+
+export default function AdGuest(props) {
+  const ad = React.useContext(AdContext);
+
+  if (!ad.portal.element) {
+    return null;
+  }
+
+  return (
+    <Portal
+      container={() => {
+        const description = document.querySelector('.description');
+
+        if (ad.portal.element === description) {
+          description.classList.add('ad');
+        } else {
+          description.classList.remove('ad');
+        }
+
+        return ad.portal.element;
+      }}
+    >
+      {props.children}
+    </Portal>
+  );
+}
+
+AdGuest.propTypes = {
+  children: PropTypes.node,
+};

--- a/docs/src/modules/components/AdInHouse.js
+++ b/docs/src/modules/components/AdInHouse.js
@@ -1,45 +1,22 @@
 /* eslint react/jsx-no-target-blank: ["error", { allowReferrer: true }] */
 import React from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import adStyles from 'docs/src/modules/components/ad.styles';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'block',
-    overflow: 'hidden',
-    backgroundColor: theme.palette.background.level2,
-    padding: `${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${
-      theme.spacing(1.5) + 130
-    }px`,
-    borderRadius: theme.shape.borderRadius,
-    '& $imageWrapper': {
-      float: 'left',
-      marginLeft: -130,
-      width: 130,
-      height: 100,
-      marginRight: theme.spacing(1.5),
+const useStyles = makeStyles((theme) => {
+  const styles = adStyles(theme);
+  return {
+    root: {
+      ...styles.root,
+      '& img': styles.img,
+      '& a, & a:hover': styles.a,
     },
-    '& img': {
-      verticalAlign: 'middle',
-    },
-    '& a, & a:hover': {
-      color: theme.palette.text.primary,
-      textDecoration: 'none',
-    },
-    '& $description': {
-      ...theme.typography.body2,
-      display: 'block',
-    },
-    '& $poweredby': {
-      ...theme.typography.caption,
-      color: theme.palette.text.secondary,
-      display: 'block',
-    },
-  },
-  imageWrapper: {},
-  description: {},
-  poweredby: {},
-}));
+    imageWrapper: styles.imgWrapper,
+    description: styles.description,
+    poweredby: styles.poweredby,
+  };
+});
 
 export default function AdInHouse(props) {
   const { ad } = props;
@@ -65,14 +42,12 @@ export default function AdInHouse(props) {
           dangerouslySetInnerHTML={{ __html: ad.description }}
         />
       </a>
-      <a href="/" className={classes.poweredby}>
-        ad by Material-UI
-      </a>
+      <span className={classes.poweredby}>ad by Material-UI</span>
     </span>
   );
   /* eslint-enable material-ui/no-hardcoded-labels, react/no-danger */
 }
 
 AdInHouse.propTypes = {
-  ad: propTypes.object.isRequired,
+  ad: PropTypes.object.isRequired,
 };

--- a/docs/src/modules/components/AdManager.js
+++ b/docs/src/modules/components/AdManager.js
@@ -10,14 +10,18 @@ export const AdContext = React.createContext();
 
 // Persisted for the whole session.
 // The state is used to use different ad placements.
-const randomSession = Math.random();
+const randomSession1 = Math.random();
+const randomSession2 = Math.random();
 
 // Distribution profile:
-// 50% body
-// 30% tocs-bottom
-// 20% tocs-top
+// 25% body-image
+// 25% body-inline
+// 25% tocs-bottom-image
+// 25% tocs-top-image
 export const adPlacement =
-  randomSession < 0.5 ? `tocs-${randomSession < 0.2 ? 'top' : 'bottom'}` : 'body';
+  randomSession1 < 0.5 ? 'body' : `tocs-${randomSession1 < 0.75 ? 'top' : 'bottom'}`;
+
+export const adShape = randomSession1 < 0.5 && randomSession2 < 0.5 ? 'inline' : 'image';
 
 export default function AdManager(props) {
   const [portal, setPortal] = React.useState({});
@@ -49,7 +53,7 @@ export default function AdManager(props) {
         return true;
       }
 
-      if (node.offsetTop - lastPosition > window.innerHeight * 4.5) {
+      if (node.offsetTop - lastPosition > window.innerHeight * 4) {
         lastPosition = node.offsetTop;
         return true;
       }
@@ -70,7 +74,7 @@ export default function AdManager(props) {
         let placement;
         if (index === 0) {
           placement = 'body-top';
-        } else if (placement === selectedNodes.length - 1) {
+        } else if (index === selectedNodes.length - 1) {
           placement = 'body-bottom';
         } else {
           placement = `body-${index}`;

--- a/docs/src/modules/components/AdManager.js
+++ b/docs/src/modules/components/AdManager.js
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+const useEnhancedEffect =
+  typeof window !== 'undefined' && process.env.NODE_ENV !== 'test'
+    ? React.useLayoutEffect
+    : React.useEffect;
+
+export const AdContext = React.createContext();
+
+// Persisted for the whole session.
+// The state is used to use different ad placements.
+const randomSession = Math.random();
+
+// Distribution profile:
+// 50% body
+// 30% tocs-bottom
+// 20% tocs-top
+export const adPlacement =
+  randomSession < 0.5 ? `tocs-${randomSession < 0.2 ? 'top' : 'bottom'}` : 'body';
+
+export default function AdManager(props) {
+  const [portal, setPortal] = React.useState({});
+
+  useEnhancedEffect(() => {
+    if (
+      adPlacement !== 'body' ||
+      typeof IntersectionObserver === 'undefined' ||
+      !Array.prototype.findIndex
+    ) {
+      return undefined;
+    }
+
+    const description = document.querySelector('.description');
+    setPortal({ placement: 'body-top', element: description });
+
+    const nodes = [description, ...Array.from(document.querySelectorAll('[data-ad="slot"]'))].map(
+      (element) => ({
+        element,
+        offsetTop: element.offsetTop,
+      }),
+    );
+
+    let lastPosition;
+
+    const selectedNodes = nodes.filter((node, index) => {
+      if (index === 0) {
+        lastPosition = node.offsetTop;
+        return true;
+      }
+
+      if (node.offsetTop - lastPosition > window.innerHeight * 4.5) {
+        lastPosition = node.offsetTop;
+        return true;
+      }
+      return false;
+    });
+
+    const footer = nodes[nodes.length - 1];
+
+    if (selectedNodes.length > 1 && selectedNodes.indexOf(footer) === -1) {
+      selectedNodes[selectedNodes.length - 1] = footer;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        const element = entries[0].target;
+        const index = selectedNodes.findIndex((node) => node.element === element);
+
+        let placement;
+        if (index === 0) {
+          placement = 'body-top';
+        } else if (placement === selectedNodes.length - 1) {
+          placement = 'body-bottom';
+        } else {
+          placement = `body-${index}`;
+        }
+
+        setPortal({ placement, element });
+      }
+    });
+
+    selectedNodes.forEach((node, index) => {
+      if (index !== 0 && !node.element.style.height) {
+        node.element.style.height = '130px';
+      }
+      observer.observe(node.element);
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <AdContext.Provider
+      value={{
+        portal,
+      }}
+    >
+      {props.children}
+    </AdContext.Provider>
+  );
+}
+
+AdManager.propTypes = {
+  children: PropTypes.node,
+};

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -6,8 +6,10 @@ import clsx from 'clsx';
 import { useSelector } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import NoSsr from '@material-ui/core/NoSsr';
 import Link from 'docs/src/modules/components/Link';
 import PageContext from 'docs/src/modules/components/PageContext';
+import Ad from 'docs/src/modules/components/Ad';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -201,6 +203,9 @@ export default function AppTableOfContents(props) {
 
   return (
     <nav className={classes.root} aria-label={t('pageTOC')}>
+      <NoSsr>
+        <Ad placement="tocs-top" />
+      </NoSsr>
       {items.length > 0 ? (
         <React.Fragment>
           <Typography gutterBottom className={classes.contents}>
@@ -222,6 +227,9 @@ export default function AppTableOfContents(props) {
           </Typography>
         </React.Fragment>
       ) : null}
+      <NoSsr>
+        <Ad placement="tocs-bottom" />
+      </NoSsr>
     </nav>
   );
 }

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -22,6 +22,7 @@ function handleClick(event) {
         eventCategory: category,
         eventAction: element.getAttribute('data-ga-event-action'),
         eventLabel: element.getAttribute('data-ga-event-label'),
+        eventValue: element.getAttribute('data-ga-event-value'),
       });
       break;
     }

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -3,7 +3,6 @@ import * as PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { useSelector } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
-import Portal from '@material-ui/core/Portal';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import Button from '@material-ui/core/Button';
@@ -21,6 +20,8 @@ import Demo from 'docs/src/modules/components/Demo';
 import AppTableOfContents from 'docs/src/modules/components/AppTableOfContents';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import Ad from 'docs/src/modules/components/Ad';
+import AdManager from 'docs/src/modules/components/AdManager';
+import AdGuest from 'docs/src/modules/components/AdGuest';
 
 function flattenPages(pages, current = []) {
   return pages.reduce((items, item) => {
@@ -60,7 +61,7 @@ const styles = (theme) => ({
   },
   ad: {
     '& .description': {
-      marginBottom: 196,
+      marginBottom: 198,
     },
     '& .description.ad': {
       marginBottom: 40,
@@ -107,118 +108,117 @@ function MarkdownDocs(props) {
 
   return (
     <AppFrame>
-      <Head title={`${title} - Material-UI`} description={description} />
-      {disableAd ? null : (
-        <Portal
-          container={() => {
-            const container = document.querySelector('.description');
-            container.classList.add('ad');
-            return container;
-          }}
-        >
-          <Ad />
-        </Portal>
-      )}
-      <div
-        className={clsx(classes.root, {
-          [classes.ad]: !disableAd,
-          [classes.toc]: !disableToc,
-        })}
-      >
-        <AppContainer className={classes.container}>
-          <div className={classes.actions}>
-            <EditPage markdownLocation={location} />
-          </div>
-          {rendered.map((renderedMarkdownOrDemo, index) => {
-            if (typeof renderedMarkdownOrDemo === 'string') {
-              const renderedMarkdown = renderedMarkdownOrDemo;
-              return <MarkdownElement key={index} renderedMarkdown={renderedMarkdown} />;
-            }
-
-            const demoOptions = renderedMarkdownOrDemo;
-            const name = demoOptions.demo;
-            const demo = demos?.[name];
-            if (demo === undefined) {
-              const errorMessage = [
-                `Missing demo: ${name}. You can use one of the following:`,
-                Object.keys(demos),
-              ].join('\n');
-
-              if (userLanguage === 'en') {
-                throw new Error(errorMessage);
-              }
-
-              if (process.env.NODE_ENV !== 'production') {
-                console.error(errorMessage);
-              }
-
-              const warnIcon = (
-                <span role="img" aria-label={t('emojiWarning')}>
-                  ⚠️
-                </span>
-              );
-              return (
-                <div key={index}>
-                  {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-                  {warnIcon} Missing demo `{name}` {warnIcon}
-                </div>
-              );
-            }
-
-            return (
-              <Demo
-                key={index}
-                demo={{
-                  raw: demo.raw,
-                  js: requireDemo(demo.module).default,
-                  rawTS: demo.rawTS,
-                  tsx: demo.moduleTS ? requireDemo(demo.moduleTS).default : null,
-                }}
-                demoOptions={demoOptions}
-                githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
-              />
-            );
+      <AdManager>
+        <Head title={`${title} - Material-UI`} description={description} />
+        {disableAd ? null : (
+          <AdGuest>
+            <Ad placement="body" />
+          </AdGuest>
+        )}
+        <div
+          className={clsx(classes.root, {
+            [classes.ad]: !disableAd,
+            [classes.toc]: !disableToc,
           })}
-          <footer className={classes.footer}>
-            {!currentPage ||
-            currentPage.displayNav === false ||
-            (nextPage.displayNav === false && !prevPage) ? null : (
-              <React.Fragment>
-                <Divider />
-                <div className={classes.pagination}>
-                  {prevPage ? (
-                    <Button
-                      component={Link}
-                      naked
-                      href={prevPage.pathname}
-                      size="large"
-                      className={classes.pageLinkButton}
-                      startIcon={<ChevronLeftIcon />}
-                    >
-                      {pageToTitleI18n(prevPage, t)}
-                    </Button>
-                  ) : (
-                    <div />
-                  )}
-                  {nextPage.displayNav === false ? null : (
-                    <Button
-                      component={Link}
-                      naked
-                      href={nextPage.pathname}
-                      size="large"
-                      className={classes.pageLinkButton}
-                      endIcon={<ChevronRightIcon />}
-                    >
-                      {pageToTitleI18n(nextPage, t)}
-                    </Button>
-                  )}
-                </div>
-              </React.Fragment>
-            )}
-          </footer>
-        </AppContainer>
-      </div>
-      {disableToc ? null : <AppTableOfContents items={toc} />}
+        >
+          <AppContainer className={classes.container}>
+            <div className={classes.actions}>
+              <EditPage markdownLocation={location} />
+            </div>
+            {rendered.map((renderedMarkdownOrDemo, index) => {
+              if (typeof renderedMarkdownOrDemo === 'string') {
+                const renderedMarkdown = renderedMarkdownOrDemo;
+                return <MarkdownElement key={index} renderedMarkdown={renderedMarkdown} />;
+              }
+
+              const demoOptions = renderedMarkdownOrDemo;
+              const name = demoOptions.demo;
+              const demo = demos?.[name];
+              if (demo === undefined) {
+                const errorMessage = [
+                  `Missing demo: ${name}. You can use one of the following:`,
+                  Object.keys(demos),
+                ].join('\n');
+
+                if (userLanguage === 'en') {
+                  throw new Error(errorMessage);
+                }
+
+                if (process.env.NODE_ENV !== 'production') {
+                  console.error(errorMessage);
+                }
+
+                const warnIcon = (
+                  <span role="img" aria-label={t('emojiWarning')}>
+                    ⚠️
+                  </span>
+                );
+                return (
+                  <div key={index}>
+                    {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
+                    {warnIcon} Missing demo `{name}` {warnIcon}
+                  </div>
+                );
+              }
+
+              return (
+                <React.Fragment key={index}>
+                  <Demo
+                    demo={{
+                      raw: demo.raw,
+                      js: requireDemo(demo.module).default,
+                      rawTS: demo.rawTS,
+                      tsx: demo.moduleTS ? requireDemo(demo.moduleTS).default : null,
+                    }}
+                    demoOptions={demoOptions}
+                    githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
+                  />
+                  {index % 16 === 0 ? <div data-ad="slot" style={{ height: 130 }} /> : null}
+                </React.Fragment>
+              );
+            })}
+            <div data-ad="slot" />
+            <footer className={classes.footer}>
+              {!currentPage ||
+              currentPage.displayNav === false ||
+              (nextPage.displayNav === false && !prevPage) ? null : (
+                <React.Fragment>
+                  <Divider />
+                  <div className={classes.pagination}>
+                    {prevPage ? (
+                      <Button
+                        component={Link}
+                        naked
+                        href={prevPage.pathname}
+                        size="large"
+                        className={classes.pageLinkButton}
+                        startIcon={<ChevronLeftIcon />}
+                      >
+                        {pageToTitleI18n(prevPage, t)}
+                      </Button>
+                    ) : (
+                      <div />
+                    )}
+                    {nextPage.displayNav === false ? null : (
+                      <Button
+                        component={Link}
+                        naked
+                        href={nextPage.pathname}
+                        size="large"
+                        className={classes.pageLinkButton}
+                        endIcon={<ChevronRightIcon />}
+                      >
+                        {pageToTitleI18n(nextPage, t)}
+                      </Button>
+                    )}
+                  </div>
+                </React.Fragment>
+              )}
+            </footer>
+          </AppContainer>
+        </div>
+        {disableToc ? null : <AppTableOfContents items={toc} />}
+      </AdManager>
     </AppFrame>
   );
 }

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -173,7 +173,6 @@ function MarkdownDocs(props) {
                     demoOptions={demoOptions}
                     githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
                   />
-                  {index % 16 === 0 ? <div data-ad="slot" style={{ height: 130 }} /> : null}
                 </React.Fragment>
               );
             })}

--- a/docs/src/modules/components/ad.styles.js
+++ b/docs/src/modules/components/ad.styles.js
@@ -1,0 +1,91 @@
+import { fade } from '@material-ui/core/styles';
+import { adPlacement } from 'docs/src/modules/components/AdManager';
+
+const adBodyStyles = (theme) => ({
+  root: {
+    display: 'block',
+    overflow: 'hidden',
+    border: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
+    padding: `${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${theme.spacing(1.5)}px ${
+      theme.spacing(1.5) + 130
+    }px`,
+    borderRadius: theme.shape.borderRadius,
+  },
+  imgWrapper: {
+    float: 'left',
+    marginLeft: -130,
+    width: 130,
+    height: 100,
+  },
+  img: {
+    verticalAlign: 'middle',
+  },
+  a: {
+    color: theme.palette.text.primary,
+    textDecoration: 'none',
+  },
+  description: {
+    ...theme.typography.body1,
+    display: 'block',
+    marginLeft: theme.spacing(1.5),
+  },
+  poweredby: {
+    ...theme.typography.caption,
+    marginLeft: theme.spacing(1.5),
+    color: theme.palette.text.secondary,
+    display: 'block',
+    marginTop: theme.spacing(0.5),
+  },
+});
+
+const adTocsTopStyles = (theme) => ({
+  root: {
+    display: 'flex',
+    borderBottom: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
+    marginBottom: theme.spacing(3),
+    paddingBottom: theme.spacing(1.5),
+    flexDirection: 'column',
+    width: 135,
+  },
+  imgWrapper: {
+    display: 'block',
+    width: 130,
+    height: 100,
+    marginBottom: theme.spacing(1),
+  },
+  img: {},
+  a: {
+    color: theme.palette.text.primary,
+    textDecoration: 'none',
+  },
+  description: {
+    ...theme.typography.body1,
+    fontSize: theme.typography.pxToRem(13),
+    display: 'block',
+  },
+  poweredby: {
+    ...theme.typography.caption,
+    fontSize: theme.typography.pxToRem(11),
+    color: theme.palette.text.secondary,
+    display: 'block',
+    marginTop: theme.spacing(0.5),
+  },
+});
+
+const adTocsBottomStyles = (theme) => ({
+  ...adTocsTopStyles(theme),
+  root: {
+    display: 'flex',
+    borderTop: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
+    marginTop: theme.spacing(3),
+    paddingTop: theme.spacing(1.5),
+    flexDirection: 'column',
+    width: 135,
+  },
+});
+
+export default {
+  body: adBodyStyles,
+  'tocs-top': adTocsTopStyles,
+  'tocs-bottom': adTocsBottomStyles,
+}[adPlacement];

--- a/docs/src/modules/components/ad.styles.js
+++ b/docs/src/modules/components/ad.styles.js
@@ -1,7 +1,7 @@
 import { fade } from '@material-ui/core/styles';
-import { adPlacement } from 'docs/src/modules/components/AdManager';
+import { adPlacement, adShape } from 'docs/src/modules/components/AdManager';
 
-const adBodyStyles = (theme) => ({
+const adBodyImageStyles = (theme) => ({
   root: {
     display: 'block',
     overflow: 'hidden',
@@ -38,7 +38,48 @@ const adBodyStyles = (theme) => ({
   },
 });
 
-const adTocsTopStyles = (theme) => ({
+const adBodyInlineStyles = (theme) => {
+  const baseline = adBodyImageStyles(theme);
+
+  return {
+    ...baseline,
+    root: {},
+    imgWrapper: {
+      display: 'none',
+    },
+    description: {
+      ...baseline.description,
+      marginLeft: 0,
+      '&:before': {
+        backgroundColor: '#4caf50',
+        color: '#fff',
+        marginRight: 4,
+        padding: '2px 6px',
+        borderRadius: 3,
+        content: '"Ad"',
+        fontSize: theme.typography.pxToRem(14),
+      },
+      '&:after': {
+        marginLeft: 4,
+        content: '"Get started"',
+        // Style taken from the Link component
+        color: theme.palette.secondary.main,
+        '&:hover': {
+          textDecoration: 'underline',
+        },
+      },
+    },
+    poweredby: {
+      ...baseline.poweredby,
+      marginLeft: 0,
+    },
+    link: {
+      display: 'none',
+    },
+  };
+};
+
+const adTocsTopImageStyles = (theme) => ({
   root: {
     display: 'flex',
     borderBottom: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
@@ -72,8 +113,8 @@ const adTocsTopStyles = (theme) => ({
   },
 });
 
-const adTocsBottomStyles = (theme) => ({
-  ...adTocsTopStyles(theme),
+const adTocsBottomImageStyles = (theme) => ({
+  ...adTocsTopImageStyles(theme),
   root: {
     display: 'flex',
     borderTop: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
@@ -85,7 +126,8 @@ const adTocsBottomStyles = (theme) => ({
 });
 
 export default {
-  body: adBodyStyles,
-  'tocs-top': adTocsTopStyles,
-  'tocs-bottom': adTocsBottomStyles,
-}[adPlacement];
+  'body-image': adBodyImageStyles,
+  'body-inline': adBodyInlineStyles,
+  'tocs-top-image': adTocsTopImageStyles,
+  'tocs-bottom-image': adTocsBottomImageStyles,
+}[`${adPlacement}-${adShape}`];

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -286,6 +286,9 @@ DialogDetails.propTypes = {
 DialogDetails = React.memo(DialogDetails);
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    minHeight: 500,
+  },
   form: {
     margin: theme.spacing(2, 0),
   },
@@ -440,7 +443,7 @@ export default function SearchIcons() {
   );
 
   return (
-    <Grid container>
+    <Grid container className={classes.root}>
       <Grid item xs={12} sm={3}>
         <form className={classes.form}>
           <RadioGroup>


### PR DESCRIPTION
- Try different placements randomly, per session
- Add analytics to check which placement works best
- The last time we had an ad on the tocs was in v1: https://v1.material-ui.com/demos/autocomplete/.
- We have longer and longer documentation pages (making improvements after improvements), to account for it, the ad can now be displayed in the middle of the page, but at most every 8 demos and 4.5 screen height. In practice, it means that the short pages (e.g. Link) have 1 ad, the medium pages (e.g. Breadcrumb) have 2, and the long pages (e.g. Autocomplete) have 3.
- The approach taken optimizes for less layout shift
- I hope that the changes won't harm the DX, I have made them considering how I would best enjoy consuming the documentation, as a user

### Why

- Ad revenues have been flattening lately while the volume of usage of the documentation grew and the other sources grew. Something is off.
- Remove an incentive to break down the long pages of the documentation to optimize for ad revenue (more pages = more display). The incentive should be solely about improving the DX.
- Explore the options we have available (random new placement + analytics to measure)

### Benchmark

1. Ad at the top of the drawer: https://panjiachen.github.io/vue-element-admin-site/guide/essentials/router-and-nav.html.
2. Ad at to the bottom of the drawer: https://react.semantic-ui.com/views/comment/.
3. "native ad" at the bottom of the drawer: https://materializecss.com/buttons.html or https://d.pr/i/XifOZH
4. "native ad" at the bottom of the demos, after the interaction: https://react.semantic-ui.com/views/comment/#variations-minimal

<img width="300" alt="Capture d’écran 2020-05-30 à 00 49 28" src="https://user-images.githubusercontent.com/3165635/83328681-239c0900-a285-11ea-8239-c216912d2248.png">

5. Ad to the top of the TOC: https://materializecss.com/buttons.html
6. Ad to the bottom of the TOC: https://vuejs.org/v2/guide/events.html#Key-Codes.
7. Ad jump layout: https://stackoverflow.com/questions/687948/timeout-a-command-in-bash-without-unnecessary-delay.
8. More ad as the user consume the content: https://vuetifyjs.com/en/components/banners/.