### PR TITLE
[Skeleton] Improve component

### DIFF
--- a/docs/src/pages/components/skeleton/SkeletonTypography.js
+++ b/docs/src/pages/components/skeleton/SkeletonTypography.js
@@ -12,7 +12,7 @@ function TypographyDemo(props) {
   return (
     <div>
       {variants.map((variant) => (
-        <Typography key={variant} variant={variant}>
+        <Typography component="div" key={variant} variant={variant}>
           {loading ? <Skeleton /> : variant}
         </Typography>
       ))}

--- a/docs/src/pages/components/skeleton/SkeletonTypography.tsx
+++ b/docs/src/pages/components/skeleton/SkeletonTypography.tsx
@@ -11,7 +11,7 @@ function TypographyDemo(props: { loading?: boolean }) {
   return (
     <div>
       {variants.map((variant) => (
-        <Typography key={variant} variant={variant}>
+        <Typography component="div" key={variant} variant={variant}>
           {loading ? <Skeleton /> : variant}
         </Typography>
       ))}

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -66,5 +66,9 @@ loading
 
 {{"demo": "pages/components/skeleton/SkeletonChildren.js", "defaultCodeOpen": false}}
 
-### Accessibility
+## Accessibility
 
+Skeleton screens provide an alternative to the traditional spinner methods.
+Rather than showing an abstract widget, skeleton screens create anticipation of what is to come and reduce cognitive load.
+
+The background color of the skeleton uses the least amount of luminance to be visible in good conditions (good ambient light, good screen, no visual impairments).

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -32,11 +32,11 @@ By default, the skeleton pulsate, but you can change the animation for a wave or
 
 {{"demo": "pages/components/skeleton/Animations.js"}}
 
-## YouTube example
+### Pulsate example
 
 {{"demo": "pages/components/skeleton/YouTube.js", "defaultCodeOpen": false}}
 
-## Facebook example
+### Wave example
 
 {{"demo": "pages/components/skeleton/Facebook.js", "defaultCodeOpen": false, "bg": true}}
 

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -65,3 +65,6 @@ loading
 ```
 
 {{"demo": "pages/components/skeleton/SkeletonChildren.js", "defaultCodeOpen": false}}
+
+### Accessibility
+

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -7,8 +7,8 @@ export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
     display: 'block',
-    // Create a "on paper" color with sufficient contrast.
-    backgroundColor: fade(theme.palette.text.primary, 0.16),
+    // Create a "on paper" color with sufficient contrast retaining the color
+    backgroundColor: fade(theme.palette.text.primary, theme.palette.type === 'light' ? 0.11 : 0.13),
     height: '1.2em',
   },
   /* Styles applied to the root element if `variant="text"`. */


### PR DESCRIPTION
Keep exploring after #21122.

- Fix double h1 issue in the docs, reported by ahrefs
- Rename demos to be more accurate, Facebook and YouTube don't use these animations
- Pick the luminance of facebook.com and slightly increase it, as a result, it's:
  - Darker than medium.com
  - Darker than facebook.com
  - Darker than netlify.com
  - Darker than ant.design
  - Same as youtube.com's avatar
- Add a note about accessibility
