### PR TITLE
[List] Add ‘alignItemsFlexStart’ to ListItemIconClassKey

### DIFF
--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -5,7 +5,7 @@ export interface ListItemIconProps
   children: React.ReactElement;
 }
 
-export type ListItemIconClassKey = 'root';
+export type ListItemIconClassKey = 'root' | 'alignItemsFlexStart';
 
 declare const ListItemIcon: React.ComponentType<ListItemIconProps>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Hi! Noticed `alignItemsFlexStart` was missing in `ListItemIconClassKey`