### PR TITLE
[Dialog] Fix dialog children being announced as clickable

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
@@ -234,7 +233,7 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
         <div
           className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}
-          onClick={handleBackdropClick}
+          onMouseUp={handleBackdropClick}
           onMouseDown={handleMouseDown}
           data-mui-test="FakeBackdrop"
         >

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -14,6 +14,7 @@ import Dialog from './Dialog';
  */
 function userClick(element) {
   fireEvent.mouseDown(element);
+  fireEvent.mouseUp(element);
   element.click();
 }
 


### PR DESCRIPTION
Closes #16758

~Need to check if we shouldn't use `pointerup` instead and if it shouldn't have been `pointerdown` instead of `mousedown` all along.~ Tested on Chrome 81 on iOS 13.3.1, whatever version of safari is installed on iOS 13.3.1 and Chrome 83 on Android 7. Forgot that touch input does fire mouse events.

Tested the following interaction
1. goto [/components/dialogs/#simple-dialogs](https://deploy-preview-21285--material-ui.netlify.app/components/dialogs/#simple-dialogs)
2. Click "reset focus"
3. Tab 6 times (loops through list and dialog)

<details>
<summary>NVDA 2020.1 + Firefox 76.0.1 speechlog diff</summary>

```diff

// mouseover "reset focus"
Reset focus to test keyboard navigation  Schalter
// click "reset focus"
A generic container that is programmatically focused to test keyboard navigation of our components.  Schalter  
// tab
OPEN SIMPLE DIALOG  Schalter  
// enter
Set backup account  Dialogfeld
Liste
Liste  mit 3 Einträgen  Add account  Schalter  
Set backup account
Schalter    Add account

// tab (dialog focused)
-anklickbar  Dialogfeld    Set backup account
+Dialogfeld    Set backup account
Leer
// tab (first item focused)
Set backup account  Dialogfeld
Schalter    Add account
username@gmail.com  Schalter  
// tab (second item focused)
user02@gmail.com  Schalter  
// tab (third item focused)
Add account  Schalter  
// tab (dialog focused)
-anklickbar  Dialogfeld    Set backup account
+Dialogfeld    Set backup account
// tab (first item focused)
Set backup account  Dialogfeld
Schalter    Add account
username@gmail.com  Schalter 
```

</details>

Speechlog includes some German words because this was tested on a German version of Windows 10:
- "Schalter" - "Button"
- "anklickbar" - "clickable"
- "Leer" - "empty" (not spoken)