### PR TITLE
[test] Type-test event handlers on ListItem

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.spec.tsx
+++ b/packages/material-ui/src/ListItem/ListItem.spec.tsx
@@ -19,3 +19,14 @@ function BooleanButtonTest() {
     return <ListItem>Editable? No</ListItem>;
   }
 }
+
+// verify that https://github.com/mui-org/material-ui/issues/19756 already worked.
+function MouseEnterTest() {
+  function handleMouseEnter(event: React.MouseEvent<HTMLLIElement>) {}
+  <ListItem onMouseEnter={handleMouseEnter} />;
+
+  function handleMouseEnterButton(event: React.MouseEvent<HTMLDivElement>) {}
+  // $ExpectError
+  <ListItem onMouseEnter={handleMouseEnterButton} />; // desired: missing property button
+  <ListItem button onMouseEnter={handleMouseEnterButton} />;
+}


### PR DESCRIPTION
Test for #19756 which illustrates that the user-typed `someHandler` had the wrong type. Our types are correct in that regard.