### PR TITLE
[core] Don't ship type tests

### DIFF
--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-codemod/**/*.test.js'",
     "prebuild": "rimraf lib",
-    "build": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./lib --ignore **/*.test.js",
+    "build": "node ../../scripts/build cjs --out-dir ./lib",
     "release": "yarn build && npm publish"
   },
   "repository": {

--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:copy-files",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-icons",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:typings && yarn build:copy-files",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
     "build:es": "echo 'skip es folder'",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:typings": "babel-node --config-file ../../babel.config.js ./scripts/create-typings.js",

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -24,9 +24,9 @@
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
+    "build:es": "node ../../scripts/build es",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -28,9 +28,9 @@
   },
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
+    "build:es": "node ../../scripts/build es",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -28,9 +28,9 @@
   },
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
+    "build:es": "node ../../scripts/build es",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -24,9 +24,9 @@
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-utils",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
+    "build:es": "node ../../scripts/build es",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -26,9 +26,9 @@
   },
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:umd && yarn build:copy-files && yarn build:types",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js --extensions \".js,.ts\" ./src --out-dir ./build --ignore \"**/*.test.js,**/*.d.ts\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js --extensions \".js,.ts\" ./src --out-dir ./build/esm --ignore \"**/*.test.js,**/*.d.ts\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js --extensions \".js,.ts\" ./src --out-dir ./build/es --ignore \"**/*.test.js,**/*.d.ts\"",
+    "build:cjs": "node ../../scripts/build cjs",
+    "build:esm": "node ../../scripts/build esm",
+    "build:es": "node ../../scripts/build es",
     "build:umd": "cross-env BABEL_ENV=production-umd rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "tsc -p tsconfig.build.json",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,65 @@
+const childProcess = require('child_process');
+const path = require('path');
+const { promisify } = require('util');
+const yargs = require('yargs');
+
+const exec = promisify(childProcess.exec);
+
+async function run(argv) {
+  const { bundle, outDir: relativeOutDir, verbose } = argv;
+
+  const env = {
+    NODE_ENV: 'production',
+    BABEL_ENV: bundle,
+  };
+  const babelConfigPath = path.resolve(__dirname, '../babel.config.js');
+  const srcDir = path.resolve('./src');
+  const outDir = path.resolve(
+    relativeOutDir,
+    {
+      cjs: '.',
+      esm: './esm',
+      es: './es',
+    }[bundle],
+  );
+
+  const command = [
+    'yarn babel',
+    '--config-file',
+    babelConfigPath,
+    '--extensions',
+    '".js,.ts"',
+    srcDir,
+    '--out-dir',
+    outDir,
+    '--ignore',
+    '"**/*.test.js,**/*.d.ts"',
+  ].join(' ');
+
+  if (verbose) {
+    // eslint-disable-next-line no-console
+    console.log(`running '${command}' with ${JSON.stringify(env)}`);
+  }
+
+  return exec(command, { env });
+}
+
+yargs
+  .command({
+    command: '$0 <bundle>',
+    description: 'build package',
+    builder: (command) => {
+      return command
+        .positional('bundle', {
+          description: '"cjs" | "esm" | "esnext"',
+          type: 'string',
+        })
+        .option('out-dir', { default: './build', type: 'string' })
+        .option('verbose', { type: 'boolean' });
+    },
+    handler: run,
+  })
+  .help()
+  .strict(true)
+  .version(false)
+  .parse();

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -33,7 +33,7 @@ async function run(argv) {
     '--out-dir',
     outDir,
     '--ignore',
-    '"**/*.test.js,**/*.d.ts"',
+    '"**/*.test.js","**/*.spec.ts","**/*.d.ts"',
   ].join(' ');
 
   if (verbose) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,8 +5,23 @@ const yargs = require('yargs');
 
 const exec = promisify(childProcess.exec);
 
+const validBundles = [
+  // legacy build using commonJS modules
+  'cjs',
+  // modern build
+  'es',
+  // legacy build using ES6 modules
+  'esm',
+];
+
 async function run(argv) {
   const { bundle, outDir: relativeOutDir, verbose } = argv;
+
+  if (validBundles.indexOf(bundle) === -1) {
+    throw new TypeError(
+      `Unrecognized bundle '${bundle}'. Did you mean one of "${validBundles.join('", "')}"?`,
+    );
+  }
 
   const env = {
     NODE_ENV: 'production',
@@ -51,7 +66,7 @@ yargs
     builder: (command) => {
       return command
         .positional('bundle', {
-          description: '"cjs" | "esm" | "es"',
+          description: `Valid bundles: "${validBundles.join('" | "')}"`,
           type: 'string',
         })
         .option('out-dir', { default: './build', type: 'string' })

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -51,7 +51,7 @@ yargs
     builder: (command) => {
       return command
         .positional('bundle', {
-          description: '"cjs" | "esm" | "esnext"',
+          description: '"cjs" | "esm" | "es"',
           type: 'string',
         })
         .option('out-dir', { default: './build', type: 'string' })


### PR DESCRIPTION
Since we started using TypeScript for source files we also transpiled and shipped type tests.

Instead of fixing every package.json scrip I unified the task in `scripts/build`