### PR TITLE
[core] Use custom $ExpectType assertion

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -51,7 +51,9 @@
     "prop-types": "^15.7.2",
     "react-is": "^16.8.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@material-ui/types": "^5.1.0"
+  },
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.spec.tsx
@@ -1,4 +1,5 @@
 import { Autocomplete, AutocompleteProps } from '@material-ui/lab';
+import { expectType } from '@material-ui/types';
 
 interface MyAutocomplete<
   T,
@@ -22,8 +23,7 @@ function MyAutocomplete<
 <MyAutocomplete
   options={['1', '2', '3']}
   onChange={(event, value) => {
-    // $ExpectType string[]
-    value;
+    expectType<string[], typeof value>(value);
   }}
   renderInput={() => null}
   multiple

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.spec.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.spec.ts
@@ -1,4 +1,5 @@
-import { useAutocomplete } from '@material-ui/lab';
+import { useAutocomplete, FilterOptionsState } from '@material-ui/lab';
+import { expectType } from '@material-ui/types';
 
 interface Person {
   id: string;
@@ -18,8 +19,7 @@ const persons: Person[] = [
 useAutocomplete({
   options: ['1', '2', '3'],
   onChange(event, value) {
-    // $ExpectType string | null
-    value;
+    expectType<string | null, typeof value>(value);
   },
 });
 
@@ -28,8 +28,7 @@ useAutocomplete({
   options: ['1', '2', '3'],
   multiple: false,
   onChange(event, value) {
-    // $ExpectType string | null
-    value;
+    expectType<string | null, typeof value>(value);
   },
 });
 
@@ -37,8 +36,7 @@ useAutocomplete({
 useAutocomplete({
   options: ['1', '2', '3', 4, true],
   onChange(event, value) {
-    // $ExpectType string | number | boolean | null
-    value;
+    expectType<string | number | boolean | null, typeof value>(value);
   },
 });
 
@@ -46,8 +44,7 @@ useAutocomplete({
 useAutocomplete({
   options: persons,
   onChange(event, value) {
-    // $ExpectType Person | null
-    value;
+    expectType<Person | null, typeof value>(value);
   },
 });
 
@@ -55,19 +52,16 @@ useAutocomplete({
 useAutocomplete({
   options: ['1', '2', '3'],
   onChange(event, value) {
-    // $ExpectType string | null
+    expectType<string | null, typeof value>(value);
     value;
   },
   filterOptions(options, state) {
-    // $ExpectType FilterOptionsState<string>
-    state;
-    // $ExpectType string[]
-    options;
+    expectType<FilterOptionsState<string>, typeof state>(state);
+    expectType<string[], typeof options>(options);
     return options;
   },
   getOptionLabel(option) {
-    // $ExpectType string
-    option;
+    expectType<string, typeof option>(option);
     return option;
   },
   value: null,
@@ -80,7 +74,7 @@ useAutocomplete({
   options: ['1', '2', '3'],
   multiple: true,
   onChange(event, value) {
-    // $ExpectType string[]
+    expectType<string[], typeof value>(value);
     value;
   },
 });
@@ -90,8 +84,7 @@ useAutocomplete({
   options: ['1', '2', '3', 4, true],
   multiple: true,
   onChange(event, value) {
-    // $ExpectType (string | number | boolean)[]
-    value;
+    expectType<Array<string | number | boolean>, typeof value>(value);
   },
 });
 
@@ -100,7 +93,7 @@ useAutocomplete({
   options: persons,
   multiple: true,
   onChange(event, value) {
-    // $ExpectType Person[]
+    expectType<Person[], typeof value>(value);
     value;
   },
 });
@@ -118,8 +111,7 @@ useAutocomplete({
   options: ['1', '2', '3'],
   disableClearable: true,
   onChange(event, value) {
-    // $ExpectType string
-    value;
+    expectType<string, typeof value>(value);
   },
 });
 
@@ -127,16 +119,14 @@ useAutocomplete({
   options: ['1', '2', '3'],
   disableClearable: false,
   onChange(event, value) {
-    // $ExpectType string | null
-    value;
+    expectType<string | null, typeof value>(value);
   },
 });
 
 useAutocomplete({
   options: ['1', '2', '3'],
   onChange(event, value) {
-    // $ExpectType string | null
-    value;
+    expectType<string | null, typeof value>(value);
   },
 });
 
@@ -144,8 +134,7 @@ useAutocomplete({
 useAutocomplete({
   options: persons,
   onChange(event, value) {
-    // $ExpectType string | Person | null
-    value;
+    expectType<string | Person | null, typeof value>(value);
   },
   freeSolo: true,
 });
@@ -154,8 +143,7 @@ useAutocomplete({
   options: persons,
   disableClearable: true,
   onChange(event, value) {
-    // $ExpectType string | Person
-    value;
+    expectType<string | Person, typeof value>(value);
   },
   freeSolo: true,
 });
@@ -164,8 +152,7 @@ useAutocomplete({
   options: persons,
   multiple: true,
   onChange(event, value) {
-    // $ExpectType (string | Person)[]
-    value;
+    expectType<Array<string | Person>, typeof value>(value);
   },
   freeSolo: true,
 });

--- a/packages/material-ui-styles/src/defaultTheme/defaultTheme.spec.ts
+++ b/packages/material-ui-styles/src/defaultTheme/defaultTheme.spec.ts
@@ -1,5 +1,6 @@
 import { useTheme, makeStyles, styled } from '@material-ui/styles';
 import Grid from '@material-ui/core/Grid';
+import { expectType } from '@material-ui/types';
 
 declare module '@material-ui/styles' {
   interface DefaultTheme {
@@ -8,14 +9,14 @@ declare module '@material-ui/styles' {
 }
 
 {
-  // $ExpectType string
   const value = useTheme().myProperty;
+  expectType<string, typeof value>(value);
 }
 
 {
   makeStyles((theme) => {
-    // $ExpectType string
     const value = theme.myProperty;
+    expectType<string, typeof value>(value);
 
     return {
       root: {
@@ -27,8 +28,8 @@ declare module '@material-ui/styles' {
 
 {
   styled(Grid)(({ theme }) => {
-    // $ExpectType string
     const value = theme.myProperty;
+    expectType<string, typeof value>(value);
 
     return {
       width: 1,

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -9,7 +9,7 @@ export {};
 
 type JSSFontface = CSS.FontFace & { fallbacks?: CSS.FontFace[] };
 
-type PropsFunc<Props extends object, T> = (props: Props) => T;
+export type PropsFunc<Props extends object, T> = (props: Props) => T;
 
 /**
  * Allows the user to augment the properties available

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -6,9 +6,13 @@ import {
   WithTheme,
   WithStyles,
   makeStyles,
+  CSSProperties,
+  CreateCSSProperties,
+  PropsFunc,
 } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { Theme } from '@material-ui/core/styles';
+import { expectType } from '@material-ui/types';
 
 // Example 1
 const styles = ({ palette, spacing }: Theme) => ({
@@ -449,38 +453,49 @@ function forwardRefTest() {
   }));
 
   const styles = useStyles({ foo: true });
-  // $ExpectType string
-  const root = styles.root;
-  // $ExpectType string
-  const root2 = styles.root2;
+  expectType<Record<'root' | 'root2', string>, typeof styles>(styles);
 }
 
 {
   // If there are no props, use the definition that doesn't accept them
   // https://github.com/mui-org/material-ui/issues/16198
 
-  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<{}> | PropsFunc<{}, CreateCSSProperties<{}>>>
   const styles = createStyles({
     root: {
       width: 1,
     },
   });
+  expectType<
+    Record<'root', CSSProperties | CreateCSSProperties | PropsFunc<{}, CreateCSSProperties>>,
+    typeof styles
+  >(styles);
 
-  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<{}> | PropsFunc<{}, CreateCSSProperties<{}>>>
   const styles2 = createStyles({
     root: () => ({
       width: 1,
     }),
   });
+  expectType<
+    Record<'root', CSSProperties | CreateCSSProperties | PropsFunc<{}, CreateCSSProperties>>,
+    typeof styles2
+  >(styles2);
 
   interface testProps {
     foo: boolean;
   }
 
-  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<testProps> | PropsFunc<testProps, CreateCSSProperties<testProps>>>
   const styles3 = createStyles({
     root: (props: testProps) => ({
       width: 1,
     }),
   });
+  expectType<
+    Record<
+      'root',
+      | CSSProperties
+      | CreateCSSProperties<testProps>
+      | PropsFunc<testProps, CreateCSSProperties<testProps>>
+    >,
+    typeof styles3
+  >(styles3);
 }

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -62,3 +62,24 @@ type GenerateStringUnion<T> = Extract<
   }[keyof T],
   string
 >;
+
+// https://stackoverflow.com/questions/53807517/how-to-test-if-two-types-are-exactly-the-same
+type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) extends <
+  G
+>() => G extends U ? 1 : 2
+  ? Y
+  : N;
+
+/**
+ * Issues a type error if `Expected` is not identical to `Actual`.
+ *
+ * `Expected` should be declared when invoking `expectType`.
+ * `Actual` should almost always we be a `typeof value` statement.
+ *
+ * @example `expectType<number | string, typeof value>(value)`
+ * TypeScript issues a type error since `value is not assignable to never`.
+ * This means `typeof value` is not identical to `number | string`
+ *
+ * @param actual
+ */
+export function expectType<Expected, Actual>(actual: IfEquals<Actual, Expected, Actual>): void;

--- a/packages/material-ui-types/index.spec.ts
+++ b/packages/material-ui-types/index.spec.ts
@@ -1,0 +1,9 @@
+import { expectType } from '@material-ui/types';
+
+function expectTypeTypes() {
+  // it rejects assignability to `any`
+  function onClick(event: any) {
+    // @ts-expect-error
+    expectType<MouseEvent, typeof event>(event);
+  }
+}

--- a/packages/material-ui/src/Button/Button.spec.tsx
+++ b/packages/material-ui/src/Button/Button.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import { Link as ReactRouterLink, LinkProps } from 'react-router-dom';
+import { expectType } from '@material-ui/types';
 
 const log = console.log;
 
@@ -37,10 +38,10 @@ const ButtonTest = () => (
     // By default the underlying component is a button element:
     <Button
       ref={(elem) => {
-        elem; // $ExpectType HTMLButtonElement | null
+        expectType<HTMLButtonElement | null, typeof elem>(elem);
       }}
       onClick={(e) => {
-        e; // $ExpectType MouseEvent<HTMLButtonElement, MouseEvent>
+        expectType<React.MouseEvent<HTMLButtonElement, MouseEvent>, typeof e>(e);
         log(e);
       }}
     >
@@ -50,10 +51,10 @@ const ButtonTest = () => (
     <Button
       href="/open-collective"
       ref={(elem) => {
-        elem; // $ExpectType HTMLAnchorElement | null
+        expectType<HTMLAnchorElement | null, typeof elem>(elem);
       }}
       onClick={(e) => {
-        e; // $ExpectType MouseEvent<HTMLAnchorElement, MouseEvent>
+        expectType<React.MouseEvent<HTMLAnchorElement, MouseEvent>, typeof e>(e);
         log(e);
       }}
     >
@@ -63,10 +64,10 @@ const ButtonTest = () => (
     <Button<'div'>
       component="div"
       ref={(elem) => {
-        elem; // $ExpectType HTMLDivElement | null
+        expectType<HTMLDivElement | null, typeof elem>(elem);
       }}
       onClick={(e) => {
-        e; // $ExpectType MouseEvent<HTMLDivElement, MouseEvent>
+        expectType<React.MouseEvent<HTMLDivElement, MouseEvent>, typeof e>(e);
         log(e);
       }}
     >

--- a/packages/material-ui/src/TextField/TextField.spec.tsx
+++ b/packages/material-ui/src/TextField/TextField.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
+import { expectType } from '@material-ui/types';
 
 {
   // https://github.com/mui-org/material-ui/issues/12999
@@ -28,7 +29,8 @@ import TextField from '@material-ui/core/TextField';
       InputProps={{ classes: { inputAdornedStart: 'adorned-start' } }}
       onChange={(event) => {
         // type inference for event still works?
-        const value = event.target.value; // $ExpectType string
+        const value = event.target.value;
+        expectType<string, typeof value>(value);
       }}
     />
   );

--- a/packages/material-ui/src/styles/createTypography.spec.ts
+++ b/packages/material-ui/src/styles/createTypography.spec.ts
@@ -1,4 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles';
+import { expectType } from '@material-ui/types';
 
 {
   // properties of the variants can be "unset"
@@ -10,6 +11,6 @@ import { createMuiTheme } from '@material-ui/core/styles';
     },
   });
 
-  // $ExpectType string | undefined
   const maybeFontStyle = theme.typography.body1.fontStyle;
+  expectType<string | undefined, typeof maybeFontStyle>(maybeFontStyle);
 }

--- a/packages/material-ui/test/typescript/OverridableComponent.spec.tsx
+++ b/packages/material-ui/test/typescript/OverridableComponent.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { OverridableComponent } from '@material-ui/core/OverridableComponent';
+import { expectType } from '@material-ui/types';
 
 interface MyOverrideProps {
   className: string;
@@ -72,10 +73,10 @@ declare const Foo: OverridableComponent<{
   numberProp={3}
   component="button"
   ref={(elem) => {
-    elem; // $ExpectType HTMLButtonElement | null
+    expectType<HTMLButtonElement | null, typeof elem>(elem);
   }}
   onClick={(e) => {
-    e; // $ExpectType MouseEvent<HTMLButtonElement, MouseEvent>
+    expectType<React.MouseEvent<HTMLButtonElement, MouseEvent>, typeof e>(e);
     e.currentTarget.checkValidity();
   }}
 />;
@@ -85,7 +86,7 @@ declare const Foo: OverridableComponent<{
   numberProp={3}
   component={MyOverrideClassComponent}
   ref={(elem) => {
-    elem; // $ExpectType MyOverrideClassComponent | null
+    expectType<MyOverrideClassComponent | null, typeof elem>(elem);
   }}
 />;
 
@@ -94,7 +95,7 @@ declare const Foo: OverridableComponent<{
   numberProp={42}
   component={MyOverrideRefForwardingComponent}
   ref={(elem) => {
-    elem; // $ExpectType HTMLLegendElement | null
+    expectType<HTMLLegendElement | null, typeof elem>(elem);
   }}
 />;
 
@@ -127,7 +128,7 @@ declare const Foo: OverridableComponent<{
   // @ts-expect-error
   myString={4} // should be a string
   myCallback={(n) => {
-    n; // $ExpectType number
+    expectType<number, typeof n>(n);
   }}
   numberProp={3}
 />;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -82,6 +82,7 @@ import { Link as ReactRouterLink, LinkProps as ReactRouterLinkProps } from 'reac
 import { ButtonBaseActions } from '@material-ui/core/ButtonBase';
 import { IconButtonProps } from '@material-ui/core/IconButton';
 import ScopedCssBaseline from '@material-ui/core/ScopedCssBaseline';
+import { expectType } from '@material-ui/types';
 
 const log = console.log;
 const FakeIcon = () => <div>ICON</div>;
@@ -108,10 +109,10 @@ const AvatarTest = () => (
   <div>
     <Avatar
       ref={(elem) => {
-        elem; // $ExpectType HTMLDivElement | null
+        expectType<HTMLDivElement | null, typeof elem>(elem);
       }}
       onClick={(e) => {
-        e; // $ExpectType MouseEvent<HTMLDivElement, MouseEvent>
+        expectType<React.MouseEvent<HTMLDivElement, MouseEvent>, typeof e>(e);
         log(e);
       }}
       alt="Image Alt"
@@ -120,10 +121,10 @@ const AvatarTest = () => (
     <Avatar<'button'>
       component="button"
       ref={(elem) => {
-        elem; // $ExpectType HTMLButtonElement | null
+        expectType<HTMLButtonElement | null, typeof elem>(elem);
       }}
       onClick={(e) => {
-        e; // $ExpectType MouseEvent<HTMLButtonElement, MouseEvent>
+        expectType<React.MouseEvent<HTMLButtonElement, MouseEvent>, typeof e>(e);
         log(e);
       }}
       alt="Image Alt"
@@ -140,7 +141,7 @@ const AvatarTest = () => (
     <Avatar<typeof TestOverride>
       component={TestOverride}
       ref={(elem) => {
-        elem; // $ExpectType HTMLDivElement | null
+        expectType<HTMLDivElement | null, typeof elem>(elem);
       }}
       x={3}
       alt="Image Alt"
@@ -320,10 +321,10 @@ const DialogTest = () => {
           ))}
           <ListItem
             ref={(elem) => {
-              elem; // $ExpectType HTMLLIElement | null
+              expectType<HTMLLIElement | null, typeof elem>(elem);
             }}
             onClick={(e) => {
-              e; // $ExpectType MouseEvent<HTMLLIElement, MouseEvent>
+              expectType<React.MouseEvent<HTMLLIElement, MouseEvent>, typeof e>(e);
               log(e);
             }}
           >
@@ -335,10 +336,10 @@ const DialogTest = () => {
           <ListItem
             button
             ref={(elem) => {
-              elem; // $ExpectType HTMLDivElement | null
+              expectType<HTMLDivElement | null, typeof elem>(elem);
             }}
             onClick={(e) => {
-              e; // $ExpectType MouseEvent<HTMLDivElement, MouseEvent>
+              expectType<React.MouseEvent<HTMLDivElement, MouseEvent>, typeof e>(e);
               log(e);
             }}
           >
@@ -352,10 +353,10 @@ const DialogTest = () => {
           <ListItem<'a'>
             component="a"
             ref={(elem) => {
-              elem; // $ExpectType HTMLAnchorElement | null
+              expectType<HTMLAnchorElement | null, typeof elem>(elem);
             }}
             onClick={(e) => {
-              e; // $ExpectType MouseEvent<HTMLAnchorElement, MouseEvent>
+              expectType<React.MouseEvent<HTMLAnchorElement, MouseEvent>, typeof e>(e);
               log(e);
             }}
             button
@@ -574,10 +575,10 @@ const MenuTest = () => {
           key={option}
           selected={false}
           ref={(elem) => {
-            elem; // $ExpectType HTMLLIElement | null
+            expectType<HTMLLIElement | null, typeof elem>(elem);
           }}
           onClick={(e) => {
-            e; // $ExpectType MouseEvent<HTMLLIElement, MouseEvent>
+            expectType<React.MouseEvent<HTMLLIElement, MouseEvent>, typeof e>(e);
             log(e);
           }}
         >
@@ -590,10 +591,10 @@ const MenuTest = () => {
         }}
         component="a"
         ref={(elem) => {
-          elem; // $ExpectType HTMLAnchorElement | null
+          expectType<HTMLAnchorElement | null, typeof elem>(elem);
         }}
         onClick={(e) => {
-          e; // $ExpectType MouseEvent<HTMLAnchorElement, MouseEvent>
+          expectType<React.MouseEvent<HTMLAnchorElement, MouseEvent>, typeof e>(e);
           log(e);
         }}
       >
@@ -602,7 +603,7 @@ const MenuTest = () => {
       <MenuItem
         button={false}
         ref={(elem) => {
-          elem; // $ExpectType HTMLLIElement | null
+          expectType<HTMLLIElement | null, typeof elem>(elem);
         }}
       />
       <MenuItem
@@ -613,7 +614,7 @@ const MenuTest = () => {
         button={false}
         ref={(elem) => {
           // inferred from `button={false}` instead of `action`
-          elem; // $ExpectType HTMLLIElement | null
+          expectType<HTMLLIElement | null, typeof elem>(elem);
         }}
       />
     </Menu>

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -14,6 +14,7 @@ import {
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { blue } from '@material-ui/core/colors';
+import { expectType } from '@material-ui/types';
 
 // Shared types for examples
 interface ComponentProps extends WithStyles<typeof styles> {
@@ -475,11 +476,10 @@ withStyles((theme) =>
 {
   // theme is defaulted to type of Theme
   const useStyles = makeStyles((theme) => {
-    // $ExpectType Theme
-    const t = theme;
+    expectType<Theme, typeof theme>(theme);
     return {
       root: {
-        margin: t.spacing(1),
+        margin: theme.spacing(1),
       },
     };
   });
@@ -504,10 +504,7 @@ withStyles((theme) =>
     });
 
     const styles = useStyles({ foo: true });
-    // $ExpectType string
-    const root = styles.root;
-    // $ExpectType string
-    const root2 = styles.root2;
+    expectType<Record<'root' | 'root2', string>, typeof styles>(styles);
   }
 
   // makeStyles accepts properties as functions using a callback
@@ -523,10 +520,7 @@ withStyles((theme) =>
     }));
 
     const styles = useStyles({ foo: true });
-    // $ExpectType string
-    const root = styles.root;
-    // $ExpectType string
-    const root2 = styles.root2;
+    expectType<Record<'root' | 'root2', string>, typeof styles>(styles);
   }
 
   // createStyles accepts properties as functions
@@ -540,8 +534,8 @@ withStyles((theme) =>
       }),
     });
 
-    // $ExpectType string
     const root = makeStyles(styles)({ foo: true }).root;
+    expectType<string, typeof root>(root);
   }
 
   // withStyles accepts properties as functions
@@ -619,8 +613,7 @@ withStyles((theme) =>
 
   // Theme has default type
   styled(Button)(({ theme }) => {
-    // $ExpectType Theme
-    theme;
+    expectType<Theme, typeof theme>(theme);
 
     return { padding: theme.spacing(1) };
   });
@@ -631,19 +624,14 @@ withStyles((theme) =>
 
   // Type of props follow all the way to css properties
   styled(Button)<Theme, myProps>(({ theme, testValue }) => {
-    // $ExpectType Theme
-    theme;
-
-    // $ExpectType boolean
-    testValue;
+    expectType<Theme, typeof theme>(theme);
+    expectType<boolean, typeof testValue>(testValue);
 
     return {
       padding: (props) => {
-        // $ExpectType myProps
-        props;
+        expectType<myProps, typeof props>(props);
 
-        // $ExpectType boolean
-        props.testValue;
+        expectType<boolean, typeof props.testValue>(props.testValue);
         return theme.spacing(1);
       },
     };

--- a/scripts/jsonlint.js
+++ b/scripts/jsonlint.js
@@ -17,7 +17,7 @@ async function run() {
 
   const filenames = glob.sync('**/*.json', {
     cwd: workspaceRoot,
-    ignore: [...eslintignore, 'tsconfig*.json'],
+    ignore: [...eslintignore, 'tsconfig*.json', 'tslint.json'],
   });
 
   let passed = true;

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,9 @@
   "jsRules": {},
   "rules": {
     "deprecation": true,
+    // $ExpectError -> @ts-expect-error
+    // $ExpectType -> `expectType` from `@material-ui/types`
+    "expect": false,
     "file-name-casing": false,
     "no-boolean-literal-compare": false,
     "no-empty-interface": false,


### PR DESCRIPTION
```diff
-// $ExpectType string
-value;
+ expectType<string, typeof value>(value);
```

With #21308 we no longer have a dependency on `dtslint#expect` moving us closers to #19413.

The `typeof value(value)` repetition and error message if it fails is not ideal but documentation for `expectType` hopefully helps. The upside is that we now compare types structurally and not by name (and even worse by order).

Didn't use `tsd#expectType` since they bundle their own TypeScript. Minor versions of TypeScript might be incompatible which can become a problem. They also use the compiler API of TypeScript which is largely undocumented. It's unclear whether their approach is intended or if the actual TypeScript language server has the correct/better approach.