### PR TITLE
[Stepper] Only render label container if a label exists

### DIFF
--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -140,9 +140,9 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
           display="block"
         >
           {children}
-        </Typography>}
+        </Typography>
         {optional}
-      </span>
+      </span>}
     </span>
   );
 });

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -127,22 +127,24 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
           />
         </span>
       ) : null}
-      {children && <span className={classes.labelContainer}>
-        <Typography
-          variant="body2"
-          component="span"
-          className={clsx(classes.label, {
-            [classes.alternativeLabel]: alternativeLabel,
-            [classes.completed]: completed,
-            [classes.active]: active,
-            [classes.error]: error,
-          })}
-          display="block"
-        >
-          {children}
-        </Typography>
+      <span className={classes.labelContainer}>
+        {children ? (
+          <Typography
+            variant="body2"
+            component="span"
+            display="block"
+            className={clsx(classes.label, {
+              [classes.alternativeLabel]: alternativeLabel,
+              [classes.completed]: completed,
+              [classes.active]: active,
+              [classes.error]: error,
+            })}
+          >
+            {children}
+          </Typography>
+        ) : null}
         {optional}
-      </span>}
+      </span>
     </span>
   );
 });

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -127,7 +127,7 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
           />
         </span>
       ) : null}
-      <span className={classes.labelContainer}>
+      {children && <span className={classes.labelContainer}>
         <Typography
           variant="body2"
           component="span"
@@ -140,7 +140,7 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
           display="block"
         >
           {children}
-        </Typography>
+        </Typography>}
         {optional}
       </span>
     </span>


### PR DESCRIPTION
We'd like to use the Stepper without labels, but the labelContainer is still there and takes up a bit of height, making vertical alignment difficult.

Todo: Adjust code formatting