### PR TITLE
[ExpansionPanel] Change the expanded state type to string

### DIFF
--- a/docs/src/pages/components/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/components/expansion-panels/ControlledExpansionPanels.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function ControlledExpansionPanels() {
   const classes = useStyles();
-  const [expanded, setExpanded] = React.useState(false);
+  const [expanded, setExpanded] = React.useState('');
 
   const handleChange = (panel) => (event, isExpanded) => {
     setExpanded(isExpanded ? panel : false);


### PR DESCRIPTION
Variable `expanded` is initialised as a bool type on line 26 by the follow code:
`const [expanded, setExpanded] = React.useState(false);`

On line 34 `expanded` is compared with a string value:
`<ExpansionPanel expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>`

Resulting in a TypeScript TS2367 error / condition will always return 'false' since the types 'boolean' and 'string' have no overlap.

Changed the type to string to resolve the error

Closes #21337

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
