### PR TITLE
[SpeedDial] Improve tooltip work break

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -54,6 +54,7 @@ export const styles = (theme) => ({
     boxShadow: theme.shadows[1],
     color: theme.palette.text.secondary,
     padding: '4px 16px',
+    wordBreak: 'keep-all',
   },
   /* Styles applied to the root if `tooltipOpen={true}` and `tooltipPlacement="left"`` */
   tooltipPlacementLeft: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).


Tooltip of SpeedDialAction didn't support Japanese literal style, so I added word break property to `staticTooltipLabel` in order to avoid that the word is vertical.
I think that literals in the tooltip should be horizontal in any languages.
However I don't know why the tooltip is vertical in Japanese. Cloud you comment the reason if you have any ideas.

## Before

<img width="297" alt="スクリーンショット 2020-06-07 17 17 44" src="https://user-images.githubusercontent.com/15076603/83963743-27fa9e80-a8e3-11ea-8ec5-9358731973f7.png">

## After
<img width="343" alt="スクリーンショット 2020-06-07 17 17 23" src="https://user-images.githubusercontent.com/15076603/83963748-30eb7000-a8e3-11ea-81d2-56c6b7e26229.png">

## Try it

```
diff --git a/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.js b/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.js
index 2f3e88544..68811170e 100644
--- a/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.js
+++ b/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.js
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
 }));

 const actions = [
-  { icon: <FileCopyIcon />, name: 'Copy' },
+  { icon: <FileCopyIcon />, name: 'あああああ' },
   { icon: <SaveIcon />, name: 'Save' },
   { icon: <PrintIcon />, name: 'Print' },
```