### PR TITLE
[Checkbox] Fix custom icon fontSize prop support

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -91,10 +91,14 @@ const Checkbox = React.forwardRef(function Checkbox(props, ref) {
         ...inputProps,
       }}
       icon={React.cloneElement(icon, {
-        fontSize: icon.props.fontSize === undefined && size !== 'medium' ? size : icon.props.fontSize,
+        fontSize:
+          icon.props.fontSize === undefined && size !== 'medium' ? size : icon.props.fontSize,
       })}
       checkedIcon={React.cloneElement(indeterminateIcon, {
-        fontSize: indeterminateIcon.props.fontSize === undefined && size !== 'medium' ? size : indeterminateIcon.props.fontSize
+        fontSize:
+          indeterminateIcon.props.fontSize === undefined && size !== 'medium'
+            ? size
+            : indeterminateIcon.props.fontSize,
       })}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -64,13 +64,16 @@ const Checkbox = React.forwardRef(function Checkbox(props, ref) {
     checkedIcon = defaultCheckedIcon,
     classes,
     color = 'secondary',
-    icon = defaultIcon,
+    icon: iconProp = defaultIcon,
     indeterminate = false,
-    indeterminateIcon = defaultIndeterminateIcon,
+    indeterminateIcon: indeterminateIconProp = defaultIndeterminateIcon,
     inputProps,
     size = 'medium',
     ...other
   } = props;
+
+  const icon = indeterminate ? indeterminateIconProp : iconProp;
+  const indeterminateIcon = indeterminate ? indeterminateIconProp : checkedIcon;
 
   return (
     <SwitchBase
@@ -87,11 +90,11 @@ const Checkbox = React.forwardRef(function Checkbox(props, ref) {
         'data-indeterminate': indeterminate,
         ...inputProps,
       }}
-      icon={React.cloneElement(indeterminate ? indeterminateIcon : icon, {
-        fontSize: size === 'small' ? 'small' : 'default',
+      icon={React.cloneElement(icon, {
+        fontSize: icon.props.fontSize === undefined && size !== 'medium' ? size : icon.props.fontSize,
       })}
-      checkedIcon={React.cloneElement(indeterminate ? indeterminateIcon : checkedIcon, {
-        fontSize: size === 'small' ? 'small' : 'default',
+      checkedIcon={React.cloneElement(indeterminateIcon, {
+        fontSize: indeterminateIcon.props.fontSize === undefined && size !== 'medium' ? size : indeterminateIcon.props.fontSize
       })}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -115,4 +115,20 @@ describe('<Checkbox />', () => {
       });
     });
   });
+
+  it('should allow custom icon font sizes', () => {
+    const fontSizeSpy = spy();
+    const MyIcon = (props) => {
+      const { fontSize, ...other } = props;
+
+      React.useEffect(() => {
+        fontSizeSpy(fontSize);
+      });
+
+      return <div {...other} />;
+    };
+    render(<Checkbox icon={<MyIcon fontSize="foo" />} />);
+
+    expect(fontSizeSpy.args[0][0]).to.equal('foo');
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

I tried a couple of different things and this solution works great. I almost feel guilty because I couldn't really change much from the original solution provided by @oliviertassinari except the fact that `size: PropTypes.oneOf(['medium', 'small']),` doesn't require any changes since this refers to the size prop of the Checkbox component and the issue was caused by the fontSize prop of the icon being used.

Also, I tested the Radio component for the same issue and it seemed to be working fine, unless I'm missing something obvious?

![radioWorks](https://user-images.githubusercontent.com/22865625/83977681-0cfa4f80-a920-11ea-9a91-30027c2c6043.png)


Closes #21289