### PR TITLE
[docs] Use rem in responsive font sizes chart

### DIFF
--- a/docs/src/pages/customization/typography/ResponsiveFontSizesChart.js
+++ b/docs/src/pages/customization/typography/ResponsiveFontSizesChart.js
@@ -88,7 +88,7 @@ export default function ResponsiveFontSizes() {
           </XAxis>
           <YAxis dataKey="fontSize" type="number">
             <Label position="top" offset={20}>
-              font-size (px)
+              font-size (rem)
             </Label>
           </YAxis>
           <Tooltip />


### PR DESCRIPTION
Changes vertical axis from `font-size (px)` to `font-size (rem)` which
better matches the vertical axis values.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Edit @eps1lon: Closes #21372