### PR TITLE
[test] Speed up slow TablePagination tests

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -132,7 +132,7 @@ describe('<TablePagination />', () => {
 
   describe('prop: page', () => {
     it('should disable the back button on the first page', () => {
-      const { getByRole } = render(
+      const { getAllByRole } = render(
         <table>
           <TableFooter>
             <TableRow>
@@ -147,14 +147,14 @@ describe('<TablePagination />', () => {
           </TableFooter>
         </table>,
       );
-      const backButton = getByRole('button', { name: 'Previous page' });
-      const nextButton = getByRole('button', { name: 'Next page' });
+
+      const [, backButton, nextButton] = getAllByRole('button');
       expect(backButton).to.have.property('disabled', true);
       expect(nextButton).to.have.property('disabled', false);
     });
 
     it('should disable the next button on the last page', () => {
-      const { getByRole } = render(
+      const { getAllByRole } = render(
         <table>
           <TableFooter>
             <TableRow>
@@ -170,8 +170,7 @@ describe('<TablePagination />', () => {
         </table>,
       );
 
-      const backButton = getByRole('button', { name: 'Previous page' });
-      const nextButton = getByRole('button', { name: 'Next page' });
+      const [, backButton, nextButton] = getAllByRole('button');
       expect(backButton).to.have.property('disabled', false);
       expect(nextButton).to.have.property('disabled', true);
     });


### PR DESCRIPTION
Table tests have a deeper DOM tree than other tests (table > tbody > tr > td) which makes them noticeably slower if we can't access style caches for common subtrees.

We can't share style computation caches between individual queries (yet) without having to deal with hard cache problems. We're moving the two descriptive, individual queries into one less descriptive query. 

Brings us down from 50 getComputedStyle calls to 16 which can cause timeouts in CircleCI.

In the future we might be able to "batch queries" so that testing-library can safely share caches of getComputedStyle. I think the browser already has this built in but JSDOM doesn't fully implement getComputedStyle (here: a live CSSDeclaration).