### PR TITLE
[Autocomplete]: add prop disbleResetInputOnSelect

### DIFF
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -95,6 +95,10 @@ export interface UseAutocompleteProps<
    */
   disableListWrap?: boolean;
   /**
+   * If `true`, the input value will not be reset after an option is toggled.
+   */
+  disableResetInputOnSelect?: boolean;
+  /**
    * A filter function that determines the options that are eligible.
    *
    * @param {T[]} options The options to render.

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -81,6 +81,7 @@ export default function useAutocomplete(props) {
     disableCloseOnSelect = false,
     disabledItemsFocusable = false,
     disableListWrap = false,
+    disableResetInputOnSelect = false,
     filterOptions = defaultFilterOptions,
     filterSelectedOptions = false,
     freeSolo = false,
@@ -560,7 +561,9 @@ export default function useAutocomplete(props) {
       }
     }
 
-    resetInputValue(event, newValue);
+    if (!disableResetInputOnSelect) {
+      resetInputValue(event, newValue);
+    }
 
     handleValue(event, newValue, reason, { option });
     if (!disableCloseOnSelect) {


### PR DESCRIPTION
For the useAutocomplete hook, every time an option is selected/unselected, the search input value is reset. I'd like to be able to control that via a prop so it's possible to build a dropdown where the search stays always the same and the user has to manually clear it.