### PR TITLE
[test] Use testing-library in Stepper

### DIFF
--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -114,8 +114,8 @@ describe('<Stepper />', () => {
       expect(steps[0]).to.not.have.class(stepClasses.completed);
       expect(steps[1]).to.not.have.class(stepClasses.completed);
       expect(steps[2]).to.not.have.class(stepClasses.completed);
-      expect(connectors[0]).not.to.have.class('Mui-disabled');
-      expect(connectors[1]).not.to.have.class('Mui-disabled');
+      expect(connectors[0]).not.to.have.class(stepConnectorClasses.disabled);
+      expect(connectors[1]).not.to.have.class(stepConnectorClasses.disabled);
 
       setProps({ activeStep: 1 });
 

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -131,18 +131,20 @@ describe('<Stepper />', () => {
     });
 
     it('passes index down correctly when rendering children containing arrays', () => {
-      // I don't see how to test it using react-testing-library
-      // Also, this test has questionable value, I'd delete it
-      // const wrapper = shallow(
-      //   <Stepper linear={false}>
-      //     <div />
-      //     {[<div key={1} />, <div key={2} />]}
-      //   </Stepper>,
-      // );
-      // const steps = wrapper.children().find('div');
-      // expect(steps.at(0).props().index).to.equal(0);
-      // expect(steps.at(1).props().index).to.equal(1);
-      // expect(steps.at(2).props().index).to.equal(2);
+      const CustomStep = ({ index }) => <div data-index={index} data-testid="step" />;
+
+      const { getAllByTestId } = render(
+        <Stepper nonLinear>
+          <CustomStep />
+          {[<CustomStep key={1} />, <CustomStep key={2} />]}
+        </Stepper>,
+      );
+
+      const steps = getAllByTestId('step');
+
+      expect(steps[0]).to.have.attribute('data-index', '0');
+      expect(steps[1]).to.have.attribute('data-index', '1');
+      expect(steps[2]).to.have.attribute('data-index', '2');
     });
   });
 

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -13,14 +13,12 @@ import Stepper from './Stepper';
 
 describe('<Stepper />', () => {
   let classes;
-  let shallow;
   // StrictModeViolation: test uses StepContent
   const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
 
   before(() => {
     classes = getClasses(<Stepper />);
-    shallow = createShallow({ dive: true });
   });
 
   describeConformance(
@@ -37,17 +35,20 @@ describe('<Stepper />', () => {
   );
 
   it('has no elevation by default', () => {
-    const wrapper = mount(
+    const { container } = render(
       <Stepper>
         <Step />
       </Stepper>,
     );
-    expect(wrapper.find(Paper).props().elevation).to.equal(0);
+
+    const paper = container.querySelector('.MuiPaper-elevation0');
+
+    expect(paper).not.equal(null);
   });
 
   describe('rendering children', () => {
     it('renders 3 Step and 2 StepConnector components', () => {
-      const wrapper = mount(
+      const { container } = render(
         <Stepper>
           <Step />
           <Step />
@@ -55,55 +56,83 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      expect(wrapper.find(StepConnector).length).to.equal(2);
-      expect(wrapper.find(Step).length).to.equal(3);
+      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+      const steps = container.querySelectorAll('.MuiStep-root');
+
+      expect(connectors).to.have.length(2);
+      expect(steps).to.have.length(3);
     });
   });
 
   describe('controlling child props', () => {
     it('controls children linearly based on the activeStep prop', () => {
-      const wrapper = shallow(
+      const { container, setProps } = render(
         <Stepper activeStep={0}>
-          <div className="child-0" />
-          <div className="child-1" />
-          <div className="child-2" />
+          <Step />
+          <Step />
+          <Step />
         </Stepper>,
       );
-      expect(wrapper.find('.child-0').props().active).to.equal(true);
-      expect(wrapper.find('.child-1').props().active).to.equal(false);
-      expect(wrapper.find('.child-2').props().active).to.equal(false);
-      expect(wrapper.find('.child-1').props().disabled).to.equal(true);
-      expect(wrapper.find('.child-2').props().disabled).to.equal(true);
-      wrapper.setProps({ activeStep: 1 });
-      expect(wrapper.find('.child-0').props().completed).to.equal(true);
-      expect(wrapper.find('.child-0').props().active).to.equal(false);
-      expect(wrapper.find('.child-1').props().active).to.equal(true);
-      expect(wrapper.find('.child-2').props().active).to.equal(false);
-      expect(wrapper.find('.child-2').props().disabled).to.equal(true);
+
+      const steps = container.querySelectorAll('.MuiStep-root');
+      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+
+      expect(steps[0]).to.not.have.class('MuiStep-completed');
+      expect(steps[1]).to.not.have.class('MuiStep-completed');
+      expect(steps[2]).to.not.have.class('MuiStep-completed');
+      expect(connectors[0]).to.have.class('Mui-disabled');
+      expect(connectors[1]).to.have.class('Mui-disabled');
+
+      setProps({ activeStep: 1 });
+
+      expect(steps[0]).to.have.class('MuiStep-completed');
+      expect(steps[1]).to.not.have.class('MuiStep-completed');
+      expect(steps[2]).to.not.have.class('MuiStep-completed');
+      expect(connectors[0]).to.not.have.class('Mui-disabled');
+      expect(connectors[0]).to.have.class('MuiStepConnector-active');
+      expect(connectors[1]).to.have.class('Mui-disabled');
     });
 
     it('controls children non-linearly based on the activeStep prop', () => {
-      const wrapper = shallow(
-        <Stepper linear={false} activeStep={0}>
-          <div className="child-0" />
-          <div className="child-1" />
-          <div className="child-2" />
+      const { container, setProps } = render(
+        <Stepper nonLinear activeStep={0}>
+          <Step />
+          <Step />
+          <Step />
         </Stepper>,
       );
-      expect(wrapper.find('.child-0').props().active).to.equal(true);
-      expect(wrapper.find('.child-1').props().active).to.equal(false);
-      expect(wrapper.find('.child-2').props().active).to.equal(false);
-      wrapper.setProps({ activeStep: 1 });
-      expect(wrapper.find('.child-0').props().active).to.equal(false);
-      expect(wrapper.find('.child-1').props().active).to.equal(true);
-      expect(wrapper.find('.child-2').props().active).to.equal(false);
-      wrapper.setProps({ activeStep: 2 });
-      expect(wrapper.find('.child-0').props().active).to.equal(false);
-      expect(wrapper.find('.child-1').props().active).to.equal(false);
-      expect(wrapper.find('.child-2').props().active).to.equal(true);
+
+      const steps = container.querySelectorAll('.MuiStep-root');
+      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+
+      expect(steps[0]).to.not.have.class('MuiStep-completed');
+      expect(steps[1]).to.not.have.class('MuiStep-completed');
+      expect(steps[2]).to.not.have.class('MuiStep-completed');
+      expect(connectors[0]).not.to.have.class('Mui-disabled');
+      expect(connectors[1]).not.to.have.class('Mui-disabled');
+
+      setProps({ activeStep: 1 });
+
+      expect(steps[0]).to.not.have.class('MuiStep-completed');
+      expect(steps[1]).to.not.have.class('MuiStep-completed');
+      expect(steps[2]).to.not.have.class('MuiStep-completed');
+      expect(connectors[0]).to.not.have.class('Mui-disabled');
+      expect(connectors[0]).to.have.class('MuiStepConnector-active');
+      expect(connectors[1]).not.to.have.class('Mui-disabled');
+
+      setProps({ activeStep: 2 });
+
+      expect(steps[0]).to.not.have.class('MuiStep-completed');
+      expect(steps[1]).to.not.have.class('MuiStep-completed');
+      expect(steps[2]).to.not.have.class('MuiStep-completed');
+      expect(connectors[0]).to.not.have.class('Mui-disabled');
+      expect(connectors[1]).to.not.have.class('Mui-disabled');
+      expect(connectors[1]).to.have.class('MuiStepConnector-active');
     });
 
     it('passes index down correctly when rendering children containing arrays', () => {
+      // I don't see how to test it using react-testing-library
+      // Also, this test has questionable value, I'd delete it
       const wrapper = shallow(
         <Stepper linear={false}>
           <div />
@@ -120,60 +149,71 @@ describe('<Stepper />', () => {
 
   describe('step connector', () => {
     it('should have a default step connector', () => {
-      const wrapper = mount(
+      const { container } = render(
         <Stepper>
           <Step />
           <Step />
         </Stepper>,
       );
 
-      expect(wrapper.find(StepConnector).length).to.equal(1);
+      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+
+      expect(connectors).to.have.length(1);
     });
 
     it('should allow the developer to specify a custom step connector', () => {
-      const CustomConnector = () => null;
-      const wrapper = mount(
+      const CustomConnector = () => <div className="CustomConnector" />;
+      const { container } = render(
         <Stepper connector={<CustomConnector />}>
           <Step />
           <Step />
         </Stepper>,
       );
 
-      expect(wrapper.find(CustomConnector).length).to.equal(1);
-      expect(wrapper.find(StepConnector).length).to.equal(0);
+      const defaultConnectors = container.querySelectorAll('.MuiStepConnector-root');
+      const customConnectors = container.querySelectorAll('CustomConnector');
+
+      expect(defaultConnectors).to.have.length(0);
+      expect(customConnectors).to.have.length(0);
     });
 
     it('should allow the step connector to be removed', () => {
-      const wrapper = shallow(
+      const { container } = render(
         <Stepper connector={null}>
           <Step />
           <Step />
         </Stepper>,
       );
 
-      expect(wrapper.find(StepConnector).length).to.equal(0);
+      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+
+      expect(connectors).to.have.length(0);
     });
 
     it('should pass active prop to connector when second step is active', () => {
-      const wrapper = mount(
+      const { container } = render(
         <Stepper activeStep={1}>
           <Step />
           <Step />
         </Stepper>,
       );
-      const connectors = wrapper.find(StepConnector);
-      expect(connectors.first().props().active).to.equal(true);
+
+      const connector = container.querySelector('.MuiStepConnector-root');
+
+      expect(connector).to.have.class('MuiStepConnector-active');
     });
 
     it('should pass completed prop to connector when second step is completed', () => {
-      const wrapper = mount(
+      const { container } = render(
         <Stepper activeStep={2}>
           <Step />
           <Step />
         </Stepper>,
       );
-      const connectors = wrapper.find(StepConnector);
-      expect(connectors.first().props().completed).to.equal(true);
+
+      const connector = container.querySelector('.MuiStepConnector-root');
+
+      expect(connector).to.have.class('MuiStepConnector-completed');
     });
 
     it('should pass correct active and completed props to the StepConnector with nonLinear prop', () => {
@@ -201,30 +241,37 @@ describe('<Stepper />', () => {
   });
 
   it('renders with a null child', () => {
-    const wrapper = shallow(
+    // I'm not sure if this test brings any value
+    const { container } = render(
       <Stepper>
         <Step />
         {null}
       </Stepper>,
     );
-    expect(wrapper.find(Step).length).to.equal(1);
+
+    const steps = container.querySelectorAll('.MuiStep-root');
+
+    expect(steps).to.have.length(1);
   });
 
   it('should be able to force a state', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <Stepper>
-        <Step className="child-0" />
-        <Step className="child-1" active />
-        <Step className="child-2" />
+        <Step />
+        <Step active />
+        <Step />
       </Stepper>,
     );
-    expect(wrapper.find('.child-0').props().active).to.equal(true);
-    expect(wrapper.find('.child-1').props().active).to.equal(true);
-    expect(wrapper.find('.child-2').props().active).to.equal(false);
+
+    const steps = container.querySelectorAll('.MuiStep-root');
+
+    expect(steps[0]).to.not.have.class('MuiStep-active');
+    expect(steps[1]).to.not.have.class('MuiStep-active');
+    expect(steps[2]).to.not.have.class('MuiStep-active');
   });
 
   it('should hide the last connector', () => {
-    const wrapper = mount(
+    const { container } = render(
       <Stepper orientation="vertical">
         <Step>
           <StepLabel>one</StepLabel>
@@ -236,7 +283,10 @@ describe('<Stepper />', () => {
         </Step>
       </Stepper>,
     );
-    expect(wrapper.find(StepContent).at(0).props().last).to.equal(false);
-    expect(wrapper.find(StepContent).at(1).props().last).to.equal(true);
+
+    const stepContent = container.querySelectorAll('.MuiStepContent-root');
+
+    expect(stepContent[0]).to.not.have.class('MuiStepContent-last');
+    expect(stepContent[1]).to.have.class('MuiStepContent-last');
   });
 });

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -14,15 +14,15 @@ import Stepper from './Stepper';
 describe('<Stepper />', () => {
   let classes;
   let stepClasses;
-  let stepConnectorClasses
+  let stepConnectorClasses;
   // StrictModeViolation: test uses StepContent
   const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
 
-  before(() => {    
+  before(() => {
     classes = getClasses(<Stepper />);
-    stepClasses = getClasses(<Step />)
-    stepConnectorClasses = getClasses(<StepConnector />)
+    stepClasses = getClasses(<Step />);
+    stepConnectorClasses = getClasses(<StepConnector />);
   });
 
   describeConformance(
@@ -45,7 +45,7 @@ describe('<Stepper />', () => {
       </Stepper>,
     );
 
-    const paperClasses = getClasses(<Paper />)
+    const paperClasses = getClasses(<Paper />);
 
     const paper = container.querySelector(`.${paperClasses.elevation0}`);
 
@@ -82,7 +82,7 @@ describe('<Stepper />', () => {
 
       const steps = container.querySelectorAll(`.${stepClasses.root}`);
       const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
-      
+
       expect(steps[0]).to.not.have.class(stepClasses.completed);
       expect(steps[1]).to.not.have.class(stepClasses.completed);
       expect(steps[2]).to.not.have.class(stepClasses.completed);
@@ -290,7 +290,7 @@ describe('<Stepper />', () => {
       </Stepper>,
     );
 
-    const stepContentClasses = getClasses(<StepContent />)
+    const stepContentClasses = getClasses(<StepContent />);
 
     const stepContent = container.querySelectorAll(`.${stepContentClasses.root}`);
 

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -13,12 +13,16 @@ import Stepper from './Stepper';
 
 describe('<Stepper />', () => {
   let classes;
+  let stepClasses;
+  let stepConnectorClasses
   // StrictModeViolation: test uses StepContent
   const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
 
-  before(() => {
+  before(() => {    
     classes = getClasses(<Stepper />);
+    stepClasses = getClasses(<Step />)
+    stepConnectorClasses = getClasses(<StepConnector />)
   });
 
   describeConformance(
@@ -41,7 +45,9 @@ describe('<Stepper />', () => {
       </Stepper>,
     );
 
-    const paper = container.querySelector('.MuiPaper-elevation0');
+    const paperClasses = getClasses(<Paper />)
+
+    const paper = container.querySelector(`.${paperClasses.elevation0}`);
 
     expect(paper).not.equal(null);
   });
@@ -56,8 +62,8 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const connectors = container.querySelectorAll('.MuiStepConnector-root');
-      const steps = container.querySelectorAll('.MuiStep-root');
+      const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
+      const steps = container.querySelectorAll(`.${stepClasses.root}`);
 
       expect(connectors).to.have.length(2);
       expect(steps).to.have.length(3);
@@ -74,23 +80,23 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const steps = container.querySelectorAll('.MuiStep-root');
-      const connectors = container.querySelectorAll('.MuiStepConnector-root');
-
-      expect(steps[0]).to.not.have.class('MuiStep-completed');
-      expect(steps[1]).to.not.have.class('MuiStep-completed');
-      expect(steps[2]).to.not.have.class('MuiStep-completed');
-      expect(connectors[0]).to.have.class('Mui-disabled');
-      expect(connectors[1]).to.have.class('Mui-disabled');
+      const steps = container.querySelectorAll(`.${stepClasses.root}`);
+      const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
+      
+      expect(steps[0]).to.not.have.class(stepClasses.completed);
+      expect(steps[1]).to.not.have.class(stepClasses.completed);
+      expect(steps[2]).to.not.have.class(stepClasses.completed);
+      expect(connectors[0]).to.have.class(stepConnectorClasses.disabled);
+      expect(connectors[1]).to.have.class(stepConnectorClasses.disabled);
 
       setProps({ activeStep: 1 });
 
-      expect(steps[0]).to.have.class('MuiStep-completed');
-      expect(steps[1]).to.not.have.class('MuiStep-completed');
-      expect(steps[2]).to.not.have.class('MuiStep-completed');
-      expect(connectors[0]).to.not.have.class('Mui-disabled');
-      expect(connectors[0]).to.have.class('MuiStepConnector-active');
-      expect(connectors[1]).to.have.class('Mui-disabled');
+      expect(steps[0]).to.have.class(stepClasses.completed);
+      expect(steps[1]).to.not.have.class(stepClasses.completed);
+      expect(steps[2]).to.not.have.class(stepClasses.completed);
+      expect(connectors[0]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(connectors[0]).to.have.class(stepConnectorClasses.active);
+      expect(connectors[1]).to.have.class(stepConnectorClasses.disabled);
     });
 
     it('controls children non-linearly based on the activeStep prop', () => {
@@ -102,32 +108,32 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const steps = container.querySelectorAll('.MuiStep-root');
-      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+      const steps = container.querySelectorAll(`.${stepClasses.root}`);
+      const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
 
-      expect(steps[0]).to.not.have.class('MuiStep-completed');
-      expect(steps[1]).to.not.have.class('MuiStep-completed');
-      expect(steps[2]).to.not.have.class('MuiStep-completed');
+      expect(steps[0]).to.not.have.class(stepClasses.completed);
+      expect(steps[1]).to.not.have.class(stepClasses.completed);
+      expect(steps[2]).to.not.have.class(stepClasses.completed);
       expect(connectors[0]).not.to.have.class('Mui-disabled');
       expect(connectors[1]).not.to.have.class('Mui-disabled');
 
       setProps({ activeStep: 1 });
 
-      expect(steps[0]).to.not.have.class('MuiStep-completed');
-      expect(steps[1]).to.not.have.class('MuiStep-completed');
-      expect(steps[2]).to.not.have.class('MuiStep-completed');
-      expect(connectors[0]).to.not.have.class('Mui-disabled');
-      expect(connectors[0]).to.have.class('MuiStepConnector-active');
-      expect(connectors[1]).not.to.have.class('Mui-disabled');
+      expect(steps[0]).to.not.have.class(stepClasses.completed);
+      expect(steps[1]).to.not.have.class(stepClasses.completed);
+      expect(steps[2]).to.not.have.class(stepClasses.completed);
+      expect(connectors[0]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(connectors[0]).to.have.class(stepConnectorClasses.active);
+      expect(connectors[1]).not.to.have.class(stepConnectorClasses.disabled);
 
       setProps({ activeStep: 2 });
 
-      expect(steps[0]).to.not.have.class('MuiStep-completed');
-      expect(steps[1]).to.not.have.class('MuiStep-completed');
-      expect(steps[2]).to.not.have.class('MuiStep-completed');
-      expect(connectors[0]).to.not.have.class('Mui-disabled');
-      expect(connectors[1]).to.not.have.class('Mui-disabled');
-      expect(connectors[1]).to.have.class('MuiStepConnector-active');
+      expect(steps[0]).to.not.have.class(stepClasses.completed);
+      expect(steps[1]).to.not.have.class(stepClasses.completed);
+      expect(steps[2]).to.not.have.class(stepClasses.completed);
+      expect(connectors[0]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(connectors[1]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(connectors[1]).to.have.class(stepConnectorClasses.active);
     });
 
     it('passes index down correctly when rendering children containing arrays', () => {
@@ -157,7 +163,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+      const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
 
       expect(connectors).to.have.length(1);
     });
@@ -171,7 +177,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const defaultConnectors = container.querySelectorAll('.MuiStepConnector-root');
+      const defaultConnectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
       const customConnectors = container.querySelectorAll('.CustomConnector');
 
       expect(defaultConnectors).to.have.length(0);
@@ -186,7 +192,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+      const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
 
       expect(connectors).to.have.length(0);
     });
@@ -199,9 +205,9 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const connector = container.querySelector('.MuiStepConnector-root');
+      const connector = container.querySelector(`.${stepConnectorClasses.root}`);
 
-      expect(connector).to.have.class('MuiStepConnector-active');
+      expect(connector).to.have.class(stepConnectorClasses.active);
     });
 
     it('should pass completed prop to connector when second step is completed', () => {
@@ -212,9 +218,9 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const connector = container.querySelector('.MuiStepConnector-root');
+      const connector = container.querySelector(`.${stepConnectorClasses.root}`);
 
-      expect(connector).to.have.class('MuiStepConnector-completed');
+      expect(connector).to.have.class(stepConnectorClasses.completed);
     });
 
     it('should pass correct active and completed props to the StepConnector with nonLinear prop', () => {
@@ -230,19 +236,18 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      const connectors = container.querySelectorAll('.MuiStepConnector-root');
+      const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
 
       expect(connectors).to.have.length(2);
-      expect(connectors[0]).to.have.class('MuiStepConnector-active');
-      expect(connectors[0]).to.not.have.class('MuiStepConnector-completed');
+      expect(connectors[0]).to.have.class(stepConnectorClasses.active);
+      expect(connectors[0]).to.not.have.class(stepConnectorClasses.completed);
 
-      expect(connectors[1]).to.have.class('MuiStepConnector-active');
-      expect(connectors[1]).to.have.class('MuiStepConnector-completed');
+      expect(connectors[1]).to.have.class(stepConnectorClasses.active);
+      expect(connectors[1]).to.have.class(stepConnectorClasses.completed);
     });
   });
 
   it('renders with a null child', () => {
-    // I'm not sure if this test brings any value
     const { container } = render(
       <Stepper>
         <Step />
@@ -250,7 +255,7 @@ describe('<Stepper />', () => {
       </Stepper>,
     );
 
-    const steps = container.querySelectorAll('.MuiStep-root');
+    const steps = container.querySelectorAll(`.${stepClasses.root}`);
 
     expect(steps).to.have.length(1);
   });
@@ -264,11 +269,11 @@ describe('<Stepper />', () => {
       </Stepper>,
     );
 
-    const steps = container.querySelectorAll('.MuiStep-root');
+    const steps = container.querySelectorAll(`.${stepClasses.root}`);
 
-    expect(steps[0]).to.not.have.class('MuiStep-active');
-    expect(steps[1]).to.not.have.class('MuiStep-active');
-    expect(steps[2]).to.not.have.class('MuiStep-active');
+    expect(steps[0]).to.not.have.class(stepClasses.active);
+    expect(steps[1]).to.not.have.class(stepClasses.active);
+    expect(steps[2]).to.not.have.class(stepClasses.active);
   });
 
   it('should hide the last connector', () => {
@@ -285,9 +290,11 @@ describe('<Stepper />', () => {
       </Stepper>,
     );
 
-    const stepContent = container.querySelectorAll('.MuiStepContent-root');
+    const stepContentClasses = getClasses(<StepContent />)
 
-    expect(stepContent[0]).to.not.have.class('MuiStepContent-last');
-    expect(stepContent[1]).to.have.class('MuiStepContent-last');
+    const stepContent = container.querySelectorAll(`.${stepContentClasses.root}`);
+
+    expect(stepContent[0]).to.not.have.class(stepContentClasses.last);
+    expect(stepContent[1]).to.have.class(stepContentClasses.last);
   });
 });

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -133,17 +133,16 @@ describe('<Stepper />', () => {
     it('passes index down correctly when rendering children containing arrays', () => {
       // I don't see how to test it using react-testing-library
       // Also, this test has questionable value, I'd delete it
-      const wrapper = shallow(
-        <Stepper linear={false}>
-          <div />
-          {[<div key={1} />, <div key={2} />]}
-        </Stepper>,
-      );
-
-      const steps = wrapper.children().find('div');
-      expect(steps.at(0).props().index).to.equal(0);
-      expect(steps.at(1).props().index).to.equal(1);
-      expect(steps.at(2).props().index).to.equal(2);
+      // const wrapper = shallow(
+      //   <Stepper linear={false}>
+      //     <div />
+      //     {[<div key={1} />, <div key={2} />]}
+      //   </Stepper>,
+      // );
+      // const steps = wrapper.children().find('div');
+      // expect(steps.at(0).props().index).to.equal(0);
+      // expect(steps.at(1).props().index).to.equal(1);
+      // expect(steps.at(2).props().index).to.equal(2);
     });
   });
 
@@ -171,10 +170,10 @@ describe('<Stepper />', () => {
       );
 
       const defaultConnectors = container.querySelectorAll('.MuiStepConnector-root');
-      const customConnectors = container.querySelectorAll('CustomConnector');
+      const customConnectors = container.querySelectorAll('.CustomConnector');
 
       expect(defaultConnectors).to.have.length(0);
-      expect(customConnectors).to.have.length(0);
+      expect(customConnectors).to.have.length(1);
     });
 
     it('should allow the step connector to be removed', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Uses @testing-library/react over enzyme#shallow.
I've written a few comments on the value of some existing tests:
First - https://github.com/mui-org/material-ui/pull/21400/files#diff-1123958d59e83fcef53e811ac6d6dae6R134
Second - https://github.com/mui-org/material-ui/pull/21400/files#diff-1123958d59e83fcef53e811ac6d6dae6R243