### PR TITLE
[core] Extend env for build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,9 +24,9 @@ async function run(argv) {
   }
 
   const env = {
+    ...process.env,
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
-    PATH: process.env.PATH,
   };
   const babelConfigPath = path.resolve(__dirname, '../babel.config.js');
   const srcDir = path.resolve('./src');


### PR DESCRIPTION
[Default value for `env` is `process.env`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback). We want to extend not replace.

@oliviertassinari Could you check if this works for you locally?
