### PR TITLE
[Divider] Add support for vertical middle divider

### DIFF
--- a/docs/pages/api-docs/divider.md
+++ b/docs/pages/api-docs/divider.md
@@ -34,7 +34,7 @@ The `MuiDivider` name can be used for providing [default props](/customization/g
 | <span class="prop-name">flexItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, a vertical divider will have the correct height when used in flex container. (By default, a vertical divider will have a calculated height of `0px` if it is the child of a flex container.) |
 | <span class="prop-name">light</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
 | <span class="prop-name">orientation</span> | <span class="prop-type">'horizontal'<br>&#124;&nbsp;'vertical'</span> | <span class="prop-default">'horizontal'</span> | The divider orientation. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'fullWidth'<br>&#124;&nbsp;'inset'<br>&#124;&nbsp;'middle'</span> | <span class="prop-default">'fullWidth'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'fullWidth'<br>&#124;&nbsp;'inset'<br>&#124;&nbsp;'middle'<br>&#124;&nbsp;'verticalMiddle'</span> | <span class="prop-default">'fullWidth'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 
@@ -49,6 +49,7 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">inset</span> | <span class="prop-name">.MuiDivider-inset</span> | Styles applied to the root element if `variant="inset"`.
 | <span class="prop-name">light</span> | <span class="prop-name">.MuiDivider-light</span> | Styles applied to the root element if `light={true}`.
 | <span class="prop-name">middle</span> | <span class="prop-name">.MuiDivider-middle</span> | Styles applied to the root element if `variant="middle"`.
+| <span class="prop-name">verticalMiddle</span> | <span class="prop-name">.MuiDivider-verticalMiddle</span> | Styles applied to the root element if `variant="verticalMiddle"`.
 | <span class="prop-name">vertical</span> | <span class="prop-name">.MuiDivider-vertical</span> | Styles applied to the root element if `orientation="vertical"`.
 | <span class="prop-name">flexItem</span> | <span class="prop-name">.MuiDivider-flexItem</span> | Styles applied to the root element if `flexItem={true}`.
 

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -22,7 +22,7 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
     /**
      * The variant to use.
      */
-    variant?: 'fullWidth' | 'inset' | 'middle';
+    variant?: 'fullWidth' | 'inset' | 'middle' | 'verticalMiddle';
   };
   defaultComponent: D;
   classKey: DividerClassKey;
@@ -41,7 +41,14 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
  */
 declare const Divider: OverridableComponent<DividerTypeMap>;
 
-export type DividerClassKey = 'root' | 'absolute' | 'inset' | 'light' | 'middle' | 'vertical';
+export type DividerClassKey =
+  | 'root'
+  | 'absolute'
+  | 'inset'
+  | 'light'
+  | 'middle'
+  | 'vertical'
+  | 'verticalMiddle';
 
 export type DividerProps<
   D extends React.ElementType = DividerTypeMap['defaultComponent'],

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -33,6 +33,11 @@ export const styles = (theme) => ({
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
   },
+  /* Styles applied to the root element if `variant="verticalMiddle"`. */
+  verticalMiddle: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
   /* Styles applied to the root element if `orientation="vertical"`. */
   vertical: {
     height: '100%',
@@ -126,7 +131,7 @@ Divider.propTypes = {
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['fullWidth', 'inset', 'middle']),
+  variant: PropTypes.oneOf(['fullWidth', 'inset', 'middle', 'verticalMiddle']),
 };
 
 export default withStyles(styles, { name: 'MuiDivider' })(Divider);

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -65,6 +65,13 @@ describe('<Divider />', () => {
         expect(wrapper.hasClass(classes.middle)).to.equal(true);
       });
     });
+
+    describe('prop: variant="verticalMiddle"', () => {
+      it('should set the verticalMiddle class', () => {
+        const wrapper = shallow(<Divider variant="verticalMiddle" />);
+        expect(wrapper.hasClass(classes.verticalMiddle)).to.equal(true);
+      });
+    });
   });
 
   describe('role', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

I'd like to add support for vertical middle divider.
I tried `<Divider orientation="vertical" variant="middle" flexItem />`  to get a vertical middle divider like the second screenshot below, but it didn't work. Of course we can get the divider by setting margin via style props, but I think this `verticalMiddle` would be useful.

- `<Divider orientation="vertical" flexItem />`
![vertical](https://user-images.githubusercontent.com/26599201/84559803-e5204700-ad78-11ea-8295-2e80ebc15d22.png)

- `<Divider orientation="vertical" variant="verticalMiddle" flexItem  />`
![verticalMiddle](https://user-images.githubusercontent.com/26599201/84559813-f9644400-ad78-11ea-9b2b-b58136586328.png)

