### PR TITLE
[core] Disable caching for yarn proptypes permanently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           command: yarn prettier check-changed
       - run:
           name: Generate PropTypes
-          command: yarn proptypes --disable-cache
+          command: yarn proptypes
       - run:
           name: '`yarn proptypes` changes committed?'
           command: git diff --exit-code

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -251,12 +251,11 @@ async function generateProptypes(
 }
 
 interface HandlerArgv {
-  'disable-cache': boolean;
   pattern: string;
   verbose: boolean;
 }
 async function run(argv: HandlerArgv) {
-  const { 'disable-cache': ignoreCache, pattern, verbose } = argv;
+  const { pattern, verbose } = argv;
 
   const filePattern = new RegExp(pattern);
   if (pattern.length > 0) {
@@ -295,11 +294,6 @@ async function run(argv: HandlerArgv) {
   const promises = files.map<Promise<GenerateResult>>(async (tsFile) => {
     const jsFile = tsFile.replace('.d.ts', '.js');
 
-    if (!ignoreCache && (await fse.stat(jsFile)).mtimeMs > (await fse.stat(tsFile)).mtimeMs) {
-      // Javascript version is newer, skip file
-      return GenerateResult.Skipped;
-    }
-
     if (todoComponents.includes(path.basename(jsFile, '.js'))) {
       return GenerateResult.TODO;
     }
@@ -331,11 +325,6 @@ yargs
     describe: 'Generates Component.propTypes from TypeScript declarations',
     builder: (command) => {
       return command
-        .option('disable-cache', {
-          default: false,
-          describe: 'Considers all files on every run',
-          type: 'boolean',
-        })
         .option('verbose', {
           default: false,
           describe: 'Logs result for each file',


### PR DESCRIPTION
> There are 2 hard problems in computer science: cache invalidation, naming things, and off-by-1 errors.

Since the gain is negligible (at best 4s vs 8s) and the caching mechanism is too simplistic (only compares last change of input and output file) I'm removing this since it's too confusing. If you are debugging a single file you should rather use `--pattern` which was created for that specific use case.

If you don't know the script (which you shouldn't need to) you could create results different from CI.
