### PR TITLE
[LinearProgress] High frequency updates

### DIFF
--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -105,7 +105,7 @@ See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 
 The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
 The default transition duration is 200ms.
-In the event a parent component updates the `value` prop too quickly, you will experience at least a 200ms delay between the update and the progress bar fully updating.
+In the event a parent component updates the `value` prop too quickly, you will at least experience a 200ms delay between the re-render and the progress bar fully updated.
 
 If you need to perform 30 re-renders per second or more, we recommend disabling the transition:
 

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -104,8 +104,10 @@ See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 ### High frequency updates
 
 The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
-In the event a parent component updates the `value` prop too quickly (>30 Hz), you might experience a delay.
-If the update frequency is higher than the frame rate (>60 FPS), you might not see any update at all.
+In the event a parent component updates the `value` prop too quickly, you might experience a delay or event not see any update at all.
+
+- At 30 re-renders per second, and with a default transition duration of 200ms, the transition only has time to reach 17% of the expected value before being updated. It will lag behind.
+- Above 60 re-renders per second, the frequency is higher than the frame rate the browser can handle (>60 FPS), you might not see any update at all.
 
 In these cases, we recommend disabling the transition:
 

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -107,7 +107,7 @@ The `LinearProgress` uses a transition on the CSS transform property to provide 
 In the event a parent component updates the `value` prop too quickly, you might experience a delay or event not see any update at all.
 
 - At 30 re-renders per second, and with a default transition duration of 200ms, the transition only has time to reach 17% of the expected value before being updated. It will lag behind.
-- Above 60 re-renders per second, the frequency is higher than the frame rate the browser can handle (>60 FPS), you might not see any update at all.
+- Above 60 re-renders per second, the frequency is higher than the frame rate the browser can handle, you might not see any update at all.
 
 In these cases, we recommend disabling the transition:
 

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -106,7 +106,7 @@ See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
 In the event a parent component updates the `value` prop too quickly, you might experience a delay or event not see any update at all.
 
-- At 30 re-renders per second, and with a default transition duration of 200ms, the transition only has time to reach 17% of the expected value before being updated. It will lag behind.
+- At 30 re-renders per second, and with a default transition duration of 200ms, the transition only has time to reach 17% of the expected value before being updated, it lags.
 - Above 60 re-renders per second, the frequency is higher than the frame rate the browser can handle, you might not see any update at all.
 
 In these cases, we recommend disabling the transition:

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -104,12 +104,10 @@ See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 ### High frequency updates
 
 The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
-In the event a parent component updates the `value` prop too quickly, you might experience a delay or event not see any update at all.
+The default transition duration is 200ms.
+In the event a parent component updates the `value` prop too quickly, you will experience at least a 200ms delay between the update and the progress bar fully updating.
 
-- At 30 re-renders per second, and with a default transition duration of 200ms, the transition only has time to reach 17% of the expected value before being updated, it lags.
-- Above 60 re-renders per second, the frequency is higher than the frame rate the browser can handle, you might not see any update at all.
-
-In these cases, we recommend disabling the transition:
+If you need to perform 30 re-renders per second or more, we recommend disabling the transition:
 
 ```css
 .MuiLinearProgress-bar {

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -89,7 +89,9 @@ After 1.0 second, you can display a loader to keep user's flow of thought uninte
 
 ## Limitations
 
-Under heavy load, you might lose the stroke dash animation or see random CircularProgress ring widths.
+### High CPU Load
+
+Under heavy load, you might lose the stroke dash animation or see random `CircularProgress` ring widths.
 You should run processor intensive operations in a web worker or by batch in order not to block the main rendering thread.
 
 ![heavy load](/static/images/progress/heavy-load.gif)
@@ -98,3 +100,17 @@ When it's not possible, you can leverage the `disableShrink` property to mitigat
 See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 
 {{"demo": "pages/components/progress/CircularUnderLoad.js"}}
+
+### High frequency updates
+
+The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
+In the event a parent component updates the `value` prop too quickly (>30 fps), you might experience a delay.
+If the update frequency is higher than the frame rate (>60 fps), you might not see any update at all.
+
+In these cases, we recommend disabling the transition:
+
+```css
+.MuiLinearProgress-bar {
+  transition: none;
+}
+```

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -89,7 +89,7 @@ After 1.0 second, you can display a loader to keep user's flow of thought uninte
 
 ## Limitations
 
-### High CPU Load
+### High CPU load
 
 Under heavy load, you might lose the stroke dash animation or see random `CircularProgress` ring widths.
 You should run processor intensive operations in a web worker or by batch in order not to block the main rendering thread.
@@ -104,8 +104,8 @@ See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 ### High frequency updates
 
 The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
-In the event a parent component updates the `value` prop too quickly (>30 fps), you might experience a delay.
-If the update frequency is higher than the frame rate (>60 fps), you might not see any update at all.
+In the event a parent component updates the `value` prop too quickly (>30 Hz), you might experience a delay.
+If the update frequency is higher than the frame rate (>60 Hz), you might not see any update at all.
 
 In these cases, we recommend disabling the transition:
 

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -105,7 +105,7 @@ See [this issue](https://github.com/mui-org/material-ui/issues/10327).
 
 The `LinearProgress` uses a transition on the CSS transform property to provide a smooth update between different values.
 In the event a parent component updates the `value` prop too quickly (>30 Hz), you might experience a delay.
-If the update frequency is higher than the frame rate (>60 Hz), you might not see any update at all.
+If the update frequency is higher than the frame rate (>60 FPS), you might not see any update at all.
 
 In these cases, we recommend disabling the transition:
 


### PR DESCRIPTION
Describe how disabling the transition animation can be beneficial when the value updates frequently and with small increments.

Related to #21411.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
