### PR TITLE
[Stepper] Fix optional label alignment

### DIFF
--- a/docs/src/pages/components/steppers/VerticalLinearStepper.js
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.js
@@ -3,13 +3,14 @@ import { makeStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
+import StepContent from '@material-ui/core/StepContent';
 import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     width: '100%',
-    height: '325px',
   },
   button: {
     marginTop: theme.spacing(1),
@@ -48,102 +49,62 @@ function getStepContent(step) {
 export default function VerticalLinearStepper() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
-  const [skipped, setSkipped] = React.useState(new Set());
   const steps = getSteps();
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  const isStepOptional = (step) => {
-    return step === 1;
-  };
-
-  const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-    if (isStepOptional(activeStep) && skipped.has(activeStep)) {
-      setSkipped((prevSkipped) => {
-        const newSkipped = new Set(prevSkipped.values());
-        newSkipped.delete(activeStep);
-        return newSkipped;
-      });
-    }
-  };
-
-  const handleSkip = () => {
-    if (!isStepOptional(activeStep)) {
-      throw new Error("You can't skip a step that isn't optional.");
-    }
-
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-    setSkipped((prevSkipped) => {
-      const newSkipped = new Set(prevSkipped.values());
-      newSkipped.add(activeStep);
-      return newSkipped;
-    });
-  };
-
   const handleReset = () => {
     setActiveStep(0);
-    setSkipped(new Set());
-  };
-
-  const isStepSkipped = (step) => {
-    return skipped.has(step);
   };
 
   return (
     <div className={classes.root}>
       <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map((label, index) => {
-          const stepProps = {};
-          const stepLabelProps = {};
-          if (isStepSkipped(index)) {
-            stepProps.completed = false;
-          }
-          if (isStepOptional(index)) {
-            stepLabelProps.optional = <Typography variant="caption">Optional</Typography>;
-          }
-          return (
-            <Step key={label} {...stepProps}>
-              <StepLabel {...stepLabelProps}>{label}</StepLabel>
-            </Step>
-          );
-        })}
+        {steps.map((label, index) => (
+          <Step key={label}>
+            <StepLabel
+              optional={index === 2 ? <Typography variant="caption">Last step</Typography> : null}
+            >
+              {label}
+            </StepLabel>
+            <StepContent>
+              <Typography>{getStepContent(index)}</Typography>
+              <div className={classes.actionsContainer}>
+                <div>
+                  <Button
+                    disabled={activeStep === 0}
+                    onClick={handleBack}
+                    className={classes.button}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleNext}
+                    className={classes.button}
+                  >
+                    {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+                  </Button>
+                </div>
+              </div>
+            </StepContent>
+          </Step>
+        ))}
       </Stepper>
-      {activeStep === steps.length ? (
-        <div>
+      {activeStep === steps.length && (
+        <Paper square elevation={0} className={classes.resetContainer}>
           <Typography>All steps completed - you&apos;re finished</Typography>
           <Button onClick={handleReset} className={classes.button}>
             Reset
           </Button>
-        </div>
-      ) : (
-        <div>
-          <Typography>{getStepContent(activeStep)}</Typography>
-          <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
-            Back
-          </Button>
-          {isStepOptional(activeStep) && (
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSkip}
-              className={classes.button}
-            >
-              Skip
-            </Button>
-          )}
-
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleNext}
-            className={classes.button}
-          >
-            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
-          </Button>
-        </div>
+        </Paper>
       )}
     </div>
   );

--- a/docs/src/pages/components/steppers/VerticalLinearStepper.js
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.js
@@ -3,14 +3,13 @@ import { makeStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
-import StepContent from '@material-ui/core/StepContent';
 import Button from '@material-ui/core/Button';
-import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     width: '100%',
+    height: '325px',
   },
   button: {
     marginTop: theme.spacing(1),
@@ -49,58 +48,102 @@ function getStepContent(step) {
 export default function VerticalLinearStepper() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
+  const [skipped, setSkipped] = React.useState(new Set());
   const steps = getSteps();
-
-  const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-  };
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const isStepOptional = (step) => {
+    return step === 1;
+  };
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+    if (isStepOptional(activeStep) && skipped.has(activeStep)) {
+      setSkipped((prevSkipped) => {
+        const newSkipped = new Set(prevSkipped.values());
+        newSkipped.delete(activeStep);
+        return newSkipped;
+      });
+    }
+  };
+
+  const handleSkip = () => {
+    if (!isStepOptional(activeStep)) {
+      throw new Error("You can't skip a step that isn't optional.");
+    }
+
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+    setSkipped((prevSkipped) => {
+      const newSkipped = new Set(prevSkipped.values());
+      newSkipped.add(activeStep);
+      return newSkipped;
+    });
+  };
+
   const handleReset = () => {
     setActiveStep(0);
+    setSkipped(new Set());
+  };
+
+  const isStepSkipped = (step) => {
+    return skipped.has(step);
   };
 
   return (
     <div className={classes.root}>
       <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map((label, index) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-            <StepContent>
-              <Typography>{getStepContent(index)}</Typography>
-              <div className={classes.actionsContainer}>
-                <div>
-                  <Button
-                    disabled={activeStep === 0}
-                    onClick={handleBack}
-                    className={classes.button}
-                  >
-                    Back
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleNext}
-                    className={classes.button}
-                  >
-                    {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
-                  </Button>
-                </div>
-              </div>
-            </StepContent>
-          </Step>
-        ))}
+        {steps.map((label, index) => {
+          const stepProps = {};
+          const stepLabelProps = {};
+          if (isStepSkipped(index)) {
+            stepProps.completed = false;
+          }
+          if (isStepOptional(index)) {
+            stepLabelProps.optional = <Typography variant="caption">Optional</Typography>;
+          }
+          return (
+            <Step key={label} {...stepProps}>
+              <StepLabel {...stepLabelProps}>{label}</StepLabel>
+            </Step>
+          );
+        })}
       </Stepper>
-      {activeStep === steps.length && (
-        <Paper square elevation={0} className={classes.resetContainer}>
+      {activeStep === steps.length ? (
+        <div>
           <Typography>All steps completed - you&apos;re finished</Typography>
           <Button onClick={handleReset} className={classes.button}>
             Reset
           </Button>
-        </Paper>
+        </div>
+      ) : (
+        <div>
+          <Typography>{getStepContent(activeStep)}</Typography>
+          <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
+            Back
+          </Button>
+          {isStepOptional(activeStep) && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSkip}
+              className={classes.button}
+            >
+              Skip
+            </Button>
+          )}
+
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleNext}
+            className={classes.button}
+          >
+            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
@@ -3,15 +3,14 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
-import StepContent from '@material-ui/core/StepContent';
 import Button from '@material-ui/core/Button';
-import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       width: '100%',
+      height: '325px',
     },
     button: {
       marginTop: theme.spacing(1),
@@ -51,58 +50,101 @@ function getStepContent(step: number) {
 export default function VerticalLinearStepper() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
+  const [skipped, setSkipped] = React.useState(new Set<number>());
   const steps = getSteps();
-
-  const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-  };
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const isStepOptional = (step: number) => {
+    return step === 1;
+  };
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+    if (isStepOptional(activeStep) && skipped.has(activeStep)) {
+      setSkipped((prevSkipped) => {
+        const newSkipped = new Set(prevSkipped.values());
+        newSkipped.delete(activeStep);
+        return newSkipped;
+      });
+    }
+  };
+
+  const handleSkip = () => {
+    if (!isStepOptional(activeStep)) {
+      throw new Error("You can't skip a step that isn't optional.");
+    }
+
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+    setSkipped((prevSkipped) => {
+      const newSkipped = new Set(prevSkipped.values());
+      newSkipped.add(activeStep);
+      return newSkipped;
+    });
+  };
+
   const handleReset = () => {
     setActiveStep(0);
+    setSkipped(new Set());
+  };
+
+  const isStepSkipped = (step: number) => {
+    return skipped.has(step);
   };
 
   return (
     <div className={classes.root}>
       <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map((label, index) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-            <StepContent>
-              <Typography>{getStepContent(index)}</Typography>
-              <div className={classes.actionsContainer}>
-                <div>
-                  <Button
-                    disabled={activeStep === 0}
-                    onClick={handleBack}
-                    className={classes.button}
-                  >
-                    Back
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleNext}
-                    className={classes.button}
-                  >
-                    {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
-                  </Button>
-                </div>
-              </div>
-            </StepContent>
-          </Step>
-        ))}
+        {steps.map((label, index) => {
+          const stepProps: { completed?: boolean } = {};
+          const stepLabelProps: { optional?: React.ReactNode } = {};
+          if (isStepSkipped(index)) {
+            stepProps.completed = false;
+          }
+          if (isStepOptional(index)) {
+            stepLabelProps.optional = <Typography variant="caption">Optional</Typography>;
+          }
+          return (
+            <Step key={label} {...stepProps}>
+              <StepLabel {...stepLabelProps}>{label}</StepLabel>
+            </Step>
+          );
+        })}
       </Stepper>
-      {activeStep === steps.length && (
-        <Paper square elevation={0} className={classes.resetContainer}>
+      {activeStep === steps.length ? (
+        <div>
           <Typography>All steps completed - you&apos;re finished</Typography>
           <Button onClick={handleReset} className={classes.button}>
             Reset
           </Button>
-        </Paper>
+        </div>
+      ) : (
+        <div>
+          <Typography>{getStepContent(activeStep)}</Typography>
+          <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
+            Back
+          </Button>
+          {isStepOptional(activeStep) && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSkip}
+              className={classes.button}
+            >
+              Skip
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleNext}
+            className={classes.button}
+          >
+            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
@@ -3,14 +3,15 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
+import StepContent from '@material-ui/core/StepContent';
 import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       width: '100%',
-      height: '325px',
     },
     button: {
       marginTop: theme.spacing(1),
@@ -50,101 +51,62 @@ function getStepContent(step: number) {
 export default function VerticalLinearStepper() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
-  const [skipped, setSkipped] = React.useState(new Set<number>());
   const steps = getSteps();
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  const isStepOptional = (step: number) => {
-    return step === 1;
-  };
-
-  const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-    if (isStepOptional(activeStep) && skipped.has(activeStep)) {
-      setSkipped((prevSkipped) => {
-        const newSkipped = new Set(prevSkipped.values());
-        newSkipped.delete(activeStep);
-        return newSkipped;
-      });
-    }
-  };
-
-  const handleSkip = () => {
-    if (!isStepOptional(activeStep)) {
-      throw new Error("You can't skip a step that isn't optional.");
-    }
-
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-    setSkipped((prevSkipped) => {
-      const newSkipped = new Set(prevSkipped.values());
-      newSkipped.add(activeStep);
-      return newSkipped;
-    });
-  };
-
   const handleReset = () => {
     setActiveStep(0);
-    setSkipped(new Set());
-  };
-
-  const isStepSkipped = (step: number) => {
-    return skipped.has(step);
   };
 
   return (
     <div className={classes.root}>
       <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map((label, index) => {
-          const stepProps: { completed?: boolean } = {};
-          const stepLabelProps: { optional?: React.ReactNode } = {};
-          if (isStepSkipped(index)) {
-            stepProps.completed = false;
-          }
-          if (isStepOptional(index)) {
-            stepLabelProps.optional = <Typography variant="caption">Optional</Typography>;
-          }
-          return (
-            <Step key={label} {...stepProps}>
-              <StepLabel {...stepLabelProps}>{label}</StepLabel>
-            </Step>
-          );
-        })}
+        {steps.map((label, index) => (
+          <Step key={label}>
+            <StepLabel
+              optional={index === 2 ? <Typography variant="caption">Last step</Typography> : null}
+            >
+              {label}
+            </StepLabel>
+            <StepContent>
+              <Typography>{getStepContent(index)}</Typography>
+              <div className={classes.actionsContainer}>
+                <div>
+                  <Button
+                    disabled={activeStep === 0}
+                    onClick={handleBack}
+                    className={classes.button}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleNext}
+                    className={classes.button}
+                  >
+                    {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+                  </Button>
+                </div>
+              </div>
+            </StepContent>
+          </Step>
+        ))}
       </Stepper>
-      {activeStep === steps.length ? (
-        <div>
+      {activeStep === steps.length && (
+        <Paper square elevation={0} className={classes.resetContainer}>
           <Typography>All steps completed - you&apos;re finished</Typography>
           <Button onClick={handleReset} className={classes.button}>
             Reset
           </Button>
-        </div>
-      ) : (
-        <div>
-          <Typography>{getStepContent(activeStep)}</Typography>
-          <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
-            Back
-          </Button>
-          {isStepOptional(activeStep) && (
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSkip}
-              className={classes.button}
-            >
-              Skip
-            </Button>
-          )}
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleNext}
-            className={classes.button}
-          >
-            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
-          </Button>
-        </div>
+        </Paper>
       )}
     </div>
   );

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -10,7 +10,6 @@ export const styles = (theme) => ({
   root: {
     display: 'flex',
     alignItems: 'center',
-    textAlign: 'left',
     '&$alternativeLabel': {
       flexDirection: 'column',
     },
@@ -21,7 +20,9 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `orientation="horizontal"`. */
   horizontal: {},
   /* Styles applied to the root element if `orientation="vertical"`. */
-  vertical: {},
+  vertical: {
+    textAlign: 'left',
+  },
   /* Styles applied to the `Typography` component which wraps `children`. */
   label: {
     '&$active': {

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -10,6 +10,7 @@ export const styles = (theme) => ({
   root: {
     display: 'flex',
     alignItems: 'center',
+    textAlign: 'left',
     '&$alternativeLabel': {
       flexDirection: 'column',
     },
@@ -23,7 +24,6 @@ export const styles = (theme) => ({
   vertical: {},
   /* Styles applied to the `Typography` component which wraps `children`. */
   label: {
-    color: theme.palette.text.secondary,
     '&$active': {
       color: theme.palette.text.primary,
       fontWeight: 500,
@@ -62,6 +62,7 @@ export const styles = (theme) => ({
   /* Styles applied to the container element which wraps `Typography` and `optional`. */
   labelContainer: {
     width: '100%',
+    color: theme.palette.text.secondary,
   },
 });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
In addition to this small style change, I've updated the VerticalLinearStepper demo to have an optional label (informal visual test) that demonstrates orientation='vertical' with the correct styling!

closes #21327
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
