### PR TITLE
[docs] Improve npm homepage links

### DIFF
--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-icons",
+  "homepage": "https://material-ui.com/components/icons",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:typings && yarn build:copy-files",
     "build:cjs": "node ../../scripts/build cjs",

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab",
+  "homepage": "https://material-ui.com/components/about-the-lab",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "node ../../scripts/build cjs",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-styles",
+  "homepage": "https://material-ui.com/styles/basics/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-system",
+  "homepage": "https://material-ui.com/system/basics/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/material-ui-types/README.md
+++ b/packages/material-ui-types/README.md
@@ -1,1 +1,3 @@
 # @material-ui/types
+
+Utility types used by Material-UI.

--- a/packages/material-ui-utils/README.md
+++ b/packages/material-ui-utils/README.md
@@ -1,1 +1,3 @@
 # @material-ui/utils
+
+Shared utilities used by Material-UI packages.


### PR DESCRIPTION
- [docs] Link to actual homepage where applicable
  Previous link add an (IMO) unnecessary roundtrip to github. I imagine that most people go from npm -> github readme -> material-ui.com
- [docs] Add rudimentary docs for shared utils