### PR TITLE
[docs] Add explicit example for extending existing palette colors

### DIFF
--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -139,6 +139,10 @@ const theme = createMuiTheme({
     danger: '#e53e3e',
   },
   palette: {
+    primary: {
+      main: '#0971f1',
+      darker: '#053e85',
+    },
     neutral: {
       main: '#5c6ac4',
     },
@@ -154,6 +158,12 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     status: {
       danger: React.CSSProperties['color'],
     }
+  }
+  interface PaletteColor {
+    darker?: string;
+  }
+  interface SimplePaletteColorOptions {
+    darker?: string;
   }
   interface ThemeOptions {
     status: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Apply the changes discussed here: https://github.com/mui-org/material-ui/issues/20277#issuecomment-644318896

Closes #20277