### PR TITLE
[core] Misc branch cleaning 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,7 @@ workflows:
             branches:
               only:
                 - master
+                - next
     jobs:
       - test_unit:
           react-dist-tag: next
@@ -256,5 +257,6 @@ workflows:
             branches:
               only:
                 - master
+                - next
     jobs:
       - test_types_next

--- a/scripts/sizeSnapshot/loadComparison.js
+++ b/scripts/sizeSnapshot/loadComparison.js
@@ -16,7 +16,12 @@ async function loadCurrentSnapshot() {
  * @param {string} commitId - the sha of a commit
  * @param {string} ref - the branch containing that commit
  */
-async function loadSnapshot(commitId, ref = 'master') {
+async function loadSnapshot(commitId, ref) {
+  if (ref === undefined) {
+    throw new TypeError(
+      `Need a ref for that commit. Did you mean \`loadSnapshot(commitId, 'master')\`?`,
+    );
+  }
   const response = await fetch(`${artifactServer}/artifacts/${ref}/${commitId}/size-snapshot.json`);
   return response.json();
 }


### PR DESCRIPTION
Minor changes that became an issue with switching the default branch:

- don't know if we need the default ref in `loadComparison`. Let's find out.
- run React/typescript nightlies on next branch