### PR TITLE
[Tabs] Fix useCallback missing arguments

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -338,10 +338,12 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     };
   }, [updateIndicatorState, updateScrollButtonState]);
 
-  const handleTabsScroll = React.useCallback(
-    debounce(() => {
-      updateScrollButtonState();
-    }),
+  const handleTabsScroll = React.useMemo(
+    () =>
+      debounce(() => {
+        updateScrollButtonState();
+      }),
+    [updateScrollButtonState],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
Fixes #20442

Just a small change to provide an empty second argument to the useCallback method.

- [x] I have followed (at least) the PR section of the contributing guide.

* checked out a branch from master first time 😅