### PR TITLE
[test] Move size comparison details to separate page

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,8 +77,14 @@ steps:
       yarn size:snapshot
     displayName: 'create a size snapshot'
 
+  - task: PublishPipelineArtifact@1
+    displayName: 'persist size snapshot as pipeline artifact'
+    inputs:
+      artifactName: 'size-snapshot'
+      targetPath: 'size-snapshot.json'
+
   - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
-    displayName: 'persist size snapshot'
+    displayName: 'persist size snapshot on S3'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     inputs:
       awsCredentials: 's3 artifacts'
@@ -112,4 +118,5 @@ steps:
     displayName: 'run danger on PRs'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
+      AZURE_BUILD_ID: $(Build.BuildId)
       DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -135,7 +135,7 @@ async function run() {
       markdown(importantChanges.join('\n'));
     }
 
-    const details = `[Details of bundle changes](https://mui-dashboard.netlify.app/size-comparison?buildId=${process.env.AZURE_BUILD_ID}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit})`;
+    const details = `[Details of bundle changes](https://mui-dashboard.netlify.app/size-comparison?buildId=${process.env.AZURE_BUILD_ID}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number})`;
 
     markdown(details);
   } else {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -2,7 +2,6 @@
 // danger has to be the first thing required!
 const { danger, markdown } = require('danger');
 const { exec } = require('child_process');
-const prettyBytes = require('pretty-bytes');
 const { loadComparison } = require('./scripts/sizeSnapshot');
 
 const parsedSizeChangeThreshold = 300;
@@ -76,94 +75,12 @@ function addPercent(change, goodEmoji = '', badEmoji = ':small_red_triangle:') {
   return `+${formatted}% ${badEmoji}`;
 }
 
-function formatDiff(absoluteChange, relativeChange) {
-  if (absoluteChange === 0) {
-    return '--';
-  }
-
-  const trendIcon = absoluteChange < 0 ? '▼' : '▲';
-
-  return `${trendIcon} ${prettyBytes(absoluteChange, { signed: true })} (${addPercent(
-    relativeChange,
-    '',
-    '',
-  )})`;
-}
-
-/**
- * Generates a Markdown table
- * @param {{ label: string, align: 'left' | 'center' | 'right'}[]} headers
- * @param {string[][]} body
- * @returns {string}
- */
-function generateMDTable(headers, body) {
-  const headerRow = headers.map((header) => header.label);
-  const alignmentRow = headers.map((header) => {
-    if (header.align === 'right') {
-      return ' ---:';
-    }
-    if (header.align === 'center') {
-      return ':---:';
-    }
-    return ' --- ';
-  });
-
-  return [headerRow, alignmentRow, ...body].map((row) => row.join(' | ')).join('\n');
-}
-
 function generateEmphasizedChange([bundle, { parsed, gzip }]) {
   // increase might be a bug fix which is a nice thing. reductions are always nice
   const changeParsed = addPercent(parsed.relativeDiff, ':heart_eyes:', '');
   const changeGzip = addPercent(gzip.relativeDiff, ':heart_eyes:', '');
 
   return `**${bundle}**: parsed: ${changeParsed}, gzip: ${changeGzip}`;
-}
-
-/**
- *
- * @param {[string, object][]} entries
- * @param {object} options
- * @param {function (string): string} options.computeBundleLabel
- */
-function createComparisonTable(entries, options) {
-  const { computeBundleLabel } = options;
-
-  return generateMDTable(
-    [
-      { label: 'bundle' },
-      { label: 'Size Change', align: 'right' },
-      { label: 'Size', align: 'right' },
-      { label: 'Gzip Change', align: 'right' },
-      { label: 'Gzip', align: 'right' },
-    ],
-    entries
-      .map(([bundleId, size]) => [computeBundleLabel(bundleId), size])
-      // orderBy(|parsedDiff| DESC, |gzipDiff| DESC, name ASC)
-      .sort(([labelA, statsA], [labelB, statsB]) => {
-        const compareParsedDiff =
-          Math.abs(statsB.parsed.absoluteDiff) - Math.abs(statsA.parsed.absoluteDiff);
-        const compareGzipDiff =
-          Math.abs(statsB.gzip.absoluteDiff) - Math.abs(statsA.gzip.absoluteDiff);
-        const compareName = labelA.localeCompare(labelB);
-
-        if (compareParsedDiff === 0 && compareGzipDiff === 0) {
-          return compareName;
-        }
-        if (compareParsedDiff === 0) {
-          return compareGzipDiff;
-        }
-        return compareParsedDiff;
-      })
-      .map(([label, { parsed, gzip }]) => {
-        return [
-          label,
-          formatDiff(parsed.absoluteDiff, parsed.relativeDiff),
-          prettyBytes(parsed.current),
-          formatDiff(gzip.absoluteDiff, gzip.relativeDiff),
-          prettyBytes(gzip.current),
-        ];
-      }),
-  );
 }
 
 /**
@@ -204,9 +121,7 @@ async function run() {
 
   const comparison = await loadComparison(mergeBaseCommit, upstreamRef);
 
-  const { all: allResults, main: mainResults, pages: pageResults } = sieveResults(
-    Object.entries(comparison.bundles),
-  );
+  const { all: allResults, main: mainResults } = sieveResults(Object.entries(comparison.bundles));
   const anyResultsChanges = allResults.filter(createComparisonFilter(1, 1));
 
   if (anyResultsChanges.length > 0) {
@@ -220,52 +135,7 @@ async function run() {
       markdown(importantChanges.join('\n'));
     }
 
-    const mainDetailsTable = createComparisonTable(mainResults, {
-      computeBundleLabel: (bundleId) => {
-        if (bundleId === 'packages/material-ui/build/umd/material-ui.production.min.js') {
-          return '@material-ui/core[umd]';
-        }
-        if (bundleId === '@material-ui/core/Textarea') {
-          return 'TextareaAutosize';
-        }
-        if (bundleId === 'docs.main') {
-          return 'docs:/_app';
-        }
-        if (bundleId === 'docs.landing') {
-          return 'docs:/';
-        }
-        return bundleId.replace(/^@material-ui\/core\//, '').replace(/\.esm$/, '');
-      },
-    });
-    const pageDetailsTable = createComparisonTable(pageResults, {
-      computeBundleLabel: (bundleId) => {
-        // a page
-        if (bundleId.startsWith('docs:/')) {
-          const host = `https://deploy-preview-${danger.github.pr.number}--material-ui.netlify.app`;
-          const page = bundleId.replace(/^docs:/, '');
-          return `[${page}](${host}${page})`;
-        }
-
-        // shared
-        return bundleId;
-      },
-    });
-
-    const details = `
-  <details>
-  <summary>Details of bundle changes.</summary>
-
-  <p>Comparing: ${commitRange}</p>
-
-  <details>
-  <summary>Details of page changes</summary>
-
-  ${pageDetailsTable}
-  </details>
-
-  ${mainDetailsTable}
-
-  </details>`;
+    const details = `[Details of bundle changes](https://mui-dashboard.netlify.app/size-comparison?buildId=${process.env.AZURE_BUILD_ID}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit})`;
 
     markdown(details);
   } else {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -124,7 +124,7 @@ async function run() {
   const { all: allResults, main: mainResults } = sieveResults(Object.entries(comparison.bundles));
   const anyResultsChanges = allResults.filter(createComparisonFilter(1, 1));
 
-  if (anyResultsChanges.length !== 'nonsense') {
+  if (anyResultsChanges.length > 0) {
     const importantChanges = mainResults
       .filter(createComparisonFilter(parsedSizeChangeThreshold, gzipSizeChangeThreshold))
       .filter(isPackageComparison)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -124,7 +124,7 @@ async function run() {
   const { all: allResults, main: mainResults } = sieveResults(Object.entries(comparison.bundles));
   const anyResultsChanges = allResults.filter(createComparisonFilter(1, 1));
 
-  if (anyResultsChanges.length > 0) {
+  if (anyResultsChanges.length !== 'nonsense') {
     const importantChanges = mainResults
       .filter(createComparisonFilter(parsedSizeChangeThreshold, gzipSizeChangeThreshold))
       .filter(isPackageComparison)

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "node-fetch": "^ 2.6.0",
     "nyc": "^15.0.0",
     "prettier": "^2.0.1",
-    "pretty-bytes": "^5.3.0",
     "pretty-format-v24": "npm:pretty-format@24",
     "prop-types": "^15.7.2",
     "puppeteer": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13409,11 +13409,6 @@ prettier@^2.0.1, prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
-pretty-bytes@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
-  integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
-
 "pretty-format-v24@npm:pretty-format@24":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"


### PR DESCRIPTION
The size snapshot comment no longer includes the markdown details table. It was moved to a dedicated page.

The markdown table used to be hidden using the `<details>` element. This requires that the markdown is rendered to html which isn't always the case (e.g. email notifications, mobile app). This makes PRs in non-html environments unreadable.

By using a dedicated page we unlock more features like sorting.

Preview of size comparison page: https://deploy-preview-8--mui-dashboard.netlify.app/size-comparison?buildId=10406&baseRef=next&baseCommit=038a62dc638e1b1f91b835034afc98823fbece1c&prNumber=21504