### PR TITLE
[ButtonGroup] Improve contained hover style

### DIFF
--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -126,6 +126,9 @@ export const styles = (theme) => ({
   /* Styles applied to the children if `variant="contained"`. */
   groupedContained: {
     boxShadow: 'none',
+    '&:hover': {
+      boxShadow: 'none',
+    },
   },
   /* Styles applied to the children if `variant="contained"` and `orientation="horizontal"`. */
   groupedContainedHorizontal: {


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #21492 

Hovering over an item in a `ButtonGroup` with the `contained` style was producing two layers of box shadows, which also resulted in the visual highlighting of the button separator. This change simply disables the second layer of box shadow on hover.