### PR TITLE
[test] Fix type tests not being type checked

### DIFF
--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -991,7 +991,11 @@ const SelectTest = () => (
   </Select>
 );
 
-const InputAdornmentTest = () => <InputAdornment position="end" onClick={() => alert('Hello')} />;
+const InputAdornmentTest = () => (
+  <InputAdornment position="end" onClick={() => alert('Hello')}>
+    Some Icon
+  </InputAdornment>
+);
 
 const TooltipComponentTest = () => (
   <div>

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,9 @@
     "deprecation": true,
     // $ExpectError -> @ts-expect-error
     // $ExpectType -> `expectType` from `@material-ui/types`
-    "expect": false,
+    // Don't disable this rule unless you made sure `tsc` runs on the same files
+    // Otherwise some files won't be type-checked
+    "expect": true,
     "file-name-casing": false,
     "no-boolean-literal-compare": false,
     "no-empty-interface": false,


### PR DESCRIPTION
The `dtslint` rule `expect` was not only responsible for `$Expect` directives but also to let `tslint` fail if the file failed type checking.

Re-enabling it until we actually need to migrate to `eslint`. Need to manually verify we don't use the `$Expect` directives.