### PR TITLE
[FormControl] use Event Loop to handle focus and blur

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -156,6 +156,14 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
     setFilled(false);
   }, []);
 
+  const focusTimeout = React.useRef(false);
+
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(focusTimeout.current);
+    };
+  });
+
   const childContext = {
     adornedStart,
     setAdornedStart,
@@ -168,12 +176,18 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
     hiddenLabel,
     margin: (size === 'small' ? 'dense' : undefined) || margin,
     onBlur: () => {
-      setFocused(false);
+      clearTimeout(focusTimeout.current);
+      focusTimeout.current = setTimeout(() => {
+        setFocused(false);
+      });
     },
     onEmpty,
     onFilled,
     onFocus: () => {
-      setFocused(true);
+      clearTimeout(focusTimeout.current);
+      focusTimeout.current = setTimeout(() => {
+        setFocused(true);
+      });
     },
     registerEffect,
     required,

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
@@ -14,6 +14,7 @@ describe('<FormControl />', () => {
   const mount = createMount();
   const render = createClientRender();
   let classes;
+  let clock;
 
   function TestComponent(props) {
     const context = useFormControl();
@@ -25,6 +26,11 @@ describe('<FormControl />', () => {
 
   before(() => {
     classes = getClasses(<FormControl />);
+    clock = useFakeTimers();
+  });
+
+  after(() => {
+    clock.restore();
   });
 
   describeConformance(<FormControl />, () => ({
@@ -97,14 +103,18 @@ describe('<FormControl />', () => {
           <TestComponent contextCallback={readContext} />
         </FormControl>,
       );
+      clock.tick(1);
       expect(readContext.args[0][0]).to.have.property('focused', false);
 
       act(() => {
         container.querySelector('input').focus();
+        clock.tick(1);
       });
+
       expect(readContext.args[1][0]).to.have.property('focused', true);
 
       setProps({ disabled: true });
+      clock.tick(1);
       expect(readContext.args[2][0]).to.have.property('focused', false);
     });
   });
@@ -288,12 +298,15 @@ describe('<FormControl />', () => {
         it('should set the focused state', () => {
           const formControlRef = React.createRef();
           render(<FormControlled ref={formControlRef} />);
+          clock.tick(1);
           expect(formControlRef.current).to.have.property('focused', false);
 
           formControlRef.current.onFocus();
+          clock.tick(1);
           expect(formControlRef.current).to.have.property('focused', true);
 
           formControlRef.current.onFocus();
+          clock.tick(1);
           expect(formControlRef.current).to.have.property('focused', true);
         });
       });
@@ -305,12 +318,15 @@ describe('<FormControl />', () => {
           expect(formControlRef.current).to.have.property('focused', false);
 
           formControlRef.current.onFocus();
+          clock.tick(1);
           expect(formControlRef.current).to.have.property('focused', true);
 
           formControlRef.current.onBlur();
+          clock.tick(1);
           expect(formControlRef.current).to.have.property('focused', false);
 
           formControlRef.current.onBlur();
+          clock.tick(1);
           expect(formControlRef.current).to.have.property('focused', false);
         });
       });

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
+import { useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
@@ -12,9 +13,15 @@ describe('<FormLabel />', () => {
   const mount = createMount();
   const render = createClientRender();
   let classes;
+  let clock;
 
   before(() => {
     classes = getClasses(<FormLabel />);
+    clock = useFakeTimers();
+  });
+
+  after(() => {
+    clock.restore();
   });
 
   describeConformance(<FormLabel />, () => ({
@@ -101,6 +108,7 @@ describe('<FormLabel />', () => {
         expect(container.querySelector('label')).not.to.have.class(classes.focused);
 
         formControlRef.current.onFocus();
+        clock.tick(1);
         expect(container.querySelector('label')).to.have.class(classes.focused);
       });
 
@@ -119,13 +127,16 @@ describe('<FormLabel />', () => {
           wrapper: Wrapper,
         });
         formControlRef.current.onFocus();
+        clock.tick(1);
 
         expect(container.querySelector('label')).to.have.class(classes.focused);
 
         setProps({ focused: false });
+        clock.tick(1);
         expect(container.querySelector('label')).not.to.have.class(classes.focused);
 
         setProps({ focused: true });
+        clock.tick(1);
         expect(container.querySelector('label')).to.have.class(classes.focused);
       });
     });

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
@@ -16,11 +16,17 @@ import Select from '../Select';
 
 describe('<InputBase />', () => {
   let classes;
+  let clock;
   const mount = createMount();
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<InputBase />);
+    clock = useFakeTimers();
+  });
+
+  after(() => {
+    clock.restore();
   });
 
   describeConformance(<InputBase />, () => ({
@@ -394,12 +400,15 @@ describe('<InputBase />', () => {
         act(() => {
           getByRole('textbox').focus();
         });
+        clock.tick(1);
         expect(getByTestId('root')).to.have.class(classes.focused);
 
         controlRef.current.onBlur();
+        clock.tick(1);
         expect(getByTestId('root')).not.to.have.class(classes.focused);
 
         controlRef.current.onFocus();
+        clock.tick(1);
         expect(getByTestId('root')).to.have.class(classes.focused);
       });
 
@@ -414,16 +423,21 @@ describe('<InputBase />', () => {
             <InputBase id="input" />
           </FormControl>,
         );
+        clock.tick(1);
         expect(getByTestId('label')).to.have.text('focused: false');
 
         act(() => {
           getByRole('textbox').focus();
+          clock.tick(1);
         });
+
         expect(getByTestId('label')).to.have.text('focused: true');
 
         act(() => {
           getByRole('textbox').blur();
+          clock.tick(1);
         });
+
         expect(getByTestId('label')).to.have.text('focused: false');
       });
     });

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
+import { useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
@@ -14,9 +15,15 @@ describe('<InputLabel />', () => {
   const mount = createMount();
   const render = createClientRender();
   let classes;
+  let clock;
 
   before(() => {
     classes = getClasses(<InputLabel />);
+    clock = useFakeTimers();
+  });
+
+  after(() => {
+    clock.restore();
   });
 
   describeConformance(<InputLabel>Foo</InputLabel>, () => ({
@@ -80,9 +87,11 @@ describe('<InputLabel />', () => {
         expect(getByTestId('root')).to.have.class(classes.shrink);
 
         setProps({ shrink: false });
+        clock.tick(1);
         expect(getByTestId('root')).not.to.have.class(classes.shrink);
 
         setProps({ shrink: true });
+        clock.tick(1);
         expect(getByTestId('root')).to.have.class(classes.shrink);
       });
     });
@@ -103,13 +112,16 @@ describe('<InputLabel />', () => {
           wrapper: Wrapper,
         });
         container.querySelector('input').focus();
+        clock.tick(1);
 
         expect(getByTestId('root')).to.have.class(classes.shrink);
 
         setProps({ shrink: false });
+        clock.tick(1);
         expect(getByTestId('root')).not.to.have.class(classes.shrink);
 
         setProps({ shrink: true });
+        clock.tick(1);
         expect(getByTestId('root')).to.have.class(classes.shrink);
       });
     });

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender, waitFor } from 'test/utils/createClientRender';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';
@@ -23,9 +23,15 @@ describe('<SwitchBase />', () => {
   const render = createClientRender();
   const mount = createMount();
   let classes;
+  let clock;
 
   before(() => {
     classes = getClasses(<SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />);
+    clock = useFakeTimers();
+  });
+
+  after(() => {
+    clock.restore();
   });
 
   describeConformance(
@@ -341,11 +347,14 @@ describe('<SwitchBase />', () => {
       const checkbox = getByRole('checkbox');
 
       checkbox.focus();
+      clock.tick(1);
 
       expect(getByTestId('focus-monitor')).to.have.text('focused: true');
+      clock.tick(1);
       expect(handleFocus.callCount).to.equal(1);
 
       checkbox.blur();
+      clock.tick(1);
 
       expect(getByTestId('focus-monitor')).to.have.text('focused: false');
       expect(handleBlur.callCount).to.equal(1);

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -5,7 +5,7 @@ import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createClientRender, waitFor } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -12,6 +12,18 @@ describe('<Select> integration', () => {
   // StrictModeViolation: uses Fade
   const render = createClientRender({ strict: false });
 
+  /**
+   * @type {ReturnType<typeof useFakeTimers>}
+   */
+  let clock;
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
   describe('with Dialog', () => {
     function SelectAndDialog() {
       const [value, setValue] = React.useState(10);
@@ -39,18 +51,6 @@ describe('<Select> integration', () => {
         </Dialog>
       );
     }
-
-    /**
-     * @type {ReturnType<typeof useFakeTimers>}
-     */
-    let clock;
-    beforeEach(() => {
-      clock = useFakeTimers();
-    });
-
-    afterEach(() => {
-      clock.restore();
-    });
 
     it('should focus the selected item', () => {
       const { getByTestId, getAllByRole, getByRole, queryByRole } = render(<SelectAndDialog />);
@@ -128,6 +128,7 @@ describe('<Select> integration', () => {
       const trigger = getByRole('button');
       trigger.focus();
       fireEvent.keyDown(trigger, { key: 'Enter' });
+      clock.tick(1);
 
       expect(getByTestId('label')).to.have.class('focused-label');
     });
@@ -150,14 +151,16 @@ describe('<Select> integration', () => {
       const trigger = getByRole('button');
 
       trigger.focus();
-
+      clock.tick(1);
       expect(container.querySelector('[for="age-simple"]')).to.have.class('focused-label');
 
       fireEvent.keyDown(trigger, { key: 'Enter' });
+      clock.tick(1);
 
       expect(container.querySelector('[for="age-simple"]')).to.have.class('focused-label');
 
       trigger.blur();
+      clock.tick(1);
 
       expect(container.querySelector('[for="age-simple"]')).not.to.have.class('focused-label');
     });


### PR DESCRIPTION
Fixes #21509

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

# Description
Using JS Even Loop to handle FormControl focus and blur events.
[Concurrency model and the event loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop)

