### PR TITLE
[Skeleton] Fix text border

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -19,7 +19,7 @@ export const styles = (theme) => ({
     transformOrigin: '0 55%',
     transform: 'scale(1, 0.60)',
     borderRadius: `${theme.shape.borderRadius}px/${
-      Math.round(((theme.shape.borderRadius * 1) / 0.6) * 10) / 10
+      Math.round((theme.shape.borderRadius / 0.6) * 10) / 10
     }px`,
     '&:empty:before': {
       content: '"\\00a0"',

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -18,7 +18,9 @@ export const styles = (theme) => ({
     height: 'auto',
     transformOrigin: '0 60%',
     transform: 'scale(1, 0.60)',
-    borderRadius: theme.shape.borderRadius,
+    borderRadius: `${theme.shape.borderRadius}px/${
+      Math.round(theme.shape.borderRadius * 1 / 0.6 * 10) / 10
+    }px`,
     '&:empty:before': {
       content: '"\\00a0"',
     },

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -16,7 +16,7 @@ export const styles = (theme) => ({
     marginTop: 0,
     marginBottom: 0,
     height: 'auto',
-    transformOrigin: '0 60%',
+    transformOrigin: '0 55%',
     transform: 'scale(1, 0.60)',
     borderRadius: `${theme.shape.borderRadius}px/${
       Math.round(theme.shape.borderRadius * 1 / 0.6 * 10) / 10

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -19,7 +19,7 @@ export const styles = (theme) => ({
     transformOrigin: '0 55%',
     transform: 'scale(1, 0.60)',
     borderRadius: `${theme.shape.borderRadius}px/${
-      Math.round(theme.shape.borderRadius * 1 / 0.6 * 10) / 10
+      Math.round(((theme.shape.borderRadius * 1) / 0.6) * 10) / 10
     }px`,
     '&:empty:before': {
       content: '"\\00a0"',


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Changes the border-radius in the Text Skeleton variant in order to make sure the borders are always rounded despite the skeleton being subjected to a scale transform.

closes #21499 
