### PR TITLE
Add Typescript InputClassKeys for adornments

### DIFF
--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -22,6 +22,8 @@ export type InputClassKey =
   | 'fullWidth'
   | 'input'
   | 'inputMarginDense'
+  | 'adornedEnd'
+  | 'adornedStart'
   | 'inputMultiline'
   | 'inputTypeSearch';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).


I was using `InputProps` in the React & Typescript project I am working on and wanted to style the end adornment, then I saw this defenition was missing in `Input.d.ts`. Its working now with this notation:

```classes: { adornedEnd: classes.endAdornment } as any```

But I am getting console errors;

Material-UI: The key `adornedEnd` provided to the classes prop is not implemented in ForwardRef(Input).

So i thought I should add the definitions here, I also added the definition for `adornedStart`. Im not 100% sure if I should have targeted the `next` branch but I just followed the `Sending a Pull Request
` guide.

Thanks in advance,

Youri.