### PR TITLE
[Badge] Fix transition flicker

### DIFF
--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -218,7 +218,6 @@ const Badge = React.forwardRef(function Badge(props, ref) {
       <span
         className={clsx(
           classes.badge,
-          classes[`${anchorOrigin.horizontal}${capitalize(anchorOrigin.vertical)}`],
           classes[
             `anchorOrigin${capitalize(anchorOrigin.vertical)}${capitalize(
               anchorOrigin.horizontal,

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -152,11 +152,11 @@ export const styles = (theme) => ({
 });
 
 const usePreviousProps = (value) => {
-  const ref = React.useRef();
+  const ref = React.useRef({});
   React.useEffect(() => {
     ref.current = value;
   });
-  return ref.current || {};
+  return ref.current;
 };
 
 const Badge = React.forwardRef(function Badge(props, ref) {

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -161,18 +161,21 @@ const usePreviousProps = (value) => {
 
 const Badge = React.forwardRef(function Badge(props, ref) {
   const {
-    anchorOrigin: anchorOriginProp,
+    anchorOrigin: anchorOriginProp = {
+      vertical: 'top',
+      horizontal: 'right',
+    },
     badgeContent: badgeContentProp,
     children,
     classes,
     className,
-    color: colorProp,
+    color: colorProp = 'default',
     component: ComponentProp = 'span',
     invisible: invisibleProp,
-    max: mapProp,
-    overlap: overlapProp,
+    max: maxProp = 99,
+    overlap: overlapProp = 'rectangle',
     showZero = false,
-    variant: variantProp,
+    variant: variantProp = 'standard',
     ...other
   } = props;
 
@@ -180,7 +183,7 @@ const Badge = React.forwardRef(function Badge(props, ref) {
     anchorOrigin: anchorOriginProp,
     badgeContent: badgeContentProp,
     color: colorProp,
-    max: mapProp,
+    max: maxProp,
     overlap: overlapProp,
     variant: variantProp,
   });
@@ -195,15 +198,12 @@ const Badge = React.forwardRef(function Badge(props, ref) {
   }
 
   const {
-    anchorOrigin = {
-      vertical: 'top',
-      horizontal: 'right',
-    },
+    anchorOrigin = anchorOriginProp,
     badgeContent,
-    color = 'default',
-    max = 99,
-    overlap = 'rectangle',
-    variant = 'standard',
+    color = colorProp,
+    max = maxProp,
+    overlap = overlapProp,
+    variant = variantProp,
   } = invisible ? prevProps : props;
 
   let displayValue = '';

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -157,7 +157,7 @@ const usePreviousProps = (value) => {
     ref.current = value;
   });
   return ref.current || {};
-}
+};
 
 const Badge = React.forwardRef(function Badge(props, ref) {
   const {
@@ -218,7 +218,7 @@ const Badge = React.forwardRef(function Badge(props, ref) {
       <span
         className={clsx(
           classes.badge,
-          classes[`${anchorOrigin.horizontal}${capitalize(anchorOrigin.vertical)}}`],
+          classes[`${anchorOrigin.horizontal}${capitalize(anchorOrigin.vertical)}`],
           classes[
             `anchorOrigin${capitalize(anchorOrigin.vertical)}${capitalize(
               anchorOrigin.horizontal,

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -151,34 +151,60 @@ export const styles = (theme) => ({
   },
 });
 
+const usePreviousProps = (value) => {
+  const ref = React.useRef();
+  React.useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current || {};
+}
+
 const Badge = React.forwardRef(function Badge(props, ref) {
+  const {
+    anchorOrigin: anchorOriginProp,
+    badgeContent: badgeContentProp,
+    children,
+    classes,
+    className,
+    color: colorProp,
+    component: ComponentProp = 'span',
+    invisible: invisibleProp,
+    max: mapProp,
+    overlap: overlapProp,
+    showZero = false,
+    variant: variantProp,
+    ...other
+  } = props;
+
+  const prevProps = usePreviousProps({
+    anchorOrigin: anchorOriginProp,
+    badgeContent: badgeContentProp,
+    color: colorProp,
+    max: mapProp,
+    overlap: overlapProp,
+    variant: variantProp,
+  });
+
+  let invisible = invisibleProp;
+
+  if (
+    invisibleProp == null &&
+    ((badgeContentProp === 0 && !showZero) || (badgeContentProp == null && variantProp !== 'dot'))
+  ) {
+    invisible = true;
+  }
+
   const {
     anchorOrigin = {
       vertical: 'top',
       horizontal: 'right',
     },
     badgeContent,
-    children,
-    classes,
-    className,
     color = 'default',
-    component: ComponentProp = 'span',
-    invisible: invisibleProp,
     max = 99,
     overlap = 'rectangle',
-    showZero = false,
     variant = 'standard',
-    ...other
-  } = props;
-
-  let invisible = invisibleProp;
-
-  if (
-    invisibleProp == null &&
-    ((badgeContent === 0 && !showZero) || (badgeContent == null && variant !== 'dot'))
-  ) {
-    invisible = true;
-  }
+  } = invisible ? prevProps : props;
 
   let displayValue = '';
 

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Badge from './Badge';
 
@@ -174,18 +174,17 @@ describe('<Badge />', () => {
   it('retains anchorOrigin, content, color, max, overlap and variant when invisible is true for consistent disappearing transition', () => {
     const wrapper = render(<Badge {...defaultProps} color="secondary" variant="dot" />);
 
-    act(() => {
-      wrapper.setProps({
-        badgeContent: 0,
-        color: 'primary',
-        variant: 'standard',
-        overlap: 'circle',
-        anchorOrigin: {
-          vertical: 'bottom',
-          horizontal: 'left',
-        },
-      });
+    wrapper.setProps({
+      badgeContent: 0,
+      color: 'primary',
+      variant: 'standard',
+      overlap: 'circle',
+      anchorOrigin: {
+        vertical: 'bottom',
+        horizontal: 'left',
+      },
     });
+
     expect(findBadge(wrapper.container)).to.have.text('');
     expect(findBadge(wrapper.container)).to.have.class(classes.colorSecondary);
     expect(findBadge(wrapper.container)).to.have.class(classes.dot);

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Badge from './Badge';
 
@@ -169,5 +169,26 @@ describe('<Badge />', () => {
       const { container } = render(<Badge {...defaultProps} badgeContent={50} max={1000} />);
       expect(findBadge(container)).to.have.text('50');
     });
+  });
+
+  it('retains anchorOrigin, content, color, max, overlap and variant when invisible is true for consistent disappearing transition', () => {
+    const wrapper = render(<Badge {...defaultProps} color="secondary" variant="dot" />);
+
+    act(() => {
+      wrapper.setProps({
+        badgeContent: 0,
+        color: 'primary',
+        variant: 'standard',
+        overlap: 'circle',
+        anchorOrigin: {
+          vertical: 'bottom',
+          horizontal: 'left',
+        },
+      });
+    });
+    expect(findBadge(wrapper.container)).to.have.text('');
+    expect(findBadge(wrapper.container)).to.have.class(classes.colorSecondary);
+    expect(findBadge(wrapper.container)).to.have.class(classes.dot);
+    expect(findBadge(wrapper.container)).to.have.class(classes.anchorOriginTopRightRectangle);
   });
 });


### PR DESCRIPTION
This PR is fixing the flickering of the badge components, when transitioning to invisible state.

Previously:
![bug-badge](https://user-images.githubusercontent.com/4512430/85583324-737cae80-b63e-11ea-9236-4126da99c8c7.gif)

(You can see the middle transition - the 0 being applied while it is disappearing)

Now: 
![fix-badge](https://user-images.githubusercontent.com/4512430/85583357-7bd4e980-b63e-11ea-8484-a663a50c62aa.gif)

The provided solution is based on the prev properties on the Badge component (only the props used in the classes + the content are being considered.

As an alternative I tried using the `SwitchTransition` component from `react-transition-group`, but the flickering was still there...
