### PR TITLE
add missing "component" field to List props

### DIFF
--- a/packages/material-ui/src/List/List.d.ts
+++ b/packages/material-ui/src/List/List.d.ts
@@ -3,6 +3,7 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
   props: P & {
+    component?: React.ElementType;
     dense?: boolean;
     disablePadding?: boolean;
     subheader?: React.ReactElement;


### PR DESCRIPTION
Adds missing `component` field to `ListProps`.  The referenced documentation for these props can be found here: https://material-ui.com/api/list/#props

Fix:  https://github.com/mui-org/material-ui/issues/17579


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
