### PR TITLE
[test] Improve makeStyles error coverage

### DIFF
--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -116,10 +116,19 @@ describe('makeStyles', () => {
       const mountWithProps2 = createGetClasses(styles);
       expect(() => {
         mountWithProps2({});
-      }).to.throw();
+      }).to.throw('theme.spacing is not a function');
       expect(consoleErrorMock.callCount()).to.equal(4);
+      expect(consoleErrorMock.messages()[0]).to.include(
+        'Material-UI: The `styles` argument provided is invalid.\nYou are providing a function without a theme in the context.',
+      );
       expect(consoleErrorMock.messages()[1]).to.include(
         'Material-UI: The `styles` argument provided is invalid.\nYou are providing a function without a theme in the context.',
+      );
+      expect(consoleErrorMock.messages()[2]).to.include(
+        'Uncaught [TypeError: theme.spacing is not a function',
+      );
+      expect(consoleErrorMock.messages()[3]).to.include(
+        'The above error occurred in the <TestComponent> component',
       );
     });
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -119,8 +119,20 @@ describe('makeStyles', () => {
       }).to.throw();
       expect(consoleErrorMock.callCount()).to.equal(4);
       expect(consoleErrorMock.messages()[1]).to.include(
-        'Material-UI: The `styles` argument provided is invalid',
+        'Material-UI: The `styles` argument provided is invalid.\nYou are providing a function without a theme in the context.',
       );
+    });
+
+    it('should warn but not throw if providing an invalid styles type', () => {
+      const mountWithProps2 = createGetClasses(undefined);
+
+      expect(consoleErrorMock.messages()).to.have.length(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
+        'Material-UI: The `styles` argument provided is invalid.\nYou need to provide a function generating the styles or a styles object.',
+      );
+      expect(() => {
+        mountWithProps2({});
+      }).not.to.throw();
     });
   });
 


### PR DESCRIPTION
Had some untested branches or incomplete assertions. The test wasn't clear to me doing other work related to console.error matching. It wasn't obvious that `makeStyles(undefined)` doesn't actually throw because of spread in https://github.com/mui-org/material-ui/blob/a1018937b3df5aaa1c6f11bfcafc662a8249f7e2/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.js#L44

Actually pretty funny that even new JS features allow quirks such as `{ ...15 }; // {}` and not throw a TypeError.