### PR TITLE
 [test] Add type test CardHeader title component

### DIFF
--- a/packages/material-ui/src/CardHeader/CardHeader.spec.tsx
+++ b/packages/material-ui/src/CardHeader/CardHeader.spec.tsx
@@ -216,6 +216,12 @@ function titleTypographyPropsTest() {
       propThatDoesntExist: 'shouldNotWork',
     }}
   />;
+  // Regression test for https://github.com/mui-org/material-ui/issues/21583
+  // which was probably fixed in https://github.com/mui-org/material-ui/pull/21552.
+  <CardHeader
+    title={<strong>Contemplative Reptile</strong>}
+    titleTypographyProps={{ component: 'h2' }}
+  />;
 }
 
 function subheaderTypographyPropsTest() {


### PR DESCRIPTION
Closes #21583 which was likely fixed in #21552. Adding a type test to prevent regression.