### PR TITLE
[Button] Make primary the default color

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,7 @@ import ReactDOM from 'react-dom';
 import Button from '@material-ui/core/Button';
 
 function App() {
-  return (
-    <Button variant="contained" color="primary">
-      Hello World
-    </Button>
-  );
+  return <Button variant="contained">Hello World</Button>;
 }
 
 ReactDOM.render(<App />, document.querySelector('#app'));

--- a/docs/pages/api-docs/button-group.md
+++ b/docs/pages/api-docs/button-group.md
@@ -30,7 +30,7 @@ The `MuiButtonGroup` name can be used for providing [default props](/customizati
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the button group. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">'default'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">color</span> | <span class="prop-type">'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the buttons will be disabled. |
 | <span class="prop-name">disableElevation</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, no elevation is used. |

--- a/docs/pages/api-docs/button.md
+++ b/docs/pages/api-docs/button.md
@@ -30,7 +30,7 @@ The `MuiButton` name can be used for providing [default props](/customization/gl
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the button. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">'default'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">color</span> | <span class="prop-type">'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableElevation</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, no elevation is used. |

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -147,7 +147,6 @@ export default function LandingPage(props) {
                   component={GettingStartedLink}
                   className={classes.button}
                   variant="outlined"
-                  color="primary"
                 >
                   {t('getStarted')}
                 </Button>

--- a/docs/src/pages/components/accordion/DetailedAccordion.js
+++ b/docs/src/pages/components/accordion/DetailedAccordion.js
@@ -84,9 +84,7 @@ export default function DetailedAccordion() {
         <Divider />
         <AccordionActions>
           <Button size="small">Cancel</Button>
-          <Button size="small" color="primary">
-            Save
-          </Button>
+          <Button size="small">Save</Button>
         </AccordionActions>
       </Accordion>
     </div>

--- a/docs/src/pages/components/accordion/DetailedAccordion.tsx
+++ b/docs/src/pages/components/accordion/DetailedAccordion.tsx
@@ -86,9 +86,7 @@ export default function DetailedAccordion() {
         <Divider />
         <AccordionActions>
           <Button size="small">Cancel</Button>
-          <Button size="small" color="primary">
-            Save
-          </Button>
+          <Button size="small">Save</Button>
         </AccordionActions>
       </Accordion>
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
@@ -139,12 +139,8 @@ export default function FreeSoloCreateOptionDialog() {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose} color="primary">
-              Cancel
-            </Button>
-            <Button type="submit" color="primary">
-              Add
-            </Button>
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button type="submit">Add</Button>
           </DialogActions>
         </form>
       </Dialog>

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
@@ -137,12 +137,8 @@ export default function FreeSoloCreateOptionDialog() {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose} color="primary">
-              Cancel
-            </Button>
-            <Button type="submit" color="primary">
-              Add
-            </Button>
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button type="submit">Add</Button>
           </DialogActions>
         </form>
       </Dialog>

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.js
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.js
@@ -23,7 +23,7 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleToggle}>
+      <Button variant="outlined" onClick={handleToggle}>
         Show backdrop
       </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.tsx
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.tsx
@@ -25,7 +25,7 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleToggle}>
+      <Button variant="outlined" onClick={handleToggle}>
         Show backdrop
       </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>

--- a/docs/src/pages/components/badges/BadgeVisibility.js
+++ b/docs/src/pages/components/badges/BadgeVisibility.js
@@ -62,11 +62,7 @@ export default function BadgeVisibility() {
         </Badge>
         <FormControlLabel
           control={
-            <Switch
-              color="primary"
-              checked={!invisible}
-              onChange={handleBadgeVisibility}
-            />
+            <Switch checked={!invisible} onChange={handleBadgeVisibility} />
           }
           label="Show Badge"
         />

--- a/docs/src/pages/components/badges/BadgeVisibility.tsx
+++ b/docs/src/pages/components/badges/BadgeVisibility.tsx
@@ -64,11 +64,7 @@ export default function BadgeVisibility() {
         </Badge>
         <FormControlLabel
           control={
-            <Switch
-              color="primary"
-              checked={!invisible}
-              onChange={handleBadgeVisibility}
-            />
+            <Switch checked={!invisible} onChange={handleBadgeVisibility} />
           }
           label="Show Badge"
         />

--- a/docs/src/pages/components/button-group/SplitButton.js
+++ b/docs/src/pages/components/button-group/SplitButton.js
@@ -53,7 +53,6 @@ export default function SplitButton() {
         >
           <Button onClick={handleClick}>{options[selectedIndex]}</Button>
           <Button
-            color="primary"
             size="small"
             aria-controls={open ? 'split-button-menu' : undefined}
             aria-expanded={open ? 'true' : undefined}

--- a/docs/src/pages/components/button-group/SplitButton.tsx
+++ b/docs/src/pages/components/button-group/SplitButton.tsx
@@ -59,7 +59,6 @@ export default function SplitButton() {
         >
           <Button onClick={handleClick}>{options[selectedIndex]}</Button>
           <Button
-            color="primary"
             size="small"
             aria-controls={open ? 'split-button-menu' : undefined}
             aria-expanded={open ? 'true' : undefined}

--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -31,54 +31,24 @@ export default function ButtonSizes() {
         </Button>
       </div>
       <div>
-        <Button
-          variant="outlined"
-          size="small"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="outlined" size="small" className={classes.margin}>
           Small
         </Button>
-        <Button
-          variant="outlined"
-          size="medium"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="outlined" size="medium" className={classes.margin}>
           Medium
         </Button>
-        <Button
-          variant="outlined"
-          size="large"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="outlined" size="large" className={classes.margin}>
           Large
         </Button>
       </div>
       <div>
-        <Button
-          variant="contained"
-          size="small"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="contained" size="small" className={classes.margin}>
           Small
         </Button>
-        <Button
-          variant="contained"
-          size="medium"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="contained" size="medium" className={classes.margin}>
           Medium
         </Button>
-        <Button
-          variant="contained"
-          size="large"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="contained" size="large" className={classes.margin}>
           Large
         </Button>
       </div>

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -33,54 +33,24 @@ export default function ButtonSizes() {
         </Button>
       </div>
       <div>
-        <Button
-          variant="outlined"
-          size="small"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="outlined" size="small" className={classes.margin}>
           Small
         </Button>
-        <Button
-          variant="outlined"
-          size="medium"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="outlined" size="medium" className={classes.margin}>
           Medium
         </Button>
-        <Button
-          variant="outlined"
-          size="large"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="outlined" size="large" className={classes.margin}>
           Large
         </Button>
       </div>
       <div>
-        <Button
-          variant="contained"
-          size="small"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="contained" size="small" className={classes.margin}>
           Small
         </Button>
-        <Button
-          variant="contained"
-          size="medium"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="contained" size="medium" className={classes.margin}>
           Medium
         </Button>
-        <Button
-          variant="contained"
-          size="large"
-          color="primary"
-          className={classes.margin}
-        >
+        <Button variant="contained" size="large" className={classes.margin}>
           Large
         </Button>
       </div>

--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -16,16 +16,14 @@ export default function ContainedButtons() {
   return (
     <div className={classes.root}>
       <Button variant="contained">Default</Button>
-      <Button variant="contained" color="primary">
-        Primary
-      </Button>
+      <Button variant="contained">Primary</Button>
       <Button variant="contained" color="secondary">
         Secondary
       </Button>
       <Button variant="contained" disabled>
         Disabled
       </Button>
-      <Button variant="contained" color="primary" href="#contained-buttons">
+      <Button variant="contained" href="#contained-buttons">
         Link
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -15,7 +15,6 @@ export default function ContainedButtons() {
 
   return (
     <div className={classes.root}>
-      <Button variant="contained">Default</Button>
       <Button variant="contained">Primary</Button>
       <Button variant="contained" color="secondary">
         Secondary

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -18,16 +18,14 @@ export default function ContainedButtons() {
   return (
     <div className={classes.root}>
       <Button variant="contained">Default</Button>
-      <Button variant="contained" color="primary">
-        Primary
-      </Button>
+      <Button variant="contained">Primary</Button>
       <Button variant="contained" color="secondary">
         Secondary
       </Button>
       <Button variant="contained" disabled>
         Disabled
       </Button>
-      <Button variant="contained" color="primary" href="#contained-buttons">
+      <Button variant="contained" href="#contained-buttons">
         Link
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -17,7 +17,6 @@ export default function ContainedButtons() {
 
   return (
     <div className={classes.root}>
-      <Button variant="contained">Default</Button>
       <Button variant="contained">Primary</Button>
       <Button variant="contained" color="secondary">
         Secondary

--- a/docs/src/pages/components/buttons/CustomizedButtons.js
+++ b/docs/src/pages/components/buttons/CustomizedButtons.js
@@ -73,21 +73,16 @@ export default function CustomizedButtons() {
 
   return (
     <div>
-      <ColorButton
-        variant="contained"
-        color="primary"
-        className={classes.margin}
-      >
+      <ColorButton variant="contained" className={classes.margin}>
         Custom CSS
       </ColorButton>
       <ThemeProvider theme={theme}>
-        <Button variant="contained" color="primary" className={classes.margin}>
+        <Button variant="contained" className={classes.margin}>
           Theme Provider
         </Button>
       </ThemeProvider>
       <BootstrapButton
         variant="contained"
-        color="primary"
         disableRipple
         className={classes.margin}
       >

--- a/docs/src/pages/components/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/components/buttons/CustomizedButtons.tsx
@@ -77,21 +77,16 @@ export default function CustomizedButtons() {
 
   return (
     <div>
-      <ColorButton
-        variant="contained"
-        color="primary"
-        className={classes.margin}
-      >
+      <ColorButton variant="contained" className={classes.margin}>
         Custom CSS
       </ColorButton>
       <ThemeProvider theme={theme}>
-        <Button variant="contained" color="primary" className={classes.margin}>
+        <Button variant="contained" className={classes.margin}>
           Theme Provider
         </Button>
       </ThemeProvider>
       <BootstrapButton
         variant="contained"
-        color="primary"
         disableRipple
         className={classes.margin}
       >

--- a/docs/src/pages/components/buttons/DisableElevation.js
+++ b/docs/src/pages/components/buttons/DisableElevation.js
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 
 export default function DisableElevation() {
   return (
-    <Button variant="contained" color="primary" disableElevation>
+    <Button variant="contained" disableElevation>
       Disable elevation
     </Button>
   );

--- a/docs/src/pages/components/buttons/DisableElevation.tsx
+++ b/docs/src/pages/components/buttons/DisableElevation.tsx
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 
 export default function DisableElevation() {
   return (
-    <Button variant="contained" color="primary" disableElevation>
+    <Button variant="contained" disableElevation>
       Disable elevation
     </Button>
   );

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -36,7 +36,6 @@ export default function IconLabelButtons() {
       </Button>
       <Button
         variant="contained"
-        color="default"
         className={classes.button}
         startIcon={<CloudUploadIcon />}
       >

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -29,7 +29,6 @@ export default function IconLabelButtons() {
       {/* This Button uses a Font Icon, see the installation instructions in the Icon component docs. */}
       <Button
         variant="contained"
-        color="primary"
         className={classes.button}
         endIcon={<Icon>send</Icon>}
       >
@@ -54,7 +53,6 @@ export default function IconLabelButtons() {
       </Button>
       <Button
         variant="contained"
-        color="primary"
         size="small"
         className={classes.button}
         startIcon={<SaveIcon />}
@@ -63,7 +61,6 @@ export default function IconLabelButtons() {
       </Button>
       <Button
         variant="contained"
-        color="primary"
         size="large"
         className={classes.button}
         startIcon={<SaveIcon />}

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -38,7 +38,6 @@ export default function IconLabelButtons() {
       </Button>
       <Button
         variant="contained"
-        color="default"
         className={classes.button}
         startIcon={<CloudUploadIcon />}
       >

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -31,7 +31,6 @@ export default function IconLabelButtons() {
       {/* This Button uses a Font Icon, see the installation instructions in the Icon component docs. */}
       <Button
         variant="contained"
-        color="primary"
         className={classes.button}
         endIcon={<Icon>send</Icon>}
       >
@@ -56,7 +55,6 @@ export default function IconLabelButtons() {
       </Button>
       <Button
         variant="contained"
-        color="primary"
         size="small"
         className={classes.button}
         startIcon={<SaveIcon />}
@@ -65,7 +63,6 @@ export default function IconLabelButtons() {
       </Button>
       <Button
         variant="contained"
-        color="primary"
         size="large"
         className={classes.button}
         startIcon={<SaveIcon />}

--- a/docs/src/pages/components/buttons/LoadingButtonsTransition.js
+++ b/docs/src/pages/components/buttons/LoadingButtonsTransition.js
@@ -47,7 +47,6 @@ export default function LoadingButtonsTransition() {
       </LoadingButton>
       <LoadingButton
         variant="contained"
-        color="primary"
         pending={pending}
         pendingPosition="end"
         endIcon={<SendIcon />}

--- a/docs/src/pages/components/buttons/LoadingButtonsTransition.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtonsTransition.tsx
@@ -47,7 +47,6 @@ export default function LoadingButtonsTransition() {
       </LoadingButton>
       <LoadingButton
         variant="contained"
-        color="primary"
         pending={pending}
         pendingPosition="end"
         endIcon={<SendIcon />}

--- a/docs/src/pages/components/buttons/OutlinedButtons.js
+++ b/docs/src/pages/components/buttons/OutlinedButtons.js
@@ -15,17 +15,14 @@ export default function OutlinedButtons() {
 
   return (
     <div className={classes.root}>
-      <Button variant="outlined">Default</Button>
-      <Button variant="outlined" color="primary">
-        Primary
-      </Button>
+      <Button variant="outlined">Primary</Button>
       <Button variant="outlined" color="secondary">
         Secondary
       </Button>
       <Button variant="outlined" disabled>
         Disabled
       </Button>
-      <Button variant="outlined" color="primary" href="#outlined-buttons">
+      <Button variant="outlined" href="#outlined-buttons">
         Link
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/OutlinedButtons.tsx
+++ b/docs/src/pages/components/buttons/OutlinedButtons.tsx
@@ -17,17 +17,14 @@ export default function OutlinedButtons() {
 
   return (
     <div className={classes.root}>
-      <Button variant="outlined">Default</Button>
-      <Button variant="outlined" color="primary">
-        Primary
-      </Button>
+      <Button variant="outlined">Primary</Button>
       <Button variant="outlined" color="secondary">
         Secondary
       </Button>
       <Button variant="outlined" disabled>
         Disabled
       </Button>
-      <Button variant="outlined" color="primary" href="#outlined-buttons">
+      <Button variant="outlined" href="#outlined-buttons">
         Link
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/TextButtons.js
+++ b/docs/src/pages/components/buttons/TextButtons.js
@@ -15,13 +15,10 @@ export default function TextButtons() {
 
   return (
     <div className={classes.root}>
-      <Button>Default</Button>
-      <Button color="primary">Primary</Button>
+      <Button>Primary</Button>
       <Button color="secondary">Secondary</Button>
       <Button disabled>Disabled</Button>
-      <Button href="#text-buttons" color="primary">
-        Link
-      </Button>
+      <Button href="#text-buttons">Link</Button>
     </div>
   );
 }

--- a/docs/src/pages/components/buttons/TextButtons.tsx
+++ b/docs/src/pages/components/buttons/TextButtons.tsx
@@ -17,13 +17,10 @@ export default function TextButtons() {
 
   return (
     <div className={classes.root}>
-      <Button>Default</Button>
-      <Button color="primary">Primary</Button>
+      <Button>Primary</Button>
       <Button color="secondary">Secondary</Button>
       <Button disabled>Disabled</Button>
-      <Button href="#text-buttons" color="primary">
-        Link
-      </Button>
+      <Button href="#text-buttons">Link</Button>
     </div>
   );
 }

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -28,7 +28,7 @@ export default function UploadButtons() {
         type="file"
       />
       <label htmlFor="contained-button-file">
-        <Button variant="contained" color="primary" component="span">
+        <Button variant="contained" component="span">
           Upload
         </Button>
       </label>

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -30,7 +30,7 @@ export default function UploadButtons() {
         type="file"
       />
       <label htmlFor="contained-button-file">
-        <Button variant="contained" color="primary" component="span">
+        <Button variant="contained" component="span">
           Upload
         </Button>
       </label>

--- a/docs/src/pages/components/cards/ImgMediaCard.js
+++ b/docs/src/pages/components/cards/ImgMediaCard.js
@@ -38,12 +38,8 @@ export default function ImgMediaCard() {
         </CardContent>
       </CardActionArea>
       <CardActions>
-        <Button size="small" color="primary">
-          Share
-        </Button>
-        <Button size="small" color="primary">
-          Learn More
-        </Button>
+        <Button size="small">Share</Button>
+        <Button size="small">Learn More</Button>
       </CardActions>
     </Card>
   );

--- a/docs/src/pages/components/cards/ImgMediaCard.tsx
+++ b/docs/src/pages/components/cards/ImgMediaCard.tsx
@@ -38,12 +38,8 @@ export default function ImgMediaCard() {
         </CardContent>
       </CardActionArea>
       <CardActions>
-        <Button size="small" color="primary">
-          Share
-        </Button>
-        <Button size="small" color="primary">
-          Learn More
-        </Button>
+        <Button size="small">Share</Button>
+        <Button size="small">Learn More</Button>
       </CardActions>
     </Card>
   );

--- a/docs/src/pages/components/cards/MediaCard.js
+++ b/docs/src/pages/components/cards/MediaCard.js
@@ -39,12 +39,8 @@ export default function MediaCard() {
         </CardContent>
       </CardActionArea>
       <CardActions>
-        <Button size="small" color="primary">
-          Share
-        </Button>
-        <Button size="small" color="primary">
-          Learn More
-        </Button>
+        <Button size="small">Share</Button>
+        <Button size="small">Learn More</Button>
       </CardActions>
     </Card>
   );

--- a/docs/src/pages/components/cards/MediaCard.tsx
+++ b/docs/src/pages/components/cards/MediaCard.tsx
@@ -39,12 +39,8 @@ export default function MediaCard() {
         </CardContent>
       </CardActionArea>
       <CardActions>
-        <Button size="small" color="primary">
-          Share
-        </Button>
-        <Button size="small" color="primary">
-          Learn More
-        </Button>
+        <Button size="small">Share</Button>
+        <Button size="small">Learn More</Button>
       </CardActions>
     </Card>
   );

--- a/docs/src/pages/components/dialogs/AlertDialog.js
+++ b/docs/src/pages/components/dialogs/AlertDialog.js
@@ -19,7 +19,7 @@ export default function AlertDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open alert dialog
       </Button>
       <Dialog
@@ -38,10 +38,8 @@ export default function AlertDialog() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Disagree
-          </Button>
-          <Button onClick={handleClose} color="primary" autoFocus>
+          <Button onClick={handleClose}>Disagree</Button>
+          <Button onClick={handleClose} autoFocus>
             Agree
           </Button>
         </DialogActions>

--- a/docs/src/pages/components/dialogs/AlertDialog.tsx
+++ b/docs/src/pages/components/dialogs/AlertDialog.tsx
@@ -19,7 +19,7 @@ export default function AlertDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open alert dialog
       </Button>
       <Dialog
@@ -38,10 +38,8 @@ export default function AlertDialog() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Disagree
-          </Button>
-          <Button onClick={handleClose} color="primary" autoFocus>
+          <Button onClick={handleClose}>Disagree</Button>
+          <Button onClick={handleClose} autoFocus>
             Agree
           </Button>
         </DialogActions>

--- a/docs/src/pages/components/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/components/dialogs/AlertDialogSlide.js
@@ -24,7 +24,7 @@ export default function AlertDialogSlide() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Slide in alert dialog
       </Button>
       <Dialog
@@ -45,12 +45,8 @@ export default function AlertDialogSlide() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Disagree
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Agree
-          </Button>
+          <Button onClick={handleClose}>Disagree</Button>
+          <Button onClick={handleClose}>Agree</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/AlertDialogSlide.tsx
+++ b/docs/src/pages/components/dialogs/AlertDialogSlide.tsx
@@ -30,7 +30,7 @@ export default function AlertDialogSlide() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Slide in alert dialog
       </Button>
       <Dialog
@@ -51,12 +51,8 @@ export default function AlertDialogSlide() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Disagree
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Agree
-          </Button>
+          <Button onClick={handleClose}>Disagree</Button>
+          <Button onClick={handleClose}>Agree</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.js
@@ -89,12 +89,10 @@ function ConfirmationDialogRaw(props) {
         </RadioGroup>
       </DialogContent>
       <DialogActions>
-        <Button autoFocus onClick={handleCancel} color="primary">
+        <Button autoFocus onClick={handleCancel}>
           Cancel
         </Button>
-        <Button onClick={handleOk} color="primary">
-          Ok
-        </Button>
+        <Button onClick={handleOk}>Ok</Button>
       </DialogActions>
     </Dialog>
   );

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
@@ -97,12 +97,10 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
         </RadioGroup>
       </DialogContent>
       <DialogActions>
-        <Button autoFocus onClick={handleCancel} color="primary">
+        <Button autoFocus onClick={handleCancel}>
           Cancel
         </Button>
-        <Button onClick={handleOk} color="primary">
-          Ok
-        </Button>
+        <Button onClick={handleOk}>Ok</Button>
       </DialogActions>
     </Dialog>
   );

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.js
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.js
@@ -65,7 +65,7 @@ export default function CustomizedDialogs() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open dialog
       </Button>
       <Dialog
@@ -94,7 +94,7 @@ export default function CustomizedDialogs() {
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={handleClose} color="primary">
+          <Button autoFocus onClick={handleClose}>
             Save changes
           </Button>
         </DialogActions>

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
@@ -77,7 +77,7 @@ export default function CustomizedDialogs() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open dialog
       </Button>
       <Dialog
@@ -106,7 +106,7 @@ export default function CustomizedDialogs() {
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={handleClose} color="primary">
+          <Button autoFocus onClick={handleClose}>
             Save changes
           </Button>
         </DialogActions>

--- a/docs/src/pages/components/dialogs/DraggableDialog.js
+++ b/docs/src/pages/components/dialogs/DraggableDialog.js
@@ -32,7 +32,7 @@ export default function DraggableDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
       <Dialog
@@ -51,12 +51,10 @@ export default function DraggableDialog() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={handleClose} color="primary">
+          <Button autoFocus onClick={handleClose}>
             Cancel
           </Button>
-          <Button onClick={handleClose} color="primary">
-            Subscribe
-          </Button>
+          <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/DraggableDialog.tsx
+++ b/docs/src/pages/components/dialogs/DraggableDialog.tsx
@@ -32,7 +32,7 @@ export default function DraggableDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
       <Dialog
@@ -51,12 +51,10 @@ export default function DraggableDialog() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={handleClose} color="primary">
+          <Button autoFocus onClick={handleClose}>
             Cancel
           </Button>
-          <Button onClick={handleClose} color="primary">
-            Subscribe
-          </Button>
+          <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/FormDialog.js
+++ b/docs/src/pages/components/dialogs/FormDialog.js
@@ -20,7 +20,7 @@ export default function FormDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
       <Dialog
@@ -44,12 +44,8 @@ export default function FormDialog() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Subscribe
-          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/FormDialog.tsx
+++ b/docs/src/pages/components/dialogs/FormDialog.tsx
@@ -20,7 +20,7 @@ export default function FormDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
       <Dialog
@@ -44,12 +44,8 @@ export default function FormDialog() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Subscribe
-          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/components/dialogs/FullScreenDialog.js
@@ -41,7 +41,7 @@ export default function FullScreenDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open full-screen dialog
       </Button>
       <Dialog

--- a/docs/src/pages/components/dialogs/FullScreenDialog.tsx
+++ b/docs/src/pages/components/dialogs/FullScreenDialog.tsx
@@ -49,7 +49,7 @@ export default function FullScreenDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open full-screen dialog
       </Button>
       <Dialog

--- a/docs/src/pages/components/dialogs/MaxWidthDialog.js
+++ b/docs/src/pages/components/dialogs/MaxWidthDialog.js
@@ -53,7 +53,7 @@ export default function MaxWidthDialog() {
 
   return (
     <React.Fragment>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open max-width dialog
       </Button>
       <Dialog
@@ -98,9 +98,7 @@ export default function MaxWidthDialog() {
           </form>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Close
-          </Button>
+          <Button onClick={handleClose}>Close</Button>
         </DialogActions>
       </Dialog>
     </React.Fragment>

--- a/docs/src/pages/components/dialogs/MaxWidthDialog.tsx
+++ b/docs/src/pages/components/dialogs/MaxWidthDialog.tsx
@@ -59,7 +59,7 @@ export default function MaxWidthDialog() {
 
   return (
     <React.Fragment>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open max-width dialog
       </Button>
       <Dialog
@@ -104,9 +104,7 @@ export default function MaxWidthDialog() {
           </form>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Close
-          </Button>
+          <Button onClick={handleClose}>Close</Button>
         </DialogActions>
       </Dialog>
     </React.Fragment>

--- a/docs/src/pages/components/dialogs/ResponsiveDialog.js
+++ b/docs/src/pages/components/dialogs/ResponsiveDialog.js
@@ -23,7 +23,7 @@ export default function ResponsiveDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open responsive dialog
       </Button>
       <Dialog
@@ -42,10 +42,10 @@ export default function ResponsiveDialog() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={handleClose} color="primary">
+          <Button autoFocus onClick={handleClose}>
             Disagree
           </Button>
-          <Button onClick={handleClose} color="primary" autoFocus>
+          <Button onClick={handleClose} autoFocus>
             Agree
           </Button>
         </DialogActions>

--- a/docs/src/pages/components/dialogs/ResponsiveDialog.tsx
+++ b/docs/src/pages/components/dialogs/ResponsiveDialog.tsx
@@ -23,7 +23,7 @@ export default function ResponsiveDialog() {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open responsive dialog
       </Button>
       <Dialog
@@ -42,10 +42,10 @@ export default function ResponsiveDialog() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={handleClose} color="primary">
+          <Button autoFocus onClick={handleClose}>
             Disagree
           </Button>
-          <Button onClick={handleClose} color="primary" autoFocus>
+          <Button onClick={handleClose} autoFocus>
             Agree
           </Button>
         </DialogActions>

--- a/docs/src/pages/components/dialogs/ScrollDialog.js
+++ b/docs/src/pages/components/dialogs/ScrollDialog.js
@@ -58,12 +58,8 @@ Praesent commodo cursus magna, vel scelerisque nisl consectetur et.`,
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Subscribe
-          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/ScrollDialog.tsx
+++ b/docs/src/pages/components/dialogs/ScrollDialog.tsx
@@ -58,12 +58,8 @@ Praesent commodo cursus magna, vel scelerisque nisl consectetur et.`,
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Subscribe
-          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/dialogs/SimpleDialog.js
+++ b/docs/src/pages/components/dialogs/SimpleDialog.js
@@ -97,7 +97,7 @@ export default function SimpleDialogDemo() {
     <div>
       <Typography variant="subtitle1">Selected: {selectedValue}</Typography>
       <br />
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open simple dialog
       </Button>
       <SimpleDialog

--- a/docs/src/pages/components/dialogs/SimpleDialog.tsx
+++ b/docs/src/pages/components/dialogs/SimpleDialog.tsx
@@ -95,7 +95,7 @@ export default function SimpleDialogDemo() {
     <div>
       <Typography variant="subtitle1">Selected: {selectedValue}</Typography>
       <br />
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="outlined" onClick={handleClickOpen}>
         Open simple dialog
       </Button>
       <SimpleDialog

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -62,7 +62,7 @@ export default function MiddleDividers() {
         </div>
       </div>
       <div className={classes.section3}>
-        <Button color="primary">Add to cart</Button>
+        <Button>Add to cart</Button>
       </div>
     </div>
   );

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -64,7 +64,7 @@ export default function MiddleDividers() {
         </div>
       </div>
       <div className={classes.section3}>
-        <Button color="primary">Add to cart</Button>
+        <Button>Add to cart</Button>
       </div>
     </div>
   );

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -292,9 +292,7 @@ let DialogDetails = (props) => {
             </Grid>
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose} color="primary">
-              Close
-            </Button>
+            <Button onClick={handleClose}>Close</Button>
           </DialogActions>
         </React.Fragment>
       ) : (

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -57,7 +57,6 @@ export default function CustomizedMenus() {
         aria-controls="customized-menu"
         aria-haspopup="true"
         variant="contained"
-        color="primary"
         onClick={handleClick}
       >
         Open Menu

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -57,7 +57,6 @@ export default function CustomizedMenus() {
         aria-controls="customized-menu"
         aria-haspopup="true"
         variant="contained"
-        color="primary"
         onClick={handleClick}
       >
         Open Menu

--- a/docs/src/pages/components/menus/MenuPopupState.js
+++ b/docs/src/pages/components/menus/MenuPopupState.js
@@ -9,11 +9,7 @@ export default function MenuPopupState() {
     <PopupState variant="popover" popupId="demo-popup-menu">
       {(popupState) => (
         <React.Fragment>
-          <Button
-            variant="contained"
-            color="primary"
-            {...bindTrigger(popupState)}
-          >
+          <Button variant="contained" {...bindTrigger(popupState)}>
             Open Menu
           </Button>
           <Menu {...bindMenu(popupState)}>

--- a/docs/src/pages/components/menus/MenuPopupState.tsx
+++ b/docs/src/pages/components/menus/MenuPopupState.tsx
@@ -9,11 +9,7 @@ export default function MenuPopupState() {
     <PopupState variant="popover" popupId="demo-popup-menu">
       {(popupState) => (
         <React.Fragment>
-          <Button
-            variant="contained"
-            color="primary"
-            {...bindTrigger(popupState)}
-          >
+          <Button variant="contained" {...bindTrigger(popupState)}>
             Open Menu
           </Button>
           <Menu {...bindMenu(popupState)}>

--- a/docs/src/pages/components/popover/AnchorPlayground.js
+++ b/docs/src/pages/components/popover/AnchorPlayground.js
@@ -271,11 +271,7 @@ function AnchorPlayground(props) {
               value={transformOriginVertical}
               onChange={handleChange}
             >
-              <FormControlLabel
-                value="top"
-                control={<Radio color="primary" />}
-                label="Top"
-              />
+              <FormControlLabel value="top" control={<Radio />} label="Top" />
               <FormControlLabel
                 value="center"
                 control={<Radio color="primary" />}

--- a/docs/src/pages/components/popover/PopoverPopupState.js
+++ b/docs/src/pages/components/popover/PopoverPopupState.js
@@ -10,11 +10,7 @@ export default function PopoverPopupState() {
     <PopupState variant="popover" popupId="demo-popup-popover">
       {(popupState) => (
         <div>
-          <Button
-            variant="contained"
-            color="primary"
-            {...bindTrigger(popupState)}
-          >
+          <Button variant="contained" {...bindTrigger(popupState)}>
             Open Popover
           </Button>
           <Popover

--- a/docs/src/pages/components/popover/PopoverPopupState.tsx
+++ b/docs/src/pages/components/popover/PopoverPopupState.tsx
@@ -10,11 +10,7 @@ export default function PopoverPopupState() {
     <PopupState variant="popover" popupId="demo-popup-popover">
       {(popupState) => (
         <div>
-          <Button
-            variant="contained"
-            color="primary"
-            {...bindTrigger(popupState)}
-          >
+          <Button variant="contained" {...bindTrigger(popupState)}>
             Open Popover
           </Button>
           <Popover

--- a/docs/src/pages/components/popover/SimplePopover.js
+++ b/docs/src/pages/components/popover/SimplePopover.js
@@ -27,12 +27,7 @@ export default function SimplePopover() {
 
   return (
     <div>
-      <Button
-        aria-describedby={id}
-        variant="contained"
-        color="primary"
-        onClick={handleClick}
-      >
+      <Button aria-describedby={id} variant="contained" onClick={handleClick}>
         Open Popover
       </Button>
       <Popover

--- a/docs/src/pages/components/popover/SimplePopover.tsx
+++ b/docs/src/pages/components/popover/SimplePopover.tsx
@@ -31,12 +31,7 @@ export default function SimplePopover() {
 
   return (
     <div>
-      <Button
-        aria-describedby={id}
-        variant="contained"
-        color="primary"
-        onClick={handleClick}
-      >
+      <Button aria-describedby={id} variant="contained" onClick={handleClick}>
         Open Popover
       </Button>
       <Popover

--- a/docs/src/pages/components/popper/PopperPopupState.js
+++ b/docs/src/pages/components/popper/PopperPopupState.js
@@ -20,11 +20,7 @@ export default function PopperPopupState() {
     <PopupState variant="popper" popupId="demo-popup-popper">
       {(popupState) => (
         <div>
-          <Button
-            variant="contained"
-            color="primary"
-            {...bindToggle(popupState)}
-          >
+          <Button variant="contained" {...bindToggle(popupState)}>
             Toggle Popper
           </Button>
           <Popper {...bindPopper(popupState)} transition>

--- a/docs/src/pages/components/popper/PopperPopupState.tsx
+++ b/docs/src/pages/components/popper/PopperPopupState.tsx
@@ -22,11 +22,7 @@ export default function PopperPopupState() {
     <PopupState variant="popper" popupId="demo-popup-popper">
       {(popupState) => (
         <div>
-          <Button
-            variant="contained"
-            color="primary"
-            {...bindToggle(popupState)}
-          >
+          <Button variant="contained" {...bindToggle(popupState)}>
             Toggle Popper
           </Button>
           <Popper {...bindPopper(popupState)} transition>

--- a/docs/src/pages/components/popper/ScrollPlayground.js
+++ b/docs/src/pages/components/popper/ScrollPlayground.js
@@ -209,12 +209,8 @@ export default function ScrollPlayground() {
                   </DialogContentText>
                 </DialogContent>
                 <DialogActions>
-                  <Button onClick={handleClickButton} color="primary">
-                    Disagree
-                  </Button>
-                  <Button onClick={handleClickButton} color="primary">
-                    Agree
-                  </Button>
+                  <Button onClick={handleClickButton}>Disagree</Button>
+                  <Button onClick={handleClickButton}>Agree</Button>
                 </DialogActions>
               </Paper>
             </Popper>

--- a/docs/src/pages/components/progress/CircularIntegration.js
+++ b/docs/src/pages/components/progress/CircularIntegration.js
@@ -85,7 +85,6 @@ export default function CircularIntegration() {
       <div className={classes.wrapper}>
         <Button
           variant="contained"
-          color="primary"
           className={buttonClassname}
           disabled={loading}
           onClick={handleButtonClick}

--- a/docs/src/pages/components/progress/CircularIntegration.tsx
+++ b/docs/src/pages/components/progress/CircularIntegration.tsx
@@ -87,7 +87,6 @@ export default function CircularIntegration() {
       <div className={classes.wrapper}>
         <Button
           variant="contained"
-          color="primary"
           className={buttonClassname}
           disabled={loading}
           onClick={handleButtonClick}

--- a/docs/src/pages/components/radio-buttons/ErrorRadios.js
+++ b/docs/src/pages/components/radio-buttons/ErrorRadios.js
@@ -70,12 +70,7 @@ export default function ErrorRadios() {
           />
         </RadioGroup>
         <FormHelperText>{helperText}</FormHelperText>
-        <Button
-          type="submit"
-          variant="outlined"
-          color="primary"
-          className={classes.button}
-        >
+        <Button type="submit" variant="outlined" className={classes.button}>
           Check Answer
         </Button>
       </FormControl>

--- a/docs/src/pages/components/radio-buttons/ErrorRadios.tsx
+++ b/docs/src/pages/components/radio-buttons/ErrorRadios.tsx
@@ -70,12 +70,7 @@ export default function ErrorRadios() {
           />
         </RadioGroup>
         <FormHelperText>{helperText}</FormHelperText>
-        <Button
-          type="submit"
-          variant="outlined"
-          color="primary"
-          className={classes.button}
-        >
+        <Button type="submit" variant="outlined" className={classes.button}>
           Check Answer
         </Button>
       </FormControl>

--- a/docs/src/pages/components/selects/DialogSelect.js
+++ b/docs/src/pages/components/selects/DialogSelect.js
@@ -85,12 +85,8 @@ export default function DialogSelect() {
           </form>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Ok
-          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Ok</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/selects/DialogSelect.tsx
+++ b/docs/src/pages/components/selects/DialogSelect.tsx
@@ -87,12 +87,8 @@ export default function DialogSelect() {
           </form>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleClose} color="primary">
-            Ok
-          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Ok</Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/docs/src/pages/components/steppers/CustomizedSteppers.js
+++ b/docs/src/pages/components/steppers/CustomizedSteppers.js
@@ -276,7 +276,6 @@ export default function CustomizedSteppers() {
               </Button>
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >

--- a/docs/src/pages/components/steppers/CustomizedSteppers.tsx
+++ b/docs/src/pages/components/steppers/CustomizedSteppers.tsx
@@ -257,7 +257,6 @@ export default function CustomizedSteppers() {
               </Button>
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >

--- a/docs/src/pages/components/steppers/HorizontalLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/components/steppers/HorizontalLinearAlternativeLabelStepper.js
@@ -87,7 +87,7 @@ export default function HorizontalLabelPositionBelowStepper() {
               >
                 Back
               </Button>
-              <Button variant="contained" color="primary" onClick={handleNext}>
+              <Button variant="contained" onClick={handleNext}>
                 {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
               </Button>
             </div>

--- a/docs/src/pages/components/steppers/HorizontalLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalLinearAlternativeLabelStepper.tsx
@@ -89,7 +89,7 @@ export default function HorizontalLabelPositionBelowStepper() {
               >
                 Back
               </Button>
-              <Button variant="contained" color="primary" onClick={handleNext}>
+              <Button variant="contained" onClick={handleNext}>
                 {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
               </Button>
             </div>

--- a/docs/src/pages/components/steppers/HorizontalLinearStepper.js
+++ b/docs/src/pages/components/steppers/HorizontalLinearStepper.js
@@ -131,7 +131,6 @@ export default function HorizontalLinearStepper() {
               {isStepOptional(activeStep) && (
                 <Button
                   variant="contained"
-                  color="primary"
                   onClick={handleSkip}
                   className={classes.button}
                 >
@@ -141,7 +140,6 @@ export default function HorizontalLinearStepper() {
 
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >

--- a/docs/src/pages/components/steppers/HorizontalLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalLinearStepper.tsx
@@ -135,7 +135,6 @@ export default function HorizontalLinearStepper() {
               {isStepOptional(activeStep) && (
                 <Button
                   variant="contained"
-                  color="primary"
                   onClick={handleSkip}
                   className={classes.button}
                 >
@@ -144,7 +143,6 @@ export default function HorizontalLinearStepper() {
               )}
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >

--- a/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.js
@@ -186,7 +186,6 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
               </Button>
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >
@@ -195,7 +194,6 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
               {isStepOptional(activeStep) && !completed.has(activeStep) && (
                 <Button
                   variant="contained"
-                  color="primary"
                   onClick={handleSkip}
                   className={classes.button}
                 >
@@ -209,11 +207,7 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
                     Step {activeStep + 1} already completed
                   </Typography>
                 ) : (
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleComplete}
-                  >
+                  <Button variant="contained" onClick={handleComplete}>
                     {completedSteps() === totalSteps() - 1
                       ? 'Finish'
                       : 'Complete Step'}

--- a/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
@@ -190,7 +190,6 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
               </Button>
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >
@@ -199,7 +198,6 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
               {isStepOptional(activeStep) && !completed.has(activeStep) && (
                 <Button
                   variant="contained"
-                  color="primary"
                   onClick={handleSkip}
                   className={classes.button}
                 >
@@ -212,11 +210,7 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
                     Step {activeStep + 1} already completed
                   </Typography>
                 ) : (
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleComplete}
-                  >
+                  <Button variant="contained" onClick={handleComplete}>
                     {completedSteps() === totalSteps() - 1
                       ? 'Finish'
                       : 'Complete Step'}

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepper.js
@@ -128,7 +128,6 @@ export default function HorizontalNonLinearStepper() {
               </Button>
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >
@@ -140,11 +139,7 @@ export default function HorizontalNonLinearStepper() {
                     Step {activeStep + 1} already completed
                   </Typography>
                 ) : (
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleComplete}
-                  >
+                  <Button variant="contained" onClick={handleComplete}>
                     {completedSteps() === totalSteps() - 1
                       ? 'Finish'
                       : 'Complete Step'}

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepper.tsx
@@ -132,7 +132,6 @@ export default function HorizontalNonLinearStepper() {
               </Button>
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >
@@ -144,11 +143,7 @@ export default function HorizontalNonLinearStepper() {
                     Step {activeStep + 1} already completed
                   </Typography>
                 ) : (
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleComplete}
-                  >
+                  <Button variant="contained" onClick={handleComplete}>
                     {completedSteps() === totalSteps() - 1
                       ? 'Finish'
                       : 'Complete Step'}

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepperWithError.js
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepperWithError.js
@@ -140,7 +140,6 @@ export default function HorizontalNonLinearStepperWithError() {
               {isStepOptional(activeStep) && (
                 <Button
                   variant="contained"
-                  color="primary"
                   onClick={handleSkip}
                   className={classes.button}
                 >
@@ -150,7 +149,6 @@ export default function HorizontalNonLinearStepperWithError() {
 
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepperWithError.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepperWithError.tsx
@@ -145,7 +145,6 @@ export default function HorizontalNonLinearStepperWithError() {
               {isStepOptional(activeStep) && (
                 <Button
                   variant="contained"
-                  color="primary"
                   onClick={handleSkip}
                   className={classes.button}
                 >
@@ -154,7 +153,6 @@ export default function HorizontalNonLinearStepperWithError() {
               )}
               <Button
                 variant="contained"
-                color="primary"
                 onClick={handleNext}
                 className={classes.button}
               >

--- a/docs/src/pages/components/steppers/VerticalLinearStepper.js
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.js
@@ -90,7 +90,6 @@ export default function VerticalLinearStepper() {
                   </Button>
                   <Button
                     variant="contained"
-                    color="primary"
                     onClick={handleNext}
                     className={classes.button}
                   >

--- a/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
@@ -92,7 +92,6 @@ export default function VerticalLinearStepper() {
                   </Button>
                   <Button
                     variant="contained"
-                    color="primary"
                     onClick={handleNext}
                     className={classes.button}
                   >

--- a/docs/src/pages/customization/color/ColorTool.js
+++ b/docs/src/pages/customization/color/ColorTool.js
@@ -287,16 +287,11 @@ function ColorTool(props) {
         <ColorDemo data={state} />
       </Grid>
       <Grid item xs={12}>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleChangeDocsColors}
-        >
+        <Button variant="contained" onClick={handleChangeDocsColors}>
           Set Docs Colors
         </Button>
         <Button
           variant="outlined"
-          color="primary"
           onClick={handleResetDocsColors}
           className={classes.button}
         >

--- a/docs/src/pages/customization/density/DensityTool.js
+++ b/docs/src/pages/customization/density/DensityTool.js
@@ -97,7 +97,7 @@ export default function DensityTool() {
         </Grid>
       </Grid>
       <Grid item>
-        <Button color="primary" variant="contained" onClick={resetDensity}>
+        <Button variant="contained" onClick={resetDensity}>
           {t('resetDensity')}
         </Button>
       </Grid>

--- a/docs/src/pages/customization/globals/GlobalCss.js
+++ b/docs/src/pages/customization/globals/GlobalCss.js
@@ -7,7 +7,7 @@ const theme = createMuiTheme({
     // Style sheet name ⚛️
     MuiButton: {
       // Name of the rule
-      text: {
+      textPrimary: {
         // Some CSS
         background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
         borderRadius: 3,

--- a/docs/src/pages/customization/globals/GlobalCss.tsx
+++ b/docs/src/pages/customization/globals/GlobalCss.tsx
@@ -7,7 +7,7 @@ const theme = createMuiTheme({
     // Style sheet name ⚛️
     MuiButton: {
       // Name of the rule
-      text: {
+      textPrimary: {
         // Some CSS
         background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
         borderRadius: 3,

--- a/docs/src/pages/customization/globals/globals.md
+++ b/docs/src/pages/customization/globals/globals.md
@@ -14,7 +14,7 @@ const theme = createMuiTheme({
     // Style sheet name ⚛️
     MuiButton: {
       // Name of the rule
-      text: {
+      textPrimary: {
         // Some CSS
         color: 'white',
       },

--- a/docs/src/pages/customization/palette/Palette.js
+++ b/docs/src/pages/customization/palette/Palette.js
@@ -20,7 +20,7 @@ const theme = createMuiTheme({
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Button color="primary">Primary</Button>
+      <Button>Primary</Button>
       <Button color="secondary">Secondary</Button>
     </ThemeProvider>
   );

--- a/docs/src/pages/customization/palette/Palette.tsx
+++ b/docs/src/pages/customization/palette/Palette.tsx
@@ -20,7 +20,7 @@ const theme = createMuiTheme({
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Button color="primary">Primary</Button>
+      <Button>Primary</Button>
       <Button color="secondary">Secondary</Button>
     </ThemeProvider>
   );

--- a/docs/src/pages/getting-started/templates/Templates.js
+++ b/docs/src/pages/getting-started/templates/Templates.js
@@ -131,12 +131,7 @@ function Templates(props) {
               <Typography component="p">{layout.description}</Typography>
             </CardContent>
             <CardActions>
-              <Button
-                component="a"
-                href={layout.source}
-                size="small"
-                color="primary"
-              >
+              <Button component="a" href={layout.source} size="small">
                 {t('sourceCode')}
               </Button>
             </CardActions>

--- a/docs/src/pages/getting-started/templates/album/Album.js
+++ b/docs/src/pages/getting-started/templates/album/Album.js
@@ -101,14 +101,10 @@ export default function Album() {
             <div className={classes.heroButtons}>
               <Grid container spacing={2} justify="center">
                 <Grid item>
-                  <Button variant="contained" color="primary">
-                    Main call to action
-                  </Button>
+                  <Button variant="contained">Main call to action</Button>
                 </Grid>
                 <Grid item>
-                  <Button variant="outlined" color="primary">
-                    Secondary action
-                  </Button>
+                  <Button variant="outlined">Secondary action</Button>
                 </Grid>
               </Grid>
             </div>
@@ -135,12 +131,8 @@ export default function Album() {
                     </Typography>
                   </CardContent>
                   <CardActions>
-                    <Button size="small" color="primary">
-                      View
-                    </Button>
-                    <Button size="small" color="primary">
-                      Edit
-                    </Button>
+                    <Button size="small">View</Button>
+                    <Button size="small">Edit</Button>
                   </CardActions>
                 </Card>
               </Grid>

--- a/docs/src/pages/getting-started/templates/checkout/Checkout.js
+++ b/docs/src/pages/getting-started/templates/checkout/Checkout.js
@@ -136,7 +136,6 @@ export default function Checkout() {
                   )}
                   <Button
                     variant="contained"
-                    color="primary"
                     onClick={handleNext}
                     className={classes.button}
                   >

--- a/docs/src/pages/getting-started/templates/pricing/Pricing.js
+++ b/docs/src/pages/getting-started/templates/pricing/Pricing.js
@@ -191,12 +191,7 @@ export default function Pricing() {
               Support
             </Link>
           </nav>
-          <Button
-            href="#"
-            color="primary"
-            variant="outlined"
-            className={classes.link}
-          >
+          <Button href="#" variant="outlined" className={classes.link}>
             Login
           </Button>
         </Toolbar>
@@ -269,11 +264,7 @@ export default function Pricing() {
                   </ul>
                 </CardContent>
                 <CardActions>
-                  <Button
-                    fullWidth
-                    variant={tier.buttonVariant}
-                    color="primary"
-                  >
+                  <Button fullWidth variant={tier.buttonVariant}>
                     {tier.buttonText}
                   </Button>
                 </CardActions>

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
@@ -105,7 +105,6 @@ export default function SignInSide() {
               type="submit"
               fullWidth
               variant="contained"
-              color="primary"
               className={classes.submit}
             >
               Sign In

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.js
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.js
@@ -90,7 +90,6 @@ export default function SignIn() {
             type="submit"
             fullWidth
             variant="contained"
-            color="primary"
             className={classes.submit}
           >
             Sign In

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.js
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.js
@@ -118,7 +118,6 @@ export default function SignUp() {
             type="submit"
             fullWidth
             variant="contained"
-            color="primary"
             className={classes.submit}
           >
             Sign Up

--- a/docs/src/pages/getting-started/usage/usage.md
+++ b/docs/src/pages/getting-started/usage/usage.md
@@ -19,11 +19,7 @@ import ReactDOM from 'react-dom';
 import Button from '@material-ui/core/Button';
 
 function App() {
-  return (
-    <Button variant="contained" color="primary">
-      Hello World
-    </Button>
-  );
+  return <Button variant="contained">Hello World</Button>;
 }
 
 ReactDOM.render(<App />, document.querySelector('#app'));

--- a/docs/src/pages/guides/composition/ButtonRouter.js
+++ b/docs/src/pages/guides/composition/ButtonRouter.js
@@ -11,13 +11,11 @@ export default function ButtonRouter() {
   return (
     <Router>
       <div>
-        <Button color="primary" component={RouterLink} to="/">
+        <Button component={RouterLink} to="/">
           With prop forwarding
         </Button>
         <br />
-        <Button color="primary" component={LinkBehavior}>
-          Without prop forwarding
-        </Button>
+        <Button component={LinkBehavior}>Without prop forwarding</Button>
       </div>
     </Router>
   );

--- a/docs/src/pages/guides/composition/ButtonRouter.tsx
+++ b/docs/src/pages/guides/composition/ButtonRouter.tsx
@@ -17,13 +17,11 @@ export default function ButtonRouter() {
   return (
     <Router>
       <div>
-        <Button color="primary" component={RouterLink} to="/">
+        <Button component={RouterLink} to="/">
           With prop forwarding
         </Button>
         <br />
-        <Button color="primary" component={LinkBehavior}>
-          Without prop forwarding
-        </Button>
+        <Button component={LinkBehavior}>Without prop forwarding</Button>
       </div>
     </Router>
   );

--- a/docs/src/pages/guides/interoperability/StyledComponentsPortal.js
+++ b/docs/src/pages/guides/interoperability/StyledComponentsPortal.js
@@ -33,7 +33,6 @@ export default function StyledComponentsPortal() {
         aria-owns={anchorEl ? 'simple-menu' : undefined}
         aria-haspopup="true"
         variant="contained"
-        color="primary"
         onClick={handleClick}
       >
         Open Menu

--- a/docs/src/pages/guides/interoperability/StyledComponentsPortal.tsx
+++ b/docs/src/pages/guides/interoperability/StyledComponentsPortal.tsx
@@ -33,7 +33,6 @@ export default function StyledComponentsPortal() {
         aria-owns={anchorEl ? 'simple-menu' : undefined}
         aria-haspopup="true"
         variant="contained"
-        color="primary"
         onClick={handleClick}
       >
         Open Menu

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -6,7 +6,7 @@ Looking for the v4 docs? [Find them here](https://material-ui.com/versions/).
 
 > This document is a work in progress.
 > Have you upgraded your site and run into something that's not covered here?
-> [Add your changes on GitHub](https://github.com/mui-org/material-ui/blob/master/docs/src/pages/guides/migration-v4/migration-v4.md).
+> [Add your changes on GitHub](https://github.com/mui-org/material-ui/blob/next/docs/src/pages/guides/migration-v4/migration-v4.md).
 
 ## Introduction
 
@@ -55,7 +55,7 @@ yarn add @material-ui/core@next
 
 ### Button
 
-- The button `color` prop is now "primary" by default, and "default" has been deprecated.
+- The button `color` prop is now "primary" by default, and "default" has been removed.
 
   ```diff
   <Button color="primary">Primary</Button>

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -58,8 +58,10 @@ yarn add @material-ui/core@next
 - The button `color` prop is now "primary" by default, and "default" has been removed.
 
   ```diff
-  <Button color="primary">Primary</Button>
-  <Button>Primary</Button>
+  -<Button color="primary" />
+  -<Button color="default" />
+  +<Button />
+  +<Button />
   ```
 
   ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -64,10 +64,6 @@ yarn add @material-ui/core@next
   +<Button />
   ```
 
-  ```
-  /(<Button(\n*.*?)*?)color="primary"/$1/g
-  ```
-
 ### Divider
 
 - Use border instead of background color. It prevents inconsistent height on scaled screens. For people customizing the color of the border, the change requires changing the override CSS property:

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -55,7 +55,7 @@ yarn add @material-ui/core@next
 
 ### Button
 
-- The button `color` prop is now "primary" by default, and "default" has been removed.
+- The button `color` prop is now "primary" by default, and "default" has been removed. This makes the button closer to the Material Design specification and simplifies the API.
 
   ```diff
   -<Button color="primary" />

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -6,7 +6,7 @@ Looking for the v4 docs? [Find them here](https://material-ui.com/versions/).
 
 > This document is a work in progress.
 > Have you upgraded your site and run into something that's not covered here?
-> [Add your changes on GitHub](https://github.com/mui-org/material-ui/blob/next/docs/src/pages/guides/migration-v3/migration-v3.md).
+> [Add your changes on GitHub](https://github.com/mui-org/material-ui/blob/master/docs/src/pages/guides/migration-v4/migration-v4.md).
 
 ## Introduction
 
@@ -51,6 +51,19 @@ yarn add @material-ui/core@next
   ```diff
   -<BottomNavigation onChange={(event: React.ChangEvent<{}>) => {}} />
   +<BottomNavigation onChange={(event: React.SyntheticEvent) => {}} />
+  ```
+
+### Button
+
+- The button `color` prop is now "primary" by default, and "default" has been deprecated.
+
+  ```diff
+  <Button color="primary">Primary</Button>
+  <Button>Primary</Button>
+  ```
+
+  ```
+  /(<Button(\n*.*?)*?)color="primary"/$1/g
   ```
 
 ### Divider
@@ -151,7 +164,7 @@ yarn add @material-ui/core@next
   -  <ExpansionPanelActions>
   +  <AccordionActions>
        <Button size="small">Cancel</Button>
-       <Button size="small" color="primary">Save</Button>
+       <Button size="small">Save</Button>
   -  </ExpansionPanelActions>
   +  </AccordionActions>
   -</ExpansionPanel>

--- a/docs/src/pages/landing/Steps.js
+++ b/docs/src/pages/landing/Steps.js
@@ -150,7 +150,7 @@ import React from 'react';
 import { Button } from '@material-ui/core';
 
 function App() {
-  return <Button color="primary">Hello World</Button>;
+  return <Button>Hello World</Button>;
 }`}
               language="jsx"
             />

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
@@ -90,7 +90,6 @@ function ProductCTA(props) {
               />
               <Button
                 type="submit"
-                color="primary"
                 variant="contained"
                 className={classes.button}
               >

--- a/docs/src/pages/premium-themes/paperbase/Content.js
+++ b/docs/src/pages/premium-themes/paperbase/Content.js
@@ -63,11 +63,7 @@ function Content(props) {
               />
             </Grid>
             <Grid item>
-              <Button
-                variant="contained"
-                color="primary"
-                className={classes.addUser}
-              >
+              <Button variant="contained" className={classes.addUser}>
                 Add user
               </Button>
               <Tooltip title="Reload">

--- a/docs/src/pages/premium-themes/paperbase/Content.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Content.tsx
@@ -70,11 +70,7 @@ function Content(props: ContentProps) {
               />
             </Grid>
             <Grid item>
-              <Button
-                variant="contained"
-                color="primary"
-                className={classes.addUser}
-              >
+              <Button variant="contained" className={classes.addUser}>
                 Add user
               </Button>
               <Tooltip title="Reload">

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -119,7 +119,6 @@ function Header(props) {
       <AppBar
         component="div"
         className={classes.secondaryBar}
-        color="primary"
         position="static"
         elevation={0}
       >

--- a/docs/src/pages/premium-themes/paperbase/Header.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Header.tsx
@@ -128,7 +128,6 @@ function Header(props: HeaderProps) {
       <AppBar
         component="div"
         className={classes.secondaryBar}
-        color="primary"
         position="static"
         elevation={0}
       >

--- a/docs/src/pages/system/basics/RealWorld.js
+++ b/docs/src/pages/system/basics/RealWorld.js
@@ -27,7 +27,7 @@ export default function RealWorld() {
         </Grid>
         <Grid container justify="flex-end" spacing={1}>
           <Grid item>
-            <Button color="primary">Turn on wifi</Button>
+            <Button>Turn on wifi</Button>
           </Grid>
         </Grid>
       </Paper>

--- a/docs/src/pages/system/basics/RealWorld.tsx
+++ b/docs/src/pages/system/basics/RealWorld.tsx
@@ -27,7 +27,7 @@ export default function RealWorld() {
         </Grid>
         <Grid container justify="flex-end" spacing={1}>
           <Grid item>
-            <Button color="primary">Turn on wifi</Button>
+            <Button>Turn on wifi</Button>
           </Grid>
         </Grid>
       </Paper>

--- a/examples/nextjs/pages/about.js
+++ b/examples/nextjs/pages/about.js
@@ -14,7 +14,7 @@ export default function About() {
         <Typography variant="h4" component="h1" gutterBottom>
           Next.js example
         </Typography>
-        <Button variant="contained" color="primary" component={Link} naked href="/">
+        <Button variant="contained" component={Link} naked href="/">
           Go to the main page
         </Button>
         <ProTip />

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -1,5 +1,6 @@
+import { PropTypes } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
-import { OverrideProps } from '../OverridableComponent';
+import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 
 export type ButtonTypeMap<
   P = {},
@@ -56,6 +57,22 @@ export type ButtonTypeMap<
   defaultComponent: D;
   classKey: ButtonClassKey;
 }>;
+
+/**
+ * utility to create component types that inherit props from ButtonBase.
+ * This component has an additional overload if the `href` prop is set which
+ * can make extension quite tricky
+ */
+export interface ExtendButtonTypeMap<M extends OverridableTypeMap> {
+  props: M['props'] & ButtonTypeMap['props'];
+  defaultComponent: M['defaultComponent'];
+  classKey: M['classKey'];
+}
+
+export type ExtendButton<M extends OverridableTypeMap> = ((
+  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>
+) => JSX.Element) &
+  OverridableComponent<ExtendButtonBaseTypeMap<M>>;
 
 /**
  *

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -1,4 +1,3 @@
-import { PropTypes } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -1,6 +1,6 @@
 import { PropTypes } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
-import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
+import { OverrideProps } from '../OverridableComponent';
 
 export type ButtonTypeMap<
   P = {},
@@ -14,7 +14,7 @@ export type ButtonTypeMap<
     /**
      * The color of the component. It supports those theme colors that make sense for this component.
      */
-    color?: PropTypes.Color;
+    color?: 'inherit' | 'primary' | 'secondary';
     /**
      * If `true`, the button will be disabled.
      */
@@ -57,22 +57,6 @@ export type ButtonTypeMap<
   defaultComponent: D;
   classKey: ButtonClassKey;
 }>;
-
-/**
- * utility to create component types that inherit props from ButtonBase.
- * This component has an additional overload if the `href` prop is set which
- * can make extension quite tricky
- */
-export interface ExtendButtonTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & ButtonTypeMap['props'];
-  defaultComponent: M['defaultComponent'];
-  classKey: M['classKey'];
-}
-
-export type ExtendButton<M extends OverridableTypeMap> = ((
-  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>
-) => JSX.Element) &
-  OverridableComponent<ExtendButtonBaseTypeMap<M>>;
 
 /**
  *

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -14,7 +14,6 @@ export const styles = (theme) => ({
     minWidth: 64,
     padding: '6px 16px',
     borderRadius: theme.shape.borderRadius,
-    color: theme.palette.text.primary,
     transition: theme.transitions.create(['background-color', 'box-shadow', 'border'], {
       duration: theme.transitions.duration.short,
     }),
@@ -264,7 +263,7 @@ const Button = React.forwardRef(function Button(props, ref) {
     children,
     classes,
     className,
-    color = 'default',
+    color = 'primary',
     component = 'button',
     disabled = false,
     disableElevation = false,
@@ -297,7 +296,7 @@ const Button = React.forwardRef(function Button(props, ref) {
         classes.root,
         classes[variant],
         {
-          [classes[`${variant}${capitalize(color)}`]]: color !== 'default' && color !== 'inherit',
+          [classes[`${variant}${capitalize(color)}`]]: color !== 'inherit',
           [classes[`${variant}Size${capitalize(size)}`]]: size !== 'medium',
           [classes[`size${capitalize(size)}`]]: size !== 'medium',
           [classes.disableElevation]: disableElevation,
@@ -351,7 +350,7 @@ Button.propTypes = {
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
    */
-  color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
+  color: PropTypes.oneOf(['inherit', 'primary', 'secondary']),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.

--- a/packages/material-ui/src/Button/Button.spec.tsx
+++ b/packages/material-ui/src/Button/Button.spec.tsx
@@ -19,7 +19,7 @@ const ButtonTest = () => (
     <Button href="#link-button">Link</Button>
     <Button size="small">Small</Button>
     <Button variant="contained">Contained</Button>
-    <Button variant="outlined" color="primary" aria-label="add">
+    <Button variant="outlined" aria-label="add">
       Outlined
     </Button>
     <Button tabIndex={1} title="some button">
@@ -90,18 +90,14 @@ const ReactRouterLinkTest = () => {
     <Button {...props} component={ReactRouterLink} />
   );
 
-  const reactRouterButtonLink1 = (
-    <ButtonLink color="primary" to="/">
-      Go Home
-    </ButtonLink>
-  );
+  const reactRouterButtonLink1 = <ButtonLink to="/">Go Home</ButtonLink>;
 
   const MyLink = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
     return <ReactRouterLink innerRef={ref} {...props} />;
   });
 
   const reactRouterButtonLink2 = (
-    <Button color="primary" component={MyLink} to="/router-future">
+    <Button component={MyLink} to="/router-future">
       Go Home
     </Button>
   );

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -25,13 +25,13 @@ describe('<Button />', () => {
     skip: ['componentProp'],
   }));
 
-  it('should render with the root & text classes but no others', () => {
+  it('should render with the root, text, and textPrimary classes but no others', () => {
     const { getByRole } = render(<Button>Hello World</Button>);
     const button = getByRole('button');
 
     expect(button).to.have.class(classes.root);
     expect(button).to.have.class(classes.text);
-    expect(button).not.to.have.class(classes.textPrimary);
+    expect(button).to.have.class(classes.textPrimary);
     expect(button).not.to.have.class(classes.textSecondary);
     expect(button).not.to.have.class(classes.outlined);
     expect(button).not.to.have.class(classes.outlinedPrimary);

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
@@ -11,7 +11,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
     /**
      * The color of the component. It supports those theme colors that make sense for this component.
      */
-    color?: PropTypes.Color;
+    color?: 'inherit' | 'primary' | 'secondary';
     /**
      * If `true`, the buttons will be disabled.
      */

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -167,7 +167,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(props, ref) {
     children,
     classes,
     className,
-    color = 'default',
+    color = 'primary',
     component: Component = 'div',
     disabled = false,
     disableElevation = false,
@@ -260,7 +260,7 @@ ButtonGroup.propTypes = {
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
    */
-  color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
+  color: PropTypes.oneOf(['inherit', 'primary', 'secondary']),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -55,7 +55,7 @@ describe('<ButtonGroup />', () => {
     expect(button).to.have.class('MuiButton-outlined');
     expect(button).to.have.class(classes.grouped);
     expect(button).to.have.class(classes.groupedOutlined);
-    expect(button).to.not.have.class(classes.groupedOutlinedPrimary);
+    expect(button).to.have.class(classes.groupedOutlinedPrimary);
     expect(button).to.not.have.class(classes.groupedOutlinedSecondary);
   });
 
@@ -83,7 +83,7 @@ describe('<ButtonGroup />', () => {
     expect(button).to.have.class('MuiButton-contained');
     expect(button).to.have.class(classes.grouped);
     expect(button).to.have.class(classes.groupedContained);
-    expect(button).to.not.have.class(classes.groupedContainedPrimary);
+    expect(button).to.have.class(classes.groupedContainedPrimary);
     expect(button).to.not.have.class(classes.groupedContainedSecondary);
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Breaking change

- The button `color` prop is now "primary" by default, and "default" has been removed. This makes the button closer to the Material Design specification and simplifies the API.

```diff
-<Button color="default" />
-<Button color="primary" />
+<Button />
+<Button />
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Closes #17530