### PR TITLE
[Stepper] Use context API

### DIFF
--- a/docs/pages/api-docs/step-button.md
+++ b/docs/pages/api-docs/step-button.md
@@ -30,7 +30,6 @@ The `MuiStepButton` name can be used for providing [default props](/customizatio
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Can be a `StepLabel` or a node to place inside `StepLabel` as children. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">completed</span> | <span class="prop-type">bool</span> |  | For non-linear Steppers you need to manually set which steps are completed. Otherwise the Stepper determines if a step is completed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | The icon displayed by the step label. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node</span> |  | The optional node to display. |
 

--- a/docs/pages/api-docs/step-label.md
+++ b/docs/pages/api-docs/step-label.md
@@ -30,7 +30,6 @@ The `MuiStepLabel` name can be used for providing [default props](/customization
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | In most cases will simply be a string containing a title for the label. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as disabled, will also disable the button if `StepLabelButton` is a child of `StepLabel`. Is passed to child components. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | Override the default label of the step icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node</span> |  | The optional node to display. |

--- a/docs/pages/api-docs/step.md
+++ b/docs/pages/api-docs/step.md
@@ -28,12 +28,14 @@ The `MuiStep` name can be used for providing [default props](/customization/glob
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">active</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Sets the step as active. Is passed to child components. |
+| <span class="prop-name">active</span> | <span class="prop-type">bool</span> |  | Sets the step as active. Is passed to child components. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Should be `Step` sub-components such as `StepLabel`, `StepContent`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">completed</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as completed. Is passed to child components. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as disabled, will also disable the button if `StepButton` is a child of `Step`. Is passed to child components. |
+| <span class="prop-name">completed</span> | <span class="prop-type">bool</span> |  | Mark the step as completed. Is passed to child components. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | Mark the step as disabled, will also disable the button if `StepButton` is a child of `Step`. Is passed to child components. |
 | <span class="prop-name">expanded</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Expand the step. |
+| <span class="prop-name">index</span> | <span class="prop-type">number</span> |  | The position of the step. |
+| <span class="prop-name">last</span> | <span class="prop-type">bool</span> |  | If `true`, the Step will be displayed as rendered last. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.js
@@ -151,12 +151,8 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
             stepProps.completed = false;
           }
           return (
-            <Step key={label} {...stepProps}>
-              <StepButton
-                onClick={handleStep(index)}
-                completed={isStepComplete(index)}
-                {...buttonProps}
-              >
+            <Step key={label} completed={isStepComplete(index)} {...stepProps}>
+              <StepButton onClick={handleStep(index)} {...buttonProps}>
                 {label}
               </StepButton>
             </Step>

--- a/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
@@ -155,12 +155,8 @@ export default function HorizontalNonLinearAlternativeLabelStepper() {
             stepProps.completed = false;
           }
           return (
-            <Step key={label} {...stepProps}>
-              <StepButton
-                onClick={handleStep(index)}
-                completed={isStepComplete(index)}
-                {...buttonProps}
-              >
+            <Step key={label} completed={isStepComplete(index)} {...stepProps}>
+              <StepButton onClick={handleStep(index)} {...buttonProps}>
                 {label}
               </StepButton>
             </Step>

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepper.js
@@ -95,13 +95,8 @@ export default function HorizontalNonLinearStepper() {
     <div className={classes.root}>
       <Stepper nonLinear activeStep={activeStep}>
         {steps.map((label, index) => (
-          <Step key={label}>
-            <StepButton
-              onClick={handleStep(index)}
-              completed={completed[index]}
-            >
-              {label}
-            </StepButton>
+          <Step key={label} completed={completed[index]}>
+            <StepButton onClick={handleStep(index)}>{label}</StepButton>
           </Step>
         ))}
       </Stepper>

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepper.tsx
@@ -99,13 +99,8 @@ export default function HorizontalNonLinearStepper() {
     <div className={classes.root}>
       <Stepper nonLinear activeStep={activeStep}>
         {steps.map((label, index) => (
-          <Step key={label}>
-            <StepButton
-              onClick={handleStep(index)}
-              completed={completed[index]}
-            >
-              {label}
-            </StepButton>
+          <Step key={label} completed={completed[index]}>
+            <StepButton onClick={handleStep(index)}>{label}</StepButton>
           </Step>
         ))}
       </Stepper>

--- a/packages/material-ui/src/Step/Step.d.ts
+++ b/packages/material-ui/src/Step/Step.d.ts
@@ -25,6 +25,14 @@ export interface StepProps
    * Expand the step.
    */
   expanded?: boolean;
+  /**
+   * The position of the step.
+   */
+  index?: number;
+  /**
+   * If `true`, the Step will be displayed as rendered last.
+   */
+  last?: boolean;
 }
 
 export type StepClasskey = 'root' | 'horizontal' | 'vertical' | 'alternativeLabel' | 'completed';

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -3,6 +3,8 @@ import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
+import StepperContext from '../Stepper/StepperContext'
+import StepContext from './StepContext'
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -26,35 +28,21 @@ export const styles = {
 const Step = React.forwardRef(function Step(props, ref) {
   const {
     active = false,
-    // eslint-disable-next-line react/prop-types
-    alternativeLabel,
     children,
     classes,
     className,
     completed = false,
-    // eslint-disable-next-line react/prop-types
-    connector: connectorProp,
     disabled = false,
     expanded = false,
-    // eslint-disable-next-line react/prop-types
     index,
-    // eslint-disable-next-line react/prop-types
     last,
-    // eslint-disable-next-line react/prop-types
-    orientation,
     ...other
   } = props;
 
-  const connector = connectorProp
-    ? React.cloneElement(connectorProp, {
-        orientation,
-        alternativeLabel,
-        index,
-        active,
-        completed,
-        disabled,
-      })
-    : null;
+  const { connector, alternativeLabel, orientation } = React.useContext(StepperContext)
+  const contextValue = React.useMemo(() => ({ index, active, last, completed, disabled, expanded, icon: index + 1 }), [
+    index, active, last, completed, disabled, expanded
+  ]);
 
   const newChildren = (
     <div
@@ -70,6 +58,8 @@ const Step = React.forwardRef(function Step(props, ref) {
       ref={ref}
       {...other}
     >
+      <StepContext.Provider value={contextValue}>
+
       {connector && alternativeLabel && index !== 0 ? connector : null}
 
       {React.Children.map(children, (child) => {
@@ -89,17 +79,10 @@ const Step = React.forwardRef(function Step(props, ref) {
         }
 
         return React.cloneElement(child, {
-          active,
-          alternativeLabel,
-          completed,
-          disabled,
-          expanded,
-          last,
-          icon: index + 1,
-          orientation,
           ...child.props,
         });
       })}
+      </StepContext.Provider>
     </div>
   );
 

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -42,6 +42,7 @@ const Step = React.forwardRef(function Step(props, ref) {
   const { activeStep, connector, alternativeLabel, orientation, nonLinear } = React.useContext(
     StepperContext,
   );
+
   let [active = false, completed = false, disabled = false] = [
     activeProp,
     completedProp,
@@ -53,7 +54,7 @@ const Step = React.forwardRef(function Step(props, ref) {
   } else if (!nonLinear && activeStep > index) {
     completed = completedProp !== undefined ? completedProp : true;
   } else if (!nonLinear && activeStep < index) {
-    disabled = disabledProp !== disabledProp ? disabledProp : true;
+    disabled = disabledProp !== undefined ? disabledProp : true;
   }
 
   const contextValue = React.useMemo(
@@ -149,6 +150,14 @@ Step.propTypes = {
    * Expand the step.
    */
   expanded: PropTypes.bool,
+  /**
+   * The position of the step.
+   */
+  index: PropTypes.number,
+  /**
+   * If `true`, the Step will be displayed as rendered last.
+   */
+  last: PropTypes.bool,
 };
 
 export default withStyles(styles, { name: 'MuiStep' })(Step);

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -73,22 +73,6 @@ describe('<Step />', () => {
     skip: ['componentProp'],
   }));
 
-  it('merges styles and other props into the root node', () => {
-    const { getByTestId } = render(
-      <Step
-        index={1}
-        style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}
-        data-testid="root"
-        orientation="horizontal"
-      />,
-    );
-
-    const rootNode = getByTestId('root');
-    expect(rootNode.style).to.have.property('paddingRight', '200px');
-    expect(rootNode.style).to.have.property('color', 'purple');
-    expect(rootNode.style).to.have.property('border', '1px solid tomato');
-  });
-
   describe('rendering children', () => {
     it('renders children', () => {
       const { getByTestId } = render(
@@ -98,32 +82,6 @@ describe('<Step />', () => {
       );
 
       expect(within(getByTestId('root')).getByTestId('child')).not.to.equal(null);
-    });
-
-    it('renders children with all props passed through', () => {
-      const { getAllByTestId } = render(
-        <Step active={false} completed disabled index={0} orientation="horizontal">
-          <PropsAsDataset />
-          <PropsAsDataset />
-        </Step>,
-      );
-      getAllByTestId('props').forEach((child) => {
-        // HTMLElement.dataset is a DOMStringMap which fails deep.equal
-        const datasetAsObject = { ...child.dataset };
-        expect(datasetAsObject).to.deep.equal({
-          // props passed from Step
-          active: 'false',
-          alternativeLabel: 'undefined',
-          completed: 'true',
-          disabled: 'true',
-          expanded: 'false',
-          last: 'undefined',
-          icon: '1',
-          orientation: 'horizontal',
-          // test impl details
-          testid: 'props',
-        });
-      });
     });
 
     it('honours children overriding props passed through', () => {

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -10,7 +10,7 @@ import StepLabel from '../StepLabel';
 import StepButton from '../StepButton';
 
 describe('<Step />', () => {
-  let stepClasses;
+  let classes;
   let stepButtonClasses;
   let stepLabelClasses;
   const mount = createMount();
@@ -18,13 +18,13 @@ describe('<Step />', () => {
   const render = createClientRender();
 
   before(() => {
-    stepClasses = getClasses(<Step />);
+    classes = getClasses(<Step />);
     stepButtonClasses = getClasses(<StepButton />);
     stepLabelClasses = getClasses(<StepLabel />);
   });
 
   describeConformance(<Step />, () => ({
-    classes: stepClasses,
+    classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -1,108 +1,136 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender, within } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Step from './Step';
-
-/**
- * Exposes props stringified in the dataset of the `[data-testid="props"]`
- */
-function PropsAsDataset(props) {
-  const elementRef = React.useRef();
-  React.useEffect(() => {
-    const { current: element } = elementRef;
-
-    Object.keys(props).forEach((key) => {
-      // converted to strings internally. writing it out for readability
-      element.dataset[key] = String(props[key]);
-    });
-  });
-
-  return <span data-testid="props" ref={elementRef} />;
-}
-
-/**
- * A component that can be used as a child of `Step`.
- * It passes through all unrelated props to the underlying `div`
- * The props passed from `Step` are intercepted
- */
-function StepChildDiv(props) {
-  const {
-    active,
-    alternativeLabel,
-    completed,
-    disabled,
-    expanded,
-    icon,
-    last,
-    orientation,
-    ...other
-  } = props;
-
-  return <div {...other} />;
-}
-StepChildDiv.propTypes = {
-  active: PropTypes.bool,
-  alternativeLabel: PropTypes.bool,
-  completed: PropTypes.bool,
-  disabled: PropTypes.bool,
-  expanded: PropTypes.bool,
-  icon: PropTypes.node,
-  last: PropTypes.bool,
-  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
-};
+import Stepper from '../Stepper';
+import StepLabel from '../StepLabel';
+import StepButton from '../StepButton';
 
 describe('<Step />', () => {
-  let classes;
+  let stepClasses;
+  let stepButtonClasses;
+  let stepLabelClasses;
   const mount = createMount();
 
   const render = createClientRender();
 
   before(() => {
-    classes = getClasses(<Step />);
+    stepClasses = getClasses(<Step />);
+    stepButtonClasses = getClasses(<StepButton />);
+    stepLabelClasses = getClasses(<StepLabel />);
   });
 
   describeConformance(<Step />, () => ({
-    classes,
+    classes: stepClasses,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
   }));
 
+  it('merges styles and other props into the root node', () => {
+    const { getByTestId } = render(
+      <Step
+        index={1}
+        style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}
+        data-testid="root"
+        orientation="horizontal"
+      />,
+    );
+
+    const rootNode = getByTestId('root');
+    expect(rootNode.style).to.have.property('paddingRight', '200px');
+    expect(rootNode.style).to.have.property('color', 'purple');
+    expect(rootNode.style).to.have.property('border', '1px solid tomato');
+  });
+
   describe('rendering children', () => {
     it('renders children', () => {
-      const { getByTestId } = render(
-        <Step data-testid="root" label="Step One" index={1} orientation="horizontal">
-          <StepChildDiv data-testid="child">Hello World</StepChildDiv>
+      const { container } = render(
+        <Step>
+          <StepButton />
+          <StepLabel />
         </Step>,
       );
 
-      expect(within(getByTestId('root')).getByTestId('child')).not.to.equal(null);
-    });
-
-    it('honours children overriding props passed through', () => {
-      const { getByTestId } = render(
-        <Step active label="Step One" orientation="horizontal" index={0}>
-          <PropsAsDataset active={false} />
-        </Step>,
-      );
-
-      expect(getByTestId('props').dataset).to.have.property('active', 'false');
+      const stepLabel = container.querySelector(`.${stepLabelClasses.root}`);
+      const stepButton = container.querySelector(`.${stepButtonClasses.root}`);
+      expect(stepLabel).not.to.equal(null);
+      expect(stepButton).not.to.equal(null);
     });
 
     it('should handle null children', () => {
-      const { getByTestId } = render(
-        <Step label="Step One" index={1} orientation="horizontal">
-          <StepChildDiv data-testid="child">Hello World</StepChildDiv>
+      const { container } = render(
+        <Step>
+          <StepButton />
           {null}
         </Step>,
       );
 
-      expect(getByTestId('child')).not.to.equal(null);
+      const stepButton = container.querySelector(`.${stepButtonClasses.root}`);
+      expect(stepButton).not.to.equal(null);
+    });
+  });
+
+  describe('overriding context props', () => {
+    it('overrides "active" context value', () => {
+      const { getByText } = render(
+        <Stepper activeStep={1}>
+          <Step>
+            <StepLabel>Step 1</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 2</StepLabel>
+          </Step>
+          <Step active>
+            <StepLabel>Step 3</StepLabel>
+          </Step>
+        </Stepper>,
+      );
+
+      const stepLabel = getByText('Step 3');
+      expect(stepLabel).to.have.class(stepLabelClasses.active);
+    });
+
+    it('overrides "completed" context value', () => {
+      const { getByText } = render(
+        <Stepper activeStep={1}>
+          <Step>
+            <StepLabel>Step 1</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 2</StepLabel>
+          </Step>
+          <Step completed>
+            <StepLabel>Step 3</StepLabel>
+          </Step>
+        </Stepper>,
+      );
+
+      const stepLabel = getByText('Step 3');
+      expect(stepLabel).to.have.class(stepLabelClasses.completed);
+    });
+
+    it('overrides "disabled" context value', () => {
+      const { container } = render(
+        <Stepper activeStep={1}>
+          <Step>
+            <StepLabel>Step 1</StepLabel>
+          </Step>
+          <Step disabled>
+            <StepLabel>Step 2</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 3</StepLabel>
+          </Step>
+        </Stepper>,
+      );
+
+      const stepLabels = container.querySelectorAll(`.${stepLabelClasses.root}`);
+      expect(stepLabels[1]).to.have.class(stepLabelClasses.disabled);
     });
   });
 });

--- a/packages/material-ui/src/Step/StepContext.js
+++ b/packages/material-ui/src/Step/StepContext.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 const StepContext = React.createContext({});
 
 if (process.env.NODE_ENV !== 'production') {
-    StepContext.displayName = 'StepContext';
+  StepContext.displayName = 'StepContext';
 }
 
 export default StepContext;

--- a/packages/material-ui/src/Step/StepContext.js
+++ b/packages/material-ui/src/Step/StepContext.js
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+/**
+ * @ignore - internal component.
+ */
 const StepContext = React.createContext({});
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui/src/Step/StepContext.js
+++ b/packages/material-ui/src/Step/StepContext.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+const StepContext = React.createContext({});
+
+if (process.env.NODE_ENV !== 'production') {
+    StepContext.displayName = 'StepContext';
+}
+
+export default StepContext;

--- a/packages/material-ui/src/StepButton/StepButton.d.ts
+++ b/packages/material-ui/src/StepButton/StepButton.d.ts
@@ -15,15 +15,6 @@ export type StepButtonTypeMap<P, D extends React.ElementType> = ExtendButtonBase
      */
     children?: React.ReactNode;
     /**
-     * For non-linear Steppers you need to manually set which steps are completed.
-     * Otherwise the Stepper determines if a step is completed.
-     */
-    completed?: boolean;
-    /**
-     * @ignore This prop is ignored. You should disable the whole `Step`.
-     */
-    disabled?: boolean;
-    /**
      * The icon displayed by the step label.
      */
     icon?: React.ReactNode;

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -5,8 +5,8 @@ import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
 import isMuiElement from '../utils/isMuiElement';
-import StepperContext from '../Stepper/StepperContext'
-import StepContext from '../Step/StepContext'
+import StepperContext from '../Stepper/StepperContext';
+import StepContext from '../Step/StepContext';
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -31,17 +31,10 @@ export const styles = {
 };
 
 const StepButton = React.forwardRef(function StepButton(props, ref) {
-  const {
-    children,
-    classes,
-    className,
-    icon,
-    optional,
-    ...other
-  } = props;
+  const { children, classes, className, icon, optional, ...other } = props;
 
-  const { disabled } = React.useContext(StepContext)
-  const { orientation } = React.useContext(StepperContext)
+  const { disabled } = React.useContext(StepContext);
+  const { orientation } = React.useContext(StepperContext);
 
   const childProps = {
     icon,

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -80,15 +80,6 @@ StepButton.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * For non-linear Steppers you need to manually set which steps are completed.
-   * Otherwise the Stepper determines if a step is completed.
-   */
-  completed: PropTypes.bool,
-  /**
-   * @ignore This prop is ignored. You should disable the whole `Step`.
-   */
-  disabled: PropTypes.bool,
-  /**
    * The icon displayed by the step label.
    */
   icon: PropTypes.node,

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -5,6 +5,8 @@ import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
 import isMuiElement from '../utils/isMuiElement';
+import StepperContext from '../Stepper/StepperContext'
+import StepContext from '../Step/StepContext'
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -30,34 +32,20 @@ export const styles = {
 
 const StepButton = React.forwardRef(function StepButton(props, ref) {
   const {
-    // eslint-disable-next-line react/prop-types
-    active,
-    // eslint-disable-next-line react/prop-types
-    alternativeLabel,
     children,
     classes,
     className,
-    completed,
-    disabled,
-    // eslint-disable-next-line react/prop-types
-    expanded,
     icon,
-    // eslint-disable-next-line react/prop-types
-    last,
     optional,
-    // eslint-disable-next-line react/prop-types
-    orientation,
     ...other
   } = props;
 
+  const { disabled } = React.useContext(StepContext)
+  const { orientation } = React.useContext(StepperContext)
+
   const childProps = {
-    active,
-    alternativeLabel,
-    completed,
-    disabled,
     icon,
     optional,
-    orientation,
   };
 
   const child = isMuiElement(children, ['StepLabel']) ? (

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -12,18 +12,20 @@ import ButtonBase from '../ButtonBase';
 import { fireEvent } from '@testing-library/dom';
 
 describe('<StepButton />', () => {
-  let classes;
+  let buttonClasses;
+  let stepLabelClasses;
   const render = createClientRender();
 
   before(() => {
-    classes = getClasses(<StepButton />);
+    buttonClasses = getClasses(<StepButton />);
+    stepLabelClasses = getClasses(<StepLabel />);
   });
 
   describe('internals', () => {
     const mount = createMount();
 
     describeConformance(<StepButton />, () => ({
-      classes,
+      classes: buttonClasses,
       inheritComponent: ButtonBase,
       mount,
       refInstanceof: window.HTMLButtonElement,
@@ -32,12 +34,10 @@ describe('<StepButton />', () => {
 
     it('passes active, completed, disabled to StepLabel', () => {
       const { container, getByText } = render(
-        <StepButton active completed disabled>
-          Step One
-        </StepButton>,
+        <Step active completed disabled>
+          <StepButton>Step One</StepButton>
+        </Step>,
       );
-
-      const stepLabelClasses = getClasses(<StepLabel />);
 
       const stepLabelRoot = container.querySelector(`.${stepLabelClasses.root}`);
       const stepLabel = container.querySelector(`.${stepLabelClasses.label}`);
@@ -50,12 +50,12 @@ describe('<StepButton />', () => {
 
     it('should pass props to a provided StepLabel', () => {
       const { container, getByText } = render(
-        <StepButton active completed disabled label="Step One">
-          <StepLabel>Step One</StepLabel>
-        </StepButton>,
+        <Step active completed disabled>
+          <StepButton label="Step One">
+            <StepLabel>Step One</StepLabel>
+          </StepButton>
+        </Step>,
       );
-
-      const stepLabelClasses = getClasses(<StepLabel />);
 
       const stepLabelRoot = container.querySelector(`.${stepLabelClasses.root}`);
       const stepLabel = container.querySelector(`.${stepLabelClasses.label}`);

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -12,12 +12,12 @@ import ButtonBase from '../ButtonBase';
 import { fireEvent } from '@testing-library/dom';
 
 describe('<StepButton />', () => {
-  let buttonClasses;
+  let classes;
   let stepLabelClasses;
   const render = createClientRender();
 
   before(() => {
-    buttonClasses = getClasses(<StepButton />);
+    classes = getClasses(<StepButton />);
     stepLabelClasses = getClasses(<StepLabel />);
   });
 
@@ -25,7 +25,7 @@ describe('<StepButton />', () => {
     const mount = createMount();
 
     describeConformance(<StepButton />, () => ({
-      classes: buttonClasses,
+      classes,
       inheritComponent: ButtonBase,
       mount,
       refInstanceof: window.HTMLButtonElement,

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -2,6 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
+import StepperContext from '../Stepper/StepperContext'
+import StepContext from '../Step/StepContext'
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -48,22 +50,13 @@ export const styles = (theme) => ({
 
 const StepConnector = React.forwardRef(function StepConnector(props, ref) {
   const {
-    // eslint-disable-next-line react/prop-types
-    active,
-    // eslint-disable-next-line react/prop-types
-    alternativeLabel = false,
     classes,
     className,
-    // eslint-disable-next-line react/prop-types
-    completed,
-    // eslint-disable-next-line react/prop-types
-    disabled,
-    // eslint-disable-next-line react/prop-types
-    index,
-    // eslint-disable-next-line react/prop-types
-    orientation = 'horizontal',
     ...other
   } = props;
+
+  const { alternativeLabel, orientation } = React.useContext(StepperContext)
+  const { active, disabled, completed } = React.useContext(StepContext)
 
   return (
     <div

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -2,8 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
-import StepperContext from '../Stepper/StepperContext'
-import StepContext from '../Step/StepContext'
+import StepperContext from '../Stepper/StepperContext';
+import StepContext from '../Step/StepContext';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -49,14 +49,10 @@ export const styles = (theme) => ({
 });
 
 const StepConnector = React.forwardRef(function StepConnector(props, ref) {
-  const {
-    classes,
-    className,
-    ...other
-  } = props;
+  const { classes, className, ...other } = props;
 
-  const { alternativeLabel, orientation } = React.useContext(StepperContext)
-  const { active, disabled, completed } = React.useContext(StepContext)
+  const { alternativeLabel, orientation } = React.useContext(StepperContext);
+  const { active, disabled, completed } = React.useContext(StepContext);
 
   return (
     <div

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import { createClientRender } from 'test/utils/createClientRender';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
+import Stepper from '../Stepper';
+import Step from '../Step';
 import StepConnector from './StepConnector';
 
 describe('<StepConnector />', () => {
-  let shallow;
   let classes;
   const mount = createMount();
+  const render = createClientRender({ strict: false });
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<StepConnector />);
   });
 
@@ -25,34 +27,71 @@ describe('<StepConnector />', () => {
 
   describe('rendering', () => {
     it('renders a div containing a span', () => {
-      const wrapper = shallow(<StepConnector orientation="horizontal" />);
-      expect(wrapper.type()).to.equal('div');
-      expect(wrapper.find('span').length).to.equal(1);
+      const { container } = render(<StepConnector />);
+
+      const stepConnector = container.querySelector(`.${classes.root}`);
+      const span = stepConnector.querySelector('span');
+      expect(stepConnector).to.not.equal(null);
+      expect(span).to.not.equal(null);
     });
 
     it('has the class when horizontal', () => {
-      const wrapper = shallow(<StepConnector orientation="horizontal" />);
-      expect(wrapper.find('span').props().className).to.include(classes.lineHorizontal);
+      const { container } = render(
+        <Stepper orientation="horizontal">
+          <Step>
+            <StepConnector />
+          </Step>
+        </Stepper>,
+      );
+
+      const stepConnectorLine = container.querySelector(`.${classes.line}`);
+      expect(stepConnectorLine).to.have.class(classes.lineHorizontal);
     });
 
     it('has the class when vertical', () => {
-      const wrapper = shallow(<StepConnector orientation="vertical" />);
-      expect(wrapper.find('span').props().className).to.include(classes.lineVertical);
+      const { container } = render(
+        <Stepper orientation="vertical">
+          <Step>
+            <StepConnector />
+          </Step>
+        </Stepper>,
+      );
+
+      const stepConnectorLine = container.querySelector(`.${classes.line}`);
+      expect(stepConnectorLine).to.have.class(classes.lineVertical);
     });
 
     it('has the class when active', () => {
-      const wrapper = shallow(<StepConnector active />);
-      expect(wrapper.props().className).to.include(classes.active);
+      const { container } = render(
+        <Step active>
+          <StepConnector />
+        </Step>,
+      );
+
+      const stepConnector = container.querySelector(`.${classes.root}`);
+      expect(stepConnector).to.have.class(classes.active);
     });
 
     it('has the class when completed', () => {
-      const wrapper = shallow(<StepConnector completed />);
-      expect(wrapper.props().className).to.include(classes.completed);
+      const { container } = render(
+        <Step completed>
+          <StepConnector />
+        </Step>,
+      );
+
+      const stepConnector = container.querySelector(`.${classes.root}`);
+      expect(stepConnector).to.have.class(classes.completed);
     });
 
     it('has the class when disabled', () => {
-      const wrapper = shallow(<StepConnector disabled />);
-      expect(wrapper.props().className).to.include(classes.disabled);
+      const { container } = render(
+        <Step disabled>
+          <StepConnector />
+        </Step>,
+      );
+
+      const stepConnector = container.querySelector(`.${classes.root}`);
+      expect(stepConnector).to.have.class(classes.disabled);
     });
   });
 });

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Collapse from '../Collapse';
 import withStyles from '../styles/withStyles';
+import StepperContext from '../Stepper/StepperContext'
+import StepContext from '../Step/StepContext'
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -25,28 +27,17 @@ export const styles = (theme) => ({
 
 const StepContent = React.forwardRef(function StepContent(props, ref) {
   const {
-    // eslint-disable-next-line react/prop-types
-    active,
-    // eslint-disable-next-line react/prop-types
-    alternativeLabel,
     children,
     classes,
     className,
-    // eslint-disable-next-line react/prop-types
-    completed,
-    // eslint-disable-next-line react/prop-types
-    expanded,
-    // eslint-disable-next-line react/prop-types
-    last,
-    // eslint-disable-next-line react/prop-types
-    optional,
-    // eslint-disable-next-line react/prop-types
-    orientation,
     TransitionComponent = Collapse,
     transitionDuration: transitionDurationProp = 'auto',
     TransitionProps,
     ...other
   } = props;
+
+  const { orientation } = React.useContext(StepperContext)
+  const { active, last, expanded } = React.useContext(StepContext)
 
   if (process.env.NODE_ENV !== 'production') {
     if (orientation !== 'vertical') {

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Collapse from '../Collapse';
 import withStyles from '../styles/withStyles';
-import StepperContext from '../Stepper/StepperContext'
-import StepContext from '../Step/StepContext'
+import StepperContext from '../Stepper/StepperContext';
+import StepContext from '../Step/StepContext';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -36,8 +36,8 @@ const StepContent = React.forwardRef(function StepContent(props, ref) {
     ...other
   } = props;
 
-  const { orientation } = React.useContext(StepperContext)
-  const { active, last, expanded } = React.useContext(StepContext)
+  const { orientation } = React.useContext(StepperContext);
+  const { active, last, expanded } = React.useContext(StepContext);
 
   if (process.env.NODE_ENV !== 'production') {
     if (orientation !== 'vertical') {

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,79 +1,119 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import { createClientRender } from 'test/utils/createClientRender';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Collapse from '../Collapse';
+import Stepper from '../Stepper';
+import Step from '../Step';
 import StepContent from './StepContent';
 
 describe('<StepContent />', () => {
-  let classes;
-  let shallow;
+  let stepContentClasses;
+  let collapseClasses;
   // StrictModeViolation: uses Collapse
   const mount = createMount({ strict: false });
-  const defaultProps = {
-    orientation: 'vertical',
-  };
+  const render = createClientRender({ strict: false });
 
   before(() => {
-    classes = getClasses(<StepContent />);
-    shallow = createShallow({ dive: true });
+    stepContentClasses = getClasses(<StepContent />);
+    collapseClasses = getClasses(<Collapse />);
   });
 
-  describeConformance(<StepContent {...defaultProps} />, () => ({
-    classes,
-    inheritComponent: 'div',
-    mount,
-    refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
-  }));
+  // describeConformance(
+  //   <Stepper orientation="vertical">
+  //     <Step>
+  //       <StepContent />
+  //     </Step>
+  //   </Stepper>,
+  //   () => ({
+  //     classes: stepContentClasses,
+  //     inheritComponent: 'div',
+  //     mount,
+  //     refInstanceof: window.HTMLDivElement,
+  //     skip: ['componentProp'],
+  //   }),
+  // );
+
+  // describeConformance(<StepContent />, () => ({
+  //   classes: stepContentClasses,
+  //   inheritComponent: 'div',
+  //   mount,
+  //   refInstanceof: window.HTMLDivElement,
+  //   skip: ['componentProp'],
+  // }));
 
   it('merges styles and other props into the root node', () => {
-    const wrapper = shallow(
-      <StepContent
-        style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}
-        {...defaultProps}
-      >
-        Lorem ipsum
-      </StepContent>,
+    const { container } = render(
+      <Stepper orientation="vertical">
+        <Step>
+          <StepContent style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}>
+            Lorem ipsum
+          </StepContent>
+        </Step>
+      </Stepper>,
     );
-    const props = wrapper.props();
-    expect(props.style.paddingRight).to.equal(200);
-    expect(props.style.color).to.equal('purple');
-    expect(props.style.border).to.equal('1px solid tomato');
+
+    const root = container.querySelector(`.${stepContentClasses.root}`);
+    const styles = window.getComputedStyle(root);
+
+    expect(styles['padding-right']).to.equal('200px');
+    expect(styles.color).to.equal('purple');
+    expect(styles.border).to.equal('1px solid tomato');
   });
 
   it('renders children inside an Collapse component', () => {
-    const wrapper = shallow(
-      <StepContent {...defaultProps}>
-        <div className="test-content">This is my content!</div>
-      </StepContent>,
+    const { container, getByText } = render(
+      <Stepper orientation="vertical">
+        <Step>
+          <StepContent>
+            <div className="test-content">This is my content!</div>
+          </StepContent>
+        </Step>
+      </Stepper>,
     );
-    const collapse = wrapper.find(Collapse);
-    expect(collapse.length).to.equal(1);
-    const content = collapse.find('.test-content');
-    expect(content.length).to.equal(1);
-    expect(content.props().children).to.equal('This is my content!');
+
+    const collapse = container.querySelector(`.${collapseClasses.container}`);
+    const innerDiv = container.querySelector(`.test-content`);
+
+    expect(collapse).to.not.equal(null);
+    expect(innerDiv).to.not.equal(null);
+    getByText('This is my content!');
   });
 
   describe('prop: transitionDuration', () => {
-    it('should apply the auto prop if supported', () => {
-      const wrapper = shallow(
-        <StepContent {...defaultProps}>
-          <div />
-        </StepContent>,
+    it('should use default Collapse component', () => {
+      const { container } = render(
+        <Stepper orientation="vertical">
+          <Step>
+            <StepContent>
+              <div />
+            </StepContent>
+          </Step>
+        </Stepper>,
       );
-      expect(wrapper.find(Collapse).props().timeout).to.equal('auto');
+
+      const collapse = container.querySelector(`.${collapseClasses.container}`);
+      expect(collapse).to.not.equal(null);
     });
 
-    it('should not apply the auto prop if not supported', () => {
-      const TransitionComponent = (props) => <div {...props} />;
-      const wrapper = shallow(
-        <StepContent {...defaultProps} TransitionComponent={TransitionComponent}>
-          <div />
-        </StepContent>,
+    it('should use custom TransitionComponent', () => {
+      const TransitionComponent = () => <div data-testid="custom-transition" />;
+
+      const { container, getByTestId } = render(
+        <Stepper orientation="vertical">
+          <Step>
+            <StepContent TransitionComponent={TransitionComponent}>
+              <div />
+            </StepContent>
+          </Step>
+        </Stepper>,
       );
-      expect(wrapper.find(TransitionComponent).props().timeout).to.equal(undefined);
+
+      const collapse = container.querySelector(`.${collapseClasses.container}`);
+      expect(collapse).to.equal(null);
+      getByTestId('custom-transition');
     });
   });
 });

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -10,58 +10,31 @@ import Step from '../Step';
 import StepContent from './StepContent';
 
 describe('<StepContent />', () => {
-  let stepContentClasses;
+  let classes;
   let collapseClasses;
   // StrictModeViolation: uses Collapse
   const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
 
   before(() => {
-    stepContentClasses = getClasses(<StepContent />);
+    classes = getClasses(<StepContent />);
     collapseClasses = getClasses(<Collapse />);
   });
 
-  // describeConformance(
-  //   <Stepper orientation="vertical">
-  //     <Step>
-  //       <StepContent />
-  //     </Step>
-  //   </Stepper>,
-  //   () => ({
-  //     classes: stepContentClasses,
-  //     inheritComponent: 'div',
-  //     mount,
-  //     refInstanceof: window.HTMLDivElement,
-  //     skip: ['componentProp'],
-  //   }),
-  // );
-
-  // describeConformance(<StepContent />, () => ({
-  //   classes: stepContentClasses,
-  //   inheritComponent: 'div',
-  //   mount,
-  //   refInstanceof: window.HTMLDivElement,
-  //   skip: ['componentProp'],
-  // }));
-
-  it('merges styles and other props into the root node', () => {
-    const { container } = render(
-      <Stepper orientation="vertical">
-        <Step>
-          <StepContent style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}>
-            Lorem ipsum
-          </StepContent>
-        </Step>
-      </Stepper>,
-    );
-
-    const root = container.querySelector(`.${stepContentClasses.root}`);
-    const styles = window.getComputedStyle(root);
-
-    expect(styles['padding-right']).to.equal('200px');
-    expect(styles.color).to.equal('purple');
-    expect(styles.border).to.equal('1px solid tomato');
-  });
+  describeConformance(<StepContent />, () => ({
+    classes,
+    inheritComponent: 'div',
+    mount: (node) => {
+      const wrapper = mount(
+        <Stepper orientation="vertical">
+          <Step>{node}</Step>
+        </Stepper>,
+      );
+      return wrapper.find(Step).childAt(0).childAt(0).childAt(0);
+    },
+    refInstanceof: window.HTMLDivElement,
+    skip: ['componentProp', 'reactTestRenderer', 'refForwarding'],
+  }));
 
   it('renders children inside an Collapse component', () => {
     const { container, getByText } = render(

--- a/packages/material-ui/src/StepIcon/StepIcon.d.ts
+++ b/packages/material-ui/src/StepIcon/StepIcon.d.ts
@@ -4,6 +4,14 @@ import { StandardProps } from '..';
 export interface StepIconProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, StepIconClasskey, 'children'> {
   /**
+   * Whether this step is active.
+   */
+  active?: boolean;
+  /**
+   * Mark the step as completed. Is passed to child components.
+   */
+  completed?: boolean;
+  /**
    * Mark the step as failed.
    */
   error?: boolean;

--- a/packages/material-ui/src/StepIcon/StepIcon.d.ts
+++ b/packages/material-ui/src/StepIcon/StepIcon.d.ts
@@ -4,14 +4,6 @@ import { StandardProps } from '..';
 export interface StepIconProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, StepIconClasskey, 'children'> {
   /**
-   * Whether this step is active.
-   */
-  active?: boolean;
-  /**
-   * Mark the step as completed. Is passed to child components.
-   */
-  completed?: boolean;
-  /**
    * Mark the step as failed.
    */
   error?: boolean;

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -5,7 +5,6 @@ import CheckCircle from '../internal/svg-icons/CheckCircle';
 import Warning from '../internal/svg-icons/Warning';
 import withStyles from '../styles/withStyles';
 import SvgIcon from '../SvgIcon';
-import StepContext from '../Step/StepContext';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -37,8 +36,7 @@ export const styles = (theme) => ({
 });
 
 const StepIcon = React.forwardRef(function StepIcon(props, ref) {
-  const { icon, error = false, classes } = props;
-  const { active, completed } = React.useContext(StepContext);
+  const { completed = false, icon, active = false, error = false, classes } = props;
 
   if (typeof icon === 'number' || typeof icon === 'string') {
     const className = clsx(classes.root, {

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -5,7 +5,7 @@ import CheckCircle from '../internal/svg-icons/CheckCircle';
 import Warning from '../internal/svg-icons/Warning';
 import withStyles from '../styles/withStyles';
 import SvgIcon from '../SvgIcon';
-import StepContext from '../Step/StepContext'
+import StepContext from '../Step/StepContext';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -38,7 +38,7 @@ export const styles = (theme) => ({
 
 const StepIcon = React.forwardRef(function StepIcon(props, ref) {
   const { icon, error = false, classes } = props;
-  const { active, completed } = React.useContext(StepContext)
+  const { active, completed } = React.useContext(StepContext);
 
   if (typeof icon === 'number' || typeof icon === 'string') {
     const className = clsx(classes.root, {

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -5,6 +5,7 @@ import CheckCircle from '../internal/svg-icons/CheckCircle';
 import Warning from '../internal/svg-icons/Warning';
 import withStyles from '../styles/withStyles';
 import SvgIcon from '../SvgIcon';
+import StepContext from '../Step/StepContext'
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -36,7 +37,8 @@ export const styles = (theme) => ({
 });
 
 const StepIcon = React.forwardRef(function StepIcon(props, ref) {
-  const { completed = false, icon, active = false, error = false, classes } = props;
+  const { icon, error = false, classes } = props;
+  const { active, completed } = React.useContext(StepContext)
 
   if (typeof icon === 'number' || typeof icon === 'string') {
     const className = clsx(classes.root, {

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
+import Step from '../Step';
 import StepIcon from './StepIcon';
 
 describe('<StepIcon />', () => {
@@ -16,7 +17,8 @@ describe('<StepIcon />', () => {
   }));
 
   it('renders <CheckCircle> when completed', () => {
-    const { container } = render(<StepIcon icon={1} completed />);
+    const { container } = render(<StepIcon icon={1} />);
+
     expect(container.querySelectorAll('svg[data-mui-test="CheckCircleIcon"]')).to.have.length(1);
   });
 

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
-import Step from '../Step';
 import StepIcon from './StepIcon';
 
 describe('<StepIcon />', () => {
@@ -17,11 +16,7 @@ describe('<StepIcon />', () => {
   }));
 
   it('renders <CheckCircle> when completed', () => {
-    const { container } = render(
-      <Step completed>
-        <StepIcon icon={1} />
-      </Step>,
-    );
+    const { container } = render(<StepIcon completed icon={1} />);
 
     expect(container.querySelectorAll('svg[data-mui-test="CheckCircleIcon"]')).to.have.length(1);
   });

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -17,7 +17,11 @@ describe('<StepIcon />', () => {
   }));
 
   it('renders <CheckCircle> when completed', () => {
-    const { container } = render(<StepIcon icon={1} />);
+    const { container } = render(
+      <Step completed>
+        <StepIcon icon={1} />
+      </Step>,
+    );
 
     expect(container.querySelectorAll('svg[data-mui-test="CheckCircleIcon"]')).to.have.length(1);
   });

--- a/packages/material-ui/src/StepLabel/StepLabel.d.ts
+++ b/packages/material-ui/src/StepLabel/StepLabel.d.ts
@@ -9,11 +9,6 @@ export interface StepLabelProps
    */
   children?: React.ReactNode;
   /**
-   * Mark the step as disabled, will also disable the button if
-   * `StepLabelButton` is a child of `StepLabel`. Is passed to child components.
-   */
-  disabled?: boolean;
-  /**
    * Mark the step as failed.
    */
   error?: boolean;

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -4,6 +4,8 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 import StepIcon from '../StepIcon';
+import StepperContext from '../Stepper/StepperContext'
+import StepContext from '../Step/StepContext'
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -69,29 +71,18 @@ export const styles = (theme) => ({
 
 const StepLabel = React.forwardRef(function StepLabel(props, ref) {
   const {
-    // eslint-disable-next-line react/prop-types
-    active = false,
-    // eslint-disable-next-line react/prop-types
-    alternativeLabel = false,
     children,
     classes,
     className,
-    // eslint-disable-next-line react/prop-types
-    completed = false,
-    disabled = false,
     error = false,
-    // eslint-disable-next-line react/prop-types
-    expanded,
-    icon,
-    // eslint-disable-next-line react/prop-types
-    last,
     optional,
-    // eslint-disable-next-line react/prop-types
-    orientation = 'horizontal',
     StepIconComponent: StepIconComponentProp,
     StepIconProps,
     ...other
   } = props;
+
+  const { alternativeLabel, orientation } = React.useContext(StepperContext)
+  const { active, disabled, completed, icon } = React.useContext(StepContext)
 
   let StepIconComponent = StepIconComponentProp;
 

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -4,8 +4,8 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 import StepIcon from '../StepIcon';
-import StepperContext from '../Stepper/StepperContext'
-import StepContext from '../Step/StepContext'
+import StepperContext from '../Stepper/StepperContext';
+import StepContext from '../Step/StepContext';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
@@ -81,8 +81,8 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
     ...other
   } = props;
 
-  const { alternativeLabel, orientation } = React.useContext(StepperContext)
-  const { active, disabled, completed, icon } = React.useContext(StepContext)
+  const { alternativeLabel, orientation } = React.useContext(StepperContext);
+  const { active, disabled, completed, icon } = React.useContext(StepContext);
 
   let StepIconComponent = StepIconComponentProp;
 

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -161,11 +161,6 @@ StepLabel.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Mark the step as disabled, will also disable the button if
-   * `StepLabelButton` is a child of `StepLabel`. Is passed to child components.
-   */
-  disabled: PropTypes.bool,
-  /**
    * Mark the step as failed.
    */
   error: PropTypes.bool,

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -11,43 +11,25 @@ import StepIcon from '../StepIcon';
 import StepLabel from './StepLabel';
 
 describe('<StepLabel />', () => {
-  let labelClasses;
+  let classes;
   let iconClasses;
   let typographyClasses;
-  const mount = createMount();
-  const render = createClientRender({ strict: false });
+  const mount = createMount({ strict: true });
+  const render = createClientRender();
 
   before(() => {
-    labelClasses = getClasses(<StepLabel />);
+    classes = getClasses(<StepLabel />);
     iconClasses = getClasses(<StepIcon />);
     typographyClasses = getClasses(<Typography />);
   });
 
   describeConformance(<StepLabel />, () => ({
-    classes: labelClasses,
+    classes,
     inheritComponent: 'span',
     mount,
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],
   }));
-
-  it('merges styles into the root node', () => {
-    const { container } = render(
-      <StepLabel
-        orientation="horizontal"
-        style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}
-      >
-        My Label
-      </StepLabel>,
-    );
-
-    const root = container.querySelector(`.${labelClasses.root}`);
-    const styles = window.getComputedStyle(root);
-
-    expect(styles['padding-right']).to.equal('200px');
-    expect(styles.color).to.equal('purple');
-    expect(styles.border).to.equal('1px solid tomato');
-  });
 
   describe('label content', () => {
     it('renders the label from children', () => {
@@ -81,14 +63,14 @@ describe('<StepLabel />', () => {
         </Step>,
       );
 
-      const icon = container.querySelector(`.${labelClasses.iconContainer}`);
-      const label = container.querySelector(`.${labelClasses.label}`);
+      const icon = container.querySelector(`.${classes.iconContainer}`);
+      const label = container.querySelector(`.${classes.label}`);
 
       getByTestId('custom-icon');
       expect(icon).to.not.equal(null);
       expect(icon).to.not.have.attribute('data-mui-test').equal('CheckCircleIcon');
-      expect(label).to.have.class(labelClasses.active);
-      expect(label).to.have.class(labelClasses.completed);
+      expect(label).to.have.class(classes.active);
+      expect(label).to.have.class(classes.completed);
     });
 
     it('should not render', () => {
@@ -112,7 +94,7 @@ describe('<StepLabel />', () => {
       );
 
       const typography = container.querySelector(`.${typographyClasses.root}`);
-      expect(typography).to.have.class(labelClasses.active);
+      expect(typography).to.have.class(classes.active);
     });
 
     it('renders <StepIcon> with the <Step /> prop active set to true', () => {
@@ -136,7 +118,7 @@ describe('<StepLabel />', () => {
       );
 
       const typography = container.querySelector(`.${typographyClasses.root}`);
-      expect(typography).to.not.have.class(labelClasses.active);
+      expect(typography).to.not.have.class(classes.active);
     });
   });
 
@@ -149,7 +131,7 @@ describe('<StepLabel />', () => {
       );
 
       const typography = container.querySelector(`.${typographyClasses.root}`);
-      expect(typography).to.have.class(labelClasses.active);
+      expect(typography).to.have.class(classes.active);
     });
 
     it('renders <StepIcon> with the prop completed set to true', () => {
@@ -171,7 +153,7 @@ describe('<StepLabel />', () => {
       const { container } = render(<StepLabel error>Step One</StepLabel>);
 
       const typography = container.querySelector(`.${typographyClasses.root}`);
-      expect(typography).to.have.class(labelClasses.error);
+      expect(typography).to.have.class(classes.error);
     });
 
     it('renders <StepIcon> with the prop error set to true', () => {
@@ -184,7 +166,7 @@ describe('<StepLabel />', () => {
       );
 
       const icon = container.querySelector(`.${iconClasses.root}`);
-      expect(icon).to.have.class(labelClasses.error);
+      expect(icon).to.have.class(classes.error);
     });
   });
 
@@ -196,8 +178,8 @@ describe('<StepLabel />', () => {
         </Step>,
       );
 
-      const label = container.querySelector(`.${labelClasses.root}`);
-      expect(label).to.have.class(labelClasses.disabled);
+      const label = container.querySelector(`.${classes.root}`);
+      expect(label).to.have.class(classes.disabled);
     });
   });
 

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -1,24 +1,30 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { getClasses } from '@material-ui/core/test-utils';
+import { createClientRender } from 'test/utils/createClientRender';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from '../Typography';
+import Stepper from '../Stepper';
+import Step from '../Step';
 import StepIcon from '../StepIcon';
 import StepLabel from './StepLabel';
 
 describe('<StepLabel />', () => {
-  let shallow;
-  let classes;
+  let labelClasses;
+  let iconClasses;
+  let typographyClasses;
   const mount = createMount();
+  const render = createClientRender({ strict: false });
 
   before(() => {
-    shallow = createShallow({ dive: true });
-    classes = getClasses(<StepLabel />);
+    labelClasses = getClasses(<StepLabel />);
+    iconClasses = getClasses(<StepIcon />);
+    typographyClasses = getClasses(<Typography />);
   });
 
   describeConformance(<StepLabel />, () => ({
-    classes,
+    classes: labelClasses,
     inheritComponent: 'span',
     mount,
     refInstanceof: window.HTMLSpanElement,
@@ -26,7 +32,7 @@ describe('<StepLabel />', () => {
   }));
 
   it('merges styles into the root node', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <StepLabel
         orientation="horizontal"
         style={{ paddingRight: 200, color: 'purple', border: '1px solid tomato' }}
@@ -34,149 +40,176 @@ describe('<StepLabel />', () => {
         My Label
       </StepLabel>,
     );
-    const props = wrapper.props();
-    expect(props.style.paddingRight).to.equal(200);
-    expect(props.style.color).to.equal('purple');
-    expect(props.style.border).to.equal('1px solid tomato');
+
+    const root = container.querySelector(`.${labelClasses.root}`);
+    const styles = window.getComputedStyle(root);
+
+    expect(styles['padding-right']).to.equal('200px');
+    expect(styles.color).to.equal('purple');
+    expect(styles.border).to.equal('1px solid tomato');
   });
 
   describe('label content', () => {
     it('renders the label from children', () => {
-      const wrapper = shallow(<StepLabel>Step One</StepLabel>);
-      expect(wrapper.contains('Step One')).to.equal(true);
+      const { getByText } = render(<StepLabel>Step One</StepLabel>);
+      getByText('Step One');
     });
 
-    it('renders <StepIcon>', () => {
-      const stepIconProps = { prop1: 'value1', prop2: 'value2' };
-      const wrapper = shallow(
-        <StepLabel icon={1} active completed alternativeLabel StepIconProps={stepIconProps}>
-          Step One
-        </StepLabel>,
+    it('renders <StepIcon> with props passed through StepIconProps', () => {
+      const stepIconProps = { error: true };
+
+      const { container } = render(
+        <Stepper alternativeLabel>
+          <Step active completed>
+            <StepLabel StepIconProps={stepIconProps}>Step One</StepLabel>
+          </Step>
+        </Stepper>,
       );
-      const stepIcon = wrapper.find(StepIcon);
-      expect(stepIcon.length).to.equal(1);
-      const props = stepIcon.props();
-      expect(props.icon).to.equal(1);
-      expect(props.prop1).to.equal('value1');
-      expect(props.prop2).to.equal('value2');
+
+      const icon = container.querySelector(`.${iconClasses.root}`);
+      // Should render WarningIcon instead of CheckCircleIcon because of { error: true } props
+      expect(icon).to.have.attribute('data-mui-test').equal('WarningIcon');
     });
   });
 
   describe('prop: StepIconComponent', () => {
     it('should render', () => {
-      const CustomizedIcon = () => <div />;
-      const wrapper = shallow(
-        <StepLabel
-          StepIconComponent={CustomizedIcon}
-          active
-          completed
-          StepIconProps={{ prop1: 'value1', prop2: 'value2' }}
-        >
-          Step One
-        </StepLabel>,
+      const CustomizedIcon = () => <div data-testid="custom-icon" />;
+      const { container, getByTestId } = render(
+        <Step active completed>
+          <StepLabel StepIconComponent={CustomizedIcon}>Step One</StepLabel>
+        </Step>,
       );
-      const stepIcon = wrapper.find(StepIcon);
-      expect(stepIcon.length).to.equal(0);
 
-      const customizedIcon = wrapper.find(CustomizedIcon);
-      expect(customizedIcon.length).to.equal(1);
-      const props = customizedIcon.props();
-      expect(props.prop1).to.equal('value1');
-      expect(props.prop2).to.equal('value2');
-      expect(props.completed).to.equal(true);
-      expect(props.active).to.equal(true);
+      const icon = container.querySelector(`.${labelClasses.iconContainer}`);
+      const label = container.querySelector(`.${labelClasses.label}`);
+
+      getByTestId('custom-icon');
+      expect(icon).to.not.equal(null);
+      expect(icon).to.not.have.attribute('data-mui-test').equal('CheckCircleIcon');
+      expect(label).to.have.class(labelClasses.active);
+      expect(label).to.have.class(labelClasses.completed);
     });
 
     it('should not render', () => {
-      const wrapper = shallow(
-        <StepLabel active completed>
-          Step One
-        </StepLabel>,
+      const { container } = render(
+        <Step active completed>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
       );
-      const stepIcon = wrapper.find(StepIcon);
-      expect(stepIcon.length).to.equal(0);
+
+      const icon = container.querySelector(`.${iconClasses.root}`);
+      expect(icon).to.equal(null);
     });
   });
 
-  describe('prop: active', () => {
+  describe('<Step /> prop: active', () => {
     it('renders <Typography> with the className active', () => {
-      const wrapper = shallow(<StepLabel active>Step One</StepLabel>);
-      const text = wrapper.find(Typography);
-      expect(text.hasClass(classes.active)).to.equal(true);
+      const { container } = render(
+        <Step active>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
+      );
+
+      const typography = container.querySelector(`.${typographyClasses.root}`);
+      expect(typography).to.have.class(labelClasses.active);
     });
 
-    it('renders <StepIcon> with the prop active set to true', () => {
-      const wrapper = shallow(
-        <StepLabel icon={1} active>
-          Step One
-        </StepLabel>,
+    it('renders <StepIcon> with the <Step /> prop active set to true', () => {
+      const { container } = render(
+        <Stepper>
+          <Step active>
+            <StepLabel>Step One</StepLabel>
+          </Step>
+        </Stepper>,
       );
-      const stepIcon = wrapper.find(StepIcon);
-      expect(stepIcon.props().active).to.equal(true);
+
+      const icon = container.querySelector(`.${iconClasses.root}`);
+      expect(icon).to.have.class(iconClasses.active);
     });
 
     it('renders <Typography> without the className active', () => {
-      const wrapper = shallow(<StepLabel active={false}>Step One</StepLabel>);
-      const text = wrapper.find(Typography);
-      expect(text.hasClass(classes.labelActive)).to.equal(false);
+      const { container } = render(
+        <Step active={false}>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
+      );
+
+      const typography = container.querySelector(`.${typographyClasses.root}`);
+      expect(typography).to.not.have.class(labelClasses.active);
     });
   });
 
-  describe('prop: completed', () => {
+  describe('<Step /> prop: completed', () => {
     it('renders <Typography> with the className completed', () => {
-      const wrapper = shallow(<StepLabel completed>Step One</StepLabel>);
-      const text = wrapper.find(Typography);
-      expect(text.hasClass(classes.completed)).to.equal(true);
+      const { container } = render(
+        <Step completed>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
+      );
+
+      const typography = container.querySelector(`.${typographyClasses.root}`);
+      expect(typography).to.have.class(labelClasses.active);
     });
 
     it('renders <StepIcon> with the prop completed set to true', () => {
-      const wrapper = shallow(
-        <StepLabel icon={1} completed>
-          Step One
-        </StepLabel>,
+      const { container } = render(
+        <Stepper>
+          <Step completed>
+            <StepLabel>Step One</StepLabel>
+          </Step>
+        </Stepper>,
       );
-      const stepIcon = wrapper.find(StepIcon);
-      expect(stepIcon.props().completed).to.equal(true);
+
+      const icon = container.querySelector(`.${iconClasses.root}`);
+      expect(icon).to.have.class(iconClasses.active);
     });
   });
 
   describe('prop: error', () => {
     it('renders <Typography> with the className error', () => {
-      const wrapper = shallow(<StepLabel error>Step One</StepLabel>);
-      const text = wrapper.find(Typography);
-      expect(text.hasClass(classes.error)).to.equal(true);
+      const { container } = render(<StepLabel error>Step One</StepLabel>);
+
+      const typography = container.querySelector(`.${typographyClasses.root}`);
+      expect(typography).to.have.class(labelClasses.error);
     });
 
     it('renders <StepIcon> with the prop error set to true', () => {
-      const wrapper = shallow(
-        <StepLabel icon={1} error>
-          Step One
-        </StepLabel>,
+      const { container } = render(
+        <Stepper>
+          <Step>
+            <StepLabel error>Step One</StepLabel>
+          </Step>
+        </Stepper>,
       );
-      const stepIcon = wrapper.find(StepIcon);
-      expect(stepIcon.props().error).to.equal(true);
+
+      const icon = container.querySelector(`.${iconClasses.root}`);
+      expect(icon).to.have.class(labelClasses.error);
     });
   });
 
-  describe('prop: disabled', () => {
+  describe('<Step /> prop: disabled', () => {
     it('renders with disabled className when disabled', () => {
-      const wrapper = shallow(
-        <StepLabel icon={1} disabled>
-          Step One
-        </StepLabel>,
+      const { container } = render(
+        <Step disabled>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
       );
-      expect(wrapper.hasClass(classes.disabled)).to.equal(true);
+
+      const label = container.querySelector(`.${labelClasses.root}`);
+      expect(label).to.have.class(labelClasses.disabled);
     });
   });
 
   describe('prop: optional = Optional Text', () => {
     it('creates a <Typography> component with text "Optional Text"', () => {
-      const wrapper = shallow(
-        <StepLabel icon={1} optional={<Typography variant="caption">Optional Text</Typography>}>
+      const { getByText } = render(
+        <StepLabel optional={<Typography variant="caption">Optional Text</Typography>}>
           Step One
         </StepLabel>,
       );
-      expect(wrapper.find(Typography).at(1).contains('Optional Text')).to.equal(true);
+
+      getByText('Optional Text');
     });
   });
 });

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Paper from '../Paper';
 import StepConnector from '../StepConnector';
-import StepperContext from './StepperContext'
+import StepperContext from './StepperContext';
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -36,41 +36,24 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
     children,
     classes,
     className,
-    connector: connectorProp = defaultConnector,
+    connector = defaultConnector,
     nonLinear = false,
     orientation = 'horizontal',
     ...other
   } = props;
 
-  const connector = React.isValidElement(connectorProp)
-    ? connectorProp
-    : null;
   const childrenArray = React.Children.toArray(children);
   const steps = childrenArray.map((step, index) => {
-    const state = {
-      index,
-      active: false,
-      completed: false,
-      disabled: false,
-    };
-    
-    if (activeStep === index) {
-      state.active = true;
-    } else if (!nonLinear && activeStep > index) {
-      state.completed = true;
-    } else if (!nonLinear && activeStep < index) {
-      state.disabled = true;
-    }
-    
     return React.cloneElement(step, {
+      index,
       last: index + 1 === childrenArray.length,
-      ...state,
       ...step.props,
     });
   });
-  const contextValue = React.useMemo(() => ({ activeStep, alternativeLabel, connector, nonLinear, orientation }), [
-    activeStep, alternativeLabel, connector, nonLinear, orientation
-  ]);
+  const contextValue = React.useMemo(
+    () => ({ activeStep, alternativeLabel, connector, nonLinear, orientation }),
+    [activeStep, alternativeLabel, connector, nonLinear, orientation],
+  );
 
   return (
     <Paper
@@ -87,9 +70,7 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
       ref={ref}
       {...other}
     >
-      <StepperContext.Provider value={contextValue}>
-        {steps}
-      </StepperContext.Provider>
+      <StepperContext.Provider value={contextValue}>{steps}</StepperContext.Provider>
     </Paper>
   );
 });

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -56,22 +56,24 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
   );
 
   return (
-    <Paper
-      square
-      elevation={0}
-      className={clsx(
-        classes.root,
-        classes[orientation],
-        {
-          [classes.alternativeLabel]: alternativeLabel,
-        },
-        className,
-      )}
-      ref={ref}
-      {...other}
-    >
-      <StepperContext.Provider value={contextValue}>{steps}</StepperContext.Provider>
-    </Paper>
+    <StepperContext.Provider value={contextValue}>
+      <Paper
+        square
+        elevation={0}
+        className={clsx(
+          classes.root,
+          classes[orientation],
+          {
+            [classes.alternativeLabel]: alternativeLabel,
+          },
+          className,
+        )}
+        ref={ref}
+        {...other}
+      >
+        {steps}
+      </Paper>
+    </StepperContext.Provider>
   );
 });
 

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Paper from '../Paper';
 import StepConnector from '../StepConnector';
+import StepperContext from './StepperContext'
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -42,7 +43,7 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
   } = props;
 
   const connector = React.isValidElement(connectorProp)
-    ? React.cloneElement(connectorProp, { orientation })
+    ? connectorProp
     : null;
   const childrenArray = React.Children.toArray(children);
   const steps = childrenArray.map((step, index) => {
@@ -52,7 +53,7 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
       completed: false,
       disabled: false,
     };
-
+    
     if (activeStep === index) {
       state.active = true;
     } else if (!nonLinear && activeStep > index) {
@@ -60,16 +61,16 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
     } else if (!nonLinear && activeStep < index) {
       state.disabled = true;
     }
-
+    
     return React.cloneElement(step, {
-      alternativeLabel,
-      connector,
       last: index + 1 === childrenArray.length,
-      orientation,
       ...state,
       ...step.props,
     });
   });
+  const contextValue = React.useMemo(() => ({ activeStep, alternativeLabel, connector, nonLinear, orientation }), [
+    activeStep, alternativeLabel, connector, nonLinear, orientation
+  ]);
 
   return (
     <Paper
@@ -86,7 +87,9 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
       ref={ref}
       {...other}
     >
-      {steps}
+      <StepperContext.Provider value={contextValue}>
+        {steps}
+      </StepperContext.Provider>
     </Paper>
   );
 });

--- a/packages/material-ui/src/Stepper/StepperContext.js
+++ b/packages/material-ui/src/Stepper/StepperContext.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 const StepperContext = React.createContext({});
 
 if (process.env.NODE_ENV !== 'production') {
-    StepperContext.displayName = 'StepperContext';
+  StepperContext.displayName = 'StepperContext';
 }
 
 export default StepperContext;

--- a/packages/material-ui/src/Stepper/StepperContext.js
+++ b/packages/material-ui/src/Stepper/StepperContext.js
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+/**
+ * @ignore - internal component.
+ */
 const StepperContext = React.createContext({});
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui/src/Stepper/StepperContext.js
+++ b/packages/material-ui/src/Stepper/StepperContext.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+const StepperContext = React.createContext({});
+
+if (process.env.NODE_ENV !== 'production') {
+    StepperContext.displayName = 'StepperContext';
+}
+
+export default StepperContext;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).  

Hello! This PR is not fully complete. I decided that you should take a look first to make sure that my implementation is correct. 
`StepperContext` and `StepContext` are now capable of providing props for the `Stepper` children.   
As far as I understand all `Step` related components are not being used without the `Step`, so we can safely remove props which shared through context.  
If I'm right then I'll update tests and type definitions for those components.

Closes https://github.com/mui-org/material-ui/issues/21326