### PR TITLE
[Card] Fix vertically center header action

### DIFF
--- a/packages/material-ui/src/CardHeader/CardHeader.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.js
@@ -20,8 +20,9 @@ export const styles = {
   action: {
     flex: '0 0 auto',
     alignSelf: 'flex-start',
-    marginTop: -8,
+    marginTop: -4,
     marginRight: -8,
+    marginBottom: -4,
   },
   /* Styles applied to the content wrapper element. */
   content: {


### PR DESCRIPTION
Fixes #21645 

CardHeader's action is not vertically centered as is depicted in the [Material Design spec](https://material.io/components/cards#actions).  

To fix this, I split the action's negative top margin between top and bottom.  This ensures that the action is centered vertically without altering the CardHeader's height.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
