### PR TITLE
[core] Simplify debounce

### DIFF
--- a/packages/material-ui/src/utils/debounce.js
+++ b/packages/material-ui/src/utils/debounce.js
@@ -3,10 +3,8 @@
 export default function debounce(func, wait = 166) {
   let timeout;
   function debounced(...args) {
-    // eslint-disable-next-line consistent-this
-    const that = this;
     const later = () => {
-      func.apply(that, args);
+      func.apply(this, args);
     };
     clearTimeout(timeout);
     timeout = setTimeout(later, wait);


### PR DESCRIPTION
`this` will be correct thanks to the arrow function.

Also see how Babel would transpile it to [ES5](https://babeljs.io/en/repl#?browsers=defaults%2C%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&spec=false&loose=false&code_lz=PTAEGEHsCdoUwM4AdIDsAmDQBdKgIwAMoAZtAIYC2io52oAbMQBIBeAdAFAigCCpcAO6gARgE9sNJOTEAbSOXShIANzjQAFnEWhBW1KHnpyCDcHRwRkAK6oAxnFABLLAD8AzKADWAIVoZQCytbB1APQmIfLhIQ7Cc0QMsbezgAChj7ABpdcid6AF4CBgYASlAAb05QQzh6OOobbABuKtJY-IMg5Id0VPZ-8mgAcwQyyurquzQEelk6dVBC1LL8gD4K1om2-3ZyJCRZMVTsDRdswZGSlq2AX2uJu1ltaAAVJwbrbGP3uEarzZwP0ai1ACFqbw-Xzmkmg2UEuWw_2qN04rS6ITg6HYj2eIOWi3W4weT0GEN-n2-kKRoDuqOq8Gw1mgnSSGPQLRRQA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2%2Cenv&prettier=false&targets=&version=7.10.4&externalPlugins=) - it inserts `var _this = this` back.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
