### PR TITLE
[docs] Move more prop docs into IntelliSense

### DIFF
--- a/docs/pages/api-docs/pagination-item.md
+++ b/docs/pages/api-docs/pagination-item.md
@@ -28,15 +28,16 @@ The `MuiPaginationItem` name can be used for providing [default props](/customiz
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">color</span> | <span class="prop-type">'standard'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'standard'</span> | The active color. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The active color. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> |  | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the item will be disabled. |
 | <span class="prop-name">page</span> | <span class="prop-type">number</span> |  | The current page number. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true` the pagination item is selected. |
 | <span class="prop-name">shape</span> | <span class="prop-type">'round'<br>&#124;&nbsp;'rounded'</span> | <span class="prop-default">'round'</span> | The shape of the pagination item. |
-| <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'</span> | <span class="prop-default">'medium'</span> | The size of the pagination item. |
-| <span class="prop-name">type</span> | <span class="prop-type">'page'<br>&#124;&nbsp;'first'<br>&#124;&nbsp;'last'<br>&#124;&nbsp;'next'<br>&#124;&nbsp;'previous'<br>&#124;&nbsp;'start-ellipsis'<br>&#124;&nbsp;'end-ellipsis'</span> | <span class="prop-default">'page'</span> | The type of pagination item. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'outlined'</span> | <span class="prop-default">'text'</span> | The pagination item variant. |
+| <span class="prop-name">size</span> | <span class="prop-type">'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'</span> | <span class="prop-default">'medium'</span> | The size of the pagination item. |
+| <span class="prop-name">type</span> | <span class="prop-type">'end-ellipsis'<br>&#124;&nbsp;'first'<br>&#124;&nbsp;'last'<br>&#124;&nbsp;'next'<br>&#124;&nbsp;'page'<br>&#124;&nbsp;'previous'<br>&#124;&nbsp;'start-ellipsis'</span> | <span class="prop-default">'page'</span> | The type of pagination item. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'outlined'<br>&#124;&nbsp;'text'</span> | <span class="prop-default">'text'</span> | The pagination item variant. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/skeleton.md
+++ b/docs/pages/api-docs/skeleton.md
@@ -33,7 +33,7 @@ The `MuiSkeleton` name can be used for providing [default props](/customization/
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'span'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">height</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Height of the skeleton. Useful when you don't want to adapt the skeleton to a text element but for instance a card. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'rect'<br>&#124;&nbsp;'circle'</span> | <span class="prop-default">'text'</span> | The type of content that will be rendered. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'circle'<br>&#124;&nbsp;'rect'<br>&#124;&nbsp;'text'</span> | <span class="prop-default">'text'</span> | The type of content that will be rendered. |
 | <span class="prop-name">width</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Width of the skeleton. Useful when the skeleton is inside an inline element with no width of its own. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/tab-list.md
+++ b/docs/pages/api-docs/tab-list.md
@@ -26,7 +26,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">Array&lt;element&gt;</span> |  |  |
+| <span class="prop-name">children</span> | <span class="prop-type">Array&lt;element&gt;</span> |  | A list of `<Tab />` elements. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/toggle-button.md
+++ b/docs/pages/api-docs/toggle-button.md
@@ -28,11 +28,11 @@ The `MuiToggleButton` name can be used for providing [default props](/customizat
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children<abbr title="required">*</abbr></span> | <span class="prop-type">node</span> |  | The content of the button. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the button. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. |
-| <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
+| <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled.<br>⚠️ Without a ripple there is no styling for :focus-visible by default. Be sure to highlight the element by applying separate styles with the `focusVisibleClassName`. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> |  | If `true`, the button will be rendered in an active state. |
 | <span class="prop-name required">value<abbr title="required">*</abbr></span> | <span class="prop-type">any</span> |  | The value to associate with the button when selected in a ToggleButtonGroup. |
 

--- a/packages/material-ui-lab/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui-lab/src/PaginationItem/PaginationItem.js
@@ -230,6 +230,7 @@ const PaginationItem = React.forwardRef(function PaginationItem(props, ref) {
           first: FirstPageIcon,
           last: LastPageIcon,
         };
+
   const Icon = normalizedIcons[type];
 
   return type === 'start-ellipsis' || type === 'end-ellipsis' ? (
@@ -270,10 +271,19 @@ const PaginationItem = React.forwardRef(function PaginationItem(props, ref) {
 });
 
 PaginationItem.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * @ignore
    */
-  classes: PropTypes.object.isRequired,
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css) below for more details.
+   */
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -281,7 +291,7 @@ PaginationItem.propTypes = {
   /**
    * The active color.
    */
-  color: PropTypes.oneOf(['standard', 'primary', 'secondary']),
+  color: PropTypes.oneOf(['primary', 'secondary', 'standard']),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -306,23 +316,23 @@ PaginationItem.propTypes = {
   /**
    * The size of the pagination item.
    */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(['large', 'medium', 'small']),
   /**
    * The type of pagination item.
    */
   type: PropTypes.oneOf([
-    'page',
+    'end-ellipsis',
     'first',
     'last',
     'next',
+    'page',
     'previous',
     'start-ellipsis',
-    'end-ellipsis',
   ]),
   /**
    * The pagination item variant.
    */
-  variant: PropTypes.oneOf(['text', 'outlined']),
+  variant: PropTypes.oneOf(['outlined', 'text']),
 };
 
 export default withStyles(styles, { name: 'MuiPaginationItem' })(PaginationItem);

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
@@ -3,10 +3,28 @@ import { OverridableComponent, OverrideProps } from '@material-ui/core/Overridab
 
 export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P & {
+    /**
+     * The animation.
+     * If `false` the animation effect is disabled.
+     */
     animation?: 'pulse' | 'wave' | false;
+    /**
+     * Optional children to infer width and height from.
+     */
     children?: React.ReactNode;
+    /**
+     * Height of the skeleton.
+     * Useful when you don't want to adapt the skeleton to a text element but for instance a card.
+     */
     height?: number | string;
+    /**
+     * The type of content that will be rendered.
+     */
     variant?: 'text' | 'rect' | 'circle';
+    /**
+     * Width of the skeleton.
+     * Useful when the skeleton is inside an inline element with no width of its own.
+     */
     width?: number | string;
   };
   defaultComponent: 'div';

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -97,6 +97,7 @@ const Skeleton = React.forwardRef(function Skeleton(props, ref) {
     className,
     component: Component = 'span',
     height,
+    style,
     variant = 'text',
     width,
     ...other
@@ -122,13 +123,17 @@ const Skeleton = React.forwardRef(function Skeleton(props, ref) {
       style={{
         width,
         height,
-        ...other.style,
+        ...style,
       }}
     />
   );
 });
 
 Skeleton.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The animation.
    * If `false` the animation effect is disabled.
@@ -142,7 +147,7 @@ Skeleton.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -158,9 +163,13 @@ Skeleton.propTypes = {
    */
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
+   * @ignore
+   */
+  style: PropTypes.object,
+  /**
    * The type of content that will be rendered.
    */
-  variant: PropTypes.oneOf(['text', 'rect', 'circle']),
+  variant: PropTypes.oneOf(['circle', 'rect', 'text']),
   /**
    * Width of the skeleton.
    * Useful when the skeleton is inside an inline element with no width of its own.

--- a/packages/material-ui-lab/src/TabList/TabList.d.ts
+++ b/packages/material-ui-lab/src/TabList/TabList.d.ts
@@ -7,7 +7,12 @@ export interface TabListTypeMap<
   P = {},
   D extends React.ElementType = TabsTypeMap['defaultComponent']
 > {
-  props: P & Omit<TabsTypeMap['props'], 'value'>;
+  props: P & {
+    /**
+     * A list of `<Tab />` elements.
+     */
+    children?: React.ReactElement[];
+  } & Omit<TabsTypeMap['props'], 'children' | 'value'>;
   defaultComponent: D;
   classKey: TabListClassKey;
 }

--- a/packages/material-ui-lab/src/TabList/TabList.js
+++ b/packages/material-ui-lab/src/TabList/TabList.js
@@ -25,6 +25,13 @@ const TabList = React.forwardRef(function TabList(props, ref) {
 });
 
 TabList.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * A list of `<Tab />` elements.
+   */
   children: PropTypes.arrayOf(PropTypes.element),
 };
 

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -10,10 +10,27 @@ export type ToggleButtonTypeMap<
   D extends React.ElementType = 'button'
 > = ExtendButtonBaseTypeMap<{
   props: P & {
+    /**
+     * The content of the button.
+     */
+    children?: React.ReactNode;
+    /**
+     * If `true`, the button will be disabled.
+     */
+    disabled?: boolean;
+    /**
+     * If `true`, the  keyboard focus ripple will be disabled.
+     */
     disableFocusRipple?: boolean;
+    /**
+     * If `true`, the button will be rendered in an active state.
+     */
     selected?: boolean;
-    size?: 'small' | 'medium' | 'large';
-    value?: any;
+    /**
+     * The value to associate with the button when selected in a
+     * ToggleButtonGroup.
+     */
+    value: NonNullable<unknown>;
   };
   defaultComponent: D;
   classKey: ToggleButtonClassKey;

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -75,6 +75,7 @@ const ToggleButton = React.forwardRef(function ToggleButton(props, ref) {
     onChange,
     onClick,
     selected,
+    // eslint-disable-next-line react/prop-types
     size = 'medium',
     value,
     ...other
@@ -119,15 +120,19 @@ const ToggleButton = React.forwardRef(function ToggleButton(props, ref) {
 });
 
 ToggleButton.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the button.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -142,6 +147,9 @@ ToggleButton.propTypes = {
   disableFocusRipple: PropTypes.bool,
   /**
    * If `true`, the ripple effect will be disabled.
+   *
+   * ⚠️ Without a ripple there is no styling for :focus-visible by default. Be sure
+   * to highlight the element by applying separate styles with the `focusVisibleClassName`.
    */
   disableRipple: PropTypes.bool,
   /**
@@ -156,10 +164,6 @@ ToggleButton.propTypes = {
    * If `true`, the button will be rendered in an active state.
    */
   selected: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
   /**
    * The value to associate with the button when selected in a
    * ToggleButtonGroup.

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -18,13 +18,10 @@ enum GenerateResult {
   TODO,
 }
 
-const todoComponents = [
-  // lab
-  'PaginationItem',
-  'Skeleton',
-  'TabList',
-  'ToggleButton',
-];
+/**
+ * Includes component names for which we can't generate .propTypes from the TypeScript types.
+ */
+const todoComponents: string[] = [];
 
 const useExternalPropsFromInputBase = [
   'autoComplete',
@@ -92,6 +89,7 @@ const useExternalDocumentation: Record<string, string[]> = {
     'variant',
   ],
   Tab: ['disableRipple'],
+  ToggleButton: ['disableRipple'],
 };
 const transitionCallbacks = [
   'onEnter',


### PR DESCRIPTION
Finishes rest of lab components. All component prop APIs are now generated from their types.

`ToggleButton#value` is now `NonNullable<unknown>` instead of `any`. This is in line with their runtime prop-types validation.