### PR TITLE
[docs] Remove `@document` directive from IntelliSense

### DIFF
--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -10,7 +10,6 @@ export interface MenuProps
   /**
    * A HTML element, or a function that returns it.
    * It's used to set the position of the menu.
-   * @document
    */
   anchorEl?: PopoverProps['anchorEl'];
   /**
@@ -44,32 +43,26 @@ export interface MenuProps
   onClose?: PopoverProps['onClose'];
   /**
    * Callback fired before the Menu enters.
-   * @document
    */
   onEnter?: PopoverProps['onEnter'];
   /**
    * Callback fired when the Menu has entered.
-   * @document
    */
   onEntered?: PopoverProps['onEntered'];
   /**
    * Callback fired when the Menu is entering.
-   * @document
    */
   onEntering?: PopoverProps['onEntering'];
   /**
    * Callback fired before the Menu exits.
-   * @document
    */
   onExit?: PopoverProps['onExit'];
   /**
    * Callback fired when the Menu has exited.
-   * @document
    */
   onExited?: PopoverProps['onExited'];
   /**
    * Callback fired when the Menu is exiting.
-   * @document
    */
   onExiting?: PopoverProps['onExiting'];
   /**

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -27,12 +27,10 @@ export interface NativeSelectProps
    *
    * @param {object} event The event source of the callback.
    * You can pull out the new value by accessing `event.target.value` (string).
-   * @document
    */
   onChange?: NativeSelectInputProps['onChange'];
   /**
    * The input value. The DOM API casts this to a string.
-   * @document
    */
   value?: unknown;
   /**

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -21,7 +21,6 @@ export interface SelectProps
   children?: React.ReactNode;
   /**
    * The default element value. Use when the component is not controlled.
-   * @document
    */
   defaultValue?: unknown;
   /**
@@ -79,7 +78,6 @@ export interface SelectProps
    * @param {object} event The event source of the callback.
    * You can pull out the new value by accessing `event.target.value` (any).
    * @param {object} [child] The react element that was selected when `native` is `false` (default).
-   * @document
    */
   onChange?: SelectInputProps['onChange'];
   /**
@@ -120,7 +118,6 @@ export interface SelectProps
    *
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
-   * @document
    */
   value?: unknown;
   /**

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -52,7 +52,6 @@ export interface SnackbarProps
    * <Snackbar/>, add the key prop to ensure independent treatment of each message.
    * e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and
    * features such as autoHideDuration may be canceled.
-   * @document
    */
   key?: any;
   /**

--- a/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
@@ -24,7 +24,6 @@ export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
      * The shape-rendering attribute. The behavior of the different options is described on the
      * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering).
      * If you are having issues with blurry icons you should investigate this prop.
-     * @document
      */
     shapeRendering?: string;
     /**

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -208,24 +208,18 @@ async function generateProptypes(
 
       return generated;
     },
-    shouldInclude: ({ component, prop, usedProps }) => {
+    shouldInclude: ({ component, prop }) => {
       if (prop.name === 'children') {
         return true;
       }
       let shouldDocument;
 
-      const documentRegExp = new RegExp(/\r?\n?@document/);
-      if (prop.jsDoc && documentRegExp.test(prop.jsDoc)) {
-        prop.jsDoc = prop.jsDoc.replace(documentRegExp, '');
-        shouldDocument = true;
-      } else {
-        prop.filenames.forEach((filename) => {
-          const isExternal = filename !== tsFile;
-          if (!isExternal) {
-            shouldDocument = true;
-          }
-        });
-      }
+      prop.filenames.forEach((filename) => {
+        const isExternal = filename !== tsFile;
+        if (!isExternal) {
+          shouldDocument = true;
+        }
+      });
 
       const { name: componentName } = component;
       if (


### PR DESCRIPTION
Forcing a prop to be documented happens either by recognizing that it is not an external prop (i.e. it is documented directly in the declaration file) or by hardcoding it in https://github.com/mui-org/material-ui/blob/c9fd3bf3d6998be82208b5dcdc6b4f8fae54fc65/scripts/generateProptypes.ts#L61.

Custom directives appear in IntelliSense and can be confusing to users.