### PR TITLE
[autocomplete] Fail form validation if required is filled when `multiple`

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -432,6 +432,19 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
+    it('has no textbox value', () => {
+      render(
+        <Autocomplete
+          options={['one', 'two', 'three']}
+          renderInput={(params) => <TextField {...params} />}
+          multiple
+          value={['one', 'two']}
+        />,
+      );
+
+      expect(screen.getByRole('textbox')).to.have.property('value', '');
+    });
+
     it('should fail validation if a required field has no value', function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // Enable once https://github.com/jsdom/jsdom/issues/2898 is resolved
@@ -442,10 +455,9 @@ describe('<Autocomplete />', () => {
       render(
         <form onSubmit={handleSubmit}>
           <Autocomplete
-            {...defaultProps}
             multiple
             options={['one', 'two']}
-            renderInput={(params) => <TextField {...params} autoFocus required />}
+            renderInput={(params) => <TextField {...params} required />}
             value={[]}
           />
           <button type="submit">Submit</button>
@@ -457,7 +469,8 @@ describe('<Autocomplete />', () => {
       expect(handleSubmit.callCount).to.equal(0);
     });
 
-    it('should pass validation if a required field has a value', () => {
+    it('should fail validation if a required field has a value', function test() {
+      // Unclear how native Constraint validation can be enabled for `multiple`
       if (/jsdom/.test(window.navigator.userAgent)) {
         // Enable once https://github.com/jsdom/jsdom/issues/2898 is resolved
         // The test is passing in JSDOM but form validation is buggy in JSDOM so we rather skip than have false confidence
@@ -468,10 +481,9 @@ describe('<Autocomplete />', () => {
       render(
         <form onSubmit={handleSubmit}>
           <Autocomplete
-            {...defaultProps}
             multiple
             options={['one', 'two']}
-            renderInput={(params) => <TextField {...params} autoFocus required />}
+            renderInput={(params) => <TextField {...params} required />}
             value={['one']}
           />
           <button type="submit">Submit</button>
@@ -480,7 +492,7 @@ describe('<Autocomplete />', () => {
 
       screen.getByRole('button', { name: 'Submit' }).click();
 
-      expect(handleSubmit.callCount).to.equal(1);
+      expect(handleSubmit.callCount).to.equal(0);
     });
   });
 

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -431,6 +431,46 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(firstSelectedValue, { key: 'ArrowRight' });
       expect(textbox).toHaveFocus();
     });
+
+    it('should fail validation if a required field has no value', () => {
+      const handleSubmit = spy((event) => event.preventDefault());
+      render(
+        <form onSubmit={handleSubmit}>
+          <Autocomplete
+            {...defaultProps}
+            multiple
+            options={['one', 'two']}
+            renderInput={(params) => <TextField {...params} autoFocus required />}
+            value={[]}
+          />
+          <button type="submit">Submit</button>
+        </form>,
+      );
+
+      screen.getByRole('button', { name: 'Submit' }).click();
+
+      expect(handleSubmit.callCount).to.equal(0);
+    });
+
+    it('should pass validation if a required field has a value', () => {
+      const handleSubmit = spy((event) => event.preventDefault());
+      render(
+        <form onSubmit={handleSubmit}>
+          <Autocomplete
+            {...defaultProps}
+            multiple
+            options={['one', 'two']}
+            renderInput={(params) => <TextField {...params} autoFocus required />}
+            value={['one']}
+          />
+          <button type="submit">Submit</button>
+        </form>,
+      );
+
+      screen.getByRole('button', { name: 'Submit' }).click();
+
+      expect(handleSubmit.callCount).to.equal(1);
+    });
   });
 
   it('should trigger a form expectedly', () => {

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -432,7 +432,12 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
-    it('should fail validation if a required field has no value', () => {
+    it('should fail validation if a required field has no value', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // Enable once https://github.com/jsdom/jsdom/issues/2898 is resolved
+        this.skip();
+      }
+
       const handleSubmit = spy((event) => event.preventDefault());
       render(
         <form onSubmit={handleSubmit}>
@@ -453,6 +458,12 @@ describe('<Autocomplete />', () => {
     });
 
     it('should pass validation if a required field has a value', () => {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // Enable once https://github.com/jsdom/jsdom/issues/2898 is resolved
+        // The test is passing in JSDOM but form validation is buggy in JSDOM so we rather skip than have false confidence
+        this.skip();
+      }
+
       const handleSubmit = spy((event) => event.preventDefault());
       render(
         <form onSubmit={handleSubmit}>

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -431,24 +431,6 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(firstSelectedValue, { key: 'ArrowRight' });
       expect(textbox).toHaveFocus();
     });
-
-    it('should not be required if a value is selected', () => {
-      const { getByRole, setProps } = render(
-        <Autocomplete
-          {...defaultProps}
-          multiple
-          options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus required />}
-          value={[]}
-        />,
-      );
-
-      const textbox = getByRole('textbox');
-      expect(textbox.hasAttribute('required')).to.equal(true);
-
-      setProps({ value: ['one'] });
-      expect(textbox.hasAttribute('required')).to.equal(false);
-    });
   });
 
   it('should trigger a form expectedly', () => {

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -962,7 +962,6 @@ export default function useAutocomplete(props) {
       ref: inputRef,
       autoCapitalize: 'none',
       spellCheck: 'false',
-      ...(multiple && value.length > 0 ? { required: null } : {}),
     }),
     getClearProps: () => ({
       tabIndex: -1,


### PR DESCRIPTION
A fix for #21663 should be based on this PR.

Based on #21691

Reverts #21670 which did not include a test for the issue it was trying to solve. Removing attributes affects styling, assistive technology etc.