### PR TITLE
[docs] Track web-vitals

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -375,7 +375,7 @@ export function reportWebVitals({ id, name, label, value }) {
   // Track fraction of actual events to prevent exceeding event quota
   // TODO: Track all for `next` branch for testing.
   // Reduce to .1% before release of v5
-  if (Math.random() <= 1) {
+  if (Math.random() > 1) {
     return;
   }
 

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -373,16 +373,12 @@ MyApp.getInitialProps = async ({ ctx, Component }) => {
 
 export function reportWebVitals({ id, name, label, value }) {
   // Track fraction of actual events to prevent exceeding event quota
-  // TODO: Track all for `next` branch for testing.
-  // Reduce to .1% before release of v5
-  if (Math.random() > 1) {
+  if (Math.random() > 0.0001) {
     return;
   }
 
-  const eventCategory = label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric';
-  console.log('sending %s', eventCategory);
   window.ga('send', 'event', {
-    eventCategory,
+    eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
     eventAction: name,
     eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
     eventLabel: id, // id unique to current page load

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -379,8 +379,10 @@ export function reportWebVitals({ id, name, label, value }) {
     return;
   }
 
+  const eventCategory = label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric';
+  console.log('sending %s', eventCategory);
   window.ga('send', 'event', {
-    eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    eventCategory,
     eventAction: name,
     eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
     eventLabel: id, // id unique to current page load

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -372,6 +372,13 @@ MyApp.getInitialProps = async ({ ctx, Component }) => {
 };
 
 export function reportWebVitals({ id, name, label, value }) {
+  // Track fraction of actual events to prevent exceeding event quota
+  // TODO: Track all for `next` branch for testing.
+  // Reduce to .1% before release of v5
+  if (Math.random() <= 1) {
+    return;
+  }
+
   window.ga('send', 'event', {
     eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
     eventAction: name,

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -370,3 +370,13 @@ MyApp.getInitialProps = async ({ ctx, Component }) => {
     },
   };
 };
+
+export function reportWebVitals({ id, name, label, value }) {
+  window.ga('send', 'event', {
+    eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    eventAction: name,
+    eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
+    eventLabel: id, // id unique to current page load
+    nonInteraction: true, // avoids affecting bounce rate.
+  });
+}

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -371,9 +371,11 @@ MyApp.getInitialProps = async ({ ctx, Component }) => {
   };
 };
 
+// Track fraction of actual events to prevent exceeding event quota.
+// Filter sessions instead of individual events so that we can track multiple metrics per device.
+const disableWebVitalsReporting = Math.random() > 0.0001;
 export function reportWebVitals({ id, name, label, value }) {
-  // Track fraction of actual events to prevent exceeding event quota
-  if (Math.random() > 0.0001) {
+  if (disableWebVitalsReporting) {
     return;
   }
 


### PR DESCRIPTION
Tracks [web vitals](https://web.dev/vitals/) following [next's recommended implementation](https://nextjs.org/docs/advanced-features/measuring-performance#sending-results-to-analytics).

Helps identifying slow component (pages) and possibly bad UX (e.g. layout shifts).

@oliviertassinari Do we send analytics events for deploy previews and branch builds?