### PR TITLE
 [TablePagination] Fix broken labelling if SelectProps provided ids

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -107,8 +107,8 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
     colSpan = colSpanProp || 1000; // col-span over everything
   }
 
-  const selectId = useId();
-  const labelId = useId();
+  const selectId = useId(SelectProps.id);
+  const labelId = useId(SelectProps.labelId);
   const MenuItemComponent = SelectProps.native ? 'option' : MenuItem;
 
   return (

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -374,4 +374,29 @@ describe('<TablePagination />', () => {
       );
     });
   });
+
+  describe('prop: SelectProps', () => {
+    it('does allow manual label ids', () => {
+      const { getAllByRole } = render(
+        <table>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                count={1}
+                page={0}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={10}
+                SelectProps={{ id: 'foo', labelId: 'bar' }}
+              />
+            </TableRow>
+          </TableFooter>
+        </table>,
+      );
+
+      // will be `getByRole('combobox')` in aria 1.2
+      const [combobox] = getAllByRole('button');
+      expect(combobox).toHaveAccessibleName('Rows per page: 10');
+    });
+  });
 });


### PR DESCRIPTION
`<TablePagination SelectProps={{ id: 'stable-select-id', labelId: 'stable-select-label-id' }} />` caused  the id of the label id to not match `aria-labelledby`. This props pattern is useful to force stable IDs for e.g. snapshot testing.

Closes #21293