### PR TITLE
[docs] Reduce tracking events

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -113,52 +113,32 @@ function Ad(props) {
   const [adblock, setAdblock] = React.useState(null);
   const [carbonOut, setCarbonOut] = React.useState(null);
 
-  let children;
-
-  // Hide the content to google bot.
-  if (/Googlebot/.test(navigator.userAgent) || disable) {
-    children = <span />;
-  }
-
   const { current: randomAdblock } = React.useRef(Math.random());
   const { current: randomInHouse } = React.useRef(Math.random());
 
-  if (!children && adblock) {
+  let children;
+  let label;
+  // Hide the content to google bot.
+  if (/Googlebot/.test(navigator.userAgent) || disable) {
+    children = <span />;
+  } else if (adblock) {
     if (randomAdblock < 0.2) {
       children = <PleaseDisableAdblock className={classes.paper} />;
-    } else {
-      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
-    }
-  }
-
-  if (!children) {
-    if (carbonOut) {
-      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
-    } else {
-      children = <AdCarbon />;
-    }
-  }
-
-  const getNetwork = () => {
-    let label;
-
-    if (children.type === AdCarbon) {
-      label = 'carbon';
-    } else if (children.type === AdInHouse) {
-      if (!adblock && carbonOut) {
-        label = 'in-house-carbon';
-      } else {
-        label = 'in-house';
-      }
-    } else if (children.type === PleaseDisableAdblock) {
       label = 'in-house-adblock';
+    } else {
+      children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
+      label = 'in-house';
     }
-
-    return label;
-  };
+  } else if (carbonOut) {
+    children = <AdInHouse ad={inHouseAds[Math.floor(inHouseAds.length * randomInHouse)]} />;
+    label = 'in-house-carbon';
+  } else {
+    children = <AdCarbon />;
+    label = 'carbon';
+  }
 
   const ad = React.useContext(AdContext);
-  const eventLabel = `${getNetwork()}-${ad.portal.placement}-${adShape}`;
+  const eventLabel = `${label}-${ad.portal.placement}-${adShape}`;
 
   const timerAdblock = React.useRef();
 

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -192,10 +192,6 @@ function Ad(props) {
     }
 
     const delay = setTimeout(() => {
-      if (!eventLabel) {
-        return;
-      }
-
       window.ga('send', {
         hitType: 'event',
         eventCategory: 'ad',

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -202,21 +202,12 @@ function Ad(props) {
         eventAction: 'display',
         eventLabel,
       });
-
-      if (eventLabel.indexOf('in-house') === 0) {
-        window.ga('send', {
-          hitType: 'event',
-          eventCategory: 'in-house-ad',
-          eventAction: 'display',
-          eventLabel: children.props.ad.name,
-        });
-      }
     }, 2500);
 
     return () => {
       clearTimeout(delay);
     };
-  }, [eventLabel, children.props.ad]);
+  }, [eventLabel]);
 
   const key = 0;
 

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -205,8 +205,6 @@ function Ad(props) {
     };
   }, [eventLabel]);
 
-  const key = 0;
-
   return (
     <span
       className={clsx(classes.root, classes[`placement-body-${adShape}`])}
@@ -214,7 +212,7 @@ function Ad(props) {
       data-ga-event-action="click"
       data-ga-event-label={eventLabel}
     >
-      {React.cloneElement(children, { key })}
+      {children}
     </span>
   );
 }

--- a/docs/src/modules/components/AdInHouse.js
+++ b/docs/src/modules/components/AdInHouse.js
@@ -29,9 +29,9 @@ export default function AdInHouse(props) {
         href={ad.link}
         target="_blank"
         rel="noopener sponsored"
-        data-ga-event-category="in-house-ad"
+        data-ga-event-category="ad"
         data-ga-event-action="click"
-        data-ga-event-label={ad.name}
+        data-ga-event-label={`in-house-${ad.name}`}
       >
         <span className={classes.imageWrapper}>
           <img height="100" width="130" className={classes.image} src={ad.img} alt={ad.name} />

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -459,9 +459,15 @@ function DemoToolbar(props) {
               <IconButton
                 aria-controls={openDemoSource ? demoSourceId : null}
                 aria-label={showCodeLabel}
-                data-ga-event-category="demo"
-                data-ga-event-label={demoOptions.demo}
-                data-ga-event-action="expand"
+                {...(codeOpen
+                  ? // We want to track if a Demo is looked at.
+                    // Tracking if a demo is collapsed is less interesting.
+                    {
+                      'data-ga-event-category': 'demo',
+                      'data-ga-event-label': demoOptions.demo,
+                      'data-ga-event-action': 'expand',
+                    }
+                  : undefined)}
                 onClick={handleCodeOpenClick}
                 color={demoHovered ? 'primary' : 'default'}
                 {...getControlProps(2)}


### PR DESCRIPTION
Review on per-commit basis is advised.

- reduces indirection between displayed Ad and its label (revealing which Ads are not labelled)
- removes tracking of demo source collapse events
  The previous label was misleading ("expand" for collapsing and showing demo source). It's also less interesting as far as I can tell. At least I use it primarily to see which demos are popular. Collapsing tracking would only make sense if we could track how long the source code is viewed but that's probably too inaccurate to be useful.
  Demo source toggle makes up 40% of our events. Maybe we can cut some (in my opinion noisy) events to get below the rate limit (we're currently 40% over it: 14M where 10M is allowed)
- Removes addition event when an in-house ad is displayed.
  We currently dispatch two events if an in-house ad is displayed when we can already derive from the first event if the ad is in-house
