### PR TITLE
[core] Add method for useId to generate stable ids

### DIFF
--- a/packages/material-ui/src/utils/unstable_useId.js
+++ b/packages/material-ui/src/utils/unstable_useId.js
@@ -1,18 +1,22 @@
 import * as React from 'react';
 
 /**
+ * @ignore - internal component.
+ */
+export const IdContext = React.createContext({
+  generateId: () => `mui-${Math.round(Math.random() * 1e5)}`,
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  IdContext.displayName = 'IdContext';
+}
+
+/**
  * Private module reserved for @material-ui/x packages.
  */
 export default function useId(idOverride) {
-  const [defaultId, setDefaultId] = React.useState(idOverride);
+  const idContext = React.useContext(IdContext);
+  const [defaultId] = React.useState(idOverride || idContext.generateId());
   const id = idOverride || defaultId;
-  React.useEffect(() => {
-    if (defaultId == null) {
-      // Fallback to this default id when possible.
-      // Use the random value for client-side rendering only.
-      // We can't use it server-side.
-      setDefaultId(`mui-${Math.round(Math.random() * 1e5)}`);
-    }
-  }, [defaultId]);
   return id;
 }

--- a/packages/material-ui/src/utils/unstable_useId.test.js
+++ b/packages/material-ui/src/utils/unstable_useId.test.js
@@ -2,11 +2,19 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils/createClientRender';
-import useId from './unstable_useId';
+import useId, { IdContext } from './unstable_useId';
 
 const TestComponent = ({ id: idProp }) => {
   const id = useId(idProp);
   return <span>{id}</span>;
+};
+
+const TestContextComponent = ({ id }) => {
+  return (
+    <IdContext.Provider value={{ generateId: () => 'context-id' }}>
+      <TestComponent id={id} />
+    </IdContext.Provider>
+  );
 };
 
 TestComponent.propTypes = {
@@ -32,5 +40,23 @@ describe('unstable_useId', () => {
 
     setProps({ id: 'another-id' });
     expect(getByText('another-id')).not.to.equal(null);
+  });
+
+  it('generates an ID using generateId if provided', () => {
+    const { getByText, setProps } = render(<TestContextComponent />);
+
+    expect(getByText('context-id')).not.to.equal(null);
+
+    setProps({ id: 'a-new-id' });
+    expect(getByText('a-new-id')).not.to.equal(null);
+  });
+
+  it('override when using generateId', () => {
+    const { getByText, setProps } = render(<TestContextComponent id="attached-id" />);
+
+    expect(getByText('attached-id')).not.to.equal(null);
+
+    setProps({ id: 'a-new-id' });
+    expect(getByText('a-new-id')).not.to.equal(null);
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fix #21293 and other similar issues

This PR gives a way for developers who care about stable IDs to do so using a simple context and custom function.

This is useful to those who do snapshot testing, for example developers who use Storybooks and StoryShots, or for those who want stable IDs when doing server side rendering for caching purposes.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
