### PR TITLE
[TreeView] Test current behavior of active item removal

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -331,6 +331,42 @@ describe('<TreeItem />', () => {
         fireEvent.focusIn(getByTestId('two'));
         expect(getByTestId('two')).toHaveVirtualFocus();
       });
+
+      it('should work when focused node is removed', () => {
+        let removeActiveItem;
+        // a TreeItem which can remove from the tree by calling `removeActiveItem`
+        function ControlledTreeItem(props) {
+          const [mounted, setMounted] = React.useReducer(() => false, true);
+          removeActiveItem = setMounted;
+
+          if (!mounted) {
+            return null;
+          }
+          return <TreeItem {...props} />;
+        }
+
+        const { getByTestId, getByText } = render(
+          <TreeView defaultExpanded={['parent']}>
+            <TreeItem nodeId="parent" label="parent" data-testid="parent">
+              <TreeItem nodeId="1" label="one" data-testid="one" />
+              <ControlledTreeItem nodeId="2" label="two" data-testid="two" />
+            </TreeItem>
+          </TreeView>,
+        );
+        expect(getByTestId('parent')).to.have.attribute('tabindex', '0');
+
+        fireEvent.click(getByText('two'));
+
+        expect(getByTestId('two')).to.have.attribute('tabindex', '0');
+
+        // generic action that removes an item.
+        // Could be promise based, or timeout, or another user interaction
+        act(() => {
+          removeActiveItem();
+        });
+
+        expect(getByTestId('parent')).to.have.attribute('tabindex', '0');
+      });
     });
 
     describe('Navigation', () => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import * as PropTypes from 'prop-types';
 import { spy } from 'sinon';
 import {
   getClasses,
@@ -32,6 +33,10 @@ describe('<TreeItem />', () => {
   }));
 
   describe('warnings', () => {
+    beforeEach(() => {
+      PropTypes.resetWarningCache();
+    });
+
     it('should warn if an onFocus callback is supplied', () => {
       expect(() => {
         render(
@@ -345,7 +350,7 @@ describe('<TreeItem />', () => {
           return <TreeItem {...props} />;
         }
 
-        const { getByTestId, getByText } = render(
+        const { getByRole, getByTestId, getByText } = render(
           <TreeView defaultExpanded={['parent']}>
             <TreeItem nodeId="parent" label="parent" data-testid="parent">
               <TreeItem nodeId="1" label="one" data-testid="one" />
@@ -353,11 +358,17 @@ describe('<TreeItem />', () => {
             </TreeItem>
           </TreeView>,
         );
-        expect(getByTestId('parent')).to.have.attribute('tabindex', '0');
+        const tree = getByRole('tree');
+
+        act(() => {
+          tree.focus();
+        });
+
+        expect(getByTestId('parent')).toHaveVirtualFocus();
 
         fireEvent.click(getByText('two'));
 
-        expect(getByTestId('two')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('two')).toHaveVirtualFocus();
 
         // generic action that removes an item.
         // Could be promise based, or timeout, or another user interaction
@@ -365,7 +376,7 @@ describe('<TreeItem />', () => {
           removeActiveItem();
         });
 
-        expect(getByTestId('parent')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('parent')).toHaveVirtualFocus();
       });
     });
 


### PR DESCRIPTION
Adds a test for #20204 which was closed in #21695 but no test was added as far as I can tell.

The test is especially interesting since the behavior is novel: Removing the focused item moves focus to another item of the widget. In other widgets we let focus return to `document.body`.