### PR TITLE
[Paper] Support dark mode brightening based on elevation

### DIFF
--- a/docs/pages/api-docs/paper.md
+++ b/docs/pages/api-docs/paper.md
@@ -71,6 +71,31 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">elevation22</span> | <span class="prop-name">.MuiPaper-elevation22</span> | 
 | <span class="prop-name">elevation23</span> | <span class="prop-name">.MuiPaper-elevation23</span> | 
 | <span class="prop-name">elevation24</span> | <span class="prop-name">.MuiPaper-elevation24</span> | 
+| <span class="prop-name">overlay0</span> | <span class="prop-name">.MuiPaper-overlay0</span> | 
+| <span class="prop-name">overlay1</span> | <span class="prop-name">.MuiPaper-overlay1</span> | 
+| <span class="prop-name">overlay2</span> | <span class="prop-name">.MuiPaper-overlay2</span> | 
+| <span class="prop-name">overlay3</span> | <span class="prop-name">.MuiPaper-overlay3</span> | 
+| <span class="prop-name">overlay4</span> | <span class="prop-name">.MuiPaper-overlay4</span> | 
+| <span class="prop-name">overlay5</span> | <span class="prop-name">.MuiPaper-overlay5</span> | 
+| <span class="prop-name">overlay6</span> | <span class="prop-name">.MuiPaper-overlay6</span> | 
+| <span class="prop-name">overlay7</span> | <span class="prop-name">.MuiPaper-overlay7</span> | 
+| <span class="prop-name">overlay8</span> | <span class="prop-name">.MuiPaper-overlay8</span> | 
+| <span class="prop-name">overlay9</span> | <span class="prop-name">.MuiPaper-overlay9</span> | 
+| <span class="prop-name">overlay10</span> | <span class="prop-name">.MuiPaper-overlay10</span> | 
+| <span class="prop-name">overlay11</span> | <span class="prop-name">.MuiPaper-overlay11</span> | 
+| <span class="prop-name">overlay12</span> | <span class="prop-name">.MuiPaper-overlay12</span> | 
+| <span class="prop-name">overlay13</span> | <span class="prop-name">.MuiPaper-overlay13</span> | 
+| <span class="prop-name">overlay14</span> | <span class="prop-name">.MuiPaper-overlay14</span> | 
+| <span class="prop-name">overlay15</span> | <span class="prop-name">.MuiPaper-overlay15</span> | 
+| <span class="prop-name">overlay16</span> | <span class="prop-name">.MuiPaper-overlay16</span> | 
+| <span class="prop-name">overlay17</span> | <span class="prop-name">.MuiPaper-overlay17</span> | 
+| <span class="prop-name">overlay18</span> | <span class="prop-name">.MuiPaper-overlay18</span> | 
+| <span class="prop-name">overlay19</span> | <span class="prop-name">.MuiPaper-overlay19</span> | 
+| <span class="prop-name">overlay20</span> | <span class="prop-name">.MuiPaper-overlay20</span> | 
+| <span class="prop-name">overlay21</span> | <span class="prop-name">.MuiPaper-overlay21</span> | 
+| <span class="prop-name">overlay22</span> | <span class="prop-name">.MuiPaper-overlay22</span> | 
+| <span class="prop-name">overlay23</span> | <span class="prop-name">.MuiPaper-overlay23</span> | 
+| <span class="prop-name">overlay24</span> | <span class="prop-name">.MuiPaper-overlay24</span> | 
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -198,9 +198,6 @@ export function ThemeProvider(props) {
             main: paletteType === 'light' ? darken(pink.A400, 0.1) : pink[200],
           },
           type: paletteType,
-          background: {
-            default: paletteType === 'light' ? '#fff' : '#121212',
-          },
           ...paletteColors,
         },
         spacing,

--- a/docs/src/pages/components/paper/SimplePaper.js
+++ b/docs/src/pages/components/paper/SimplePaper.js
@@ -19,7 +19,7 @@ export default function SimplePaper() {
 
   return (
     <div className={classes.root}>
-      <Paper elevation={0} />
+      <Paper variant="outlined" elevation={0} />
       <Paper />
       <Paper elevation={3} />
     </div>

--- a/docs/src/pages/components/paper/SimplePaper.tsx
+++ b/docs/src/pages/components/paper/SimplePaper.tsx
@@ -21,7 +21,7 @@ export default function SimplePaper() {
 
   return (
     <div className={classes.root}>
-      <Paper elevation={0} />
+      <Paper variant="outlined" elevation={0} />
       <Paper />
       <Paper elevation={3} />
     </div>

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -55,7 +55,32 @@ export type PaperClassKey =
   | 'elevation21'
   | 'elevation22'
   | 'elevation23'
-  | 'elevation24';
+  | 'elevation24'
+  | 'overlay0'
+  | 'overlay1'
+  | 'overlay2'
+  | 'overlay3'
+  | 'overlay4'
+  | 'overlay5'
+  | 'overlay6'
+  | 'overlay7'
+  | 'overlay8'
+  | 'overlay9'
+  | 'overlay10'
+  | 'overlay11'
+  | 'overlay12'
+  | 'overlay13'
+  | 'overlay14'
+  | 'overlay15'
+  | 'overlay16'
+  | 'overlay17'
+  | 'overlay18'
+  | 'overlay19'
+  | 'overlay20'
+  | 'overlay21'
+  | 'overlay22'
+  | 'overlay23'
+  | 'overlay24';
 
 /**
  *

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -28,7 +28,15 @@ export const styles = (theme) => {
   const overlays = {};
   theme.shadows.forEach((_, index) => {
     overlays[`overlay${index}`] = {
-      backgroundColor: fade(theme.palette.background.paper, calculateAlpha(index)),
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        background: fade('#fff', calculateAlpha(index)),
+      },
     };
   });
 
@@ -38,6 +46,7 @@ export const styles = (theme) => {
       backgroundColor: theme.palette.background.paper,
       color: theme.palette.text.primary,
       transition: theme.transitions.create('box-shadow'),
+      position: 'relative',
     },
     /* Styles applied to the root element if `square={false}`. */
     rounded: {

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -3,12 +3,32 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
+import { fade, useTheme } from '../styles';
+
+// Inspired by https://github.com/material-components/material-components-ios/blob/bca36107405594d5b7b16265a5b0ed698f85a5ee/components/Elevation/src/UIColor%2BMaterialElevation.m#L61
+function calculateAlpha(elevation) {
+  let alphaValue;
+  if (elevation < 1) {
+    alphaValue = 5.11916 * elevation ** 2;
+  } else {
+    alphaValue = 4.5 * Math.log(elevation + 1) + 2;
+  }
+
+  return (alphaValue / 100).toFixed(2);
+}
 
 export const styles = (theme) => {
   const elevations = {};
   theme.shadows.forEach((shadow, index) => {
     elevations[`elevation${index}`] = {
       boxShadow: shadow,
+    };
+  });
+
+  const overlays = {};
+  theme.shadows.forEach((_, index) => {
+    overlays[`overlay${index}`] = {
+      backgroundColor: fade(theme.palette.background.paper, calculateAlpha(index)),
     };
   });
 
@@ -28,6 +48,7 @@ export const styles = (theme) => {
       border: `1px solid ${theme.palette.divider}`,
     },
     ...elevations,
+    ...overlays,
   };
 };
 
@@ -42,6 +63,8 @@ const Paper = React.forwardRef(function Paper(props, ref) {
     ...other
   } = props;
 
+  const theme = useTheme();
+
   return (
     <Component
       className={clsx(
@@ -49,6 +72,7 @@ const Paper = React.forwardRef(function Paper(props, ref) {
         {
           [classes.rounded]: !square,
           [classes[`elevation${elevation}`]]: variant === 'elevation',
+          [classes[`overlay${elevation}`]]: theme.palette.type === 'dark',
           [classes.outlined]: variant === 'outlined',
         },
         className,

--- a/packages/material-ui/src/styles/createPalette.js
+++ b/packages/material-ui/src/styles/createPalette.js
@@ -28,7 +28,7 @@ export const light = {
   // Consistency between these values is important.
   background: {
     paper: common.white,
-    default: grey[50],
+    default: common.white,
   },
   // The colors used to style the action elements.
   action: {
@@ -61,8 +61,8 @@ export const dark = {
   },
   divider: 'rgba(255, 255, 255, 0.12)',
   background: {
-    paper: grey[800],
-    default: '#303030',
+    paper: '#121212',
+    default: '#121212',
   },
   action: {
     active: common.white,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Closes #18309

I've added the overlay as a separate class and not as part of elevation because you can't currently have elevation and overlay at the same time unlike in the material spec so you couldn't have the elevation class and an outline.

https://material.io/design/color/dark-theme.html