### PR TITLE
[Select] Allow range selection using shift key

### DIFF
--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1048,4 +1048,90 @@ describe('<Select />', () => {
     fireEvent.click(container.querySelector('button[type=submit]'));
     expect(handleSubmit.callCount).to.equal(1);
   });
+
+  describe('range multiple selection using shift key', () => {
+    function ControlledWrapper({ onChange, initialValue = [] }) {
+      const [value, setValue] = React.useState(initialValue);
+
+      return (
+        <Select
+          open
+          multiple
+          value={value}
+          onChange={({ target }) => {
+            onChange(target.value);
+            setValue(target.value);
+          }}
+        >
+          <MenuItem value="france">France</MenuItem>
+          <MenuItem value="germany">Germany</MenuItem>
+          <MenuItem value="china">China</MenuItem>
+          <MenuItem value="israel">Israel</MenuItem>
+          <MenuItem value="italy">Italy</MenuItem>
+        </Select>
+      );
+    }
+
+    it('should select range of values', () => {
+      const handleChange = spy();
+      const { getAllByRole } = render(<ControlledWrapper onChange={handleChange} />);
+
+      fireEvent.click(getAllByRole('option')[0]);
+      fireEvent.click(getAllByRole('option')[3], { shiftKey: true });
+
+      expect(handleChange.args[1][0]).to.deep.equal(['france', 'germany', 'china', 'israel']);
+    });
+
+    it('should select range of values in reverse direction', () => {
+      const handleChange = spy();
+      const { getAllByRole } = render(<ControlledWrapper onChange={handleChange} />);
+
+      fireEvent.click(getAllByRole('option')[3]);
+      fireEvent.click(getAllByRole('option')[0], { shiftKey: true });
+
+      expect(handleChange.args[1][0]).to.deep.equal(['israel', 'france', 'germany', 'china']);
+    });
+
+    it('should select range of values and keep uniqueness', () => {
+      const handleChange = spy();
+      const { getAllByRole } = render(
+        <ControlledWrapper onChange={handleChange} initialValue={['germany']} />,
+      );
+
+      fireEvent.click(getAllByRole('option')[0]);
+      fireEvent.click(getAllByRole('option')[3], { shiftKey: true });
+
+      expect(handleChange.args[1][0]).to.deep.equal(['germany', 'france', 'china', 'israel']);
+    });
+
+    it('should deselect range of values', () => {
+      const handleChange = spy();
+      const { getAllByRole } = render(
+        <ControlledWrapper
+          onChange={handleChange}
+          initialValue={['france', 'germany', 'china', 'israel', 'italy']}
+        />,
+      );
+
+      fireEvent.click(getAllByRole('option')[1]);
+      fireEvent.click(getAllByRole('option')[3], { shiftKey: true });
+
+      expect(handleChange.args[1][0]).to.deep.equal(['france', 'italy']);
+    });
+
+    it('should deselect range of values in reverse direction', () => {
+      const handleChange = spy();
+      const { getAllByRole } = render(
+        <ControlledWrapper
+          onChange={handleChange}
+          initialValue={['france', 'germany', 'china', 'israel', 'italy']}
+        />,
+      );
+
+      fireEvent.click(getAllByRole('option')[3]);
+      fireEvent.click(getAllByRole('option')[1], { shiftKey: true });
+
+      expect(handleChange.args[1][0]).to.deep.equal(['france', 'italy']);
+    });
+  });
 });

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -67,6 +67,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   });
 
   const inputRef = React.useRef(null);
+  const lastItemIndex = React.useRef(null);
   const [displayNode, setDisplayNode] = React.useState(null);
   const { current: isOpenControlled } = React.useRef(openProp != null);
   const [menuMinWidthState, setMenuMinWidthState] = React.useState();
@@ -169,8 +170,29 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     if (multiple) {
       newValue = Array.isArray(value) ? value.slice() : [];
       const itemIndex = value.indexOf(child.props.value);
-      if (itemIndex === -1) {
+      if (
+        event.shiftKey &&
+        lastItemIndex.current &&
+        lastItemIndex.current !== child.props.value &&
+        value.indexOf(lastItemIndex.current) > -1
+      ) {
+        const optionValues = React.Children.map(children, (c) => c.props.value);
+        const startOptionIndex = optionValues.indexOf(lastItemIndex.current);
+        const endOptionIndex = optionValues.indexOf(child.props.value);
+
+        if (startOptionIndex > -1 && endOptionIndex > -1) {
+          let range = [];
+          if (endOptionIndex > startOptionIndex) {
+            range = optionValues.slice(startOptionIndex, endOptionIndex + 1);
+          } else {
+            range = optionValues.slice(endOptionIndex, startOptionIndex + 1);
+          }
+          // Selected range chould contain selected values so we filter them out if exists.
+          newValue.push(...range.filter((v) => !value.some((vv) => areEqualValues(v, vv))));
+        }
+      } else if (itemIndex === -1) {
         newValue.push(child.props.value);
+        lastItemIndex.current = child.props.value;
       } else {
         newValue.splice(itemIndex, 1);
       }

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -67,7 +67,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   });
 
   const inputRef = React.useRef(null);
-  const lastItemIndex = React.useRef(null);
+  const lastSelectedItemValue = React.useRef(null);
   const [displayNode, setDisplayNode] = React.useState(null);
   const { current: isOpenControlled } = React.useRef(openProp != null);
   const [menuMinWidthState, setMenuMinWidthState] = React.useState();
@@ -172,12 +172,12 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       const itemIndex = value.indexOf(child.props.value);
       if (
         event.shiftKey &&
-        lastItemIndex.current &&
-        lastItemIndex.current !== child.props.value &&
-        value.indexOf(lastItemIndex.current) > -1
+        lastSelectedItemValue.current &&
+        lastSelectedItemValue.current !== child.props.value &&
+        value.indexOf(lastSelectedItemValue.current) > -1
       ) {
         const optionValues = React.Children.map(children, (c) => c.props.value);
-        const startOptionIndex = optionValues.indexOf(lastItemIndex.current);
+        const startOptionIndex = optionValues.indexOf(lastSelectedItemValue.current);
         const endOptionIndex = optionValues.indexOf(child.props.value);
 
         if (startOptionIndex > -1 && endOptionIndex > -1) {
@@ -187,12 +187,12 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
           } else {
             range = optionValues.slice(endOptionIndex, startOptionIndex + 1);
           }
-          // Selected range chould contain selected values so we filter them out if exists.
+          // Selected range could contain selected values so we filter them out if they exists.
           newValue.push(...range.filter((v) => !value.some((vv) => areEqualValues(v, vv))));
         }
       } else if (itemIndex === -1) {
         newValue.push(child.props.value);
-        lastItemIndex.current = child.props.value;
+        lastSelectedItemValue.current = child.props.value;
       } else {
         newValue.splice(itemIndex, 1);
       }


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

I've added a feature to the `Select` component (multiple-values variant) which allows the user to use the shift key in order to select multiple options.