### PR TITLE
[test] Restore clock between each test

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -11,23 +11,23 @@ import SpeedDialAction from './SpeedDialAction';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 
 describe('<SpeedDialAction />', () => {
-  // StrictModeViolation: uses Tooltip
-  const mount = createMount({ strict: false });
-  const render = createClientRender({ strict: false });
-  let classes;
-  const fabClasses = getClasses(<Fab>Fab</Fab>);
   let clock;
-
-  before(() => {
-    classes = getClasses(<SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="placeholder" />);
-  });
-
   beforeEach(() => {
     clock = useFakeTimers();
   });
 
   afterEach(() => {
     clock.restore();
+  });
+
+  // StrictModeViolation: uses Tooltip
+  const mount = createMount({ strict: false });
+  const render = createClientRender({ strict: false });
+  let classes;
+  const fabClasses = getClasses(<Fab>Fab</Fab>);
+
+  before(() => {
+    classes = getClasses(<SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="placeholder" />);
   });
 
   describeConformance(

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -157,11 +157,11 @@ describe('<TouchRipple />', () => {
      */
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -143,11 +143,11 @@ describe('<Collapse />', () => {
   describe('prop: timeout', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -34,6 +34,14 @@ function clickBackdrop(container) {
 
 describe('<Dialog />', () => {
   let clock;
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
   // StrictModeViolation: uses Fade
   const mount = createMount({ strict: false });
   let classes;
@@ -41,14 +49,6 @@ describe('<Dialog />', () => {
 
   before(() => {
     classes = getClasses(<Dialog>foo</Dialog>);
-  });
-
-  beforeEach(() => {
-    clock = useFakeTimers();
-  });
-
-  afterEach(() => {
-    clock.restore();
   });
 
   describeConformance(<Dialog open>foo</Dialog>, () => ({

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -201,16 +201,16 @@ describe('<Popper />', () => {
 
   describe('prop: transition', () => {
     let clock;
-    const looseRender = createClientRender({ strict: false });
-
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
       // StrictModeViolation: uses Grow
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
+
+    const looseRender = createClientRender({ strict: false });
 
     it('should work', () => {
       const { queryByRole, getByRole, setProps } = looseRender(

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -617,11 +617,11 @@ describe('<Select />', () => {
   describe('prop: open (controlled)', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -45,11 +45,11 @@ describe('<Snackbar />', () => {
   describe('Consecutive messages', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 
@@ -100,11 +100,11 @@ describe('<Snackbar />', () => {
   describe('prop: autoHideDuration', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 
@@ -242,11 +242,11 @@ describe('<Snackbar />', () => {
   describe('prop: resumeHideDuration', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 
@@ -324,11 +324,11 @@ describe('<Snackbar />', () => {
   describe('prop: disableWindowBlurListener', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -8,10 +8,9 @@ import { act, createClientRender, fireEvent } from 'test/utils/createClientRende
 import Tab from './Tab';
 import ButtonBase from '../ButtonBase';
 
-const render = createClientRender();
-
 describe('<Tab />', () => {
   const mount = createMount();
+  const render = createClientRender();
   let classes;
 
   before(() => {

--- a/packages/material-ui/src/Tabs/ScrollbarSize.test.js
+++ b/packages/material-ui/src/Tabs/ScrollbarSize.test.js
@@ -5,16 +5,17 @@ import ScrollbarSize from './ScrollbarSize';
 import { createClientRender } from 'test/utils/createClientRender';
 
 describe('<ScrollbarSize />', () => {
-  const render = createClientRender();
   let clock;
 
-  before(() => {
+  beforeEach(() => {
     clock = useFakeTimers();
   });
 
-  after(() => {
+  afterEach(() => {
     clock.restore();
   });
+
+  const render = createClientRender();
 
   describe('mount', () => {
     it('should call on initial load', () => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -332,11 +332,11 @@ describe('<Tabs />', () => {
       </Tabs>
     );
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 
@@ -409,11 +409,11 @@ describe('<Tabs />', () => {
   describe('prop: scrollButtons', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 
@@ -543,11 +543,11 @@ describe('<Tabs />', () => {
   describe('scroll button behavior', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 
@@ -584,11 +584,11 @@ describe('<Tabs />', () => {
   describe('scroll into view behavior', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -52,11 +52,11 @@ describe('<TextareaAutosize />', () => {
     describe('resize', () => {
       let clock;
 
-      before(() => {
+      beforeEach(() => {
         clock = useFakeTimers();
       });
 
-      after(() => {
+      afterEach(() => {
         clock.restore();
       });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -24,20 +24,7 @@ function simulatePointerDevice() {
 }
 
 describe('<Tooltip />', () => {
-  // StrictModeViolation: uses Grow and tests a lot of impl details
-  const mount = createMount({ strict: null });
-  let classes;
-  const render = createClientRender({ strict: false });
   let clock;
-
-  before(() => {
-    classes = getClasses(
-      <Tooltip title="Hello World">
-        <button type="submit">Hello World</button>
-      </Tooltip>,
-    );
-  });
-
   beforeEach(() => {
     testReset();
     clock = useFakeTimers();
@@ -46,6 +33,19 @@ describe('<Tooltip />', () => {
   afterEach(() => {
     clock.tick(800); // cleanup the hystersis timer
     clock.restore();
+  });
+
+  // StrictModeViolation: uses Grow and tests a lot of impl details
+  const mount = createMount({ strict: null });
+  let classes;
+  const render = createClientRender({ strict: false });
+
+  before(() => {
+    classes = getClasses(
+      <Tooltip title="Hello World">
+        <button type="submit">Hello World</button>
+      </Tooltip>,
+    );
   });
 
   describeConformance(

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -34,11 +34,11 @@ describe('<Zoom />', () => {
   describe('transition lifecycle', () => {
     let clock;
 
-    before(() => {
+    beforeEach(() => {
       clock = useFakeTimers();
     });
 
-    after(() => {
+    afterEach(() => {
       clock.restore();
     });
 

--- a/packages/material-ui/src/utils/debounce.test.js
+++ b/packages/material-ui/src/utils/debounce.test.js
@@ -5,11 +5,11 @@ import debounce from './debounce';
 describe('debounce', () => {
   let clock;
 
-  before(() => {
+  beforeEach(() => {
     clock = useFakeTimers();
   });
 
-  after(() => {
+  afterEach(() => {
     clock.restore();
   });
 

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -73,9 +73,6 @@ describe('<Menu /> integration', () => {
    * @type {ReturnType<useFakeTimers>}
    */
   let clock;
-  // StrictModeViolation: uses Popover
-  const render = createClientRender({ strict: false });
-
   beforeEach(() => {
     clock = useFakeTimers();
   });
@@ -83,6 +80,9 @@ describe('<Menu /> integration', () => {
   afterEach(() => {
     clock.restore();
   });
+
+  // StrictModeViolation: uses Popover
+  const render = createClientRender({ strict: false });
 
   it('is part of the DOM by default but hidden', () => {
     const { getByRole } = render(<ButtonMenu />);


### PR DESCRIPTION
It's important to restore fake timers between tests so that other cleanup tasks can rely on real timers. This is not yet problematic but makes it hard to reason about time with `react@next` or `react@experimental`.

In the future we likely expose a complete function that takes care of cleanup. But since we can't hide `sinon` yet (need yarn v2+test package) I'm sticking with manual cleanup + errors if done incorrectly.