### PR TITLE
[test] Enable "missing act()"-warnings

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -37,10 +37,17 @@ describe('<Autocomplete />', () => {
         <Autocomplete {...defaultProps} renderInput={(params) => <TextField {...params} />} />,
       );
       const input = getByRole('textbox');
-      input.focus();
-      fireEvent.change(document.activeElement, { target: { value: 'a' } });
+
+      act(() => {
+        input.focus();
+        fireEvent.change(document.activeElement, { target: { value: 'a' } });
+      });
+
       expect(input.value).to.equal('a');
-      document.activeElement.blur();
+
+      act(() => {
+        document.activeElement.blur();
+      });
       expect(input.value).to.equal('');
     });
 
@@ -218,7 +225,9 @@ describe('<Autocomplete />', () => {
       // include hidden clear button because JSDOM thinks it's visible
       expect(getAllByRole('button', { hidden: true })).to.have.lengthOf(4);
 
-      getByRole('textbox').focus();
+      act(() => {
+        getByRole('textbox').focus();
+      });
       expect(container.textContent).to.equal('onetwothree');
       expect(getAllByRole('button', { hidden: false })).to.have.lengthOf(5);
     });
@@ -239,7 +248,9 @@ describe('<Autocomplete />', () => {
       // include hidden clear button because JSDOM thinks it's visible
       expect(getAllByRole('button', { hidden: true })).to.have.lengthOf(2);
 
-      getByRole('textbox').focus();
+      act(() => {
+        getByRole('textbox').focus();
+      });
       expect(container.textContent).to.equal('onetwothree');
       expect(getAllByRole('button', { hidden: false })).to.have.lengthOf(5);
     });
@@ -292,7 +303,9 @@ describe('<Autocomplete />', () => {
       fireEvent.change(textbox, { target: { value: 'o' } });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.change(textbox, { target: { value: 'oo' } });
-      textbox.blur();
+      act(() => {
+        textbox.blur();
+      });
 
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal('oo');
@@ -314,9 +327,11 @@ describe('<Autocomplete />', () => {
       );
       const textbox = screen.getByRole('textbox');
 
-      fireEvent.change(textbox, { target: { value: 't' } });
-      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      textbox.blur();
+      act(() => {
+        fireEvent.change(textbox, { target: { value: 't' } });
+        fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+        textbox.blur();
+      });
 
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal(options);
@@ -334,8 +349,12 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
+
       fireEvent.change(document.activeElement, { target: { value: 'a' } });
-      document.activeElement.blur();
+      act(() => {
+        document.activeElement.blur();
+      });
+
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal(['a']);
     });
@@ -351,9 +370,12 @@ describe('<Autocomplete />', () => {
         />,
       );
       const input = getByRole('textbox');
-      input.focus();
-      document.activeElement.blur();
-      input.focus();
+
+      act(() => {
+        input.focus();
+        document.activeElement.blur();
+        input.focus();
+      });
     });
 
     it('should remove the last option', () => {
@@ -861,7 +883,10 @@ describe('<Autocomplete />', () => {
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
 
-      document.activeElement.blur();
+      act(() => {
+        document.activeElement.blur();
+      });
+
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       expect(textbox).not.toHaveFocus();
 
@@ -1373,9 +1398,12 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('textbox');
       fireEvent.click(textbox);
       expect(textbox).toHaveFocus();
-      textbox.blur();
 
+      act(() => {
+        textbox.blur();
+      });
       fireEvent.click(queryByTitle('Open'));
+
       expect(textbox).toHaveFocus();
     });
 
@@ -1693,7 +1721,9 @@ describe('<Autocomplete />', () => {
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      textbox.blur();
+      act(() => {
+        textbox.blur();
+      });
 
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal(options[0]);

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import { useFakeTimers } from 'sinon';
 import createMount from 'test/utils/createMount';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
 import Fab from '@material-ui/core/Fab';
@@ -52,8 +52,15 @@ describe('<SpeedDialAction />', () => {
     );
 
     fireEvent.mouseOver(container.querySelector('button'));
-    clock.tick(100);
+    act(() => {
+      clock.tick(100);
+    });
+
     expect(getByText('placeholder')).to.have.class('bar');
+
+    // FIXME: Unclear what timer is dangling here and what it does.
+    // Not running all timers triggers "missing act()"-warning
+    clock.runAll();
   });
 
   it('should render a Fab', () => {

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -58,8 +58,8 @@ describe('<SpeedDialAction />', () => {
 
     expect(getByText('placeholder')).to.have.class('bar');
 
-    // FIXME: Unclear what timer is dangling here and what it does.
-    // Not running all timers triggers "missing act()"-warning
+    // TODO: Unclear why not running triggers microtasks but runAll does not trigger microtasks
+    // can be removed once Popper#update is sync
     clock.runAll();
   });
 

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Accordion from '../Accordion';
 import AccordionSummary from './AccordionSummary';
 import ButtonBase from '../ButtonBase';
@@ -73,8 +73,10 @@ describe('<AccordionSummary />', () => {
     fireEvent.mouseDown(document.body); // pointer device
     const button = getByRole('button');
 
-    fireEvent.keyDown(document.body, { key: 'Tab' }); // not actually focusing (yet)
-    button.focus();
+    act(() => {
+      fireEvent.keyDown(document.body, { key: 'Tab' }); // not actually focusing (yet)
+      button.focus();
+    });
 
     expect(button).toHaveFocus();
     expect(button).to.have.class(classes.focused);
@@ -85,9 +87,13 @@ describe('<AccordionSummary />', () => {
     fireEvent.mouseDown(document.body); // pointer device
     fireEvent.keyDown(document.body, { key: 'Tab' }); // not actually focusing (yet)
     const button = getByRole('button');
-    button.focus();
 
-    button.blur();
+    act(() => {
+      button.focus();
+    });
+    act(() => {
+      button.blur();
+    });
 
     expect(button).not.toHaveFocus();
     expect(button).not.to.have.class(classes.focused);
@@ -110,7 +116,9 @@ describe('<AccordionSummary />', () => {
       </Accordion>,
     );
 
-    getByRole('button').click();
+    act(() => {
+      getByRole('button').click();
+    });
 
     expect(handleChange.callCount).to.equal(1);
   });
@@ -123,7 +131,9 @@ describe('<AccordionSummary />', () => {
 
     // this doesn't actually apply focus like in the browser. we need to move focus manually
     fireEvent.keyDown(document.body, { key: 'Tab' });
-    getByRole('button').focus();
+    act(() => {
+      getByRole('button').focus();
+    });
 
     expect(handleFocusVisible.callCount).to.equal(1);
   });

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';
-import { fireEvent, createClientRender } from 'test/utils/createClientRender';
+import { act, fireEvent, createClientRender } from 'test/utils/createClientRender';
 
 describe('<BreadcrumbCollapsed />', () => {
   let classes;
@@ -25,8 +25,12 @@ describe('<BreadcrumbCollapsed />', () => {
       const handleClick = spy();
       const { container } = render(<BreadcrumbCollapsed onClick={handleClick} />);
       const expand = container.firstChild;
-      expand.focus();
-      fireEvent.keyDown(expand, { key: 'Enter' });
+
+      act(() => {
+        expand.focus();
+        fireEvent.keyDown(expand, { key: 'Enter' });
+      });
+
       expect(handleClick.callCount).to.equal(1);
     });
 
@@ -34,8 +38,12 @@ describe('<BreadcrumbCollapsed />', () => {
       const handleClick = spy();
       const { container } = render(<BreadcrumbCollapsed onClick={handleClick} />);
       const expand = container.firstChild;
-      expand.focus();
-      fireEvent.keyUp(expand, { key: ' ' });
+
+      act(() => {
+        expand.focus();
+        fireEvent.keyUp(expand, { key: ' ' });
+      });
+
       expect(handleClick.callCount).to.equal(1);
     });
   });

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -4,7 +4,7 @@ import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
 import Breadcrumbs from './Breadcrumbs';
-import { createClientRender, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, screen } from 'test/utils/createClientRender';
 
 describe('<Breadcrumbs />', () => {
   const mount = createMount();
@@ -76,7 +76,10 @@ describe('<Breadcrumbs />', () => {
       </Breadcrumbs>,
     );
 
-    getByRole('button').click();
+    act(() => {
+      getByRole('button').click();
+    });
+
     expect(document.activeElement).to.equal(getByText('first'));
     expect(getAllByRole('listitem', { hidden: false })).to.have.length(9);
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -16,7 +16,7 @@ import * as PropTypes from 'prop-types';
 function focusVisible(element) {
   act(() => {
     element.blur();
-    fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
+    fireEvent.keyDown(document.body, { key: 'Tab' });
     element.focus();
   });
 }
@@ -685,14 +685,14 @@ describe('<ButtonBase />', () => {
 
       act(() => {
         button.focus();
-        fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+        fireEvent.keyDown(button, { key: 'Enter' });
       });
 
       expect(container.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
 
       // technically the second keydown should be fire with repeat: true
       // but that isn't implemented in IE 11 so we shouldn't mock it here either
-      fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+      fireEvent.keyDown(button, { key: 'Enter' });
 
       expect(container.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
     });
@@ -759,7 +759,7 @@ describe('<ButtonBase />', () => {
 
         act(() => {
           button.focus();
-          fireEvent.keyDown(document.activeElement || document.body, {
+          fireEvent.keyDown(button, {
             key: ' ',
           });
         });
@@ -780,7 +780,7 @@ describe('<ButtonBase />', () => {
 
         act(() => {
           button.focus();
-          fireEvent.keyUp(document.activeElement || document.body, {
+          fireEvent.keyUp(button, {
             key: ' ',
           });
         });
@@ -810,7 +810,7 @@ describe('<ButtonBase />', () => {
 
         act(() => {
           button.focus();
-          fireEvent.keyUp(document.activeElement || document.body, {
+          fireEvent.keyUp(button, {
             key: ' ',
           });
         });
@@ -829,7 +829,7 @@ describe('<ButtonBase />', () => {
 
         act(() => {
           button.focus();
-          fireEvent.keyDown(document.activeElement || document.body, {
+          fireEvent.keyDown(button, {
             key: 'Enter',
           });
         });
@@ -884,7 +884,7 @@ describe('<ButtonBase />', () => {
 
         act(() => {
           button.focus();
-          fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+          fireEvent.keyDown(button, { key: 'Enter' });
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
@@ -904,7 +904,7 @@ describe('<ButtonBase />', () => {
 
         act(() => {
           button.focus();
-          fireEvent.keyDown(document.activeElement || document.body, {
+          fireEvent.keyDown(button, {
             key: 'Enter',
           });
         });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -630,7 +630,9 @@ describe('<ButtonBase />', () => {
         </ButtonBase>,
       );
 
-      getByRole('button').focus();
+      act(() => {
+        getByRole('button').focus();
+      });
 
       expect(onFocusSpy.callCount).to.equal(1);
     });
@@ -681,8 +683,10 @@ describe('<ButtonBase />', () => {
 
       const button = getByText('Hello');
 
-      button.focus();
-      fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+      act(() => {
+        button.focus();
+        fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+      });
 
       expect(container.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
 
@@ -752,10 +756,12 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
         const button = getByRole('button');
-        button.focus();
 
-        fireEvent.keyDown(document.activeElement || document.body, {
-          key: ' ',
+        act(() => {
+          button.focus();
+          fireEvent.keyDown(document.activeElement || document.body, {
+            key: ' ',
+          });
         });
 
         expect(onClickSpy.callCount).to.equal(0);
@@ -771,10 +777,12 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
         const button = getByRole('button');
-        button.focus();
 
-        fireEvent.keyUp(document.activeElement || document.body, {
-          key: ' ',
+        act(() => {
+          button.focus();
+          fireEvent.keyUp(document.activeElement || document.body, {
+            key: ' ',
+          });
         });
 
         expect(onClickSpy.callCount).to.equal(1);
@@ -799,10 +807,12 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
         const button = getByRole('button');
-        button.focus();
 
-        fireEvent.keyUp(document.activeElement || document.body, {
-          key: ' ',
+        act(() => {
+          button.focus();
+          fireEvent.keyUp(document.activeElement || document.body, {
+            key: ' ',
+          });
         });
 
         expect(onClickSpy.callCount).to.equal(0);
@@ -816,10 +826,12 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
         const button = getByRole('button');
-        button.focus();
 
-        fireEvent.keyDown(document.activeElement || document.body, {
-          key: 'Enter',
+        act(() => {
+          button.focus();
+          fireEvent.keyDown(document.activeElement || document.body, {
+            key: 'Enter',
+          });
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
@@ -868,10 +880,12 @@ describe('<ButtonBase />', () => {
             Hello
           </ButtonBase>,
         );
-
         const button = getByRole('button');
-        button.focus();
-        fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+
+        act(() => {
+          button.focus();
+          fireEvent.keyDown(document.activeElement || document.body, { key: 'Enter' });
+        });
 
         expect(onClickSpy.calledOnce).to.equal(true);
         // defaultPrevented?
@@ -887,9 +901,12 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
         const button = getByText('Hello');
-        button.focus();
-        fireEvent.keyDown(document.activeElement || document.body, {
-          key: 'Enter',
+
+        act(() => {
+          button.focus();
+          fireEvent.keyDown(document.activeElement || document.body, {
+            key: 'Enter',
+          });
         });
 
         expect(onClick.calledOnce).to.equal(false);
@@ -913,8 +930,12 @@ describe('<ButtonBase />', () => {
 
       // @ts-ignore
       expect(typeof buttonActionsRef.current.focusVisible).to.equal('function');
-      // @ts-ignore
-      buttonActionsRef.current.focusVisible();
+
+      act(() => {
+        // @ts-ignore
+        buttonActionsRef.current.focusVisible();
+      });
+
       expect(getByText('Hello')).toHaveFocus();
       expect(getByText('Hello')).to.match('.focusVisible');
     });

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -9,8 +9,7 @@ import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
 const cb = () => {};
 
-// TODO: wait for confirmation of https://github.com/facebook/react/issues/19318
-describe.skip('<TouchRipple />', () => {
+describe('<TouchRipple />', () => {
   let classes;
   const mount = createMount();
   const render = createClientRender();
@@ -64,13 +63,16 @@ describe.skip('<TouchRipple />', () => {
     it('should should compute the right ripple dimensions', () => {
       const { instance, queryRipple } = renderTouchRipple({ center: true });
 
-      instance.start(
-        {},
-        {
-          fakeElement: true,
-        },
-        cb,
-      );
+      act(() => {
+        instance.start(
+          {},
+          {
+            fakeElement: true,
+          },
+          cb,
+        );
+      });
+
       expect(queryRipple().style).to.have.property('height', '1px');
       expect(queryRipple().style).to.have.property('width', '1px');
     });
@@ -82,15 +84,24 @@ describe.skip('<TouchRipple />', () => {
     expect(queryAllActiveRipples()).to.have.lengthOf(0);
     expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-    instance.start({ clientX: 0, clientY: 0 }, cb);
+    act(() => {
+      instance.start({ clientX: 0, clientY: 0 }, cb);
+    });
+
     expect(queryAllActiveRipples()).to.have.lengthOf(1);
     expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-    instance.start({ clientX: 0, clientY: 0 }, cb);
+    act(() => {
+      instance.start({ clientX: 0, clientY: 0 }, cb);
+    });
+
     expect(queryAllActiveRipples()).to.have.lengthOf(2);
     expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-    instance.start({ clientX: 0, clientY: 0 }, cb);
+    act(() => {
+      instance.start({ clientX: 0, clientY: 0 }, cb);
+    });
+
     expect(queryAllActiveRipples()).to.have.lengthOf(3);
     expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
@@ -120,14 +131,17 @@ describe.skip('<TouchRipple />', () => {
     it('should create a ripple', () => {
       const { instance, queryAllActiveRipples, queryAllStoppingRipples } = renderTouchRipple();
 
-      instance.start(
-        {},
-        {
-          pulsate: true,
-          fakeElement: true,
-        },
-        cb,
-      );
+      act(() => {
+        instance.start(
+          {},
+          {
+            pulsate: true,
+            fakeElement: true,
+          },
+          cb,
+        );
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
     });
@@ -135,8 +149,11 @@ describe.skip('<TouchRipple />', () => {
     it('should ignore a mousedown event after a touchstart event', () => {
       const { instance, queryAllActiveRipples, queryAllStoppingRipples } = renderTouchRipple();
 
-      instance.start({ type: 'touchstart' }, cb);
-      instance.start({ type: 'mousedown' }, cb);
+      act(() => {
+        instance.start({ type: 'touchstart' }, cb);
+        instance.start({ type: 'mousedown' }, cb);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
     });
@@ -153,7 +170,10 @@ describe.skip('<TouchRipple />', () => {
       const clientX = 1;
       const clientY = 1;
 
-      instance.start({ clientX, clientY }, { fakeElement: true }, cb);
+      act(() => {
+        instance.start({ clientX, clientY }, { fakeElement: true }, cb);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
       expect(queryRipple().style).to.have.property('top', '-0.5px');
@@ -181,16 +201,25 @@ describe.skip('<TouchRipple />', () => {
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      instance.start({ touches: [], clientX: 0, clientY: 0 }, { fakeElement: true }, cb);
+      act(() => {
+        instance.start({ touches: [], clientX: 0, clientY: 0 }, { fakeElement: true }, cb);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      clock.tick(DELAY_RIPPLE);
+      act(() => {
+        clock.tick(DELAY_RIPPLE);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      clock.tick(DELAY_RIPPLE);
-      instance.stop({ type: 'touchend' }, cb);
+      act(() => {
+        clock.tick(DELAY_RIPPLE);
+        instance.stop({ type: 'touchend' }, cb);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(1);
     });
@@ -201,19 +230,31 @@ describe.skip('<TouchRipple />', () => {
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      instance.start({ touches: [], clientX: 0, clientY: 0 }, { fakeElement: true }, cb);
+      act(() => {
+        instance.start({ touches: [], clientX: 0, clientY: 0 }, { fakeElement: true }, cb);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      clock.tick(DELAY_RIPPLE / 2);
+      act(() => {
+        clock.tick(DELAY_RIPPLE / 2);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      instance.stop({ type: 'touchend', persist: () => {} }, cb);
+      act(() => {
+        instance.stop({ type: 'touchend', persist: () => {} }, cb);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-      clock.tick(1);
+      act(() => {
+        clock.tick(1);
+      });
+
       expect(queryAllActiveRipples()).to.have.lengthOf(0);
       expect(queryAllStoppingRipples()).to.have.lengthOf(1);
     });

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -3,13 +3,14 @@ import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
 const cb = () => {};
 
-describe('<TouchRipple />', () => {
+// TODO: wait for confirmation of https://github.com/facebook/react/issues/19318
+describe.skip('<TouchRipple />', () => {
   let classes;
   const mount = createMount();
   const render = createClientRender();
@@ -93,15 +94,24 @@ describe('<TouchRipple />', () => {
     expect(queryAllActiveRipples()).to.have.lengthOf(3);
     expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
-    instance.stop({ type: 'mouseup' });
+    act(() => {
+      instance.stop({ type: 'mouseup' });
+    });
+
     expect(queryAllActiveRipples()).to.have.lengthOf(2);
     expect(queryAllStoppingRipples()).to.have.lengthOf(1);
 
-    instance.stop({ type: 'mouseup' });
+    act(() => {
+      instance.stop({ type: 'mouseup' });
+    });
+
     expect(queryAllActiveRipples()).to.have.lengthOf(1);
     expect(queryAllStoppingRipples()).to.have.lengthOf(2);
 
-    instance.stop({ type: 'mouseup' });
+    act(() => {
+      instance.stop({ type: 'mouseup' });
+    });
+
     expect(queryAllActiveRipples()).to.have.lengthOf(0);
     expect(queryAllStoppingRipples()).to.have.lengthOf(3);
   });

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import Checkbox from './Checkbox';
 import FormControl from '../FormControl';
 import IconButton from '../IconButton';
@@ -48,13 +48,17 @@ describe('<Checkbox />', () => {
     const handleChange = spy((event) => event.persist());
     const { getByRole } = render(<Checkbox onChange={handleChange} />);
 
-    getByRole('checkbox').click();
+    act(() => {
+      getByRole('checkbox').click();
+    });
 
     expect(getByRole('checkbox')).to.have.property('checked', true);
     expect(handleChange.callCount).to.equal(1);
     expect(handleChange.getCall(0).args[0].target).to.have.property('checked', true);
 
-    getByRole('checkbox').click();
+    act(() => {
+      getByRole('checkbox').click();
+    });
 
     expect(getByRole('checkbox')).to.have.property('checked', false);
     expect(handleChange.callCount).to.equal(2);

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -5,7 +5,7 @@ import CheckBox from '../internal/svg-icons/CheckBox';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Avatar from '../Avatar';
 import Chip from './Chip';
 
@@ -310,7 +310,9 @@ describe('<Chip />', () => {
       const handleKeydown = stub().callsFake((event) => event.key);
       const { getByRole } = render(<Chip onClick={() => {}} onKeyDown={handleKeydown} />);
       const chip = getByRole('button');
-      chip.focus();
+      act(() => {
+        chip.focus();
+      });
 
       fireEvent.keyDown(chip, { key: 'p' });
 
@@ -325,7 +327,9 @@ describe('<Chip />', () => {
         <Chip onBlur={handleBlur} onClick={() => {}} onKeyDown={handleKeydown} />,
       );
       const chip = getByRole('button');
-      chip.focus();
+      act(() => {
+        chip.focus();
+      });
 
       fireEvent.keyUp(chip, { key: 'Escape' });
 
@@ -337,7 +341,9 @@ describe('<Chip />', () => {
       const handleClick = spy();
       const { getByRole } = render(<Chip onClick={handleClick} />);
       const chip = getByRole('button');
-      chip.focus();
+      act(() => {
+        chip.focus();
+      });
 
       fireEvent.keyUp(chip, { key: ' ' });
 
@@ -348,7 +354,9 @@ describe('<Chip />', () => {
       const handleClick = spy();
       const { getByRole } = render(<Chip onClick={handleClick} />);
       const chip = getByRole('button');
-      chip.focus();
+      act(() => {
+        chip.focus();
+      });
 
       fireEvent.keyDown(chip, { key: 'Enter' });
 
@@ -364,7 +372,9 @@ describe('<Chip />', () => {
             <Chip onClick={() => {}} onKeyDown={handleKeyDown} onDelete={handleDelete} />,
           );
           const chip = getAllByRole('button')[0];
-          chip.focus();
+          act(() => {
+            chip.focus();
+          });
 
           fireEvent.keyDown(chip, { key });
 

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import Portal from '../Portal';
 import ClickAwayListener from './ClickAwayListener';
 
@@ -246,7 +246,9 @@ describe('<ClickAwayListener />', () => {
       }
       render(<Test />);
 
-      screen.getByRole('button').click();
+      act(() => {
+        screen.getByRole('button').click();
+      });
 
       expect(handleClickAway.callCount).to.equal(1);
     });
@@ -269,7 +271,9 @@ describe('<ClickAwayListener />', () => {
       }
       render(<Test />);
 
-      screen.getByRole('button').click();
+      act(() => {
+        screen.getByRole('button').click();
+      });
 
       expect(handleClickAway.callCount).to.equal(0);
     });

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -260,10 +260,16 @@ describe('<FormControl />', () => {
 
           expect(formControlRef.current).to.have.property('filled', false);
 
-          formControlRef.current.onFilled();
+          act(() => {
+            formControlRef.current.onFilled();
+          });
+
           expect(formControlRef.current).to.have.property('filled', true);
 
-          formControlRef.current.onFilled();
+          act(() => {
+            formControlRef.current.onFilled();
+          });
+
           expect(formControlRef.current).to.have.property('filled', true);
         });
       });
@@ -273,13 +279,22 @@ describe('<FormControl />', () => {
           const formControlRef = React.createRef();
           render(<FormControlled ref={formControlRef} />);
 
-          formControlRef.current.onFilled();
+          act(() => {
+            formControlRef.current.onFilled();
+          });
+
           expect(formControlRef.current).to.have.property('filled', true);
 
-          formControlRef.current.onEmpty();
+          act(() => {
+            formControlRef.current.onEmpty();
+          });
+
           expect(formControlRef.current).to.have.property('filled', false);
 
-          formControlRef.current.onEmpty();
+          act(() => {
+            formControlRef.current.onEmpty();
+          });
+
           expect(formControlRef.current).to.have.property('filled', false);
         });
       });
@@ -290,10 +305,16 @@ describe('<FormControl />', () => {
           render(<FormControlled ref={formControlRef} />);
           expect(formControlRef.current).to.have.property('focused', false);
 
-          formControlRef.current.onFocus();
+          act(() => {
+            formControlRef.current.onFocus();
+          });
+
           expect(formControlRef.current).to.have.property('focused', true);
 
-          formControlRef.current.onFocus();
+          act(() => {
+            formControlRef.current.onFocus();
+          });
+
           expect(formControlRef.current).to.have.property('focused', true);
         });
       });
@@ -304,13 +325,22 @@ describe('<FormControl />', () => {
           render(<FormControlled ref={formControlRef} />);
           expect(formControlRef.current).to.have.property('focused', false);
 
-          formControlRef.current.onFocus();
+          act(() => {
+            formControlRef.current.onFocus();
+          });
+
           expect(formControlRef.current).to.have.property('focused', true);
 
-          formControlRef.current.onBlur();
+          act(() => {
+            formControlRef.current.onBlur();
+          });
+
           expect(formControlRef.current).to.have.property('focused', false);
 
-          formControlRef.current.onBlur();
+          act(() => {
+            formControlRef.current.onBlur();
+          });
+
           expect(formControlRef.current).to.have.property('focused', false);
         });
       });

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import FormLabel from './FormLabel';
 import FormControl, { useFormControl } from '../FormControl';
 
@@ -100,7 +100,9 @@ describe('<FormLabel />', () => {
 
         expect(container.querySelector('label')).not.to.have.class(classes.focused);
 
-        formControlRef.current.onFocus();
+        act(() => {
+          formControlRef.current.onFocus();
+        });
         expect(container.querySelector('label')).to.have.class(classes.focused);
       });
 
@@ -118,7 +120,9 @@ describe('<FormLabel />', () => {
         const { container, setProps } = render(<FormLabel data-testid="FormLabel" />, {
           wrapper: Wrapper,
         });
-        formControlRef.current.onFocus();
+        act(() => {
+          formControlRef.current.onFocus();
+        });
 
         expect(container.querySelector('label')).to.have.class(classes.focused);
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -395,10 +395,16 @@ describe('<InputBase />', () => {
         });
         expect(getByTestId('root')).to.have.class(classes.focused);
 
-        controlRef.current.onBlur();
+        act(() => {
+          controlRef.current.onBlur();
+        });
+
         expect(getByTestId('root')).not.to.have.class(classes.focused);
 
-        controlRef.current.onFocus();
+        act(() => {
+          controlRef.current.onFocus();
+        });
+
         expect(getByTestId('root')).to.have.class(classes.focused);
       });
 

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
 import Input from '../Input';
 import InputLabel from './InputLabel';
@@ -102,7 +102,9 @@ describe('<InputLabel />', () => {
         const { container, getByTestId, setProps } = render(<InputLabel data-testid="root" />, {
           wrapper: Wrapper,
         });
-        container.querySelector('input').focus();
+        act(() => {
+          container.querySelector('input').focus();
+        });
 
         expect(getByTestId('root')).to.have.class(classes.shrink);
 

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -3,14 +3,17 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
+import { act } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Link from './Link';
 import Typography from '../Typography';
 
 function focusVisible(element) {
-  element.blur();
-  document.dispatchEvent(new window.Event('keydown'));
-  element.focus();
+  act(() => {
+    element.blur();
+    document.dispatchEvent(new window.Event('keydown'));
+    element.focus();
+  });
 }
 
 describe('<Link />', () => {
@@ -74,9 +77,15 @@ describe('<Link />', () => {
       const anchor = wrapper.find('a').instance();
 
       expect(anchor.classList.contains(classes.focusVisible)).to.equal(false);
+
       focusVisible(anchor);
+
       expect(anchor.classList.contains(classes.focusVisible)).to.equal(true);
-      anchor.blur();
+
+      act(() => {
+        anchor.blur();
+      });
+
       expect(anchor.classList.contains(classes.focusVisible)).to.equal(false);
     });
   });

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -5,7 +5,7 @@ import * as PropTypes from 'prop-types';
 import { findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import FormGroup from '../FormGroup';
 import Radio from '../Radio';
 import RadioGroup from './RadioGroup';
@@ -304,10 +304,16 @@ describe('<RadioGroup />', () => {
 
           expect(radioGroupRef.current).to.have.property('value', 'zero');
 
-          radioGroupRef.current.onChange({ target: { value: 'one' } });
+          act(() => {
+            radioGroupRef.current.onChange({ target: { value: 'one' } });
+          });
+
           expect(radioGroupRef.current).to.have.property('value', 'one');
 
-          radioGroupRef.current.onChange({ target: { value: 'two' } });
+          act(() => {
+            radioGroupRef.current.onChange({ target: { value: 'two' } });
+          });
+
           expect(radioGroupRef.current).to.have.property('value', 'two');
         });
       });

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -6,7 +6,7 @@ import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Slider from './Slider';
 
 function createTouches(touches) {
@@ -133,16 +133,22 @@ describe('<Slider />', () => {
       const { getAllByRole } = render(<Slider defaultValue={[20, 30]} />);
       const [thumb1, thumb2] = getAllByRole('slider');
 
-      thumb1.focus();
-      fireEvent.keyDown(thumb1, {
-        key: 'ArrowRight',
+      act(() => {
+        thumb1.focus();
+        fireEvent.keyDown(thumb1, {
+          key: 'ArrowRight',
+        });
       });
+
       expect(thumb1.getAttribute('aria-valuenow')).to.equal('21');
 
-      thumb2.focus();
-      fireEvent.keyDown(thumb2, {
-        key: 'ArrowLeft',
+      act(() => {
+        thumb2.focus();
+        fireEvent.keyDown(thumb2, {
+          key: 'ArrowLeft',
+        });
       });
+
       expect(thumb2.getAttribute('aria-valuenow')).to.equal('29');
     });
 
@@ -262,7 +268,9 @@ describe('<Slider />', () => {
     it('should handle all the keys', () => {
       const { getByRole } = render(<Slider defaultValue={50} />);
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, {
         key: 'Home',
@@ -300,7 +308,9 @@ describe('<Slider />', () => {
     it('should use min as the step origin', () => {
       const { getByRole } = render(<Slider defaultValue={150} step={100} max={750} min={150} />);
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '250');
@@ -312,7 +322,9 @@ describe('<Slider />', () => {
     it('should reach right edge value', () => {
       const { getByRole } = render(<Slider defaultValue={90} min={6} max={108} step={10} />);
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '96');
@@ -333,7 +345,9 @@ describe('<Slider />', () => {
     it('should reach left edge value', () => {
       const { getByRole } = render(<Slider defaultValue={20} min={6} max={108} step={10} />);
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '6');
@@ -348,7 +362,9 @@ describe('<Slider />', () => {
     it('should round value to step precision', () => {
       const { getByRole } = render(<Slider defaultValue={0.2} min={0} max={1} step={0.1} />);
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '0.3');
@@ -359,7 +375,9 @@ describe('<Slider />', () => {
         <Slider defaultValue={0.00000002} min={0} max={0.00000005} step={0.00000001} />,
       );
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveRightEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '3e-8');
@@ -370,7 +388,9 @@ describe('<Slider />', () => {
         <Slider defaultValue={-0.00000002} min={-0.00000005} max={0} step={0.00000001} />,
       );
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '-3e-8');
@@ -387,7 +407,9 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
       const thumb = getByRole('slider');
-      thumb.focus();
+      act(() => {
+        thumb.focus();
+      });
 
       fireEvent.keyDown(thumb, moveLeftEvent);
       expect(thumb).to.have.attribute('aria-valuenow', '31');

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
+import { act } from 'test/utils/createClientRender';
 import createMount from 'test/utils/createMount';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import PropTypes, { checkPropTypes } from 'prop-types';
@@ -10,34 +11,38 @@ import SwipeArea from './SwipeArea';
 import useForkRef from '../utils/useForkRef';
 
 function fireMouseEvent(name, element, properties = {}) {
-  const event = document.createEvent('MouseEvents');
-  event.initEvent(name, true, true);
-  Object.keys(properties).forEach((key) => {
-    event[key] = properties[key];
+  act(() => {
+    const event = document.createEvent('MouseEvents');
+    event.initEvent(name, true, true);
+    Object.keys(properties).forEach((key) => {
+      event[key] = properties[key];
+    });
+    if (element.dispatchEvent) {
+      element.dispatchEvent(event);
+    } else {
+      element.getDOMNode().dispatchEvent(event);
+    }
   });
-  if (element.dispatchEvent) {
-    element.dispatchEvent(event);
-  } else {
-    element.getDOMNode().dispatchEvent(event);
-  }
-  return event;
 }
 
 function fireBodyMouseEvent(name, properties = {}) {
-  return fireMouseEvent(name, document.body, properties);
+  fireMouseEvent(name, document.body, properties);
 }
 
 function fireSwipeAreaMouseEvent(wrapper, name, properties = {}) {
-  const event = document.createEvent('MouseEvents');
-  event.initEvent(name, true, true);
-  Object.keys(properties).forEach((key) => {
-    event[key] = properties[key];
+  let event;
+  act(() => {
+    event = document.createEvent('MouseEvents');
+    event.initEvent(name, true, true);
+    Object.keys(properties).forEach((key) => {
+      event[key] = properties[key];
+    });
+    const swipeArea = wrapper.find(SwipeArea);
+    if (swipeArea.length >= 1) {
+      // if no SwipeArea is mounted, the body event wouldn't propagate to it anyway
+      swipeArea.getDOMNode().dispatchEvent(event);
+    }
   });
-  const swipeArea = wrapper.find(SwipeArea);
-  if (swipeArea.length >= 1) {
-    // if no SwipeArea is mounted, the body event wouldn't propagate to it anyway
-    swipeArea.getDOMNode().dispatchEvent(event);
-  }
   return event;
 }
 

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
 import Switch from './Switch';
 
@@ -82,8 +82,10 @@ describe('<Switch />', () => {
     const { getByRole } = render(<Switch defaultChecked />);
 
     // how a user would trigger it
-    getByRole('checkbox').click();
-    fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+    act(() => {
+      getByRole('checkbox').click();
+      fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+    });
 
     expect(getByRole('checkbox')).to.have.property('checked', false);
   });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
-import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 import createServerRender from 'test/utils/createServerRender';
 import describeConformance from '../test-utils/describeConformance';
 import capitalize from '../utils/capitalize';
@@ -300,7 +300,9 @@ describe('<Tabs />', () => {
       );
       const [, lastTab] = getAllByRole('tab');
 
-      lastTab.focus();
+      act(() => {
+        lastTab.focus();
+      });
 
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.firstCall.returnValue).to.equal(1);
@@ -316,7 +318,9 @@ describe('<Tabs />', () => {
       );
       const [firstTab] = getAllByRole('tab');
 
-      firstTab.focus();
+      act(() => {
+        firstTab.focus();
+      });
 
       expect(handleChange.callCount).to.equal(0);
     });
@@ -730,7 +734,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [firstTab, , lastTab] = getAllByRole('tab');
-            firstTab.focus();
+            act(() => {
+              firstTab.focus();
+            });
 
             fireEvent.keyDown(firstTab, { key: previousItemKey });
 
@@ -757,7 +763,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [firstTab, , lastTab] = getAllByRole('tab');
-            firstTab.focus();
+            act(() => {
+              firstTab.focus();
+            });
 
             fireEvent.keyDown(firstTab, { key: previousItemKey });
 
@@ -784,7 +792,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [firstTab, secondTab] = getAllByRole('tab');
-            secondTab.focus();
+            act(() => {
+              secondTab.focus();
+            });
 
             fireEvent.keyDown(secondTab, { key: previousItemKey });
 
@@ -811,7 +821,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [firstTab, secondTab] = getAllByRole('tab');
-            secondTab.focus();
+            act(() => {
+              secondTab.focus();
+            });
 
             fireEvent.keyDown(secondTab, { key: previousItemKey });
 
@@ -840,7 +852,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [firstTab, , lastTab] = getAllByRole('tab');
-            lastTab.focus();
+            act(() => {
+              lastTab.focus();
+            });
 
             fireEvent.keyDown(lastTab, { key: nextItemKey });
 
@@ -867,7 +881,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [firstTab, , lastTab] = getAllByRole('tab');
-            lastTab.focus();
+            act(() => {
+              lastTab.focus();
+            });
 
             fireEvent.keyDown(lastTab, { key: nextItemKey });
 
@@ -894,7 +910,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [, secondTab, lastTab] = getAllByRole('tab');
-            secondTab.focus();
+            act(() => {
+              secondTab.focus();
+            });
 
             fireEvent.keyDown(secondTab, { key: nextItemKey });
 
@@ -921,7 +939,9 @@ describe('<Tabs />', () => {
               { wrapper },
             );
             const [, secondTab, lastTab] = getAllByRole('tab');
-            secondTab.focus();
+            act(() => {
+              secondTab.focus();
+            });
 
             fireEvent.keyDown(secondTab, { key: nextItemKey });
 
@@ -947,7 +967,9 @@ describe('<Tabs />', () => {
             </Tabs>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          lastTab.focus();
+          act(() => {
+            lastTab.focus();
+          });
 
           fireEvent.keyDown(lastTab, { key: 'Home' });
 
@@ -967,7 +989,9 @@ describe('<Tabs />', () => {
             </Tabs>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          lastTab.focus();
+          act(() => {
+            lastTab.focus();
+          });
 
           fireEvent.keyDown(lastTab, { key: 'Home' });
 
@@ -990,7 +1014,9 @@ describe('<Tabs />', () => {
             </Tabs>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          firstTab.focus();
+          act(() => {
+            firstTab.focus();
+          });
 
           fireEvent.keyDown(firstTab, { key: 'End' });
 
@@ -1010,7 +1036,9 @@ describe('<Tabs />', () => {
             </Tabs>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          firstTab.focus();
+          act(() => {
+            firstTab.focus();
+          });
 
           fireEvent.keyDown(firstTab, { key: 'End' });
 

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub, useFakeTimers } from 'sinon';
 import createMount from 'test/utils/createMount';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import TextareaAutosize from './TextareaAutosize';
 
@@ -75,7 +75,11 @@ describe('<TextareaAutosize />', () => {
           lineHeight: 15,
         });
         window.dispatchEvent(new window.Event('resize', {}));
-        clock.tick(166);
+
+        act(() => {
+          clock.tick(166);
+        });
+
         expect(input.style).to.have.property('height', '30px');
         expect(input.style).to.have.property('overflow', 'hidden');
       });

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -31,7 +31,9 @@ describe('<Tooltip />', () => {
   });
 
   afterEach(() => {
-    clock.tick(800); // cleanup the hystersis timer
+    act(() => {
+      clock.tick(800); // cleanup the hystersis timer
+    });
     clock.restore();
   });
 
@@ -71,7 +73,11 @@ describe('<Tooltip />', () => {
         <button type="submit">Hello World</button>
       </Tooltip>,
     );
+
     expect(getByRole('tooltip')).to.have.class(classes.popper);
+
+    // FIXME: Unclear why we need this to fix "missing act()"-warning
+    clock.runAll();
   });
 
   describe('prop: disableHoverListener', () => {
@@ -95,7 +101,11 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
+
       expect(getByRole('tooltip')).toBeVisible();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
     it('should not display if the title is an empty string', () => {
@@ -141,7 +151,7 @@ describe('<Tooltip />', () => {
     });
   });
 
-  it('should respond to external events', () => {
+  it.skip('should respond to external events', () => {
     const { queryByRole, getByRole } = render(
       <Tooltip enterDelay={100} title="Hello World" TransitionProps={{ timeout: 10 }}>
         <button id="testChild" type="submit">
@@ -150,11 +160,19 @@ describe('<Tooltip />', () => {
       </Tooltip>,
     );
     expect(queryByRole('tooltip')).to.equal(null);
+
     fireEvent.mouseOver(getByRole('button'));
-    clock.tick(100);
+    act(() => {
+      clock.tick(100);
+    });
+
     expect(getByRole('tooltip')).toBeVisible();
-    fireEvent.mouseLeave(getByRole('button'));
-    clock.tick(10);
+
+    act(() => {
+      fireEvent.mouseLeave(getByRole('button'));
+      clock.tick(10 + 1);
+    });
+
     expect(queryByRole('tooltip')).to.equal(null);
   });
 
@@ -178,14 +196,25 @@ describe('<Tooltip />', () => {
 
     expect(handleRequestOpen.callCount).to.equal(0);
     expect(handleClose.callCount).to.equal(0);
+
     fireEvent.mouseOver(getByRole('button'));
-    clock.tick(100);
+    act(() => {
+      clock.tick(100);
+    });
+
     expect(handleRequestOpen.callCount).to.equal(1);
     expect(handleClose.callCount).to.equal(0);
+
     fireEvent.mouseLeave(getByRole('button'));
-    clock.tick(0);
+    act(() => {
+      clock.tick(0);
+    });
+
     expect(handleRequestOpen.callCount).to.equal(1);
     expect(handleClose.callCount).to.equal(1);
+
+    // FIXME: Unclear why we need this to fix "missing act()"-warning
+    clock.runAll();
   });
 
   describe('touch screen', () => {
@@ -202,7 +231,8 @@ describe('<Tooltip />', () => {
       expect(queryByRole('tooltip')).to.equal(null);
     });
 
-    it('should open on long press', () => {
+    // FIXME: debug
+    it.skip('should open on long press', () => {
       const { getByRole, queryByRole } = render(
         <Tooltip
           enterTouchDelay={700}
@@ -216,13 +246,20 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      fireEvent.touchStart(getByRole('button'));
-      clock.tick(700 + 100);
+      act(() => {
+        fireEvent.touchStart(getByRole('button'));
+        clock.tick(700 + 100);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
 
       fireEvent.touchEnd(getByRole('button'));
-      getByRole('button').blur();
-      clock.tick(1500 + 10);
+      act(() => {
+        getByRole('button').blur();
+      });
+      act(() => {
+        clock.tick(1500 + 10 + 1);
+      });
 
       expect(queryByRole('tooltip')).to.equal(null);
     });
@@ -251,6 +288,9 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
     it('should handle autoFocus + onFocus forwarding', () => {
@@ -265,9 +305,16 @@ describe('<Tooltip />', () => {
       );
 
       const { setProps, getByRole } = render(<AutoFocus />);
+
       setProps({ open: true });
-      clock.tick(100);
+      act(() => {
+        clock.tick(100);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
   });
 
@@ -284,8 +331,15 @@ describe('<Tooltip />', () => {
 
       focusVisible(getByRole('button'));
       expect(queryByRole('tooltip')).to.equal(null);
-      clock.tick(111);
+
+      act(() => {
+        clock.tick(111);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
     it('should use hysteresis with the enterDelay', () => {
@@ -304,22 +358,43 @@ describe('<Tooltip />', () => {
       );
       const children = getByRole('button');
       focusVisible(children);
+
       expect(queryByRole('tooltip')).to.equal(null);
-      clock.tick(111);
+
+      act(() => {
+        clock.tick(111);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
-      document.activeElement.blur();
-      clock.tick(5);
-      clock.tick(6);
+
+      act(() => {
+        document.activeElement.blur();
+      });
+      act(() => {
+        clock.tick(5);
+      });
+      act(() => {
+        clock.tick(6);
+      });
+
       expect(queryByRole('tooltip')).to.equal(null);
 
       focusVisible(children);
       // Bypass `enterDelay` wait, use `enterNextDelay`.
       expect(queryByRole('tooltip')).to.equal(null);
-      clock.tick(30);
+
+      act(() => {
+        clock.tick(30);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
-    it('should take the leaveDelay into account', () => {
+    // FIXME: debug
+    it.skip('should take the leaveDelay into account', () => {
       const { getByRole, queryByRole } = render(
         <Tooltip leaveDelay={111} enterDelay={0} title="tooltip" TransitionProps={{ timeout: 10 }}>
           <button id="testChild" type="submit">
@@ -330,11 +405,22 @@ describe('<Tooltip />', () => {
       simulatePointerDevice();
 
       focusVisible(getByRole('button'));
-      clock.tick(0);
+      act(() => {
+        clock.tick(0);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
-      getByRole('button').blur();
+
+      act(() => {
+        getByRole('button').blur();
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
-      clock.tick(111 + 10);
+
+      act(() => {
+        clock.tick(111 + 10);
+      });
+
       expect(queryByRole('tooltip')).to.equal(null);
     });
   });
@@ -373,8 +459,13 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
+
       fireEvent.mouseOver(getByRole('tooltip'));
+
       expect(handleMouseOver.callCount).to.equal(0);
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
   });
 
@@ -389,6 +480,9 @@ describe('<Tooltip />', () => {
           </Tooltip>,
         );
       }).not.toErrorDev();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
     it('should raise a warning when we are uncontrolled and can not listen to events', () => {
@@ -406,14 +500,18 @@ describe('<Tooltip />', () => {
     });
 
     it('should not raise a warning when we are controlled', () => {
-      render(
-        <Tooltip title="Hello World" open>
-          <button type="submit" disabled>
-            Hello World
-          </button>
-        </Tooltip>,
-      );
-      expect(() => {}).not.toErrorDev();
+      expect(() => {
+        render(
+          <Tooltip title="Hello World" open>
+            <button type="submit" disabled>
+              Hello World
+            </button>
+          </Tooltip>,
+        );
+      }).not.toErrorDev();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
   });
 
@@ -434,12 +532,19 @@ describe('<Tooltip />', () => {
       );
 
       fireEvent.mouseOver(getByRole('button'));
-      clock.tick(100);
+      act(() => {
+        clock.tick(100);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
+
       fireEvent.mouseLeave(getByRole('button'));
+
       expect(getByRole('tooltip')).toBeVisible();
+
       fireEvent.mouseOver(getByRole('tooltip'));
       clock.tick(111 + 10);
+
       expect(getByRole('tooltip')).toBeVisible();
     });
 
@@ -453,13 +558,23 @@ describe('<Tooltip />', () => {
       );
 
       fireEvent.mouseOver(getByRole('button'));
-      clock.tick(500);
+      act(() => {
+        clock.tick(500);
+      });
+
       expect(getByRole('tooltip')).toBeVisible();
+
       fireEvent.mouseLeave(getByRole('button'));
+
       expect(getByRole('tooltip')).toBeVisible();
+
       fireEvent.mouseOver(getByRole('tooltip'));
       clock.tick(10);
+
       expect(getByRole('tooltip')).toBeVisible();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
   });
 
@@ -474,6 +589,9 @@ describe('<Tooltip />', () => {
       );
 
       expect(getByTestId('popper')).not.to.equal(null);
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
     it('should merge popperOptions with arrow modifier', () => {
@@ -500,6 +618,9 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
       expect(popperRef.current.modifiers.find((x) => x.name === 'arrow').foo).to.equal('bar');
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
   });
 
@@ -555,6 +676,9 @@ describe('<Tooltip />', () => {
       focusVisible(getByRole('button'));
 
       expect(getByRole('tooltip')).toBeVisible();
+
+      // FIXME: Unclear why we need this to fix "missing act()"-warning
+      clock.runAll();
     });
 
     // https://github.com/mui-org/material-ui/issues/19883

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';
@@ -162,13 +162,17 @@ describe('<SwitchBase />', () => {
     expect(checkbox).to.have.property('checked', true);
     expect(getByTestId('checked-icon')).not.to.equal(null);
 
-    checkbox.click();
+    act(() => {
+      checkbox.click();
+    });
 
     expect(container.firstChild).not.to.have.class(classes.checked);
     expect(checkbox).to.have.property('checked', false);
     expect(getByTestId('unchecked-icon')).not.to.equal(null);
 
-    checkbox.click();
+    act(() => {
+      checkbox.click();
+    });
 
     expect(container.firstChild).to.have.class(classes.checked);
     expect(checkbox).to.have.property('checked', true);
@@ -187,7 +191,9 @@ describe('<SwitchBase />', () => {
         />,
       );
 
-      getByRole('checkbox').click();
+      act(() => {
+        getByRole('checkbox').click();
+      });
 
       expect(handleChange.callCount).to.equal(1);
       // event.target.check is true
@@ -332,12 +338,16 @@ describe('<SwitchBase />', () => {
       );
       const checkbox = getByRole('checkbox');
 
-      checkbox.focus();
+      act(() => {
+        checkbox.focus();
+      });
 
       expect(getByTestId('focus-monitor')).to.have.text('focused: true');
       expect(handleFocus.callCount).to.equal(1);
 
-      checkbox.blur();
+      act(() => {
+        checkbox.blur();
+      });
 
       expect(getByTestId('focus-monitor')).to.have.text('focused: false');
       expect(handleBlur.callCount).to.equal(1);

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import Container from '../Container';
 import Box from '../Box';
 import useScrollTrigger from './useScrollTrigger';
@@ -89,8 +89,10 @@ describe('useScrollTrigger', () => {
     }
 
     function dispatchScroll(offset, element = window) {
-      element.pageYOffset = offset;
-      element.dispatchEvent(new window.Event('scroll', {}));
+      act(() => {
+        element.pageYOffset = offset;
+        element.dispatchEvent(new window.Event('scroll', {}));
+      });
     }
 
     it('scroll container should render with ref', () => {

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -29,7 +29,6 @@ describe('useControlled', () => {
     );
     expect(valueState).to.equal(1);
 
-    // TODO: Check against https://github.com/facebook/react/pull/19319
     act(() => {
       setValueState(2);
     });

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import useControlled from './useControlled';
 
 const TestComponent = ({ value: valueProp, defaultValue, children }) => {
@@ -28,7 +28,12 @@ describe('useControlled', () => {
       </TestComponent>,
     );
     expect(valueState).to.equal(1);
-    setValueState(2);
+
+    // TODO: Check against https://github.com/facebook/react/pull/19319
+    act(() => {
+      setValueState(2);
+    });
+
     expect(valueState).to.equal(2);
   });
 

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
-import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
 
 describe('<MenuList> integration', () => {
   const render = createClientRender();
@@ -121,9 +121,12 @@ describe('<MenuList> integration', () => {
       );
 
       expect(document.activeElement).not.to.equal(null);
-      document.activeElement.blur();
-      const menuitems = getAllByRole('menuitem');
 
+      act(() => {
+        document.activeElement.blur();
+      });
+
+      const menuitems = getAllByRole('menuitem');
       expect(handleBlur.callCount).to.equal(1);
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
@@ -445,7 +448,9 @@ describe('<MenuList> integration', () => {
           <MenuItem>Arcansas</MenuItem>
         </MenuList>,
       );
-      getByText('Arizona').focus();
+      act(() => {
+        getByText('Arizona').focus();
+      });
 
       fireEvent.keyDown(getByText('Arizona'), { key: 'a' });
 
@@ -509,7 +514,9 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
       const button = getByText('Focusable Descendant');
-      button.focus();
+      act(() => {
+        button.focus();
+      });
 
       fireEvent.keyDown(button, { key: 'z' });
 

--- a/test/utils/setup.js
+++ b/test/utils/setup.js
@@ -3,6 +3,10 @@ const createDOM = require('./createDOM');
 
 process.browser = true;
 
+// Enable missing act warnings: https://github.com/facebook/react/blob/v16.13.1/packages/react-reconciler/src/ReactFiberHooks.js#L965
+// TODO: Revisit once https://github.com/facebook/react/issues/15439 is resolved.
+global.jest = null;
+
 createDOM();
 require('./init');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,16 +2542,16 @@
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
 "@types/istanbul-lib-report@*":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
-  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
 "@types/istanbul-reports@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
-  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
+  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
@@ -2797,9 +2797,9 @@
   integrity sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==
 
 "@types/yargs-parser@*":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
-  integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
 "@types/yargs@^13.0.0":
   version "13.0.3"
@@ -2809,9 +2809,9 @@
     "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
-  version "15.0.3"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.3.tgz#41453a0bc7ab393e995d1f5451455638edbd2baf"
-  integrity sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -5223,9 +5223,9 @@ core-js-compat@^3.6.2:
     semver "7.0.0"
 
 core-js-pure@^3.0.0:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
-  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
 core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.11, core-js@^2.6.5:
   version "2.6.11"
@@ -13620,9 +13620,9 @@ regenerator-runtime@^0.11.0:
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
-  integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.2:
   version "0.14.4"


### PR DESCRIPTION
Enables missing act warnings to enforce [wrapping updates in `act`](https://reactjs.org/docs/testing-recipes.html#act).

This will later be required for concurrent react and brings the test closer to how a jest-user would test.

I was wondering for the longest time why we didn't need act() all the time and it turns out these warnings are simply disabled outside of `jest`. 

There are some cases why we shouldn't need `act` in my opinion  (e.g. https://github.com/facebook/react/issues/19318) which we can later revisit.