### PR TITLE
DO NOT MERGE [test] Don't run hysteresis timers

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -45,7 +45,6 @@ describe('<Tooltip />', () => {
   });
 
   afterEach(() => {
-    clock.tick(800); // cleanup the hystersis timer
     clock.restore();
   });
 


### PR DESCRIPTION
Sanity check for https://github.com/mui-org/material-ui/pull/21802#discussion_r455052686. The tick was introduced in https://github.com/mui-org/material-ui/pull/21039/files#diff-06b65cf0fa208283f73af0b1d34854b3R48 but it seems to not be important. @joshwooding Do you remember why you added it?