### PR TITLE
[Accordion] Fix IconButtonProps spreading logic

### DIFF
--- a/docs/pages/api-docs/accordion-summary.md
+++ b/docs/pages/api-docs/accordion-summary.md
@@ -31,7 +31,7 @@ The `MuiAccordionSummary` name can be used for providing [default props](/custom
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the accordion summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node</span> |  | The icon to display as the expand indicator. |
-| <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object</span> |  | Props applied to the `IconButton` element wrapping the expand icon. |
+| <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | Props applied to the `IconButton` element wrapping the expand icon. |
 
 The `ref` is forwarded to the root element.
 

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -71,7 +71,7 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
     classes,
     className,
     expandIcon,
-    IconButtonProps,
+    IconButtonProps = {},
     onBlur,
     onClick,
     onFocusVisible,
@@ -129,15 +129,19 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
       <div className={clsx(classes.content, { [classes.expanded]: expanded })}>{children}</div>
       {expandIcon && (
         <IconButton
-          className={clsx(classes.expandIcon, {
-            [classes.expanded]: expanded,
-          })}
           edge="end"
           component="div"
           tabIndex={null}
           role={null}
           aria-hidden
           {...IconButtonProps}
+          className={clsx(
+            classes.expandIcon,
+            {
+              [classes.expanded]: expanded,
+            },
+            IconButtonProps.className,
+          )}
         >
           {expandIcon}
         </IconButton>

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -56,6 +56,19 @@ describe('<AccordionSummary />', () => {
     expect(container.querySelector(`.${classes.expandIcon}`)).to.have.class(classes.expanded);
   });
 
+  it('when expanded adds both the expanded class and the className provided with `IconButtonProps` to the expandIcon', () => {
+    const iconButtonProps = { className: 'icon' };
+    const { container } = render(
+      <Accordion expanded TransitionComponent={({ children }) => children}>
+        <AccordionSummary expandIcon="expand" IconButtonProps={iconButtonProps} />
+      </Accordion>,
+    );
+
+    const expandIcon = container.querySelector(`.${classes.expandIcon}`);
+    expect(expandIcon).to.have.class(classes.expanded);
+    expect(expandIcon).to.have.class(iconButtonProps.className);
+  });
+
   it('should render with an inaccessible expand icon and have the expandIcon class', () => {
     const { container } = render(<AccordionSummary expandIcon={<div>Icon</div>} />);
 
@@ -97,6 +110,17 @@ describe('<AccordionSummary />', () => {
 
     expect(button).not.toHaveFocus();
     expect(button).not.to.have.class(classes.focused);
+  });
+
+  it('should fire onBlur when the button blurs', () => {
+    const handleBlur = spy();
+    const { getByRole } = render(<AccordionSummary onBlur={handleBlur} />);
+
+    const button = getByRole('button');
+    button.focus();
+    button.blur();
+
+    expect(handleBlur.callCount).to.equal(1);
   });
 
   it('should fire onClick callbacks', () => {

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -115,11 +115,9 @@ describe('<AccordionSummary />', () => {
     const handleBlur = spy();
     const { getByRole } = render(<AccordionSummary onBlur={handleBlur} />);
 
-    act(() => {
-      const button = getByRole('button');
-      button.focus();
-      button.blur();
-    });
+    const button = getByRole('button');
+    button.focus();
+    button.blur();
 
     expect(handleBlur.callCount).to.equal(1);
   });
@@ -128,9 +126,7 @@ describe('<AccordionSummary />', () => {
     const handleClick = spy();
     const { getByRole } = render(<AccordionSummary onClick={handleClick} />);
 
-    act(() => {
-      getByRole('button').click();
-    });
+    getByRole('button').click();
 
     expect(handleClick.callCount).to.equal(1);
   });

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -115,9 +115,11 @@ describe('<AccordionSummary />', () => {
     const handleBlur = spy();
     const { getByRole } = render(<AccordionSummary onBlur={handleBlur} />);
 
-    const button = getByRole('button');
-    button.focus();
-    button.blur();
+    act(() => {
+      const button = getByRole('button');
+      button.focus();
+      button.blur();
+    });
 
     expect(handleBlur.callCount).to.equal(1);
   });

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -15,7 +15,6 @@ describe('<AccordionSummary />', () => {
   const render = createClientRender();
 
   before(() => {
-    // requires mocking the TransitionComponent of `Accordion`
     classes = getClasses(<AccordionSummary />);
   });
 
@@ -35,7 +34,7 @@ describe('<AccordionSummary />', () => {
 
   it('when disabled should have disabled class', () => {
     const { getByRole } = render(
-      <Accordion disabled TransitionComponent={({ children }) => children}>
+      <Accordion disabled>
         <AccordionSummary />
       </Accordion>,
     );
@@ -45,7 +44,7 @@ describe('<AccordionSummary />', () => {
 
   it('when expanded adds the expanded class to the button and expandIcon', () => {
     const { container, getByRole } = render(
-      <Accordion expanded TransitionComponent={({ children }) => children}>
+      <Accordion expanded>
         <AccordionSummary expandIcon="expand" />
       </Accordion>,
     );
@@ -59,7 +58,7 @@ describe('<AccordionSummary />', () => {
   it('when expanded adds both the expanded class and the className provided with `IconButtonProps` to the expandIcon', () => {
     const iconButtonProps = { className: 'icon' };
     const { container } = render(
-      <Accordion expanded TransitionComponent={({ children }) => children}>
+      <Accordion expanded>
         <AccordionSummary expandIcon="expand" IconButtonProps={iconButtonProps} />
       </Accordion>,
     );
@@ -78,7 +77,7 @@ describe('<AccordionSummary />', () => {
   });
 
   it('focusing adds the `focused` class if focused visible', () => {
-    // TODO: Rename `focused` -> `focus-visible`
+    // TODO v5: Rename `focused` -> `focus-visible`
     // `focused` is a global state which is applied on focus
     // only here do we constrain it to focus-visible. THe name is also not consistent
     // with :focus
@@ -116,9 +115,11 @@ describe('<AccordionSummary />', () => {
     const handleBlur = spy();
     const { getByRole } = render(<AccordionSummary onBlur={handleBlur} />);
 
-    const button = getByRole('button');
-    button.focus();
-    button.blur();
+    act(() => {
+      const button = getByRole('button');
+      button.focus();
+      button.blur();
+    });
 
     expect(handleBlur.callCount).to.equal(1);
   });
@@ -127,7 +128,9 @@ describe('<AccordionSummary />', () => {
     const handleClick = spy();
     const { getByRole } = render(<AccordionSummary onClick={handleClick} />);
 
-    getByRole('button').click();
+    act(() => {
+      getByRole('button').click();
+    });
 
     expect(handleClick.callCount).to.equal(1);
   });
@@ -135,7 +138,7 @@ describe('<AccordionSummary />', () => {
   it('fires onChange of the Accordion if clicked', () => {
     const handleChange = spy();
     const { getByRole } = render(
-      <Accordion onChange={handleChange} TransitionComponent={({ children }) => children}>
+      <Accordion onChange={handleChange}>
         <AccordionSummary />
       </Accordion>,
     );


### PR DESCRIPTION
The `expanded` class was being replaced when `IconButtonProps` was provided with a `className`.  To fix this, we revisit the application of `className` to `IconButton`.  We will continue to conditionally apply `expanded`, but now we'll combine it with `className` from `IconButtonProps`, which now defaults to an empty object.

Added `onBlur` test to improve coverage of this component.

Regenerated docs.

Closes #21744 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
