### PR TITLE
 [test] Unify import to `test/utils

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,14 @@ module.exports = {
       rules: {
         // does not work with wildcard imports. Mistakes will throw at runtime anyway
         'import/named': 'off',
+        'no-restricted-imports': [
+          'error',
+          {
+            // Use named import from `test/utils` instead.
+            // The other files are private.
+            patterns: ['test/utils/*'],
+          },
+        ],
 
         'material-ui/disallow-active-element-as-key-event-target': 'error',
 

--- a/packages/eslint-plugin-material-ui/src/rules/disallow-active-elements-as-key-event-target.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/disallow-active-elements-as-key-event-target.test.js
@@ -7,14 +7,14 @@ const ruleTester = new eslint.RuleTester({
 });
 ruleTester.run('disallow-active-element-as-key-event-target', rule, {
   valid: [
-    "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyDown(getByRole('button'), { key: ' ' })",
-    "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyDown(document.body, { key: 'Esc' })",
-    "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyUp(document.body, { key: 'Tab' })",
+    "import { fireEvent } from 'test/utils';\nfireEvent.keyDown(getByRole('button'), { key: ' ' })",
+    "import { fireEvent } from 'test/utils';\nfireEvent.keyDown(document.body, { key: 'Esc' })",
+    "import { fireEvent } from 'test/utils';\nfireEvent.keyUp(document.body, { key: 'Tab' })",
   ],
   invalid: [
     {
       code:
-        "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyUp(document.activeElement, { key: 'LeftArrow' })",
+        "import { fireEvent } from 'test/utils';\nfireEvent.keyUp(document.activeElement, { key: 'LeftArrow' })",
       errors: [
         {
           message:
@@ -25,7 +25,7 @@ ruleTester.run('disallow-active-element-as-key-event-target', rule, {
     },
     {
       code:
-        "import { fireEvent } from 'test/utils/createClientRender';\nfireEvent.keyDown(document.activeElement, { key: 'DownArrow' })",
+        "import { fireEvent } from 'test/utils';\nfireEvent.keyDown(document.activeElement, { key: 'DownArrow' })",
       errors: [
         {
           message:

--- a/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test/expected.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import {
   withStyles,
   MenuItem,

--- a/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test/expected.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
   withStyles,
   MenuItem,

--- a/packages/material-ui-lab/src/Alert/Alert.test.js
+++ b/packages/material-ui-lab/src/Alert/Alert.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Paper from '@material-ui/core/Paper';
 import Alert from './Alert';
 

--- a/packages/material-ui-lab/src/Alert/Alert.test.js
+++ b/packages/material-ui-lab/src/Alert/Alert.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Paper from '@material-ui/core/Paper';
 import Alert from './Alert';
 

--- a/packages/material-ui-lab/src/AlertTitle/AlertTitle.test.js
+++ b/packages/material-ui-lab/src/AlertTitle/AlertTitle.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import AlertTitle from './AlertTitle';
 
 describe('<AlertTitle />', () => {

--- a/packages/material-ui-lab/src/AlertTitle/AlertTitle.test.js
+++ b/packages/material-ui-lab/src/AlertTitle/AlertTitle.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import AlertTitle from './AlertTitle';
 
 describe('<AlertTitle />', () => {

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -9,9 +9,7 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-
 import { spy } from 'sinon';
-
 import TextField from '@material-ui/core/TextField';
 import Chip from '@material-ui/core/Chip';
 import { createFilterOptions } from '../useAutocomplete/useAutocomplete';

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1,10 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+  screen,
+} from 'test/utils';
+
 import { spy } from 'sinon';
-import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+
 import TextField from '@material-ui/core/TextField';
 import Chip from '@material-ui/core/Chip';
 import { createFilterOptions } from '../useAutocomplete/useAutocomplete';

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
-
 import Avatar from '@material-ui/core/Avatar';
 import AvatarGroup from './AvatarGroup';
 

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
+
 import Avatar from '@material-ui/core/Avatar';
 import AvatarGroup from './AvatarGroup';
 

--- a/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Button from '@material-ui/core/Button';
 import LoadingButton from './LoadingButton';
 

--- a/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Button from '@material-ui/core/Button';
 import LoadingButton from './LoadingButton';
 

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
+
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import Pagination from './Pagination';
 

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
-
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import Pagination from './Pagination';
 

--- a/packages/material-ui-lab/src/PaginationItem/PaginationItem.test.js
+++ b/packages/material-ui-lab/src/PaginationItem/PaginationItem.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
-
 import PaginationItem from './PaginationItem';
 
 describe('<PaginationItem />', () => {

--- a/packages/material-ui-lab/src/PaginationItem/PaginationItem.test.js
+++ b/packages/material-ui-lab/src/PaginationItem/PaginationItem.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
+
 import PaginationItem from './PaginationItem';
 
 describe('<PaginationItem />', () => {

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub, spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import Rating from './Rating';
 
 describe('<Rating />', () => {

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -8,7 +8,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import Rating from './Rating';
 
 describe('<Rating />', () => {

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
+
 import Skeleton from './Skeleton';
 
 describe('<Skeleton />', () => {

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
-
 import Skeleton from './Skeleton';
 
 describe('<Skeleton />', () => {

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -8,7 +8,6 @@ import {
   createMount,
   describeConformance,
 } from 'test/utils';
-
 import Icon from '@material-ui/core/Icon';
 import Fab from '@material-ui/core/Fab';
 import SpeedDial from './SpeedDial';

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { findOutermostIntrinsic, getClasses, wrapsIntrinsicElement } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  findOutermostIntrinsic,
+  getClasses,
+  wrapsIntrinsicElement,
+  createMount,
+  describeConformance,
+} from 'test/utils';
+
 import Icon from '@material-ui/core/Icon';
 import Fab from '@material-ui/core/Fab';
 import SpeedDial from './SpeedDial';

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,13 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
 import { useFakeTimers } from 'sinon';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
+
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
 import Fab from '@material-ui/core/Fab';
-import describeConformance from 'test/utils/describeConformance';
+
 import SpeedDialAction from './SpeedDialAction';
 
 describe('<SpeedDialAction />', () => {

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -9,11 +9,9 @@ import {
   fireEvent,
 } from 'test/utils';
 import { useFakeTimers } from 'sinon';
-
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
 import Fab from '@material-ui/core/Fab';
-
 import SpeedDialAction from './SpeedDialAction';
 
 describe('<SpeedDialAction />', () => {

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, findOutermostIntrinsic } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { getClasses, findOutermostIntrinsic, createMount, describeConformance } from 'test/utils';
+
 import Icon from '@material-ui/core/Icon';
-import describeConformance from 'test/utils/describeConformance';
+
 import SpeedDialIcon from './SpeedDialIcon';
 
 describe('<SpeedDialIcon />', () => {

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, findOutermostIntrinsic, createMount, describeConformance } from 'test/utils';
-
 import Icon from '@material-ui/core/Icon';
-
 import SpeedDialIcon from './SpeedDialIcon';
 
 describe('<SpeedDialIcon />', () => {

--- a/packages/material-ui-lab/src/TabContext/TabContext.test.js
+++ b/packages/material-ui-lab/src/TabContext/TabContext.test.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils';
 import TabContext, { getPanelId, getTabId, useTabContext } from './TabContext';
 
 describe('<TabContext />', () => {

--- a/packages/material-ui-lab/src/TabList/TabList.test.js
+++ b/packages/material-ui-lab/src/TabList/TabList.test.js
@@ -1,10 +1,8 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import TabList from './TabList';

--- a/packages/material-ui-lab/src/TabList/TabList.test.js
+++ b/packages/material-ui-lab/src/TabList/TabList.test.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
-
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import TabList from './TabList';

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.test.js
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.test.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import TabPanel from './TabPanel';
 import TabContext from '../TabContext';
 

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.test.js
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.test.js
@@ -1,10 +1,8 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import TabPanel from './TabPanel';
 import TabContext from '../TabContext';
 

--- a/packages/material-ui-lab/src/Timeline/Timeline.test.js
+++ b/packages/material-ui-lab/src/Timeline/Timeline.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Timeline from './Timeline';
 
 describe('<Timeline />', () => {

--- a/packages/material-ui-lab/src/Timeline/Timeline.test.js
+++ b/packages/material-ui-lab/src/Timeline/Timeline.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Timeline from './Timeline';
 
 describe('<Timeline />', () => {

--- a/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.test.js
+++ b/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import TimelineConnector from './TimelineConnector';
 
 describe('<TimelineConnector />', () => {

--- a/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.test.js
+++ b/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import TimelineConnector from './TimelineConnector';
 
 describe('<TimelineConnector />', () => {

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Typography from '@material-ui/core/Typography';
 import TimelineContent from './TimelineContent';
 

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Typography from '@material-ui/core/Typography';
 import TimelineContent from './TimelineContent';
 

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import TimelineDot from './TimelineDot';
 
 describe('<TimelineDot />', () => {

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import TimelineDot from './TimelineDot';
 
 describe('<TimelineDot />', () => {

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import TimelineItem from './TimelineItem';
 
 describe('<TimelineItem />', () => {

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import TimelineItem from './TimelineItem';
 
 describe('<TimelineItem />', () => {

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Typography from '@material-ui/core/Typography';
 import TimelineOppositeContent from './TimelineOppositeContent';
 

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Typography from '@material-ui/core/Typography';
 import TimelineOppositeContent from './TimelineOppositeContent';
 

--- a/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.test.js
+++ b/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import TimelineSeparator from './TimelineSeparator';
 
 describe('<TimelineSeparator />', () => {

--- a/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.test.js
+++ b/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import TimelineSeparator from './TimelineSeparator';
 
 describe('<TimelineSeparator />', () => {

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -8,7 +8,6 @@ import {
   describeConformance,
   createServerRender,
 } from 'test/utils';
-
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ToggleButton from './ToggleButton';
 

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createClientRender } from 'test/utils/createClientRender';
-import createServerRender from 'test/utils/createServerRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  createClientRender,
+  getClasses,
+  createMount,
+  describeConformance,
+  createServerRender,
+} from 'test/utils';
+
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ToggleButton from './ToggleButton';
 

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { StandardProps } from '@material-ui/core';
 
 export interface ToggleButtonGroupProps

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
-
 import ToggleButtonGroup from './ToggleButtonGroup';
 import ToggleButton from '../ToggleButton';
 

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
+
 import ToggleButtonGroup from './ToggleButtonGroup';
 import ToggleButton from '../ToggleButton';
 

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -11,7 +11,6 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-
 import TreeItem from './TreeItem';
 import TreeView from '../TreeView';
 

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
 import {
+  getClasses,
+  createMount,
+  describeConformance,
   act,
   createEvent,
   createClientRender,
   fireEvent,
   screen,
-} from 'test/utils/createClientRender';
+} from 'test/utils';
+
 import TreeItem from './TreeItem';
 import TreeView from '../TreeView';
 

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
-import { ErrorBoundary } from 'test/utils/components';
-import describeConformance from 'test/utils/describeConformance';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import {
+  createClientRender,
+  ErrorBoundary,
+  fireEvent,
+  screen,
+  describeConformance,
+  getClasses,
+  createMount,
+} from 'test/utils';
 import TreeView from './TreeView';
 import TreeItem from '../TreeItem';
 

--- a/packages/material-ui-lab/test/integration/Tabs.test.js
+++ b/packages/material-ui-lab/test/integration/Tabs.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils';
 import Tab from '@material-ui/core/Tab';
 import TabContext from '@material-ui/lab/TabContext';
 import TabList from '@material-ui/lab/TabList';

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
 import { create, SheetsRegistry } from 'jss';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import StylesProvider, { StylesContext } from './StylesProvider';
 import makeStyles from '../makeStyles';
 import createGenerateClassName from '../createGenerateClassName';

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils';
 import makeStyles from '../makeStyles';
 import useTheme from '../useTheme';
 import ThemeProvider from './ThemeProvider';

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { SheetsRegistry } from 'jss';
 import { act } from 'react-dom/test-utils';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import { createMuiTheme } from '@material-ui/core/styles';
 import createGenerateClassName from '../createGenerateClassName';
 import makeStyles from './makeStyles';

--- a/packages/material-ui-styles/src/styled/styled.test.js
+++ b/packages/material-ui-styles/src/styled/styled.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { SheetsRegistry } from 'jss';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import { createGenerateClassName } from '@material-ui/styles';
 import styled from './styled';
 import StylesProvider from '../StylesProvider';

--- a/packages/material-ui-styles/src/useTheme/useTheme.test.js
+++ b/packages/material-ui-styles/src/useTheme/useTheme.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import useTheme from './useTheme';
 import ThemeProvider from '../ThemeProvider';
 

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { stub } from 'sinon';
 import { SheetsRegistry } from 'jss';
 import { Input } from '@material-ui/core';
-import { createClientRender, screen } from 'test/utils/createClientRender';
+import { createClientRender, screen } from 'test/utils';
 import { isMuiElement } from '@material-ui/core/utils';
 import { createMuiTheme } from '@material-ui/core/styles';
 import StylesProvider from '../StylesProvider';

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import { Input } from '@material-ui/core';
 import { isMuiElement } from '@material-ui/core/utils';
 import PropTypes from 'prop-types';

--- a/packages/material-ui/src/AccordionActions/AccordionActions.test.js
+++ b/packages/material-ui/src/AccordionActions/AccordionActions.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import AccordionActions from './AccordionActions';
 
 describe('<AccordionActions />', () => {

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import AccordionDetails from './AccordionDetails';
 
 describe('<AccordionDetails />', () => {

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import AccordionDetails from './AccordionDetails';
 
 describe('<AccordionDetails />', () => {

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import Accordion from '../Accordion';
 import AccordionSummary from './AccordionSummary';
 import ButtonBase from '../ButtonBase';

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -9,7 +9,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import Accordion from '../Accordion';
 import AccordionSummary from './AccordionSummary';
 import ButtonBase from '../ButtonBase';

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import AppBar from './AppBar';
 import Paper from '../Paper';
 

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import AppBar from './AppBar';
 import Paper from '../Paper';
 

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -7,9 +7,7 @@ import {
   createMount,
   describeConformance,
 } from 'test/utils';
-
 import { spy } from 'sinon';
-
 import CancelIcon from '../internal/svg-icons/Cancel';
 import Avatar from './Avatar';
 

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import {
+  createClientRender,
+  fireEvent,
+  getClasses,
+  createMount,
+  describeConformance,
+} from 'test/utils';
+
 import { spy } from 'sinon';
-import describeConformance from 'test/utils/describeConformance';
+
 import CancelIcon from '../internal/svg-icons/Cancel';
 import Avatar from './Avatar';
 

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Backdrop from './Backdrop';
 import Fade from '../Fade';
 

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Backdrop from './Backdrop';
 import Fade from '../Fade';
 

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Badge from './Badge';
 
 function findBadge(container) {

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Badge from './Badge';
 
 function findBadge(container) {

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -8,7 +8,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import BottomNavigationAction from '../BottomNavigationAction';
 import Icon from '../Icon';
 import BottomNavigation from './BottomNavigation';

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import BottomNavigationAction from '../BottomNavigationAction';
 import Icon from '../Icon';
 import BottomNavigation from './BottomNavigation';

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender, within } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  createClientRender,
+  within,
+} from 'test/utils';
+
 import ButtonBase from '../ButtonBase';
 import BottomNavigationAction from './BottomNavigationAction';
 

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -8,7 +8,6 @@ import {
   createClientRender,
   within,
 } from 'test/utils';
-
 import ButtonBase from '../ButtonBase';
 import BottomNavigationAction from './BottomNavigationAction';
 

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createClientRender, createMount, describeConformance } from 'test/utils';
+
 import Box from './Box';
 
 describe('<Box />', () => {

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, createMount, describeConformance } from 'test/utils';
-
 import Box from './Box';
 
 describe('<Box />', () => {

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import { act, fireEvent, createClientRender } from 'test/utils/createClientRender';
+import { getClasses, act, fireEvent, createClientRender } from 'test/utils';
+
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';
 
 describe('<BreadcrumbCollapsed />', () => {

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, act, fireEvent, createClientRender } from 'test/utils';
-
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';
 
 describe('<BreadcrumbCollapsed />', () => {

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -8,7 +8,6 @@ import {
   createClientRender,
   screen,
 } from 'test/utils';
-
 import Breadcrumbs from './Breadcrumbs';
 
 describe('<Breadcrumbs />', () => {

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, screen } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  screen,
+} from 'test/utils';
+
 import Breadcrumbs from './Breadcrumbs';
 
 describe('<Breadcrumbs />', () => {

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -9,7 +9,6 @@ import {
   fireEvent,
   createServerRender,
 } from 'test/utils';
-
 import Button from './Button';
 import ButtonBase from '../ButtonBase';
 

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import createServerRender from 'test/utils/createServerRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+  createServerRender,
+} from 'test/utils';
+
 import Button from './Button';
 import ButtonBase from '../ButtonBase';
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -2,11 +2,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import * as PropTypes from 'prop-types';
-import describeConformance from 'test/utils/describeConformance';
+
 import TouchRipple from './TouchRipple';
 import ButtonBase from './ButtonBase';
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -10,9 +10,7 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import * as PropTypes from 'prop-types';
-
 import TouchRipple from './TouchRipple';
 import ButtonBase from './ButtonBase';
 

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { getClasses, createClientRender } from 'test/utils';
-
 import TouchRipple from './TouchRipple';
 import Ripple from './Ripple';
 

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createClientRender } from 'test/utils';
+
 import TouchRipple from './TouchRipple';
 import Ripple from './Ripple';
 

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
 const cb = () => {};

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
-
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
 const cb = () => {};

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Button from '../Button';
 import ButtonGroup from './ButtonGroup';
 

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Button from '../Button';
 import ButtonGroup from './ButtonGroup';
 

--- a/packages/material-ui/src/Card/Card.test.js
+++ b/packages/material-ui/src/Card/Card.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Card from './Card';
 import Paper from '../Paper';
 

--- a/packages/material-ui/src/Card/Card.test.js
+++ b/packages/material-ui/src/Card/Card.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Card from './Card';
 import Paper from '../Paper';
 

--- a/packages/material-ui/src/CardActionArea/CardActionArea.test.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import ButtonBase from '../ButtonBase';
 import CardActionArea from './CardActionArea';
 

--- a/packages/material-ui/src/CardActionArea/CardActionArea.test.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import ButtonBase from '../ButtonBase';
 import CardActionArea from './CardActionArea';
 

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import CardActions from './CardActions';
 
 describe('<CardActions />', () => {

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import CardActions from './CardActions';
 
 describe('<CardActions />', () => {

--- a/packages/material-ui/src/CardContent/CardContent.test.js
+++ b/packages/material-ui/src/CardContent/CardContent.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import CardContent from './CardContent';
 
 describe('<CardContent />', () => {

--- a/packages/material-ui/src/CardContent/CardContent.test.js
+++ b/packages/material-ui/src/CardContent/CardContent.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import CardContent from './CardContent';
 
 describe('<CardContent />', () => {

--- a/packages/material-ui/src/CardHeader/CardHeader.test.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import CardHeader from './CardHeader';
 import Typography from '../Typography';
 

--- a/packages/material-ui/src/CardHeader/CardHeader.test.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import CardHeader from './CardHeader';
 import Typography from '../Typography';
 

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import CardMedia from './CardMedia';
 
 describe('<CardMedia />', () => {

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import CardMedia from './CardMedia';
 
 describe('<CardMedia />', () => {

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+
 import Checkbox from './Checkbox';
 import FormControl from '../FormControl';
 import IconButton from '../IconButton';

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
-
 import Checkbox from './Checkbox';
 import FormControl from '../FormControl';
 import IconButton from '../IconButton';

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -9,7 +9,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import CheckBox from '../internal/svg-icons/CheckBox';
 import Avatar from '../Avatar';
 import Chip from './Chip';

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import CheckBox from '../internal/svg-icons/CheckBox';
 import Avatar from '../Avatar';
 import Chip from './Chip';

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
-
 import CircularProgress from './CircularProgress';
 
 describe('<CircularProgress />', () => {

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+
 import CircularProgress from './CircularProgress';
 
 describe('<CircularProgress />', () => {

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils';
 import Portal from '../Portal';
 import ClickAwayListener from './ClickAwayListener';
 

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -2,10 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
-
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
-
 import Collapse from './Collapse';
 
 describe('<Collapse />', () => {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createClientRender } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
-import describeConformance from 'test/utils/describeConformance';
+
 import Collapse from './Collapse';
 
 describe('<Collapse />', () => {

--- a/packages/material-ui/src/Container/Container.test.js
+++ b/packages/material-ui/src/Container/Container.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { findOutermostIntrinsic, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { findOutermostIntrinsic, getClasses, createMount, describeConformance } from 'test/utils';
+
 import Container from './Container';
 
 describe('<Container />', () => {

--- a/packages/material-ui/src/Container/Container.test.js
+++ b/packages/material-ui/src/Container/Container.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { findOutermostIntrinsic, getClasses, createMount, describeConformance } from 'test/utils';
-
 import Container from './Container';
 
 describe('<Container />', () => {

--- a/packages/material-ui/src/CssBaseline/CssBaseline.test.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import CssBaseline from './CssBaseline';
 
 describe('<CssBaseline />', () => {

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import Modal from '../Modal';
 import Dialog from './Dialog';
 

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -9,7 +9,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import Modal from '../Modal';
 import Dialog from './Dialog';
 

--- a/packages/material-ui/src/DialogActions/DialogActions.test.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import DialogActions from './DialogActions';
 
 describe('<DialogActions />', () => {

--- a/packages/material-ui/src/DialogActions/DialogActions.test.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import DialogActions from './DialogActions';
 
 describe('<DialogActions />', () => {

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import DialogContent from './DialogContent';
 
 describe('<DialogContent />', () => {

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import DialogContent from './DialogContent';
 
 describe('<DialogContent />', () => {

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import describeConformance from 'test/utils/describeConformance';
-import createMount from 'test/utils/createMount';
+import { createShallow, getClasses, describeConformance, createMount } from 'test/utils';
+
 import DialogContentText from './DialogContentText';
 import Typography from '../Typography';
 

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, describeConformance, createMount } from 'test/utils';
-
 import DialogContentText from './DialogContentText';
 import Typography from '../Typography';
 

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import DialogTitle from './DialogTitle';
 
 describe('<DialogTitle />', () => {

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import DialogTitle from './DialogTitle';
 
 describe('<DialogTitle />', () => {

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import Divider from './Divider';
 
 describe('<Divider />', () => {

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import Divider from './Divider';
 
 describe('<Divider />', () => {

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { findOutermostIntrinsic, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import {
+  findOutermostIntrinsic,
+  getClasses,
+  createMount,
+  createClientRender,
+  describeConformance,
+} from 'test/utils';
+
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+
 import Slide from '../Slide';
 import Paper from '../Paper';
 import Modal from '../Modal';

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -7,9 +7,7 @@ import {
   createClientRender,
   describeConformance,
 } from 'test/utils';
-
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-
 import Slide from '../Slide';
 import Paper from '../Paper';
 import Modal from '../Modal';

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import createServerRender from 'test/utils/createServerRender';
+import {
+  getClasses,
+  describeConformance,
+  createClientRender,
+  createMount,
+  createServerRender,
+} from 'test/utils';
+
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -7,7 +7,6 @@ import {
   createMount,
   createServerRender,
 } from 'test/utils';
-
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createMount, describeConformance } from 'test/utils';
+
 import { Transition } from 'react-transition-group';
 import Fade from './Fade';
 

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from 'test/utils';
-
 import { Transition } from 'react-transition-group';
 import Fade from './Fade';
 

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import FilledInput from './FilledInput';
 import InputBase from '../InputBase';
 

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import FilledInput from './FilledInput';
 import InputBase from '../InputBase';
 

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+
 import Input from '../Input';
 import Select from '../Select';
 import FormControl from './FormControl';

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
-
 import Input from '../Input';
 import Select from '../Select';
 import FormControl from './FormControl';

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Checkbox from '../Checkbox';
 import FormControlLabel from './FormControlLabel';
 import FormControl from '../FormControl';

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Checkbox from '../Checkbox';
 import FormControlLabel from './FormControlLabel';
 import FormControl from '../FormControl';

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import FormGroup from './FormGroup';
 
 describe('<FormGroup />', () => {

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import FormGroup from './FormGroup';
 
 describe('<FormGroup />', () => {

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import FormHelperText from './FormHelperText';
 import FormControl from '../FormControl';
 

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import FormHelperText from './FormHelperText';
 import FormControl from '../FormControl';
 

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+
 import FormLabel from './FormLabel';
 import FormControl, { useFormControl } from '../FormControl';
 

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
-
 import FormLabel from './FormLabel';
 import FormControl, { useFormControl } from '../FormControl';
 

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import { createMuiTheme } from '@material-ui/core/styles';
-import describeConformance from 'test/utils/describeConformance';
+
 import Grid, { styles } from './Grid';
 
 describe('<Grid />', () => {

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import { createMuiTheme } from '@material-ui/core/styles';
-
 import Grid, { styles } from './Grid';
 
 describe('<Grid />', () => {

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import GridList from './GridList';
 
 const tilesData = [

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import GridList from './GridList';
 
 const tilesData = [

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import GridListTile from './GridListTile';
 
 describe('<GridListTile />', () => {

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import GridListTile from './GridListTile';
 
 describe('<GridListTile />', () => {

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import GridListTileBar from './GridListTileBar';
 
 describe('<GridListTileBar />', () => {

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import GridListTileBar from './GridListTileBar';
 
 describe('<GridListTileBar />', () => {

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 // use act from test/utils/createClientRender once we drop createMount from this test
-import createMount from 'test/utils/createMount';
+import { createMount, describeConformance } from 'test/utils';
 import { act } from 'react-dom/test-utils';
-import describeConformance from 'test/utils/describeConformance';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Grow from './Grow';

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount } from 'test/utils';
-
 import HiddenCss from './HiddenCss';
 import { createMuiTheme, MuiThemeProvider } from '../styles';
 

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { createShallow, getClasses, createMount } from 'test/utils';
+
 import HiddenCss from './HiddenCss';
 import { createMuiTheme, MuiThemeProvider } from '../styles';
 

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import Icon from './Icon';
 
 describe('<Icon />', () => {

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import Icon from './Icon';
 
 describe('<Icon />', () => {

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Icon from '../Icon';
 import ButtonBase from '../ButtonBase';
 import IconButton from './IconButton';

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Icon from '../Icon';
 import ButtonBase from '../ButtonBase';
 import IconButton from './IconButton';

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Input from './Input';
 import InputBase from '../InputBase';
 

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Input from './Input';
 import InputBase from '../InputBase';
 

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Typography from '../Typography';
 import InputAdornment from './InputAdornment';
 import TextField from '../TextField';

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Typography from '../Typography';
 import InputAdornment from './InputAdornment';
 import TextField from '../TextField';

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -2,10 +2,15 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import FormControl, { useFormControl } from '../FormControl';
 import InputAdornment from '../InputAdornment';
 import TextareaAutosize from '../TextareaAutosize';

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -10,7 +10,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import FormControl, { useFormControl } from '../FormControl';
 import InputAdornment from '../InputAdornment';
 import TextareaAutosize from '../TextareaAutosize';

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+
 import FormControl from '../FormControl';
 import Input from '../Input';
 import InputLabel from './InputLabel';

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
-
 import FormControl from '../FormControl';
 import Input from '../Input';
 import InputLabel from './InputLabel';

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import { createClientRender, screen } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  createClientRender,
+  screen,
+} from 'test/utils';
+
 import LinearProgress from './LinearProgress';
 
 describe('<LinearProgress />', () => {

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -7,7 +7,6 @@ import {
   createClientRender,
   screen,
 } from 'test/utils';
-
 import LinearProgress from './LinearProgress';
 
 describe('<LinearProgress />', () => {

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance, act } from 'test/utils';
+
 import Link from './Link';
 import Typography from '../Typography';
 

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, getClasses, createMount, describeConformance, act } from 'test/utils';
-
 import Link from './Link';
 import Typography from '../Typography';
 

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { findOutermostIntrinsic, getClasses, createMount, describeConformance } from 'test/utils';
-
 import ListSubheader from '../ListSubheader';
 import List from './List';
 import ListItem from '../ListItem';

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { findOutermostIntrinsic, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { findOutermostIntrinsic, getClasses, createMount, describeConformance } from 'test/utils';
+
 import ListSubheader from '../ListSubheader';
 import List from './List';
 import ListItem from '../ListItem';

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -10,7 +10,6 @@ import {
   fireEvent,
   queries,
 } from 'test/utils';
-
 import ListItemText from '../ListItemText';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import ListItem from './ListItem';

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent, queries } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+  queries,
+} from 'test/utils';
+
 import ListItemText from '../ListItemText';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import ListItem from './ListItem';

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import ListItemAvatar from './ListItemAvatar';
 
 describe('<ListItemAvatar />', () => {

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import ListItemAvatar from './ListItemAvatar';
 
 describe('<ListItemAvatar />', () => {

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import ListItemIcon from './ListItemIcon';
 
 describe('<ListItemIcon />', () => {

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import ListItemIcon from './ListItemIcon';
 
 describe('<ListItemIcon />', () => {

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import ListItemSecondaryAction from './ListItemSecondaryAction';
 import ListItem from '../ListItem';
 

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import ListItemSecondaryAction from './ListItemSecondaryAction';
 import ListItem from '../ListItem';
 

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Typography from '../Typography';
 import ListItemText from './ListItemText';
 

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Typography from '../Typography';
 import ListItemText from './ListItemText';
 

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import ListSubheader from './ListSubheader';
 
 describe('<ListSubheader />', () => {

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import ListSubheader from './ListSubheader';
 
 describe('<ListSubheader />', () => {

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Popover from '../Popover';
 import Menu from './Menu';
 import MenuList from '../MenuList';

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Popover from '../Popover';
 import Menu from './Menu';
 import MenuList from '../MenuList';

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -2,10 +2,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  createClientRender,
+  fireEvent,
+  screen,
+} from 'test/utils';
+
 import ListItem from '../ListItem';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import MenuItem from './MenuItem';

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -10,7 +10,6 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-
 import ListItem from '../ListItem';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import MenuItem from './MenuItem';

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createMount, describeConformance, createClientRender } from 'test/utils';
+
 import MenuList from './MenuList';
 import getScrollbarSize from '../utils/getScrollbarSize';
 import List from '../List';

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import { createMount, describeConformance, createClientRender } from 'test/utils';
-
 import MenuList from './MenuList';
 import getScrollbarSize from '../utils/getScrollbarSize';
 import List from '../List';

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, findOutermostIntrinsic } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, findOutermostIntrinsic, createMount, describeConformance } from 'test/utils';
+
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import Paper from '../Paper';

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, findOutermostIntrinsic, createMount, describeConformance } from 'test/utils';
-
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import Paper from '../Paper';

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -3,11 +3,18 @@ import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
 import { useFakeTimers, spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { act, createClientRender, fireEvent, within } from 'test/utils/createClientRender';
+import {
+  act,
+  createClientRender,
+  fireEvent,
+  within,
+  createMount,
+  describeConformance,
+} from 'test/utils';
 import { createMuiTheme } from '@material-ui/core/styles';
-import createMount from 'test/utils/createMount';
+
 import { ThemeProvider } from '@material-ui/styles';
-import describeConformance from 'test/utils/describeConformance';
+
 import Fade from '../Fade';
 import Backdrop from '../Backdrop';
 import Modal from './Modal';

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -12,9 +12,7 @@ import {
   describeConformance,
 } from 'test/utils';
 import { createMuiTheme } from '@material-ui/core/styles';
-
 import { ThemeProvider } from '@material-ui/styles';
-
 import Fade from '../Fade';
 import Backdrop from '../Backdrop';
 import Modal from './Modal';

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import Input from '../Input';
 import NativeSelect from './NativeSelect';
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import Input from '../Input';
 import NativeSelect from './NativeSelect';
 

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, describeConformance } from 'test/utils';
-
 import NativeSelectInput from './NativeSelectInput';
 
 describe('<NativeSelectInput />', () => {

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, createMount, describeConformance } from 'test/utils';
+
 import NativeSelectInput from './NativeSelectInput';
 
 describe('<NativeSelectInput />', () => {

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import createMount from 'test/utils/createMount';
-import createServerRender from 'test/utils/createServerRender';
+import { createMount, createServerRender } from 'test/utils';
+
 import NoSsr from './NoSsr';
 
 describe('<NoSsr />', () => {

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, createServerRender } from 'test/utils';
-
 import NoSsr from './NoSsr';
 
 describe('<NoSsr />', () => {

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createClientRender } from 'test/utils';
+
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import NotchedOutline from './NotchedOutline';
 

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender } from 'test/utils';
-
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import NotchedOutline from './NotchedOutline';
 

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import OutlinedInput from './OutlinedInput';
 import InputBase from '../InputBase';
 

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import OutlinedInput from './OutlinedInput';
 import InputBase from '../InputBase';
 

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import * as PropTypes from 'prop-types';
-
 import Paper from './Paper';
 import { createMuiTheme, ThemeProvider } from '../styles';
 

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import * as PropTypes from 'prop-types';
-import describeConformance from 'test/utils/describeConformance';
+
 import Paper from './Paper';
 import { createMuiTheme, ThemeProvider } from '../styles';
 

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -2,9 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { findOutermostIntrinsic, getClasses, createMount, describeConformance } from 'test/utils';
-
 import * as PropTypes from 'prop-types';
-
 import Grow from '../Grow';
 import Modal from '../Modal';
 import Paper from '../Paper';

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { findOutermostIntrinsic, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { findOutermostIntrinsic, getClasses, createMount, describeConformance } from 'test/utils';
+
 import * as PropTypes from 'prop-types';
-import describeConformance from 'test/utils/describeConformance';
+
 import Grow from '../Grow';
 import Modal from '../Modal';
 import Paper from '../Paper';

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
-import createMount from 'test/utils/createMount';
+import { createMount, describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import describeConformance from 'test/utils/describeConformance';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
+
 import PopperJs from 'popper.js';
 import Grow from '../Grow';
 import Popper from './Popper';

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -4,7 +4,6 @@ import { spy, useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
 import { createMount, describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-
 import PopperJs from 'popper.js';
 import Grow from '../Grow';
 import Popper from './Popper';

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import createServerRender from 'test/utils/createServerRender';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createServerRender, createClientRender } from 'test/utils';
+
 import Portal from './Portal';
 
 describe('<Portal />', () => {

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createServerRender, createClientRender } from 'test/utils';
-
 import Portal from './Portal';
 
 describe('<Portal />', () => {

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
+
 import FormControl from '../FormControl';
 import IconButton from '../IconButton';
 import Radio from './Radio';

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, describeConformance, createClientRender } from 'test/utils';
-
 import FormControl from '../FormControl';
 import IconButton from '../IconButton';
 import Radio from './Radio';

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -9,7 +9,6 @@ import {
   act,
   createClientRender,
 } from 'test/utils';
-
 import FormGroup from '../FormGroup';
 import Radio from '../Radio';
 import RadioGroup from './RadioGroup';

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -2,10 +2,14 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import * as PropTypes from 'prop-types';
-import { findOutermostIntrinsic } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  findOutermostIntrinsic,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+} from 'test/utils';
+
 import FormGroup from '../FormGroup';
 import Radio from '../Radio';
 import RadioGroup from './RadioGroup';

--- a/packages/material-ui/src/RootRef/RootRef.test.js
+++ b/packages/material-ui/src/RootRef/RootRef.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import RootRef from './RootRef';
 
 const Fn = () => <div />;

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import ScopedCssBaseline from './ScopedCssBaseline';
 
 describe('<ScopedCssBaseline />', () => {

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import ScopedCssBaseline from './ScopedCssBaseline';
 
 describe('<ScopedCssBaseline />', () => {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
-import { ErrorBoundary } from 'test/utils/components';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  ErrorBoundary,
+  act,
+  createClientRender,
+  fireEvent,
+  screen,
+} from 'test/utils';
 import MenuItem from '../MenuItem';
 import Input from '../Input';
 import InputLabel from '../InputLabel';

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from 'test/utils';
-
 import { createMuiTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Slide, { setTranslateValue } from './Slide';

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createMount, describeConformance } from 'test/utils';
+
 import { createMuiTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Slide, { setTranslateValue } from './Slide';

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -10,9 +10,7 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-
 import Slider from './Slider';
 
 function createTouches(touches) {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -2,11 +2,17 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
+
 import Slider from './Slider';
 
 function createTouches(touches) {

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import Snackbar from './Snackbar';
 
 describe('<Snackbar />', () => {

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -9,7 +9,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import Snackbar from './Snackbar';
 
 describe('<Snackbar />', () => {

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+
 import Paper from '../Paper';
 import SnackbarContent from './SnackbarContent';
 

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
-
 import Paper from '../Paper';
 import SnackbarContent from './SnackbarContent';
 

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Step from './Step';
 import Stepper from '../Stepper';
 import StepLabel from '../StepLabel';

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Step from './Step';
 import Stepper from '../Stepper';
 import StepLabel from '../StepLabel';

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import { fireEvent } from '@testing-library/dom';
-import describeConformance from 'test/utils/describeConformance';
+
 import StepButton from './StepButton';
 import Step from '../Step';
 import StepLabel from '../StepLabel';

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -2,9 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import { fireEvent } from '@testing-library/dom';
-
 import StepButton from './StepButton';
 import Step from '../Step';
 import StepLabel from '../StepLabel';

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import { createClientRender } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
+
 import Stepper from '../Stepper';
 import Step from '../Step';
 import StepConnector from './StepConnector';

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
-
 import Stepper from '../Stepper';
 import Step from '../Step';
 import StepConnector from './StepConnector';

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
-
 import Collapse from '../Collapse';
 import Stepper from '../Stepper';
 import Step from '../Step';

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import { createClientRender } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
+
 import Collapse from '../Collapse';
 import Stepper from '../Stepper';
 import Step from '../Step';

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, describeConformance, createClientRender } from 'test/utils';
-
 import StepIcon from './StepIcon';
 
 describe('<StepIcon />', () => {

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createMount, describeConformance, createClientRender } from 'test/utils';
+
 import StepIcon from './StepIcon';
 
 describe('<StepIcon />', () => {

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import { createClientRender } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
+
 import Typography from '../Typography';
 import Stepper from '../Stepper';
 import Step from '../Step';

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
-
 import Typography from '../Typography';
 import Stepper from '../Stepper';
 import Step from '../Step';

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Paper from '../Paper';
 import Step from '../Step';
 import StepLabel from '../StepLabel';

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Paper from '../Paper';
 import Step from '../Step';
 import StepLabel from '../StepLabel';

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
-
 import SvgIcon from './SvgIcon';
 
 describe('<SvgIcon />', () => {

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+
 import SvgIcon from './SvgIcon';
 
 describe('<SvgIcon />', () => {

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { act, createMount, describeConformance } from 'test/utils';
+
 import PropTypes, { checkPropTypes } from 'prop-types';
 import Drawer from '../Drawer';
 import SwipeableDrawer, { reset } from './SwipeableDrawer';

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createMount, describeConformance } from 'test/utils';
-
 import PropTypes, { checkPropTypes } from 'prop-types';
 import Drawer from '../Drawer';
 import SwipeableDrawer, { reset } from './SwipeableDrawer';

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import FormControl from '../FormControl';
 import Switch from './Switch';
 

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -8,7 +8,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import FormControl from '../FormControl';
 import Switch from './Switch';
 

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -9,7 +9,6 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import Tab from './Tab';
 import ButtonBase from '../ButtonBase';
 

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import Tab from './Tab';
 import ButtonBase from '../ButtonBase';
 

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import TabScrollButton from './TabScrollButton';
 
 describe('<TabScrollButton />', () => {

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import TabScrollButton from './TabScrollButton';
 
 describe('<TabScrollButton />', () => {

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Table from './Table';
 import TableContext from './TableContext';
 

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Table from './Table';
 import TableContext from './TableContext';
 

--- a/packages/material-ui/src/TableBody/TableBody.test.js
+++ b/packages/material-ui/src/TableBody/TableBody.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import TableBody from './TableBody';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 

--- a/packages/material-ui/src/TableBody/TableBody.test.js
+++ b/packages/material-ui/src/TableBody/TableBody.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import TableBody from './TableBody';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+
 import TableCell from './TableCell';
 
 describe('<TableCell />', () => {

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
-
 import TableCell from './TableCell';
 
 describe('<TableCell />', () => {

--- a/packages/material-ui/src/TableContainer/TableContainer.test.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance } from 'test/utils';
+
 import TableContainer from './TableContainer';
 
 describe('<TableContainer />', () => {

--- a/packages/material-ui/src/TableContainer/TableContainer.test.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
-
 import TableContainer from './TableContainer';
 
 describe('<TableContainer />', () => {

--- a/packages/material-ui/src/TableFooter/TableFooter.test.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import TableFooter from './TableFooter';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 

--- a/packages/material-ui/src/TableFooter/TableFooter.test.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import TableFooter from './TableFooter';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import TableHead from './TableHead';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import TableHead from './TableHead';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -9,7 +9,6 @@ import {
   fireEvent,
   createClientRender,
 } from 'test/utils';
-
 import TableFooter from '../TableFooter';
 import TableCell from '../TableCell';
 import TableRow from '../TableRow';

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -2,10 +2,14 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { fireEvent, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  fireEvent,
+  createClientRender,
+} from 'test/utils';
+
 import TableFooter from '../TableFooter';
 import TableCell from '../TableCell';
 import TableRow from '../TableRow';

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import TableRow from './TableRow';
 
 describe('<TableRow />', () => {

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import TableRow from './TableRow';
 
 describe('<TableRow />', () => {

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
-
 import Sort from '@material-ui/icons/Sort';
-
 import TableSortLabel from './TableSortLabel';
 import ButtonBase from '../ButtonBase';
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+
 import Sort from '@material-ui/icons/Sort';
-import describeConformance from 'test/utils/describeConformance';
+
 import TableSortLabel from './TableSortLabel';
 import ButtonBase from '../ButtonBase';
 

--- a/packages/material-ui/src/Tabs/ScrollbarSize.test.js
+++ b/packages/material-ui/src/Tabs/ScrollbarSize.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers, stub } from 'sinon';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils';
 import ScrollbarSize from './ScrollbarSize';
 
 describe('<ScrollbarSize />', () => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
-import createServerRender from 'test/utils/createServerRender';
-import describeConformance from 'test/utils/describeConformance';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+  screen,
+  createServerRender,
+} from 'test/utils';
+
 import capitalize from '../utils/capitalize';
 import Tab from '../Tab';
 import Tabs from './Tabs';

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -11,7 +11,6 @@ import {
   screen,
   createServerRender,
 } from 'test/utils';
-
 import capitalize from '../utils/capitalize';
 import Tab from '../Tab';
 import Tabs from './Tabs';

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import FormControl from '../FormControl';
 import Input from '../Input';
 import OutlinedInput from '../OutlinedInput';

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import FormControl from '../FormControl';
 import Input from '../Input';
 import OutlinedInput from '../OutlinedInput';

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub, useFakeTimers } from 'sinon';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { createMount, describeConformance, act, createClientRender, fireEvent } from 'test/utils';
+
 import TextareaAutosize from './TextareaAutosize';
 
 describe('<TextareaAutosize />', () => {

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, describeConformance, act, createClientRender, fireEvent } from 'test/utils';
-
 import TextareaAutosize from './TextareaAutosize';
 
 describe('<TextareaAutosize />', () => {

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+
 import Toolbar from './Toolbar';
 
 describe('<Toolbar />', () => {

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
-
 import Toolbar from './Toolbar';
 
 describe('<Toolbar />', () => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import {
+  getClasses,
+  createMount,
+  describeConformance,
+  act,
+  createClientRender,
+  fireEvent,
+} from 'test/utils';
+
 import { camelCase } from 'lodash/string';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+
 import Tooltip, { testReset } from './Tooltip';
 import Input from '../Input';
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -9,9 +9,7 @@ import {
   createClientRender,
   fireEvent,
 } from 'test/utils';
-
 import { camelCase } from 'lodash/string';
-
 import Tooltip, { testReset } from './Tooltip';
 import Input from '../Input';
 

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -1,10 +1,8 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import { createClientRender } from 'test/utils/createClientRender';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
+
 import Typography from './Typography';
 
 describe('<Typography />', () => {

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
-
 import Typography from './Typography';
 
 describe('<Typography />', () => {

--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import { createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent, screen } from 'test/utils';
 import TrapFocus from './Unstable_TrapFocus';
 import Portal from '../Portal';
 

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from 'test/utils';
-
 import { Transition } from 'react-transition-group';
 import Zoom from './Zoom';
 

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import createMount from 'test/utils/createMount';
-import describeConformance from 'test/utils/describeConformance';
+import { createMount, describeConformance } from 'test/utils';
+
 import { Transition } from 'react-transition-group';
 import Zoom from './Zoom';
 

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
-
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import describeConformance from 'test/utils/describeConformance';
+import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
-import { act, createClientRender } from 'test/utils/createClientRender';
-import createServerRender from 'test/utils/createServerRender';
+import { act, createClientRender, createServerRender } from 'test/utils';
+
 import mediaQuery from 'css-mediaquery';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
 import { act, createClientRender, createServerRender } from 'test/utils';
-
 import mediaQuery from 'css-mediaquery';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils';
 import Container from '../Container';
 import Box from '../Box';
 import useScrollTrigger from './useScrollTrigger';

--- a/packages/material-ui/src/utils/focusVisible.test.js
+++ b/packages/material-ui/src/utils/focusVisible.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import useIsFocusVisible, { teardown as teardownFocusVisible } from './useIsFocusVisible';
 import useForkRef from './useForkRef';
 

--- a/packages/material-ui/src/utils/unstable_useId.test.js
+++ b/packages/material-ui/src/utils/unstable_useId.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils';
 import useId from './unstable_useId';
 
 const TestComponent = ({ id: idProp }) => {

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils';
 import useControlled from './useControlled';
 
 const TestComponent = ({ value: valueProp, defaultValue, children }) => {

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -3,7 +3,6 @@ import { act } from 'react-dom/test-utils';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import { createShallow, createMount } from 'test/utils';
-
 import mediaQuery from 'css-mediaquery';
 import withWidth, { isWidthDown, isWidthUp } from './withWidth';
 import createMuiTheme from '../styles/createMuiTheme';

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { createShallow } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { createShallow, createMount } from 'test/utils';
+
 import mediaQuery from 'css-mediaquery';
 import withWidth, { isWidthDown, isWidthUp } from './withWidth';
 import createMuiTheme from '../styles/createMuiTheme';

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -5,7 +5,7 @@ import { useFakeTimers } from 'sinon';
 import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
-import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils';
 
 const options = [
   'Show some love to Material-UI',

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
-import { act, createClientRender, fireEvent, screen } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, screen } from 'test/utils';
 
 describe('<MenuList> integration', () => {
   const render = createClientRender();

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, within } from 'test/utils/createClientRender';
+import { createClientRender, within } from 'test/utils';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { useFakeTimers } from 'sinon';
-import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import Dialog from '@material-ui/core/Dialog';

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { findOutermostIntrinsic, getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
-import { createClientRender } from 'test/utils/createClientRender';
+import { findOutermostIntrinsic, getClasses, createMount, createClientRender } from 'test/utils';
+
 import TableCell from '@material-ui/core/TableCell';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { findOutermostIntrinsic, getClasses, createMount, createClientRender } from 'test/utils';
-
 import TableCell from '@material-ui/core/TableCell';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';

--- a/packages/material-ui/test/integration/TableRow.test.js
+++ b/packages/material-ui/test/integration/TableRow.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses } from 'test/utils';
-import createMount from 'test/utils/createMount';
+import { getClasses, createMount } from 'test/utils';
+
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';

--- a/packages/material-ui/test/integration/TableRow.test.js
+++ b/packages/material-ui/test/integration/TableRow.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount } from 'test/utils';
-
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';

--- a/packages/typescript-to-proptypes/src/index.ts
+++ b/packages/typescript-to-proptypes/src/index.ts
@@ -3,6 +3,5 @@ export * from './generator';
 export * from './parser';
 export * from './injector';
 export * from './types';
-
 import * as ts from 'typescript';
 export { ts };

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,6 +1,5 @@
 // https://github.com/airbnb/enzyme/issues/1792
 import 'core-js/modules/es6.array.from';
-
 import './utils/init';
 
 const integrationContext = require.context(

--- a/test/utils/findOutermostIntrinsic.test.js
+++ b/test/utils/findOutermostIntrinsic.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import createMount from 'test/utils/createMount';
+import { createMount } from 'test/utils';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 
 describe('findOutermostIntrinsic', () => {


### PR DESCRIPTION
Testing utilities are now imported from a single entry point: `test/utils`. 

Makes it easier to know what you can and can't use.

For review: Stacked on top of #21855. [Diff to #21855](https://github.com/eps1lon/material-ui/compare/feat/remove-test-utils...eps1lon:test/single-utils-entry).