### PR TITLE
[docs] Fix the type of the second argument of 'createMuiTheme' function

### DIFF
--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -70,7 +70,7 @@ Generate a theme base on the options received.
 #### Arguments
 
 1. `options` (_Object_): Takes an incomplete theme object and adds the missing parts.
-2. `...args` (_Array_): Deep merge the arguments with the about to be returned theme.
+2. `...args` (_Object[]_): Deep merge the arguments with the about to be returned theme.
 
 #### Returns
 
@@ -138,7 +138,7 @@ Currently `unstable_createMuiStrictModeTheme` adds no additional requirements.
 #### Arguments
 
 1. `options` (_Object_): Takes an incomplete theme object and adds the missing parts.
-2. `...args` (_Array_): Deep merge the arguments with the about to be returned theme.
+2. `...args` (_Object[]_): Deep merge the arguments with the about to be returned theme.
 
 #### Returns
 

--- a/packages/material-ui/src/styles/createMuiTheme.d.ts
+++ b/packages/material-ui/src/styles/createMuiTheme.d.ts
@@ -44,4 +44,11 @@ export interface Theme {
   unstable_strictMode?: boolean;
 }
 
+/**
+ * Generate a theme base on the options received.
+ *
+ * @param options Takes an incomplete theme object and adds the missing parts.
+ * @param args Deep merge the arguments with the about to be returned theme.
+ * @returns A complete, ready to use theme object.
+ */
 export default function createMuiTheme(options?: ThemeOptions, ...args: object[]): Theme;


### PR DESCRIPTION
This PR aims to fix the `type` of the second argument of the `createMuiTheme` function which currently is marked as `Array` in the documentation. 

After following the discussion in the related ticket I've changed the `type` to `Object[]`.

Fixes #21781

_Disclaimer_: This is my first PR so if I didn't do something the right way please point it out and I will fix it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
