### PR TITLE
[CssBaseline] Export ScopedCssBaseline from barrel index

### DIFF
--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { withStyles } from '@material-ui/core/styles';
+import withStyles from '../styles/withStyles';
 import { html, body } from '../CssBaseline/CssBaseline';
 
 export const styles = (theme) => ({

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -297,6 +297,9 @@ export * from './RadioGroup';
 export { default as RootRef } from './RootRef';
 export * from './RootRef';
 
+export { default as ScopedCssBaseline } from './ScopedCssBaseline';
+export * from './ScopedCssBaseline';
+
 export { default as Select } from './Select';
 export * from './Select';
 

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -243,6 +243,9 @@ export * from './RadioGroup';
 export { default as RootRef } from './RootRef';
 export * from './RootRef';
 
+export { default as ScopedCssBaseline } from './ScopedCssBaseline';
+export * from './ScopedCssBaseline';
+
 export { default as Select } from './Select';
 export * from './Select';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).


Not sure if not re-exporting `ScopedCssBaseline` was on purpose or not, but creating a PR was faster then creating a ticket.

It wasn't causing any issues as such, but the inconsistency of having to import it separately bothered me.


### Behavior Previously

```javascript
import ScopedCssBaseline from '@material-ui/core/ScopedCssBaseline';
import { createMuiTheme, ThemeProvider } from '@material-ui/core';
```

### Behavior Now

```javascript
import { createMuiTheme, ScopedCssBaseline, ThemeProvider } from '@material-ui/core';
```