### PR TITLE
[test] Pass didWarnControlledToUncontrolled between tests

### DIFF
--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -6,8 +6,6 @@ import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';
 
-let didWarnControlledToUncontrolled;
-
 describe('<SwitchBase />', () => {
   const render = createClientRender();
   const mount = createMount();
@@ -353,7 +351,7 @@ describe('<SwitchBase />', () => {
 
   describe('check transitioning between controlled states throws errors', () => {
     it('should error when uncontrolled and changed to controlled', function test() {
-      if (didWarnControlledToUncontrolled) {
+      if (global['didWarnControlledToUncontrolled']) {
         this.skip();
       }
 
@@ -366,6 +364,7 @@ describe('<SwitchBase />', () => {
 
       expect(() => {
         setProps({ checked: true });
+        global['didWarnControlledToUncontrolled'] = true;
       }).toErrorDev([
         'Warning: A component is changing an uncontrolled input of type checkbox to be controlled.',
         'Material-UI: A component is changing the uncontrolled checked state of SwitchBase to be controlled.',
@@ -373,7 +372,7 @@ describe('<SwitchBase />', () => {
     });
 
     it('should error when controlled and changed to uncontrolled', function test() {
-      if (didWarnControlledToUncontrolled) {
+      if (global['didWarnControlledToUncontrolled']) {
         this.skip();
       }
 
@@ -386,6 +385,7 @@ describe('<SwitchBase />', () => {
 
       expect(() => {
         setProps({ checked: undefined });
+        global['didWarnControlledToUncontrolled'] = true;
       }).toErrorDev([
         'Warning: A component is changing a controlled input of type checkbox to be uncontrolled.',
         'Material-UI: A component is changing the controlled checked state of SwitchBase to be uncontrolled.',


### PR DESCRIPTION
Fixes SwitchBase failing in `--watch`.

Mocha decides to reset globals within a module but not imported modules. Makes it a bit awkward to reason about globals. Hopefully this doesn't take too much debugging time.