### PR TITLE
[core] Automatically tweet about good first issues

### DIFF
--- a/.github/workflows/contributor-twitter.yml
+++ b/.github/workflows/contributor-twitter.yml
@@ -6,6 +6,7 @@ jobs:
   tweet:
     runs-on: ubuntu-latest
     steps:
+      # This has essentially zero costs and helps debugging if the workflow fails.
       - uses: hmarr/debug-action@master
       - uses: ethomson/send-tweet-action@v1
         if: ${{ github.event.label.name == 'good first issue' && github.event.issue.state == 'open' }}

--- a/.github/workflows/contributor-twitter.yml
+++ b/.github/workflows/contributor-twitter.yml
@@ -12,8 +12,8 @@ jobs:
         if: ${{ github.event.label.name == 'good first issue' && github.event.issue.state == 'open' }}
         with:
           status: >
-            A new issue on the @materialui repository has been marked as a "good first issue". Any help resolving this issue would be greatly appreciated. 
-            Before starting the work make sure the issue is not assigned to anybody. 
+            A new issue in the @materialui repository has been labelled as a good first issue. If you haven't contributed before, now's your chance!
+            (Just check that it hasn't already been assigned to anyone before starting.)
             ${{ github.event.issue.html_url }}"
           consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
           consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}

--- a/.github/workflows/contributor-twitter.yml
+++ b/.github/workflows/contributor-twitter.yml
@@ -1,0 +1,20 @@
+name: contributor-twitter
+on:
+  issues:
+    types: [labeled]
+jobs:
+  tweet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@master
+      - uses: ethomson/send-tweet-action@v1
+        if: ${{ github.event.label.name == 'good first issue' && github.event.issue.state == 'open' }}
+        with:
+          status: >
+            A new issue on the @materialui repository has been marked as a "good first issue". Any help resolving this issue would be greatly appreciated. 
+            Before starting the work make sure the issue is not assigned to anybody. 
+            ${{ github.event.issue.html_url }}"
+          consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+          consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
+          access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
Maybe we can reduce the [backlog of open "good first issue"s](https://github.com/mui-org/material-ui/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22) and gain more active contributors by increasing engagement on twitter.

The idea is to tweet out issues that are marked as "good first issues" once they receive that label. For now it tweets every time the label gets added on open issues.

I think we should do this from a separate account. This may be too spammy for existing followers. 

Proof-of-concept: 
- label added in https://github.com/eps1lon/mui-scripts-incubator/issues/599
- tweet sent: https://twitter.com/MuiContrib/status/1285670876915077121

Just need to add the secrets accordingly if we decide to  merge it. It will only use the workflow on the default branch.

Future ideas:
- signal-boost twitter accounts from people:
  - resolving "good first issue"s (leave a comment with the twitter account of the PR author and let GH actions pick it up)
  We might want to do it from the main account for maximum boosting to not spam people waiting for new issues to pop up
- tweet out RFCs (though they're rare enough that a manual tweet might suffice)
- GitHub discussions might open up a bit more (tweeting Support issues that were moved to discussions)