### PR TITLE
[TreeView] Fix crash when shift clicking a clean tree

### DIFF
--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -459,12 +459,14 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
 
   const selectRange = (event, nodes, stacked = false) => {
     const { start = lastSelectedNode.current, end, current } = nodes;
-    if (stacked) {
-      handleRangeArrowSelect(event, { start, next: end, current });
-    } else {
-      handleRangeSelect(event, { start, end });
+    if (start != null && end != null) {
+      if (stacked) {
+        handleRangeArrowSelect(event, { start, next: end, current });
+      } else {
+        handleRangeSelect(event, { start, end });
+      }
+      lastSelectionWasRange.current = true;
     }
-    lastSelectionWasRange.current = true;
     return true;
   };
 

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -61,6 +61,17 @@ describe('<TreeView />', () => {
       );
     });
 
+    it('should not crash when shift clicking a clean tree', () => {
+      render(
+        <TreeView multiSelect>
+          <TreeItem nodeId="one" label="one" />
+          <TreeItem nodeId="two" label="two" />
+        </TreeView>,
+      );
+
+      fireEvent.click(screen.getByText('one'), { shiftKey: true });
+    });
+
     it('should not crash when unmounting with duplicate ids', () => {
       const CustomTreeItem = () => {
         return <TreeItem nodeId="iojerogj" />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
