### PR TITLE
[Fab] Rename round -> circular for consistency

### DIFF
--- a/docs/pages/api-docs/fab.md
+++ b/docs/pages/api-docs/fab.md
@@ -37,7 +37,7 @@ The `MuiFab` name can be used for providing [default props](/customization/globa
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">href</span> | <span class="prop-type">string</span> |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">size</span> | <span class="prop-type">'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'</span> | <span class="prop-default">'large'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'circle'<br>&#124;&nbsp;'extended'</span> | <span class="prop-default">'circle'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'circular'<br>&#124;&nbsp;'extended'</span> | <span class="prop-default">'circular'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/fab.md
+++ b/docs/pages/api-docs/fab.md
@@ -37,7 +37,7 @@ The `MuiFab` name can be used for providing [default props](/customization/globa
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">href</span> | <span class="prop-type">string</span> |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">size</span> | <span class="prop-type">'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'</span> | <span class="prop-default">'large'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'extended'<br>&#124;&nbsp;'circle'</span> | <span class="prop-default">'circle'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'circle'<br>&#124;&nbsp;'extended'</span> | <span class="prop-default">'circle'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/fab.md
+++ b/docs/pages/api-docs/fab.md
@@ -37,7 +37,7 @@ The `MuiFab` name can be used for providing [default props](/customization/globa
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">href</span> | <span class="prop-type">string</span> |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">size</span> | <span class="prop-type">'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'</span> | <span class="prop-default">'large'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'extended'<br>&#124;&nbsp;'round'</span> | <span class="prop-default">'round'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'extended'<br>&#124;&nbsp;'circle'</span> | <span class="prop-default">'circle'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -257,6 +257,7 @@ This change affects almost all components where you're using the `component` pro
   -<Typography variant="srOnly">Create a user</Typography>
   +<Span>Create a user</Span>
   ```
+
   ## Fab
 
   - Rename `round` to `circle` for consistency:

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -97,6 +97,7 @@ This change affects almost all components where you're using the `component` pro
   }
   ```
 
+<<<<<<< HEAD
 ### Expansion Panel
 
 - Rename the `ExpansionPanel` components with `Accordion` to use a more common naming convention:
@@ -162,12 +163,20 @@ This change affects almost all components where you're using the `component` pro
   ```
 
 ### PaginationItem
+=======
+### Fab
+>>>>>>> Update migration-v4.md
 
 - Rename `round` to `circular` for consistency. The possible values should be adjectives, not nouns:
 
   ```diff
+<<<<<<< HEAD
   -<PaginationItem shape="round">
   +<PaginationItem shape="circular">
+=======
+  -<Fab variant="round">
+  +<Fab variant="circular">
+>>>>>>> Update migration-v4.md
   ```
 
 ### Rating
@@ -258,6 +267,7 @@ This change affects almost all components where you're using the `component` pro
   +<Span>Create a user</Span>
   ```
 
+<<<<<<< HEAD
   ## Fab
 
   - Rename `round` to `circular` for consistency:
@@ -265,4 +275,59 @@ This change affects almost all components where you're using the `component` pro
   ```diff
   -<Fab variant="round">
   +<Fab variant="circular">
+=======
+### Expansion Panel
+
+- Rename the `ExpansionPanel` components with `Accordion` to use a more common naming convention:
+
+  ```diff
+  -import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+  -import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+  -import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+  -import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
+  +import Accordion from '@material-ui/core/Accordion';
+  +import AccordionSummary from '@material-ui/core/AccordionSummary';
+  +import AccordionDetails from '@material-ui/core/AccordionDetails';
+  +import AccordionActions from '@material-ui/core/AccordionActions';
+
+  -<ExpansionPanel>
+  +<Accordion>
+  -  <ExpansionPanelSummary>
+  +  <AccordionSummary>
+       <Typography>Location</Typography>
+       <Typography>Select trip destination</Typography>
+  -  </ExpansionPanelSummary>
+  +  </AccordionSummary>
+  -  <ExpansionPanelDetails>
+  +  <AccordionDetails>
+       <Chip label="Barbados" onDelete={() => {}} />
+       <Typography variant="caption">Select your destination of choice</Typography>
+  -  </ExpansionPanelDetails>
+  +  </AccordionDetails>
+     <Divider />
+  -  <ExpansionPanelActions>
+  +  <AccordionActions>
+       <Button size="small">Cancel</Button>
+       <Button size="small">Save</Button>
+  -  </ExpansionPanelActions>
+  +  </AccordionActions>
+  -</ExpansionPanel>
+  +</Accordion>
+  ```
+
+- typescript: The `event` in `onChange` is no longer typed as a `React.ChangeEvent` but `React.SyntheticEvent`.
+
+  ```diff
+  -<Accordion onChange={(event: React.ChangeEvent<{}>, expanded: boolean) => {}} />
+  +<Accordion onChange={(event: React.SyntheticEvent, expanded: boolean) => {}} />
+  ```
+
+  ## Grid
+
+  - Rename `justify` prop with `justifyContent` to be aligned with the CSS property name.
+
+  ```diff
+  -<Grid justify="center">
+  +<Grid justifyContent="center">
+>>>>>>> Update migration-v4.md
   ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -257,3 +257,11 @@ This change affects almost all components where you're using the `component` pro
   -<Typography variant="srOnly">Create a user</Typography>
   +<Span>Create a user</Span>
   ```
+  ## Fab
+
+  - Rename `round` to `circle` for consistency:
+
+  ```diff
+  -<Fab variant="round">
+  +<Fab variant="circle">
+  ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -97,7 +97,6 @@ This change affects almost all components where you're using the `component` pro
   }
   ```
 
-<<<<<<< HEAD
 ### Expansion Panel
 
 - Rename the `ExpansionPanel` components with `Accordion` to use a more common naming convention:
@@ -144,6 +143,15 @@ This change affects almost all components where you're using the `component` pro
   +<Accordion onChange={(event: React.SyntheticEvent, expanded: boolean) => {}} />
   ```
 
+### Fab
+
+- Rename `round` to `circular` for consistency. The possible values should be adjectives, not nouns:
+
+  ```diff
+  -<Fab variant="round">
+  +<Fab variant="circular">
+  ```
+
 ### Grid
 
 - Rename `justify` prop with `justifyContent` to be aligned with the CSS property name.
@@ -163,20 +171,12 @@ This change affects almost all components where you're using the `component` pro
   ```
 
 ### PaginationItem
-=======
-### Fab
->>>>>>> Update migration-v4.md
 
 - Rename `round` to `circular` for consistency. The possible values should be adjectives, not nouns:
 
   ```diff
-<<<<<<< HEAD
   -<PaginationItem shape="round">
   +<PaginationItem shape="circular">
-=======
-  -<Fab variant="round">
-  +<Fab variant="circular">
->>>>>>> Update migration-v4.md
   ```
 
 ### Rating
@@ -265,69 +265,4 @@ This change affects almost all components where you're using the `component` pro
 
   -<Typography variant="srOnly">Create a user</Typography>
   +<Span>Create a user</Span>
-  ```
-
-<<<<<<< HEAD
-  ## Fab
-
-  - Rename `round` to `circular` for consistency:
-
-  ```diff
-  -<Fab variant="round">
-  +<Fab variant="circular">
-=======
-### Expansion Panel
-
-- Rename the `ExpansionPanel` components with `Accordion` to use a more common naming convention:
-
-  ```diff
-  -import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-  -import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-  -import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-  -import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
-  +import Accordion from '@material-ui/core/Accordion';
-  +import AccordionSummary from '@material-ui/core/AccordionSummary';
-  +import AccordionDetails from '@material-ui/core/AccordionDetails';
-  +import AccordionActions from '@material-ui/core/AccordionActions';
-
-  -<ExpansionPanel>
-  +<Accordion>
-  -  <ExpansionPanelSummary>
-  +  <AccordionSummary>
-       <Typography>Location</Typography>
-       <Typography>Select trip destination</Typography>
-  -  </ExpansionPanelSummary>
-  +  </AccordionSummary>
-  -  <ExpansionPanelDetails>
-  +  <AccordionDetails>
-       <Chip label="Barbados" onDelete={() => {}} />
-       <Typography variant="caption">Select your destination of choice</Typography>
-  -  </ExpansionPanelDetails>
-  +  </AccordionDetails>
-     <Divider />
-  -  <ExpansionPanelActions>
-  +  <AccordionActions>
-       <Button size="small">Cancel</Button>
-       <Button size="small">Save</Button>
-  -  </ExpansionPanelActions>
-  +  </AccordionActions>
-  -</ExpansionPanel>
-  +</Accordion>
-  ```
-
-- typescript: The `event` in `onChange` is no longer typed as a `React.ChangeEvent` but `React.SyntheticEvent`.
-
-  ```diff
-  -<Accordion onChange={(event: React.ChangeEvent<{}>, expanded: boolean) => {}} />
-  +<Accordion onChange={(event: React.SyntheticEvent, expanded: boolean) => {}} />
-  ```
-
-  ## Grid
-
-  - Rename `justify` prop with `justifyContent` to be aligned with the CSS property name.
-
-  ```diff
-  -<Grid justify="center">
-  +<Grid justifyContent="center">
->>>>>>> Update migration-v4.md
   ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -260,9 +260,9 @@ This change affects almost all components where you're using the `component` pro
 
   ## Fab
 
-  - Rename `round` to `circle` for consistency:
+  - Rename `round` to `circular` for consistency:
 
   ```diff
   -<Fab variant="round">
-  +<Fab variant="circle">
+  +<Fab variant="circular">
   ```

--- a/framer/Material-UI.framerfx/code/Fab.tsx
+++ b/framer/Material-UI.framerfx/code/Fab.tsx
@@ -8,7 +8,7 @@ interface Props {
   disabled: boolean;
   href?: string;
   size: 'large' | 'medium' | 'small';
-  variant: 'extended' | 'circle';
+  variant: 'circle' | 'extended';
   icon: string;
   iconTheme: 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
   label: string;

--- a/framer/Material-UI.framerfx/code/Fab.tsx
+++ b/framer/Material-UI.framerfx/code/Fab.tsx
@@ -8,7 +8,7 @@ interface Props {
   disabled: boolean;
   href?: string;
   size: 'large' | 'medium' | 'small';
-  variant: 'circle' | 'extended';
+  variant: 'circular' | 'extended';
   icon: string;
   iconTheme: 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
   label: string;
@@ -34,7 +34,7 @@ Fab.defaultProps = {
   color: 'default' as 'default',
   disabled: false,
   size: 'large' as 'large',
-  variant: 'circle' as 'circle',
+  variant: 'circular' as 'circular',
   icon: 'add',
   iconTheme: 'Filled' as 'Filled',
   label: 'extended',
@@ -64,7 +64,7 @@ addPropertyControls(Fab, {
   variant: {
     type: ControlType.Enum,
     title: 'Variant',
-    options: ['extended', 'circle'],
+    options: ['circular', 'extended'],
   },
   icon: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Fab.tsx
+++ b/framer/Material-UI.framerfx/code/Fab.tsx
@@ -8,7 +8,7 @@ interface Props {
   disabled: boolean;
   href?: string;
   size: 'large' | 'medium' | 'small';
-  variant: 'extended' | 'round';
+  variant: 'extended' | 'circle';
   icon: string;
   iconTheme: 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
   label: string;
@@ -34,7 +34,7 @@ Fab.defaultProps = {
   color: 'default' as 'default',
   disabled: false,
   size: 'large' as 'large',
-  variant: 'round' as 'round',
+  variant: 'circle' as 'circle',
   icon: 'add',
   iconTheme: 'Filled' as 'Filled',
   label: 'extended',
@@ -64,7 +64,7 @@ addPropertyControls(Fab, {
   variant: {
     type: ControlType.Enum,
     title: 'Variant',
-    options: ['extended', 'round'],
+    options: ['extended', 'circle'],
   },
   icon: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/design/document.json
+++ b/framer/Material-UI.framerfx/design/document.json
@@ -3331,7 +3331,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "large",
-              "variant" : "circle"
+              "variant" : "round"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,
@@ -3392,7 +3392,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "medium",
-              "variant" : "circle"
+              "variant" : "round"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,
@@ -3453,7 +3453,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "small",
-              "variant" : "circle"
+              "variant" : "round"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,
@@ -5556,7 +5556,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "large",
-              "variant" : "circle"
+              "variant" : "round"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,

--- a/framer/Material-UI.framerfx/design/document.json
+++ b/framer/Material-UI.framerfx/design/document.json
@@ -3331,7 +3331,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "large",
-              "variant" : "round"
+              "variant" : "circle"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,
@@ -3392,7 +3392,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "medium",
-              "variant" : "round"
+              "variant" : "circle"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,
@@ -3453,7 +3453,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "small",
-              "variant" : "round"
+              "variant" : "circle"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,
@@ -5556,7 +5556,7 @@
               "iconTheme" : "Filled",
               "label" : "extended",
               "size" : "large",
-              "variant" : "round"
+              "variant" : "circle"
             },
             "codeOverrideEnabled" : false,
             "constraintsLocked" : false,

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -37,7 +37,7 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
     /**
      * The variant to use.
      */
-    variant?: 'circle' | 'extended';
+    variant?: 'circular' | 'extended';
   };
   defaultComponent: D;
   classKey: FabClassKey;

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -37,7 +37,7 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
     /**
      * The variant to use.
      */
-    variant?: 'round' | 'extended';
+    variant?: 'circle' | 'extended';
   };
   defaultComponent: D;
   classKey: FabClassKey;

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -130,7 +130,7 @@ const Fab = React.forwardRef(function Fab(props, ref) {
     disableFocusRipple = false,
     focusVisibleClassName,
     size = 'large',
-    variant = 'round',
+    variant = 'circle',
     ...other
   } = props;
 
@@ -216,7 +216,7 @@ Fab.propTypes = {
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['extended', 'round']),
+  variant: PropTypes.oneOf(['extended', 'circle']),
 };
 
 export default withStyles(styles, { name: 'MuiFab' })(Fab);

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -216,7 +216,7 @@ Fab.propTypes = {
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['extended', 'circle']),
+  variant: PropTypes.oneOf(['circle', 'extended']),
 };
 
 export default withStyles(styles, { name: 'MuiFab' })(Fab);

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -130,7 +130,7 @@ const Fab = React.forwardRef(function Fab(props, ref) {
     disableFocusRipple = false,
     focusVisibleClassName,
     size = 'large',
-    variant = 'circle',
+    variant = 'circular',
     ...other
   } = props;
 
@@ -216,7 +216,7 @@ Fab.propTypes = {
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['circle', 'extended']),
+  variant: PropTypes.oneOf(['circular', 'extended']),
 };
 
 export default withStyles(styles, { name: 'MuiFab' })(Fab);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

> [Fab] Rename Fab round -> circle for consistency

I thought we should do the same on `Pagination ` and `PaginationItem`

Part of #21964