### PR TITLE
[slider] Make `index` public in the ValueLabel props

### DIFF
--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -7,6 +7,7 @@ export interface Mark {
 }
 
 export interface ValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
+  index: number;
   value: number;
   open: boolean;
   children: React.ReactElement;

--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -7,10 +7,10 @@ export interface Mark {
 }
 
 export interface ValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
-  index: number;
-  value: number;
-  open: boolean;
   children: React.ReactElement;
+  index: number;
+  open: boolean;
+  value: number;
 }
 
 export interface SliderTypeMap<P = {}, D extends React.ElementType = 'span'> {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -743,7 +743,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
         return (
           <ValueLabelComponent
             key={index}
-            valueLabelFormat={valueLabelFormat}
             valueLabelDisplay={valueLabelDisplay}
             className={classes.valueLabel}
             value={

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -743,6 +743,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
         return (
           <ValueLabelComponent
             key={index}
+            valueLabelFormat={valueLabelFormat}
             valueLabelDisplay={valueLabelDisplay}
             className={classes.valueLabel}
             value={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Closes #21889