### PR TITLE
[test] Lint useThemeVariants with custom rules plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': 'off', // doesn't work?
     'jsx-a11y/no-autofocus': 'off', // We are a library, we need to support it too
     'material-ui/docgen-ignore-before-comment': 'error',
+    'material-ui/rules-of-use-theme-variants': 'error',
     'react-hooks/exhaustive-deps': ['error', { additionalHooks: 'useEnhancedEffect' }],
     'react-hooks/rules-of-hooks': 'error',
     'react/destructuring-assignment': 'off', // It's fine.

--- a/packages/eslint-plugin-material-ui/README.md
+++ b/packages/eslint-plugin-material-ui/README.md
@@ -40,3 +40,8 @@ Removed in favor of [`no-restricted-imports`](https://eslint.org/docs/rules/no-r
   }
 }
 ```
+
+### rules-of-use-theme-variants
+
+Ensures correct usage of `useThemeVariants` so that all props are passed as well
+as their resolved default values.

--- a/packages/eslint-plugin-material-ui/src/index.js
+++ b/packages/eslint-plugin-material-ui/src/index.js
@@ -3,4 +3,5 @@ module.exports.rules = {
   'disallow-active-element-as-key-event-target': require('./rules/disallow-active-element-as-key-event-target'),
   'docgen-ignore-before-comment': require('./rules/docgen-ignore-before-comment'),
   'no-hardcoded-labels': require('./rules/no-hardcoded-labels'),
+  'rules-of-use-theme-variants': require('./rules/rules-of-use-theme-variants'),
 };

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.js
@@ -1,0 +1,108 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+  },
+  create(context) {
+    function getComponentProps(componentBlockNode) {
+      // finds the declarator in `const {...} = props;`
+      let componentPropsDeclarator = null;
+      componentBlockNode.body.forEach((node) => {
+        if (node.type === 'VariableDeclaration') {
+          const propsDeclarator = node.declarations.find((declarator) => {
+            return declarator.init.name === 'props';
+          });
+          if (propsDeclarator !== undefined) {
+            componentPropsDeclarator = propsDeclarator;
+          }
+        }
+      });
+
+      return componentPropsDeclarator !== null ? componentPropsDeclarator.id : undefined;
+    }
+
+    function getComponentBlockNode(hookCallNode) {
+      let node = hookCallNode.parent;
+      while (node !== undefined) {
+        if (node.type === 'BlockStatement') {
+          return node;
+        }
+        node = node.parent;
+      }
+      return null;
+    }
+
+    return {
+      CallExpression(node) {
+        if (node.callee.name === 'useThemeVariants') {
+          const componentBlockNode = getComponentBlockNode(node);
+
+          const componentProps = getComponentProps(componentBlockNode);
+          const defaultProps =
+            componentProps === undefined
+              ? []
+              : componentProps.properties.filter((objectProperty) => {
+                  return (
+                    objectProperty.type === 'Property' &&
+                    objectProperty.value.type === 'AssignmentPattern'
+                  );
+                });
+
+          const [variantProps] = node.arguments;
+
+          const unsupportedComponentPropsNode =
+            componentProps !== undefined && componentProps.type !== 'ObjectPattern';
+
+          if (unsupportedComponentPropsNode) {
+            context.report({
+              node: componentProps,
+              message: `Can only analyze object patterns but found '${componentProps.type}'. Prefer \`const {...} = props;\``,
+            });
+          }
+
+          if (defaultProps.length === 0) {
+            return;
+          }
+
+          if (variantProps.type !== 'ObjectExpression') {
+            context.report({
+              node: variantProps,
+              message: `Can only analyze object patterns but found '${variantProps.type}'. Prefer \`{...props}\`.`,
+            });
+            return;
+          }
+
+          const variantPropsRestNode = variantProps.properties.find((objectProperty) => {
+            return objectProperty.type === 'SpreadElement';
+          });
+
+          if (
+            variantPropsRestNode !== undefined &&
+            variantProps.properties.indexOf(variantPropsRestNode) !== 0 &&
+            defaultProps.length > 0
+          ) {
+            context.report({
+              node: variantPropsRestNode,
+              message:
+                'The props spread must come first in the `useThemeVariant` props. Otherwise destructured props with default values could be overridden.',
+            });
+          }
+
+          defaultProps.forEach((componentProp) => {
+            const isPassedToVariantProps =
+              variantProps.properties.find((variantProp) => {
+                return (
+                  variantProp.type === 'Property' && componentProp.key.name === variantProp.key.name
+                );
+              }) !== undefined;
+            if (!isPassedToVariantProps) {
+              context.report({
+                node: componentProp,
+                message: 'Prop is not passed to `useThemeVariant` props.',
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.js
@@ -83,7 +83,7 @@ module.exports = {
             context.report({
               node: variantPropsRestNode,
               message:
-                'The props spread must come first in the `useThemeVariant` props. Otherwise destructured props with default values could be overridden.',
+                'The props spread must come first in the `useThemeVariants` props. Otherwise destructured props with default values could be overridden.',
             });
           }
 
@@ -97,7 +97,7 @@ module.exports = {
             if (!isPassedToVariantProps) {
               context.report({
                 node: variantProps,
-                message: `Prop \`${componentProp.key.name}\` is not passed to \`useThemeVariant\` props.`,
+                message: `Prop \`${componentProp.key.name}\` is not passed to \`useThemeVariants\` props.`,
               });
             }
           });

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.js
@@ -96,8 +96,8 @@ module.exports = {
               }) !== undefined;
             if (!isPassedToVariantProps) {
               context.report({
-                node: componentProp,
-                message: 'Prop is not passed to `useThemeVariant` props.',
+                node: variantProps,
+                message: `Prop \`${componentProp.key.name}\` is not passed to \`useThemeVariant\` props.`,
               });
             }
           });

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
@@ -57,7 +57,7 @@ ruleTester.run('rules-of-use-theme-variants', rule, {
   `,
       errors: [
         {
-          message: 'Prop `disabled` is not passed to `useThemeVariant` props.',
+          message: 'Prop `disabled` is not passed to `useThemeVariants` props.',
           line: 4,
           column: 20,
           endLine: 4,
@@ -74,7 +74,7 @@ ruleTester.run('rules-of-use-theme-variants', rule, {
   `,
       errors: [
         {
-          message: 'Prop `variant` is not passed to `useThemeVariant` props.',
+          message: 'Prop `variant` is not passed to `useThemeVariants` props.',
           line: 4,
           column: 20,
           endLine: 4,
@@ -92,7 +92,7 @@ ruleTester.run('rules-of-use-theme-variants', rule, {
       errors: [
         {
           message:
-            'The props spread must come first in the `useThemeVariant` props. Otherwise destructured props with default values could be overridden.',
+            'The props spread must come first in the `useThemeVariants` props. Otherwise destructured props with default values could be overridden.',
           line: 4,
           column: 32,
           endLine: 4,

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
@@ -9,7 +9,7 @@ const ruleTester = new eslint.RuleTester({
 });
 ruleTester.run('rules-of-use-theme-variants', rule, {
   valid: [
-    // allowed bug dangerous
+    // allowed but dangerous
     `
 {
   const useCustomThemeVariants = props => useThemeVariants(props);

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
@@ -57,11 +57,11 @@ ruleTester.run('rules-of-use-theme-variants', rule, {
   `,
       errors: [
         {
-          message: 'Prop is not passed to `useThemeVariant` props.',
-          line: 3,
-          column: 11,
-          endLine: 3,
-          endColumn: 27,
+          message: 'Prop `disabled` is not passed to `useThemeVariant` props.',
+          line: 4,
+          column: 20,
+          endLine: 4,
+          endColumn: 31,
         },
       ],
     },
@@ -74,11 +74,11 @@ ruleTester.run('rules-of-use-theme-variants', rule, {
   `,
       errors: [
         {
-          message: 'Prop is not passed to `useThemeVariant` props.',
-          line: 3,
-          column: 29,
-          endLine: 3,
-          endColumn: 45,
+          message: 'Prop `variant` is not passed to `useThemeVariant` props.',
+          line: 4,
+          column: 20,
+          endLine: 4,
+          endColumn: 42,
         },
       ],
     },

--- a/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js
@@ -1,0 +1,123 @@
+const eslint = require('eslint');
+const rule = require('./rules-of-use-theme-variants');
+
+const ruleTester = new eslint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaFeatures: { jsx: true },
+  },
+});
+ruleTester.run('rules-of-use-theme-variants', rule, {
+  valid: [
+    // allowed bug dangerous
+    `
+{
+  const useCustomThemeVariants = props => useThemeVariants(props);
+}`,
+    `
+{
+  useThemeVariants(props);
+}
+`,
+    `
+{
+  const { className, value: valueProp, ...other } = props;
+  useThemeVariants(props);
+}
+`,
+    `
+{
+  const { className, disabled = false, value: valueProp, ...other } = props;
+  useThemeVariants({ ...props, disabled });
+}
+`,
+    `
+{
+  const { className, value: valueProp, ...other } = props;
+  const [stateA, setStateA] = React.useState(0);
+  const [stateB, setStateB] = React.useState(0);
+  useThemeVariants({ stateA, ...props, stateB });
+}
+`,
+    // unneccessary spread but it's not the responsibility of this rule to catch "unnecessary" spread
+    `
+{
+  const { className, value: valueProp, ...other } = props;
+  useThemeVariants({ ...props});
+}
+  `,
+  ],
+  invalid: [
+    {
+      code: `
+{
+  const { disabled = false, ...other } = props;
+  useThemeVariants({ ...props});
+}
+  `,
+      errors: [
+        {
+          message: 'Prop is not passed to `useThemeVariant` props.',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 27,
+        },
+      ],
+    },
+    {
+      code: `
+{
+  const { disabled = false, variant = 'text', ...other } = props;
+  useThemeVariants({ ...props, disabled });
+}
+  `,
+      errors: [
+        {
+          message: 'Prop is not passed to `useThemeVariant` props.',
+          line: 3,
+          column: 29,
+          endLine: 3,
+          endColumn: 45,
+        },
+      ],
+    },
+    {
+      code: `
+{
+  const { disabled = false, ...other } = props;
+  useThemeVariants({ disabled, ...props });
+}
+  `,
+      errors: [
+        {
+          message:
+            'The props spread must come first in the `useThemeVariant` props. Otherwise destructured props with default values could be overridden.',
+          line: 4,
+          column: 32,
+          endLine: 4,
+          endColumn: 40,
+        },
+      ],
+    },
+    // this is valid code but not analyzeable by this rule
+    {
+      code: `
+{
+  const { disabled = false, ...other } = props;
+  const themeVariantProps = { ...props, disabled };
+  useThemeVariants(themeVariantProps);
+}
+  `,
+      errors: [
+        {
+          message: "Can only analyze object patterns but found 'Identifier'. Prefer `{...props}`.",
+          line: 5,
+          column: 20,
+          endLine: 5,
+          endColumn: 37,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -284,7 +284,6 @@ const Button = React.forwardRef(function Button(props, ref) {
       ...props,
       color,
       component,
-      disabled,
       disableElevation,
       disableFocusRipple,
       fullWidth,

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -284,6 +284,7 @@ const Button = React.forwardRef(function Button(props, ref) {
       ...props,
       color,
       component,
+      disabled,
       disableElevation,
       disableFocusRipple,
       fullWidth,


### PR DESCRIPTION
Resolves https://github.com/mui-org/material-ui/pull/21648#discussion_r460762150

Changed quite a bit from the original implementation.

Test explain best what valid and invalid patterns are caught: https://github.com/eps1lon/material-ui/blob/test/lint-usethemevariants/packages/eslint-plugin-material-ui/src/rules/rules-of-use-theme-variants.test.js

Change to existing code is meant as a sanity check for the rule. CI should fail since we no longer pass the resolved value of `disabled` in `Button` to `useThemeVariants`.

Edit: Fails as expected: https://app.circleci.com/pipelines/github/mui-org/material-ui/16138/workflows/d1b315c8-315b-460c-bd10-7c40dcb27f26/jobs/166269/parallel-runs/0/steps/0-113