### PR TITLE
[core] Improve hook dependencies in useControlled.js

### DIFF
--- a/packages/material-ui/src/utils/useControlled.js
+++ b/packages/material-ui/src/utils/useControlled.js
@@ -42,7 +42,7 @@ export default function useControlled({ controlled, default: defaultProp, name, 
     if (!isControlled) {
       setValue(newValue);
     }
-  }, []);
+  }, [isControlled]);
 
   return [value, setValueIfUncontrolled];
 }

--- a/packages/material-ui/src/utils/useControlled.js
+++ b/packages/material-ui/src/utils/useControlled.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 export default function useControlled({ controlled, default: defaultProp, name, state = 'value' }) {
+  // isControlled is ignored in the hook dependency lists as it should never change.
   const { current: isControlled } = React.useRef(controlled !== undefined);
   const [valueState, setValue] = React.useState(defaultProp);
   const value = isControlled ? controlled : valueState;
@@ -22,7 +23,7 @@ export default function useControlled({ controlled, default: defaultProp, name, 
           ].join('\n'),
         );
       }
-    }, [controlled]);
+    }, [state, name, controlled]);
 
     const { current: defaultValue } = React.useRef(defaultProp);
 
@@ -42,7 +43,7 @@ export default function useControlled({ controlled, default: defaultProp, name, 
     if (!isControlled) {
       setValue(newValue);
     }
-  }, [isControlled]);
+  }, []);
 
   return [value, setValueIfUncontrolled];
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).


React Hook React.useCallback has a missing dependency: 'isControlled'. Either include it or remove the dependency array  react-hooks/exhaustive-deps