### PR TITLE
[Slide] overflow bug when direction is up or left

### DIFF
--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -208,31 +208,33 @@ const Slide = React.forwardRef(function Slide(props, ref) {
   }, [inProp, updatePosition]);
 
   return (
-    <TransitionComponent
-      nodeRef={childrenRef}
-      onEnter={handleEnter}
-      onEntered={handleEntered}
-      onEntering={handleEntering}
-      onExit={handleExit}
-      onExited={handleExited}
-      onExiting={handleExiting}
-      appear
-      in={inProp}
-      timeout={timeout}
-      {...other}
-    >
-      {(state, childProps) => {
-        return React.cloneElement(children, {
-          ref: handleRef,
-          style: {
-            visibility: state === 'exited' && !inProp ? 'hidden' : undefined,
-            ...style,
-            ...children.props.style,
-          },
-          ...childProps,
-        });
-      }}
-    </TransitionComponent>
+    <div style={{ overflow: 'hidden' }}>
+      <TransitionComponent
+        nodeRef={childrenRef}
+        onEnter={handleEnter}
+        onEntered={handleEntered}
+        onEntering={handleEntering}
+        onExit={handleExit}
+        onExited={handleExited}
+        onExiting={handleExiting}
+        appear
+        in={inProp}
+        timeout={timeout}
+        {...other}
+      >
+        {(state, childProps) => {
+          return React.cloneElement(children, {
+            ref: handleRef,
+            style: {
+              visibility: state === 'exited' && !inProp ? 'hidden' : undefined,
+              ...style,
+              ...children.props.style,
+            },
+            ...childProps,
+          });
+        }}
+      </TransitionComponent>
+    </div>
   );
 });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

## Details: 
> The slide animation overflows when:
>   - The ```in``` prop is ```false```
>   - The ```direction``` prop has value of  ```'up'``` or ```'left'```.


## Issue: 

Closes  #13701