### PR TITLE
[docs] Add missing JSDOC for various props

### DIFF
--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.d.ts
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.d.ts
@@ -20,8 +20,6 @@ export type BottomNavigationActionTypeMap<
      * The label element.
      */
     label?: React.ReactNode;
-    onClick?: React.ReactEventHandler<any>;
-    selected?: boolean;
     /**
      * If `true`, the `BottomNavigationAction` will show its label.
      * By default, only the selected `BottomNavigationAction`

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -61,6 +61,7 @@ const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(
     label,
     onChange,
     onClick,
+    // eslint-disable-next-line react/prop-types -- private, always overridden by BottomNavigation
     selected,
     showLabel,
     value,
@@ -142,10 +143,6 @@ BottomNavigationAction.propTypes = {
    * @ignore
    */
   onClick: PropTypes.func,
-  /**
-   * @ignore
-   */
-  selected: PropTypes.bool,
   /**
    * If `true`, the `BottomNavigationAction` will show its label.
    * By default, only the selected `BottomNavigationAction`

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -47,7 +47,6 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
      * If `true`, a 1px light border is added to the bottom of the list item.
      */
     divider?: boolean;
-    focusVisibleClassName?: string;
     /**
      * Use to apply selected styling.
      */

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -93,8 +93,6 @@ export interface SnackbarProps
    * Callback fired when the transition is exiting.
    */
   onExiting?: TransitionHandlerProps['onExiting'];
-  onMouseEnter?: React.MouseEventHandler<any>;
-  onMouseLeave?: React.MouseEventHandler<any>;
   /**
    * If `true`, `Snackbar` is open.
    */

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -92,13 +92,6 @@ export interface BaseTextFieldProps
    */
   name?: string;
   onBlur?: InputBaseProps['onBlur'];
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: InputBaseProps['onChange'];
   onFocus?: StandardInputProps['onFocus'];
   /**
    * The short hint displayed in the input before the user enters a value.
@@ -141,6 +134,13 @@ export interface BaseTextFieldProps
 
 export interface StandardTextFieldProps extends BaseTextFieldProps {
   /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: StandardInputProps['onChange'];
+  /**
    * The variant to use.
    */
   variant?: 'standard';
@@ -155,6 +155,13 @@ export interface StandardTextFieldProps extends BaseTextFieldProps {
 
 export interface FilledTextFieldProps extends BaseTextFieldProps {
   /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: FilledInputProps['onChange'];
+  /**
    * The variant to use.
    */
   variant: 'filled';
@@ -168,6 +175,13 @@ export interface FilledTextFieldProps extends BaseTextFieldProps {
 }
 
 export interface OutlinedTextFieldProps extends BaseTextFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: OutlinedInputProps['onChange'];
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StandardProps, PropTypes } from '..';
 import { FormControlProps } from '../FormControl';
 import { FormHelperTextProps } from '../FormHelperText';
+import { InputBaseProps } from '../InputBase';
 import { InputProps as StandardInputProps } from '../Input';
 import { FilledInputProps } from '../FilledInput';
 import { OutlinedInputProps } from '../OutlinedInput';
@@ -67,6 +68,10 @@ export interface BaseTextFieldProps
    */
   InputLabelProps?: Partial<InputLabelProps>;
   /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps?: InputBaseProps['inputProps'];
+  /**
    * Pass a ref to the `input` element.
    */
   inputRef?: React.Ref<any>;
@@ -86,6 +91,15 @@ export interface BaseTextFieldProps
    * Name attribute of the `input` element.
    */
   name?: string;
+  onBlur?: InputBaseProps['onBlur'];
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: InputBaseProps['onChange'];
+  onFocus?: StandardInputProps['onFocus'];
   /**
    * The short hint displayed in the input before the user enters a value.
    */
@@ -126,15 +140,6 @@ export interface BaseTextFieldProps
 }
 
 export interface StandardTextFieldProps extends BaseTextFieldProps {
-  onBlur?: StandardInputProps['onBlur'];
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: StandardInputProps['onChange'];
-  onFocus?: StandardInputProps['onFocus'];
   /**
    * The variant to use.
    */
@@ -146,22 +151,9 @@ export interface StandardTextFieldProps extends BaseTextFieldProps {
    * component depending on the `variant` prop value.
    */
   InputProps?: Partial<StandardInputProps>;
-  /**
-   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
-   */
-  inputProps?: StandardInputProps['inputProps'];
 }
 
 export interface FilledTextFieldProps extends BaseTextFieldProps {
-  onBlur?: FilledInputProps['onBlur'];
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: FilledInputProps['onChange'];
-  onFocus?: FilledInputProps['onFocus'];
   /**
    * The variant to use.
    */
@@ -173,22 +165,9 @@ export interface FilledTextFieldProps extends BaseTextFieldProps {
    * component depending on the `variant` prop value.
    */
   InputProps?: Partial<FilledInputProps>;
-  /**
-   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
-   */
-  inputProps?: FilledInputProps['inputProps'];
 }
 
 export interface OutlinedTextFieldProps extends BaseTextFieldProps {
-  onBlur?: OutlinedInputProps['onBlur'];
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: OutlinedInputProps['onChange'];
-  onFocus?: OutlinedInputProps['onFocus'];
   /**
    * The variant to use.
    */
@@ -200,10 +179,6 @@ export interface OutlinedTextFieldProps extends BaseTextFieldProps {
    * component depending on the `variant` prop value.
    */
   InputProps?: Partial<OutlinedInputProps>;
-  /**
-   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
-   */
-  inputProps?: OutlinedInputProps['inputProps'];
 }
 
 export type TextFieldProps = StandardTextFieldProps | FilledTextFieldProps | OutlinedTextFieldProps;

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -117,6 +117,7 @@ const ignoreExternalDocumentation: Record<string, string[]> = {
   Fab: ['focusVisibleClassName'],
   Fade: transitionCallbacks,
   Grow: transitionCallbacks,
+  ListItem: ['focusVisibleClassName'],
   InputBase: ['aria-describedby'],
   Menu: ['PaperProps'],
   MenuItem: ['button', 'disabled', 'selected'],


### PR DESCRIPTION
Declaring a prop in TypeScript without JSDOC overrides the JSDOC of that prop in the extended interface. We only want to skip this JSDOC on material-ui.com not in IntelliSense.