### PR TITLE
[Table] Cell small's right padding is bigger than medium

### DIFF
--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -42,17 +42,10 @@ export const styles = (theme) => ({
   },
   /* Styles applied to the root element if `size="small"`. */
   sizeSmall: {
-    padding: '6px 24px 6px 16px',
-    '&:last-child': {
-      paddingRight: 16,
-    },
+    padding: '6px 16px',
     '&$paddingCheckbox': {
       width: 24, // prevent the checkbox column from growing
       padding: '0 12px 0 16px',
-      '&:last-child': {
-        paddingLeft: 12,
-        paddingRight: 16,
-      },
       '& > *': {
         padding: 0,
       },
@@ -62,17 +55,10 @@ export const styles = (theme) => ({
   paddingCheckbox: {
     width: 48, // prevent the checkbox column from growing
     padding: '0 0 0 4px',
-    '&:last-child': {
-      paddingLeft: 0,
-      paddingRight: 4,
-    },
   },
   /* Styles applied to the root element if `padding="none"`. */
   paddingNone: {
     padding: 0,
-    '&:last-child': {
-      padding: 0,
-    },
   },
   /* Styles applied to the root element if `align="left"`. */
   alignLeft: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

This pull request is solving the bug from the following issue: https://github.com/mui-org/material-ui/issues/22004, it uses the proposed solution in the comments.

Closes #22004