### PR TITLE
Update Tooltip.js

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -182,7 +182,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     placement = 'bottom',
     PopperComponent = Popper,
     PopperProps,
-    title,
+    title = '',
     TransitionComponent = Grow,
     TransitionProps,
     ...other


### PR DESCRIPTION
Initialize title prop with an empty string, so it will not display an empty tooltip when undefined is passed to title

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
