### PR TITLE
[core] Bump csstype to 3.0.0

### DIFF
--- a/docs/src/pages/components/tree-view/GmailTreeView.tsx
+++ b/docs/src/pages/components/tree-view/GmailTreeView.tsx
@@ -14,8 +14,8 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import { SvgIconProps } from '@material-ui/core/SvgIcon';
 
-declare module 'csstype' {
-  interface Properties {
+declare module 'react' {
+  interface CSSProperties {
     '--tree-view-color'?: string;
     '--tree-view-bg-color'?: string;
   }

--- a/framer/package.json
+++ b/framer/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "dependencies": {
     "@types/draft-js": "^0.10.43",
-    "@types/react": "^16.8.24",
+    "@types/react": "^16.9.44",
     "case": "1.6.3",
     "deepmerge": "^4.0.0",
     "docs": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/lodash": "^4.14.138",
     "@types/mocha": "^8.0.0",
     "@types/prettier": "^2.0.0",
-    "@types/react": "^16.9.3",
+    "@types/react": "^16.9.44",
     "@types/sinon": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -53,7 +53,7 @@
     "@material-ui/types": "^5.1.0",
     "@material-ui/utils": "^5.0.0-alpha.1",
     "clsx": "^1.0.4",
-    "csstype": "^2.5.2",
+    "csstype": "^3.0.2",
     "hoist-non-react-statics": "^3.3.2",
     "jss": "^10.0.3",
     "jss-plugin-camel-case": "^10.0.3",

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -7,14 +7,16 @@ import { DefaultTheme } from '../defaultTheme';
 // Disable automatic export
 export {};
 
-type JSSFontface = CSS.FontFace & { fallbacks?: CSS.FontFace[] };
+// private JSS type that should be public
+type JSSNormalCssProperties = CSS.Properties<number | string>;
+type JSSFontface = CSS.AtRule.FontFace & { fallbacks?: CSS.AtRule.FontFace[] };
 
 export type PropsFunc<Props extends object, T> = (props: Props) => T;
 
 /**
  * Allows the user to augment the properties available
  */
-export interface BaseCSSProperties extends CSS.Properties<number | string> {
+export interface BaseCSSProperties extends JSSNormalCssProperties {
   '@font-face'?: JSSFontface | JSSFontface[];
 }
 

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@material-ui/utils": "^5.0.0-alpha.1",
-    "csstype": "^2.5.2",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {},

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import * as React from 'react';
 // disable automatic export
 export {};
 
@@ -170,7 +170,7 @@ export type SpacingProps = PropsFor<typeof spacing>;
 
 // style.js
 export interface StyleOptions<PropKey, Theme extends object> {
-  cssProperty?: PropKey | keyof CSS.Properties | false;
+  cssProperty?: PropKey | keyof React.CSSProperties | false;
   prop: PropKey;
   /**
    * dot access in `Theme`
@@ -201,7 +201,7 @@ export const typography: SimpleStyleFunction<
 >;
 export type TypographyProps = PropsFor<typeof typography>;
 
-export const visuallyHidden: CSS.Properties;
+export const visuallyHidden: React.CSSProperties;
 
 // utils
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/packages/material-ui/src/styles/createTypography.spec.ts
+++ b/packages/material-ui/src/styles/createTypography.spec.ts
@@ -12,5 +12,17 @@ import { expectType } from '@material-ui/types';
   });
 
   const maybeFontStyle = theme.typography.body1.fontStyle;
-  expectType<string | undefined, typeof maybeFontStyle>(maybeFontStyle);
+  expectType<
+    | '-moz-initial'
+    | 'inherit'
+    | 'initial'
+    | 'revert'
+    | 'unset'
+    | 'italic'
+    | 'normal'
+    | 'oblique'
+    | (string & {})
+    | undefined,
+    typeof maybeFontStyle
+  >(maybeFontStyle);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,13 +2813,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.23", "@types/react@^16.8.24", "@types/react@^16.9.3":
-  version "16.9.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
-  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
+"@types/react@*", "@types/react@^16.8.23", "@types/react@^16.9.44":
+  version "16.9.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.44.tgz#da84b179c031aef67dc92c33bd3401f1da2fa3bc"
+  integrity sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^2.2.0"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -5823,7 +5823,7 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0, csstype@^2.5.2, csstype@^2.5.7, csstype@^2.6.5, csstype@^2.6.7:
+csstype@^2.5.7, csstype@^2.6.5, csstype@^2.6.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,7 +1047,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.0.0", "@babel/runtime@7.9.6", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@7.0.0", "@babel/runtime@7.9.6", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
@@ -5823,7 +5823,7 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.5.7, csstype@^2.6.5, csstype@^2.6.7:
+csstype@^2.5.7, csstype@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
@@ -6351,12 +6351,12 @@ dom-helpers@^3.4.0:
     "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.0.0, dom-helpers@^5.0.1:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.3.tgz#7233248eb3a2d1f74aafca31e52c5299cc8ce821"
-  integrity sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
   dependencies:
-    "@babel/runtime" "^7.6.3"
-    csstype "^2.6.7"
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serialize@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
These shouldn't actually conflict. If they reveal assignability conflicts then you accidentally used types `csstype` instead of `@material-ui/*`.

Some places in the repo wrongly used `csstype` where `React.CSSProperties` was more appropriate. `csstype` is an implementation detail of `@types/react`.
 
Closes #22000