### PR TITLE
[core] Improve merge-conflict label automation

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/1.x
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: 'PR: out-of-date'
           removeOnDirtyLabel: 'PR: ready to ship'

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -2,10 +2,17 @@ name: 'Maintenance'
 on:
   # So that PRs touching the same files as the push are updated
   push:
+    branches-ignore:
+      # PRs are almost never based off of dependabot PRs
+      - 'dependabot/**'
   # So that the `dirtyLabel` is removed if conflicts are resolved
   # Could put too much strain on rate limit
   # If we hit the rate limit too often remove this event
   pull_request_target:
+    branches-ignore:
+      # These PRs are almost fully automated so labelling them is not as important.
+      # They do burst the GitHub API though so we're ignoring them to not hit the rate limit
+      - 'dependabot/**'
     types: [synchronize]
 
 jobs:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -3,9 +3,10 @@ on:
   # So that PRs touching the same files as the push are updated
   push:
   # So that the `dirtyLabel` is removed if conflicts are resolved
-  # On forks the secret isn't set. We need to manually remove it.
-  #pull_request:
-  #  types: [synchronize]
+  # Could put too much strain on rate limit
+  # If we hit the rate limit too often remove this event
+  pull_request_target:
+    types: [synchronize]
 
 jobs:
   main:


### PR DESCRIPTION
- update label when a PR is synchronized (by using new [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event)
- Bump `actions-label-merge-conflict` to 2.x. 2.x reduces requests thus reducing risk of exceeding the GitHub API rate limit)
- ignore dependabot PRs (they're almost always automated or not bases of PRs). Should also reduce risk of exceeding the GitHub API rate limit.