### PR TITLE
[Badge] Add overlap circular and rectangular

### DIFF
--- a/docs/pages/api-docs/badge.md
+++ b/docs/pages/api-docs/badge.md
@@ -36,7 +36,7 @@ The `MuiBadge` name can be used for providing [default props](/customization/glo
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'span'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">invisible</span> | <span class="prop-type">bool</span> |  | If `true`, the badge will be invisible. |
 | <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">99</span> | Max count to show. |
-| <span class="prop-name">overlap</span> | <span class="prop-type">'circle'<br>&#124;&nbsp;'rectangle'</span> | <span class="prop-default">'rectangle'</span> | Wrapped shape the badge should overlap. |
+| <span class="prop-name">overlap</span> | <span class="prop-type">'circular'<br>&#124;&nbsp;'rectangular'</span> | <span class="prop-default">'rectangular'</span> | Wrapped shape the badge should overlap. |
 | <span class="prop-name">showZero</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Controls whether the badge is hidden when `badgeContent` is zero. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'dot'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
@@ -54,14 +54,14 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">colorSecondary</span> | <span class="prop-name">.MuiBadge-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 | <span class="prop-name">colorError</span> | <span class="prop-name">.MuiBadge-colorError</span> | Styles applied to the root element if `color="error"`.
 | <span class="prop-name">dot</span> | <span class="prop-name">.MuiBadge-dot</span> | Styles applied to the root element if `variant="dot"`.
-| <span class="prop-name">anchorOriginTopRightRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangle"`.
-| <span class="prop-name">anchorOriginBottomRightRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangle"`.
-| <span class="prop-name">anchorOriginTopLeftRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangle"`.
-| <span class="prop-name">anchorOriginBottomLeftRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangle"`.
-| <span class="prop-name">anchorOriginTopRightCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="circle"`.
-| <span class="prop-name">anchorOriginBottomRightCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circle"`.
-| <span class="prop-name">anchorOriginTopLeftCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="circle"`.
-| <span class="prop-name">anchorOriginBottomLeftCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circle"`.
+| <span class="prop-name">anchorOriginTopRightRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginBottomRightRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginTopLeftRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginBottomLeftRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginTopRightCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="circular"`.
+| <span class="prop-name">anchorOriginBottomRightCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circular"`.
+| <span class="prop-name">anchorOriginTopLeftCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="circular"`.
+| <span class="prop-name">anchorOriginBottomLeftCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circular"`.
 | <span class="prop-name">invisible</span> | <span class="prop-name">.MuiBadge-invisible</span> | Pseudo-class to the badge `span` element if `invisible={true}`.
 
 You can override the style of the component thanks to one of these customization points:

--- a/docs/pages/api-docs/badge.md
+++ b/docs/pages/api-docs/badge.md
@@ -36,7 +36,7 @@ The `MuiBadge` name can be used for providing [default props](/customization/glo
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'span'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">invisible</span> | <span class="prop-type">bool</span> |  | If `true`, the badge will be invisible. |
 | <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">99</span> | Max count to show. |
-| <span class="prop-name">overlap</span> | <span class="prop-type">'circular'<br>&#124;&nbsp;'rectangular'</span> | <span class="prop-default">'rectangle'</span> | Wrapped shape the badge should overlap. |
+| <span class="prop-name">overlap</span> | <span class="prop-type">'circle'<br>&#124;&nbsp;'rectangle'<br>&#124;&nbsp;'circular'<br>&#124;&nbsp;'rectangular'</span> | <span class="prop-default">'rectangle'</span> | Wrapped shape the badge should overlap. |
 | <span class="prop-name">showZero</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Controls whether the badge is hidden when `badgeContent` is zero. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'dot'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
 

--- a/docs/pages/api-docs/badge.md
+++ b/docs/pages/api-docs/badge.md
@@ -36,7 +36,7 @@ The `MuiBadge` name can be used for providing [default props](/customization/glo
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'span'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">invisible</span> | <span class="prop-type">bool</span> |  | If `true`, the badge will be invisible. |
 | <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">99</span> | Max count to show. |
-| <span class="prop-name">overlap</span> | <span class="prop-type">'circular'<br>&#124;&nbsp;'rectangular'</span> | <span class="prop-default">'rectangular'</span> | Wrapped shape the badge should overlap. |
+| <span class="prop-name">overlap</span> | <span class="prop-type">'circular'<br>&#124;&nbsp;'rectangular'</span> | <span class="prop-default">'rectangle'</span> | Wrapped shape the badge should overlap. |
 | <span class="prop-name">showZero</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Controls whether the badge is hidden when `badgeContent` is zero. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'dot'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
@@ -54,13 +54,21 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">colorSecondary</span> | <span class="prop-name">.MuiBadge-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 | <span class="prop-name">colorError</span> | <span class="prop-name">.MuiBadge-colorError</span> | Styles applied to the root element if `color="error"`.
 | <span class="prop-name">dot</span> | <span class="prop-name">.MuiBadge-dot</span> | Styles applied to the root element if `variant="dot"`.
+| <span class="prop-name">anchorOriginTopRightRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangle"`.
 | <span class="prop-name">anchorOriginTopRightRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginBottomRightRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangle"`.
 | <span class="prop-name">anchorOriginBottomRightRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginTopLeftRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangle"`.
 | <span class="prop-name">anchorOriginTopLeftRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginBottomLeftRectangle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftRectangle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangle"`.
 | <span class="prop-name">anchorOriginBottomLeftRectangular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftRectangular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangular"`.
+| <span class="prop-name">anchorOriginTopRightCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="circle"`.
 | <span class="prop-name">anchorOriginTopRightCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopRightCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="circular"`.
+| <span class="prop-name">anchorOriginBottomRightCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circle"`.
 | <span class="prop-name">anchorOriginBottomRightCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomRightCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circular"`.
+| <span class="prop-name">anchorOriginTopLeftCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="circle"`.
 | <span class="prop-name">anchorOriginTopLeftCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginTopLeftCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="circular"`.
+| <span class="prop-name">anchorOriginBottomLeftCircle</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftCircle</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circle"`.
 | <span class="prop-name">anchorOriginBottomLeftCircular</span> | <span class="prop-name">.MuiBadge-anchorOriginBottomLeftCircular</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circular"`.
 | <span class="prop-name">invisible</span> | <span class="prop-name">.MuiBadge-invisible</span> | Pseudo-class to the badge `span` element if `invisible={true}`.
 

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -203,6 +203,12 @@ export function ThemeProvider(props) {
           },
           ...paletteColors,
         },
+        // v5 migration
+        props: {
+          MuiBadge: {
+            overlap: 'rectangular',
+          },
+        },
         spacing,
       },
       dense ? highDensity : null,

--- a/docs/src/pages/components/avatars/BadgeAvatars.js
+++ b/docs/src/pages/components/avatars/BadgeAvatars.js
@@ -55,7 +55,7 @@ export default function BadgeAvatars() {
   return (
     <div className={classes.root}>
       <StyledBadge
-        overlap="circle"
+        overlap="circular"
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',
@@ -65,7 +65,7 @@ export default function BadgeAvatars() {
         <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       </StyledBadge>
       <Badge
-        overlap="circle"
+        overlap="circular"
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',

--- a/docs/src/pages/components/avatars/BadgeAvatars.tsx
+++ b/docs/src/pages/components/avatars/BadgeAvatars.tsx
@@ -61,7 +61,7 @@ export default function BadgeAvatars() {
   return (
     <div className={classes.root}>
       <StyledBadge
-        overlap="circle"
+        overlap="circular"
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',
@@ -71,7 +71,7 @@ export default function BadgeAvatars() {
         <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       </StyledBadge>
       <Badge
-        overlap="circle"
+        overlap="circular"
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',

--- a/docs/src/pages/components/badges/BadgeOverlap.js
+++ b/docs/src/pages/components/badges/BadgeOverlap.js
@@ -33,10 +33,10 @@ export default function BadgeOverlap() {
       <Badge color="secondary" badgeContent=" " variant="dot">
         {rectangle}
       </Badge>
-      <Badge color="secondary" overlap="circle" badgeContent=" ">
+      <Badge color="secondary" overlap="circular" badgeContent=" ">
         {circle}
       </Badge>
-      <Badge color="secondary" overlap="circle" badgeContent=" " variant="dot">
+      <Badge color="secondary" overlap="circular" badgeContent=" " variant="dot">
         {circle}
       </Badge>
     </div>

--- a/docs/src/pages/components/badges/BadgeOverlap.tsx
+++ b/docs/src/pages/components/badges/BadgeOverlap.tsx
@@ -35,10 +35,10 @@ export default function BadgeOverlap() {
       <Badge color="secondary" badgeContent=" " variant="dot">
         {rectangle}
       </Badge>
-      <Badge color="secondary" overlap="circle" badgeContent=" ">
+      <Badge color="secondary" overlap="circular" badgeContent=" ">
         {circle}
       </Badge>
-      <Badge color="secondary" overlap="circle" badgeContent=" " variant="dot">
+      <Badge color="secondary" overlap="circular" badgeContent=" " variant="dot">
         {circle}
       </Badge>
     </div>

--- a/packages/material-ui/src/Badge/Badge.d.ts
+++ b/packages/material-ui/src/Badge/Badge.d.ts
@@ -15,7 +15,7 @@ export interface BadgeTypeMap<P = {}, D extends React.ElementType = 'div'> {
     /**
      * Wrapped shape the badge should overlap.
      */
-    overlap?: 'rectangle' | 'circle';
+    overlap?: 'rectangle' | 'circle' | 'rectangular' | 'circular';
     /**
      * The content rendered within the badge.
      */
@@ -63,6 +63,13 @@ export type BadgeClassKey =
   | 'anchorOriginTopRightCircle'
   | 'anchorOriginBottomRightCircle'
   | 'anchorOriginTopLeftCircle'
+  | 'anchorOriginTopRightRectangular'
+  | 'anchorOriginBottomRightRectangular'
+  | 'anchorOriginTopLeftRectangular'
+  | 'anchorOriginBottomLeftRectangular'
+  | 'anchorOriginTopRightCircular'
+  | 'anchorOriginBottomRightCircular'
+  | 'anchorOriginTopLeftCircular'
   | 'invisible';
 /**
  *

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -331,7 +331,10 @@ Badge.propTypes = {
       ['anchorOriginBottomRightCircle', 'anchorOriginBottomRightCircular'],
       ['anchorOriginTopLeftCircle', 'anchorOriginTopLeftCircular'],
     ].forEach(([deprecatedClassKey, newClassKey]) => {
-      if (classes[deprecatedClassKey] != null) {
+      if (
+        classes[deprecatedClassKey] != null &&
+        classes[deprecatedClassKey].split(' ').length > 1
+      ) {
         throw new Error(
           `Material-UI: The \`${deprecatedClassKey}\` class was deprecated. Use \`${newClassKey}\` instead.`,
         );
@@ -364,23 +367,26 @@ Badge.propTypes = {
   /**
    * Wrapped shape the badge should overlap.
    */
-  overlap: chainPropTypes(PropTypes.oneOf(['circular', 'rectangular']), (props) => {
-    const { overlap } = props;
+  overlap: chainPropTypes(
+    PropTypes.oneOf(['circle', 'rectangle', 'circular', 'rectangular']),
+    (props) => {
+      const { overlap } = props;
 
-    if (overlap === 'rectangle') {
-      throw new Error(
-        'Material-UI: `overlap="rectangle"` was deprecated. Use `overlap="rectangular"` instead.',
-      );
-    }
+      if (overlap === 'rectangle') {
+        throw new Error(
+          'Material-UI: `overlap="rectangle"` was deprecated. Use `overlap="rectangular"` instead.',
+        );
+      }
 
-    if (overlap === 'circle') {
-      throw new Error(
-        'Material-UI: `overlap="circle"` was deprecated. Use `overlap="circular"` instead.',
-      );
-    }
+      if (overlap === 'circle') {
+        throw new Error(
+          'Material-UI: `overlap="circle"` was deprecated. Use `overlap="circular"` instead.',
+        );
+      }
 
-    return null;
-  }),
+      return null;
+    },
+  ),
   /**
    * Controls whether the badge is hidden when `badgeContent` is zero.
    */

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -72,8 +72,28 @@ export const styles = (theme) => ({
       transform: 'scale(0) translate(50%, -50%)',
     },
   },
+  /* Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangular"`. */
+  anchorOriginTopRightRectangular: {
+    top: 0,
+    right: 0,
+    transform: 'scale(1) translate(50%, -50%)',
+    transformOrigin: '100% 0%',
+    '&$invisible': {
+      transform: 'scale(0) translate(50%, -50%)',
+    },
+  },
   /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangle"`. */
   anchorOriginBottomRightRectangle: {
+    bottom: 0,
+    right: 0,
+    transform: 'scale(1) translate(50%, 50%)',
+    transformOrigin: '100% 100%',
+    '&$invisible': {
+      transform: 'scale(0) translate(50%, 50%)',
+    },
+  },
+  /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangular"`. */
+  anchorOriginBottomRightRectangular: {
     bottom: 0,
     right: 0,
     transform: 'scale(1) translate(50%, 50%)',
@@ -92,8 +112,28 @@ export const styles = (theme) => ({
       transform: 'scale(0) translate(-50%, -50%)',
     },
   },
+  /* Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangular"`. */
+  anchorOriginTopLeftRectangular: {
+    top: 0,
+    left: 0,
+    transform: 'scale(1) translate(-50%, -50%)',
+    transformOrigin: '0% 0%',
+    '&$invisible': {
+      transform: 'scale(0) translate(-50%, -50%)',
+    },
+  },
   /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangle"`. */
   anchorOriginBottomLeftRectangle: {
+    bottom: 0,
+    left: 0,
+    transform: 'scale(1) translate(-50%, 50%)',
+    transformOrigin: '0% 100%',
+    '&$invisible': {
+      transform: 'scale(0) translate(-50%, 50%)',
+    },
+  },
+  /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangular"`. */
+  anchorOriginBottomLeftRectangular: {
     bottom: 0,
     left: 0,
     transform: 'scale(1) translate(-50%, 50%)',
@@ -112,8 +152,28 @@ export const styles = (theme) => ({
       transform: 'scale(0) translate(50%, -50%)',
     },
   },
+  /* Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }} overlap="circular"`. */
+  anchorOriginTopRightCircular: {
+    top: '14%',
+    right: '14%',
+    transform: 'scale(1) translate(50%, -50%)',
+    transformOrigin: '100% 0%',
+    '&$invisible': {
+      transform: 'scale(0) translate(50%, -50%)',
+    },
+  },
   /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circle"`. */
   anchorOriginBottomRightCircle: {
+    bottom: '14%',
+    right: '14%',
+    transform: 'scale(1) translate(50%, 50%)',
+    transformOrigin: '100% 100%',
+    '&$invisible': {
+      transform: 'scale(0) translate(50%, 50%)',
+    },
+  },
+  /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circular"`. */
+  anchorOriginBottomRightCircular: {
     bottom: '14%',
     right: '14%',
     transform: 'scale(1) translate(50%, 50%)',
@@ -132,8 +192,28 @@ export const styles = (theme) => ({
       transform: 'scale(0) translate(-50%, -50%)',
     },
   },
+  /* Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }} overlap="circular"`. */
+  anchorOriginTopLeftCircular: {
+    top: '14%',
+    left: '14%',
+    transform: 'scale(1) translate(-50%, -50%)',
+    transformOrigin: '0% 0%',
+    '&$invisible': {
+      transform: 'scale(0) translate(-50%, -50%)',
+    },
+  },
   /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circle"`. */
   anchorOriginBottomLeftCircle: {
+    bottom: '14%',
+    left: '14%',
+    transform: 'scale(1) translate(-50%, 50%)',
+    transformOrigin: '0% 100%',
+    '&$invisible': {
+      transform: 'scale(0) translate(-50%, 50%)',
+    },
+  },
+  /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circular"`. */
+  anchorOriginBottomLeftCircular: {
     bottom: '14%',
     left: '14%',
     transform: 'scale(1) translate(-50%, 50%)',
@@ -260,7 +340,7 @@ Badge.propTypes = {
   /**
    * Wrapped shape the badge should overlap.
    */
-  overlap: PropTypes.oneOf(['circle', 'rectangle']),
+  overlap: PropTypes.oneOf(['circular', 'rectangular']),
   /**
    * Controls whether the badge is hidden when `badgeContent` is zero.
    */
@@ -271,4 +351,50 @@ Badge.propTypes = {
   variant: PropTypes.oneOf(['dot', 'standard']),
 };
 
-export default withStyles(styles, { name: 'MuiBadge' })(Badge);
+const MuiBadge = withStyles(styles, { name: 'MuiBadge' })(Badge);
+
+MuiBadge.propTypes = {
+  classes: (props) => {
+    const { classes } = props;
+    if (classes == null) {
+      return null;
+    }
+
+    [
+      ['anchorOriginTopRightRectangle', 'anchorOriginTopRightRectangular'],
+      ['anchorOriginBottomRightRectangle', 'anchorOriginBottomRightRectangular'],
+      ['anchorOriginTopLeftRectangle', 'anchorOriginTopLeftRectangular'],
+      ['anchorOriginBottomLeftRectangle', 'anchorOriginBottomLeftRectangular'],
+      ['anchorOriginTopRightCircle', 'anchorOriginTopRightCircular'],
+      ['anchorOriginBottomRightCircle', 'anchorOriginBottomRightCircular'],
+      ['anchorOriginTopLeftCircle', 'anchorOriginTopLeftCircular'],
+    ].forEach(([deprecatedClassKey, newClassKey]) => {
+      if (classes[deprecatedClassKey] != null) {
+        throw new Error(
+          `Material-UI: The \`${deprecatedClassKey}\` class was deprecated. Use \`${newClassKey}\` instead.`,
+        );
+      }
+    });
+
+    return null;
+  },
+  overlap: (props) => {
+    const { overlap } = props;
+
+    if (overlap === 'rectangle') {
+      throw new Error(
+        'Material-UI: `overlap="rectangle"` was deprecated. Use `overlap="rectangular"` instead.',
+      );
+    }
+
+    if (overlap === 'circle') {
+      throw new Error(
+        'Material-UI: `overlap="circle"` was deprecated. Use `overlap="circular"` instead.',
+      );
+    }
+
+    return null;
+  },
+};
+
+export default MuiBadge;

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import capitalize from '../utils/capitalize';
 
@@ -315,7 +316,30 @@ Badge.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object,
+  classes: chainPropTypes(PropTypes.object, (props) => {
+    const { classes } = props;
+    if (classes == null) {
+      return null;
+    }
+
+    [
+      ['anchorOriginTopRightRectangle', 'anchorOriginTopRightRectangular'],
+      ['anchorOriginBottomRightRectangle', 'anchorOriginBottomRightRectangular'],
+      ['anchorOriginTopLeftRectangle', 'anchorOriginTopLeftRectangular'],
+      ['anchorOriginBottomLeftRectangle', 'anchorOriginBottomLeftRectangular'],
+      ['anchorOriginTopRightCircle', 'anchorOriginTopRightCircular'],
+      ['anchorOriginBottomRightCircle', 'anchorOriginBottomRightCircular'],
+      ['anchorOriginTopLeftCircle', 'anchorOriginTopLeftCircular'],
+    ].forEach(([deprecatedClassKey, newClassKey]) => {
+      if (classes[deprecatedClassKey] != null) {
+        throw new Error(
+          `Material-UI: The \`${deprecatedClassKey}\` class was deprecated. Use \`${newClassKey}\` instead.`,
+        );
+      }
+    });
+
+    return null;
+  }),
   /**
    * @ignore
    */
@@ -340,45 +364,7 @@ Badge.propTypes = {
   /**
    * Wrapped shape the badge should overlap.
    */
-  overlap: PropTypes.oneOf(['circular', 'rectangular']),
-  /**
-   * Controls whether the badge is hidden when `badgeContent` is zero.
-   */
-  showZero: PropTypes.bool,
-  /**
-   * The variant to use.
-   */
-  variant: PropTypes.oneOf(['dot', 'standard']),
-};
-
-const MuiBadge = withStyles(styles, { name: 'MuiBadge' })(Badge);
-
-MuiBadge.propTypes = {
-  classes: (props) => {
-    const { classes } = props;
-    if (classes == null) {
-      return null;
-    }
-
-    [
-      ['anchorOriginTopRightRectangle', 'anchorOriginTopRightRectangular'],
-      ['anchorOriginBottomRightRectangle', 'anchorOriginBottomRightRectangular'],
-      ['anchorOriginTopLeftRectangle', 'anchorOriginTopLeftRectangular'],
-      ['anchorOriginBottomLeftRectangle', 'anchorOriginBottomLeftRectangular'],
-      ['anchorOriginTopRightCircle', 'anchorOriginTopRightCircular'],
-      ['anchorOriginBottomRightCircle', 'anchorOriginBottomRightCircular'],
-      ['anchorOriginTopLeftCircle', 'anchorOriginTopLeftCircular'],
-    ].forEach(([deprecatedClassKey, newClassKey]) => {
-      if (classes[deprecatedClassKey] != null) {
-        throw new Error(
-          `Material-UI: The \`${deprecatedClassKey}\` class was deprecated. Use \`${newClassKey}\` instead.`,
-        );
-      }
-    });
-
-    return null;
-  },
-  overlap: (props) => {
+  overlap: chainPropTypes(PropTypes.oneOf(['circular', 'rectangular']), (props) => {
     const { overlap } = props;
 
     if (overlap === 'rectangle') {
@@ -394,7 +380,15 @@ MuiBadge.propTypes = {
     }
 
     return null;
-  },
+  }),
+  /**
+   * Controls whether the badge is hidden when `badgeContent` is zero.
+   */
+  showZero: PropTypes.bool,
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf(['dot', 'standard']),
 };
 
-export default MuiBadge;
+export default withStyles(styles, { name: 'MuiBadge' })(Badge);

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -333,6 +333,7 @@ Badge.propTypes = {
     ].forEach(([deprecatedClassKey, newClassKey]) => {
       if (
         classes[deprecatedClassKey] != null &&
+        // 2 classnames? one from withStyles the other must be custom
         classes[deprecatedClassKey].split(' ').length > 1
       ) {
         throw new Error(

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -185,7 +185,7 @@ describe('<Badge />', () => {
 
     it('issues a warning for overlap="circle"', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
           overlap: 'circle',
         },
@@ -201,7 +201,7 @@ describe('<Badge />', () => {
 
     it('issues a warning for overlap="rectangle"', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
           overlap: 'rectangle',
         },
@@ -217,9 +217,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginTopRightRectangle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginTopRightRectangle: 'my-class' },
+          classes: { anchorOriginTopRightRectangle: 'mui-class my-class' },
         },
         'props',
         'Badge',
@@ -233,9 +233,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginBottomRightRectangle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginBottomRightRectangle: 'my-class' },
+          classes: { anchorOriginBottomRightRectangle: 'mui-class my-class' },
         },
         'props',
         'Badge',
@@ -249,9 +249,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginTopLeftRectangle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginTopLeftRectangle: 'my-class' },
+          classes: { anchorOriginTopLeftRectangle: 'mui-class my-class' },
         },
         'props',
         'Badge',
@@ -265,9 +265,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginBottomLeftRectangle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginBottomLeftRectangle: 'my-class' },
+          classes: { anchorOriginBottomLeftRectangle: 'mui-class my-class' },
         },
         'props',
         'Badge',
@@ -281,9 +281,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginTopRightCircle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginTopRightCircle: 'my-class' },
+          classes: { anchorOriginTopRightCircle: 'mui-class my-class' },
         },
         'props',
         'Badge',
@@ -297,9 +297,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginBottomRightCircle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginBottomRightCircle: 'my-class' },
+          classes: { anchorOriginBottomRightCircle: 'mui-class my-class' },
         },
         'props',
         'Badge',
@@ -313,9 +313,9 @@ describe('<Badge />', () => {
 
     it('issues a warning for the `anchorOriginTopLeftCircle` class', () => {
       PropTypes.checkPropTypes(
-        Badge.propTypes,
+        Badge.Naked.propTypes,
         {
-          classes: { anchorOriginTopLeftCircle: 'my-class' },
+          classes: { anchorOriginTopLeftCircle: 'mui-class my-class' },
         },
         'props',
         'Badge',

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import { expect } from 'chai';
+import { stub } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -168,6 +170,161 @@ describe('<Badge />', () => {
     it('should not cap if badgeContent is lower than max', () => {
       const { container } = render(<Badge {...defaultProps} badgeContent={50} max={1000} />);
       expect(findBadge(container)).to.have.text('50');
+    });
+  });
+
+  describe('v5 deprecations', () => {
+    beforeEach(() => {
+      PropTypes.resetWarningCache();
+      stub(console, 'error');
+    });
+
+    afterEach(() => {
+      console.error.restore();
+    });
+
+    it('issues a warning for overlap="circle"', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          overlap: 'circle',
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: `overlap="circle"` was deprecated. Use `overlap="circular"` instead.',
+      );
+    });
+
+    it('issues a warning for overlap="rectangle"', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          overlap: 'rectangle',
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: `overlap="rectangle"` was deprecated. Use `overlap="rectangular"` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginTopRightRectangle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginTopRightRectangle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginTopRightRectangle` class was deprecated. Use `anchorOriginTopRightRectangular` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginBottomRightRectangle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginBottomRightRectangle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginBottomRightRectangle` class was deprecated. Use `anchorOriginBottomRightRectangular` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginTopLeftRectangle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginTopLeftRectangle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginTopLeftRectangle` class was deprecated. Use `anchorOriginTopLeftRectangular` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginBottomLeftRectangle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginBottomLeftRectangle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginBottomLeftRectangle` class was deprecated. Use `anchorOriginBottomLeftRectangular` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginTopRightCircle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginTopRightCircle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginTopRightCircle` class was deprecated. Use `anchorOriginTopRightCircular` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginBottomRightCircle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginBottomRightCircle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginBottomRightCircle` class was deprecated. Use `anchorOriginBottomRightCircular` instead.',
+      );
+    });
+
+    it('issues a warning for the `anchorOriginTopLeftCircle` class', () => {
+      PropTypes.checkPropTypes(
+        Badge.propTypes,
+        {
+          classes: { anchorOriginTopLeftCircle: 'my-class' },
+        },
+        'props',
+        'Badge',
+      );
+
+      expect(console.error.callCount).to.equal(1);
+      expect(console.error.firstCall.args[0]).to.equal(
+        'Warning: Failed props type: Material-UI: The `anchorOriginTopLeftCircle` class was deprecated. Use `anchorOriginTopLeftCircular` instead.',
+      );
     });
   });
 });


### PR DESCRIPTION
Backport of #22050 with a deprecation instead of a breaking change. Part of #22074.