### PR TITLE
Update InputLabel.js

### DIFF
--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -9,6 +9,11 @@ import FormLabel from '../FormLabel';
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
+    // Chrome's autofill feature gives the input field a yellow background.
+    // Since the input field is behind the label in the HTML tree,
+    // the input field is drawn last and hides the label with an opaque background color.
+    // zIndex: 1 will raise the label above opaque background-colors of input.
+    zIndex: 1,
     display: 'block',
     transformOrigin: 'top left',
   },
@@ -49,11 +54,6 @@ export const styles = (theme) => ({
   },
   /* Styles applied to the root element if `variant="filled"`. */
   filled: {
-    // Chrome's autofill feature gives the input field a yellow background.
-    // Since the input field is behind the label in the HTML tree,
-    // the input field is drawn last and hides the label with an opaque background color.
-    // zIndex: 1 will raise the label above opaque background-colors of input.
-    zIndex: 1,
     pointerEvents: 'none',
     transform: 'translate(12px, 20px) scale(1)',
     '&$marginDense': {
@@ -68,8 +68,6 @@ export const styles = (theme) => ({
   },
   /* Styles applied to the root element if `variant="outlined"`. */
   outlined: {
-    // see comment above on filled.zIndex
-    zIndex: 1,
     pointerEvents: 'none',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {


### PR DESCRIPTION
The z-index problem seems to also be a problem (hiding labels in default state) on standard variants as well.

In my case, I'm only able to get it to render while using a filled or outlined variant.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
