### PR TITLE
[Badge] Add missing class key

### DIFF
--- a/packages/material-ui/src/Badge/Badge.d.ts
+++ b/packages/material-ui/src/Badge/Badge.d.ts
@@ -63,6 +63,7 @@ export type BadgeClassKey =
   | 'anchorOriginTopRightCircular'
   | 'anchorOriginBottomRightCircular'
   | 'anchorOriginTopLeftCircular'
+  | 'anchorOriginBottomLeftCircular'
   | 'invisible';
 /**
  *


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

`anchorOriginBottomLeftCircule` is missing from the classKey.

on the master branch missing `anchorOriginBottomLeftCircule`
on the next branch missing `anchorOriginBottomLeftCircular`