### PR TITLE
[TreeView] Simplify focus logic

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -266,7 +266,6 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   React.useEffect(() => {
     if (nodeRef && treeId) {
       const handleFocusIn = (event) => {
-        event.preventDefault();
         const tree = ownerDocument(nodeRef).getElementById(treeId);
 
         // Some browsers don't focus the tree when using active-descendant.

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -140,16 +140,16 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     id = `${treeId}-${nodeId}`;
   }
 
-  const [nodeRef, setNodeRef] = React.useState(null);
+  const [treeitemElement, setTreeitemElement] = React.useState(null);
   const contentRef = React.useRef(null);
-  const handleRef = useForkRef(setNodeRef, ref);
+  const handleRef = useForkRef(setTreeitemElement, ref);
 
   const descendant = React.useMemo(
     () => ({
-      element: nodeRef,
+      element: treeitemElement,
       id: nodeId,
     }),
-    [nodeId, nodeRef],
+    [nodeId, treeitemElement],
   );
 
   const { index, parentId } = useDescendant(descendant);
@@ -264,13 +264,13 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   }
 
   React.useEffect(() => {
-    if (nodeRef && treeId) {
+    if (treeitemElement && treeId) {
       const handleFocusIn = (event) => {
-        const tree = ownerDocument(nodeRef).getElementById(treeId);
+        const tree = ownerDocument(treeitemElement).getElementById(treeId);
 
         // Some browsers don't focus the tree when using active-descendant.
         // Probably can remove when we drop IE11 support.
-        if (ownerDocument(nodeRef).activeElement !== tree) {
+        if (ownerDocument(treeitemElement).activeElement !== tree) {
           tree.focus();
         }
 
@@ -281,14 +281,14 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
       };
 
       // Using focusin to avoid blurring the tree.
-      nodeRef.addEventListener('focusin', handleFocusIn);
+      treeitemElement.addEventListener('focusin', handleFocusIn);
 
       return () => {
-        nodeRef.removeEventListener('focusin', handleFocusIn);
+        treeitemElement.removeEventListener('focusin', handleFocusIn);
       };
     }
     return undefined;
-  }, [focus, focused, nodeId, nodeRef, treeId, disabledItemsFocusable, disabled]);
+  }, [focus, focused, nodeId, treeitemElement, treeId, disabledItemsFocusable, disabled]);
 
   return (
     <li

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -263,32 +263,17 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     ariaSelected = true;
   }
 
-  React.useEffect(() => {
-    if (treeitemElement && treeId) {
-      const handleFocusIn = (event) => {
-        const tree = ownerDocument(treeitemElement).getElementById(treeId);
-
-        // Some browsers don't focus the tree when using active-descendant.
-        // Probably can remove when we drop IE11 support.
-        if (ownerDocument(treeitemElement).activeElement !== tree) {
-          tree.focus();
-        }
-
-        const unfocusable = !disabledItemsFocusable && disabled;
-        if (!focused && event.currentTarget === event.target && !unfocusable) {
-          focus(event, nodeId);
-        }
-      };
-
-      // Using focusin to avoid blurring the tree.
-      treeitemElement.addEventListener('focusin', handleFocusIn);
-
-      return () => {
-        treeitemElement.removeEventListener('focusin', handleFocusIn);
-      };
+  function handleFocus(event) {
+    // DOM focus stays on the tree which manages focus with aria-activedescendant
+    if (event.target === event.currentTarget) {
+      ownerDocument(event.target).getElementById(treeId).focus();
     }
-    return undefined;
-  }, [focus, focused, nodeId, treeitemElement, treeId, disabledItemsFocusable, disabled]);
+
+    const unfocusable = !disabledItemsFocusable && disabled;
+    if (!focused && event.currentTarget === event.target && !unfocusable) {
+      focus(event, nodeId);
+    }
+  }
 
   return (
     <li
@@ -301,6 +286,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
       id={id}
       tabIndex={-1}
       {...other}
+      onFocus={handleFocus}
     >
       {/* Key event is handled by the TreeView */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -737,8 +737,11 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
   };
 
   const handleFocus = (event) => {
-    const firstSelected = Array.isArray(selected) ? selected[0] : selected;
-    focus(event, firstSelected || getNavigableChildrenIds(null)[0]);
+    // if the event bubbled (which is React specific) we don't want to steal focus
+    if (event.target === event.currentTarget) {
+      const firstSelected = Array.isArray(selected) ? selected[0] : selected;
+      focus(event, firstSelected || getNavigableChildrenIds(null)[0]);
+    }
 
     if (onFocus) {
       onFocus(event);


### PR DESCRIPTION
`react@experimental` changed how focus events are handled (they're listening to focusin/focusout now internally) which broke some TreeItem tests. It seems like we can simplify this by relying on React's event system which should be more robust long term.

- remove event.preventDefault which is a no-op since [`focusin` is not cancelable](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusin_event)
- rename `nodeRef` -> `treeitemElement` because it is not a ref (a ref has a `{ current: T | null }` shape)
- only redirect focus if focus is targeted at the treeitem (and not bubble)
- don't focus the first selected from the TreeView if focus is bubbled

Verified that this PR indeed fixes tests on `react@experimental` with https://github.com/eps1lon/material-ui/compare/test/fix-react-next...eps1lon:test/fix-react-experimental