### PR TITLE
[useIsFocusVisible] Remove focus-visible if focus is re-targetted

### DIFF
--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -179,7 +179,12 @@ const Rating = React.forwardRef(function Rating(props, ref) {
     value = focus;
   }
 
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();
   const [focusVisible, setFocusVisible] = React.useState(false);
 
   const rootRef = React.useRef();
@@ -267,7 +272,8 @@ const Rating = React.forwardRef(function Rating(props, ref) {
   };
 
   const handleFocus = (event) => {
-    if (isFocusVisible(event)) {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
       setFocusVisible(true);
     }
 
@@ -287,9 +293,9 @@ const Rating = React.forwardRef(function Rating(props, ref) {
       return;
     }
 
-    if (focusVisible !== false) {
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
       setFocusVisible(false);
-      onBlurVisible();
     }
 
     const newFocus = -1;

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -145,7 +145,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   const handleBlur = useRippleHandler(
     'stop',
     (event) => {
-      if (focusVisible) {
+      if (isFocusVisible(event)) {
         onBlurVisible(event);
         setFocusVisible(false);
       }

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -142,10 +142,18 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   const handleTouchStart = useRippleHandler('start', onTouchStart);
   const handleTouchEnd = useRippleHandler('stop', onTouchEnd);
   const handleTouchMove = useRippleHandler('stop', onTouchMove);
+
+  const hadFocusVisibleEventRef = React.useRef(false);
   const handleBlur = useRippleHandler(
     'stop',
     (event) => {
-      if (isFocusVisible(event)) {
+      // checking against `focusVisible` does not suffice if we focus and blur syncronously.
+      // React wouldn't have time to trigger a re-render so `focusVisible` would be stale.
+      // Ideally we would adjust `isFocusVisible(event)` to look at `relatedTarget` for blur events.
+      // This doesn't work in IE 11 due to https://github.com/facebook/react/issues/3751
+      // TODO: check again if React releases their internal changes to focus event handling (https://github.com/facebook/react/pull/19186).
+      if (hadFocusVisibleEventRef.current) {
+        hadFocusVisibleEventRef.current = false;
         onBlurVisible(event);
         setFocusVisible(false);
       }
@@ -163,6 +171,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     }
 
     if (isFocusVisible(event)) {
+      hadFocusVisibleEventRef.current = true;
       setFocusVisible(true);
 
       if (onFocusVisible) {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -654,11 +654,25 @@ describe('<ButtonBase />', () => {
     });
 
     it('removes foucs-visible if focus is re-targetted', () => {
+      /**
+       * @type {string[]}
+       */
       const eventLog = [];
       function Test() {
+        /**
+         * @type {React.Ref<HTMLButtonElement>}
+         */
         const focusRetargetRef = React.useRef(null);
         return (
-          <div onFocus={() => focusRetargetRef.current.focus()}>
+          <div
+            onFocus={() => {
+              const { current: focusRetarget } = focusRetargetRef;
+              if (focusRetarget === null) {
+                throw new TypeError('Nothing to focous. Test cannot work.');
+              }
+              focusRetarget.focus();
+            }}
+          >
             <button ref={focusRetargetRef} type="button">
               you cannot escape me
             </button>

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -653,6 +653,37 @@ describe('<ButtonBase />', () => {
       expect(button).to.have.class(classes.focusVisible);
     });
 
+    it('removes foucs-visible if focus is re-targetted', () => {
+      const eventLog = [];
+      function Test() {
+        const focusRetargetRef = React.useRef(null);
+        return (
+          <div onFocus={() => focusRetargetRef.current.focus()}>
+            <button ref={focusRetargetRef} type="button">
+              you cannot escape me
+            </button>
+            <ButtonBase
+              onBlur={() => eventLog.push('blur')}
+              onFocus={() => eventLog.push('focus')}
+              onFocusVisible={() => eventLog.push('focus-visible')}
+            >
+              Hello
+            </ButtonBase>
+          </div>
+        );
+      }
+      const { getByText } = render(<Test />);
+      const buttonBase = getByText('Hello');
+      const focusRetarget = getByText('you cannot escape me');
+      simulatePointerDevice();
+
+      focusVisible(buttonBase);
+
+      expect(focusRetarget).toHaveFocus();
+      expect(eventLog).to.deep.equal(['focus-visible', 'focus', 'blur']);
+      expect(buttonBase).not.to.have.class(classes.focusVisible);
+    });
+
     it('onFocusVisibleHandler() should propagate call to onFocusVisible prop', () => {
       const onFocusVisibleSpy = spy();
       const { getByRole } = render(

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -68,12 +68,17 @@ const Link = React.forwardRef(function Link(props, ref) {
     ...other
   } = props;
 
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();
   const [focusVisible, setFocusVisible] = React.useState(false);
   const handlerRef = useForkRef(ref, focusVisibleRef);
   const handleBlur = (event) => {
-    if (focusVisible) {
-      onBlurVisible();
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
       setFocusVisible(false);
     }
     if (onBlur) {
@@ -81,7 +86,8 @@ const Link = React.forwardRef(function Link(props, ref) {
     }
   };
   const handleFocus = (event) => {
-    if (isFocusVisible(event)) {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
       setFocusVisible(true);
     }
     if (onFocus) {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -394,7 +394,12 @@ const Slider = React.forwardRef(function Slider(props, ref) {
         }))
       : marksProp || [];
 
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();
   const [focusVisible, setFocusVisible] = React.useState(-1);
 
   const sliderRef = React.useRef();
@@ -403,15 +408,16 @@ const Slider = React.forwardRef(function Slider(props, ref) {
 
   const handleFocus = useEventCallback((event) => {
     const index = Number(event.currentTarget.getAttribute('data-index'));
-    if (isFocusVisible(event)) {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
       setFocusVisible(index);
     }
     setOpen(index);
   });
-  const handleBlur = useEventCallback(() => {
-    if (focusVisible !== -1) {
+  const handleBlur = useEventCallback((event) => {
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
       setFocusVisible(-1);
-      onBlurVisible();
     }
     setOpen(-1);
   });

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -291,12 +291,19 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }
   };
 
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
-  const [childIsFocusVisible, setChildIsFocusVisible] = React.useState(false);
-  const handleBlur = () => {
-    if (childIsFocusVisible) {
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();
+  // We don't necessarily care about the focusVisible state (which is safe to access via ref anyway).
+  // We just need to re-render the Tooltip if the focus-visible state changes.
+  const [, setChildIsFocusVisible] = React.useState(false);
+  const handleBlur = (event) => {
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
       setChildIsFocusVisible(false);
-      onBlurVisible();
     }
   };
 
@@ -308,7 +315,8 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
       setChildNode(event.currentTarget);
     }
 
-    if (isFocusVisible(event)) {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
       setChildIsFocusVisible(true);
       handleEnter()(event);
     }
@@ -343,7 +351,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
       if (childrenProps.onBlur && forward) {
         childrenProps.onBlur(event);
       }
-      handleBlur();
+      handleBlur(event);
     }
 
     if (

--- a/packages/material-ui/src/utils/useIsFocusVisible.d.ts
+++ b/packages/material-ui/src/utils/useIsFocusVisible.d.ts
@@ -1,5 +1,8 @@
+import * as React from 'react';
+
 export default function useIsFocusVisible(): {
-  isFocusVisible: (event: React.ChangeEvent) => boolean;
-  onBlurVisible: () => void;
+  isFocusVisibleRef: React.MutableRefObject<boolean>;
+  onBlur: (event: React.FocusEvent<any>) => void;
+  onFocus: (event: React.FocusEvent<any>) => void;
   ref: React.Ref<unknown>;
 };

--- a/packages/material-ui/src/utils/useIsFocusVisible.test.js
+++ b/packages/material-ui/src/utils/useIsFocusVisible.test.js
@@ -17,21 +17,27 @@ function simulatePointerDevice() {
 }
 
 const SimpleButton = React.forwardRef(function SimpleButton(props, ref) {
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();
 
   const handleRef = useForkRef(focusVisibleRef, ref);
 
   const [focusVisible, setFocusVisible] = React.useState(false);
 
-  const handleBlur = () => {
-    if (focusVisible) {
+  const handleBlur = (event) => {
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
       setFocusVisible(false);
-      onBlurVisible();
     }
   };
 
   const handleFocus = (event) => {
-    if (isFocusVisible(event)) {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
       setFocusVisible(true);
     }
   };

--- a/test/regressions/tests/Menu/MenuContentAnchors.js
+++ b/test/regressions/tests/Menu/MenuContentAnchors.js
@@ -11,6 +11,19 @@ const useMenuStyles = makeStyles({
     // give the anchor enough space so that the menu can align the selected item
     margin: '80px 0',
   },
+  listItem: {
+    '&$listItemFocusVisible': {
+      border: '3px dashed black',
+    },
+    '&$listItemSelected': {
+      border: '3px dotted black',
+    },
+    '&$listItemFocusVisible$listItemSelected': {
+      border: '3px solid black',
+    },
+  },
+  listItemFocusVisible: {},
+  listItemSelected: {},
 });
 
 /**
@@ -20,6 +33,12 @@ function SimpleMenu({ selectedItem, ...props }) {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const classes = useMenuStyles();
 
+  const listItemClasses = {
+    root: classes.listItem,
+    focusVisible: classes.listItemFocusVisible,
+    selected: classes.listItemSelected,
+  };
+
   return (
     <Grid item>
       <Button className={classes.anchorEl} ref={setAnchorEl}>
@@ -27,9 +46,13 @@ function SimpleMenu({ selectedItem, ...props }) {
       </Button>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} transitionDuration={0} {...props}>
         {null}
-        <MenuItem selected={selectedItem === 1}>Item 1</MenuItem>
-        <MenuItem selected={selectedItem === 2}>Item 2</MenuItem>
-        <MenuItem>Item 3</MenuItem>
+        <MenuItem ListItemClasses={listItemClasses} selected={selectedItem === 1}>
+          Item 1
+        </MenuItem>
+        <MenuItem ListItemClasses={listItemClasses} selected={selectedItem === 2}>
+          Item 2
+        </MenuItem>
+        <MenuItem ListItemClasses={listItemClasses}>Item 3</MenuItem>
       </Menu>
     </Grid>
   );


### PR DESCRIPTION
**BREAKING CHANGE**

```diff
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();

  const handleFocus = (event) => {
-    if (isFocusVisible(event)) {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
      setFocusVisible(true);
    }

-    if (focusVisible !== false) {
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
      setFocusVisible(false);
-      onBlurVisible();
    }
```

Observed this bug a couple of times but wasn't able to understand/reproduce it. Saw it again in https://github.com/mui-org/material-ui/pull/22062 but this time reproducible: 

1. goto https://deploy-preview-22062--material-ui.netlify.app/components/trap-focus/#example
2. click "open" to open the TrapFocus
3. reset focus

the focus marker is still focus-visible but focus is on the the focus trap. Only every second click removes the focus-visible style:

![demo](https://i.ibb.co/4NJBPQg/blur-visible-ignored.gif)

Added a test that mimics TrapFocus to prevent future regression.