### PR TITLE
[icons] Consider as written in TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+packages/material-ui-icons/src/*.js linguist-language=TypeScript

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+# These files are automatically generated and kept in git so we can
+# review the impact when changing the generation script.
+# This prevent us to use `linguist-generated`.
+# We also generate all the .d.ts manually to be included in the npm archive.
 packages/material-ui-icons/src/*.js linguist-language=TypeScript


### PR DESCRIPTION
A continuation on https://github.com/mui-org/material-ui/issues/15984#issuecomment-670546675. It seems that migrating the icons from .js to a .tsx extension wouldn't make sense considering that we generate all these files as well as their .d.ts definitions. The current approach is more efficient. However, I believe we can consider these files are written in TypeScript.

Before

```
$ github-linguist
94.80%  JavaScript
5.19%   TypeScript
0.01%   HTML
0.00%   Shell
```

After

```
$ github-linguist
54.48%  TypeScript
45.50%  JavaScript
0.01%   HTML
0.00%   Shell
```

I have considered using `linguist-generated` until I saw: 

> be ignored for the repository's language statistics **and hidden by default in diffs**

https://docs.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github