### PR TITLE
[Benchmark] Add benchmarking for typechecking and typescript compile time

### DIFF
--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -17,6 +17,7 @@
     "server": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/server.js --inspect=0.0.0.0:9229",
     "styles": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/styles.js --inspect=0.0.0.0:9229",
     "system": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/system.js --inspect=0.0.0.0:9229",
+    "types": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/types.js --inspect=0.0.0.0:9229",
     "test": "exit 0"
   },
   "engines": {

--- a/packages/material-ui-benchmark/src/styles.js
+++ b/packages/material-ui-benchmark/src/styles.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-console */
+import { css } from '@emotion/core';
+import styledEmotion from '@emotion/styled';
+import Box from '@material-ui/core/Box';
+import { makeStyles, styled as styledMui, StylesProvider, withStyles } from '@material-ui/styles';
 import Benchmark from 'benchmark';
+import { renderStylesToString } from 'emotion-server';
+import jss, { getDynamicStyles } from 'jss';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import styledComponents, { ServerStyleSheet } from 'styled-components';
-import styledEmotion from '@emotion/styled';
-import { css } from '@emotion/core';
-import { renderStylesToString } from 'emotion-server';
 import injectSheet, { JssProvider, SheetsRegistry } from 'react-jss';
-import { styled as styledMui, withStyles, makeStyles, StylesProvider } from '@material-ui/styles';
-import jss, { getDynamicStyles } from 'jss';
-import Box from '@material-ui/core/Box';
+import styledComponents, { ServerStyleSheet } from 'styled-components';
 
 const suite = new Benchmark.Suite('styles', {
   onError: (event) => {

--- a/packages/material-ui-benchmark/src/types.js
+++ b/packages/material-ui-benchmark/src/types.js
@@ -1,0 +1,92 @@
+import Benchmark from 'benchmark';
+import React from 'react';
+import * as ts from 'typescript';
+
+// not sure typescript should be defined again in the benchmark's package.json (if this is published)
+// or if its alright to just implicitly use the workspace version
+const suite = new Benchmark.Suite('system', {
+  onError: (event) => {
+    console.log(event.target.error);
+  }
+});
+Benchmark.options.minSamples = 10;
+
+// https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
+function compile(fileNames, options) {
+  const host = ts.createCompilerHost(options);
+  host.writeFile = () => { }; // writeFile is a noop for us, since we just care about execution time
+  let program = ts.createProgram(fileNames, options, host);
+  let emitResult = program.emit();
+
+  let allDiagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
+
+  allDiagnostics.forEach(diagnostic => {
+    if (diagnostic.file) {
+      let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+      console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+    } else {
+      console.log(ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
+    }
+  });
+  if (emitResult.emitSkipped) {
+    process.exit(1);
+  }
+}
+const compilerOptions = {
+  noEmitOnError: true,
+  noImplicitAny: true,
+  target: ts.ScriptTarget.ES5,
+  module: ts.ModuleKind.CommonJS,
+  esModuleInterop: true,
+  jsx: 'react',
+  module: "commonjs",
+  lib: ["lib", "lib.dom.d.ts"],
+  skipLibCheck: true,
+  baseUrl: ".",
+  paths: {
+    "@material-ui/core/*": ["node_modules/@material-ui/core/build/*"],
+    "@material-ui/styles/*": ["node_modules/@material-ui/styles/build/*"],
+    "@material-ui/core": ["node_modules/@material-ui/core/build"]
+  }
+}
+
+
+suite
+  .add('typography.classname', () => {
+    compile([__dirname + '/types/typographyClassname.tsx'], compilerOptions);
+  })
+  .add('typography.classname.component', () => {
+    compile([__dirname + '/types/typographyClassnameComponent.tsx'], compilerOptions);
+  })
+
+  .add('div.classname', () => {
+    compile([__dirname + '/types/divClassname.tsx'], compilerOptions);
+  })
+  // .add('box.classname', () => {
+  //   compile([__dirname + '/types/boxClassname.tsx'], compilerOptions);
+  // })
+  // .add('grid.classname', () => {
+  //   compile([__dirname + '/types/gridClassname.tsx'], compilerOptions);
+  // })
+  // .add('card.classname', () => {
+  //   compile([__dirname + '/types/cardClassname.tsx'], compilerOptions);
+  // })
+  // .add('div.style', () => {
+  //   compile([__dirname + '/types/typographyStyle.tsx'], compilerOptions);
+  // })
+  // .add('typography.style', () => {
+  //   compile([__dirname + '/types/typographyStyle.tsx'], compilerOptions);
+  // })
+  // .add('div.themed', () => {
+  //   compile([__dirname + '/types/divThemed.tsx'], compilerOptions);
+  // })
+  // .add('typography.themed', () => {
+  //   compile([__dirname + '/types/typographyThemed.tsx'], compilerOptions);
+  // })
+  .on('cycle', (event) => {
+    console.log(String(event.target));
+  })
+  .run();

--- a/packages/material-ui-benchmark/src/types.js
+++ b/packages/material-ui-benchmark/src/types.js
@@ -55,37 +55,36 @@ const compilerOptions = {
 
 
 suite
-  .add('typography.classname', () => {
-    compile([__dirname + '/types/typographyClassname.tsx'], compilerOptions);
-  })
-  .add('typography.classname.component', () => {
-    compile([__dirname + '/types/typographyClassnameComponent.tsx'], compilerOptions);
-  })
-
   .add('div.classname', () => {
     compile([__dirname + '/types/divClassname.tsx'], compilerOptions);
   })
-  // .add('box.classname', () => {
-  //   compile([__dirname + '/types/boxClassname.tsx'], compilerOptions);
+  .add('typography.classname', () => {
+    compile([__dirname + '/types/typographyClassname.tsx'], compilerOptions);
+  })
+  // .add('typography.classname.component', () => {
+  //   compile([__dirname + '/types/typographyClassnameComponent.tsx'], compilerOptions);
   // })
-  // .add('grid.classname', () => {
-  //   compile([__dirname + '/types/gridClassname.tsx'], compilerOptions);
-  // })
-  // .add('card.classname', () => {
-  //   compile([__dirname + '/types/cardClassname.tsx'], compilerOptions);
-  // })
-  // .add('div.style', () => {
-  //   compile([__dirname + '/types/typographyStyle.tsx'], compilerOptions);
-  // })
-  // .add('typography.style', () => {
-  //   compile([__dirname + '/types/typographyStyle.tsx'], compilerOptions);
-  // })
-  // .add('div.themed', () => {
-  //   compile([__dirname + '/types/divThemed.tsx'], compilerOptions);
-  // })
-  // .add('typography.themed', () => {
-  //   compile([__dirname + '/types/typographyThemed.tsx'], compilerOptions);
-  // })
+  .add('box.classname', () => {
+    compile([__dirname + '/types/boxClassname.tsx'], compilerOptions);
+  })
+  .add('grid.classname', () => {
+    compile([__dirname + '/types/gridClassname.tsx'], compilerOptions);
+  })
+  .add('card.classname', () => {
+    compile([__dirname + '/types/cardClassname.tsx'], compilerOptions);
+  })
+  .add('div.style', () => {
+    compile([__dirname + '/types/typographyStyle.tsx'], compilerOptions);
+  })
+  .add('typography.style', () => {
+    compile([__dirname + '/types/typographyStyle.tsx'], compilerOptions);
+  })
+  .add('div.themed', () => {
+    compile([__dirname + '/types/divThemed.tsx'], compilerOptions);
+  })
+  .add('typography.themed', () => {
+    compile([__dirname + '/types/typographyThemed.tsx'], compilerOptions);
+  })
   .on('cycle', (event) => {
     console.log(String(event.target));
   })

--- a/packages/material-ui-benchmark/src/types/boxClassname.tsx
+++ b/packages/material-ui-benchmark/src/types/boxClassname.tsx
@@ -1,0 +1,4 @@
+import { Box } from '@material-ui/core';
+import React from 'react';
+
+export const Component = () => <Box className="jss" />;

--- a/packages/material-ui-benchmark/src/types/cardClassname.tsx
+++ b/packages/material-ui-benchmark/src/types/cardClassname.tsx
@@ -1,0 +1,4 @@
+import { Card } from '@material-ui/core';
+import React from 'react';
+
+export const Component = () => <Card className="jss" />;

--- a/packages/material-ui-benchmark/src/types/divClassname.tsx
+++ b/packages/material-ui-benchmark/src/types/divClassname.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const Component = () => <div className="jss" />;

--- a/packages/material-ui-benchmark/src/types/divStyle.tsx
+++ b/packages/material-ui-benchmark/src/types/divStyle.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const Component = () => <div style={{ width: 100 }} />;

--- a/packages/material-ui-benchmark/src/types/divThemed.tsx
+++ b/packages/material-ui-benchmark/src/types/divThemed.tsx
@@ -1,0 +1,18 @@
+import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.primary.main,
+    padding: theme.spacing(1),
+    ...theme.typography.body2,
+  },
+}));
+export const Component = () => {
+  const classes = useStyles();
+  return <div className={classes.root} />;
+};
+export const App = () => (
+  <ThemeProvider theme={createMuiTheme()}>
+    <Component />
+  </ThemeProvider>
+);

--- a/packages/material-ui-benchmark/src/types/gridClassname.tsx
+++ b/packages/material-ui-benchmark/src/types/gridClassname.tsx
@@ -1,0 +1,4 @@
+import { Grid } from '@material-ui/core';
+import React from 'react';
+
+export const Component = () => <Grid className="jss" />;

--- a/packages/material-ui-benchmark/src/types/typographyClassname.tsx
+++ b/packages/material-ui-benchmark/src/types/typographyClassname.tsx
@@ -1,0 +1,4 @@
+import { Typography } from '@material-ui/core';
+import React from 'react';
+
+export const Component = () => <Typography className="jss" />;

--- a/packages/material-ui-benchmark/src/types/typographyClassnameComponent.tsx
+++ b/packages/material-ui-benchmark/src/types/typographyClassnameComponent.tsx
@@ -1,0 +1,4 @@
+import { Typography } from '@material-ui/core';
+import React from 'react';
+
+export const Component = () => <Typography component="div" className="jss" />;

--- a/packages/material-ui-benchmark/src/types/typographyStyle.tsx
+++ b/packages/material-ui-benchmark/src/types/typographyStyle.tsx
@@ -1,0 +1,4 @@
+import { Typography } from '@material-ui/core';
+import React from 'react';
+
+export const Component = () => <Typography style={{ width: 100 }} />;

--- a/packages/material-ui-benchmark/src/types/typographyThemed.tsx
+++ b/packages/material-ui-benchmark/src/types/typographyThemed.tsx
@@ -1,0 +1,18 @@
+import { createMuiTheme, makeStyles, ThemeProvider, Typography } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.primary.main,
+    padding: theme.spacing(1),
+    ...theme.typography.body2,
+  },
+}));
+export const Component = () => {
+  const classes = useStyles();
+  return <Typography className={classes.root} />;
+};
+export const App = () => (
+  <ThemeProvider theme={createMuiTheme()}>
+    <Component />
+  </ThemeProvider>
+);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

This adds some naive benchmarking to gauge where MUI types are slow.

Results
```
div.classname x 0.94 ops/sec ±3.34% (12 runs sampled)
typography.classname x 0.52 ops/sec ±1.96% (11 runs sampled)
typography.classname.component x 0.49 ops/sec ±3.12% (11 runs sampled)
box.classname x 0.69 ops/sec ±1.50% (11 runs sampled)
grid.classname x 0.47 ops/sec ±2.82% (11 runs sampled)
card.classname x 0.74 ops/sec ±2.09% (11 runs sampled)
div.style x 0.48 ops/sec ±2.88% (11 runs sampled)
typography.style x 0.48 ops/sec ±2.34% (11 runs sampled)
div.themed x 0.70 ops/sec ±2.02% (11 runs sampled)
typography.themed x 0.49 ops/sec ±1.95% (11 runs sampled)
```

What I did here is using div as a baseline, and then compare it against different components. One thing I noticed is that among the tested the components, the ones which use the `OverridableComponent` (`Typography`, `Grid`) build significantly slower than those that do not (`Card`, `Box`).

For reference this is the type:

```tsx
export interface OverridableComponent<M extends OverridableTypeMap> {
  <C extends React.ElementType>(
    props: {
      /**
       * The component used for the root node.
       * Either a string to use a HTML element or a component.
       */
      component: C;
    } & OverrideProps<M, C>
  ): JSX.Element;
  (props: DefaultComponentProps<M>): JSX.Element;
}
```

Removing the first overload, for the case that the `component` prop is defined , seemed to remove the slowdown. Obviously, this breaks type checking for the case that `component` is defined.
However, based on that I assume that the additional type inference of the `component` increases compile time drastically.

Since that type inference is required to allow type checking of props that are passed through to the underlying component, I do not see a way to have this fixed on MUI's end right now.

Given that this type check has to be performed for every single usage of an `OverridableComponent` component, any kind of increase in speed here would likely be noticeable in most larger projects. 
So, if there would be a way to at least short circuit some of the type inference for the case that `component` is not defined - e.g. typescript would only need to know if `component` is defined or not, and then only resolve type based on the second overload (assuming that right now it resolves both and then picks based on the type of `component`), we should be able to see an improvement in type checking time.

Results for the case that the first overload is removed: 
```ts
export interface OverridableComponent<M extends OverridableTypeMap> {
  (props: DefaultComponentProps<M>): JSX.Element;
}
```

```
div.classname x 0.98 ops/sec ±3.02% (12 runs sampled)
typography.classname x 0.76 ops/sec ±2.65% (11 runs sampled)
box.classname x 0.73 ops/sec ±3.55% (11 runs sampled)
grid.classname x 0.74 ops/sec ±2.70% (11 runs sampled)
card.classname x 0.77 ops/sec ±2.25% (11 runs sampled)
div.style x 0.72 ops/sec ±3.21% (11 runs sampled)
typography.style x 0.65 ops/sec ±5.18% (11 runs sampled)
div.themed x 0.67 ops/sec ±2.54% (11 runs sampled)
typography.themed x 0.63 ops/sec ±3.41% (11 runs sampled)
```

