### PR TITLE
[TrapFocus] Listen to focusin intead of focus to contain

### DIFF
--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
@@ -130,7 +130,7 @@ function Unstable_TrapFocus(props) {
       }
     };
 
-    doc.addEventListener('focus', contain, true);
+    doc.addEventListener('focusin', contain, true);
     doc.addEventListener('keydown', loopFocus, true);
 
     // With Edge, Safari and Firefox, no focus related events are fired when the focused area stops being a focused area.
@@ -148,7 +148,7 @@ function Unstable_TrapFocus(props) {
     return () => {
       clearInterval(interval);
 
-      doc.removeEventListener('focus', contain, true);
+      doc.removeEventListener('focusin', contain, true);
       doc.removeEventListener('keydown', loopFocus, true);
 
       // restoreLastFocus()


### PR DESCRIPTION
Edit: This doesn't work yet.

Listening to the native `focus` breaks tests with `react@next`. Native and react focus events are interleaved which causes the TrapFocus to trying to steal focus too often when a child auto-focuses. 

I'll definitely file an issue upstream in case this isn't intended. However, the fix for `react@next` works with stable react as well so we might as well get it in the be future proof.

## Test plan

- [ ] CI green with `react@16.13.1`
- [ ] CI green with `react@next` (and an updated patch)