### PR TITLE
[ButtonBase] Forward type to other components than 'button'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,6 +178,8 @@ module.exports = {
         'jsx-a11y/no-static-element-interactions': 'off',
         'jsx-a11y/tabindex-no-positive': 'off',
 
+        // In tests this is generally intended.
+        'react/button-has-type': 'off',
         // They are accessed to test custom validator implementation with PropTypes.checkPropTypes
         'react/forbid-foreign-prop-types': 'off',
         // components that are defined in test are isolated enough

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -82,7 +82,6 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     onDragLeave,
     tabIndex = 0,
     TouchRippleProps,
-    type = 'button',
     ...other
   } = props;
 
@@ -272,7 +271,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
 
   const buttonProps = {};
   if (ComponentProp === 'button') {
-    buttonProps.type = type;
+    buttonProps.type = other.type === undefined ? 'button' : other.type;
     buttonProps.disabled = disabled;
   } else {
     if (ComponentProp !== 'a' || !other.href) {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -9,6 +9,7 @@ import {
   act,
   createClientRender,
   fireEvent,
+  screen,
 } from 'test/utils';
 import * as PropTypes from 'prop-types';
 import TouchRipple from './TouchRipple';
@@ -1034,6 +1035,47 @@ describe('<ButtonBase />', () => {
       expect(() => {
         render(<ButtonBase component={Component} />);
       }).toErrorDev('Please make sure the children prop is rendered in this custom component.');
+    });
+  });
+
+  describe('prop: type', () => {
+    it('is `button` by default', () => {
+      render(<ButtonBase />);
+
+      expect(screen.getByRole('button')).to.have.property('type', 'button');
+    });
+
+    it('can be changed to other button types', () => {
+      render(<ButtonBase type="submit" />);
+
+      expect(screen.getByRole('button')).to.have.property('type', 'submit');
+    });
+
+    it('allows non-standard values', () => {
+      // @ts-expect-error `@types/react` only lists standard values
+      render(<ButtonBase type="fictional-type" />);
+
+      expect(screen.getByRole('button')).to.have.attribute('type', 'fictional-type');
+      // By spec non-supported types result in the default type for `<button>` which is `submit`
+      expect(screen.getByRole('button')).to.have.property('type', 'submit');
+    });
+
+    it('undesired: is ignored in anchor components', () => {
+      render(<ButtonBase component="a" href="some-recording.ogg" download type="audio/ogg" />);
+
+      expect(screen.getByRole('link')).not.to.have.attribute('type');
+      expect(screen.getByRole('link')).to.have.property('type', '');
+    });
+
+    it('undesired: is ignored in custom components', () => {
+      /**
+       * @type {React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement>>}
+       */
+      const CustomButton = React.forwardRef((props, ref) => <button ref={ref} {...props} />);
+      render(<ButtonBase component={CustomButton} type="reset" />);
+
+      expect(screen.getByRole('button')).not.to.have.attribute('type');
+      expect(screen.getByRole('button')).to.have.property('type', 'submit');
     });
   });
 });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -1060,22 +1060,21 @@ describe('<ButtonBase />', () => {
       expect(screen.getByRole('button')).to.have.property('type', 'submit');
     });
 
-    it('undesired: is ignored in anchor components', () => {
+    it('is forwarded to anchor components', () => {
       render(<ButtonBase component="a" href="some-recording.ogg" download type="audio/ogg" />);
 
-      expect(screen.getByRole('link')).not.to.have.attribute('type');
-      expect(screen.getByRole('link')).to.have.property('type', '');
+      expect(screen.getByRole('link')).to.have.attribute('type', 'audio/ogg');
+      expect(screen.getByRole('link')).to.have.property('type', 'audio/ogg');
     });
 
-    it('undesired: is ignored in custom components', () => {
+    it('is forwarded to custom components', () => {
       /**
        * @type {React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement>>}
        */
       const CustomButton = React.forwardRef((props, ref) => <button ref={ref} {...props} />);
       render(<ButtonBase component={CustomButton} type="reset" />);
 
-      expect(screen.getByRole('button')).not.to.have.attribute('type');
-      expect(screen.getByRole('button')).to.have.property('type', 'submit');
+      expect(screen.getByRole('button')).to.have.property('type', 'reset');
     });
   });
 });


### PR DESCRIPTION
First commits includes the undesired behavior on `next`. Notice how the undesired behavior did type-check even though `type` wasn't technically supported. Related to #21924