### PR TITLE
[test] Improve toHaveVirtualFocus error message

### DIFF
--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -102,19 +102,19 @@ chai.use((chaiAPI, utils) => {
     const element = utils.flag(this, 'object');
     const id = element.getAttribute('id');
 
-    const virutallyFocusedElementId = document.activeElement!.getAttribute('aria-activedescendant');
+    const virtuallyFocusedElementId = document.activeElement!.getAttribute('aria-activedescendant');
 
     this.assert(
-      virutallyFocusedElementId === id,
+      virtuallyFocusedElementId === id,
       `expected element to be virtually focused\nexpected id #{exp}\n${
-        virutallyFocusedElementId === null
+        virtuallyFocusedElementId === null
           ? `activeElement: ${elementToString(document.activeElement)}`
           : 'actual id: #{act}'
       }`,
       'expected element to NOT to be virtually focused',
       id,
-      virutallyFocusedElementId,
-      virutallyFocusedElementId !== null,
+      virtuallyFocusedElementId,
+      virtuallyFocusedElementId !== null,
     );
   });
 

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -114,6 +114,7 @@ chai.use((chaiAPI, utils) => {
       'expected element to NOT to be virtually focused',
       id,
       virutallyFocusedElementId,
+      virutallyFocusedElementId !== null,
     );
   });
 

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -106,12 +106,14 @@ chai.use((chaiAPI, utils) => {
 
     this.assert(
       virutallyFocusedElementId === id,
-      `expected element to be virtually focused${
-        isInKarma() ? '\nexpected #{exp}\nactual: #{act}' : ''
+      `expected element to be virtually focused\nexpected id #{exp}\n${
+        virutallyFocusedElementId === null
+          ? `activeElement: ${elementToString(document.activeElement)}`
+          : 'actual id: #{act}'
       }`,
       'expected element to NOT to be virtually focused',
-      elementToString(document.getElementById(id)),
-      elementToString(document.getElementById(virutallyFocusedElementId!)),
+      id,
+      virutallyFocusedElementId,
     );
   });
 


### PR DESCRIPTION
I suspect while working on the TreeView sometimes virtual focus wouldn't have switched to another element. In those cases simply displaying the mismatched ids was probably more helpful.

Restored the ID diff but added an extended display if the activeElement did not have an aria-activedescendant. In these cases we print `document.activeElement`

Resolves https://github.com/mui-org/material-ui/pull/22179#discussion_r469920818