### PR TITLE
[docs] Better track usage of icons

### DIFF
--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
@@ -114,7 +116,6 @@ let Icons = (props) => {
         return (
           <span
             key={icon.key}
-            role="presentation"
             onClick={handleIconClick(icon.searchable)}
             className={clsx('markdown-body', classes.icon)}
           >

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -93,13 +93,19 @@ function selectNode(node) {
 let Icons = (props) => {
   const { icons, classes, handleOpenClick } = props;
 
-  const handleIconClick = (name) => () => {
+  const handleIconClick = (icon) => () => {
     if (Math.random() < 0.1) {
       window.ga('send', {
         hitType: 'event',
         eventCategory: 'material-icons',
         eventAction: 'click',
-        eventLabel: name,
+        eventLabel: icon.name,
+      });
+      window.ga('send', {
+        hitType: 'event',
+        eventCategory: 'material-icons-theme',
+        eventAction: 'click',
+        eventLabel: icon.theme,
       });
     }
   };
@@ -115,17 +121,17 @@ let Icons = (props) => {
         return (
           // eslint-disable-next-line jsx-a11y/no-static-element-interactions
           <span
-            key={icon.key}
-            onClick={handleIconClick(icon.searchable)}
+            key={icon.importName}
+            onClick={handleIconClick(icon)}
             className={clsx('markdown-body', classes.icon)}
           >
-            <icon.Icon
+            <icon.Component
               tabIndex={-1}
               onClick={handleOpenClick}
-              title={icon.key}
+              title={icon.importName}
               className={classes.iconSvg}
             />
-            <p onClick={handleLabelClick}>{icon.key}</p>
+            <p onClick={handleLabelClick}>{icon.importName}</p>
             {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
           </span>
         );
@@ -216,12 +222,12 @@ let DialogDetails = (props) => {
       {selectedIcon ? (
         <React.Fragment>
           <DialogTitle id="icon-dialog-title" onClick={handleClick}>
-            {selectedIcon.key}
+            {selectedIcon.importName}
           </DialogTitle>
           <HighlightedCode
             className={classes.markdown}
             onClick={handleClick}
-            code={`import ${selectedIcon.key}Icon from '@material-ui/icons/${selectedIcon.key}';`}
+            code={`import ${selectedIcon.importName}Icon from '@material-ui/icons/${selectedIcon.importName}';`}
             language="js"
           />
           <Link
@@ -391,39 +397,40 @@ const searchIndex = FlexSearch.create({
 const allIconsMap = {};
 const allIcons = Object.keys(mui)
   .sort()
-  .map((key) => {
-    let tag;
-    if (key.indexOf('Outlined') !== -1) {
-      tag = 'Outlined';
-    } else if (key.indexOf('TwoTone') !== -1) {
-      tag = 'Two tone';
-    } else if (key.indexOf('Rounded') !== -1) {
-      tag = 'Rounded';
-    } else if (key.indexOf('Sharp') !== -1) {
-      tag = 'Sharp';
+  .map((importName) => {
+    let theme;
+    if (importName.indexOf('Outlined') !== -1) {
+      theme = 'Outlined';
+    } else if (importName.indexOf('TwoTone') !== -1) {
+      theme = 'Two tone';
+    } else if (importName.indexOf('Rounded') !== -1) {
+      theme = 'Rounded';
+    } else if (importName.indexOf('Sharp') !== -1) {
+      theme = 'Sharp';
     } else {
-      tag = 'Filled';
+      theme = 'Filled';
     }
 
-    let searchable = key.replace(/(Outlined|TwoTone|Rounded|Sharp)$/, '');
+    const name = importName.replace(/(Outlined|TwoTone|Rounded|Sharp)$/, '');
+    let searchable = name;
     if (synonyms[searchable]) {
       searchable += ` ${synonyms[searchable]}`;
     }
-    searchIndex.add(key, searchable);
+    searchIndex.add(importName, searchable);
 
     const icon = {
-      key,
-      tag,
-      searchable,
-      Icon: mui[key],
+      importName,
+      name,
+      theme,
+      Component: mui[importName],
     };
-    allIconsMap[key] = icon;
+    allIconsMap[importName] = icon;
     return icon;
   });
 
 export default function SearchIcons() {
   const classes = useStyles();
-  const [tag, setTag] = React.useState('Filled');
+  const [theme, setTheme] = React.useState('Filled');
   const [keys, setKeys] = React.useState(null);
   const [open, setOpen] = React.useState(false);
   const [selectedIcon, setSelectedIcon] = React.useState(null);
@@ -476,9 +483,9 @@ export default function SearchIcons() {
   const icons = React.useMemo(
     () =>
       (keys === null ? allIcons : keys.map((key) => allIconsMap[key])).filter(
-        (icon) => tag === icon.tag,
+        (icon) => theme === icon.theme,
       ),
-    [tag, keys],
+    [theme, keys],
   );
 
   return (
@@ -487,18 +494,18 @@ export default function SearchIcons() {
         <form className={classes.form}>
           <RadioGroup>
             {['Filled', 'Outlined', 'Rounded', 'Two tone', 'Sharp'].map(
-              (key) => {
+              (currentTheme) => {
                 return (
                   <FormControlLabel
-                    key={key}
+                    key={currentTheme}
                     control={
                       <Radio
-                        checked={tag === key}
-                        onChange={() => setTag(key)}
-                        value={key}
+                        checked={theme === currentTheme}
+                        onChange={() => setTheme(currentTheme)}
+                        value={currentTheme}
                       />
                     }
-                    label={key}
+                    label={currentTheme}
                   />
                 );
               },

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
@@ -113,7 +111,9 @@ let Icons = (props) => {
   return (
     <div>
       {icons.map((icon) => {
+        /* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
         return (
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
           <span
             key={icon.key}
             onClick={handleIconClick(icon.searchable)}
@@ -125,8 +125,8 @@ let Icons = (props) => {
               title={icon.key}
               className={classes.iconSvg}
             />
-            {/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
             <p onClick={handleLabelClick}>{icon.key}</p>
+            {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
           </span>
         );
       })}

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -91,9 +91,20 @@ function selectNode(node) {
 }
 
 let Icons = (props) => {
-  const { icons, classes, handleClickOpen } = props;
+  const { icons, classes, handleOpenClick } = props;
 
-  const handleClick = (event) => {
+  const handleIconClick = (name) => () => {
+    if (Math.random() < 0.1) {
+      window.ga('send', {
+        hitType: 'event',
+        eventCategory: 'material-icons',
+        eventAction: 'click',
+        eventLabel: name,
+      });
+    }
+  };
+
+  const handleLabelClick = (event) => {
     selectNode(event.currentTarget);
   };
 
@@ -101,18 +112,20 @@ let Icons = (props) => {
     <div>
       {icons.map((icon) => {
         return (
-          <span key={icon.key} className={clsx('markdown-body', classes.icon)}>
+          <span
+            key={icon.key}
+            role="presentation"
+            onClick={handleIconClick(icon.searchable)}
+            className={clsx('markdown-body', classes.icon)}
+          >
             <icon.Icon
               tabIndex={-1}
-              onClick={handleClickOpen}
+              onClick={handleOpenClick}
               title={icon.key}
               className={classes.iconSvg}
-              data-ga-event-category="material-icons"
-              data-ga-event-action="click"
-              data-ga-event-label={icon.key}
             />
             {/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
-            <p onClick={handleClick}>{icon.key}</p>
+            <p onClick={handleLabelClick}>{icon.key}</p>
           </span>
         );
       })}
@@ -122,7 +135,7 @@ let Icons = (props) => {
 
 Icons.propTypes = {
   classes: PropTypes.object.isRequired,
-  handleClickOpen: PropTypes.func.isRequired,
+  handleOpenClick: PropTypes.func.isRequired,
   icons: PropTypes.array.isRequired,
 };
 Icons = React.memo(Icons);
@@ -400,6 +413,7 @@ const allIcons = Object.keys(mui)
     const icon = {
       key,
       tag,
+      searchable,
       Icon: mui[key],
     };
     allIconsMap[key] = icon;
@@ -413,7 +427,7 @@ export default function SearchIcons() {
   const [open, setOpen] = React.useState(false);
   const [selectedIcon, setSelectedIcon] = React.useState(null);
 
-  const handleClickOpen = React.useCallback((event) => {
+  const handleOpenClick = React.useCallback((event) => {
     setSelectedIcon(allIconsMap[event.currentTarget.getAttribute('title')]);
     setOpen(true);
   }, []);
@@ -512,7 +526,7 @@ export default function SearchIcons() {
         <Icons
           icons={icons}
           classes={classes}
-          handleClickOpen={handleClickOpen}
+          handleOpenClick={handleOpenClick}
         />
       </Grid>
       <DialogDetails


### PR DESCRIPTION
Problem 1: we don't track clicks on the label of the icons.
Problem 2: we want to track the icons only, we don't care about the variant per say, outlined, filled, etc. In the future, we might want to track the usage of the different variants, as a whole.

Long term objective: remove useless (the least frequently used) icons from the package. I suspect Google will keep adding useless icons. I also suspect we have a hard limit on how many icons we can publish to npm and bundle in the documentation. I don't know where this limit is. With this change, we can better track the most and least popular icons. 