### PR TITLE
[Stepper] Fix spacing without StepContent

### DIFF
--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -15,7 +15,6 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `orientation="vertical"`. */
   vertical: {
     marginLeft: 12, // half icon
-    padding: '0 0 8px',
   },
   /* Styles applied to the root element if `alternativeLabel={true}`. */
   alternativeLabel: {

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -9,7 +9,6 @@ import StepContext from '../Step/StepContext';
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
-    marginTop: 8,
     marginLeft: 12, // half icon
     paddingLeft: 8 + 12, // margin + half icon
     paddingRight: 8,

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -24,6 +24,7 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `orientation="vertical"`. */
   vertical: {
     textAlign: 'left',
+    padding: '8px 0',
   },
   /* Styles applied to the `Typography` component which wraps `children`. */
   label: {


### PR DESCRIPTION
The suggestion works well, even though there can always be different gaps depending on what your `StepLabel` contains (2 lines of text here):

<img width="248" alt="Screenshot 2020-08-14 at 18 00 46" src="https://user-images.githubusercontent.com/10428082/90269167-7d5da980-de58-11ea-9348-686c1a6d7549.png">


Closes #22167
