### PR TITLE
[docs] Improve codesandbox generation logic

### DIFF
--- a/docs/src/modules/utils/helpers.js
+++ b/docs/src/modules/utils/helpers.js
@@ -77,10 +77,27 @@ function includePeerDependencies(deps, versions) {
   Object.assign(deps, {
     'react-dom': versions['react-dom'],
     react: versions.react,
-    '@material-ui/core': versions['@material-ui/core'],
   });
 
-  if (deps['@material-ui/pickers'] && !deps['date-fns']) {
+  if (
+    deps['@material-ui/lab'] ||
+    deps['@material-ui/pickers'] ||
+    deps['@material-ui/x'] ||
+    deps['@material-ui/x-grid'] ||
+    deps['@material-ui/x-pickers'] ||
+    deps['@material-ui/x-tree-view'] ||
+    deps['@material-ui/data-grid']
+  ) {
+    deps['@material-ui/core'] = versions['@material-ui/core'];
+  }
+
+  if (deps['@material-ui/x-data-grid-generator']) {
+    deps['@material-ui/core'] = versions['@material-ui/core'];
+    deps['@material-ui/icons'] = versions['@material-ui/icons'];
+    deps['@material-ui/lab'] = versions['@material-ui/lab'];
+  }
+
+  if (deps['@material-ui/pickers']) {
     deps['date-fns'] = 'latest';
   }
 }
@@ -106,7 +123,6 @@ function getDependencies(raw, options = {}) {
     '@material-ui/styles': 'next',
     '@material-ui/system': 'next',
     '@material-ui/utils': 'next',
-    // TODO: Remove, moving into the lab
     '@material-ui/pickers': 'next',
   };
 

--- a/docs/src/modules/utils/helpers.js
+++ b/docs/src/modules/utils/helpers.js
@@ -77,11 +77,9 @@ function includePeerDependencies(deps, versions) {
   Object.assign(deps, {
     'react-dom': versions['react-dom'],
     react: versions.react,
+    '@material-ui/core': versions['@material-ui/core'],
   });
 
-  if (deps['@material-ui/lab'] && !deps['@material-ui/core']) {
-    deps['@material-ui/core'] = versions['@material-ui/core'];
-  }
   if (deps['@material-ui/pickers'] && !deps['date-fns']) {
     deps['date-fns'] = 'latest';
   }
@@ -108,7 +106,7 @@ function getDependencies(raw, options = {}) {
     '@material-ui/styles': 'next',
     '@material-ui/system': 'next',
     '@material-ui/utils': 'next',
-    // TODO: Remove once v4 is stable
+    // TODO: Remove, moving into the lab
     '@material-ui/pickers': 'next',
   };
 

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -114,13 +114,14 @@ import {
 
     expect(getDependencies(source)).to.deep.equal({
       'date-fns': 'latest',
+      '@material-ui/core': 'next',
       '@material-ui/pickers': 'next',
       react: 'latest',
       'react-dom': 'latest',
     });
   });
 
-  it('should include core if lab present', () => {
+  it('should always include core', () => {
     const source = `
 import lab from '@material-ui/lab';
     `;

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -121,7 +121,7 @@ import {
     });
   });
 
-  it('should always include core', () => {
+  it('should include core if lab present', () => {
     const source = `
 import lab from '@material-ui/lab';
     `;


### PR DESCRIPTION
When using the export to codesandbox feature of the demos with the data grid, we get: https://codesandbox.io/s/quirky-galois-9kfv5?file=/demo.tsx. For instance, using https://deploy-preview-165--material-ui-x.netlify.app/components/autocomplete/#ComboBox.tsx. I think that we can simply include @material-ui/core, always in the list of dependency. It seems to be a simple default, with no significant downside.

Closes https://github.com/mui-org/material-ui-x/issues/157