### PR TITLE
[l10n] Add Thai (th-TH) locale

### DIFF
--- a/docs/src/pages/guides/localization/localization.md
+++ b/docs/src/pages/guides/localization/localization.md
@@ -65,6 +65,7 @@ const theme = createMuiTheme(
 | Spanish                 | es-ES               | `esES`      |
 | Swedish                 | sv-SE               | `svSE`      |
 | Turkish                 | tr-TR               | `trTR`      |
+| Thai                    | th-TH               | `thTH`      |
 | Ukrainian               | uk-UA               | `ukUA`      |
 | Vietnamese              | vi-VN               | `viVN`      |
 

--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -1798,6 +1798,65 @@ export const svSE: Localization = {
   },
 };
 
+export const thTH: Localization = {
+  props: {
+    MuiBreadcrumbs: {
+      expandText: 'ดูเส้นทาง',
+    },
+    MuiTablePagination: {
+      getItemAriaLabel: (type) => {
+        if (type === 'first') {
+          return 'ไปที่หน้าแรก';
+        }
+        if (type === 'last') {
+          return 'ไปยังหน้าสุดท้าย';
+        }
+        if (type === 'next') {
+          return 'หน้าต่อไป';
+        }
+        // if (type === 'previous') {
+        return 'หน้าก่อน';
+      },
+      labelRowsPerPage: 'จำนวนแถวต่อหน้า:',
+      labelDisplayedRows: ({ from, to, count }) =>
+  `${from}-${to} จาก ${count !== -1 ? count : `มากกว่า ${to}`}`,
+    },
+    MuiRating: {
+      getLabelText: value => `${value} ดาว${value !== 1 ? 's' : ''}`,
+      emptyLabelText: 'ว่างเปล่า',
+    },
+    MuiAutocomplete: {
+      clearText: 'เคลียร์',
+      closeText: 'ปิด',
+      loadingText: 'กำลังโหลด…',
+      noOptionsText: 'ไม่มีตัวเลือก',
+      openText: 'เปิด',
+    },
+    MuiAlert: {
+      closeText: 'ปิด',
+    },
+    MuiPagination: {
+      'aria-label': '',
+      getItemAriaLabel: (type, page, selected) => {
+        if (type === 'page') {
+          return `${selected ? '' : 'ไปที่'}หน้า ${page}`;
+        }
+        if (type === 'first') {
+          return 'ไปยังหน้าแรก';
+        }
+        if (type === 'last') {
+          return 'ไปยังหน้าหน้าสุดท้าย';
+        }
+        if (type === 'next') {
+          return 'ไปหน้าต่อไป';
+        }
+        // if (type === 'previous') {
+        return 'ไปหน้าก่อน';
+      },
+    },
+  },
+};
+
 export const trTR: Localization = {
   props: {
     MuiBreadcrumbs: {

--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -1819,10 +1819,10 @@ export const thTH: Localization = {
       },
       labelRowsPerPage: 'จำนวนแถวต่อหน้า:',
       labelDisplayedRows: ({ from, to, count }) =>
-  `${from}-${to} จาก ${count !== -1 ? count : `มากกว่า ${to}`}`,
+        `${from}-${to} จาก ${count !== -1 ? count : `มากกว่า ${to}`}`,
     },
     MuiRating: {
-      getLabelText: value => `${value} ดาว${value !== 1 ? 's' : ''}`,
+      getLabelText: (value) => `${value} ดาว${value !== 1 ? 's' : ''}`,
       emptyLabelText: 'ว่างเปล่า',
     },
     MuiAutocomplete: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Hello,
This PR adds support for Thai localization for [https://material-ui.com/guides/localization/#localization](https://material-ui.com/guides/localization/#localization)
According to [https://en.wikipedia.org/wiki/List_of_languages_by_number_of_native_speakers](https://en.wikipedia.org/wiki/List_of_languages_by_number_of_native_speakers), Thai is spoken by 20.7 millions (0.269). Most (Thai-speaking) users do benefit from having Thai UI so I hope this justifies adding support for it.

Please let me know if I need to fix any issue or anything (really). Thanks! 