### PR TITLE
[slider] Respect disabled property when already focused 

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -589,6 +589,10 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   };
 
   const handleTouchMove = useEventCallback((nativeEvent) => {
+    if (disabled) {
+      return;
+    }
+
     const finger = trackFinger(nativeEvent, touchId);
 
     if (!finger) {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -144,6 +144,8 @@ function doesSupportTouchActionNone() {
   return cachedSupportsTouchActionNone;
 }
 
+const useEnhancedEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 export const styles = (theme) => ({
   /* Styles applied to the root element. */
   root: {
@@ -449,6 +451,15 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     setOpen(-1);
   });
 
+  useEnhancedEffect(() => {
+    if (disabled && sliderRef.current.contains(document.activeElement)) {
+      // This is necessary because Firefox and Safari will keep focus
+      // on a disabled element:
+      // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
+      document.activeElement.blur();
+    }
+  }, [disabled]);
+
   if (disabled && active !== -1) {
     setActive(-1);
   }
@@ -459,13 +470,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {
-    if (disabled) {
-      // This check is necessary because Firefox and Safari will keep focus
-      // on a disabled slider, even though we blur it:
-      // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
-      return;
-    }
-
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];
     const tenPercents = (max - min) / 10;

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -452,9 +452,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {
-    if (disabled) {
-      return;
-    }
+    // if (disabled) {
+    //   return;
+    // }
 
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -449,6 +449,13 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     setOpen(-1);
   });
 
+  if (disabled && active !== -1) {
+    setActive(-1);
+  }
+  if (disabled && focusVisible !== -1) {
+    setFocusVisible(-1);
+  }
+
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -452,9 +452,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {
-    // if (disabled) {
-    //   return;
-    // }
+    if (disabled) {
+      return;
+    }
 
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];
@@ -589,10 +589,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   };
 
   const handleTouchMove = useEventCallback((nativeEvent) => {
-    // if (disabled) {
-    //   return;
-    // }
-
     const finger = trackFinger(nativeEvent, touchId);
 
     if (!finger) {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -461,7 +461,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const handleKeyDown = useEventCallback((event) => {
     if (disabled) {
       // This check is necessary because Firefox and Safari will keep focus
-      // on a disabled slider, even though we blur it: 
+      // on a disabled slider, even though we blur it:
       // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
       return;
     }

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -452,6 +452,10 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {
+    if (disabled) {
+      return;
+    }
+
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];
     const tenPercents = (max - min) / 10;

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -695,7 +695,17 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       doc.removeEventListener('touchmove', handleTouchMove);
       doc.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [disabled, handleTouchEnd, handleTouchMove, handleTouchStart]);
+  }, [handleTouchEnd, handleTouchMove, handleTouchStart]);
+
+  React.useEffect(() => {
+    if (disabled) {
+      const doc = ownerDocument(sliderRef.current);
+      doc.removeEventListener('mousemove', handleTouchMove);
+      doc.removeEventListener('mouseup', handleTouchEnd);
+      doc.removeEventListener('touchmove', handleTouchMove);
+      doc.removeEventListener('touchend', handleTouchEnd);
+    }
+  }, [disabled, handleTouchEnd, handleTouchMove]);
 
   const handleMouseDown = useEventCallback((event) => {
     if (onMouseDown) {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -460,6 +460,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
 
   const handleKeyDown = useEventCallback((event) => {
     if (disabled) {
+      // This check is necessary because Firefox and Safari will keep focus
+      // on a disabled slider, even though we blur it: 
+      // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
       return;
     }
 

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -6,6 +6,7 @@ import withStyles from '../styles/withStyles';
 import useTheme from '../styles/useTheme';
 import { fade, lighten, darken } from '../styles/colorManipulator';
 import useIsFocusVisible from '../utils/useIsFocusVisible';
+import useEnhancedEffect from '../utils/useEnhancedEffect';
 import ownerDocument from '../utils/ownerDocument';
 import useEventCallback from '../utils/useEventCallback';
 import useForkRef from '../utils/useForkRef';
@@ -143,8 +144,6 @@ function doesSupportTouchActionNone() {
   }
   return cachedSupportsTouchActionNone;
 }
-
-const useEnhancedEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -452,9 +452,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {
-    if (disabled) {
-      return;
-    }
+    // if (disabled) {
+    //   return;
+    // }
 
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];
@@ -589,9 +589,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   };
 
   const handleTouchMove = useEventCallback((nativeEvent) => {
-    if (disabled) {
-      return;
-    }
+    // if (disabled) {
+    //   return;
+    // }
 
     const finger = trackFinger(nativeEvent, touchId);
 
@@ -685,7 +685,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       doc.removeEventListener('touchmove', handleTouchMove);
       doc.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [handleTouchEnd, handleTouchMove, handleTouchStart]);
+  }, [disabled, handleTouchEnd, handleTouchMove, handleTouchStart]);
 
   const handleMouseDown = useEventCallback((event) => {
     if (onMouseDown) {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -452,9 +452,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const isRtl = theme.direction === 'rtl';
 
   const handleKeyDown = useEventCallback((event) => {
-    // if (disabled) {
-    //   return;
-    // }
+    if (disabled) {
+      return;
+    }
 
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -255,6 +255,11 @@ describe('<Slider />', () => {
       expect(getByRole('slider')).to.not.have.attribute('tabIndex');
     });
 
+    // jsdom doesn't blur correctly
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      return;
+    }
+
     it('should not respond to drag events after becoming disabled', () => {
       const { getByRole, setProps, container } = render(<Slider defaultValue={0} />);
 
@@ -273,8 +278,11 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
 
       expect(thumb).to.have.attribute('aria-valuenow', '21');
+      expect(thumb).toHaveFocus();
 
       setProps({ disabled: true });
+      expect(thumb).not.toHaveFocus();
+      expect(thumb).to.not.have.class(classes.active);
 
       fireEvent.touchMove(
         container.firstChild,
@@ -282,33 +290,17 @@ describe('<Slider />', () => {
       );
 
       expect(thumb).to.have.attribute('aria-valuenow', '21');
-      expect(thumb).to.not.have.class(classes.active);
     });
 
     it('should not respond to the keyboard after becoming disabled', () => {
       const { getByRole, setProps } = render(<Slider defaultValue={0} />);
 
       const thumb = getByRole('slider');
-
       act(() => {
         thumb.focus();
       });
-
       setProps({ disabled: true });
-
-      // This branch is necessary because Firefox and Safari will keep focus
-      // on a disabled slider, even though we blur it:
-      // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
-      if (document.activeElement === thumb) {
-        expect(thumb).toHaveFocus();
-        fireEvent.keyDown(thumb, {
-          key: 'PageUp',
-        });
-      } else {
-        expect(thumb).not.toHaveFocus();
-      }
-
-      expect(thumb).to.have.attribute('aria-valuenow', '0');
+      expect(thumb).not.toHaveFocus();
       expect(thumb).to.not.have.class(classes.focusVisible);
     });
   });

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -256,7 +256,7 @@ describe('<Slider />', () => {
     });
 
     it('should not respond to drag events after becoming disabled', function test() {
-      // jsdom doesn't blur correctly
+      // TODO: Don't skip once a fix for https://github.com/jsdom/jsdom/issues/3029 is released.
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
@@ -293,7 +293,7 @@ describe('<Slider />', () => {
     });
 
     it('is not focused (visibly) after becoming disabled', function test() {
-      // jsdom doesn't blur correctly
+      // TODO: Don't skip once a fix for https://github.com/jsdom/jsdom/issues/3029 is released.
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -296,8 +296,6 @@ describe('<Slider />', () => {
 
       setProps({ disabled: true });
 
-      // expect(thumb).not.toHaveFocus();
-
       // If the active element is no longer the thumb, we have already exited the state we're trying to test for.
       if (document.activeElement === thumb) {
         fireEvent.keyDown(thumb, {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -296,11 +296,16 @@ describe('<Slider />', () => {
 
       setProps({ disabled: true });
 
-      // If the active element is no longer the thumb, we have already exited the state we're trying to test for.
+      // This branch is necessary because Firefox and Safari will keep focus
+      // on a disabled slider, even though we blur it: 
+      // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
       if (document.activeElement === thumb) {
+        expect(thumb).toHaveFocus();
         fireEvent.keyDown(thumb, {
           key: 'PageUp',
         });
+      } else {
+        expect(thumb).not.toHaveFocus();
       }
 
       expect(thumb).to.have.attribute('aria-valuenow', '0');

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -160,7 +160,7 @@ describe('<Slider />', () => {
       const { getByRole } = render(<Slider defaultValue={30} step={10} marks />);
       const thumb = getByRole('slider');
       fireEvent.mouseDown(thumb);
-      expect(document.activeElement).to.equal(thumb);
+      expect(thumb).toHaveFocus();
     });
 
     it('should support mouse events', () => {
@@ -210,6 +210,15 @@ describe('<Slider />', () => {
     );
 
     fireEvent.touchMove(document.body, createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]));
+  });
+
+  it('focuses the thumb on when touching', () => {
+    const { getByRole } = render(<Slider value={0} min={20} max={40} />);
+    const thumb = getByRole('slider');
+
+    fireEvent.touchStart(thumb, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
+
+    expect(thumb).toHaveFocus();
   });
 
   describe('prop: step', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -285,7 +285,7 @@ describe('<Slider />', () => {
     });
 
     it('should not respond to the keyboard after becoming disabled', () => {
-      const { getByRole, setProps, container } = render(<Slider defaultValue={0} />);
+      const { getByRole, setProps } = render(<Slider defaultValue={0} />);
 
       const thumb = getByRole('slider');
 

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -292,7 +292,7 @@ describe('<Slider />', () => {
       expect(thumb).to.have.attribute('aria-valuenow', '21');
     });
 
-    it('should not respond to the keyboard after becoming disabled', () => {
+    it('is not focused (visibly) after becoming disabled', () => {
       const { getByRole, setProps } = render(<Slider defaultValue={0} />);
 
       const thumb = getByRole('slider');

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -297,7 +297,7 @@ describe('<Slider />', () => {
       setProps({ disabled: true });
 
       // This branch is necessary because Firefox and Safari will keep focus
-      // on a disabled slider, even though we blur it: 
+      // on a disabled slider, even though we blur it:
       // https://codesandbox.io/s/mui-pr-22247-forked-h151h?file=/src/App.js
       if (document.activeElement === thumb) {
         expect(thumb).toHaveFocus();

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -287,34 +287,24 @@ describe('<Slider />', () => {
     it('should not respond to the keyboard after becoming disabled', () => {
       const { getByRole, setProps, container } = render(<Slider defaultValue={0} />);
 
-      stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
-        width: 100,
-        height: 10,
-        bottom: 10,
-        left: 0,
-      }));
-
-      fireEvent.touchStart(
-        container.firstChild,
-        createTouches([{ identifier: 1, clientX: 21, clientY: 0 }]),
-      );
-
       const thumb = getByRole('slider');
 
-      expect(thumb).to.have.attribute('aria-valuenow', '21');
+      act(() => {
+        thumb.focus();
+      });
 
       setProps({ disabled: true });
 
-      expect(thumb).not.toHaveFocus();
+      // expect(thumb).not.toHaveFocus();
 
       // If the active element is no longer the thumb, we have already exited the state we're trying to test for.
-      // if (document.activeElement === thumb) {
-      //   fireEvent.keyDown(thumb, {
-      //     key: 'PageDown',
-      //   });
-      // }
+      if (document.activeElement === thumb) {
+        fireEvent.keyDown(thumb, {
+          key: 'PageUp',
+        });
+      }
 
-      // expect(thumb).to.have.attribute('aria-valuenow', '21');
+      expect(thumb).to.have.attribute('aria-valuenow', '0');
     });
   });
 

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -282,6 +282,7 @@ describe('<Slider />', () => {
       );
 
       expect(thumb).to.have.attribute('aria-valuenow', '21');
+      expect(thumb).to.not.have.class(classes.active);
     });
 
     it('should not respond to the keyboard after becoming disabled', () => {
@@ -305,6 +306,7 @@ describe('<Slider />', () => {
       }
 
       expect(thumb).to.have.attribute('aria-valuenow', '0');
+      expect(thumb).to.not.have.class(classes.focusVisible);
     });
   });
 

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -307,12 +307,15 @@ describe('<Slider />', () => {
 
       expect(thumb).to.have.attribute('aria-valuenow', '21');
 
-      fireEvent.keyDown(thumb, {
-        key: 'PageDown',
-      });
-      
+      // If the active element is no longer the thumb, we have already exited the state we're trying to test for.
+      if (document.activeElement === thumb) {
+        fireEvent.keyDown(thumb, {
+          key: 'PageDown',
+        });
+      }
+
       expect(thumb).to.have.attribute('aria-valuenow', '21');
-    })
+    });
   });
 
   describe('prop: track', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -255,14 +255,8 @@ describe('<Slider />', () => {
       expect(getByRole('slider')).to.not.have.attribute('tabIndex');
     });
 
-    const SelfDisablingSlider = () => {
-      const [isDisabled, setIsDisabled] = React.useState(false);
-
-      return <Slider defaultValue={0} disabled={isDisabled} onChange={() => setIsDisabled(true)} />;
-    };
-
     it('should not respond to drag events after becoming disabled', () => {
-      const { getByRole, container } = render(<SelfDisablingSlider />);
+      const { getByRole, setProps, container } = render(<Slider defaultValue={0} />);
 
       stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
         width: 100,
@@ -279,6 +273,8 @@ describe('<Slider />', () => {
       const thumb = getByRole('slider');
 
       expect(thumb).to.have.attribute('aria-valuenow', '21');
+
+      setProps({ disabled: true });
 
       fireEvent.touchMove(
         container.firstChild,
@@ -289,7 +285,7 @@ describe('<Slider />', () => {
     });
 
     it('should not respond to the keyboard after becoming disabled', () => {
-      const { getByRole, container } = render(<SelfDisablingSlider />);
+      const { getByRole, setProps, container } = render(<Slider defaultValue={0} />);
 
       stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
         width: 100,
@@ -307,14 +303,18 @@ describe('<Slider />', () => {
 
       expect(thumb).to.have.attribute('aria-valuenow', '21');
 
-      // If the active element is no longer the thumb, we have already exited the state we're trying to test for.
-      if (document.activeElement === thumb) {
-        fireEvent.keyDown(thumb, {
-          key: 'PageDown',
-        });
-      }
+      setProps({ disabled: true });
 
-      expect(thumb).to.have.attribute('aria-valuenow', '21');
+      expect(thumb).not.toHaveFocus();
+
+      // If the active element is no longer the thumb, we have already exited the state we're trying to test for.
+      // if (document.activeElement === thumb) {
+      //   fireEvent.keyDown(thumb, {
+      //     key: 'PageDown',
+      //   });
+      // }
+
+      // expect(thumb).to.have.attribute('aria-valuenow', '21');
     });
   });
 

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -254,6 +254,65 @@ describe('<Slider />', () => {
       expect(container.firstChild).to.have.class(classes.disabled);
       expect(getByRole('slider')).to.not.have.attribute('tabIndex');
     });
+
+    const SelfDisablingSlider = () => {
+      const [isDisabled, setIsDisabled] = React.useState(false);
+
+      return <Slider defaultValue={0} disabled={isDisabled} onChange={() => setIsDisabled(true)} />;
+    };
+
+    it('should not respond to drag events after becoming disabled', () => {
+      const { getByRole, container } = render(<SelfDisablingSlider />);
+
+      stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+        width: 100,
+        height: 10,
+        bottom: 10,
+        left: 0,
+      }));
+
+      fireEvent.touchStart(
+        container.firstChild,
+        createTouches([{ identifier: 1, clientX: 21, clientY: 0 }]),
+      );
+
+      const thumb = getByRole('slider');
+
+      expect(thumb).to.have.attribute('aria-valuenow', '21');
+
+      fireEvent.touchMove(
+        container.firstChild,
+        createTouches([{ identifier: 1, clientX: 30, clientY: 0 }]),
+      );
+
+      expect(thumb).to.have.attribute('aria-valuenow', '21');
+    });
+
+    it('should not respond to the keyboard after becoming disabled', () => {
+      const { getByRole, container } = render(<SelfDisablingSlider />);
+
+      stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+        width: 100,
+        height: 10,
+        bottom: 10,
+        left: 0,
+      }));
+
+      fireEvent.touchStart(
+        container.firstChild,
+        createTouches([{ identifier: 1, clientX: 21, clientY: 0 }]),
+      );
+
+      const thumb = getByRole('slider');
+
+      expect(thumb).to.have.attribute('aria-valuenow', '21');
+
+      fireEvent.keyDown(thumb, {
+        key: 'PageDown',
+      });
+      
+      expect(thumb).to.have.attribute('aria-valuenow', '21');
+    })
   });
 
   describe('prop: track', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -255,12 +255,12 @@ describe('<Slider />', () => {
       expect(getByRole('slider')).to.not.have.attribute('tabIndex');
     });
 
-    // jsdom doesn't blur correctly
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
+    it('should not respond to drag events after becoming disabled', function test() {
+      // jsdom doesn't blur correctly
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
 
-    it('should not respond to drag events after becoming disabled', () => {
       const { getByRole, setProps, container } = render(<Slider defaultValue={0} />);
 
       stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
@@ -292,7 +292,12 @@ describe('<Slider />', () => {
       expect(thumb).to.have.attribute('aria-valuenow', '21');
     });
 
-    it('is not focused (visibly) after becoming disabled', () => {
+    it('is not focused (visibly) after becoming disabled', function test() {
+      // jsdom doesn't blur correctly
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
       const { getByRole, setProps } = render(<Slider defaultValue={0} />);
 
       const thumb = getByRole('slider');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Hi, this isn't only my first PR to mui but also my first PR to any large open source project, so I'm happy to fill in any parts of the process that I've missed out on.

I have a reproduction of the problem this is supposed to fix on [this branch](https://github.com/pireads/material-ui/tree/disable-slider-repro). Running docs over there and changing the `Temperature` slider should disable it, but you can continue to change its value if you don't let go with your mouse or use arrow keys.

Thanks for making this project happen, it's been super clean to use so far :D
