### PR TITLE
[TrapFocus] Prevent possible crash in React 17

### DIFF
--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
@@ -112,6 +112,13 @@ function Unstable_TrapFocus(props) {
     const doc = ownerDocument(rootRef.current);
 
     const contain = (nativeEvent) => {
+      const { current: rootElement } = rootRef;
+      // Cleanup functions are executed lazily in React 17.
+      // Contain can be called between the component being unmounted and its cleanup function being run.
+      if (rootElement === null) {
+        return;
+      }
+
       if (
         !doc.hasFocus() ||
         disableEnforceFocus ||
@@ -122,7 +129,7 @@ function Unstable_TrapFocus(props) {
         return;
       }
 
-      if (!rootRef.current.contains(doc.activeElement)) {
+      if (!rootElement.contains(doc.activeElement)) {
         // if the focus event is not coming from inside the children's react tree, reset the refs
         if (
           (nativeEvent && reactFocusEventTarget.current !== nativeEvent.target) ||
@@ -137,7 +144,7 @@ function Unstable_TrapFocus(props) {
           return;
         }
 
-        rootRef.current.focus();
+        rootElement.focus();
       } else {
         activated.current = true;
       }


### PR DESCRIPTION
Includes a part of the `react@next` patch into our release. 

This makes it easier to test our v5 with React 17. Will backport it to `master` since it's fairly cheap. 

I think generally we won't recommend the next v4 release for production anyway. It's for deprecations only and if we introduce bugs in that release we don't want to put time into fixing those anyway. It's only meant as a migration helper.
