### PR TITLE
[TrapFocus] Fix compatibility issues with React 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,6 @@ workflows:
                 - l10n
                 - /dependabot\//
       - test_unit:
-          react-dist-tag: next
           requires:
             - checkout
       - test_static:
@@ -244,11 +243,9 @@ workflows:
           requires:
             - checkout
       - test_browser:
-          react-dist-tag: next
           requires:
             - checkout
       - test_regressions:
-          react-dist-tag: next
           requires:
             - test_unit
             - test_static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ workflows:
                 - l10n
                 - /dependabot\//
       - test_unit:
+          react-dist-tag: next
           requires:
             - checkout
       - test_static:
@@ -243,9 +244,11 @@ workflows:
           requires:
             - checkout
       - test_browser:
+          react-dist-tag: next
           requires:
             - checkout
       - test_regressions:
+          react-dist-tag: next
           requires:
             - test_unit
             - test_static

--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
@@ -169,7 +169,7 @@ function Unstable_TrapFocus(props) {
       }
     };
 
-    doc.addEventListener('focus', contain, true);
+    doc.addEventListener('focusin', contain);
     doc.addEventListener('keydown', loopFocus, true);
 
     // With Edge, Safari and Firefox, no focus related events are fired when the focused area stops being a focused area.
@@ -187,7 +187,7 @@ function Unstable_TrapFocus(props) {
     return () => {
       clearInterval(interval);
 
-      doc.removeEventListener('focus', contain, true);
+      doc.removeEventListener('focusin', contain);
       doc.removeEventListener('keydown', loopFocus, true);
     };
   }, [disableAutoFocus, disableEnforceFocus, disableRestoreFocus, isEnabled, open]);

--- a/scripts/react-next.diff
+++ b/scripts/react-next.diff
@@ -187,42 +187,6 @@ index 9cd267a0c0..7323483c87 100644
        });
      });
    });
-diff --git a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
-index 0c70635965..bdef6b3c45 100644
---- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
-+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
-@@ -112,6 +112,13 @@ function Unstable_TrapFocus(props) {
-     const doc = ownerDocument(rootRef.current);
- 
-     const contain = (nativeEvent) => {
-+      const { current: rootElement } = rootRef;
-+      // Contain can be called between the component being unmounted and its cleanup function being run.
-+      // Cleanup functions are executed lazily in React 17
-+      if (rootElement === null) {
-+        return;
-+      }
-+
-       if (
-         !doc.hasFocus() ||
-         disableEnforceFocus ||
-@@ -122,7 +129,7 @@ function Unstable_TrapFocus(props) {
-         return;
-       }
- 
--      if (!rootRef.current.contains(doc.activeElement)) {
-+      if (!rootElement.contains(doc.activeElement)) {
-         // if the focus event is not coming from inside the children's react tree, reset the refs
-         if (
-           (nativeEvent && reactFocusEventTarget.current !== nativeEvent.target) ||
-@@ -137,7 +144,7 @@ function Unstable_TrapFocus(props) {
-           return;
-         }
- 
--        rootRef.current.focus();
-+        rootElement.focus();
-       } else {
-         activated.current = true;
-       }
 diff --git a/packages/material-ui/src/internal/SwitchBase.test.js b/packages/material-ui/src/internal/SwitchBase.test.js
 index 8c8f59a9d8..657a5e57bc 100644
 --- a/packages/material-ui/src/internal/SwitchBase.test.js

--- a/scripts/react-next.diff
+++ b/scripts/react-next.diff
@@ -223,41 +223,6 @@ index 0c70635965..bdef6b3c45 100644
        } else {
          activated.current = true;
        }
-diff --git a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
-index 174e4ae5d4..ec4c2c90f1 100644
---- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
-+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
-@@ -60,7 +60,7 @@ describe('<TrapFocus />', () => {
-   it('should focus first focusable child in portal', () => {
-     const { getByTestId } = render(
-       <TrapFocus {...defaultProps} open>
--        <div tabIndex={-1}>
-+        <div data-testid="focus-trap-root" tabIndex={-1}>
-           <Portal>
-             <input autoFocus data-testid="auto-focus" />
-           </Portal>
-@@ -68,7 +68,8 @@ describe('<TrapFocus />', () => {
-       </TrapFocus>,
-     );
- 
--    expect(getByTestId('auto-focus')).toHaveFocus();
-+    // FIXME: should be `auto-focus`
-+    expect(getByTestId('focus-trap-root')).toHaveFocus();
-   });
- 
-   it('should warn if the modal content is not focusable', () => {
-@@ -382,7 +383,10 @@ describe('<TrapFocus />', () => {
- 
-         // restore the focus to the first element before triggering the trap
-         setProps({ open: false });
--        expect(getByRole('textbox')).toHaveFocus();
-+
-+        // FIXME: should be
-+        // expect(getByRole('textbox')).toHaveFocus();
-+        expect(getByTestId('modal')).toHaveFocus();
-       });
-     });
-   });
 diff --git a/packages/material-ui/src/internal/SwitchBase.test.js b/packages/material-ui/src/internal/SwitchBase.test.js
 index 8c8f59a9d8..657a5e57bc 100644
 --- a/packages/material-ui/src/internal/SwitchBase.test.js


### PR DESCRIPTION
Since React 17 switches from listening to `focus` to `focusin` and does listen on React roots rather then the document the focus event time is slightly off.

Before `contain` would be called after React's focus event i.e. the native focus capture. Because React's listener was attached to the document **before** our component was mounted i.e. when we added our listener. Now it's called before because react has its listener attached inside the document. 

The easiest change is to trigger contain in the bubble phase of `focusin` and not capture phase of `focus`. However, this could be potentially problematic if people use `event.nativeEvent.stopPropagation()`. But until we get an API to attach event listeners to the React root I can't think of a better solution.

Test Plan:
- [x] CI green: https://app.circleci.com/pipelines/github/mui-org/material-ui/16997/workflows/ff8fd66d-9c8f-4ac9-8bed-3957d56dbbf4
- [x] CI green with `react_dist_tag: 'next'`: https://app.circleci.com/pipelines/github/mui-org/material-ui/17000/workflows/90633f97-f897-469c-9229-b75a597bb239

