### PR TITLE
[core] Include TypeScript definitions in source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+# Undo the GitHub's default
+# https://github.com/github/linguist/blob/96ad1185828f44bb9b774328a584551ee57ed264/lib/linguist/vendor.yml#L177
+packages/**/*.d.ts -linguist-vendored


### PR DESCRIPTION
GitHub assumes that .d.ts files are coming from some other place.
In our case, we manually author them, they are part of our sources, they are not vendor.

Before
```
$ github-linguist
94.56%  JavaScript
5.43%   TypeScript
0.01%   HTML
```

After
```
$ github-linguist
88.07%  JavaScript
11.93%  TypeScript
0.01%   HTML
```