### PR TITLE
[Tabs] Add aria-orientation of vertical

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -494,6 +494,7 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
         <div
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
+          aria-orientation={orientation === 'vertical' ? 'vertical' : null}
           className={clsx(classes.flexContainer, {
             [classes.flexContainerVertical]: vertical,
             [classes.centered]: centered && !scrollable,

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -689,6 +689,18 @@ describe('<Tabs />', () => {
       expect(style.top).to.equal('60px');
       expect(style.height).to.equal('50px');
     });
+
+    it('does not add aria-orientation by default', () => {
+      render(<Tabs value={0} />);
+
+      expect(screen.getByRole('tablist')).not.to.have.attribute('aria-orientation');
+    });
+
+    it('adds the proper aria-orientation when vertical', () => {
+      render(<Tabs value={0} orientation="vertical" />);
+
+      expect(screen.getByRole('tablist')).to.have.attribute('aria-orientation', 'vertical');
+    });
   });
 
   describe('server-side render', () => {


### PR DESCRIPTION
Implements 

> If the tablist element is vertically oriented, it has the property aria-orientation set to vertical. The default value of aria-orientation for a tablist element is horizontal.

-- https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel

Closes https://github.com/mui-org/material-ui/issues/22272