### PR TITLE
[core] Update config to use tab indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 
 # Unix-style newlines with a newline ending every file
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 2
 end_of_line = lf
 charset = utf-8

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,21 +1,22 @@
 module.exports = {
-  printWidth: 100,
-  singleQuote: true,
-  trailingComma: 'all',
-  overrides: [
-    {
-      files: '*.d.ts',
-      options: {
-        // This is needed for TypeScript 3.2 support
-        trailingComma: 'es5',
-      },
-    },
-    {
-      files: ['docs/**/*.md', 'docs/src/pages/**/*.{js,tsx}'],
-      options: {
-        // otherwise code blocks overflow on the docs website
-        printWidth: 80,
-      },
-    },
-  ],
+	printWidth: 100,
+	singleQuote: true,
+	trailingComma: 'all',
+	useTabs: true,
+	overrides: [
+		{
+			files: '*.d.ts',
+			options: {
+				// This is needed for TypeScript 3.2 support
+				trailingComma: 'es5',
+			},
+		},
+		{
+			files: ['docs/**/*.md', 'docs/src/pages/**/*.{js,tsx}'],
+			options: {
+				// otherwise code blocks overflow on the docs website
+				printWidth: 80,
+			},
+		},
+	],
 };


### PR DESCRIPTION
Experimental PR to see how CI treats a config-only change (to ease PR migration to tab indents).

Related to #22283.
