### PR TITLE
[Dialog] Fix unexpected close when releasing click on backdrop

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -165,17 +165,19 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
     ...other
   } = props;
 
-  const mouseDownTarget = React.useRef();
+  const backdropClick = React.useRef();
   const handleMouseDown = (event) => {
-    mouseDownTarget.current = event.currentTarget;
+    // We don't want to close the dialog when clicking the dialog content.
+    // Make sure the event starts and ends on the same DOM element.
+    backdropClick.current = event.target === event.currentTarget;
   };
   const handleBackdropClick = (event) => {
-    // Make sure the event starts and ends on the same DOM element.
-    if (event.target !== mouseDownTarget.current) {
+    // Ignore the events not coming from the "backdrop".
+    if (!backdropClick.current) {
       return;
     }
 
-    mouseDownTarget.current = null;
+    backdropClick.current = null;
 
     if (onBackdropClick) {
       onBackdropClick(event);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Added the code as proposed in that fixes #22151 allowing the dialog to stay open when the click originates on the dialog and ends on the backdrop.