### PR TITLE
[docs] Resolve .tsx first

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -84,6 +84,14 @@ module.exports = {
     return {
       ...config,
       plugins,
+      resolve: {
+        ...config.resolve,
+        // resolve .tsx first
+        extensions: [
+          '.tsx',
+          ...config.resolve.extensions.filter((extension) => extension !== '.tsx'),
+        ],
+      },
       node: {
         fs: 'empty',
       },


### PR DESCRIPTION
We have some components that are duplicated, there is both a .tsx and .js version. I believe that in these cases, we should bundle the .tsx version, not the .jsx version. You can try the implications when loading http://0.0.0.0:3000/premium-themes/onepirate/forgot-password/ and editing the JS and TS version of `docs/src/pages/premium-themes/onepirate/ForgotPassword` to see what happens.