### PR TITLE
[core] Add explicit dependency on `@types/yargs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/prettier": "^2.0.0",
     "@types/react": "^16.9.44",
     "@types/sinon": "^9.0.0",
+    "@types/yargs": "^15.0.5",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "argos-cli": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,7 +2952,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^15.0.0":
+"@types/yargs@^15.0.0", "@types/yargs@^15.0.5":
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
   integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==


### PR DESCRIPTION
We started depending on them in #22055 but didn't add the dependency. Since yarn can't know about it the resulting node_modules in #22332 would pull in `@types/yargs@13` in instead.