### PR TITLE
[Tooltip] Improve readability

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -78,13 +78,12 @@ export const styles = (theme) => ({
   popperArrow: arrowGenerator(),
   /* Styles applied to the tooltip (label wrapper) element. */
   tooltip: {
-    backgroundColor: fade(theme.palette.grey[700], 0.9),
+    backgroundColor: fade(theme.palette.grey[700], 0.92),
     borderRadius: theme.shape.borderRadius,
     color: theme.palette.common.white,
     fontFamily: theme.typography.fontFamily,
     padding: '4px 8px',
-    fontSize: theme.typography.pxToRem(10),
-    lineHeight: `${round(14 / 10)}em`,
+    fontSize: theme.typography.pxToRem(11),
     maxWidth: 300,
     wordWrap: 'break-word',
     fontWeight: theme.typography.fontWeightMedium,

--- a/test/regressions/tests/Tooltip/PositionedTooltips.js
+++ b/test/regressions/tests/Tooltip/PositionedTooltips.js
@@ -8,8 +8,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 const styles = {
   root: {
     width: 400,
-    height: 400,
-    padding: 60,
+    padding: '50px 70px',
   },
 };
 


### PR DESCRIPTION
### The issue

<img width="325" alt="Capture d’écran 2020-08-23 à 14 08 28" src="https://user-images.githubusercontent.com/3165635/90978037-c42f5b80-e54a-11ea-9c9c-a20440d3504d.png">

First reported https://github.com/mui-org/material-ui/pull/22210#discussion_r474870651. I couldn't find any direct mention of the correct background-color on the Material Design specification: https://material.io/components/tooltips#theming. There is a prior-effort in #14651 with @leMaik.

### Benchmark

- Material-UI v4: `background-color: rgba(97,97,97,0.9)`, `font-size: 10px`

<img width="127" alt="Capture d’écran 2020-08-23 à 14 17 44" src="https://user-images.githubusercontent.com/3165635/90978110-6fd8ab80-e54b-11ea-9996-6572f4fa46bd.png">

- Google Calendar: `background-color: rgba(97,97,97,0.902)`, `font-size: 12px`

<img width="115" alt="Capture d’écran 2020-08-23 à 14 04 40" src="https://user-images.githubusercontent.com/3165635/90977900-9b5a9680-e549-11ea-9a41-e5d9fab510fa.png">


- Google Keep: `background-color: rgba(60,64,67,0.9)`, `font-size: 12px`

<img width="119" alt="Capture d’écran 2020-08-23 à 14 04 17" src="https://user-images.githubusercontent.com/3165635/90977892-90076b00-e549-11ea-81b3-4c918a0ccf3e.png">


- Gmail: `background-color: rgb(60,64,67)`, `font-size: 12px`

<img width="154" alt="Capture d’écran 2020-08-23 à 14 04 04" src="https://user-images.githubusercontent.com/3165635/90977883-84b43f80-e549-11ea-8e64-f11f4227aa22.png">

- Google Doc: `background-color: rgb(43,43,43)`, `font-size: 12px`

<img width="279" alt="Capture d’écran 2020-08-23 à 14 03 21" src="https://user-images.githubusercontent.com/3165635/90977877-7ebe5e80-e549-11ea-978a-38d0c991536e.png">

- Google Drive: `background-color: rgb(97,97,97)`, `font-size: 11px`

<img width="118" alt="Capture d’écran 2020-08-23 à 14 28 32" src="https://user-images.githubusercontent.com/3165635/90978291-0fe30480-e54d-11ea-950a-2cf96c387635.png">

- YouTube: `background-color: rgb(97,97,97, 0.9)`, `font-size: 13px`

<img width="139" alt="Capture d’écran 2020-08-23 à 14 45 24" src="https://user-images.githubusercontent.com/3165635/90978599-5174af00-e54f-11ea-8ebe-684ad2c2f257.png">

- Google.com `background-color: rgb(45,45,45)`, `font-size: 11px`

<img width="175" alt="Capture d’écran 2020-08-23 à 14 48 46" src="https://user-images.githubusercontent.com/3165635/90978671-d19b1480-e54f-11ea-99af-89da822db918.png">

### Proposal

<img width="151" alt="Capture d’écran 2020-08-23 à 14 50 53" src="https://user-images.githubusercontent.com/3165635/90978707-11fa9280-e550-11ea-9abf-d7172af01239.png">
