### PR TITLE
[core] Refactor how we ignore default values in docs

### DIFF
--- a/docs/scripts/types.d.ts
+++ b/docs/scripts/types.d.ts
@@ -103,7 +103,7 @@ declare module 'react-docgen' {
     | InstanceOfPropTypeDescriptor;
 
   export interface PropDescriptor {
-    defaultValue?: unknown;
+    defaultValue?: { computed: boolean; value: string };
     description?: string;
     required?: boolean;
     /**

--- a/docs/src/modules/utils/generateMarkdown.ts
+++ b/docs/src/modules/utils/generateMarkdown.ts
@@ -322,7 +322,7 @@ function generateProps(reactAPI: ReactApi) {
     const renderedDefaultValue = prop.defaultValue?.value.replace(/\r*\n/g, '');
     const renderDefaultValue =
       renderedDefaultValue &&
-      // Ignore "large" default values which would break the table layout.
+      // Ignore "large" default values that would break the table layout.
       renderedDefaultValue.length <= 150;
 
     let defaultValueColumn = '';

--- a/docs/src/modules/utils/generateMarkdown.ts
+++ b/docs/src/modules/utils/generateMarkdown.ts
@@ -319,17 +319,18 @@ function generateProps(reactAPI: ReactApi) {
       return;
     }
 
-    let defaultValue = '';
+    const renderedDefaultValue = prop.defaultValue?.value.replace(/\r*\n/g, '');
+    const renderDefaultValue =
+      renderedDefaultValue &&
+      // Ignore "large" default values which would break the table layout.
+      renderedDefaultValue.length <= 150;
 
-    if (prop.defaultValue) {
-      defaultValue = `<span class="prop-default">${escapeCell(
-        (prop.defaultValue as any).value.replace(/\r*\n/g, ''),
+    let defaultValueColumn = '';
+    if (renderDefaultValue) {
+      defaultValueColumn = `<span class="prop-default">${escapeCell(
+        // narrowed `renderedDefaultValue` to non-nullable by `renderDefaultValue`
+        renderedDefaultValue!,
       )}</span>`;
-    }
-
-    // Give up
-    if (defaultValue.length > 180) {
-      defaultValue = '';
     }
 
     const chainedPropType = getChained(prop.type);
@@ -352,7 +353,7 @@ function generateProps(reactAPI: ReactApi) {
 
     text += `| ${propRaw} | <span class="prop-type">${generatePropType(
       prop.type,
-    )}</span> | ${defaultValue} | ${description} |\n`;
+    )}</span> | ${defaultValueColumn} | ${description} |\n`;
   });
 
   let refHint = 'The `ref` is forwarded to the root element.';


### PR DESCRIPTION
We currently strip default values from the API docs if their source **including** the markup we add exceeds 180 characters. I don't think this is intended. It seems like this is to prevent breaking the table layout (or generally only to keep readable default values) in which case we should only look at the source **without** added markup.

This doesn't affect the generated docs but the clarification is important for default values in JSDOC.