### PR TITLE
[DialogContentText] Use react-testing-library

### DIFF
--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { expect } from 'chai';
-import { createShallow, getClasses, describeConformance, createMount } from 'test/utils';
+import { createClientRender, getClasses, describeConformance, createMount } from 'test/utils';
 import DialogContentText from './DialogContentText';
 import Typography from '../Typography';
 
 describe('<DialogContentText />', () => {
   const mount = createMount();
-  let shallow;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<DialogContentText />);
   });
 
@@ -24,9 +22,10 @@ describe('<DialogContentText />', () => {
 
   describe('prop: children', () => {
     it('should render children', () => {
-      const children = <p />;
-      const wrapper = shallow(<DialogContentText>{children}</DialogContentText>);
-      expect(wrapper.children().equals(children)).to.equal(true);
+      const children = <span data-testid="test-children" />;
+      const { getByTestId } = render(<DialogContentText>{children}</DialogContentText>);
+
+      getByTestId('test-children');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Replaces enzyme for react-testing-library in the `<DialogContentText />`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
