### PR TITLE
[docs] Fix Argos-ci 404 link

### DIFF
--- a/docs/src/pages/guides/testing/testing.md
+++ b/docs/src/pages/guides/testing/testing.md
@@ -17,5 +17,5 @@ We don't recommend snapshot testing though.
 ## Internal
 
 Material-UI has **a wide range** of tests so we can
-iterate with confidence on the components, for instance, the visual regression tests provided by [Argos-CI](https://www.argos-ci.com/mui-org/material-ui) have proven to be really helpful.
+iterate with confidence on the components, for instance, the visual regression tests provided by [Argos-CI](https://www.argos-ci.com/mui-org/material-ui/builds) have proven to be really helpful.
 To learn more about the internal tests, you can have a look at the [README](https://github.com/mui-org/material-ui/blob/next/test/README.md).


### PR DESCRIPTION
The old one points to a 404 error page.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
