### PR TITLE
[test] Fix failing tests on Windows

### DIFF
--- a/packages/material-ui-utils/macros/MuiError.macro.test.js
+++ b/packages/material-ui-utils/macros/MuiError.macro.test.js
@@ -10,7 +10,9 @@ const fixturePath = path.resolve(__dirname, './__fixtures__');
 
 function readOutputFixtureSync(fixture, file) {
   // babel hardcodes the linefeed to \n
-  return fs.readFileSync(path.join(fixturePath, fixture, file), { encoding: 'utf8' }).replace(/\r?\n/g, '\n')
+  return fs
+    .readFileSync(path.join(fixturePath, fixture, file), { encoding: 'utf8' })
+    .replace(/\r?\n/g, '\n');
 }
 
 pluginTester({

--- a/packages/material-ui-utils/macros/MuiError.macro.test.js
+++ b/packages/material-ui-utils/macros/MuiError.macro.test.js
@@ -8,6 +8,11 @@ import { expect } from 'chai';
 const temporaryErrorCodesPath = path.join(os.tmpdir(), 'error-codes.json');
 const fixturePath = path.resolve(__dirname, './__fixtures__');
 
+function readOutputFixtureSync(fixture, file) {
+  // babel hardcodes the linefeed to \n
+  return fs.readFileSync(path.join(fixturePath, fixture, file), { encoding: 'utf8' }).replace(/\r?\n/g, '\n')
+}
+
 pluginTester({
   plugin,
   filename: __filename,
@@ -18,7 +23,7 @@ pluginTester({
         muiError: { errorCodesPath: path.join(fixturePath, 'literal', 'error-codes.json') },
       },
       fixture: path.join(fixturePath, 'literal', 'input.js'),
-      outputFixture: path.join(fixturePath, 'literal', 'output.js'),
+      output: readOutputFixtureSync('literal', 'output.js'),
     },
     {
       title: 'annotates missing error codes',
@@ -28,7 +33,7 @@ pluginTester({
         },
       },
       fixture: path.join(fixturePath, 'no-error-code-annotation', 'input.js'),
-      outputFixture: path.join(fixturePath, 'no-error-code-annotation', 'output.js'),
+      output: readOutputFixtureSync('no-error-code-annotation', 'output.js'),
     },
     {
       title: 'can throw on missing error codes',
@@ -53,7 +58,7 @@ pluginTester({
           missingError: 'write',
         },
       },
-      outputFixture: path.join(fixturePath, 'error-code-extraction', 'output.js'),
+      output: readOutputFixtureSync('error-code-extraction', 'output.js'),
       setup() {
         fs.copyFileSync(
           path.join(fixturePath, 'error-code-extraction', 'error-codes.before.json'),

--- a/packages/typescript-to-proptypes/test/index.test.ts
+++ b/packages/typescript-to-proptypes/test/index.test.ts
@@ -70,8 +70,8 @@ for (const testCase of testCases) {
     });
 
     if (fs.existsSync(outputPath)) {
-      expect(propTypes.replace(/\r?\n/, '\n')).to.include(
-        fs.readFileSync(outputPath, 'utf8').replace(/\r?\n/, '\n'),
+      expect(propTypes.replace(/\r?\n/g, '\n')).to.include(
+        fs.readFileSync(outputPath, 'utf8').replace(/\r?\n/g, '\n'),
       );
     } else {
       fs.writeFileSync(outputPath, propTypes);


### PR DESCRIPTION
Not sure if this is already fixed upstream but in case it's not @merceyz 

Tests failed for me as well with `core.autocrlf=false` on win10 and passed after this fix.

@mnajdova Could you check this out and see if it works? If not please include the output of `git config --get core.autocrlf` 