### PR TITLE
[docs] Include demos in source stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 # Undo the GitHub's default
 # https://github.com/github/linguist/blob/96ad1185828f44bb9b774328a584551ee57ed264/lib/linguist/vendor.yml#L177
 packages/**/*.d.ts -linguist-vendored
+/docs/** -linguist-documentation
+/examples/** -linguist-documentation


### PR DESCRIPTION
Considered the primary use case for the language state: "evaluate if the project matches the language I use in my project", I think that it could make sense to include the documentation in the language state. This assumes that for a UI project, the language of the demos is important in order to be able to copy and paste them. It wouldn't matter for a backend project.