### PR TITLE
[Breadcrumbs] More robust focus capture

### DIFF
--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -70,7 +70,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(props, ref) {
       // The clicked element received the focus but gets removed from the DOM.
       // Let's keep the focus in the component after expanding.
       // Moving it the the <ol> or <nav> does not cause any announcement in NVDA
-      // By moving it to some link/button at least gives an announcement
+      // By moving it to some link/button at least we have some announcement.
       const focusable = listRef.current.querySelector('a[href],button,[tabindex]');
       if (focusable) {
         focusable.focus();

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -69,7 +69,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(props, ref) {
 
       // The clicked element received the focus but gets removed from the DOM.
       // Let's keep the focus in the component after expanding.
-      // Moving it the the <ol> or <nav> does not cause any announcement in NVDA
+      // Moving it the the <ol> or <nav> does not cause any announcement in NVDA.
       // By moving it to some link/button at least we have some announcement.
       const focusable = listRef.current.querySelector('a[href],button,[tabindex]');
       if (focusable) {

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -62,16 +62,16 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(props, ref) {
 
   const [expanded, setExpanded] = React.useState(false);
 
+  const listRef = React.useRef(null);
   const renderItemsBeforeAndAfter = (allItems) => {
-    const handleClickExpand = (event) => {
+    const handleClickExpand = () => {
       setExpanded(true);
 
       // The clicked element received the focus but gets removed from the DOM.
       // Let's keep the focus in the component after expanding.
-      const focusable = event.currentTarget.parentNode.parentNode.querySelector(
-        'a[href],button,[tabindex]',
-      );
-
+      // Moving it the the <ol> or <nav> does not cause any announcement in NVDA
+      // By moving it to some link/button at least gives an announcement
+      const focusable = listRef.current.querySelector('a[href],button,[tabindex]');
       if (focusable) {
         focusable.focus();
       }
@@ -127,7 +127,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(props, ref) {
       className={clsx(classes.root, className)}
       {...other}
     >
-      <ol className={classes.ol}>
+      <ol className={classes.ol} ref={listRef}>
         {insertSeparators(
           expanded || (maxItems && allItems.length <= maxItems)
             ? allItems


### PR DESCRIPTION
Relying on the internal DOM structure can be brittle and subject to change (#22366). We can express the same intent with a ref on the targetted container.

While at it I did some testing with NVDA how this behavior affects user. My concern was that this could be disorienting since you only get the name of the newly focused link announced but not its context. However, neither focusing the `<ol>` or `<nav>` caused any announcement at all so I guess the current behavior is a decent approximation.

Generally it'd be interesting to look at accessible, expandable lists or how buttons controlling their parents should work.
