### PR TITLE
[Tooltip] Meet dismissable WCAG criterion

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -88,13 +88,13 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
    *
    * @param {object} event The event source of the callback.
    */
-  onClose?: (event: React.ChangeEvent<{}>) => void;
+  onClose?: (event: React.SyntheticEvent | Event) => void;
   /**
    * Callback fired when the component requests to be open.
    *
    * @param {object} event The event source of the callback.
    */
-  onOpen?: (event: React.ChangeEvent<{}>) => void;
+  onOpen?: (event: React.SyntheticEvent) => void;
   /**
    * If `true`, the tooltip is shown.
    */

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -8,6 +8,7 @@ import {
   act,
   createClientRender,
   fireEvent,
+  screen,
 } from 'test/utils';
 import { camelCase } from 'lodash/string';
 import Tooltip, { testReset } from './Tooltip';
@@ -233,6 +234,31 @@ describe('<Tooltip />', () => {
     // TODO: Unclear why not running triggers microtasks but runAll does not trigger microtasks
     // can be removed once Popper#update is sync
     clock.runAll();
+  });
+
+  it('is dismissable by pressing Escape', () => {
+    const transitionTimeout = 0;
+    render(
+      <Tooltip enterDelay={0} TransitionProps={{ timeout: transitionTimeout }} title="Movie quote">
+        <button autoFocus>Hello, Dave!</button>
+      </Tooltip>,
+    );
+
+    expect(screen.getByRole('tooltip')).not.toBeInaccessible();
+
+    act(() => {
+      fireEvent.keyDown(
+        // We don't care about the target. Any Escape should dismiss the tooltip
+        // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
+        document.activeElement,
+        { key: 'Escape' },
+      );
+    });
+    act(() => {
+      clock.tick(transitionTimeout);
+    });
+
+    expect(screen.queryByRole('tooltip')).to.equal(null);
   });
 
   describe('touch screen', () => {


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/17279

Meets "dismissable" in [WCAG 2.1 1.4.13](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus):

> A mechanism is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an input error or does not obscure or replace other content;

by listening to a global "Escape" keydown. This is similar to [SCR39](https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR39).

Follow-up:
To fully meet 1.4.13 we have to work on "hoverable" first which should also be explained in the docs.