### PR TITLE
[Tabs] Improve focus management on list with no active tabs

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -419,6 +419,7 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
       onChange,
       textColor,
       value: childValue,
+      ...(childIndex === 1 && value === false && !child.props.tabIndex ? { tabIndex: 0 } : {}),
     });
   });
 

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -1069,15 +1069,16 @@ describe('<Tabs />', () => {
 
     it('moves focus to the first tab when there are no active tabs', () => {
       const { getAllByRole } = render(
-        <Tabs
-          value={false}
-        >
+        <Tabs value={false}>
           <Tab />
           <Tab />
-        </Tabs>
+        </Tabs>,
       );
 
-      expect(getAllByRole('tab').map((tab) => tab.getAttribute('tabIndex'))).to.deep.equal(['0', '-1']);
+      expect(getAllByRole('tab').map((tab) => tab.getAttribute('tabIndex'))).to.deep.equal([
+        '0',
+        '-1',
+      ]);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -1067,7 +1067,7 @@ describe('<Tabs />', () => {
       });
     });
 
-    it('moves focus to the first tab when there are no active tabs', () => {
+    it('should allow to focus first tab when there are no active tabs', () => {
       const { getAllByRole } = render(
         <Tabs value={false}>
           <Tab />

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -1066,5 +1066,18 @@ describe('<Tabs />', () => {
         });
       });
     });
+
+    it('moves focus to the first tab when there are no active tabs', () => {
+      const { getAllByRole } = render(
+        <Tabs
+          value={false}
+        >
+          <Tab />
+          <Tab />
+        </Tabs>
+      );
+
+      expect(getAllByRole('tab').map((tab) => tab.getAttribute('tabIndex'))).to.deep.equal(['0', '-1']);
+    });
   });
 });


### PR DESCRIPTION
Closes #21854

**New behaviour:** Using the TAB key it is now possible to focus on the first tab of a Tab List with no active tabs. 

This improves accessibility through easier keyboard navigation.
