### PR TITLE
[Tabs] Don't fire onChange if current value

### DIFF
--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -118,7 +118,7 @@ const Tab = React.forwardRef(function Tab(props, ref) {
   } = props;
 
   const handleClick = (event) => {
-    if (onChange) {
+    if (!selected && onChange) {
       onChange(event, value);
     }
 

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -295,6 +295,23 @@ describe('<Tabs />', () => {
       expect(handleChange.args[0][1]).to.equal(1);
     });
 
+    it('should not call onChange when already selected', () => {
+      const handleChange = spy();
+      const { getAllByRole } = render(
+        <Tabs value={0} onChange={handleChange}>
+          <Tab />
+          <Tab />
+        </Tabs>
+      );
+
+      fireEvent.click(getAllByRole('tab')[1]);
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.equal(1);
+
+      fireEvent.click(getAllByRole('tab')[0]);
+      expect(handleChange.callCount).to.equal(1);
+    });
+
     it('when `selectionFollowsFocus` should call if an unselected tab gets focused', () => {
       const handleChange = spy((event, value) => value);
       const { getAllByRole } = render(

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -306,7 +306,6 @@ describe('<Tabs />', () => {
 
       fireEvent.click(getAllByRole('tab')[1]);
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.equal(1);
 
       fireEvent.click(getAllByRole('tab')[0]);
       expect(handleChange.callCount).to.equal(1);

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -301,7 +301,7 @@ describe('<Tabs />', () => {
         <Tabs value={0} onChange={handleChange}>
           <Tab />
           <Tab />
-        </Tabs>
+        </Tabs>,
       );
 
       fireEvent.click(getAllByRole('tab')[1]);

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -304,11 +304,8 @@ describe('<Tabs />', () => {
         </Tabs>,
       );
 
-      fireEvent.click(getAllByRole('tab')[1]);
-      expect(handleChange.callCount).to.equal(1);
-
       fireEvent.click(getAllByRole('tab')[0]);
-      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.callCount).to.equal(0);
     });
 
     it('when `selectionFollowsFocus` should call if an unselected tab gets focused', () => {


### PR DESCRIPTION
[x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Closes #22378
