### PR TITLE
[icons] Label them as vendored for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # Undo the GitHub's default
 # https://github.com/github/linguist/blob/96ad1185828f44bb9b774328a584551ee57ed264/lib/linguist/vendor.yml#L177
 packages/**/*.d.ts -linguist-vendored
+# These icons are imported from Google.
+# We kept in git so we can review the impact when changing the generation script.
+packages/material-ui-icons/src/*.js linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,5 @@
 # https://github.com/github/linguist/blob/96ad1185828f44bb9b774328a584551ee57ed264/lib/linguist/vendor.yml#L177
 packages/**/*.d.ts -linguist-vendored
 # These icons are imported from Google.
-# We kept in git so we can review the impact when changing the generation script.
+# Kept so that we can review the impact when changing the generation script.
 packages/material-ui-icons/src/*.js linguist-vendored


### PR DESCRIPTION
An alternative to https://github.com/mui-org/material-ui/pull/22188. After this, we should be in much better shape, the stats and breakdown seem to match, more or less reality:

```
$ github-linguist
75.27%  JavaScript
24.71%  TypeScript
0.02%   HTML
```

I will be done with this problem.