### PR TITLE
[slider] Edge against swallowing of mouse up event

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -591,6 +591,11 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       return;
     }
 
+    // Cancel move in case some other element consumed a mouseup event and it was not fired.
+    if (nativeEvent.buttons === 0) {
+      return;
+    }
+
     const { newValue, activeIndex } = getFingerNewValue({
       finger,
       move: true,

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -592,7 +592,9 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     }
 
     // Cancel move in case some other element consumed a mouseup event and it was not fired.
-    if (nativeEvent.buttons === 0) {
+    if (nativeEvent.type === 'mousemove' && nativeEvent.buttons === 0) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      handleTouchEnd(nativeEvent);
       return;
     }
 

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -98,6 +98,36 @@ describe('<Slider />', () => {
     expect(handleChangeCommitted.callCount).to.equal(1);
   });
 
+  it('should edge against a dropped mouseup event', () => {
+    const handleChange = spy();
+    const { container } = render(<Slider onChange={handleChange} value={0} />);
+    stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+      width: 100,
+      left: 0,
+    }));
+
+    fireEvent.mouseDown(container.firstChild, {
+      buttons: 1,
+      clientX: 1,
+    });
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleChange.args[0][1]).to.equal(1);
+
+    fireEvent.mouseMove(document.body, {
+      buttons: 1,
+      clientX: 10,
+    });
+    expect(handleChange.callCount).to.equal(2);
+    expect(handleChange.args[1][1]).to.equal(10);
+
+    fireEvent.mouseMove(document.body, {
+      buttons: 0,
+      clientX: 11,
+    });
+    // The mouse's button was released, stop the dragging session.
+    expect(handleChange.callCount).to.equal(2);
+  });
+
   describe('prop: orientation', () => {
     it('should render with the vertical classes', () => {
       const { container, getByRole } = render(<Slider orientation="vertical" value={0} />);


### PR DESCRIPTION
It can happen that another event listener consumes a mouseup event and prevents propagation to the document's mouseup listener. This guard ensured that any subsequent button-free movement captured by the document's mousemove listener results in the finalisation.

Closes #22399

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
