### PR TITLE
[test] Migrate more components to react-testing-library

### DIFF
--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
 import AccordionDetails from './AccordionDetails';
 
@@ -20,10 +21,12 @@ describe('<AccordionDetails />', () => {
   }));
 
   it('should render a children element', () => {
-    const children = <div data-testid="test-children" />;
+    const { queryByTestId } = render(
+      <AccordionDetails>
+        <div data-testid="test-children" />
+      </AccordionDetails>,
+    );
 
-    const { getByTestId } = render(<AccordionDetails>{children}</AccordionDetails>);
-
-    getByTestId('test-children');
+    expect(queryByTestId('test-children')).not.to.equal(null);
   });
 });

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import { expect } from 'chai';
-import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
 import AccordionDetails from './AccordionDetails';
 
 describe('<AccordionDetails />', () => {
   const mount = createMount();
-  let shallow;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<AccordionDetails>foo</AccordionDetails>);
   });
 
@@ -22,12 +20,10 @@ describe('<AccordionDetails />', () => {
   }));
 
   it('should render a children element', () => {
-    const wrapper = shallow(
-      <AccordionDetails>
-        <div>Hello</div>
-      </AccordionDetails>,
-    );
-    const container = wrapper.childAt(0);
-    expect(container.type()).to.equal('div');
+    const children = <div data-testid="test-children" />;
+
+    const { getByTestId } = render(<AccordionDetails>{children}</AccordionDetails>);
+
+    getByTestId('test-children');
   });
 });

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -21,13 +21,12 @@ describe('<FormGroup />', () => {
   }));
 
   it('should render a div with a div child', () => {
-    const children = <div data-testid="test-children" />;
+    const { queryByTestId } = render(
+      <FormGroup>
+        <div data-testid="test-children" />
+      </FormGroup>,
+    );
 
-    const { container, getByTestId } = render(<FormGroup>{children}</FormGroup>);
-
-    const root = container.querySelector(`.${classes.root}`);
-
-    getByTestId('test-children');
-    expect(root).to.not.equal(null);
+    expect(queryByTestId('test-children')).to.not.equal(null);
   });
 });

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
 import FormGroup from './FormGroup';
 
 describe('<FormGroup />', () => {
   const mount = createMount();
-  let shallow;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<FormGroup />);
   });
 
@@ -22,14 +21,13 @@ describe('<FormGroup />', () => {
   }));
 
   it('should render a div with a div child', () => {
-    const wrapper = shallow(
-      <FormGroup>
-        <div className="woofFormGroup" />
-      </FormGroup>,
-    );
+    const children = <div data-testid="test-children" />;
 
-    expect(wrapper.children('span').length).to.equal(0);
-    expect(wrapper.children('div').length).to.equal(1);
-    expect(wrapper.children('div').first().hasClass('woofFormGroup')).to.equal(true);
+    const { container, getByTestId } = render(<FormGroup>{children}</FormGroup>);
+
+    const root = container.querySelector(`.${classes.root}`);
+
+    getByTestId('test-children');
+    expect(root).to.not.equal(null);
   });
 });

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
 import Icon from './Icon';
 
 describe('<Icon />', () => {
   const mount = createMount();
-  let shallow;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<Icon />);
   });
 
@@ -22,36 +21,47 @@ describe('<Icon />', () => {
   }));
 
   it('renders children by default', () => {
-    const wrapper = shallow(<Icon>account_circle</Icon>);
-    expect(wrapper.contains('account_circle')).to.equal(true);
+    const { getByText } = render(<Icon>account_circle</Icon>);
+
+    getByText('account_circle');
   });
 
   describe('optional classes', () => {
     it('should render with the secondary color', () => {
-      const wrapper = shallow(<Icon color="secondary">account_circle</Icon>);
-      expect(wrapper.hasClass(classes.colorSecondary)).to.equal(true);
+      const { container } = render(<Icon color="secondary">account_circle</Icon>);
+      const node = container.querySelector(`.${classes.colorSecondary}`);
+
+      expect(node).to.not.equal(null);
     });
 
     it('should render with the action color', () => {
-      const wrapper = shallow(<Icon color="action">account_circle</Icon>);
-      expect(wrapper.hasClass(classes.colorAction)).to.equal(true);
+      const { container } = render(<Icon color="action">account_circle</Icon>);
+      const node = container.querySelector(`.${classes.colorAction}`);
+
+      expect(node).to.not.equal(null);
     });
 
     it('should render with the error color', () => {
-      const wrapper = shallow(<Icon color="error">account_circle</Icon>);
-      expect(wrapper.hasClass(classes.colorError)).to.equal(true);
+      const { container } = render(<Icon color="error">account_circle</Icon>);
+      const node = container.querySelector(`.${classes.colorError}`);
+
+      expect(node).to.not.equal(null);
     });
 
     it('should render with the primary class', () => {
-      const wrapper = shallow(<Icon color="primary">account_circle</Icon>);
-      expect(wrapper.hasClass(classes.colorPrimary)).to.equal(true);
+      const { container } = render(<Icon color="primary">account_circle</Icon>);
+      const node = container.querySelector(`.${classes.colorPrimary}`);
+
+      expect(node).to.not.equal(null);
     });
   });
 
   describe('prop: fontSize', () => {
     it('should be able to change the fontSize', () => {
-      const wrapper = shallow(<Icon fontSize="inherit">account_circle</Icon>);
-      expect(wrapper.hasClass(classes.fontSizeInherit)).to.equal(true);
+      const { container } = render(<Icon fontSize="inherit">account_circle</Icon>);
+      const node = container.querySelector(`.${classes.fontSizeInherit}`);
+
+      expect(node).to.not.equal(null);
     });
   });
 });

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -21,47 +21,62 @@ describe('<Icon />', () => {
   }));
 
   it('renders children by default', () => {
-    const { getByText } = render(<Icon>account_circle</Icon>);
+    const { getByTestId } = render(<Icon data-testid="root">account_circle</Icon>);
 
-    getByText('account_circle');
+    expect(getByTestId('root')).to.have.text('account_circle');
   });
 
   describe('optional classes', () => {
     it('should render with the secondary color', () => {
-      const { container } = render(<Icon color="secondary">account_circle</Icon>);
-      const node = container.querySelector(`.${classes.colorSecondary}`);
+      const { getByTestId } = render(
+        <Icon data-testid="root" color="secondary">
+          account_circle
+        </Icon>,
+      );
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.colorSecondary);
     });
 
     it('should render with the action color', () => {
-      const { container } = render(<Icon color="action">account_circle</Icon>);
-      const node = container.querySelector(`.${classes.colorAction}`);
+      const { getByTestId } = render(
+        <Icon data-testid="root" color="action">
+          account_circle
+        </Icon>,
+      );
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.colorAction);
     });
 
     it('should render with the error color', () => {
-      const { container } = render(<Icon color="error">account_circle</Icon>);
-      const node = container.querySelector(`.${classes.colorError}`);
+      const { getByTestId } = render(
+        <Icon data-testid="root" color="error">
+          account_circle
+        </Icon>,
+      );
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.colorError);
     });
 
     it('should render with the primary class', () => {
-      const { container } = render(<Icon color="primary">account_circle</Icon>);
-      const node = container.querySelector(`.${classes.colorPrimary}`);
+      const { getByTestId } = render(
+        <Icon data-testid="root" color="primary">
+          account_circle
+        </Icon>,
+      );
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.colorPrimary);
     });
   });
 
   describe('prop: fontSize', () => {
     it('should be able to change the fontSize', () => {
-      const { container } = render(<Icon fontSize="inherit">account_circle</Icon>);
-      const node = container.querySelector(`.${classes.fontSizeInherit}`);
+      const { getByTestId } = render(
+        <Icon data-testid="root" fontSize="inherit">
+          account_circle
+        </Icon>,
+      );
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.fontSizeInherit);
     });
   });
 });

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,17 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses, createMount, describeConformance } from 'test/utils';
+import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
 import * as PropTypes from 'prop-types';
 import Paper from './Paper';
 import { createMuiTheme, ThemeProvider } from '../styles';
 
 describe('<Paper />', () => {
   const mount = createMount();
-  let shallow;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<Paper />);
   });
 
@@ -25,42 +24,56 @@ describe('<Paper />', () => {
 
   describe('prop: square', () => {
     it('can disable the rounded class', () => {
-      const wrapper = mount(<Paper square>Hello World</Paper>);
-      expect(wrapper.find(`.${classes.root}`).some(`.${classes.rounded}`)).to.equal(false);
+      const { container } = render(<Paper square>Hello World</Paper>);
+      const node = container.querySelector(`.${classes.rounded}`);
+
+      expect(node).to.equal(null);
     });
 
     it('adds a rounded class to the root when omitted', () => {
-      const wrapper = mount(<Paper>Hello World</Paper>);
-      expect(wrapper.find(`.${classes.root}`).every(`.${classes.rounded}`)).to.equal(true);
+      const { container } = render(<Paper>Hello World</Paper>);
+      const node = container.querySelector(`.${classes.rounded}`);
+
+      expect(node).to.not.equal(null);
     });
   });
 
   describe('prop: variant', () => {
     it('adds a outlined class', () => {
-      const wrapper = mount(<Paper variant="outlined">Hello World</Paper>);
-      expect(wrapper.find(`.${classes.root}`).some(`.${classes.outlined}`)).to.equal(true);
+      const { container } = render(<Paper variant="outlined">Hello World</Paper>);
+      const node = container.querySelector(`.${classes.outlined}`);
+
+      expect(node).to.not.equal(null);
     });
   });
 
   it('should set the elevation elevation class', () => {
-    const wrapper = shallow(<Paper elevation={16}>Hello World</Paper>);
-    expect(wrapper.hasClass(classes.elevation16)).to.equal(true);
-    wrapper.setProps({ elevation: 24 });
-    expect(wrapper.hasClass(classes.elevation24)).to.equal(true);
-    wrapper.setProps({ elevation: 2 });
-    expect(wrapper.hasClass(classes.elevation2)).to.equal(true);
+    const { container, setProps } = render(<Paper elevation={16}>Hello World</Paper>);
+
+    let node = container.querySelector(`.${classes.elevation16}`);
+    expect(node).to.not.equal(null);
+
+    setProps({ elevation: 24 });
+    node = container.querySelector(`.${classes.elevation24}`);
+    expect(node).to.not.equal(null);
+
+    setProps({ elevation: 2 });
+    node = container.querySelector(`.${classes.elevation2}`);
+    expect(node).to.not.equal(null);
   });
 
   it('allows custom elevations via theme.shadows', () => {
     const theme = createMuiTheme();
     theme.shadows.push('20px 20px');
-    const wrapper = mount(
+    const { container } = render(
       <ThemeProvider theme={theme}>
-        <Paper data-testid="paper" classes={{ elevation25: 'custom-elevation' }} elevation={25} />
+        <Paper classes={{ elevation25: 'custom-elevation' }} elevation={25} />
       </ThemeProvider>,
     );
 
-    expect(wrapper.find('div[data-testid="paper"]').hasClass('custom-elevation')).to.equal(true);
+    const node = container.querySelector('.custom-elevation');
+
+    expect(node).to.not.equal(null);
   });
 
   describe('warnings', () => {

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -24,56 +24,63 @@ describe('<Paper />', () => {
 
   describe('prop: square', () => {
     it('can disable the rounded class', () => {
-      const { container } = render(<Paper square>Hello World</Paper>);
-      const node = container.querySelector(`.${classes.rounded}`);
+      const { getByTestId } = render(
+        <Paper data-testid="root" square>
+          Hello World
+        </Paper>,
+      );
 
-      expect(node).to.equal(null);
+      expect(getByTestId('root')).not.to.have.class(classes.rounded);
     });
 
     it('adds a rounded class to the root when omitted', () => {
-      const { container } = render(<Paper>Hello World</Paper>);
-      const node = container.querySelector(`.${classes.rounded}`);
+      const { getByTestId } = render(<Paper data-testid="root">Hello World</Paper>);
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.rounded);
     });
   });
 
   describe('prop: variant', () => {
     it('adds a outlined class', () => {
-      const { container } = render(<Paper variant="outlined">Hello World</Paper>);
-      const node = container.querySelector(`.${classes.outlined}`);
+      const { getByTestId } = render(
+        <Paper data-testid="root" variant="outlined">
+          Hello World
+        </Paper>,
+      );
 
-      expect(node).to.not.equal(null);
+      expect(getByTestId('root')).to.have.class(classes.outlined);
     });
   });
 
   it('should set the elevation elevation class', () => {
-    const { container, setProps } = render(<Paper elevation={16}>Hello World</Paper>);
+    const { getByTestId, setProps } = render(
+      <Paper data-testid="root" elevation={16}>
+        Hello World
+      </Paper>,
+    );
+    const root = getByTestId('root');
 
-    let node = container.querySelector(`.${classes.elevation16}`);
-    expect(node).to.not.equal(null);
+    expect(root).to.have.class(classes.elevation16);
 
     setProps({ elevation: 24 });
-    node = container.querySelector(`.${classes.elevation24}`);
-    expect(node).to.not.equal(null);
+
+    expect(root).to.have.class(classes.elevation24);
 
     setProps({ elevation: 2 });
-    node = container.querySelector(`.${classes.elevation2}`);
-    expect(node).to.not.equal(null);
+
+    expect(root).to.have.class(classes.elevation2);
   });
 
   it('allows custom elevations via theme.shadows', () => {
     const theme = createMuiTheme();
     theme.shadows.push('20px 20px');
-    const { container } = render(
+    const { getByTestId } = render(
       <ThemeProvider theme={theme}>
-        <Paper classes={{ elevation25: 'custom-elevation' }} elevation={25} />
+        <Paper data-testid="root" classes={{ elevation25: 'custom-elevation' }} elevation={25} />
       </ThemeProvider>,
     );
 
-    const node = container.querySelector('.custom-elevation');
-
-    expect(node).to.not.equal(null);
+    expect(getByTestId('root')).to.have.class('custom-elevation');
   });
 
   describe('warnings', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Replaces enzyme for react-testing-library in the `<AccordionDetails />` , `<FormGroup />`, `<Icon />`, `<Paper />`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
