### PR TITLE
[TextField] Remove excessive catching of hiddenLabel prop

### DIFF
--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -249,10 +249,6 @@ TextField.propTypes = {
    */
   helperText: PropTypes.node,
   /**
-   * @ignore
-   */
-  hiddenLabel: PropTypes.bool,
-  /**
    * The id of the `input` element.
    * Use this prop to make `label` and `helperText` accessible for screen readers.
    */

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -68,7 +68,6 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     FormHelperTextProps,
     fullWidth = false,
     helperText,
-    hiddenLabel,
     id,
     InputLabelProps,
     inputProps,
@@ -158,7 +157,6 @@ const TextField = React.forwardRef(function TextField(props, ref) {
       disabled={disabled}
       error={error}
       fullWidth={fullWidth}
-      hiddenLabel={hiddenLabel}
       ref={ref}
       required={required}
       color={color}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

The prop is only forwarded to the `FormControl` component, so no need to catch it. 


This should also be done on the `next` branch. Haven't found a section in the docs which explains to which branches (that is master or next) the new commits should land. Perhaps non-critical and new features should land only on `next`.