### PR TITLE
[core] Fix useEventCallback type

### DIFF
--- a/packages/material-ui/src/utils/useEventCallback.d.ts
+++ b/packages/material-ui/src/utils/useEventCallback.d.ts
@@ -1,5 +1,1 @@
-export interface Cancelable {
-  clear(): void;
-}
-
-export default function useEventCallback(...args: any[]): void;
+export default function useEventCallback<T extends (...args: any[]) => any>(func: T): T;


### PR DESCRIPTION
- `useEventCallback` takes one function argument and returns a function of the same type.
- `Cancelable` is not used here. 

[useEventCallback.js](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/utils/useEventCallback.js)