### PR TITLE
[docs] Improve next.js example

### DIFF
--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -7,20 +7,23 @@ import NextLink from 'next/link';
 import MuiLink from '@material-ui/core/Link';
 
 const NextComposed = React.forwardRef(function NextComposed(props, ref) {
-  const { as, replace, href, ...other } = props;
+  // eslint-disable-next-line react/prop-types
+  const { as, href, replace, scroll, passHref, shallow, prefetch, ...other } = props;
 
   return (
-    <NextLink href={href} as={as} replace={replace}>
+    <NextLink
+      href={href}
+      prefetch={prefetch}
+      as={as}
+      replace={replace}
+      scroll={scroll}
+      shallow={shallow}
+      passHref={passHref}
+    >
       <a ref={ref} {...other} />
     </NextLink>
   );
 });
-
-NextComposed.propTypes = {
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  href: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  prefetch: PropTypes.bool,
-};
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/#with-link

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -7,10 +7,10 @@ import NextLink from 'next/link';
 import MuiLink from '@material-ui/core/Link';
 
 const NextComposed = React.forwardRef(function NextComposed(props, ref) {
-  const { as, href, ...other } = props;
+  const { as, replace, href, ...other } = props;
 
   return (
-    <NextLink href={href} as={as}>
+    <NextLink href={href} as={as} replace={replace}>
       <a ref={ref} {...other} />
     </NextLink>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Forwarding replace prop to NextLink to override the default history push.

Relevant snippet from https://nextjs.org/docs/api-reference/next/link
`replace - Replace the current history state instead of adding a new url into the stack. Defaults to false`