### PR TITLE
[core] Remove onRendered from Modal and Portal

### DIFF
--- a/docs/pages/api-docs/modal.md
+++ b/docs/pages/api-docs/modal.md
@@ -53,7 +53,6 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | <span class="prop-name">onBackdropClick</span> | <span class="prop-type">func</span> |  | Callback fired when the backdrop is clicked. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |  | Callback fired when the component requests to be closed. The `reason` parameter can optionally be used to control the response to `onClose`.<br><br>**Signature:**<br>`function(event: object, reason: string) => void`<br>*event:* The event source of the callback.<br>*reason:* Can be: `"escapeKeyDown"`, `"backdropClick"`. |
 | <span class="prop-name">onEscapeKeyDown</span> | <span class="prop-type">func</span> |  | Callback fired when the escape key is pressed, `disableEscapeKeyDown` is false and the modal is in focus. |
-| <span class="prop-name">onRendered</span> | <span class="prop-type">func</span> |  | Callback fired once the children has been mounted into the `container`. It signals that the `open={true}` prop took effect.<br>This prop will be deprecated and removed in v5, the ref can be used instead. |
 | <span class="prop-name required">open<abbr title="required">*</abbr></span> | <span class="prop-type">bool</span> |  | If `true`, the modal is open. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/portal.md
+++ b/docs/pages/api-docs/portal.md
@@ -30,7 +30,6 @@ that exists outside the DOM hierarchy of the parent component.
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The children to render into the `container`. |
 | <span class="prop-name">container</span> | <span class="prop-type">HTML element<br>&#124;&nbsp;func</span> |  | A HTML element or function that returns one. The `container` will have the portal children appended to it.<br>By default, it uses the body of the top-level document object, so it's simply `document.body` most of the time. |
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | The `children` will be inside the DOM hierarchy of the parent component. |
-| <span class="prop-name">onRendered</span> | <span class="prop-type">func</span> |  | Callback fired once the children has been mounted into the `container`.<br>This prop will be deprecated and removed in v5, the ref can be used instead. |
 
 The component cannot hold a ref.
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -363,6 +363,11 @@ const theme = createMuitheme({
   >
   ```
 
+### Modal
+
+- Remove `onRendered` prop.
+  Depending on your use case either use a [callback ref]() on the the child element or an effect hook in the child component.
+
 ### Pagination
 
 - Rename `round` to `circular` for consistency. The possible values should be adjectives, not nouns:
@@ -403,6 +408,11 @@ const theme = createMuitheme({
   +  }}
   />
   ```
+
+### Portal
+
+- Remove `onRendered` prop.
+  Depending on your use case either use a [callback ref]() on the the child element or an effect hook in the child component.
 
 ### Rating
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -366,7 +366,7 @@ const theme = createMuitheme({
 ### Modal
 
 - Remove `onRendered` prop.
-  Depending on your use case either use a [callback ref]() on the the child element or an effect hook in the child component.
+  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the the child element or an effect hook in the child component.
 
 ### Pagination
 
@@ -412,7 +412,7 @@ const theme = createMuitheme({
 ### Portal
 
 - Remove `onRendered` prop.
-  Depending on your use case either use a [callback ref]() on the the child element or an effect hook in the child component.
+  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the the child element or an effect hook in the child component.
 
 ### Rating
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -366,7 +366,7 @@ const theme = createMuitheme({
 ### Modal
 
 - Remove `onRendered` prop.
-  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the the child element or an effect hook in the child component.
+  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the child element or an effect hook in the child component.
 
 ### Pagination
 
@@ -412,7 +412,7 @@ const theme = createMuitheme({
 ### Portal
 
 - Remove `onRendered` prop.
-  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the the child element or an effect hook in the child component.
+  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the child element or an effect hook in the child component.
 
 ### Rating
 

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -96,13 +96,6 @@ export interface ModalProps
    */
   onEscapeKeyDown?: React.ReactEventHandler<{}>;
   /**
-   * Callback fired once the children has been mounted into the `container`.
-   * It signals that the `open={true}` prop took effect.
-   *
-   * This prop will be deprecated and removed in v5, the ref can be used instead.
-   */
-  onRendered?: PortalProps['onRendered'];
-  /**
    * If `true`, the modal is open.
    */
   open: boolean;

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -77,7 +77,6 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     onBackdropClick,
     onClose,
     onEscapeKeyDown,
-    onRendered,
     open,
     ...other
   } = props;
@@ -121,10 +120,6 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
 
     if (!node) {
       return;
-    }
-
-    if (onRendered) {
-      onRendered();
     }
 
     if (open && isTopModal()) {
@@ -354,13 +349,6 @@ Modal.propTypes = {
    * `disableEscapeKeyDown` is false and the modal is in focus.
    */
   onEscapeKeyDown: PropTypes.func,
-  /**
-   * Callback fired once the children has been mounted into the `container`.
-   * It signals that the `open={true}` prop took effect.
-   *
-   * This prop will be deprecated and removed in v5, the ref can be used instead.
-   */
-  onRendered: PropTypes.func,
   /**
    * If `true`, the modal is open.
    */

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -531,20 +531,6 @@ describe('<Modal />', () => {
     });
   });
 
-  describe('prop: onRendered', () => {
-    it('should fire', () => {
-      const handleRendered = spy();
-
-      render(
-        <Modal open onRendered={handleRendered}>
-          <div />
-        </Modal>,
-      );
-
-      expect(handleRendered).to.have.property('callCount', 1);
-    });
-  });
-
   describe('two modal at the same time', () => {
     /**
      * @type {ReturnType<typeof useFakeTimers>}

--- a/packages/material-ui/src/Portal/Portal.d.ts
+++ b/packages/material-ui/src/Portal/Portal.d.ts
@@ -17,12 +17,6 @@ export interface PortalProps {
    * The `children` will be inside the DOM hierarchy of the parent component.
    */
   disablePortal?: boolean;
-  /**
-   * Callback fired once the children has been mounted into the `container`.
-   *
-   * This prop will be deprecated and removed in v5, the ref can be used instead.
-   */
-  onRendered?: () => void;
 }
 
 /**

--- a/packages/material-ui/src/Portal/Portal.js
+++ b/packages/material-ui/src/Portal/Portal.js
@@ -15,7 +15,7 @@ function getContainer(container) {
  * that exists outside the DOM hierarchy of the parent component.
  */
 const Portal = React.forwardRef(function Portal(props, ref) {
-  const { children, container, disablePortal = false, onRendered } = props;
+  const { children, container, disablePortal = false } = props;
   const [mountNode, setMountNode] = React.useState(null);
   const handleRef = useForkRef(React.isValidElement(children) ? children.ref : null, ref);
 
@@ -35,12 +35,6 @@ const Portal = React.forwardRef(function Portal(props, ref) {
 
     return undefined;
   }, [ref, mountNode, disablePortal]);
-
-  useEnhancedEffect(() => {
-    if (onRendered && (mountNode || disablePortal)) {
-      onRendered();
-    }
-  }, [onRendered, mountNode, disablePortal]);
 
   if (disablePortal) {
     if (React.isValidElement(children)) {
@@ -78,12 +72,6 @@ Portal.propTypes = {
    * The `children` will be inside the DOM hierarchy of the parent component.
    */
   disablePortal: PropTypes.bool,
-  /**
-   * Callback fired once the children has been mounted into the `container`.
-   *
-   * This prop will be deprecated and removed in v5, the ref can be used instead.
-   */
-  onRendered: PropTypes.func,
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -27,9 +27,8 @@ describe('<Portal />', () => {
         );
       }).toErrorDev(
         // Known issue due to using SSR APIs in a browser environment.
-        // We use 3x useLayoutEffect in the component.
+        // We use 2x useLayoutEffect in the component.
         [
-          'Warning: useLayoutEffect does nothing on the server',
           'Warning: useLayoutEffect does nothing on the server',
           'Warning: useLayoutEffect does nothing on the server',
         ],
@@ -176,23 +175,6 @@ describe('<Portal />', () => {
       disablePortal: false,
     });
     expect(document.querySelector('#test3').parentElement.nodeName).to.equal('BODY');
-  });
-
-  it('should call onRendered', () => {
-    const ref = React.createRef();
-    const handleRendered = spy();
-    render(
-      <Portal
-        ref={ref}
-        onRendered={() => {
-          handleRendered();
-          expect(ref.current !== null).to.equal(true);
-        }}
-      >
-        <div />
-      </Portal>,
-    );
-    expect(handleRendered.callCount).to.equal(1);
   });
 
   it('should call ref after child effect', () => {


### PR DESCRIPTION
### Breaking changes

- [core] Remove `onRendered` from Modal and Portal
  Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the child element or an effect hook in the child component.

Planned removal (see #20012) and https://github.com/mui-org/material-ui/pull/16262#discussion_r294750748 for context.

We haven't had any use case internally and for app code callback refs and effect hooks exist.