### PR TITLE
[docs] Bump markdown-to-jsx

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -76,7 +76,7 @@
     "jss-rtl": "^0.3.0",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",
-    "markdown-to-jsx": "^6.10.2",
+    "markdown-to-jsx": "^6.11.4",
     "marked": "^1.0.0",
     "material-table": "^1.50.0",
     "material-ui-popup-state": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10648,7 +10648,7 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
-markdown-to-jsx@^6.10.2:
+markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
   integrity sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==


### PR DESCRIPTION
Fixes [GHSA-ccrp-c664-8p4j](https://github.com/advisories/GHSA-ccrp-c664-8p4j) for which dependabot could not create an automatic update. The update should've been trivial. I went ahead and reported the issue to GitHub.