### PR TITLE
[theme] Allow spacing and border radius with CSS unit

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -2,94 +2,107 @@ import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useThemeVariants } from '@material-ui/styles';
-import { fade, withStyles } from '@material-ui/core/styles';
+import {
+  fade,
+  withStyles,
+  unstable_toUnitless as toUnitless,
+  unstable_getUnit as getUnit,
+} from '@material-ui/core/styles';
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    display: 'block',
-    // Create a "on paper" color with sufficient contrast retaining the color
-    backgroundColor: fade(theme.palette.text.primary, theme.palette.type === 'light' ? 0.11 : 0.13),
-    height: '1.2em',
-  },
-  /* Styles applied to the root element if `variant="text"`. */
-  text: {
-    marginTop: 0,
-    marginBottom: 0,
-    height: 'auto',
-    transformOrigin: '0 55%',
-    transform: 'scale(1, 0.60)',
-    borderRadius: `${theme.shape.borderRadius}px/${
-      Math.round((theme.shape.borderRadius / 0.6) * 10) / 10
-    }px`,
-    '&:empty:before': {
-      content: '"\\00a0"',
+export const styles = (theme) => {
+  const radiusUnit = getUnit(theme.shape.borderRadius);
+  const radiusValue = toUnitless(theme.shape.borderRadius);
+
+  return {
+    /* Styles applied to the root element. */
+    root: {
+      display: 'block',
+      // Create a "on paper" color with sufficient contrast retaining the color
+      backgroundColor: fade(
+        theme.palette.text.primary,
+        theme.palette.type === 'light' ? 0.11 : 0.13,
+      ),
+      height: '1.2em',
     },
-  },
-  /* Styles applied to the root element if `variant="rectangular"`. */
-  rectangular: {},
-  /* Styles applied to the root element if `variant="circular"`. */
-  circular: {
-    borderRadius: '50%',
-  },
-  /* Styles applied to the root element if `animation="pulse"`. */
-  pulse: {
-    animation: '$pulse 1.5s ease-in-out 0.5s infinite',
-  },
-  '@keyframes pulse': {
-    '0%': {
-      opacity: 1,
+    /* Styles applied to the root element if `variant="text"`. */
+    text: {
+      marginTop: 0,
+      marginBottom: 0,
+      height: 'auto',
+      transformOrigin: '0 55%',
+      transform: 'scale(1, 0.60)',
+      borderRadius: `${radiusValue}${radiusUnit}/${
+        Math.round((radiusValue / 0.6) * 10) / 10
+      }${radiusUnit}`,
+      '&:empty:before': {
+        content: '"\\00a0"',
+      },
     },
-    '50%': {
-      opacity: 0.4,
+    /* Styles applied to the root element if `variant="rectangular"`. */
+    rectangular: {},
+    /* Styles applied to the root element if `variant="circular"`. */
+    circular: {
+      borderRadius: '50%',
     },
-    '100%': {
-      opacity: 1,
+    /* Styles applied to the root element if `animation="pulse"`. */
+    pulse: {
+      animation: '$pulse 1.5s ease-in-out 0.5s infinite',
     },
-  },
-  /* Styles applied to the root element if `animation="wave"`. */
-  wave: {
-    position: 'relative',
-    overflow: 'hidden',
-    '&::after': {
-      animation: '$wave 1.6s linear 0.5s infinite',
-      background: `linear-gradient(90deg, transparent, ${theme.palette.action.hover}, transparent)`,
-      content: '""',
-      position: 'absolute',
-      transform: 'translateX(-100%)', // Avoid flash during server-side hydration
-      bottom: 0,
-      left: 0,
-      right: 0,
-      top: 0,
+    '@keyframes pulse': {
+      '0%': {
+        opacity: 1,
+      },
+      '50%': {
+        opacity: 0.4,
+      },
+      '100%': {
+        opacity: 1,
+      },
     },
-  },
-  '@keyframes wave': {
-    '0%': {
-      transform: 'translateX(-100%)',
+    /* Styles applied to the root element if `animation="wave"`. */
+    wave: {
+      position: 'relative',
+      overflow: 'hidden',
+      '&::after': {
+        animation: '$wave 1.6s linear 0.5s infinite',
+        background: `linear-gradient(90deg, transparent, ${theme.palette.action.hover}, transparent)`,
+        content: '""',
+        position: 'absolute',
+        transform: 'translateX(-100%)', // Avoid flash during server-side hydration
+        bottom: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+      },
     },
-    '60%': {
-      // +0.5s of delay between each loop
-      transform: 'translateX(100%)',
+    '@keyframes wave': {
+      '0%': {
+        transform: 'translateX(-100%)',
+      },
+      '60%': {
+        // +0.5s of delay between each loop
+        transform: 'translateX(100%)',
+      },
+      '100%': {
+        transform: 'translateX(100%)',
+      },
     },
-    '100%': {
-      transform: 'translateX(100%)',
+    /* Styles applied when the component is passed children. */
+    withChildren: {
+      '& > *': {
+        visibility: 'hidden',
+      },
     },
-  },
-  /* Styles applied when the component is passed children. */
-  withChildren: {
-    '& > *': {
-      visibility: 'hidden',
+    /* Styles applied when the component is passed children and no width. */
+    fitContent: {
+      maxWidth: 'fit-content',
     },
-  },
-  /* Styles applied when the component is passed children and no width. */
-  fitContent: {
-    maxWidth: 'fit-content',
-  },
-  /* Styles applied when the component is passed children and no height. */
-  heightAuto: {
-    height: 'auto',
-  },
-});
+    /* Styles applied when the component is passed children and no height. */
+    heightAuto: {
+      height: 'auto',
+    },
+  };
+};
 
 const Skeleton = React.forwardRef(function Skeleton(props, ref) {
   const {

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -10,7 +10,7 @@ import {
 } from '@material-ui/core/styles';
 
 export const styles = (theme) => {
-  const radiusUnit = getUnit(theme.shape.borderRadius);
+  const radiusUnit = getUnit(theme.shape.borderRadius) || 'px';
   const radiusValue = toUnitless(theme.shape.borderRadius);
 
   return {

--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -15,6 +15,9 @@ export interface Spacing {
   ): string;
 }
 
-export type SpacingOptions = number | ((factor: number) => string | number) | SpacingArgument[];
+export type SpacingOptions =
+  | number
+  | ((factor: number) => string | number)
+  | Array<string | number>;
 
 export default function createSpacing(spacing: SpacingOptions): Spacing;

--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -15,6 +15,6 @@ export interface Spacing {
   ): string;
 }
 
-export type SpacingOptions = number | ((factor: number) => string | number) | number[];
+export type SpacingOptions = number | ((factor: number) => string | number) | SpacingArgument[];
 
 export default function createSpacing(spacing: SpacingOptions): Spacing;

--- a/packages/material-ui/src/styles/createSpacing.test.js
+++ b/packages/material-ui/src/styles/createSpacing.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import createSpacing from './createSpacing';
 
 describe('createSpacing', () => {
-  it('should work as expected', () => {
+  it('should be configurable', () => {
     let spacing;
     spacing = createSpacing();
     expect(spacing(1)).to.equal(8);
@@ -10,6 +10,8 @@ describe('createSpacing', () => {
     expect(spacing(1)).to.equal(10);
     spacing = createSpacing([0, 8, 16]);
     expect(spacing(2)).to.equal(16);
+    spacing = createSpacing(['0rem', '8rem', '16rem']);
+    expect(spacing(2)).to.equal('16rem');
     spacing = createSpacing((factor) => factor ** 2);
     expect(spacing(2)).to.equal(4);
     spacing = createSpacing((factor) => `${0.25 * factor}rem`);

--- a/packages/material-ui/src/styles/index.js
+++ b/packages/material-ui/src/styles/index.js
@@ -1,8 +1,9 @@
+export { default as adaptV4Theme } from './adaptV4Theme';
 export * from './colorManipulator';
 export { default as createMuiTheme } from './createMuiTheme';
-export { default as adaptV4Theme } from './adaptV4Theme';
 export { default as unstable_createMuiStrictModeTheme } from './createMuiStrictModeTheme';
 export { default as createStyles } from './createStyles';
+export { getUnit as unstable_getUnit, toUnitless as unstable_toUnitless } from './cssUtils';
 export { default as makeStyles } from './makeStyles';
 export { default as responsiveFontSizes } from './responsiveFontSizes';
 export { default as styled } from './styled';

--- a/packages/material-ui/src/styles/shape.d.ts
+++ b/packages/material-ui/src/styles/shape.d.ts
@@ -1,5 +1,5 @@
 export interface Shape {
-  borderRadius: number;
+  borderRadius: number | string;
 }
 
 export type ShapeOptions = Partial<Shape>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Minor tweaks to the createMuiTheme TypeScript declarations to allow non-"px" (string) values to border-radius and when using an array of spacing values.

Thanks!