### PR TITLE
[core] Implement consistent disabled state

### DIFF
--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -48,7 +48,7 @@ export const styles = (theme) => ({
     textAlign: 'left',
     WebkitTapHighlightColor: 'transparent',
     '&$disabled': {
-      opacity: 0.5,
+      opacity: theme.palette.action.disabledOpacity,
       pointerEvents: 'none',
     },
     '&$focusVisible $iconActive': {

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -27,7 +27,7 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: fade(theme.palette.action.disabled, 0.12),
+      opacity: theme.palette.action.disabledOpacity,
     },
     '&:hover': {
       textDecoration: 'none',

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -34,7 +34,7 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: theme.palette.action.disabled,
+      opacity: theme.palette.action.disabledOpacity,
     },
   },
   /* Styles applied to the root element if `color="secondary"`. */
@@ -50,7 +50,7 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: theme.palette.action.disabled,
+      opacity: theme.palette.action.disabledOpacity,
     },
   },
 });

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -39,7 +39,7 @@ export const styles = (theme) => {
       verticalAlign: 'middle',
       boxSizing: 'border-box',
       '&$disabled': {
-        opacity: 0.5,
+        opacity: theme.palette.action.disabledOpacity,
         pointerEvents: 'none',
       },
       '& $avatar': {

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -29,7 +29,7 @@ export const styles = (theme) => ({
     },
     '&$disabled': {
       backgroundColor: 'transparent',
-      color: theme.palette.action.disabled,
+      opacity: theme.palette.action.disabledOpacity,
     },
   },
   /* Styles applied to the root element if `edge="start"`. */

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -32,7 +32,7 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: theme.palette.action.disabled,
+      opacity: theme.palette.action.disabledOpacity,
     },
   },
   /* Styles applied to the root element if `color="secondary"`. */
@@ -48,7 +48,7 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: theme.palette.action.disabled,
+      opacity: theme.palette.action.disabledOpacity,
     },
   },
 });

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -162,7 +162,7 @@ export const styles = (theme) => ({
     '&$disabled': {
       pointerEvents: 'none',
       cursor: 'default',
-      color: theme.palette.grey[400],
+      opacity: theme.palette.action.disabledOpacity,
     },
     '&$vertical': {
       width: 2,
@@ -209,7 +209,7 @@ export const styles = (theme) => ({
     height: 2,
     borderRadius: 1,
     backgroundColor: 'currentColor',
-    opacity: 0.38,
+    opacity: theme.palette.action.disabledOpacity,
     '$vertical &': {
       height: '100%',
       width: 2,

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -48,13 +48,10 @@ export const styles = (theme) => ({
       transform: 'translateX(20px)',
     },
     '&$disabled': {
-      color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
+      opacity: theme.palette.action.disabledOpacity,
     },
     '&$checked + $track': {
       opacity: 0.5,
-    },
-    '&$disabled + $track': {
-      opacity: theme.palette.type === 'light' ? 0.12 : 0.1,
     },
   },
   /* Styles applied to the internal SwitchBase component's root element if `color="primary"`. */
@@ -68,15 +65,8 @@ export const styles = (theme) => ({
         },
       },
     },
-    '&$disabled': {
-      color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
-    },
     '&$checked + $track': {
       backgroundColor: theme.palette.primary.main,
-    },
-    '&$disabled + $track': {
-      backgroundColor:
-        theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
     },
   },
   /* Styles applied to the internal SwitchBase component's root element if `color="secondary"`. */
@@ -90,15 +80,8 @@ export const styles = (theme) => ({
         },
       },
     },
-    '&$disabled': {
-      color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
-    },
     '&$checked + $track': {
       backgroundColor: theme.palette.secondary.main,
-    },
-    '&$disabled + $track': {
-      backgroundColor:
-        theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
     },
   },
   /* Styles applied to the root element if `size="small"`. */

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -42,7 +42,7 @@ export const styles = (theme) => ({
       opacity: 1,
     },
     '&$disabled': {
-      opacity: 0.5,
+      opacity: theme.palette.action.disabledOpacity,
     },
   },
   /* Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="primary"`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Closes #19343

## Screenshots of changes made

Note that by using `opacity` rather than `color` or `backgroundColor`, we can still see the components in color.

![Screenshot_2020-09-08 Rating React component - Material-UI](https://user-images.githubusercontent.com/10603631/92521861-3c21a500-f21e-11ea-8b35-a62f79b77b5f.png)
![Screenshot_2020-09-08 Checkbox React component - Material-UI](https://user-images.githubusercontent.com/10603631/92521864-3cba3b80-f21e-11ea-82d3-9a0a9fd566dc.png)
![Screenshot_2020-09-08 Radio buttons React component - Material-UI](https://user-images.githubusercontent.com/10603631/92521866-3d52d200-f21e-11ea-84c7-e91b988dd72a.png)
![Screenshot_2020-09-08 Toggle Button React component - Material-UI(1)](https://user-images.githubusercontent.com/10603631/92521869-3deb6880-f21e-11ea-9c65-65d5391fd6fa.png)
![Screenshot_2020-09-08 Switch React component - Material-UI](https://user-images.githubusercontent.com/10603631/92521871-3deb6880-f21e-11ea-80c6-a41712c85983.png)
![Screenshot_2020-09-08 Button React component - Material-UI](https://user-images.githubusercontent.com/10603631/92521883-42b01c80-f21e-11ea-8848-9b79768d8557.png)



## Unresolved

### General

In general, I'm not quite sure when to use `theme.palette.action.disabled` and `.disabledBackground` opposed to `.disabledOpacity`. I changed the hardcoded disabled opacity values and adapted the different inputs to keep their color when disabled (as seen [in the screenshot](https://lh3.googleusercontent.com/Q0IBZ9UnqG16so-3Y9lhU_fJBm33fuoovX3N2FdhX9pR2_fAGGIDP2z2944TmLMn8rwpBQn8kTd-z6UDysPQKrsIWo13rNSDpO2tAw=w1064-v0) from the [material design states website](https://material.io/design/interaction/states.html#disabled)).

Should we always use `disabledOpacity`? Is there a reason not to use it?

Components where `theme.palette.action.disabledBackground` is used for disabled state:
- Accordion
- Button
- Fab

Components where `theme.palette.action.disabled` is used for disabled state:
- Button
- ButtonGroup
- Fab
- Icon
- NativeSelect
- OutlinedInput
- SvgIcon
- PaginationItem

Are the uses of these correct or should we use `theme.palette.action.disabledOpacity` instead?

Below I've checked out the Accordion component in more detail, including screenshots of the different implementations (background vs opacity).

### Accordion

The Accordion component is not supported by the official google material design specs.
How should the disabled state look like?

At the moment it's setting the `backgroundColor` to `disabledBackground`, which looks like this: 
![grafik](https://user-images.githubusercontent.com/10603631/92521020-d08b0800-f21c-11ea-9a60-d13d815e373a.png)

We could also follow the other changes made in this PR and set the `opacity` instead, which would look like this (depending on the background element color):
![grafik](https://user-images.githubusercontent.com/10603631/92521699-f5cc4600-f21d-11ea-8279-0dba61ba2f7c.png)

Or we combine the `backgroundColor` and the `opacity`:
![grafik](https://user-images.githubusercontent.com/10603631/92521766-14cad800-f21e-11ea-8b15-0cae67ece8f9.png)


### Switch

The `$disabled` class is applied to the `switchBase`, which is the knob. To display the disabled switch according to the material design spec, we need to set the `opacity` on the `root` class. As there is no way in CSS to do something like `$root:has( > $switchBase$disabled)`, we need a **breaking change** here.

Spec:
![grafik](https://user-images.githubusercontent.com/10603631/92524176-ee0ea080-f221-11ea-87c4-e0f47b880f96.png)


Our version:
![grafik](https://user-images.githubusercontent.com/10603631/92524219-01ba0700-f222-11ea-9c55-64eb8bdeaf2d.png)
