### PR TITLE
[Autocomplete] Fix interfaces in the Google Maps demo

### DIFF
--- a/docs/src/pages/components/autocomplete/GoogleMaps.tsx
+++ b/docs/src/pages/components/autocomplete/GoogleMaps.tsx
@@ -29,18 +29,18 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+interface MainTextMatchedSubstrings {
+  offset: number;
+  length: number;
+}
+interface StructuredFormatting {
+  main_text: string;
+  secondary_text: string;
+  main_text_matched_substrings: MainTextMatchedSubstrings[];
+}
 interface PlaceType {
   description: string;
-  structured_formatting: {
-    main_text: string;
-    secondary_text: string;
-    main_text_matched_substrings: [
-      {
-        offset: number;
-        length: number;
-      },
-    ];
-  };
+  structured_formatting: StructuredFormatting;
 }
 
 export default function GoogleMaps() {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Hi all

Copying the demo into our project was causing issues with the newest typescript version.

We were receiving: 

```bash
Failed to compile.
./src/components/placesAutoComplete.tsx
Syntax error: Cannot read property 'map' of undefined (0:undefined)
```

By separating the interfaces, we were able to resolve this issue and successfully build our project.

Keep up the great work Material-UI team! You guys are awesome!