### PR TITLE
[slider] Improve tracking of mouse events

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -703,8 +703,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       passive: doesSupportTouchActionNone(),
     });
 
-    const doc = ownerDocument(slider);
-
     return () => {
       slider.removeEventListener('touchstart', handleTouchStart, {
         passive: doesSupportTouchActionNone(),

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -222,6 +222,41 @@ describe('<Slider />', () => {
       expect(handleChange.args[1][1]).to.deep.equal([22, 30]);
       expect(handleChange.args[2][1]).to.equal(handleChange.args[1][1]);
     });
+
+    it('should not react to right clicks', () => {
+      const handleMouseDown = spy();
+      const { getByRole } = render(
+        <Slider onMouseDown={handleMouseDown} defaultValue={30} step={10} marks />,
+      );
+      const thumb = getByRole('slider');
+      const rightClick = { buttons: 2 };
+      fireEvent.mouseDown(thumb, rightClick);
+      expect(handleMouseDown.callCount).to.equal(0);
+    });
+
+    it('should not remain focused if mouse was released outside of the window', () => {
+      const handleChange = spy();
+      const { container, getByRole } = render(
+        <Slider onChange={handleChange} defaultValue={30} step={10} marks />,
+      );
+
+      stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+        width: 100,
+        height: 10,
+        bottom: 10,
+        left: 0,
+      }));
+
+      const thumb = getByRole('slider');
+      const noButtons = { button: 0, buttons: 0 };
+      const leftMouseButton = { button: 0, buttons: 1, clientX: 20 };
+      fireEvent.mouseDown(thumb, leftMouseButton);
+      expect(handleChange.callCount).to.equal(1);
+      fireEvent.mouseMove(thumb, leftMouseButton);
+      expect(handleChange.callCount).to.equal(2);
+      fireEvent.mouseMove(thumb, noButtons);
+      expect(handleChange.callCount).to.equal(2);
+    });
   });
 
   it('should not break when initial value is out of range', () => {


### PR DESCRIPTION
Currently the slider responds to all mouse events, even right clicks, and also doesn't make sure that the mouse is still being held down when moving around.

This results in the following bugs:
 * You can right click on a slider handle, left click outside the window, then come back and the mouse is stuck dragging the slider even though you never held the mouse button.
 * You can click and drag on a slider out of the window, release the mouse outside the window, then bring the mouse back and it will be stuck dragging the slider even though you release the mouse button

This type of leaking events can, in combination with hyper specific race conditions with local navigation in iframes while dom events are bubbling, cause the component to _permanently_ leak the mousemove handler resulting in the following exception: `Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null`

This PR changes the behavior of the event tracking such that right clicks are ignored, and on each mouse move (mouse only) it makes sure you're still holding the left mouse button.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
