### PR TITLE
[Button] Remove dead code

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -36,9 +36,6 @@ export const styles = (theme) => ({
       '@media (hover: none)': {
         backgroundColor: 'transparent',
       },
-      '&$disabled': {
-        backgroundColor: 'transparent',
-      },
     },
   },
   /* Pseudo-class applied to the root element if `disabled={true}`. */

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -24,9 +24,6 @@ export const styles = (theme) => ({
       '@media (hover: none)': {
         backgroundColor: 'transparent',
       },
-      '&$disabled': {
-        backgroundColor: 'transparent',
-      },
     },
     '&$disabled': {
       color: theme.palette.action.disabled,
@@ -116,9 +113,6 @@ export const styles = (theme) => ({
       '@media (hover: none)': {
         boxShadow: theme.shadows[2],
         backgroundColor: theme.palette.grey[300],
-      },
-      '&$disabled': {
-        backgroundColor: theme.palette.action.disabledBackground,
       },
     },
     '&$focusVisible': {

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -31,9 +31,6 @@ export const styles = (theme) => ({
       '@media (hover: none)': {
         backgroundColor: theme.palette.grey[300],
       },
-      '&$disabled': {
-        backgroundColor: theme.palette.action.disabledBackground,
-      },
       textDecoration: 'none',
     },
     '&$focusVisible': {


### PR DESCRIPTION
I think that the underlying issue was solved with:

https://github.com/mui-org/material-ui/blob/ad558cb69c227976be1b6be60d291daf9504a22f/packages/material-ui/src/ButtonBase/ButtonBase.js#L38-L39

It's one less aspect to worry about when making overrides.

<img width="861" alt="Capture d’écran 2020-09-12 à 00 31 52" src="https://user-images.githubusercontent.com/3165635/92978201-64640a80-f48f-11ea-9c32-d197dc84016f.png">
