### PR TITLE
[core] Remove usage of deprecated .keyCode

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -123,12 +123,8 @@ export default function AppSearch() {
 
   React.useEffect(() => {
     const handleKeyDown = (nativeEvent) => {
-      // Use nativeEvent.keyCode to support IE 11
       if (
-        [
-          191, // '/'
-          83, // 's'
-        ].indexOf(nativeEvent.keyCode) !== -1 &&
+        ['/', 's'].indexOf(nativeEvent.key) !== -1 &&
         document.activeElement.nodeName === 'BODY' &&
         document.activeElement !== inputRef.current
       ) {

--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.js
@@ -151,8 +151,7 @@ function Unstable_TrapFocus(props) {
     };
 
     const loopFocus = (nativeEvent) => {
-      // 9 = Tab
-      if (disableEnforceFocus || !isEnabled() || nativeEvent.keyCode !== 9) {
+      if (disableEnforceFocus || !isEnabled() || nativeEvent.key !== 'Tab') {
         return;
       }
 

--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.test.js
@@ -106,17 +106,17 @@ describe('<TrapFocus />', () => {
     );
 
     fireEvent.keyDown(screen.getByTestId('modal'), {
-      keyCode: 13, // Enter
+      key: 'Enter',
     });
     fireEvent.keyDown(screen.getByTestId('modal'), {
-      keyCode: 9, // Tab
+      key: 'Tab',
     });
 
     expect(document.querySelector('[data-test="sentinelStart"]')).toHaveFocus();
 
     initialFocus.focus();
     fireEvent.keyDown(screen.getByTestId('modal'), {
-      keyCode: 9, // Tab
+      key: 'Tab',
       shiftKey: true,
     });
 


### PR DESCRIPTION
Apply https://github.com/mui-org/material-ui/pull/22376#discussion_r478378143. I have tested it in IE 11.

For reference: https://github.com/facebook/react/blob/90d212d326d8bb8f5ee414801db37e688d585712/packages/react-dom/src/events/SyntheticEvent.js#L281.