### PR TITLE
[docs] Option to disable ads

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -700,8 +700,8 @@ const useStyles = makeStyles(
   { name: 'Demo' },
 );
 
-function Demo(props) {
-  const { demo, demoOptions, githubLocation } = props;
+export default function Demo(props) {
+  const { demo, demoOptions, disableAd, githubLocation } = props;
   const classes = useStyles();
   const t = useSelector((state) => state.options.t);
   const codeVariant = useSelector((state) => state.options.codeVariant);
@@ -821,7 +821,7 @@ function Demo(props) {
           />
         </div>
       </Collapse>
-      {showAd ? <AdCarbonInline /> : null}
+      {showAd && !disableAd && !demoOptions.disableAd ? <AdCarbonInline /> : null}
     </div>
   );
 }
@@ -829,7 +829,6 @@ function Demo(props) {
 Demo.propTypes = {
   demo: PropTypes.object.isRequired,
   demoOptions: PropTypes.object.isRequired,
+  disableAd: PropTypes.bool.isRequired,
   githubLocation: PropTypes.string.isRequired,
 };
-
-export default Demo;

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -178,6 +178,7 @@ function MarkdownDocs(props) {
                     rawTS: demo.rawTS,
                     tsx: demo.moduleTS ? requireDemo(demo.moduleTS).default : null,
                   }}
+                  disableAd={disableAd}
                   demoOptions={renderedMarkdownOrDemo}
                   githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
                 />


### PR DESCRIPTION
Ads are meant to sustain the MIT licensed code. I don't think that it makes sense to keep them for code released under a paid commercial license. This change allows https://github.com/mui-org/material-ui-x to disable ads, where relevant.

Usage example:

```diff
diff --git a/docs/pages/components/alert.js b/docs/pages/components/alert.js
index caeeb16f23..54f9f2bec9 100644
--- a/docs/pages/components/alert.js
+++ b/docs/pages/components/alert.js
@@ -11,7 +11,7 @@ const requireRaw = require.context(
 );

 export default function Page({ demos, docs }) {
-  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+  return <MarkdownDocs demos={demos} docs={docs} disableAd requireDemo={requireDemo} />;
 }

 Page.getInitialProps = () => {
diff --git a/docs/src/pages/components/alert/alert.md b/docs/src/pages/components/alert/alert.md
index f77f0250f8..5209e349ae 100644
--- a/docs/src/pages/components/alert/alert.md
+++ b/docs/src/pages/components/alert/alert.md
@@ -18,7 +18,7 @@ waiAria: https://www.w3.org/TR/wai-aria-practices/#alert

 The alert offers four severity levels that set a distinctive icon and color.

-{{"demo": "pages/components/alert/SimpleAlerts.js"}}
+{{"demo": "pages/components/alert/SimpleAlerts.js", "disableAd": true}}

 ## Description

```

Hopefully, one day, we will be able to kill all the ads.