### PR TITLE
[Tabs] Only scroll the visible tabs

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -239,27 +239,27 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     scroll(scrollValue);
   };
 
-  const getScrollSize = (container) => {
-    const containerSize = container[clientSize];
+  const getScrollSize = () => {
+    const containerSize = tabsRef.current[clientSize];
     let totalSize = 0;
-    const children = Array.from(container.children);
+    const children = Array.from(tabListRef.current.children);
 
-    for (let i = 0; i < children.length; i++) {
-      const button = children[i];
-      if (totalSize + button[clientSize] > containerSize) {
+    for (let i = 0; i < children.length; i += 1) {
+      const tab = children[i];
+      if (totalSize + tab[clientSize] > containerSize) {
         break;
       }
-      totalSize += button[clientSize];
+      totalSize += tab[clientSize];
     }
     return totalSize;
   };
 
-  var handleStartScrollClick = function handleStartScrollClick() {
-    moveTabsScroll(-1 * getScrollSize(tabsRef.current.firstChild));
+  const handleStartScrollClick = () => {
+    moveTabsScroll(-1 * getScrollSize());
   };
 
-  var handleEndScrollClick = function handleEndScrollClick() {
-    moveTabsScroll(getScrollSize(tabsRef.current.firstChild));
+  const handleEndScrollClick = () => {
+    moveTabsScroll(getScrollSize());
   };
 
   // TODO Remove <ScrollbarSize /> as browser support for hidding the scrollbar

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -239,12 +239,27 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     scroll(scrollValue);
   };
 
-  const handleStartScrollClick = () => {
-    moveTabsScroll(-tabsRef.current[clientSize]);
+  const getScrollSize = container => {
+    const containerSize = container[clientSize];
+    let totalSize = 0;
+    const children = Array.from(container.children);
+
+    for(let i = 0; i < children.length; i++) {
+      const button = children[i];
+      if (totalSize + button[clientSize] > containerSize) {
+        break;
+      }
+      totalSize += button[clientSize];
+    }
+    return totalSize;
   };
 
-  const handleEndScrollClick = () => {
-    moveTabsScroll(tabsRef.current[clientSize]);
+  var handleStartScrollClick = function handleStartScrollClick() {
+    moveTabsScroll(-1 * getScrollSize(tabsRef.current.firstChild));
+  };
+
+  var handleEndScrollClick = function handleEndScrollClick() {
+    moveTabsScroll(getScrollSize(tabsRef.current.firstChild));
   };
 
   // TODO Remove <ScrollbarSize /> as browser support for hidding the scrollbar

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -239,12 +239,12 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     scroll(scrollValue);
   };
 
-  const getScrollSize = container => {
+  const getScrollSize = (container) => {
     const containerSize = container[clientSize];
     let totalSize = 0;
     const children = Array.from(container.children);
 
-    for(let i = 0; i < children.length; i++) {
+    for (let i = 0; i < children.length; i++) {
       const button = children[i];
       if (totalSize + button[clientSize] > containerSize) {
         break;

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -573,8 +573,8 @@ describe('<Tabs />', () => {
       clock.restore();
     });
 
-    it('should call moveTabsScroll', () => {
-      const { container, setProps, getByRole } = render(
+    it('should scroll visible items', () => {
+      const { container, setProps, getByRole, getAllByRole } = render(
         <Tabs value={0} variant="scrollable" scrollButtons="on" style={{ width: 200 }}>
           <Tab />
           <Tab />
@@ -582,7 +582,11 @@ describe('<Tabs />', () => {
         </Tabs>,
       );
       const tablistContainer = getByRole('tablist').parentElement;
+      const tabs = getAllByRole('tab');
       Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+      Object.defineProperty(tabs[0], 'clientWidth', { value: 60 });
+      Object.defineProperty(tabs[1], 'clientWidth', { value: 50 });
+      Object.defineProperty(tabs[2], 'clientWidth', { value: 60 });
       Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
       tablistContainer.scrollLeft = 20;
       setProps();
@@ -597,9 +601,7 @@ describe('<Tabs />', () => {
       tablistContainer.scrollLeft = 0;
       fireEvent.click(findScrollButton(container, 'right'));
       clock.tick(1000);
-      expect(tablistContainer.scrollLeft).not.to.be.below(
-        tablistContainer.scrollWidth - tablistContainer.clientWidth,
-      );
+      expect(tablistContainer.scrollLeft).equal(60 + 50);
     });
   });
 


### PR DESCRIPTION
Change scrolling behaviours for tabs to scroll by the width of visible elements as per @mnajdova and @oliviertassinari instructions.

Closes #22592

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
