### PR TITLE
[Rating] Make DOM order of radios follow value order

### DIFF
--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -371,6 +371,22 @@ const Rating = React.forwardRef(function Rating(props, ref) {
       )}
       {...other}
     >
+      {!disabled && valueRounded == null && (
+        <React.Fragment>
+          <input
+            value=""
+            id={`${name}-empty`}
+            type="radio"
+            name={name}
+            defaultChecked
+            className={classes.visuallyHidden}
+            readOnly={readOnly}
+          />
+          <label className={classes.pristine} htmlFor={`${name}-empty`}>
+            <span className={classes.visuallyHidden}>{emptyLabelText}</span>
+          </label>
+        </React.Fragment>
+      )}
       {Array.from(new Array(max)).map((_, index) => {
         const itemValue = index + 1;
 
@@ -427,22 +443,6 @@ const Rating = React.forwardRef(function Rating(props, ref) {
           checked: itemValue === valueRounded,
         });
       })}
-      {!disabled && valueRounded == null && (
-        <React.Fragment>
-          <input
-            value=""
-            id={`${name}-empty`}
-            type="radio"
-            name={name}
-            defaultChecked
-            className={classes.visuallyHidden}
-            readOnly={readOnly}
-          />
-          <label className={classes.pristine} htmlFor={`${name}-empty`}>
-            <span className={classes.visuallyHidden}>{emptyLabelText}</span>
-          </label>
-        </React.Fragment>
-      )}
     </span>
   );
 });

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -385,10 +385,8 @@ const Rating = React.forwardRef(function Rating(props, ref) {
                       items.length - 1 === indexDecimal
                         ? {}
                         : {
-                            width:
-                              itemDecimalValue === value
-                                ? `${(indexDecimal + 1) * precision * 100}%`
-                                : '0%',
+                            width: `${(indexDecimal + 1) * precision * 100}%`,
+                            opacity: itemDecimalValue <= value ? undefined : '0',
                             overflow: 'hidden',
                             zIndex: 1,
                             position: 'absolute',

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -387,6 +387,7 @@ const Rating = React.forwardRef(function Rating(props, ref) {
           </label>
         </React.Fragment>
       )}
+
       {Array.from(new Array(max)).map((_, index) => {
         const itemValue = index + 1;
 

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -41,12 +41,12 @@ describe('<Rating />', () => {
     // The position of the currently focused value is announced in e.g. NVDA.
     // This could lead to confusing announcements e.g. "Radio group no value 6/6".
     // This implies an order of `1,2,3,4,5,no value` when an incrementing order is expected.
-    expect(radios[0]).to.have.property('value', '1');
-    expect(radios[1]).to.have.property('value', '2');
-    expect(radios[2]).to.have.property('value', '3');
-    expect(radios[3]).to.have.property('value', '4');
-    expect(radios[4]).to.have.property('value', '5');
-    expect(radios[5]).to.have.property('value', '');
+    expect(radios[0]).to.have.property('value', '');
+    expect(radios[1]).to.have.property('value', '1');
+    expect(radios[2]).to.have.property('value', '2');
+    expect(radios[3]).to.have.property('value', '3');
+    expect(radios[4]).to.have.property('value', '4');
+    expect(radios[5]).to.have.property('value', '5');
   });
 
   it('should round the value to the provided precision', () => {

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { stub, spy } from 'sinon';
+import { spy } from 'sinon';
 import {
   act,
   getClasses,
@@ -54,21 +54,18 @@ describe('<Rating />', () => {
   });
 
   it('should handle mouse hover correctly', () => {
-    const { container } = render(<Rating {...defaultProps} />);
-    stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
-      left: 0,
-      right: 100,
-    }));
-    stub(container.firstChild.firstChild, 'getBoundingClientRect').callsFake(() => ({
-      width: 20,
-    }));
-    fireEvent.mouseMove(container.firstChild, {
-      clientX: 19,
-    });
+    const { container } = render(<Rating value={2} />);
+
+    fireEvent.mouseMove(
+      document.querySelector(`label[for="${screen.getByRole('radio', { name: '1 Star' }).id}"]`),
+    );
+
     expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(1);
-    fireEvent.mouseMove(container.firstChild, {
-      clientX: 21,
-    });
+
+    fireEvent.mouseMove(
+      document.querySelector(`label[for="${screen.getByRole('radio', { name: '2 Stars' }).id}"]`),
+    );
+
     expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(2);
   });
 

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -8,6 +8,7 @@ import {
   describeConformance,
   createClientRender,
   fireEvent,
+  screen,
 } from 'test/utils';
 import Rating from './Rating';
 
@@ -32,10 +33,20 @@ describe('<Rating />', () => {
     skip: ['componentProp'],
   }));
 
-  it('should render', () => {
-    const { container } = render(<Rating {...defaultProps} />);
+  it('renders radio buttons each step from 0 (inclusive) to max (inclusive)', () => {
+    render(<Rating />);
 
-    expect(container.firstChild).to.have.class(classes.root);
+    const radios = screen.getAllByRole('radio');
+    // The order and their values is important for assistive technology.
+    // The position of the currently focused value is announced in e.g. NVDA.
+    // This could lead to confusing announcements e.g. "Radio group no value 6/6".
+    // This implies an order of `1,2,3,4,5,no value` when an incrementing order is expected.
+    expect(radios[0]).to.have.property('value', '1');
+    expect(radios[1]).to.have.property('value', '2');
+    expect(radios[2]).to.have.property('value', '3');
+    expect(radios[3]).to.have.property('value', '4');
+    expect(radios[4]).to.have.property('value', '5');
+    expect(radios[5]).to.have.property('value', '');
   });
 
   it('should round the value to the provided precision', () => {

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -33,20 +33,15 @@ describe('<Rating />', () => {
     skip: ['componentProp'],
   }));
 
-  it('renders radio buttons each step from 0 (inclusive) to max (inclusive)', () => {
+  it('renders radio buttons for no rating and rating 1 to max (5 by default)', () => {
     render(<Rating />);
 
-    const radios = screen.getAllByRole('radio');
+    const radioValues = screen.getAllByRole('radio').map((radio) => radio.value);
     // The order and their values is important for assistive technology.
     // The position of the currently focused value is announced in e.g. NVDA.
     // This could lead to confusing announcements e.g. "Radio group no value 6/6".
     // This implies an order of `1,2,3,4,5,no value` when an incrementing order is expected.
-    expect(radios[0]).to.have.property('value', '');
-    expect(radios[1]).to.have.property('value', '1');
-    expect(radios[2]).to.have.property('value', '2');
-    expect(radios[3]).to.have.property('value', '3');
-    expect(radios[4]).to.have.property('value', '4');
-    expect(radios[5]).to.have.property('value', '5');
+    expect(radioValues).to.deep.equal(['', '1', '2', '3', '4', '5']);
   });
 
   it('should round the value to the provided precision', () => {


### PR DESCRIPTION
Right now the radio buttons are order `1,2,3,4,5` and `no value`. This works for keyboard navigation because it wraps around (at least for me on Ubuntu). However, screen readers announce the position of the radio button within the group so you get this slightly confusing "radio button Empty 6/6". 

If you look at our Select examples then you see that we have the empty value at the start not the end.