### PR TITLE
[Rating] Simpler customization of active "no value" styles

### DIFF
--- a/docs/pages/api-docs/rating.md
+++ b/docs/pages/api-docs/rating.md
@@ -60,7 +60,7 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">disabled</span> | <span class="prop-name">.Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">focusVisible</span> | <span class="prop-name">.Mui-focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
 | <span class="prop-name">visuallyHidden</span> | <span class="prop-name">.MuiRating-visuallyHidden</span> | Visually hide an element.
-| <span class="prop-name">pristine</span> | <span class="prop-name">.MuiRating-pristine</span> | Styles applied to the pristine label.
+| <span class="prop-name">labelEmptyValueActive</span> | <span class="prop-name">.MuiRating-labelEmptyValueActive</span> | Styles applied to the label of the empty value when no value is active.
 | <span class="prop-name">label</span> | <span class="prop-name">.MuiRating-label</span> | Styles applied to the label elements.
 | <span class="prop-name">icon</span> | <span class="prop-name">.MuiRating-icon</span> | Styles applied to the icon wrapping elements.
 | <span class="prop-name">iconEmpty</span> | <span class="prop-name">.MuiRating-iconEmpty</span> | Styles applied to the icon wrapping elements when empty.

--- a/docs/pages/api-docs/rating.md
+++ b/docs/pages/api-docs/rating.md
@@ -60,8 +60,8 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">disabled</span> | <span class="prop-name">.Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">focusVisible</span> | <span class="prop-name">.Mui-focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
 | <span class="prop-name">visuallyHidden</span> | <span class="prop-name">.MuiRating-visuallyHidden</span> | Visually hide an element.
-| <span class="prop-name">labelEmptyValueActive</span> | <span class="prop-name">.MuiRating-labelEmptyValueActive</span> | Styles applied to the label of the empty value when no value is active.
 | <span class="prop-name">label</span> | <span class="prop-name">.MuiRating-label</span> | Styles applied to the label elements.
+| <span class="prop-name">labelEmptyValueActive</span> | <span class="prop-name">.MuiRating-labelEmptyValueActive</span> | Styles applied to the label of the "no value" input when it is active.
 | <span class="prop-name">icon</span> | <span class="prop-name">.MuiRating-icon</span> | Styles applied to the icon wrapping elements.
 | <span class="prop-name">iconEmpty</span> | <span class="prop-name">.MuiRating-iconEmpty</span> | Styles applied to the icon wrapping elements when empty.
 | <span class="prop-name">iconFilled</span> | <span class="prop-name">.MuiRating-iconFilled</span> | Styles applied to the icon wrapping elements when filled.

--- a/docs/src/pages/components/rating/SimpleRating.js
+++ b/docs/src/pages/components/rating/SimpleRating.js
@@ -27,8 +27,8 @@ export default function SimpleRating() {
         <Rating name="disabled" value={value} disabled />
       </Box>
       <Box component="fieldset" mb={3} borderColor="transparent">
-        <Typography component="legend">Pristine</Typography>
-        <Rating name="pristine" value={null} />
+        <Typography component="legend">no rating given</Typography>
+        <Rating name="no-value" value={null} />
       </Box>
     </div>
   );

--- a/docs/src/pages/components/rating/SimpleRating.js
+++ b/docs/src/pages/components/rating/SimpleRating.js
@@ -27,7 +27,7 @@ export default function SimpleRating() {
         <Rating name="disabled" value={value} disabled />
       </Box>
       <Box component="fieldset" mb={3} borderColor="transparent">
-        <Typography component="legend">no rating given</Typography>
+        <Typography component="legend">No rating given</Typography>
         <Rating name="no-value" value={null} />
       </Box>
     </div>

--- a/docs/src/pages/components/rating/SimpleRating.tsx
+++ b/docs/src/pages/components/rating/SimpleRating.tsx
@@ -27,8 +27,8 @@ export default function SimpleRating() {
         <Rating name="disabled" value={value} disabled />
       </Box>
       <Box component="fieldset" mb={3} borderColor="transparent">
-        <Typography component="legend">Pristine</Typography>
-        <Rating name="pristine" value={null} />
+        <Typography component="legend">no rating given</Typography>
+        <Rating name="no-value" value={null} />
       </Box>
     </div>
   );

--- a/docs/src/pages/components/rating/SimpleRating.tsx
+++ b/docs/src/pages/components/rating/SimpleRating.tsx
@@ -27,7 +27,7 @@ export default function SimpleRating() {
         <Rating name="disabled" value={value} disabled />
       </Box>
       <Box component="fieldset" mb={3} borderColor="transparent">
-        <Typography component="legend">no rating given</Typography>
+        <Typography component="legend">No rating given</Typography>
         <Rating name="no-value" value={null} />
       </Box>
     </div>

--- a/packages/material-ui-lab/src/Rating/Rating.d.ts
+++ b/packages/material-ui-lab/src/Rating/Rating.d.ts
@@ -25,8 +25,8 @@ export interface RatingProps
     focusVisible?: string;
     /** Visually hide an element. */
     visuallyHidden?: string;
-    /** Styles applied to the pristine label. */
-    pristine?: string;
+    /** Styles applied to the label of the empty value when no value is active. */
+    labelEmptyValueActive?: string;
     /** Styles applied to the label elements. */
     label?: string;
     /** Styles applied to the icon wrapping elements. */

--- a/packages/material-ui-lab/src/Rating/Rating.d.ts
+++ b/packages/material-ui-lab/src/Rating/Rating.d.ts
@@ -25,10 +25,10 @@ export interface RatingProps
     focusVisible?: string;
     /** Visually hide an element. */
     visuallyHidden?: string;
-    /** Styles applied to the label of the empty value when no value is active. */
-    labelEmptyValueActive?: string;
     /** Styles applied to the label elements. */
     label?: string;
+    /** Styles applied to the label of the "no value" input when it is active. */
+    labelEmptyValueActive?: string;
     /** Styles applied to the icon wrapping elements. */
     icon?: string;
     /** Styles applied to the icon wrapping elements when empty. */

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -75,17 +75,17 @@ export const styles = (theme) => ({
   focusVisible: {},
   /* Visually hide an element. */
   visuallyHidden,
-  /* Styles applied to the label of the empty value when no value is active. */
+  /* Styles applied to the label elements. */
+  label: {
+    cursor: 'inherit',
+  },
+  /* Styles applied to the label of the "no value" input when it is active. */
   labelEmptyValueActive: {
     top: 0,
     bottom: 0,
     position: 'absolute',
     outline: '1px solid #999',
     width: '100%',
-  },
-  /* Styles applied to the label elements. */
-  label: {
-    cursor: 'inherit',
   },
   /* Styles applied to the icon wrapping elements. */
   icon: {
@@ -311,6 +311,8 @@ const Rating = React.forwardRef(function Rating(props, ref) {
     }
   };
 
+  const [emptyValueFocused, setEmptyValueFocused] = React.useState(false);
+
   const item = (state, labelProps) => {
     const id = `${name}-${String(state.value).replace('.', '-')}`;
     const container = (
@@ -426,10 +428,7 @@ const Rating = React.forwardRef(function Rating(props, ref) {
         });
       })}
       {!disabled && valueRounded == null && (
-        <label
-          onFocus={(event) => event.currentTarget.classList.add(classes.labelEmptyValueActive)}
-          onBlur={(event) => event.currentTarget.classList.remove(classes.labelEmptyValueActive)}
-        >
+        <label className={clsx({ [classes.labelEmptyValueActive]: emptyValueFocused })}>
           <input
             value=""
             id={`${name}-empty`}
@@ -438,6 +437,8 @@ const Rating = React.forwardRef(function Rating(props, ref) {
             defaultChecked
             className={classes.visuallyHidden}
             readOnly={readOnly}
+            onFocus={() => setEmptyValueFocused(true)}
+            onBlur={() => setEmptyValueFocused(false)}
           />
           <span className={classes.visuallyHidden}>{emptyLabelText}</span>
         </label>

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -75,15 +75,13 @@ export const styles = (theme) => ({
   focusVisible: {},
   /* Visually hide an element. */
   visuallyHidden,
-  /* Styles applied to the pristine label. */
-  pristine: {
-    'input:focus + &': {
-      top: 0,
-      bottom: 0,
-      position: 'absolute',
-      outline: '1px solid #999',
-      width: '100%',
-    },
+  /* Styles applied to the label of the empty value when no value is active. */
+  labelEmptyValueActive: {
+    top: 0,
+    bottom: 0,
+    position: 'absolute',
+    outline: '1px solid #999',
+    width: '100%',
   },
   /* Styles applied to the label elements. */
   label: {
@@ -428,7 +426,10 @@ const Rating = React.forwardRef(function Rating(props, ref) {
         });
       })}
       {!disabled && valueRounded == null && (
-        <React.Fragment>
+        <label
+          onFocus={(event) => event.currentTarget.classList.add(classes.labelEmptyValueActive)}
+          onBlur={(event) => event.currentTarget.classList.remove(classes.labelEmptyValueActive)}
+        >
           <input
             value=""
             id={`${name}-empty`}
@@ -438,10 +439,8 @@ const Rating = React.forwardRef(function Rating(props, ref) {
             className={classes.visuallyHidden}
             readOnly={readOnly}
           />
-          <label className={classes.pristine} htmlFor={`${name}-empty`}>
-            <span className={classes.visuallyHidden}>{emptyLabelText}</span>
-          </label>
-        </React.Fragment>
+          <span className={classes.visuallyHidden}>{emptyLabelText}</span>
+        </label>
       )}
     </span>
   );

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -8,6 +8,7 @@ import {
   describeConformance,
   createClientRender,
   fireEvent,
+  screen,
 } from 'test/utils';
 import Rating from './Rating';
 
@@ -110,6 +111,24 @@ describe('<Rating />', () => {
     fireEvent.click(getByRole('radio', { name: '2 Stars' }));
     checked = container.querySelector('input[name="rating-test"]:checked');
     expect(checked.value).to.equal('2');
+  });
+
+  it('has a customization point for the label of the empty value when it is active', () => {
+    const { container } = render(
+      <Rating classes={{ labelEmptyValueActive: 'customized' }} name="" value={null} />,
+    );
+
+    expect(container.querySelector('.customized')).to.equal(null);
+
+    act(() => {
+      const noValueRadio = screen.getAllByRole('radio').find((radio) => {
+        return radio.checked;
+      });
+
+      noValueRadio.focus();
+    });
+
+    expect(container.querySelector('.customized')).to.have.property('tagName', 'LABEL');
   });
 
   describe('<form> integration', () => {


### PR DESCRIPTION
**BREAKING CHANGE:**
Customization of pristine label
```diff
-input:focus + .MuiRating-pristine {
+.MuiRating-labelEmptyValueActive {
    top: 0;
    bottom: 0;
    position: absolute;
    outline: 1px solid #999;
    width: 100%;
}
```


Preliminary change which isn't required for this change but aids communication of intent: Replace `pristine` with `empty value`.
Pristine is an existing term in forms and means "untouched" or "unchanged". Right now keep using a class named `pristine` even if the user has interacted with the input. This can be confusing.

Actual change:
We usually try to use class names for styling. This allows easier customization via `classes` API and reduces specificity wars. However, previously styling of the Rating when no rating was given required a combination of class name, sibling and pseudo class selector i.e. knowledge of implementation. This change introduces a single class (`labelEmptyValueActive`) which replaces the old selector. It requires more JS for the styling but less for the label-value association since we can now rely on association by hierarchy instead of by ID.