### PR TITLE
[docs] generateMarkdown checks style rules before adding classes documentation

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.ts
+++ b/docs/src/modules/utils/generateMarkdown.ts
@@ -477,7 +477,11 @@ ${text}
 
 You can override the style of the component thanks to one of these customization points:
 
-- With a rule name of the [\`classes\` object prop](/customization/components/#overriding-styles-with-classes).
+${
+  reactAPI.styles.classes.filter((styleRule) => styleRule.indexOf('@') !== 0).length > 0
+    ? `- With a rule name of the [\`classes\` object prop](/customization/components/#overriding-styles-with-classes).`
+      : ''
+}
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [\`overrides\` property](/customization/globals/#css).
 

--- a/docs/src/modules/utils/generateMarkdown.ts
+++ b/docs/src/modules/utils/generateMarkdown.ts
@@ -480,7 +480,7 @@ You can override the style of the component thanks to one of these customization
 ${
   reactAPI.styles.classes.filter((styleRule) => styleRule.indexOf('@') !== 0).length > 0
     ? `- With a rule name of the [\`classes\` object prop](/customization/components/#overriding-styles-with-classes).`
-      : ''
+    : ''
 }
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [\`overrides\` property](/customization/globals/#css).


### PR DESCRIPTION
### Summary

I was looking to contribute and noticed open issue #20310.

Most of the suggested changes (outlined in this comment: https://github.com/mui-org/material-ui/issues/20310#issuecomment-606047787) were taken care of in #22297.

It seems like the only thing that hadn't been updated was a potential update to `generateMarkdown`.

If this change won't be needed in the future, feel free to close this PR. I did not notice any changes that would occur to current documentation as `yarn run docs:api` did not change any of the markdown documentation files.

Otherwise, if this PR gets merged, it should close #20310.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
