### PR TITLE
[test] Only run on push for master/next

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,9 +230,10 @@ workflows:
       - checkout:
           filters:
             branches:
-              ignore:
-                - l10n
-                - /dependabot\//
+              only:
+                # Other branches are considered PRs
+                - master
+                - next
       - test_unit:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,14 +226,14 @@ jobs:
 workflows:
   version: 2
   pipeline:
+    # Approximating to only run when the base branch is `master` or `next`
+    when:
+      or:
+        - equal: [master, << pipeline.git.branch >>]
+        - equal: [next, << pipeline.git.branch >>]
+        - equal: ${CIRCLE_PR_NUMBER}
     jobs:
       - checkout:
-          filters:
-            branches:
-              only:
-                # Other branches are considered PRs
-                - master
-                - next
       - test_unit:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,10 @@ jobs:
             echo ${CIRCLE_PR_NUMBER}
             if ! [[ $CIRCLE_BRANCH = "master" ]] && ! [[ $CIRCLE_BRANCH = "next" ]] && ! [[ $CIRCLE_PR_NUMBER ]]
             then
+                echo "Skipping because branch='$CIRCLE_BRANCH' and pr_number='$CIRCLE_PR_NUMBER'"
                 circleci-agent step halt
+            else
+                echo "Not skipping because branch='$CIRCLE_BRANCH' and pr_number='$CIRCLE_PR_NUMBER'"
             fi
       - checkout
       - install_js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,17 @@ jobs:
   checkout:
     <<: *defaults
     steps:
+      - run:
+          name: Filter base branch
+          # CircleCI does not apply filters to base branch (like any other CI provider)
+          # We're approximating a filter for `master` and `next` base branches here.
+          # Can't use `when` or `condition` because pipeline values don't include whether the pipeline is triggered by a PR.
+          command: |
+            echo ${CIRCLE_BRANCH}
+            echo ${CIRCLE_PR_NUMBER}
+            if [ "$CIRCLE_BRANCH" != "master" || "$CIRCLE_BRANCH" != "next" || "$CIRCLE_PR_NUMBER" == "" ]; then
+                circleci-agent step halt
+            fi
       - checkout
       - install_js
       - run:
@@ -226,14 +237,8 @@ jobs:
 workflows:
   version: 2
   pipeline:
-    # Approximating to only run when the base branch is `master` or `next`
-    when:
-      or:
-        - equal: [master, << pipeline.git.branch >>]
-        - equal: [next, << pipeline.git.branch >>]
-        - equal: ${CIRCLE_PR_NUMBER}
     jobs:
-      - checkout:
+      - checkout
       - test_unit:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,21 +55,6 @@ jobs:
   checkout:
     <<: *defaults
     steps:
-      - run:
-          name: Filter base branch
-          # CircleCI does not apply filters to base branch (like any other CI provider)
-          # We're approximating a filter for `master` and `next` base branches here.
-          # Can't use `when` or `condition` because pipeline values don't include whether the pipeline is triggered by a PR.
-          command: |
-            echo ${CIRCLE_BRANCH}
-            echo ${CIRCLE_PR_NUMBER}
-            if ! [[ $CIRCLE_BRANCH = "master" ]] && ! [[ $CIRCLE_BRANCH = "next" ]] && ! [[ $CIRCLE_PR_NUMBER ]]
-            then
-                echo "Skipping because branch='$CIRCLE_BRANCH' and pr_number='$CIRCLE_PR_NUMBER'"
-                circleci-agent step halt
-            else
-                echo "Not skipping because branch='$CIRCLE_BRANCH' and pr_number='$CIRCLE_PR_NUMBER'"
-            fi
       - checkout
       - install_js
       - run:
@@ -242,7 +227,17 @@ workflows:
   version: 2
   pipeline:
     jobs:
-      - checkout
+      - checkout:
+          filters:
+            branches:
+              # Ideally we only run this pipeline if the base branch is `master` or `next`.
+              # CircleCI doesn't support it because branch filters are based on target branch.
+              # We approximate it by running on `master`, `next` and any PR (assuming they always target master or next).
+              only:
+                - master
+                - next
+                # pull requests have its branch name following the `pull/$CIRCLE_PR_NUMBER` scheme.
+                - /pull\/.*/
       - test_unit:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ jobs:
           command: |
             echo ${CIRCLE_BRANCH}
             echo ${CIRCLE_PR_NUMBER}
-            if [ "$CIRCLE_BRANCH" != "master" || "$CIRCLE_BRANCH" != "next" || "$CIRCLE_PR_NUMBER" == "" ]; then
+            if ! [[ $CIRCLE_BRANCH = "master" ]] && ! [[ $CIRCLE_BRANCH = "next" ]] && ! [[ $CIRCLE_PR_NUMBER ]]
+            then
                 circleci-agent step halt
             fi
       - checkout

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -2,17 +2,16 @@ name: 'Maintenance'
 on:
   # So that PRs touching the same files as the push are updated
   push:
-    branches-ignore:
-      # PRs are almost never based off of dependabot PRs
-      - 'dependabot/**'
+    branches:
+      - master
+      - next
   # So that the `dirtyLabel` is removed if conflicts are resolved
   # Could put too much strain on rate limit
   # If we hit the rate limit too often remove this event
   pull_request_target:
-    branches-ignore:
-      # These PRs are almost fully automated so labelling them is not as important.
-      # They do burst the GitHub API though so we're ignoring them to not hit the rate limit
-      - 'dependabot/**'
+    branches:
+      - master
+      - next
     types: [synchronize]
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,8 @@
 trigger:
   branches:
     include:
-      - '*'
-    exclude:
-      - l10n
-      - dependabot/*
+      - 'master'
+      - 'next'
 
 schedules:
   - cron: '0 0 * * *'


### PR DESCRIPTION
This is safer since we only ever added one new branch as a long-living branch while it's much more likely to accidentally push a new, large branch to the `upstream` remote (this repository). 

We don't cancel older pipelines if new commits are pushed to branches on this repo (so that we know that merging these commits produce a green build). We previously ignored known branches but #22620 and #22618  used a different naming scheme and queued hundreds of pipeline runs. Maybe we can cancel these via API.

For future self:
- cancel jobs on a branch script: https://gist.github.com/eps1lon/9c822429bffb5db5a3f221dd00fea842
- workflows can still be considered running even if all underlying jobs are cancelled.