### PR TITLE
[docs] Fix markdown metadata yaml

### DIFF
--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -41,7 +41,9 @@ export function getHeaders(markdown) {
 
   // eslint-disable-next-line no-cond-assign
   while ((regexMatches = headerKeyValueRegExp.exec(header)) !== null) {
-    headers[regexMatches[1]] = regexMatches[2];
+    const key = regexMatches[1];
+    const value = regexMatches[2].replace(/'(.*)'/, '$1');
+    headers[key] = value;
   }
 
   if (headers.components) {

--- a/docs/src/modules/utils/parseMarkdown.test.js
+++ b/docs/src/modules/utils/parseMarkdown.test.js
@@ -10,7 +10,7 @@ describe('parseMarkdown', () => {
 title: Alert React component
 components: Alert, AlertTitle
 githubLabel: 'component: Alert'
-packageName: @material-ui/lab
+packageName: '@material-ui/lab'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 ---
 `),

--- a/docs/src/modules/utils/parseMarkdown.test.js
+++ b/docs/src/modules/utils/parseMarkdown.test.js
@@ -1,7 +1,29 @@
 import { expect } from 'chai';
-import { getContents, prepareMarkdown } from './parseMarkdown';
+import { getContents, getHeaders, prepareMarkdown } from './parseMarkdown';
 
 describe('parseMarkdown', () => {
+  describe('getHeaders', () => {
+    it('should return a correct result', () => {
+      expect(
+        getHeaders(`
+---
+title: Alert React component
+components: Alert, AlertTitle
+githubLabel: 'component: Alert'
+packageName: @material-ui/lab
+waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
+---
+`),
+      ).to.deep.equal({
+        components: ['Alert', 'AlertTitle'],
+        githubLabel: 'component: Alert',
+        packageName: '@material-ui/lab',
+        title: 'Alert React component',
+        waiAria: 'https://www.w3.org/TR/wai-aria-practices/#alert',
+      });
+    });
+  });
+
   describe('getContents', () => {
     describe('Split markdown into an array, separating demos', () => {
       it('returns a single entry without a demo', () => {

--- a/docs/src/pages/components/accordion/accordion.md
+++ b/docs/src/pages/components/accordion/accordion.md
@@ -1,7 +1,7 @@
 ---
 title: Accordion React component
 components: Accordion, AccordionActions, AccordionDetails, AccordionSummary
-githubLabel: component: Accordion
+githubLabel: 'component: Accordion'
 materialDesign: https://material.io/archive/guidelines/components/expansion-panels.html
 waiAria: https://www.w3.org/TR/wai-aria-practices/#accordion
 ---

--- a/docs/src/pages/components/alert/alert.md
+++ b/docs/src/pages/components/alert/alert.md
@@ -1,7 +1,7 @@
 ---
 title: Alert React component
 components: Alert, AlertTitle
-githubLabel: component: Alert
+githubLabel: 'component: Alert'
 packageName: @material-ui/lab
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 ---

--- a/docs/src/pages/components/alert/alert.md
+++ b/docs/src/pages/components/alert/alert.md
@@ -2,7 +2,7 @@
 title: Alert React component
 components: Alert, AlertTitle
 githubLabel: 'component: Alert'
-packageName: @material-ui/lab
+packageName: '@material-ui/lab'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 ---
 

--- a/docs/src/pages/components/app-bar/app-bar.md
+++ b/docs/src/pages/components/app-bar/app-bar.md
@@ -1,7 +1,7 @@
 ---
 title: App Bar React component
 components: AppBar, Toolbar, Menu
-githubLabel: component: AppBar
+githubLabel: 'component: AppBar'
 materialDesign: https://material.io/components/app-bars-top
 ---
 

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -1,9 +1,9 @@
 ---
 title: Autocomplete React component
 components: TextField, Popper, Autocomplete
-githubLabel: component: Autocomplete
+githubLabel: 'component: Autocomplete'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#combobox
-packageName: @material-ui/lab
+packageName: '@material-ui/lab'
 ---
 
 # Autocomplete

--- a/docs/src/pages/components/avatars/avatars.md
+++ b/docs/src/pages/components/avatars/avatars.md
@@ -1,7 +1,7 @@
 ---
 title: Avatar React component
 components: Avatar, AvatarGroup, Badge
-githubLabel: component: Avatar
+githubLabel: 'component: Avatar'
 ---
 
 # Avatar

--- a/docs/src/pages/components/backdrop/backdrop.md
+++ b/docs/src/pages/components/backdrop/backdrop.md
@@ -1,7 +1,7 @@
 ---
 title: Backdrop React Component
 components: Backdrop
-githubLabel: component: Backdrop
+githubLabel: 'component: Backdrop'
 ---
 
 # Backdrop

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -1,7 +1,7 @@
 ---
 title: Badge React component
 components: Badge
-githubLabel: component: Badge
+githubLabel: 'component: Badge'
 ---
 
 # Badge

--- a/docs/src/pages/components/bottom-navigation/bottom-navigation.md
+++ b/docs/src/pages/components/bottom-navigation/bottom-navigation.md
@@ -1,7 +1,7 @@
 ---
 title: Bottom Navigation React component
 components: BottomNavigation, BottomNavigationAction
-githubLabel: component: BottomNavigation
+githubLabel: 'component: BottomNavigation'
 materialDesign: https://material.io/components/bottom-navigation
 ---
 

--- a/docs/src/pages/components/box/box.md
+++ b/docs/src/pages/components/box/box.md
@@ -1,6 +1,6 @@
 ---
 title: Box React component
-githubLabel: component: Box
+githubLabel: 'component: Box'
 ---
 
 # Box

--- a/docs/src/pages/components/breadcrumbs/breadcrumbs.md
+++ b/docs/src/pages/components/breadcrumbs/breadcrumbs.md
@@ -1,7 +1,7 @@
 ---
 title: Breadcrumbs React component
 components: Breadcrumbs, Link, Typography
-githubLabel: component: Breadcrumbs
+githubLabel: 'component: Breadcrumbs'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#breadcrumb
 ---
 

--- a/docs/src/pages/components/button-group/button-group.md
+++ b/docs/src/pages/components/button-group/button-group.md
@@ -1,7 +1,7 @@
 ---
 title: ButtonGroup React component
 components: Button, ButtonGroup
-githubLabel: component: ButtonGroup
+githubLabel: 'component: ButtonGroup'
 ---
 
 # Button group

--- a/docs/src/pages/components/buttons/buttons.md
+++ b/docs/src/pages/components/buttons/buttons.md
@@ -2,7 +2,7 @@
 title: Button React component
 components: Button, IconButton, ButtonBase, LoadingButton
 materialDesign: https://material.io/components/buttons
-githubLabel: component: Button
+githubLabel: 'component: Button'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#button
 ---
 

--- a/docs/src/pages/components/cards/cards.md
+++ b/docs/src/pages/components/cards/cards.md
@@ -1,7 +1,7 @@
 ---
 title: Card React component
 components: Card, CardActionArea, CardActions, CardContent, CardHeader, CardMedia, Collapse, Paper
-githubLabel: component: Card
+githubLabel: 'component: Card'
 materialDesign: https://material.io/components/cards
 ---
 

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -2,7 +2,7 @@
 title: Checkbox React component
 components: Checkbox, FormControl, FormGroup, FormLabel, FormControlLabel
 materialDesign: https://material.io/components/selection-controls#checkboxes
-githubLabel: component: Checkbox
+githubLabel: 'component: Checkbox'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#checkbox
 ---
 

--- a/docs/src/pages/components/chips/chips.md
+++ b/docs/src/pages/components/chips/chips.md
@@ -1,7 +1,7 @@
 ---
 title: Chip React component
 components: Chip
-githubLabel: component: Chip
+githubLabel: 'component: Chip'
 materialDesign: https://material.io/components/chips
 ---
 

--- a/docs/src/pages/components/click-away-listener/click-away-listener.md
+++ b/docs/src/pages/components/click-away-listener/click-away-listener.md
@@ -1,7 +1,7 @@
 ---
 title: Detect click outside React component
 components: ClickAwayListener
-githubLabel: component: ClickAwayListener
+githubLabel: 'component: ClickAwayListener'
 ---
 
 # Click away listener

--- a/docs/src/pages/components/container/container.md
+++ b/docs/src/pages/components/container/container.md
@@ -1,7 +1,7 @@
 ---
 title: Container React component
 components: Container
-githubLabel: component: Container
+githubLabel: 'component: Container'
 ---
 
 # Container

--- a/docs/src/pages/components/css-baseline/css-baseline.md
+++ b/docs/src/pages/components/css-baseline/css-baseline.md
@@ -1,6 +1,6 @@
 ---
 components: CssBaseline, ScopedCssBaseline
-githubLabel: component: CssBaseline
+githubLabel: 'component: CssBaseline'
 ---
 
 # CSS Baseline

--- a/docs/src/pages/components/dialogs/dialogs.md
+++ b/docs/src/pages/components/dialogs/dialogs.md
@@ -1,7 +1,7 @@
 ---
 title: Dialog React component
 components: Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Slide
-githubLabel: component: Dialog
+githubLabel: 'component: Dialog'
 materialDesign: https://material.io/components/dialogs
 waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
 ---

--- a/docs/src/pages/components/dividers/dividers.md
+++ b/docs/src/pages/components/dividers/dividers.md
@@ -1,7 +1,7 @@
 ---
 title: Divider React component
 components: Divider
-githubLabel: component: Divider
+githubLabel: 'component: Divider'
 materialDesign: https://material.io/components/dividers
 ---
 

--- a/docs/src/pages/components/drawers/drawers.md
+++ b/docs/src/pages/components/drawers/drawers.md
@@ -1,7 +1,7 @@
 ---
 title: Drawer React component
 components: Drawer, SwipeableDrawer
-githubLabel: component: Drawer
+githubLabel: 'component: Drawer'
 materialDesign: https://material.io/components/navigation-drawer
 ---
 

--- a/docs/src/pages/components/floating-action-button/floating-action-button.md
+++ b/docs/src/pages/components/floating-action-button/floating-action-button.md
@@ -1,7 +1,7 @@
 ---
 title: Fab React component
 components: Fab
-githubLabel: component: Fab
+githubLabel: 'component: Fab'
 materialDesign: https://material.io/components/buttons-floating-action-button
 ---
 

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -1,7 +1,7 @@
 ---
 title: Grid React component
 components: Grid
-githubLabel: component: Grid
+githubLabel: 'component: Grid'
 materialDesign: https://material.io/design/layout/understanding-layout.html
 ---
 

--- a/docs/src/pages/components/hidden/hidden.md
+++ b/docs/src/pages/components/hidden/hidden.md
@@ -1,7 +1,7 @@
 ---
 title: Hidden React component
 components: Hidden
-githubLabel: component: Hidden
+githubLabel: 'component: Hidden'
 ---
 
 # Hidden

--- a/docs/src/pages/components/image-list/image-list.md
+++ b/docs/src/pages/components/image-list/image-list.md
@@ -2,7 +2,7 @@
 title: Image list React component
 components: ImageList, ImageListItem, ImageListItemBar
 materialDesign: https://material.io/components/image-lists
-githubLabel: component: ImageList
+githubLabel: 'component: ImageList'
 ---
 
 # Image list

--- a/docs/src/pages/components/links/links.md
+++ b/docs/src/pages/components/links/links.md
@@ -1,6 +1,6 @@
 ---
 components: Link
-githubLabel: component: Link
+githubLabel: 'component: Link'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#link
 ---
 

--- a/docs/src/pages/components/lists/lists.md
+++ b/docs/src/pages/components/lists/lists.md
@@ -1,7 +1,7 @@
 ---
 title: List React component
 components: Collapse, Divider, List, ListItem, ListItemAvatar, ListItemIcon, ListItemSecondaryAction, ListItemText, ListSubheader
-githubLabel: component: List
+githubLabel: 'component: List'
 materialDesign: https://material.io/components/lists
 ---
 

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -1,7 +1,7 @@
 ---
 title: Menu React component
 components: Menu, MenuItem, MenuList, ClickAwayListener, Popover, Popper
-githubLabel: component: Menu
+githubLabel: 'component: Menu'
 materialDesign: https://material.io/components/menus
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
 ---

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -1,7 +1,7 @@
 ---
 title: Modal React component
 components: Modal
-githubLabel: component: Modal
+githubLabel: 'component: Modal'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
 ---
 

--- a/docs/src/pages/components/pagination/pagination.md
+++ b/docs/src/pages/components/pagination/pagination.md
@@ -1,8 +1,8 @@
 ---
 title: Pagination React component
 components: Pagination, PaginationItem
-githubLabel: component: Pagination
-packageName: @material-ui/lab
+githubLabel: 'component: Pagination'
+packageName: '@material-ui/lab'
 ---
 
 # Pagination

--- a/docs/src/pages/components/paper/paper.md
+++ b/docs/src/pages/components/paper/paper.md
@@ -1,7 +1,7 @@
 ---
 title: Paper React component
 components: Paper
-githubLabel: component: Paper
+githubLabel: 'component: Paper'
 ---
 
 # Paper

--- a/docs/src/pages/components/pickers/pickers.md
+++ b/docs/src/pages/components/pickers/pickers.md
@@ -1,10 +1,10 @@
 ---
 title: Date picker, Time picker React components
 components: TextField
-githubLabel: component: DatePicker
+githubLabel: 'component: DatePicker'
 materialDesign: https://material.io/components/date-pickers
 waiAria: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
-packageName: @material-ui/lab
+packageName: '@material-ui/lab'
 ---
 
 # Date / Time pickers

--- a/docs/src/pages/components/popover/popover.md
+++ b/docs/src/pages/components/popover/popover.md
@@ -1,7 +1,7 @@
 ---
 title: Popover React component
 components: Grow, Popover
-githubLabel: component: Popover
+githubLabel: 'component: Popover'
 ---
 
 # Popover

--- a/docs/src/pages/components/popper/popper.md
+++ b/docs/src/pages/components/popper/popper.md
@@ -1,7 +1,7 @@
 ---
 title: Popper React component
 components: Popper
-githubLabel: component: Popper
+githubLabel: 'component: Popper'
 ---
 
 # Popper

--- a/docs/src/pages/components/portal/portal.md
+++ b/docs/src/pages/components/portal/portal.md
@@ -1,7 +1,7 @@
 ---
 title: Portal React component
 components: Portal
-githubLabel: component: Portal
+githubLabel: 'component: Portal'
 ---
 
 # Portal

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -1,7 +1,7 @@
 ---
 title: Circular, Linear progress React components
 components: CircularProgress, LinearProgress
-githubLabel: component: CircularProgress
+githubLabel: 'component: CircularProgress'
 materialDesign: https://material.io/components/progress-indicators
 ---
 

--- a/docs/src/pages/components/radio-buttons/radio-buttons.md
+++ b/docs/src/pages/components/radio-buttons/radio-buttons.md
@@ -1,7 +1,7 @@
 ---
 title: Radio buttons React component
 components: Radio, RadioGroup, FormControl, FormLabel, FormControlLabel
-githubLabel: component: Radio
+githubLabel: 'component: Radio'
 materialDesign: https://material.io/components/selection-controls#radio-buttons
 waiAria: https://www.w3.org/TR/wai-aria-practices/#radiobutton
 ---

--- a/docs/src/pages/components/rating/rating.md
+++ b/docs/src/pages/components/rating/rating.md
@@ -1,9 +1,9 @@
 ---
 title: Rating React component
 components: Rating
-githubLabel: component: Rating
+githubLabel: 'component: Rating'
 waiAria: https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rating
-packageName: @material-ui/lab
+packageName: '@material-ui/lab'
 ---
 
 # Rating

--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -1,7 +1,7 @@
 ---
 title: Select React component
 components: Select, NativeSelect
-githubLabel: component: Select
+githubLabel: 'component: Select'
 ---
 
 # Select

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -1,8 +1,8 @@
 ---
 title: Skeleton React component
 components: Skeleton
-githubLabel: component: Skeleton
-packageName: @material-ui/lab
+githubLabel: 'component: Skeleton'
+packageName: '@material-ui/lab'
 ---
 
 # Skeleton

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -1,7 +1,7 @@
 ---
 title: Slider React component
 components: Slider
-githubLabel: component: Slider
+githubLabel: 'component: Slider'
 materialDesign: https://material.io/components/sliders
 waiAria: https://www.w3.org/TR/wai-aria-practices/#slider
 ---

--- a/docs/src/pages/components/snackbars/snackbars.md
+++ b/docs/src/pages/components/snackbars/snackbars.md
@@ -1,7 +1,7 @@
 ---
 title: Snackbar React component
 components: Snackbar, SnackbarContent
-githubLabel: component: Snackbar
+githubLabel: 'component: Snackbar'
 materialDesign: https://material.io/components/snackbars
 waiAria: https://www.w3.org/TR/wai-aria-1.1/#alert
 ---

--- a/docs/src/pages/components/speed-dial/speed-dial.md
+++ b/docs/src/pages/components/speed-dial/speed-dial.md
@@ -1,8 +1,8 @@
 ---
 title: Speed Dial React component
 components: SpeedDial, SpeedDialAction, SpeedDialIcon
-githubLabel: component: SpeedDial
-packageName: @material-ui/lab
+githubLabel: 'component: SpeedDial'
+packageName: '@material-ui/lab'
 ---
 
 # Speed Dial

--- a/docs/src/pages/components/steppers/steppers.md
+++ b/docs/src/pages/components/steppers/steppers.md
@@ -1,7 +1,7 @@
 ---
 title: Stepper React component
 components: MobileStepper, Step, StepButton, StepConnector, StepContent, StepIcon, StepLabel, Stepper
-githubLabel: component: Stepper
+githubLabel: 'component: Stepper'
 materialDesign: https://material.io/archive/guidelines/components/steppers.html
 ---
 

--- a/docs/src/pages/components/switches/switches.md
+++ b/docs/src/pages/components/switches/switches.md
@@ -1,7 +1,7 @@
 ---
 title: Switch React component
 components: Switch, FormControl, FormGroup, FormLabel, FormControlLabel
-githubLabel: component: Switch
+githubLabel: 'component: Switch'
 materialDesign: https://material.io/components/selection-controls#switches
 ---
 

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -1,7 +1,7 @@
 ---
 title: Table React component
 components: Table, TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel
-githubLabel: component: Table
+githubLabel: 'component: Table'
 materialDesign: https://material.io/components/data-tables
 ---
 

--- a/docs/src/pages/components/tabs/tabs.md
+++ b/docs/src/pages/components/tabs/tabs.md
@@ -1,7 +1,7 @@
 ---
 title: Tabs React component
 components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel
-githubLabel: component: Tabs
+githubLabel: 'component: Tabs'
 materialDesign: https://material.io/components/tabs
 waiAria: https://www.w3.org/TR/wai-aria-practices/#tabpanel
 ---

--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -1,7 +1,7 @@
 ---
 title: Text Field React component
 components: FilledInput, FormControl, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField
-githubLabel: component: TextField
+githubLabel: 'component: TextField'
 materialDesign: https://material.io/components/text-fields
 ---
 

--- a/docs/src/pages/components/textarea-autosize/textarea-autosize.md
+++ b/docs/src/pages/components/textarea-autosize/textarea-autosize.md
@@ -1,7 +1,7 @@
 ---
 title: Textarea Autosize React component
 components: TextareaAutosize
-githubLabel: component: TextareaAutosize
+githubLabel: 'component: TextareaAutosize'
 ---
 
 # Textarea Autosize

--- a/docs/src/pages/components/timeline/timeline.md
+++ b/docs/src/pages/components/timeline/timeline.md
@@ -1,8 +1,8 @@
 ---
 title: Timeline React component
 components: Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent, TimelineOppositeContent
-githubLabel: component: Timeline
-packageName: @material-ui/lab
+githubLabel: 'component: Timeline'
+packageName: '@material-ui/lab'
 ---
 
 # Timeline

--- a/docs/src/pages/components/toggle-button/toggle-button.md
+++ b/docs/src/pages/components/toggle-button/toggle-button.md
@@ -1,9 +1,9 @@
 ---
 title: Toggle Button React component
 components: ToggleButton, ToggleButtonGroup
-githubLabel: component: ToggleButton
+githubLabel: 'component: ToggleButton'
 materialDesign: https://material.io/components/buttons#toggle-button
-packageName: @material-ui/lab
+packageName: '@material-ui/lab'
 ---
 
 # Toggle Buttons

--- a/docs/src/pages/components/tooltips/tooltips.md
+++ b/docs/src/pages/components/tooltips/tooltips.md
@@ -1,7 +1,7 @@
 ---
 title: Tooltip React component
 components: Tooltip
-githubLabel: component: Tooltip
+githubLabel: 'component: Tooltip'
 materialDesign: https://material.io/components/tooltips
 waiAria: https://www.w3.org/TR/wai-aria-practices/#tooltip
 ---

--- a/docs/src/pages/components/transitions/transitions.md
+++ b/docs/src/pages/components/transitions/transitions.md
@@ -1,7 +1,7 @@
 ---
 title: Transition React component
 components: Collapse, Fade, Grow, Slide, Zoom
-githubLabel: component: Transition
+githubLabel: 'component: Transition'
 ---
 
 # Transitions

--- a/docs/src/pages/components/trap-focus/trap-focus.md
+++ b/docs/src/pages/components/trap-focus/trap-focus.md
@@ -1,7 +1,7 @@
 ---
 title: Trap Focus React component
 components: Unstable_TrapFocus
-githubLabel: component: TrapFocus
+githubLabel: 'component: TrapFocus'
 ---
 
 # Trap Focus

--- a/docs/src/pages/components/tree-view/tree-view.md
+++ b/docs/src/pages/components/tree-view/tree-view.md
@@ -1,7 +1,7 @@
 ---
 title: Tree View React component
 components: TreeView, TreeItem
-githubLabel: component: TreeView
+githubLabel: 'component: TreeView'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#TreeView
 packages: @material-ui/lab
 ---

--- a/docs/src/pages/components/typography/typography.md
+++ b/docs/src/pages/components/typography/typography.md
@@ -1,7 +1,7 @@
 ---
 title: Typography React component
 components: Typography
-githubLabel: component: Typography
+githubLabel: 'component: Typography'
 materialDesign: https://material.io/design/typography/the-type-system.html
 ---
 


### PR DESCRIPTION
Fix problems surfaced by #22620. It solves the broken format I have introduced in #22210. It also solves the issue with the quotes added by Crowdin: https://github.com/mui-org/material-ui/pull/22620/files#diff-4b1e5d036f1e0753be3b78921c8a36b4R5.

<img width="1035" alt="Capture d’écran 2020-09-17 à 14 09 52" src="https://user-images.githubusercontent.com/3165635/93468618-8e825600-f8ef-11ea-96d9-9eca5a168702.png">

I have tried to look for a markdown metadata parser but I couldn't find a good candidate, maybe I didn't look close enough.

- [x] Apply the change to all the pages