### PR TITLE
[docs] Batch small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,17 @@
 
 [React](https://reactjs.org/) components for faster and simpler web development. Build your own design system, or start with [Material Design](https://material.io/design/introduction/).
 
-[![npm package](https://img.shields.io/npm/v/@material-ui/core/latest.svg)](https://www.npmjs.com/package/@material-ui/core)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/mui-org/material-ui/blob/master/LICENSE)
+[![npm latest package](https://img.shields.io/npm/v/@material-ui/core/latest.svg)](https://www.npmjs.com/package/@material-ui/core)
+[![npm next package](https://img.shields.io/npm/v/@material-ui/core/next.svg)](https://www.npmjs.com/package/@material-ui/core)
 [![npm downloads](https://img.shields.io/npm/dm/@material-ui/core.svg)](https://www.npmjs.com/package/@material-ui/core)
-[![CircleCI](https://img.shields.io/circleci/project/github/mui-org/material-ui/master.svg)](https://circleci.com/gh/mui-org/material-ui/tree/master)
-[![Build Status](https://dev.azure.com/mui-org/Material-UI/_apis/build/status/mui-org.material-ui?branchName=master)](https://dev.azure.com/mui-org/Material-UI/_build/latest?definitionId=1&branchName=master)
-[![Coverage Status](https://img.shields.io/codecov/c/github/mui-org/material-ui/master.svg)](https://codecov.io/gh/mui-org/material-ui/branch/master)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1320/badge)](https://bestpractices.coreinfrastructure.org/projects/1320)
-![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
+[![CircleCI](https://img.shields.io/circleci/project/github/mui-org/material-ui/next.svg)](https://app.circleci.com/pipelines/github/mui-org/material-ui?branch=next)
+[![Coverage Status](https://img.shields.io/codecov/c/github/mui-org/material-ui/next.svg)](https://codecov.io/gh/mui-org/material-ui/branch/next)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/MaterialUI.svg?label=follow+Material-UI)](https://twitter.com/MaterialUI)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=mui-org/material-ui)](https://dependabot.com)
-[![PeerDependencies](https://david-dm.org/mui-org/material-ui/master/peer-status.svg?path=packages/material-ui)](https://david-dm.org/mui-org/material-ui/master?type=peer&path=packages/material-ui)
-[![Dependencies](https://david-dm.org/mui-org/material-ui/master/status.svg?path=packages/material-ui)](https://david-dm.org/mui-org/material-ui/master?path=packages/material-ui)
-[![DevDependencies](https://david-dm.org/mui-org/material-ui/master/dev-status.svg?path=packages/material-ui)](https://david-dm.org/mui-org/material-ui/master?type=dev)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/mui-org/material-ui.svg)](https://isitmaintained.com/project/mui-org/material-ui 'Average time to resolve an issue')
-[![Crowdin](https://d322cqt584bo4o.cloudfront.net/material-ui-docs/localized.svg?cache=v1)](https://translate.material-ui.com/project/material-ui-docs)
+[![Crowdin](https://badges.crowdin.net/material-ui-docs/localized.svg)](https://translate.material-ui.com/project/material-ui-docs)
+[![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/material-ui)](https://opencollective.com/material-ui)
 
 </div>
 

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -296,7 +296,9 @@ function AppWrapper(props) {
 
   const activePage = findActivePage(pages, router.pathname);
 
-  let fonts = ['https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap'];
+  let fonts = [
+    'https://fonts.googleapis.com/css?family=Roboto:300,400,400italic,500,700&display=swap',
+  ];
   if (router.pathname.match(/onepirate/)) {
     fonts = [
       'https://fonts.googleapis.com/css?family=Roboto+Condensed:700|Work+Sans:300,400&display=swap',

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,9 +1,4 @@
-# Proxies
-/fr/* /:splat 200
-/de/* /:splat 200
-/ja/* /:splat 200
-
-# For Google
+# Link used in the demos, avoid 404
 /drafts / 301
 /inbox* / 301
 /trash / 301
@@ -11,14 +6,13 @@
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/master/latest/size-snapshot.json 200
 
-# To add when we finish work on v5.
+# To add when we finish work on v5
 # https://next.material-ui.com/* https://material-ui.com/:splat 301!
 
-# We like to have multiple domains O:)
-https://material-ui-next.com/* https://material-ui.com/:splat 301!
+# Support multiple domains
 https://material-ui.dev/* https://material-ui.com/:splat 301!
 
-# link shortener
+# For links hosted in the code published on npm
 /r/styles-instance-warning /getting-started/faq/#i-have-several-instances-of-styles-on-the-page 302
 /r/caveat-with-refs-guide /guides/composition/#caveat-with-refs 302
 /r/pseudo-classes-guide /customization/components/#pseudo-classes 302
@@ -28,42 +22,9 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /r/custom-component-variants /customization/components/#adding-new-component-variants
 /r/x-license https://material-ui.com/store/items/material-ui-x/
 
-# Added in chronological order, to be removed at some point.
-/css-in-js/* /styles/:splat 301
-/customization/css-in-js/ /styles/basics/ 301
-/customization/overrides/ /customization/components/ 301
-/demos/selection-controls/ /components/radio-buttons/ 301
-/demos/* /components/:splat 301
-/getting-started/page-layout-examples/* /getting-started/templates/:splat 301
-/guides/csp/ /styles/advanced/#what-is-csp-and-why-is-it-useful 301
-/guides/migration-v0.x /guides/migration-v0x/ 301
-/lab/about/ /components/about-the-lab/ 301
-/lab/api/* /api/:splat 301
-/lab/* /components/:splat 301
-/layout/basics/ /guides/responsive-ui/ 301
-/layout/breakpoints/ /customization/breakpoints/ 301
-/layout/css-in-js/ /styles/basics/ 301
-/layout/* /components/:splat 301
-/page-layout-examples/* /getting-started/templates/:splat 301
-/style/color/ /customization/color/ 301
-/style/reboot/ /components/css-baseline/ 301
-/style/typography https://v3.material-ui.com/style/typography/#migration-to-typography-v2 301
-/style/* /components/:splat 301
-/utils/modals/ /components/modal/ 301
-/utils/popovers/ /components/popover/ 301
-/utils/* /components/:splat 301
-/api/mui-theme-provider/ /styles/api/ 301
-/components/expansion-panels/ /components/accordion/ 301
-/api/expansion-panel/ /api/accordion/ 301
-/api/expansion-panel-actions/ /api/accordion-actions/ 301
-/api/expansion-panel-details/ /api/accordion-details/ 301
-/api/expansion-panel-summary/ /api/accordion-summary/ 301
-/premium-themes* https://material-ui.com/store/ 301
-/customization/themes/ /customization/theming/ 301
-https://v1-5-0.material-ui.com/* https://v1.material-ui.com/:splat 301!
-https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
-
-# Legacy
+# Legacy redirection
+# Added in chronological order
+# To be removed at some point
 /v0.20.0 https://v0.material-ui.com/v0.20.0
 /v0.19.4 https://v0.material-ui.com/v0.19.4
 /v0.19.3 https://v0.material-ui.com/v0.19.3
@@ -134,14 +95,55 @@ https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 /v0.3.2 https://v0.material-ui.com/v0.3.2
 /v0.3.1 https://v0.material-ui.com/v0.3.1
 /v0.3.0 https://v0.material-ui.com/v0.3.0
+/css-in-js/* /styles/:splat 301
+/customization/css-in-js/ /styles/basics/ 301
+/customization/overrides/ /customization/components/ 301
+/demos/selection-controls/ /components/radio-buttons/ 301
+/demos/* /components/:splat 301
+/getting-started/page-layout-examples/* /getting-started/templates/:splat 301
+/guides/csp/ /styles/advanced/#what-is-csp-and-why-is-it-useful 301
+/guides/migration-v0.x /guides/migration-v0x/ 301
+/lab/about/ /components/about-the-lab/ 301
+/lab/api/* /api/:splat 301
+/lab/* /components/:splat 301
+/layout/basics/ /guides/responsive-ui/ 301
+/layout/breakpoints/ /customization/breakpoints/ 301
+/layout/css-in-js/ /styles/basics/ 301
+/layout/* /components/:splat 301
+/page-layout-examples/* /getting-started/templates/:splat 301
+/style/color/ /customization/color/ 301
+/style/reboot/ /components/css-baseline/ 301
+/style/typography https://v3.material-ui.com/style/typography/#migration-to-typography-v2 301
+/style/* /components/:splat 301
+/utils/modals/ /components/modal/ 301
+/utils/popovers/ /components/popover/ 301
+/utils/* /components/:splat 301
+/api/mui-theme-provider/ /styles/api/ 301
+/components/expansion-panels/ /components/accordion/ 301
+/api/expansion-panel/ /api/accordion/ 301
+/api/expansion-panel-actions/ /api/accordion-actions/ 301
+/api/expansion-panel-details/ /api/accordion-details/ 301
+/api/expansion-panel-summary/ /api/accordion-summary/ 301
+/premium-themes* https://material-ui.com/store/ 301
+/customization/themes/ /customization/theming/ 301
+https://v1-5-0.material-ui.com/* https://v1.material-ui.com/:splat 301!
+https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 
 # Proxies
+
+## Localization
+/fr/* /:splat 200
+/de/* /:splat 200
+/ja/* /:splat 200
+
+## Store
 /store/* https://material-ui-store.netlify.app/:splat 200
 /store-staging/* https://master--material-ui-store.netlify.app/:splat 200
-/components/data-grid/* https://material-ui-x.netlify.app/components/data-grid/:splat 200
-/api/data-grid/ https://material-ui-x.netlify.app/api/data-grid/ 200
-/api/x-grid/ https://material-ui-x.netlify.app/api/x-grid/ 200
-# Unlike the store that expect to be hosted under a subfolder,
-# material-ui-x is configured to be hosted at the root.
+
+## material-ui-x
+## Unlike the store that expect to be hosted under a subfolder,
+## material-ui-x is configured to be hosted at the root.
+/api/*/ https://material-ui-x.netlify.app/api/:splat/ 200
+/components/* https://material-ui-x.netlify.app/components/:splat 200
 /_next/* https://material-ui-x.netlify.app/_next/:splat 200
 /static/x/* https://material-ui-x.netlify.app/static/x/:splat 200

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -128,6 +128,9 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /customization/themes/ /customization/theming/ 301
 https://v1-5-0.material-ui.com/* https://v1.material-ui.com/:splat 301!
 https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
+/:lang/components/data-grid/* /components/data-grid/:splat 302
+/:lang/api/data-grid/ /api/data-grid/ 302
+/:lang/api/x-grid/ /api/x-grid/ 302
 
 # Proxies
 

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -621,8 +621,8 @@ const useStyles = makeStyles(
   (theme) => ({
     root: {
       marginBottom: 40,
-      marginLeft: -theme.spacing(2),
-      marginRight: -theme.spacing(2),
+      marginLeft: theme.spacing(-2),
+      marginRight: theme.spacing(-2),
       [theme.breakpoints.up('sm')]: {
         padding: theme.spacing(0, 1),
         marginLeft: 0,

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -96,6 +96,11 @@ const styles = (theme) => ({
         // To prevent the link to get the focus.
         display: 'none',
       },
+      '& a:not(.anchor-link-style):hover': {
+        color: 'currentColor',
+        borderBottom: '1px solid currentColor',
+        textDecoration: 'none',
+      },
       '&:hover .anchor-link-style': {
         display: 'inline-block',
         padding: '0 8px',

--- a/docs/src/modules/utils/helpers.js
+++ b/docs/src/modules/utils/helpers.js
@@ -27,7 +27,7 @@ function pageToTitle(page) {
   const path = page.subheader || page.pathname;
   const name = path.replace(/.*\//, '');
 
-  if (path.indexOf('/api/') !== -1) {
+  if (path.indexOf('/api') === 0) {
     return upperFirst(camelCase(name));
   }
 

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -1,7 +1,7 @@
 ---
 title: React Icon Component
 components: Icon, SvgIcon
-githubLabel: components: SvgIcon
+githubLabel: 'components: SvgIcon'
 materialDesign: https://material.io/design/iconography/system-icons.html
 ---
 

--- a/docs/src/pages/components/material-icons/material-icons.md
+++ b/docs/src/pages/components/material-icons/material-icons.md
@@ -2,8 +2,8 @@
 title: Material Icons
 components: Icon, SvgIcon
 materialDesign: https://material.io/design/iconography/system-icons.html
-packageName: @material-ui/icons
-githubLabel: package: icons
+packageName: '@material-ui/icons'
+githubLabel: 'package: icons'
 ---
 
 # Material Icons

--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -1,6 +1,6 @@
 ---
 title: Media queries in React for responsive design
-githubLabel: hook: useMediaQuery
+githubLabel: 'hook: useMediaQuery'
 ---
 
 # useMediaQuery

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -23,9 +23,6 @@ const styles = (theme) => ({
   secondaryBar: {
     zIndex: 0,
   },
-  menuButton: {
-    marginLeft: -theme.spacing(1),
-  },
   iconButtonAvatar: {
     padding: 4,
   },
@@ -55,7 +52,7 @@ function Header(props) {
                   color="inherit"
                   aria-label="open drawer"
                   onClick={onDrawerToggle}
-                  className={classes.menuButton}
+                  edge="start"
                 >
                   <MenuIcon />
                 </IconButton>

--- a/docs/src/pages/premium-themes/paperbase/Header.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Header.tsx
@@ -28,9 +28,6 @@ const styles = (theme: Theme) =>
     secondaryBar: {
       zIndex: 0,
     },
-    menuButton: {
-      marginLeft: -theme.spacing(1),
-    },
     iconButtonAvatar: {
       padding: 4,
     },
@@ -64,7 +61,7 @@ function Header(props: HeaderProps) {
                   color="inherit"
                   aria-label="open drawer"
                   onClick={onDrawerToggle}
-                  className={classes.menuButton}
+                  edge="start"
                 >
                   <MenuIcon />
                 </IconButton>


### PR DESCRIPTION
- [docs] Fix more markdown metadata 2e1ee56: Found when reviewing the folder on Crowdin for v5. [An example of a broken makdown](https://github.com/mui-org/material-ui/blob/next/docs/src/pages/components/material-icons/material-icons.md).
- [docs] Load font for italic if used d5f7652: Found when adding a note in italic on the X repo. The italic font is only loaded if the pages depend on it. An example of the issue:

<img width="848" alt="Capture d’écran 2020-09-19 à 15 44 16" src="https://user-images.githubusercontent.com/3165635/93668757-05a22080-fa8f-11ea-9074-453bdc642136.png">

- [docs] Improve the README.md badges 7df4ce4: Have the badge fit in 2 lines instead of 3. Remove the dependency badge as the underlying has been disconnected.

**Before**
<img width="864" alt="Capture d’écran 2020-09-19 à 15 54 08" src="https://user-images.githubusercontent.com/3165635/93668923-62520b00-fa90-11ea-9008-22ddbad6e72b.png">

**After**
<img width="926" alt="Capture d’écran 2020-09-19 à 15 55 29" src="https://user-images.githubusercontent.com/3165635/93668948-99c0b780-fa90-11ea-9d74-bf1be54ba253.png">

- [docs] Reorganize redirection file 821ce1d: Hopefully, simpler to understand.
- [docs] Temporary no translations for X c8ec5eb: Solve the 404 of the new X pages. For instance: https://material-ui.com/zh/components/data-grid/.
- [docs] Fix display for emoji link in headers cd5ae03: This only changes the look on hover cc @dtassone 

**Before**
<img width="169" alt="Capture d’écran 2020-09-19 à 15 47 04" src="https://user-images.githubusercontent.com/3165635/93668806-62054000-fa8f-11ea-9f1a-4ef49a74f2ff.png">

**After**

<img width="249" alt="Capture d’écran 2020-09-19 à 15 11 33" src="https://user-images.githubusercontent.com/3165635/93668791-4732cb80-fa8f-11ea-87d6-be54f163c698.png">

- [docs] Fix NaN margin property 73401e3: I have found them when looking at the emotion server-side rendering warning. Turns out, we have introduced a bunch of new warnings https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext--material-ui.netlify.app%2Fcomponents%2Falert%2F. This change fixes two.
- [docs] Fix navigation API component display 5696c01: The API links should be named exactly after the name of the module exported. I have found this after seeing "X Grid" in the navigation 🧐.

**Before**

<img width="221" alt="Capture d’écran 2020-09-19 à 15 49 55" src="https://user-images.githubusercontent.com/3165635/93668861-cde7a880-fa8f-11ea-8295-6f8c2ce9cc4b.png">

**After**

<img width="216" alt="Capture d’écran 2020-09-19 à 15 50 29" src="https://user-images.githubusercontent.com/3165635/93668871-ddff8800-fa8f-11ea-812a-13c20c357422.png">
