### PR TITLE
[Table] Allow customization of the `from` and `to` calculation in pagination

### DIFF
--- a/docs/pages/api-docs/table-pagination.md
+++ b/docs/pages/api-docs/table-pagination.md
@@ -30,6 +30,7 @@ The `MuiTablePagination` name can be used for providing [default props](/customi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">ActionsComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">TablePaginationActions</span> | The component used for displaying the actions. Either a string to use a HTML element or a component. |
 | <span class="prop-name">backIconButtonProps</span> | <span class="prop-type">object</span> |  | Props applied to the back arrow [`IconButton`](/api/icon-button/) component. |
+| <span class="prop-name">calculateRowRange</span> | <span class="prop-type">func</span> |  | Customize how the `from` and `to` row range is calculated. Invoked with a `{ page, rowsPerPage, count }` object. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">TableCell</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name required">count<abbr title="required">*</abbr></span> | <span class="prop-type">number</span> |  | The total number of rows.<br>To enable server side pagination for an unknown number of items, provide -1. |

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -6,6 +6,12 @@ import { TableCellProps } from '../TableCell';
 import { IconButtonProps } from '../IconButton';
 import { SelectProps } from '../Select';
 
+export interface CalculateRowRangeArgs {
+  page: number;
+  rowsPerPage: number;
+  count: number;
+}
+
 export interface LabelDisplayedRowsArgs {
   from: number;
   to: number;
@@ -69,6 +75,18 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
        * }
        */
       getItemAriaLabel?: (type: 'first' | 'last' | 'next' | 'previous') => string;
+      /**
+       * Customize how the `from` and `to` row range is calculated. Invoked with a `{ page, rowsPerPage, count }`
+       * object.
+       *
+       * @default function defaultCalculateRowRange({ page, rowsPerPage, count }) {
+       *   return {
+       *     from: count === 0 ? 0 : page * rowsPerPage + 1,
+       *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
+       *   };
+       * }
+       */
+      calculateRowRange?: (paginationInfo: CalculateRowRangeArgs) => React.ReactNode;
       /**
        * Customize the displayed rows label. Invoked with a `{ from, to, count, page }`
        * object.

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -200,7 +200,7 @@ TablePagination.propTypes = {
    * @default function defaultCalculateRowRange({ page, rowsPerPage, count }) {
    *   return {
    *     from: count === 0 ? 0 : page * rowsPerPage + 1,
-   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage,
+   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
    *   };
    * }
    */

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -194,6 +194,18 @@ TablePagination.propTypes = {
    */
   backIconButtonProps: PropTypes.object,
   /**
+   * Customize how the `from` and `to` row range is calculated. Invoked with a `{ page, rowsPerPage, count }`
+   * object.
+   *
+   * @default function defaultCalculateRowRange({ page, rowsPerPage, count }) {
+   *   return {
+   *     from: count === 0 ? 0 : page * rowsPerPage + 1,
+   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
+   *   };
+   * }
+   */
+  calculateRowRange: PropTypes.func,
+  /**
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
@@ -228,18 +240,6 @@ TablePagination.propTypes = {
    * }
    */
   getItemAriaLabel: PropTypes.func,
-  /**
-   * Customize how the `from` and `to` row range is calculated. Invoked with a `{ page, rowsPerPage, count }`
-   * object.
-   *
-   * @default function defaultCalculateRowRange({ page, rowsPerPage, count }) {
-   *   return {
-   *     from: count === 0 ? 0 : page * rowsPerPage + 1,
-   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
-   *   };
-   * }
-   */
-  calculateRowRange: PropTypes.func,
   /**
    * Customize the displayed rows label. Invoked with a `{ from, to, count, page }`
    * object.

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -67,6 +67,13 @@ export const styles = (theme) => ({
   },
 });
 
+function defaultCalculateRowRange({ page, rowsPerPage, count }) {
+  return {
+      from: count === 0 ? 0 : page * rowsPerPage + 1,
+      to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
+  };
+}
+
 function defaultLabelDisplayedRows({ from, to, count }) {
   return `${from}-${to} of ${count !== -1 ? count : `more than ${to}`}`;
 }
@@ -88,6 +95,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
     component: Component = TableCell,
     count,
     getItemAriaLabel = defaultGetAriaLabel,
+    calculateRowRange = defaultCalculateRowRange,
     labelDisplayedRows = defaultLabelDisplayedRows,
     labelRowsPerPage = 'Rows per page:',
     nextIconButtonProps,
@@ -148,8 +156,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
 
         <Typography color="inherit" variant="body2" className={classes.caption}>
           {labelDisplayedRows({
-            from: count === 0 ? 0 : page * rowsPerPage + 1,
-            to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage,
+            ...calculateRowRange({page, rowsPerPage, count}),
             count: count === -1 ? -1 : count,
             page,
           })}
@@ -221,6 +228,18 @@ TablePagination.propTypes = {
    * }
    */
   getItemAriaLabel: PropTypes.func,
+  /**
+   * Customize how the `from` and `to` row range is calculated. Invoked with a `{ page, rowsPerPage, count }`
+   * object.
+   *
+   * @default function defaultCalculateRowRange({ page, rowsPerPage, count }) {
+   *   return {
+   *     from: count === 0 ? 0 : page * rowsPerPage + 1,
+   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
+   *   };
+   * }
+   */
+  calculateRowRange: PropTypes.func,
   /**
    * Customize the displayed rows label. Invoked with a `{ from, to, count, page }`
    * object.

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -200,7 +200,7 @@ TablePagination.propTypes = {
    * @default function defaultCalculateRowRange({ page, rowsPerPage, count }) {
    *   return {
    *     from: count === 0 ? 0 : page * rowsPerPage + 1,
-   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
+   *     to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage,
    *   };
    * }
    */

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -69,8 +69,8 @@ export const styles = (theme) => ({
 
 function defaultCalculateRowRange({ page, rowsPerPage, count }) {
   return {
-      from: count === 0 ? 0 : page * rowsPerPage + 1,
-      to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage
+    from: count === 0 ? 0 : page * rowsPerPage + 1,
+    to: count !== -1 ? Math.min(count, (page + 1) * rowsPerPage) : (page + 1) * rowsPerPage,
   };
 }
 
@@ -156,7 +156,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
 
         <Typography color="inherit" variant="body2" className={classes.caption}>
           {labelDisplayedRows({
-            ...calculateRowRange({page, rowsPerPage, count}),
+            ...calculateRowRange({ page, rowsPerPage, count }),
             count: count === -1 ? -1 : count,
             page,
           })}

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -57,8 +57,8 @@ describe('<TablePagination />', () => {
         expect(rowsPerPage).to.equal(10);
         expect(count).to.equal(42);
         return {
-          from:11,
-          to: 20
+          from: 11,
+          to: 20,
         };
       }
 

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -48,6 +48,41 @@ describe('<TablePagination />', () => {
     }),
   );
 
+  describe('prop: calculateRowRange', () => {
+    it('should use the calculateRowRange callback', () => {
+      let calculateRowRangeCalled = false;
+      function calculateRowRange({ page, rowsPerPage, count }) {
+        calculateRowRangeCalled = true;
+        expect(page).to.equal(2);
+        expect(rowsPerPage).to.equal(10);
+        expect(count).to.equal(42);
+        return {
+          from:11,
+          to: 20
+        };
+      }
+
+      const { container } = render(
+        <table>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                count={42}
+                page={2}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={10}
+                calculateRowRange={calculateRowRange}
+              />
+            </TableRow>
+          </TableFooter>
+        </table>,
+      );
+      expect(calculateRowRangeCalled).to.equal(true);
+      expect(container.innerHTML.includes('11-20 of 42')).to.equal(true);
+    });
+  });
+
   describe('prop: labelDisplayedRows', () => {
     it('should use the labelDisplayedRows callback', () => {
       let labelDisplayedRowsCalled = false;


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Currently to customize the `from` and `to` numbers in table pagination it is necessary to provide `labelDisplayedRows` which is sub-optimal because `labelDisplayRows` benefits from localization by default and that is lost with a simple customization. In addition, `labelDisplayedRows` is lacking a passed in property for `rowsPerPage` which is necessary to make the calculations for `from` and `to`.

A use-case I had in mind was that I wanted to control which rows correspond to each page. By default it will always calculate the rows per page like this:

```
1-10 of 25
11-20 of 25
21-25 of 25
```
but I had an occasion to want this:
```
1-5 of 25
6-15 of 25
16-25 of 25
```

I think it makes sense to separate the calculation of the `from` and `to` rows from the display logic of `labelDisplayedRows` into a new `calculateRowRange` function. The `defaultCalculateRowRange` function uses the current logic for calculating `from` and `to`, it's just possible to customize that like this now:

```jsx
<TablePagination
  colSpan={4}
  count={count}
  rowsPerPage={rowsPerPage}
  calculateRowRange={calculateRowRange}
  page={page}
  onChangePage={handleChangePage}
  onChangeRowsPerPage={handleChangeRowsPerPage}
/>
```