### PR TITLE
[lab] Fix transitive dependencies in @material-ui/lab

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
+    "@material-ui/system": "^5.0.0-alpha.6",
     "@material-ui/utils": "^5.0.0-alpha.8",
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",

--- a/packages/material-ui-lab/src/Alert/Alert.js
+++ b/packages/material-ui-lab/src/Alert/Alert.js
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { withStyles, lighten, darken } from '@material-ui/core/styles';
+import { withStyles, lighten, darken, useThemeVariants } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import { capitalize } from '@material-ui/core/utils';
-import { useThemeVariants } from '@material-ui/styles';
 import SuccessOutlinedIcon from '../internal/svg-icons/SuccessOutlined';
 import ReportProblemOutlinedIcon from '../internal/svg-icons/ReportProblemOutlined';
 import ErrorOutlineIcon from '../internal/svg-icons/ErrorOutline';

--- a/packages/material-ui-lab/src/Pagination/Pagination.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { useThemeVariants } from '@material-ui/styles';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useThemeVariants } from '@material-ui/core/styles';
 import usePagination from './usePagination';
 import PaginationItem from '../PaginationItem';
 

--- a/packages/material-ui-lab/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui-lab/src/PaginationItem/PaginationItem.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { useThemeVariants } from '@material-ui/styles';
-import { fade, useTheme, withStyles } from '@material-ui/core/styles';
+import { fade, useTheme, withStyles, useThemeVariants } from '@material-ui/core/styles';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import { capitalize } from '@material-ui/core/utils';
 import FirstPageIcon from '../internal/svg-icons/FirstPage';

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { useThemeVariants } from '@material-ui/styles';
 import {
   fade,
   withStyles,
   unstable_toUnitless as toUnitless,
   unstable_getUnit as getUnit,
+  useThemeVariants,
 } from '@material-ui/core/styles';
 
 export const styles = (theme) => {

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { useThemeVariants } from '@material-ui/styles';
 import { capitalize } from '@material-ui/core/utils';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useThemeVariants } from '@material-ui/core/styles';
 
 export const styles = (theme) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/styles/index.js
+++ b/packages/material-ui/src/styles/index.js
@@ -18,4 +18,5 @@ export {
   StylesProvider,
   ThemeProvider as MuiThemeProvider,
   ThemeProvider,
+  useThemeVariants,
 } from '@material-ui/styles';


### PR DESCRIPTION
Fixes using undeclared dependencies in `@material-ui/lab`:
- [x] `@material-ui/styles/useThemeVariants` by importing it from `@material-ui/core` instead (temporary)
- [x] `@material-ui/system/visuallyHidden` by adding `@material-ui/system` to the list of dependencies

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
