### PR TITLE
[test] Run CircleCI anytime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,17 +227,7 @@ workflows:
   version: 2
   pipeline:
     jobs:
-      - checkout:
-          filters:
-            branches:
-              # Ideally we only run this pipeline if the base branch is `master` or `next`.
-              # CircleCI doesn't support it because branch filters are based on target branch.
-              # We approximate it by running on `master`, `next` and any PR (assuming they always target master or next).
-              only:
-                - master
-                - next
-                # pull requests have its branch name following the `pull/$CIRCLE_PR_NUMBER` scheme.
-                - /pull\/.*/
+      - checkout
       - test_unit:
           requires:
             - checkout


### PR DESCRIPTION
Branch filters are not as granular as with azure. We can't differentiate between pull requests and pushes with the branch name. Only PRs from other remotes follow the `pull/*` branch naming scheme.

The current `only` **and** old `ignore` didn't make sense since it would've prevented **any** CircleCI run (which we currently see on dependabot PRs). 

CircleCI should still auto-cancel builds on any branch but the default branch. If we continue to see large queues for the `l10n_*` branches then we should contact support.

Ideally we want:
- build every commit for `master` and `next`
- build the latest commit for open PRs

So `l10n_next` would only build once a PR is open and auto-cancel on new commits. This is how azure pipelines and netlify deploys work so I don't understand why CircleCI works different.