### PR TITLE
[docs] Avoid confusion between layout grid and data grid

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -148,5 +148,6 @@ https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 ## material-ui-x is configured to be hosted at the root.
 /api/*/ https://material-ui-x.netlify.app/api/:splat/ 200
 /components/* https://material-ui-x.netlify.app/components/:splat 200
+/components/data-grid/full-screen-demo/ https://muix-preview.netlify.app/ 200
 /_next/* https://material-ui-x.netlify.app/_next/:splat 200
 /static/x/* https://material-ui-x.netlify.app/static/x/:splat 200

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -148,6 +148,6 @@ https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 ## material-ui-x is configured to be hosted at the root.
 /api/*/ https://material-ui-x.netlify.app/api/:splat/ 200
 /components/* https://material-ui-x.netlify.app/components/:splat 200
-/components/data-grid/full-screen-demo/ https://muix-preview.netlify.app/ 200
+/components/data-grid/demo/ https://muix-preview.netlify.app/ 200
 /_next/* https://material-ui-x.netlify.app/_next/:splat 200
 /static/x/* https://material-ui-x.netlify.app/static/x/:splat 200

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -14,6 +14,8 @@ Material Design’s responsive UI is based on a 12-column grid layout.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
+> ⚠️ The `Grid` component shouldn't be confused with a data grid. The component is closer to a layout grid. Head to this page for [a `DataGrid` component](/components/data-grid/).
+
 ## How it works
 
 The grid system is implemented with the `Grid` component:

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -14,7 +14,7 @@ Material Design’s responsive UI is based on a 12-column grid layout.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-> ⚠️ The `Grid` component shouldn't be confused with a data grid. The component is closer to a layout grid. For a data grid head to [our `DataGrid` component](/components/data-grid/).
+> ⚠️ The `Grid` component shouldn't be confused with a data grid; it is closer to a layout grid. For a data grid head to [the `DataGrid` component](/components/data-grid/).
 
 ## How it works
 

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -14,7 +14,7 @@ Material Design’s responsive UI is based on a 12-column grid layout.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-> ⚠️ The `Grid` component shouldn't be confused with a data grid. The component is closer to a layout grid. Head to this page for [a `DataGrid` component](/components/data-grid/).
+> ⚠️ The `Grid` component shouldn't be confused with a data grid. The component is closer to a layout grid. For a data grid head to [our `DataGrid` component](/components/data-grid/).
 
 ## How it works
 


### PR DESCRIPTION
This has been a point of concern early on in the development of the data grid. Historically, in the previous generation of enterprise UI components, the term "grid" was used as a shorthand for data grid. However, in Material-UI, we use it with a meaning closer to a layout grid.