### PR TITLE
[theme] Rename `type` to `mode`

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -110,8 +110,8 @@ const styles = (theme) => ({
     },
   },
   appBar: {
-    color: theme.palette.type === 'light' ? null : '#fff',
-    backgroundColor: theme.palette.type === 'light' ? null : theme.palette.background.level2,
+    color: theme.palette.mode === 'light' ? null : '#fff',
+    backgroundColor: theme.palette.mode === 'light' ? null : theme.palette.background.level2,
     transition: theme.transitions.create('width'),
   },
   language: {
@@ -171,9 +171,9 @@ function AppFrame(props) {
 
   const changeTheme = useChangeTheme();
   const handleTogglePaletteType = () => {
-    const paletteType = theme.palette.type === 'light' ? 'dark' : 'light';
+    const paletteMode = theme.palette.mode === 'light' ? 'dark' : 'light';
 
-    changeTheme({ paletteType });
+    changeTheme({ paletteMode });
   };
   const handleToggleDirection = () => {
     changeTheme({ direction: theme.direction === 'ltr' ? 'rtl' : 'ltr' });
@@ -310,7 +310,7 @@ function AppFrame(props) {
               data-ga-event-category="header"
               data-ga-event-action="dark"
             >
-              {theme.palette.type === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
+              {theme.palette.mode === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
             </IconButton>
           </Tooltip>
           <Tooltip title={t('toggleRTL')} key={theme.direction} enterDelay={300}>

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -45,7 +45,7 @@ const useStyles = makeStyles(
           fontWeight: theme.typography.fontWeightRegular,
         },
         '& .algolia-docsearch-suggestion--highlight': {
-          color: theme.palette.type === 'light' ? '#174d8c' : '#acccf1',
+          color: theme.palette.mode === 'light' ? '#174d8c' : '#acccf1',
         },
         '& .algolia-docsearch-suggestion': {
           textDecoration: 'none',

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -41,11 +41,11 @@ const useStyles = makeStyles((theme) => ({
     boxSizing: 'border-box',
     '&:hover': {
       borderLeftColor:
-        theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900],
+        theme.palette.mode === 'light' ? theme.palette.grey[200] : theme.palette.grey[900],
     },
     '&$active,&:active': {
       borderLeftColor:
-        theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
+        theme.palette.mode === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
     },
   },
   secondaryItem: {

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -57,7 +57,7 @@ export default function DiamondSponsors(props) {
         <img
           width="125"
           height="35"
-          src={`/static/in-house/octopus-${theme.palette.type}.png`}
+          src={`/static/in-house/octopus-${theme.palette.mode}.png`}
           alt="octopus"
           title="Repeatable, reliable deployments"
           loading="lazy"

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -35,7 +35,7 @@ const styles = (theme) => ({
       padding: '0 3px',
       color: theme.palette.text.primary,
       backgroundColor:
-        theme.palette.type === 'light' ? 'rgba(255, 229, 100, 0.2)' : 'rgba(255, 229, 100, 0.2)',
+        theme.palette.mode === 'light' ? 'rgba(255, 229, 100, 0.2)' : 'rgba(255, 229, 100, 0.2)',
       fontSize: '.85em',
       borderRadius: 2,
     },
@@ -130,11 +130,11 @@ const styles = (theme) => ({
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
       },
       '& .required': {
-        color: theme.palette.type === 'light' ? '#006500' : '#a5ffa5',
+        color: theme.palette.mode === 'light' ? '#006500' : '#a5ffa5',
       },
       '& .prop-type': {
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
-        color: theme.palette.type === 'light' ? '#932981' : '#ffb6ec',
+        color: theme.palette.mode === 'light' ? '#932981' : '#ffb6ec',
       },
       '& .prop-default': {
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -169,7 +169,7 @@ export function ThemeProvider(props) {
       case 'CHANGE':
         return {
           ...state,
-          paletteType: action.payload.paletteType || state.paletteType,
+          paletteMode: action.payload.paletteMode || state.paletteMode,
           direction: action.payload.direction || state.direction,
           paletteColors: action.payload.paletteColors || state.paletteColors,
         };
@@ -180,27 +180,27 @@ export function ThemeProvider(props) {
 
   const userLanguage = useSelector((state) => state.options.userLanguage);
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const preferredType = prefersDarkMode ? 'dark' : 'light';
-  const { dense, direction, paletteColors, paletteType = preferredType, spacing } = themeOptions;
+  const preferredMode = prefersDarkMode ? 'dark' : 'light';
+  const { dense, direction, paletteColors, paletteMode = preferredMode, spacing } = themeOptions;
 
   useLazyCSS('/static/styles/prism-okaidia.css', '#prismjs');
 
   React.useEffect(() => {
     if (process.browser) {
       const nextPaletteColors = JSON.parse(getCookie('paletteColors') || 'null');
-      const nextPaletteType = getCookie('paletteType');
+      const nextPaletteType = getCookie('paletteMode');
 
       dispatch({
         type: 'CHANGE',
-        payload: { paletteColors: nextPaletteColors, paletteType: nextPaletteType },
+        payload: { paletteColors: nextPaletteColors, paletteMode: nextPaletteType },
       });
     }
   }, []);
 
-  // persist paletteType
+  // persist paletteMode
   React.useEffect(() => {
-    document.cookie = `paletteType=${paletteType};path=/;max-age=31536000`;
-  }, [paletteType]);
+    document.cookie = `paletteMode=${paletteMode};path=/;max-age=31536000`;
+  }, [paletteMode]);
 
   useEnhancedEffect(() => {
     document.body.dir = direction;
@@ -211,18 +211,18 @@ export function ThemeProvider(props) {
       {
         direction,
         nprogress: {
-          color: paletteType === 'light' ? '#000' : '#fff',
+          color: paletteMode === 'light' ? '#000' : '#fff',
         },
         palette: {
           primary: {
-            main: paletteType === 'light' ? blue[700] : blue[200],
+            main: paletteMode === 'light' ? blue[700] : blue[200],
           },
           secondary: {
-            main: paletteType === 'light' ? darken(pink.A400, 0.1) : pink[200],
+            main: paletteMode === 'light' ? darken(pink.A400, 0.1) : pink[200],
           },
-          type: paletteType,
+          mode: paletteMode,
           background: {
-            default: paletteType === 'light' ? '#fff' : '#121212',
+            default: paletteMode === 'light' ? '#fff' : '#121212',
           },
           ...paletteColors,
         },
@@ -233,13 +233,13 @@ export function ThemeProvider(props) {
     );
 
     nextTheme.palette.background.level2 =
-      paletteType === 'light' ? nextTheme.palette.grey[100] : '#333';
+      paletteMode === 'light' ? nextTheme.palette.grey[100] : '#333';
 
     nextTheme.palette.background.level1 =
-      paletteType === 'light' ? '#fff' : nextTheme.palette.grey[900];
+      paletteMode === 'light' ? '#fff' : nextTheme.palette.grey[900];
 
     return nextTheme;
-  }, [dense, direction, paletteColors, paletteType, spacing, userLanguage]);
+  }, [dense, direction, paletteColors, paletteMode, spacing, userLanguage]);
 
   React.useEffect(() => {
     // Expose the theme as a global variable so people can play with it.

--- a/docs/src/pages/components/autocomplete/CustomizedHook.js
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.js
@@ -16,8 +16,8 @@ const Label = styled('label')`
 const InputWrapper = styled('div')`
   ${({ theme }) => `
   width: 300px;
-  border: 1px solid ${theme.palette.type === 'dark' ? '#434343' : '#d9d9d9'};
-  background-color: ${theme.palette.type === 'dark' ? '#141414' : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? '#434343' : '#d9d9d9'};
+  background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
   border-radius: 4px;
   padding: 1px;
   display: flex;
@@ -33,8 +33,8 @@ const InputWrapper = styled('div')`
   }
 
   & input {
-    background-color: ${theme.palette.type === 'dark' ? '#141414' : '#fff'};
-    color: ${theme.palette.type === 'dark' ? '#fff' : '#000'};
+    background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
+    color: ${theme.palette.mode === 'dark' ? '#fff' : '#000'};
     font-size: 14px;
     height: 30px;
     box-sizing: border-box;
@@ -62,9 +62,9 @@ const Tag = styled(({ label, onDelete, ...props }) => (
   margin: 2px;
   line-height: 22px;
   background-color: ${
-    theme.palette.type === 'dark' ? 'rgba(255,255,255,0.08)' : '#fafafa'
+    theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : '#fafafa'
   };
-  border: 1px solid ${theme.palette.type === 'dark' ? '#303030' : '#e8e8e8'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? '#303030' : '#e8e8e8'};
   border-radius: 2px;
   box-sizing: content-box;
   padding: 0 4px 0 10px;
@@ -97,7 +97,7 @@ const Listbox = styled('ul')`
   padding: 0;
   position: absolute;
   list-style: none;
-  background-color: ${theme.palette.type === 'dark' ? '#141414' : '#fff'};
+  background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
   overflow: auto;
   max-height: 250px;
   border-radius: 4px;
@@ -118,7 +118,7 @@ const Listbox = styled('ul')`
   }
 
   & li[aria-selected='true'] {
-    background-color: ${theme.palette.type === 'dark' ? '#2b2b2b' : '#fafafa'};
+    background-color: ${theme.palette.mode === 'dark' ? '#2b2b2b' : '#fafafa'};
     font-weight: 600;
 
     & svg {
@@ -127,7 +127,7 @@ const Listbox = styled('ul')`
   }
 
   & li[data-focus='true'] {
-    background-color: ${theme.palette.type === 'dark' ? '#003b57' : '#e6f7ff'};
+    background-color: ${theme.palette.mode === 'dark' ? '#003b57' : '#e6f7ff'};
     cursor: pointer;
 
     & svg {

--- a/docs/src/pages/components/autocomplete/CustomizedHook.tsx
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.tsx
@@ -16,8 +16,8 @@ const Label = styled('label')`
 const InputWrapper = styled('div')`
   ${({ theme }) => `
   width: 300px;
-  border: 1px solid ${theme.palette.type === 'dark' ? '#434343' : '#d9d9d9'};
-  background-color: ${theme.palette.type === 'dark' ? '#141414' : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? '#434343' : '#d9d9d9'};
+  background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
   border-radius: 4px;
   padding: 1px;
   display: flex;
@@ -33,8 +33,8 @@ const InputWrapper = styled('div')`
   }
 
   & input {
-    background-color: ${theme.palette.type === 'dark' ? '#141414' : '#fff'};
-    color: ${theme.palette.type === 'dark' ? '#fff' : '#000'};
+    background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
+    color: ${theme.palette.mode === 'dark' ? '#fff' : '#000'};
     font-size: 14px;
     height: 30px;
     box-sizing: border-box;
@@ -62,9 +62,9 @@ const Tag = styled(({ label, onDelete, ...props }) => (
   margin: 2px;
   line-height: 22px;
   background-color: ${
-    theme.palette.type === 'dark' ? 'rgba(255,255,255,0.08)' : '#fafafa'
+    theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : '#fafafa'
   };
-  border: 1px solid ${theme.palette.type === 'dark' ? '#303030' : '#e8e8e8'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? '#303030' : '#e8e8e8'};
   border-radius: 2px;
   box-sizing: content-box;
   padding: 0 4px 0 10px;
@@ -97,7 +97,7 @@ const Listbox = styled('ul')`
   padding: 0;
   position: absolute;
   list-style: none;
-  background-color: ${theme.palette.type === 'dark' ? '#141414' : '#fff'};
+  background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
   overflow: auto;
   max-height: 250px;
   border-radius: 4px;
@@ -118,7 +118,7 @@ const Listbox = styled('ul')`
   }
 
   & li[aria-selected='true'] {
-    background-color: ${theme.palette.type === 'dark' ? '#2b2b2b' : '#fafafa'};
+    background-color: ${theme.palette.mode === 'dark' ? '#2b2b2b' : '#fafafa'};
     font-weight: 600;
 
     & svg {
@@ -127,7 +127,7 @@ const Listbox = styled('ul')`
   }
 
   & li[data-focus='true'] {
-    background-color: ${theme.palette.type === 'dark' ? '#003b57' : '#e6f7ff'};
+    background-color: ${theme.palette.mode === 'dark' ? '#003b57' : '#e6f7ff'};
     cursor: pointer;
 
     & svg {

--- a/docs/src/pages/components/progress/CustomizedProgressBars.js
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.js
@@ -10,7 +10,7 @@ const BorderLinearProgress = withStyles((theme) => ({
   },
   colorPrimary: {
     backgroundColor:
-      theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
+      theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
   },
   bar: {
     borderRadius: 5,
@@ -24,7 +24,7 @@ const useStylesFacebook = makeStyles((theme) => ({
     position: 'relative',
   },
   bottom: {
-    color: theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
+    color: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
   },
   top: {
     color: '#1a90ff',

--- a/docs/src/pages/components/progress/CustomizedProgressBars.tsx
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.tsx
@@ -18,7 +18,7 @@ const BorderLinearProgress = withStyles((theme: Theme) =>
     },
     colorPrimary: {
       backgroundColor:
-        theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
+        theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
     },
     bar: {
       borderRadius: 5,
@@ -34,7 +34,7 @@ const useStylesFacebook = makeStyles((theme: Theme) =>
       position: 'relative',
     },
     bottom: {
-      color: theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
+      color: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
     },
     top: {
       color: '#1a90ff',

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -191,7 +191,7 @@ const useToolbarStyles = makeStyles((theme) => ({
     paddingRight: theme.spacing(1),
   },
   highlight:
-    theme.palette.type === 'light'
+    theme.palette.mode === 'light'
       ? {
           color: theme.palette.secondary.main,
           backgroundColor: lighten(theme.palette.secondary.light, 0.85),

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -233,7 +233,7 @@ const useToolbarStyles = makeStyles((theme: Theme) =>
       paddingRight: theme.spacing(1),
     },
     highlight:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? {
             color: theme.palette.secondary.main,
             backgroundColor: lighten(theme.palette.secondary.light, 0.85),

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -299,7 +299,7 @@ function DefaultTheme(props) {
 
   const data = React.useMemo(() => {
     return createMuiTheme({
-      palette: { type: darkTheme ? 'dark' : 'light' },
+      palette: { mode: darkTheme ? 'dark' : 'light' },
     });
   }, [darkTheme]);
 

--- a/docs/src/pages/customization/palette/DarkTheme.js
+++ b/docs/src/pages/customization/palette/DarkTheme.js
@@ -102,7 +102,7 @@ const lightTheme = createMuiTheme();
 const darkTheme = createMuiTheme({
   palette: {
     // Switching the dark mode on is a single property value change.
-    type: 'dark',
+    mode: 'dark',
   },
 });
 

--- a/docs/src/pages/getting-started/templates/dashboard/Dashboard.js
+++ b/docs/src/pages/getting-started/templates/dashboard/Dashboard.js
@@ -99,7 +99,7 @@ const useStyles = makeStyles((theme) => ({
   appBarSpacer: theme.mixins.toolbar,
   content: {
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[100]
         : theme.palette.grey[900],
     flexGrow: 1,

--- a/docs/src/pages/getting-started/templates/dashboard/Dashboard.tsx
+++ b/docs/src/pages/getting-started/templates/dashboard/Dashboard.tsx
@@ -99,7 +99,7 @@ const useStyles = makeStyles((theme) => ({
   appBarSpacer: theme.mixins.toolbar,
   content: {
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[100]
         : theme.palette.grey[900],
     flexGrow: 1,

--- a/docs/src/pages/getting-started/templates/pricing/Pricing.js
+++ b/docs/src/pages/getting-started/templates/pricing/Pricing.js
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme) => ({
   },
   cardHeader: {
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[200]
         : theme.palette.grey[700],
   },

--- a/docs/src/pages/getting-started/templates/pricing/Pricing.tsx
+++ b/docs/src/pages/getting-started/templates/pricing/Pricing.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme) => ({
   },
   cardHeader: {
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[200]
         : theme.palette.grey[700],
   },

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundImage: 'url(https://source.unsplash.com/random)',
     backgroundRepeat: 'no-repeat',
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[50]
         : theme.palette.grey[900],
     backgroundSize: 'cover',

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.tsx
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundImage: 'url(https://source.unsplash.com/random)',
     backgroundRepeat: 'no-repeat',
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[50]
         : theme.palette.grey[900],
     backgroundSize: 'cover',

--- a/docs/src/pages/getting-started/templates/sticky-footer/StickyFooter.js
+++ b/docs/src/pages/getting-started/templates/sticky-footer/StickyFooter.js
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(3, 2),
     marginTop: 'auto',
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[200]
         : theme.palette.grey[800],
   },

--- a/docs/src/pages/getting-started/templates/sticky-footer/StickyFooter.tsx
+++ b/docs/src/pages/getting-started/templates/sticky-footer/StickyFooter.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(3, 2),
     marginTop: 'auto',
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? theme.palette.grey[200]
         : theme.palette.grey[800],
   },

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -126,6 +126,15 @@ import { createMuiTheme } from '@material-ui/core/styles';
 
 - The components' definition inside the theme were restructure under the `components` key, to allow people easier discoverability about the definitions regarding one component.
 
+- The `theme.palette.type` was renamed to `theme.palette.mode`, to better follow the "dark mode" term that is usually used for describes this feature.
+
+```diff
+import { createMuiTheme } from '@material-ui/core/styles';
+
+-const theme = createMuitheme({palette: { type: 'dark' }}),
++const theme = createMuitheme({palette: { mode: 'dark' }}),
+```
+
 1. `props`
 
 ```diff

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -126,7 +126,7 @@ import { createMuiTheme } from '@material-ui/core/styles';
 
 - The components' definition inside the theme were restructure under the `components` key, to allow people easier discoverability about the definitions regarding one component.
 
-- The `theme.palette.type` was renamed to `theme.palette.mode`, to better follow the "dark mode" term that is usually used for describes this feature.
+- The `theme.palette.type` was renamed to `theme.palette.mode`, to better follow the "dark mode" term that is usually used for describing this feature.
 
 ```diff
 import { createMuiTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/landing/Themes.js
+++ b/docs/src/pages/landing/Themes.js
@@ -59,7 +59,7 @@ export default function Themes() {
               <img
                 className={classes.img}
                 alt={t('themesButton')}
-                src={`/static/images/themes-${theme.palette.type}.jpg`}
+                src={`/static/images/themes-${theme.palette.mode}.jpg`}
                 loading="eager"
                 width={500}
                 height={307}

--- a/framer/Material-UI.framerfx/code/ThemeProvider.tsx
+++ b/framer/Material-UI.framerfx/code/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import { parseColor } from './utils';
 
 interface Props {
   children?: React.ReactNode;
-  paletteType: 'dark' | 'light';
+  paletteMode: 'dark' | 'light';
   primary: string;
   secondary: string;
   error: string;
@@ -18,7 +18,7 @@ export function Theme(props: Props): JSX.Element {
   const {
     children,
     error,
-    paletteType,
+    paletteMode,
     primary,
     secondary,
     info,
@@ -29,7 +29,7 @@ export function Theme(props: Props): JSX.Element {
 
   const theme = createMuiTheme({
     palette: {
-      type: paletteType,
+      mode: paletteMode,
       primary: { main: parseColor(primary) },
       secondary: { main: parseColor(secondary) },
       error: { main: parseColor(error) },
@@ -47,7 +47,7 @@ export function Theme(props: Props): JSX.Element {
 }
 
 Theme.defaultProps = {
-  paletteType: 'light' as const,
+  paletteMode: 'light' as const,
   primary: '#3f51b5',
   secondary: '#f50057',
   error: '#f44336',
@@ -57,7 +57,7 @@ Theme.defaultProps = {
 };
 
 addPropertyControls(Theme, {
-  paletteType: {
+  paletteMode: {
     type: ControlType.Enum,
     title: 'Palette type',
     options: ['dark', 'light'],

--- a/framer/Material-UI.framerfx/design/document.json
+++ b/framer/Material-UI.framerfx/design/document.json
@@ -3779,7 +3779,7 @@
           ],
           "error" : "#f44336",
           "info" : "#2196f3",
-          "paletteType" : "light",
+          "paletteMode" : "light",
           "primary" : "#3577CB",
           "secondary" : "#CA2B51",
           "success" : "#4caf4f",

--- a/framer/scripts/additionalProps.js
+++ b/framer/scripts/additionalProps.js
@@ -200,9 +200,9 @@ const additionalProps = (component) => {
       type: { name: 'string' },
       defaultValue: { value: componentSettings[component].propValues.message },
     },
-    paletteType: {
-      type: { name: 'enum', value: [{ value: "'dark'" }, { value: "'light'" }] },
-      description: 'Theme palette type',
+    paletteMode: {
+      mode: { name: 'enum', value: [{ value: "'dark'" }, { value: "'light'" }] },
+      description: 'Theme palette mode',
       defaultValue: { value: "'light'" },
     },
     primaryAction: {

--- a/packages/material-ui-lab/src/Alert/Alert.js
+++ b/packages/material-ui-lab/src/Alert/Alert.js
@@ -13,8 +13,8 @@ import InfoOutlinedIcon from '../internal/svg-icons/InfoOutlined';
 import CloseIcon from '../internal/svg-icons/Close';
 
 export const styles = (theme) => {
-  const getColor = theme.palette.type === 'light' ? darken : lighten;
-  const getBackgroundColor = theme.palette.type === 'light' ? lighten : darken;
+  const getColor = theme.palette.mode === 'light' ? darken : lighten;
+  const getBackgroundColor = theme.palette.mode === 'light' ? lighten : darken;
 
   return {
     /* Styles applied to the root element. */

--- a/packages/material-ui-lab/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui-lab/src/PaginationItem/PaginationItem.js
@@ -127,7 +127,7 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `variant="outlined"`. */
   outlined: {
     border: `1px solid ${
-      theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+      theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
     }`,
     '&$selected': {
       '&$disabled': {

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -20,7 +20,7 @@ export const styles = (theme) => {
       // Create a "on paper" color with sufficient contrast retaining the color
       backgroundColor: fade(
         theme.palette.text.primary,
-        theme.palette.type === 'light' ? 0.11 : 0.13,
+        theme.palette.mode === 'light' ? 0.11 : 0.13,
       ),
       height: '1.2em',
     },

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -7,7 +7,7 @@ import Paper from '../Paper';
 
 export const styles = (theme) => {
   const backgroundColorDefault =
-    theme.palette.type === 'light' ? theme.palette.grey[100] : theme.palette.grey[900];
+    theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[900];
 
   return {
     /* Styles applied to the root element. */

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -26,7 +26,7 @@ export const styles = (theme) => ({
   colorDefault: {
     color: theme.palette.background.default,
     backgroundColor:
-      theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
+      theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
   },
   /* Styles applied to the root element if `variant="circular"`. */
   circular: {},

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -66,7 +66,7 @@ export const styles = (theme) => ({
   outlined: {
     padding: '5px 15px',
     border: `1px solid ${
-      theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+      theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
     }`,
     '&$disabled': {
       border: `1px solid ${theme.palette.action.disabledBackground}`,

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -72,7 +72,7 @@ export const styles = (theme) => ({
   groupedTextHorizontal: {
     '&:not(:last-child)': {
       borderRight: `1px solid ${
-        theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+        theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
       }`,
     },
   },
@@ -80,7 +80,7 @@ export const styles = (theme) => ({
   groupedTextVertical: {
     '&:not(:last-child)': {
       borderBottom: `1px solid ${
-        theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+        theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
       }`,
     },
   },

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -12,7 +12,7 @@ import ButtonBase from '../ButtonBase';
 
 export const styles = (theme) => {
   const backgroundColor =
-    theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[700];
+    theme.palette.mode === 'light' ? theme.palette.grey[300] : theme.palette.grey[700];
   const deleteIconColor = fade(theme.palette.text.primary, 0.26);
 
   return {
@@ -47,7 +47,7 @@ export const styles = (theme) => {
         marginRight: -6,
         width: 24,
         height: 24,
-        color: theme.palette.type === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
+        color: theme.palette.mode === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
         fontSize: theme.typography.pxToRem(12),
       },
       '& $avatarColorPrimary': {
@@ -128,7 +128,7 @@ export const styles = (theme) => {
     outlined: {
       backgroundColor: 'transparent',
       border: `1px solid ${
-        theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+        theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
       }`,
       '&$focusVisible, $clickable&:hover': {
         backgroundColor: fade(theme.palette.text.primary, theme.palette.action.hoverOpacity),
@@ -181,7 +181,7 @@ export const styles = (theme) => {
     avatarColorSecondary: {},
     /* Styles applied to the `icon` element. */
     icon: {
-      color: theme.palette.type === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
+      color: theme.palette.mode === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
       marginLeft: 5,
       marginRight: -6,
     },

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -6,7 +6,7 @@ import InputBase from '../InputBase';
 import withStyles from '../styles/withStyles';
 
 export const styles = (theme) => {
-  const light = theme.palette.type === 'light';
+  const light = theme.palette.mode === 'light';
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
   const backgroundColor = light ? 'rgba(0, 0, 0, 0.09)' : 'rgba(255, 255, 255, 0.09)';
 
@@ -119,9 +119,9 @@ export const styles = (theme) => {
     input: {
       padding: '25px 12px 8px',
       '&:-webkit-autofill': {
-        WebkitBoxShadow: theme.palette.type === 'light' ? null : '0 0 0 100px #266798 inset',
-        WebkitTextFillColor: theme.palette.type === 'light' ? null : '#fff',
-        caretColor: theme.palette.type === 'light' ? null : '#fff',
+        WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
+        WebkitTextFillColor: theme.palette.mode === 'light' ? null : '#fff',
+        caretColor: theme.palette.mode === 'light' ? null : '#fff',
         borderTopLeftRadius: 'inherit',
         borderTopRightRadius: 'inherit',
       },

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -6,7 +6,7 @@ import InputBase from '../InputBase';
 import withStyles from '../styles/withStyles';
 
 export const styles = (theme) => {
-  const light = theme.palette.type === 'light';
+  const light = theme.palette.mode === 'light';
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
 
   return {

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -14,7 +14,7 @@ import TextareaAutosize from '../TextareaAutosize';
 import { isFilled } from './utils';
 
 export const styles = (theme) => {
-  const light = theme.palette.type === 'light';
+  const light = theme.palette.mode === 'light';
   const placeholder = {
     color: 'currentColor',
     opacity: light ? 0.42 : 0.5,

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -10,7 +10,7 @@ const TRANSITION_DURATION = 4; // seconds
 
 export const styles = (theme) => {
   const getColor = (color) =>
-    theme.palette.type === 'light' ? lighten(color, 0.62) : darken(color, 0.5);
+    theme.palette.mode === 'light' ? lighten(color, 0.62) : darken(color, 0.5);
 
   const backgroundPrimary = getColor(theme.palette.primary.main);
   const backgroundSecondary = getColor(theme.palette.secondary.main);

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -23,7 +23,7 @@ export const styles = (theme) => ({
     '&:focus': {
       // Show that it's not an text input
       backgroundColor:
-        theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.05)' : 'rgba(255, 255, 255, 0.05)',
+        theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.05)' : 'rgba(255, 255, 255, 0.05)',
       borderRadius: 0, // Reset Chrome style
     },
     // Remove IE 11 arrow

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 
 export const styles = (theme) => {
   const borderColor =
-    theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+    theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
 
   return {
     /* Styles applied to the root element. */
@@ -73,9 +73,9 @@ export const styles = (theme) => {
     input: {
       padding: '16.5px 14px',
       '&:-webkit-autofill': {
-        WebkitBoxShadow: theme.palette.type === 'light' ? null : '0 0 0 100px #266798 inset',
-        WebkitTextFillColor: theme.palette.type === 'light' ? null : '#fff',
-        caretColor: theme.palette.type === 'light' ? null : '#fff',
+        WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
+        WebkitTextFillColor: theme.palette.mode === 'light' ? null : '#fff',
+        caretColor: theme.palette.mode === 'light' ? null : '#fff',
         borderRadius: 'inherit',
       },
     },

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -237,7 +237,7 @@ export const styles = (theme) => ({
     '& $track': {
       backgroundColor:
         // Same logic as the LinearProgress track color
-        theme.palette.type === 'light'
+        theme.palette.mode === 'light'
           ? lighten(theme.palette.primary.main, 0.62)
           : darken(theme.palette.primary.main, 0.5),
     },

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -6,7 +6,7 @@ import Paper from '../Paper';
 import { emphasize } from '../styles/colorManipulator';
 
 export const styles = (theme) => {
-  const emphasis = theme.palette.type === 'light' ? 0.8 : 0.98;
+  const emphasis = theme.palette.mode === 'light' ? 0.8 : 0.98;
   const backgroundColor = emphasize(theme.palette.background.default, emphasis);
 
   return {

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -32,7 +32,7 @@ export const styles = (theme) => ({
   /* Styles applied to the line element. */
   line: {
     display: 'block',
-    borderColor: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
+    borderColor: theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
   },
   /* Styles applied to the root element if `orientation="horizontal"`. */
   lineHorizontal: {

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -13,7 +13,7 @@ export const styles = (theme) => ({
     paddingLeft: 8 + 12, // margin + half icon
     paddingRight: 8,
     borderLeft: `1px solid ${
-      theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600]
+      theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600]
     }`,
   },
   /* Styles applied to the root element if `last={true}` (controlled by `Step`). */

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -40,7 +40,7 @@ export const styles = (theme) => ({
     top: 0,
     left: 0,
     zIndex: 1, // Render above the focus ripple.
-    color: theme.palette.type === 'light' ? theme.palette.grey[50] : theme.palette.grey[400],
+    color: theme.palette.mode === 'light' ? theme.palette.grey[50] : theme.palette.grey[400],
     transition: theme.transitions.create(['left', 'transform'], {
       duration: theme.transitions.duration.shortest,
     }),
@@ -48,13 +48,13 @@ export const styles = (theme) => ({
       transform: 'translateX(20px)',
     },
     '&$disabled': {
-      color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
+      color: theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
     },
     '&$checked + $track': {
       opacity: 0.5,
     },
     '&$disabled + $track': {
-      opacity: theme.palette.type === 'light' ? 0.12 : 0.1,
+      opacity: theme.palette.mode === 'light' ? 0.12 : 0.1,
     },
   },
   /* Styles applied to the internal SwitchBase component's root element if `color="primary"`. */
@@ -69,14 +69,14 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
+      color: theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
     },
     '&$checked + $track': {
       backgroundColor: theme.palette.primary.main,
     },
     '&$disabled + $track': {
       backgroundColor:
-        theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
+        theme.palette.mode === 'light' ? theme.palette.common.black : theme.palette.common.white,
     },
   },
   /* Styles applied to the internal SwitchBase component's root element if `color="secondary"`. */
@@ -91,14 +91,14 @@ export const styles = (theme) => ({
       },
     },
     '&$disabled': {
-      color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
+      color: theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
     },
     '&$checked + $track': {
       backgroundColor: theme.palette.secondary.main,
     },
     '&$disabled + $track': {
       backgroundColor:
-        theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
+        theme.palette.mode === 'light' ? theme.palette.common.black : theme.palette.common.white,
     },
   },
   /* Styles applied to the root element if `size="small"`. */
@@ -144,8 +144,8 @@ export const styles = (theme) => ({
       duration: theme.transitions.duration.shortest,
     }),
     backgroundColor:
-      theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
-    opacity: theme.palette.type === 'light' ? 0.38 : 0.3,
+      theme.palette.mode === 'light' ? theme.palette.common.black : theme.palette.common.white,
+    opacity: theme.palette.mode === 'light' ? 0.38 : 0.3,
   },
 });
 

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -17,7 +17,7 @@ export const styles = (theme) => ({
     // Removes the alpha (sets it to 1), and lightens or darkens the theme color.
     borderBottom: `1px solid
     ${
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? lighten(fade(theme.palette.divider, 1), 0.88)
         : darken(fade(theme.palette.divider, 1), 0.68)
     }`,

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -47,7 +47,7 @@ export type InternalStandardProps<C, Removals extends keyof C = never> = Omit<
     style?: React.CSSProperties;
   };
 
-export type PaletteType = 'light' | 'dark';
+export type PaletteMode = 'light' | 'dark';
 export interface Color {
   50: string;
   100: string;

--- a/packages/material-ui/src/styles/adaptV4Theme.js
+++ b/packages/material-ui/src/styles/adaptV4Theme.js
@@ -79,7 +79,10 @@ export default function adaptV4Theme(inputTheme) {
   // theme.palette.text.hint
   theme.palette = {
     text: {
-      hint: (palette.mode === 'dark' || palette.type === 'dark') ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.38)',
+      hint:
+        palette.mode === 'dark' || palette.type === 'dark'
+          ? 'rgba(255, 255, 255, 0.5)'
+          : 'rgba(0, 0, 0, 0.38)',
     },
     ...(paletteMode && {
       mode: paletteMode,

--- a/packages/material-ui/src/styles/adaptV4Theme.js
+++ b/packages/material-ui/src/styles/adaptV4Theme.js
@@ -74,12 +74,17 @@ export default function adaptV4Theme(inputTheme) {
     ...mixins,
   };
 
+  const { type: paletteMode, ...paletteRest } = palette;
+
   // theme.palette.text.hint
   theme.palette = {
     text: {
-      hint: palette.type === 'dark' ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.38)',
+      hint: (palette.mode === 'dark' || palette.type === 'dark') ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.38)',
     },
-    ...palette,
+    ...(paletteMode && {
+      mode: paletteMode,
+    }),
+    ...paletteRest,
   };
 
   return theme;

--- a/packages/material-ui/src/styles/adaptV4Theme.js
+++ b/packages/material-ui/src/styles/adaptV4Theme.js
@@ -74,7 +74,7 @@ export default function adaptV4Theme(inputTheme) {
     ...mixins,
   };
 
-  const { type: paletteMode, ...paletteRest } = palette;
+  const { type: mode, ...paletteRest } = palette;
 
   // theme.palette.text.hint
   theme.palette = {
@@ -84,9 +84,7 @@ export default function adaptV4Theme(inputTheme) {
           ? 'rgba(255, 255, 255, 0.5)'
           : 'rgba(0, 0, 0, 0.38)',
     },
-    ...(paletteMode && {
-      mode: paletteMode,
-    }),
+    mode,
     ...paletteRest,
   };
 

--- a/packages/material-ui/src/styles/adaptV4Theme.test.js
+++ b/packages/material-ui/src/styles/adaptV4Theme.test.js
@@ -304,7 +304,7 @@ describe('adaptV4Theme', () => {
 
   describe('theme.palette.mode', () => {
     it('converts theme.palette.type to theme.palette.mode', () => {
-      const theme = { palette: { type: 'dark'}};
+      const theme = { palette: { type: 'dark' } };
 
       let transformedTheme;
 
@@ -314,7 +314,7 @@ describe('adaptV4Theme', () => {
 
       expect(transformedTheme.palette.mode).to.equal('dark');
     });
-  })
+  });
 
   describe('theme.spacing', () => {
     it('does not add units to returned value for a single argument', () => {

--- a/packages/material-ui/src/styles/adaptV4Theme.test.js
+++ b/packages/material-ui/src/styles/adaptV4Theme.test.js
@@ -277,7 +277,7 @@ describe('adaptV4Theme', () => {
       expect(transformedTheme.palette.text.hint).to.equal('rgba(0, 0, 0, 0.38)');
     });
 
-    it('is added to a dark theme', () => {
+    it('is added to a dark theme using the old palette.type value', () => {
       const theme = { palette: { type: 'dark' } };
 
       let transformedTheme;
@@ -288,7 +288,33 @@ describe('adaptV4Theme', () => {
 
       expect(transformedTheme.palette.text.hint).to.equal('rgba(255, 255, 255, 0.5)');
     });
+
+    it('is added to a dark theme', () => {
+      const theme = { palette: { mode: 'dark' } };
+
+      let transformedTheme;
+
+      expect(() => {
+        transformedTheme = adaptV4Theme(theme);
+      }).toWarnDev(['adaptV4Theme() is deprecated']);
+
+      expect(transformedTheme.palette.text.hint).to.equal('rgba(255, 255, 255, 0.5)');
+    });
   });
+
+  describe('theme.palette.mode', () => {
+    it('converts theme.palette.type to theme.palette.mode', () => {
+      const theme = { palette: { type: 'dark'}};
+
+      let transformedTheme;
+
+      expect(() => {
+        transformedTheme = adaptV4Theme(theme);
+      }).toWarnDev(['adaptV4Theme() is deprecated']);
+
+      expect(transformedTheme.palette.mode).to.equal('dark');
+    });
+  })
 
   describe('theme.spacing', () => {
     it('does not add units to returned value for a single argument', () => {

--- a/packages/material-ui/src/styles/createPalette.d.ts
+++ b/packages/material-ui/src/styles/createPalette.d.ts
@@ -1,4 +1,4 @@
-import { Color, PaletteType } from '..';
+import { Color, PaletteMode } from '..';
 
 export {};
 // use standalone interface over typeof colors/commons
@@ -107,7 +107,7 @@ export interface PaletteOptions {
   warning?: PaletteColorOptions;
   info?: PaletteColorOptions;
   success?: PaletteColorOptions;
-  type?: PaletteType;
+  mode?: PaletteMode;
   tonalOffset?: PaletteTonalOffset;
   contrastThreshold?: number;
   common?: Partial<CommonColors>;

--- a/packages/material-ui/src/styles/createPalette.d.ts
+++ b/packages/material-ui/src/styles/createPalette.d.ts
@@ -72,7 +72,7 @@ export const dark: TypeObject;
 
 export interface Palette {
   common: CommonColors;
-  type: PaletteType;
+  mode: PaletteMode;
   contrastThreshold: number;
   tonalOffset: PaletteTonalOffset;
   primary: PaletteColor;

--- a/packages/material-ui/src/styles/createPalette.js
+++ b/packages/material-ui/src/styles/createPalette.js
@@ -123,7 +123,7 @@ export default function createPalette(palette) {
       main: green[500],
       dark: green[700],
     },
-    type = 'light',
+    mode = 'light',
     contrastThreshold = 3,
     tonalOffset = 0.2,
     ...other
@@ -193,11 +193,11 @@ export default function createPalette(palette) {
     return color;
   };
 
-  const types = { dark, light };
+  const modes = { dark, light };
 
   if (process.env.NODE_ENV !== 'production') {
-    if (!types[type]) {
-      console.error(`Material-UI: The palette type \`${type}\` is not supported.`);
+    if (!modes[mode]) {
+      console.error(`Material-UI: The palette mode \`${mode}\` is not supported.`);
     }
   }
 
@@ -205,8 +205,8 @@ export default function createPalette(palette) {
     {
       // A collection of common colors.
       common,
-      // The palette type, can be light or dark.
-      type,
+      // The palette mode, can be light or dark.
+      mode,
       // The colors used to represent primary interface elements for a user.
       primary: augmentColor(primary),
       // The colors used to represent secondary interface elements for a user.
@@ -232,8 +232,8 @@ export default function createPalette(palette) {
       // two indexes within its tonal palette.
       // E.g., shift from Red 500 to Red 300 or Red 700.
       tonalOffset,
-      // The light and dark type object.
-      ...types[type],
+      // The light and dark mode object.
+      ...modes[mode],
     },
     other,
   );

--- a/packages/material-ui/src/styles/createPalette.test.js
+++ b/packages/material-ui/src/styles/createPalette.test.js
@@ -84,7 +84,7 @@ describe('createPalette()', () => {
   });
 
   it('should create a dark palette', () => {
-    const palette = createPalette({ type: 'dark' });
+    const palette = createPalette({ mode: 'dark' });
     expect(palette.primary.main, 'should use indigo as the default primary color').to.equal(
       indigo[500],
     );
@@ -135,10 +135,10 @@ describe('createPalette()', () => {
   });
 
   describe('warnings', () => {
-    it('throws an exception when an invalid type is specified', () => {
+    it('throws an exception when an invalid mode is specified', () => {
       expect(() => {
-        createPalette({ type: 'foo' });
-      }).toErrorDev('Material-UI: The palette type `foo` is not supported');
+        createPalette({ mode: 'foo' });
+      }).toErrorDev('Material-UI: The palette mode `foo` is not supported');
     });
 
     it('throws an exception when a wrong color is provided', () => {

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -77,7 +77,7 @@ const AnotherStyledSFC = withStyles({
 // Overriding styles
 const theme = createMuiTheme({
   palette: {
-    type: 'dark',
+    mode: 'dark',
     primary: blue,
     contrastThreshold: 3,
     tonalOffset: 0.2,


### PR DESCRIPTION
Part of https://github.com/mui-org/material-ui/issues/20012

Renames `theme.palette.type` to `theme.palette.mode`, to better follow the "dark mode" term that is usually used for describing this feature.

```diff
import { createMuiTheme } from '@material-ui/core/styles';

-const theme = createMuitheme({palette: { type: 'dark' }}),
+const theme = createMuitheme({palette: { mode: 'dark' }}),
```

The changes are supported by the `adaptV4Theme` for easing the migration