### PR TITLE
[lab] Fix Autocomplete right padding with clear icon (WIP)

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -81,7 +81,7 @@ export const styles = (theme) => ({
       '$hasPopupIcon &, $hasClearIcon &': {
         paddingRight: 26 + 4 + 9,
       },
-      '$hasPopupIcon$hasClearIcon &': {
+      '$hasPopupIcon$hasClearIcon &:hover': {
         paddingRight: 52 + 4 + 9,
       },
       '& $input': {


### PR DESCRIPTION
The extended padding on the right needs to be present only when the Clear icon is visible, IMO. Otherwise, the overflowed text is being cut off more than is actually needed.

![2020-09-21 20 14 49](https://user-images.githubusercontent.com/197134/93798993-32009d00-fc47-11ea-8535-71412643384e.gif)


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
