### PR TITLE
[Tabs] Fix TabScrollButton using absolute path

### DIFF
--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.d.ts
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '@material-ui/core';
+import { InternalStandardProps as StandardProps } from '..';
 
 export interface TabScrollButtonProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**


### PR DESCRIPTION
I have MUI used as a peerDependency in a project and getting this error when trying to compile my library: 
```
ERROR in [at-loader] ./node_modules/@material-ui/core/TabScrollButton/TabScrollButton.d.ts:5:11 
    TS2709: Cannot use namespace 'StandardProps' as a type.
```
As far as I understand when StandardProps is excluded from "outside" module for compiler it looks like a namespace with a value in it and it cannot expand it and use. Replacing it with a local reference (like the rest of the modules do) fixes this problem.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
- [X] `yarn typescript` passes