### PR TITLE
[docs] Add live demo with DataGrid

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -111,6 +111,7 @@ module.exports = {
                     {
                       alias: {
                         '@material-ui/core': '../packages/material-ui/src',
+                        '@material-ui/utils': '../packages/material-ui-utils/src',
                       },
                       transformFunctions: ['require'],
                     },

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -67,9 +67,11 @@ module.exports = {
 
       config.externals = [
         (context, request, callback) => {
-          const hasDependencyOnRepoPackages = ['notistack', '@material-ui/pickers'].includes(
-            request,
-          );
+          const hasDependencyOnRepoPackages = [
+            'notistack',
+            '@material-ui/pickers',
+            '@material-ui/data-grid',
+          ].includes(request);
 
           if (hasDependencyOnRepoPackages) {
             return callback(null);
@@ -96,7 +98,7 @@ module.exports = {
           // transpile 3rd party packages with dependencies in this repository
           {
             test: /\.(js|mjs|jsx)$/,
-            include: /node_modules(\/|\\)(notistack|@material-ui(\/|\\)pickers)/,
+            include: /node_modules(\/|\\)(notistack|@material-ui(\/|\\)(pickers|data-grid))/,
             use: {
               loader: 'babel-loader',
               options: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@material-ui/core": "^4.1.2",
-    "@material-ui/data-grid": "https://pkg.csb.dev/mui-org/material-ui-x/commit/b5d0f060/@material-ui/data-grid",
+    "@material-ui/data-grid": "https://pkg.csb.dev/mui-org/material-ui-x/commit/6024274e/@material-ui/data-grid",
     "@material-ui/docs": "^4.0.0-beta.0",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/lab": "^4.0.0-alpha.18",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@material-ui/core": "^4.1.2",
-    "@material-ui/data-grid": "https://pkg.csb.dev/mui-org/material-ui-x/commit/6024274e/@material-ui/data-grid",
+    "@material-ui/data-grid": "^4.0.0-alpha.6",
     "@material-ui/docs": "^4.0.0-beta.0",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/lab": "^4.0.0-alpha.18",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@material-ui/core": "^4.1.2",
+    "@material-ui/data-grid": "https://pkg.csb.dev/mui-org/material-ui-x/commit/b5d0f060/@material-ui/data-grid",
     "@material-ui/docs": "^4.0.0-beta.0",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/lab": "^4.0.0-alpha.18",

--- a/docs/src/pages/components/progress/CircularIntegration.js
+++ b/docs/src/pages/components/progress/CircularIntegration.js
@@ -60,7 +60,7 @@ export default function CircularIntegration() {
     if (!loading) {
       setSuccess(false);
       setLoading(true);
-      timer.current = setTimeout(() => {
+      timer.current = window.setTimeout(() => {
         setSuccess(true);
         setLoading(false);
       }, 2000);

--- a/docs/src/pages/components/progress/CircularIntegration.tsx
+++ b/docs/src/pages/components/progress/CircularIntegration.tsx
@@ -62,7 +62,7 @@ export default function CircularIntegration() {
     if (!loading) {
       setSuccess(false);
       setLoading(true);
-      timer.current = setTimeout(() => {
+      timer.current = window.setTimeout(() => {
         setSuccess(true);
         setLoading(false);
       }, 2000);

--- a/docs/src/pages/components/progress/DelayingAppearance.js
+++ b/docs/src/pages/components/progress/DelayingAppearance.js
@@ -45,7 +45,7 @@ export default function DelayingAppearance() {
     }
 
     setQuery('progress');
-    timerRef.current = setTimeout(() => {
+    timerRef.current = window.setTimeout(() => {
       setQuery('success');
     }, 2000);
   };

--- a/docs/src/pages/components/progress/DelayingAppearance.tsx
+++ b/docs/src/pages/components/progress/DelayingAppearance.tsx
@@ -47,7 +47,7 @@ export default function DelayingAppearance() {
     }
 
     setQuery('progress');
-    timerRef.current = setTimeout(() => {
+    timerRef.current = window.setTimeout(() => {
       setQuery('success');
     }, 2000);
   };

--- a/docs/src/pages/components/tables/DataTable.js
+++ b/docs/src/pages/components/tables/DataTable.js
@@ -34,7 +34,7 @@ const rows = [
   { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
 ];
 
-export default function DataGridDemo() {
+export default function DataTable() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid rows={rows} columns={columns} pageSize={5} checkboxSelection />

--- a/docs/src/pages/components/tables/DataTable.js
+++ b/docs/src/pages/components/tables/DataTable.js
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+
+const columns = [
+  { field: 'id', headerName: 'ID', width: 70 },
+  { field: 'firstName', headerName: 'First name', width: 130 },
+  { field: 'lastName', headerName: 'Last name', width: 130 },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    width: 90,
+  },
+  {
+    field: 'fullName',
+    headerName: 'Full name',
+    description: 'This column has a value getter and is not sortable.',
+    sortable: false,
+    width: 160,
+    valueGetter: (params) =>
+      `${params.getValue('firstName') || ''} ${params.getValue('lastName') || ''}`,
+  },
+];
+
+const rows = [
+  { id: 1, lastName: 'Snow', firstName: 'Jon', age: 35 },
+  { id: 2, lastName: 'Lannister', firstName: 'Cersei', age: 42 },
+  { id: 3, lastName: 'Lannister', firstName: 'Jaime', age: 45 },
+  { id: 4, lastName: 'Stark', firstName: 'Arya', age: 16 },
+  { id: 5, lastName: 'Targaryen', firstName: 'Daenerys', age: null },
+  { id: 6, lastName: 'Melisandre', firstName: null, age: 150 },
+  { id: 7, lastName: 'Clifford', firstName: 'Ferrara', age: 44 },
+  { id: 8, lastName: 'Frances', firstName: 'Rossini', age: 36 },
+  { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
+];
+
+export default function DataGridDemo() {
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid rows={rows} columns={columns} pageSize={5} checkboxSelection />
+    </div>
+  );
+}

--- a/docs/src/pages/components/tables/DataTable.tsx
+++ b/docs/src/pages/components/tables/DataTable.tsx
@@ -34,7 +34,7 @@ const rows = [
   { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
 ];
 
-export default function DataGridDemo() {
+export default function DataTable() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid rows={rows} columns={columns} pageSize={5} checkboxSelection />

--- a/docs/src/pages/components/tables/DataTable.tsx
+++ b/docs/src/pages/components/tables/DataTable.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { DataGrid, ColDef, ValueGetterParams } from '@material-ui/data-grid';
+
+const columns: ColDef[] = [
+  { field: 'id', headerName: 'ID', width: 70 },
+  { field: 'firstName', headerName: 'First name', width: 130 },
+  { field: 'lastName', headerName: 'Last name', width: 130 },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    width: 90,
+  },
+  {
+    field: 'fullName',
+    headerName: 'Full name',
+    description: 'This column has a value getter and is not sortable.',
+    sortable: false,
+    width: 160,
+    valueGetter: (params: ValueGetterParams) =>
+      `${params.getValue('firstName') || ''} ${params.getValue('lastName') || ''}`,
+  },
+];
+
+const rows = [
+  { id: 1, lastName: 'Snow', firstName: 'Jon', age: 35 },
+  { id: 2, lastName: 'Lannister', firstName: 'Cersei', age: 42 },
+  { id: 3, lastName: 'Lannister', firstName: 'Jaime', age: 45 },
+  { id: 4, lastName: 'Stark', firstName: 'Arya', age: 16 },
+  { id: 5, lastName: 'Targaryen', firstName: 'Daenerys', age: null },
+  { id: 6, lastName: 'Melisandre', firstName: null, age: 150 },
+  { id: 7, lastName: 'Clifford', firstName: 'Ferrara', age: 44 },
+  { id: 8, lastName: 'Frances', firstName: 'Rossini', age: 36 },
+  { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
+];
+
+export default function DataGridDemo() {
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid rows={rows} columns={columns} pageSize={5} checkboxSelection />
+    </div>
+  );
+}

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -45,6 +45,8 @@ This constraint makes building rich data tables challenging.
 The [`DataGrid` component](/components/data-grid/) is designed for use-cases that are focused around handling a large amounts of tabular data.
 While it comes with a more rigid structure, in exchange, you gain more powerful features.
 
+{{"demo": "pages/components/tables/DataTable.js", "bg": "inline"}}
+
 ## Customized tables
 
 Here is an example of customizing the component. You can learn more about this in the

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,9 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@material-ui/data-grid@https://pkg.csb.dev/mui-org/material-ui-x/commit/b5d0f060/@material-ui/data-grid":
+"@material-ui/data-grid@https://pkg.csb.dev/mui-org/material-ui-x/commit/6024274e/@material-ui/data-grid":
   version "4.0.0-alpha.2"
-  resolved "https://pkg.csb.dev/mui-org/material-ui-x/commit/b5d0f060/@material-ui/data-grid#8fccd204c10b283c42b50a0ca9329ea21fb84d43"
+  resolved "https://pkg.csb.dev/mui-org/material-ui-x/commit/6024274e/@material-ui/data-grid#91acdbf02dd386839f63a9d2d443863b9959a9a6"
   dependencies:
     prop-types "^15.7.2"
     tslib "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,6 +2074,13 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@material-ui/data-grid@https://pkg.csb.dev/mui-org/material-ui-x/commit/b5d0f060/@material-ui/data-grid":
+  version "4.0.0-alpha.2"
+  resolved "https://pkg.csb.dev/mui-org/material-ui-x/commit/b5d0f060/@material-ui/data-grid#8fccd204c10b283c42b50a0ca9329ea21fb84d43"
+  dependencies:
+    prop-types "^15.7.2"
+    tslib "^2.0.0"
+
 "@material-ui/pickers@^3.2.5":
   version "3.2.10"
   resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.2.10.tgz#19df024895876eb0ec7cd239bbaea595f703f0ae"
@@ -16380,6 +16387,11 @@ tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tslint@5.14.0:
   version "5.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,10 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@material-ui/data-grid@https://pkg.csb.dev/mui-org/material-ui-x/commit/6024274e/@material-ui/data-grid":
-  version "4.0.0-alpha.2"
-  resolved "https://pkg.csb.dev/mui-org/material-ui-x/commit/6024274e/@material-ui/data-grid#91acdbf02dd386839f63a9d2d443863b9959a9a6"
+"@material-ui/data-grid@^4.0.0-alpha.6":
+  version "4.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@material-ui/data-grid/-/data-grid-4.0.0-alpha.6.tgz#78e14791777e1aa12b9b4b84d82d8e5ff437beb3"
+  integrity sha512-XFUdIK+It5PY3ivO4u0hDUxQNC4ASTuQHZlVe9K3RFEjZRNt70W29WoL36IvJ1o/bN208uUuQvzY9tn3J0P8lQ==
   dependencies:
     prop-types "^15.7.2"
     tslib "^2.0.0"


### PR DESCRIPTION
The new demo: https://deploy-preview-22697--material-ui.netlify.app/components/tables/#data-table.

Made to help with https://github.com/mui-org/material-ui-x/pull/339 works.
Here, we used the package published on codesandbox-ci. cc @dtassone.