### PR TITLE
[docs] Fix iOS font-size in certain code blocks

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -40,6 +40,7 @@ const styles = (theme) => ({
       borderRadius: 2,
     },
     '& code[class*="language-"]': {
+      display: 'block', // Fixes iOS code font-size issues
       backgroundColor: '#272c34',
       color: '#fff',
       // Avoid layout jump after hydration (style injected by prism)


### PR DESCRIPTION
In wide code blocks, iOS would alter the font-sizes. This pr fixes that bug.

Alternatively, theres a good argument to have language code blocks (not inline-code) as `display: block` when rendering from markdown. Tried finding any use cases of language code blocks being rendered as inline and did not find any. So this bug was lying dormant, as wide `display:inline-block` would end up behaving as a `display:block` either way.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
