### PR TITLE
[docs] Remove prop-types from demos

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,11 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 7,
   },
-  plugins: ['eslint-plugin-material-ui', 'eslint-plugin-react-hooks', '@typescript-eslint/eslint-plugin'],
+  plugins: [
+    'eslint-plugin-material-ui',
+    'eslint-plugin-react-hooks',
+    '@typescript-eslint/eslint-plugin',
+  ],
   settings: {
     'import/resolver': {
       webpack: {
@@ -199,7 +203,7 @@ module.exports = {
       },
     },
     {
-      files: ['docs/pages/**/*.js'],
+      files: ['docs/pages/**/*.js', 'docs/src/pages/**/*.js'],
       rules: {
         'react/prop-types': 'off',
       },

--- a/docs/src/pages/components/app-bar/BackToTop.js
+++ b/docs/src/pages/components/app-bar/BackToTop.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -53,15 +52,6 @@ function ScrollTop(props) {
     </Zoom>
   );
 }
-
-ScrollTop.propTypes = {
-  children: PropTypes.element.isRequired,
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  window: PropTypes.func,
-};
 
 export default function BackToTop(props) {
   return (

--- a/docs/src/pages/components/app-bar/ElevateAppBar.js
+++ b/docs/src/pages/components/app-bar/ElevateAppBar.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -23,15 +22,6 @@ function ElevationScroll(props) {
     elevation: trigger ? 4 : 0,
   });
 }
-
-ElevationScroll.propTypes = {
-  children: PropTypes.element.isRequired,
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  window: PropTypes.func,
-};
 
 export default function ElevateAppBar(props) {
   return (

--- a/docs/src/pages/components/app-bar/HideAppBar.js
+++ b/docs/src/pages/components/app-bar/HideAppBar.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -24,15 +23,6 @@ function HideOnScroll(props) {
     </Slide>
   );
 }
-
-HideOnScroll.propTypes = {
-  children: PropTypes.element.isRequired,
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  window: PropTypes.func,
-};
 
 export default function HideAppBar(props) {
   return (

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -89,10 +88,6 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(
     </div>
   );
 });
-
-ListboxComponent.propTypes = {
-  children: PropTypes.node,
-};
 
 function random(length) {
   const characters =

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-nested-ternary */
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import Link from '@material-ui/core/Link';
@@ -35,11 +34,6 @@ function ListItemLink(props) {
     </li>
   );
 }
-
-ListItemLink.propTypes = {
-  open: PropTypes.bool,
-  to: PropTypes.string.isRequired,
-};
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import List from '@material-ui/core/List';
@@ -97,12 +96,6 @@ function ConfirmationDialogRaw(props) {
     </Dialog>
   );
 }
-
-ConfirmationDialogRaw.propTypes = {
-  onClose: PropTypes.func.isRequired,
-  open: PropTypes.bool.isRequired,
-  value: PropTypes.string.isRequired,
-};
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/docs/src/pages/components/dialogs/SimpleDialog.js
+++ b/docs/src/pages/components/dialogs/SimpleDialog.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Avatar from '@material-ui/core/Avatar';
@@ -73,12 +72,6 @@ function SimpleDialog(props) {
     </Dialog>
   );
 }
-
-SimpleDialog.propTypes = {
-  onClose: PropTypes.func.isRequired,
-  open: PropTypes.bool.isRequired,
-  selectedValue: PropTypes.string.isRequired,
-};
 
 export default function SimpleDialogDemo() {
   const [open, setOpen] = React.useState(false);

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Divider from '@material-ui/core/Divider';
@@ -52,7 +51,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function ResponsiveDrawer(props) {
+export default function ResponsiveDrawer(props) {
   const { window } = props;
   const classes = useStyles();
   const theme = useTheme();
@@ -178,13 +177,3 @@ function ResponsiveDrawer(props) {
     </div>
   );
 }
-
-ResponsiveDrawer.propTypes = {
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  window: PropTypes.func,
-};
-
-export default ResponsiveDrawer;

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.js
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import SwipeableViews from 'react-swipeable-views';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
@@ -31,12 +30,6 @@ function TabPanel(props) {
     </Typography>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 function a11yProps(index) {
   return {

--- a/docs/src/pages/components/hidden/BreakpointDown.js
+++ b/docs/src/pages/components/hidden/BreakpointDown.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Hidden from '@material-ui/core/Hidden';
@@ -50,9 +49,5 @@ function BreakpointDown(props) {
     </div>
   );
 }
-
-BreakpointDown.propTypes = {
-  width: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']).isRequired,
-};
 
 export default withWidth()(BreakpointDown);

--- a/docs/src/pages/components/hidden/BreakpointOnly.js
+++ b/docs/src/pages/components/hidden/BreakpointOnly.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Hidden from '@material-ui/core/Hidden';
@@ -44,9 +43,5 @@ function BreakpointOnly(props) {
     </div>
   );
 }
-
-BreakpointOnly.propTypes = {
-  width: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']).isRequired,
-};
 
 export default withWidth()(BreakpointOnly);

--- a/docs/src/pages/components/hidden/BreakpointUp.js
+++ b/docs/src/pages/components/hidden/BreakpointUp.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Hidden from '@material-ui/core/Hidden';
@@ -50,9 +49,5 @@ function BreakpointUp(props) {
     </div>
   );
 }
-
-BreakpointUp.propTypes = {
-  width: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']).isRequired,
-};
 
 export default withWidth()(BreakpointUp);

--- a/docs/src/pages/components/hidden/GridIntegration.js
+++ b/docs/src/pages/components/hidden/GridIntegration.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
@@ -57,9 +56,5 @@ function GridIntegration(props) {
     </div>
   );
 }
-
-GridIntegration.propTypes = {
-  width: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']).isRequired,
-};
 
 export default withWidth()(GridIntegration);

--- a/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.js
+++ b/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons/faEllipsisV';
 import { faInfo } from '@fortawesome/free-solid-svg-icons/faInfo';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -34,10 +33,6 @@ const FontAwesomeSvgIcon = React.forwardRef((props, ref) => {
     </SvgIcon>
   );
 });
-
-FontAwesomeSvgIcon.propTypes = {
-  icon: PropTypes.any.isRequired,
-};
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/docs/src/pages/components/modal/SpringModal.js
+++ b/docs/src/pages/components/modal/SpringModal.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 import Backdrop from '@material-ui/core/Backdrop';
@@ -42,13 +41,6 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     </animated.div>
   );
 });
-
-Fade.propTypes = {
-  children: PropTypes.element,
-  in: PropTypes.bool.isRequired,
-  onEnter: PropTypes.func,
-  onExited: PropTypes.func,
-};
 
 export default function SpringModal() {
   const classes = useStyles();

--- a/docs/src/pages/components/popper/SpringPopper.js
+++ b/docs/src/pages/components/popper/SpringPopper.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Popper from '@material-ui/core/Popper';
 import { useSpring, animated } from 'react-spring/web.cjs'; // web.cjs is required for IE 11 support
@@ -35,13 +34,6 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     </animated.div>
   );
 });
-
-Fade.propTypes = {
-  children: PropTypes.element,
-  in: PropTypes.bool,
-  onEnter: PropTypes.func,
-  onExited: PropTypes.func,
-};
 
 export default function SpringPopper() {
   const classes = useStyles();

--- a/docs/src/pages/components/progress/CircularWithValueLabel.js
+++ b/docs/src/pages/components/progress/CircularWithValueLabel.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
@@ -25,15 +24,6 @@ function CircularProgressWithLabel(props) {
     </Box>
   );
 }
-
-CircularProgressWithLabel.propTypes = {
-  /**
-   * The value of the progress indicator for the determinate variant.
-   * Value between 0 and 100.
-   * @default 0
-   */
-  value: PropTypes.number.isRequired,
-};
 
 export default function CircularStatic() {
   const [progress, setProgress] = React.useState(10);

--- a/docs/src/pages/components/progress/LinearWithValueLabel.js
+++ b/docs/src/pages/components/progress/LinearWithValueLabel.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import Typography from '@material-ui/core/Typography';
@@ -19,14 +18,6 @@ function LinearProgressWithLabel(props) {
     </Box>
   );
 }
-
-LinearProgressWithLabel.propTypes = {
-  /**
-   * The value of the progress indicator for the determinate and buffer variants.
-   * Value between 0 and 100.
-   */
-  value: PropTypes.number.isRequired,
-};
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/components/radio-buttons/UseRadioGroup.js
+++ b/docs/src/pages/components/radio-buttons/UseRadioGroup.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import RadioGroup, { useRadioGroup } from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -30,13 +29,6 @@ function MyFormControlLabel(props) {
     />
   );
 }
-
-MyFormControlLabel.propTypes = {
-  /**
-   * The value of the component.
-   */
-  value: PropTypes.any,
-};
 
 export default function UseRadioGroup() {
   return (

--- a/docs/src/pages/components/rating/CustomizedRatings.js
+++ b/docs/src/pages/components/rating/CustomizedRatings.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Rating from '@material-ui/lab/Rating';
 import FavoriteIcon from '@material-ui/icons/Favorite';
@@ -48,10 +47,6 @@ function IconContainer(props) {
   const { value, ...other } = props;
   return <span {...other}>{customIcons[value].icon}</span>;
 }
-
-IconContainer.propTypes = {
-  value: PropTypes.number.isRequired,
-};
 
 export default function CustomizedRatings() {
   return (

--- a/docs/src/pages/components/skeleton/Facebook.js
+++ b/docs/src/pages/components/skeleton/Facebook.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
@@ -105,10 +104,6 @@ function Media(props) {
     </Card>
   );
 }
-
-Media.propTypes = {
-  loading: PropTypes.bool,
-};
 
 export default function Facebook() {
   return (

--- a/docs/src/pages/components/skeleton/SkeletonChildren.js
+++ b/docs/src/pages/components/skeleton/SkeletonChildren.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Avatar from '@material-ui/core/Avatar';
@@ -53,10 +52,6 @@ function SkeletonChildrenDemo(props) {
     </div>
   );
 }
-
-SkeletonChildrenDemo.propTypes = {
-  loading: PropTypes.bool,
-};
 
 export default function SkeletonChildren() {
   return (

--- a/docs/src/pages/components/skeleton/SkeletonTypography.js
+++ b/docs/src/pages/components/skeleton/SkeletonTypography.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Skeleton from '@material-ui/lab/Skeleton';
 import Grid from '@material-ui/core/Grid';
@@ -19,10 +18,6 @@ function TypographyDemo(props) {
     </div>
   );
 }
-
-TypographyDemo.propTypes = {
-  loading: PropTypes.bool,
-};
 
 export default function SkeletonTypography() {
   return (

--- a/docs/src/pages/components/skeleton/YouTube.js
+++ b/docs/src/pages/components/skeleton/YouTube.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
@@ -76,10 +75,6 @@ function Media(props) {
     </Grid>
   );
 }
-
-Media.propTypes = {
-  loading: PropTypes.bool,
-};
 
 export default function YouTube() {
   return (

--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles, makeStyles } from '@material-ui/core/styles';
 import Slider from '@material-ui/core/Slider';
 import Typography from '@material-ui/core/Typography';
@@ -23,12 +22,6 @@ function ValueLabelComponent(props) {
     </Tooltip>
   );
 }
-
-ValueLabelComponent.propTypes = {
-  children: PropTypes.element.isRequired,
-  open: PropTypes.bool.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 const iOSBoxShadow =
   '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1px rgba(0,0,0,0.02)';

--- a/docs/src/pages/components/steppers/CustomizedSteppers.js
+++ b/docs/src/pages/components/steppers/CustomizedSteppers.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import Stepper from '@material-ui/core/Stepper';
@@ -85,19 +84,6 @@ function QontoStepIcon(props) {
   );
 }
 
-QontoStepIcon.propTypes = {
-  /**
-   * Whether this step is active.
-   * @default false
-   */
-  active: PropTypes.bool,
-  /**
-   * Mark the step as completed. Is passed to child components.
-   * @default false
-   */
-  completed: PropTypes.bool,
-};
-
 const ColorlibConnector = withStyles({
   alternativeLabel: {
     top: 22,
@@ -166,23 +152,6 @@ function ColorlibStepIcon(props) {
     </div>
   );
 }
-
-ColorlibStepIcon.propTypes = {
-  /**
-   * Whether this step is active.
-   * @default false
-   */
-  active: PropTypes.bool,
-  /**
-   * Mark the step as completed. Is passed to child components.
-   * @default false
-   */
-  completed: PropTypes.bool,
-  /**
-   * The label displayed in the step icon.
-   */
-  icon: PropTypes.node,
-};
 
 const steps = [
   'Select campaign settings',

--- a/docs/src/pages/components/tables/CollapsibleTable.js
+++ b/docs/src/pages/components/tables/CollapsibleTable.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Collapse from '@material-ui/core/Collapse';
@@ -109,24 +108,6 @@ function Row(props) {
     </React.Fragment>
   );
 }
-
-Row.propTypes = {
-  row: PropTypes.shape({
-    calories: PropTypes.number.isRequired,
-    carbs: PropTypes.number.isRequired,
-    fat: PropTypes.number.isRequired,
-    history: PropTypes.arrayOf(
-      PropTypes.shape({
-        amount: PropTypes.number.isRequired,
-        customerId: PropTypes.string.isRequired,
-        date: PropTypes.string.isRequired,
-      }),
-    ).isRequired,
-    name: PropTypes.string.isRequired,
-    price: PropTypes.number.isRequired,
-    protein: PropTypes.number.isRequired,
-  }).isRequired,
-};
 
 const rows = [
   createData('Frozen yoghurt', 159, 6.0, 24, 4.0, 3.99),

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.js
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -84,13 +83,6 @@ function TablePaginationActions(props) {
     </div>
   );
 }
-
-TablePaginationActions.propTypes = {
-  count: PropTypes.number.isRequired,
-  onChangePage: PropTypes.func.isRequired,
-  page: PropTypes.number.isRequired,
-  rowsPerPage: PropTypes.number.isRequired,
-};
 
 function createData(name, calories, fat) {
   return { name, calories, fat };

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { lighten, makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
@@ -175,16 +174,6 @@ function EnhancedTableHead(props) {
   );
 }
 
-EnhancedTableHead.propTypes = {
-  classes: PropTypes.object.isRequired,
-  numSelected: PropTypes.number.isRequired,
-  onRequestSort: PropTypes.func.isRequired,
-  onSelectAllClick: PropTypes.func.isRequired,
-  order: PropTypes.oneOf(['asc', 'desc']).isRequired,
-  orderBy: PropTypes.string.isRequired,
-  rowCount: PropTypes.number.isRequired,
-};
-
 const useToolbarStyles = makeStyles((theme) => ({
   root: {
     paddingLeft: theme.spacing(2),
@@ -250,10 +239,6 @@ const EnhancedTableToolbar = (props) => {
       )}
     </Toolbar>
   );
-};
-
-EnhancedTableToolbar.propTypes = {
-  numSelected: PropTypes.number.isRequired,
 };
 
 export default function EnhancedTable() {

--- a/docs/src/pages/components/tables/ReactVirtualizedTable.js
+++ b/docs/src/pages/components/tables/ReactVirtualizedTable.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import TableCell from '@material-ui/core/TableCell';
@@ -137,21 +136,6 @@ class MuiVirtualizedTable extends React.PureComponent {
     );
   }
 }
-
-MuiVirtualizedTable.propTypes = {
-  classes: PropTypes.object.isRequired,
-  columns: PropTypes.arrayOf(
-    PropTypes.shape({
-      dataKey: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-      numeric: PropTypes.bool,
-      width: PropTypes.number.isRequired,
-    }),
-  ).isRequired,
-  headerHeight: PropTypes.number,
-  onRowClick: PropTypes.func,
-  rowHeight: PropTypes.number,
-};
 
 const VirtualizedTable = withStyles(styles)(MuiVirtualizedTable);
 

--- a/docs/src/pages/components/tabs/AccessibleTabs.js
+++ b/docs/src/pages/components/tabs/AccessibleTabs.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
@@ -27,12 +26,6 @@ function TabPanel(props) {
   );
 }
 
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
-
 function DemoTabs(props) {
   const { labelId, onChange, selectionFollowsFocus, value } = props;
 
@@ -55,13 +48,6 @@ function DemoTabs(props) {
     </AppBar>
   );
 }
-
-DemoTabs.propTypes = {
-  labelId: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  selectionFollowsFocus: PropTypes.bool,
-  value: PropTypes.number.isRequired,
-};
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/components/tabs/BasicTabs.js
+++ b/docs/src/pages/components/tabs/BasicTabs.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
@@ -26,12 +25,6 @@ function TabPanel(props) {
     </div>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 function a11yProps(index) {
   return {

--- a/docs/src/pages/components/tabs/FullWidthTabs.js
+++ b/docs/src/pages/components/tabs/FullWidthTabs.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import SwipeableViews from 'react-swipeable-views';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
@@ -27,12 +26,6 @@ function TabPanel(props) {
     </div>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 function a11yProps(index) {
   return {

--- a/docs/src/pages/components/tabs/NavTabs.js
+++ b/docs/src/pages/components/tabs/NavTabs.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
@@ -26,12 +25,6 @@ function TabPanel(props) {
     </div>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 function a11yProps(index) {
   return {

--- a/docs/src/pages/components/tabs/TabsWrappedLabel.js
+++ b/docs/src/pages/components/tabs/TabsWrappedLabel.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
@@ -26,12 +25,6 @@ function TabPanel(props) {
     </div>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-};
 
 function a11yProps(index) {
   return {

--- a/docs/src/pages/components/tabs/VerticalTabs.js
+++ b/docs/src/pages/components/tabs/VerticalTabs.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -25,12 +24,6 @@ function TabPanel(props) {
     </div>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 function a11yProps(index) {
   return {

--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import MaskedInput from 'react-text-mask';
 import NumberFormat from 'react-number-format';
 import { makeStyles } from '@material-ui/core/styles';
@@ -47,10 +46,6 @@ function TextMaskCustom(props) {
   );
 }
 
-TextMaskCustom.propTypes = {
-  inputRef: PropTypes.func.isRequired,
-};
-
 function NumberFormatCustom(props) {
   const { inputRef, onChange, ...other } = props;
 
@@ -72,12 +67,6 @@ function NumberFormatCustom(props) {
     />
   );
 }
-
-NumberFormatCustom.propTypes = {
-  inputRef: PropTypes.func.isRequired,
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
 
 export default function FormattedInputs() {
   const classes = useStyles();

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.js
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import SvgIcon from '@material-ui/core/SvgIcon';
 import { fade, makeStyles, withStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
@@ -57,13 +56,6 @@ function TransitionComponent(props) {
     </animated.div>
   );
 }
-
-TransitionComponent.propTypes = {
-  /**
-   * Show the component; triggers the enter or exit states
-   */
-  in: PropTypes.bool,
-};
 
 const StyledTreeItem = withStyles((theme) => ({
   iconContainer: {

--- a/docs/src/pages/components/tree-view/GmailTreeView.js
+++ b/docs/src/pages/components/tree-view/GmailTreeView.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
@@ -103,14 +102,6 @@ function StyledTreeItem(props) {
     />
   );
 }
-
-StyledTreeItem.propTypes = {
-  bgColor: PropTypes.string,
-  color: PropTypes.string,
-  labelIcon: PropTypes.elementType.isRequired,
-  labelInfo: PropTypes.string,
-  labelText: PropTypes.string.isRequired,
-};
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/css-in-js/basics/AdaptingHook.js
+++ b/docs/src/pages/css-in-js/basics/AdaptingHook.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
@@ -27,10 +26,6 @@ function MyButton(props) {
   const classes = useStyles(props);
   return <Button className={classes.root} {...other} />;
 }
-
-MyButton.propTypes = {
-  color: PropTypes.oneOf(['blue', 'red']).isRequired,
-};
 
 export default function AdaptingHook() {
   return (

--- a/docs/src/pages/customization/breakpoints/WithWidth.js
+++ b/docs/src/pages/customization/breakpoints/WithWidth.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import withWidth from '@material-ui/core/withWidth';
 import Typography from '@material-ui/core/Typography';
 
@@ -19,9 +18,5 @@ function WithWidth(props) {
     </Typography>
   );
 }
-
-WithWidth.propTypes = {
-  width: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']).isRequired,
-};
 
 export default withWidth()(WithWidth);

--- a/docs/src/pages/customization/components/ClassNames.js
+++ b/docs/src/pages/customization/components/ClassNames.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
@@ -26,11 +25,5 @@ function ClassNames(props) {
     </Button>
   );
 }
-
-ClassNames.propTypes = {
-  children: PropTypes.node,
-  classes: PropTypes.object.isRequired,
-  className: PropTypes.string,
-};
 
 export default withStyles(styles)(ClassNames);

--- a/docs/src/pages/getting-started/templates/blog/FeaturedPost.js
+++ b/docs/src/pages/getting-started/templates/blog/FeaturedPost.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
@@ -21,7 +20,7 @@ const useStyles = makeStyles({
   },
 });
 
-function FeaturedPost(props) {
+export default function FeaturedPost(props) {
   const classes = useStyles();
   const { post } = props;
 
@@ -57,15 +56,3 @@ function FeaturedPost(props) {
     </Grid>
   );
 }
-
-FeaturedPost.propTypes = {
-  post: PropTypes.shape({
-    date: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired,
-    image: PropTypes.string.isRequired,
-    imageText: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-  }).isRequired,
-};
-
-export default FeaturedPost;

--- a/docs/src/pages/getting-started/templates/blog/Footer.js
+++ b/docs/src/pages/getting-started/templates/blog/Footer.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
@@ -26,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function Footer(props) {
+export default function Footer(props) {
   const classes = useStyles();
   const { description, title } = props;
 
@@ -49,10 +48,3 @@ function Footer(props) {
     </footer>
   );
 }
-
-Footer.propTypes = {
-  description: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-};
-
-export default Footer;

--- a/docs/src/pages/getting-started/templates/blog/Header.js
+++ b/docs/src/pages/getting-started/templates/blog/Header.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import Button from '@material-ui/core/Button';
@@ -25,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function Header(props) {
+export default function Header(props) {
   const classes = useStyles();
   const { sections, title } = props;
 
@@ -71,15 +70,3 @@ function Header(props) {
     </React.Fragment>
   );
 }
-
-Header.propTypes = {
-  sections: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
-  title: PropTypes.string.isRequired,
-};
-
-export default Header;

--- a/docs/src/pages/getting-started/templates/blog/Main.js
+++ b/docs/src/pages/getting-started/templates/blog/Main.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
@@ -13,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function Main(props) {
+export default function Main(props) {
   const classes = useStyles();
   const { posts, title } = props;
 
@@ -31,10 +30,3 @@ function Main(props) {
     </Grid>
   );
 }
-
-Main.propTypes = {
-  posts: PropTypes.arrayOf(PropTypes.string).isRequired,
-  title: PropTypes.string.isRequired,
-};
-
-export default Main;

--- a/docs/src/pages/getting-started/templates/blog/MainFeaturedPost.js
+++ b/docs/src/pages/getting-started/templates/blog/MainFeaturedPost.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
@@ -35,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function MainFeaturedPost(props) {
+export default function MainFeaturedPost(props) {
   const classes = useStyles();
   const { post } = props;
 
@@ -77,15 +76,3 @@ function MainFeaturedPost(props) {
     </Paper>
   );
 }
-
-MainFeaturedPost.propTypes = {
-  post: PropTypes.shape({
-    description: PropTypes.string.isRequired,
-    image: PropTypes.string.isRequired,
-    imageText: PropTypes.string.isRequired,
-    linkText: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-  }).isRequired,
-};
-
-export default MainFeaturedPost;

--- a/docs/src/pages/getting-started/templates/blog/Sidebar.js
+++ b/docs/src/pages/getting-started/templates/blog/Sidebar.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
@@ -16,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function Sidebar(props) {
+export default function Sidebar(props) {
   const classes = useStyles();
   const { archives, description, social, title } = props;
 
@@ -58,22 +57,3 @@ function Sidebar(props) {
     </Grid>
   );
 }
-
-Sidebar.propTypes = {
-  archives: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
-  description: PropTypes.string.isRequired,
-  social: PropTypes.arrayOf(
-    PropTypes.shape({
-      icon: PropTypes.elementType.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
-  title: PropTypes.string.isRequired,
-};
-
-export default Sidebar;

--- a/docs/src/pages/getting-started/templates/dashboard/Title.js
+++ b/docs/src/pages/getting-started/templates/dashboard/Title.js
@@ -1,17 +1,10 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
-function Title(props) {
+export default function Title(props) {
   return (
     <Typography component="h2" variant="h6" color="primary" gutterBottom>
       {props.children}
     </Typography>
   );
 }
-
-Title.propTypes = {
-  children: PropTypes.node,
-};
-
-export default Title;

--- a/docs/src/pages/guides/composition/ListRouter.js
+++ b/docs/src/pages/guides/composition/ListRouter.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -33,12 +32,6 @@ function ListItemLink(props) {
     </li>
   );
 }
-
-ListItemLink.propTypes = {
-  icon: PropTypes.element,
-  primary: PropTypes.string.isRequired,
-  to: PropTypes.string.isRequired,
-};
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Paper.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Paper.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import MuiPaper from '@material-ui/core/Paper';
 import { withStyles } from '@material-ui/core/styles';
@@ -43,15 +42,5 @@ function Paper(props) {
     />
   );
 }
-
-Paper.propTypes = {
-  background: PropTypes.oneOf(['dark', 'light', 'main']).isRequired,
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object.isRequired,
-  className: PropTypes.string,
-  padding: PropTypes.bool,
-};
 
 export default withStyles(styles)(Paper);

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Snackbar.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Snackbar.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import MuiSnackbar from '@material-ui/core/Snackbar';
 import Slide from '@material-ui/core/Slide';
@@ -76,17 +75,5 @@ function Snackbar(props) {
     />
   );
 }
-
-Snackbar.propTypes = {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object.isRequired,
-  closeFunc: PropTypes.func,
-  /**
-   * The message to display.
-   */
-  message: PropTypes.node,
-};
 
 export default withStyles(styles)(Snackbar);

--- a/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import MuiTextField from '@material-ui/core/TextField';
@@ -116,29 +115,5 @@ function TextField(props) {
     />
   );
 }
-
-TextField.propTypes = {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object.isRequired,
-  /**
-   * Props applied to the [`InputLabel`](/api/input-label/) element.
-   */
-  InputLabelProps: PropTypes.object,
-  /**
-   * Props applied to the Input element.
-   * It will be a [`FilledInput`](/api/filled-input/),
-   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
-   * component depending on the `variant` prop value.
-   */
-  InputProps: PropTypes.object,
-  noBorder: PropTypes.bool,
-  /**
-   * Props applied to the [`Select`](/api/select/) element.
-   */
-  SelectProps: PropTypes.object,
-  size: PropTypes.oneOf(['large', 'medium', 'small', 'xlarge']),
-};
 
 export default withStyles(styles)(TextField);

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Typography.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Typography.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import MuiTypography from '@material-ui/core/Typography';
 
@@ -86,37 +85,5 @@ function Typography(props) {
     </MuiTypography>
   );
 }
-
-Typography.propTypes = {
-  /**
-   * The content of the component.
-   */
-  children: PropTypes.node,
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object.isRequired,
-  marked: PropTypes.oneOf(['center', 'left', 'none']),
-  /**
-   * Applies the theme typography styles.
-   * @default 'body1'
-   */
-  variant: PropTypes.oneOf([
-    'body1',
-    'body2',
-    'button',
-    'caption',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'inherit',
-    'overline',
-    'subtitle1',
-    'subtitle2',
-  ]),
-};
 
 export default withStyles(styles)(Typography);

--- a/docs/src/pages/premium-themes/onepirate/modules/form/FormButton.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/FormButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Button from '../components/Button';
 import defer from './defer';
@@ -15,14 +14,4 @@ function FormButton(props) {
     />
   );
 }
-
-FormButton.propTypes = {
-  /**
-   * If `true`, the button will be disabled.
-   * If `true`, the base button will be disabled.
-   */
-  disabled: PropTypes.bool,
-  mounted: PropTypes.bool,
-};
-
 export default defer(FormButton);

--- a/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '../components/Typography';
@@ -34,13 +33,5 @@ function FormFeedback(props) {
     </div>
   );
 }
-
-FormFeedback.propTypes = {
-  children: PropTypes.node,
-  classes: PropTypes.object.isRequired,
-  className: PropTypes.string,
-  error: PropTypes.bool,
-  success: PropTypes.bool,
-};
 
 export default withStyles(styles)(FormFeedback);

--- a/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import TextField from '../components/TextField';
 
@@ -27,52 +26,5 @@ function RFTextField(props) {
     />
   );
 }
-
-RFTextField.propTypes = {
-  /**
-   * This prop helps users to fill forms faster, especially on mobile devices.
-   * The name can be confusing, as it's more like an autofill.
-   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
-   */
-  autoComplete: PropTypes.string,
-  input: PropTypes.shape({
-    checked: PropTypes.bool,
-    multiple: PropTypes.bool,
-    name: PropTypes.string.isRequired,
-    onBlur: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
-    onFocus: PropTypes.func.isRequired,
-    type: PropTypes.string,
-    value: PropTypes.string.isRequired,
-  }).isRequired,
-  /**
-   * Props applied to the Input element.
-   * It will be a [`FilledInput`](/api/filled-input/),
-   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
-   * component depending on the `variant` prop value.
-   */
-  InputProps: PropTypes.object,
-  meta: PropTypes.shape({
-    active: PropTypes.bool,
-    data: PropTypes.object,
-    dirty: PropTypes.bool,
-    dirtySinceLastSubmit: PropTypes.bool,
-    error: PropTypes.any,
-    initial: PropTypes.string,
-    invalid: PropTypes.bool,
-    length: PropTypes.number,
-    modified: PropTypes.bool,
-    modifiedSinceLastSubmit: PropTypes.bool,
-    pristine: PropTypes.bool,
-    submitError: PropTypes.any,
-    submitFailed: PropTypes.bool,
-    submitSucceeded: PropTypes.bool,
-    submitting: PropTypes.bool,
-    touched: PropTypes.bool,
-    valid: PropTypes.bool,
-    validating: PropTypes.bool,
-    visited: PropTypes.bool,
-  }).isRequired,
-};
 
 export default RFTextField;

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppAppBar.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppAppBar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 
 import { withStyles } from '@material-ui/core/styles';
@@ -78,12 +77,5 @@ function AppAppBar(props) {
     </div>
   );
 }
-
-AppAppBar.propTypes = {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(AppAppBar);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppForm.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppForm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Container from '@material-ui/core/Container';
 import Box from '@material-ui/core/Box';
 import { withStyles } from '@material-ui/core/styles';
@@ -34,10 +33,5 @@ function AppForm(props) {
     </div>
   );
 }
-
-AppForm.propTypes = {
-  children: PropTypes.node,
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(AppForm);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Hidden from '@material-ui/core/Hidden';
@@ -118,9 +117,5 @@ function ProductCTA(props) {
     </Container>
   );
 }
-
-ProductCTA.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(ProductCTA);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCategories.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCategories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Container from '@material-ui/core/Container';
@@ -181,9 +180,5 @@ function ProductCategories(props) {
     </Container>
   );
 }
-
-ProductCategories.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(ProductCategories);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductHero.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductHero.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '../components/Button';
 import Typography from '../components/Typography';
@@ -67,9 +66,5 @@ function ProductHero(props) {
     </ProductHeroLayout>
   );
 }
-
-ProductHero.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(ProductHero);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductHeroLayout.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductHeroLayout.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
@@ -75,11 +74,5 @@ function ProductHeroLayout(props) {
     </section>
   );
 }
-
-ProductHeroLayout.propTypes = {
-  backgroundClassName: PropTypes.string.isRequired,
-  children: PropTypes.node,
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(ProductHeroLayout);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductHowItWorks.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductHowItWorks.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Container from '@material-ui/core/Container';
@@ -129,9 +128,4 @@ function ProductHowItWorks(props) {
     </section>
   );
 }
-
-ProductHowItWorks.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
 export default withStyles(styles)(ProductHowItWorks);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductSmokingHero.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductSmokingHero.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import Container from '@material-ui/core/Container';
 import { withStyles } from '@material-ui/core/styles';
@@ -49,9 +48,5 @@ function ProductSmokingHero(props) {
     </Container>
   );
 }
-
-ProductSmokingHero.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(ProductSmokingHero);

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductValues.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductValues.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Container from '@material-ui/core/Container';
@@ -110,9 +109,5 @@ function ProductValues(props) {
     </section>
   );
 }
-
-ProductValues.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(ProductValues);

--- a/docs/src/pages/premium-themes/paperbase/Content.js
+++ b/docs/src/pages/premium-themes/paperbase/Content.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -83,9 +82,5 @@ function Content(props) {
     </Paper>
   );
 }
-
-Content.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(Content);

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
@@ -129,10 +128,5 @@ function Header(props) {
     </React.Fragment>
   );
 }
-
-Header.propTypes = {
-  classes: PropTypes.object.isRequired,
-  onDrawerToggle: PropTypes.func.isRequired,
-};
 
 export default withStyles(styles)(Header);

--- a/docs/src/pages/premium-themes/paperbase/Navigator.js
+++ b/docs/src/pages/premium-themes/paperbase/Navigator.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import Divider from '@material-ui/core/Divider';
@@ -147,9 +146,5 @@ function Navigator(props) {
     </Drawer>
   );
 }
-
-Navigator.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(Navigator);

--- a/docs/src/pages/premium-themes/paperbase/Paperbase.js
+++ b/docs/src/pages/premium-themes/paperbase/Paperbase.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import {
   createMuiTheme,
   ThemeProvider,
@@ -224,9 +223,5 @@ function Paperbase(props) {
     </ThemeProvider>
   );
 }
-
-Paperbase.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(Paperbase);

--- a/docs/src/pages/styles/advanced/WithTheme.js
+++ b/docs/src/pages/styles/advanced/WithTheme.js
@@ -1,16 +1,9 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { ThemeProvider, withTheme } from '@material-ui/styles';
 
 function DeepChildRaw(props) {
   return <span>{`spacing ${props.theme.spacing}`}</span>;
 }
-
-DeepChildRaw.propTypes = {
-  theme: PropTypes.shape({
-    spacing: PropTypes.string.isRequired,
-  }).isRequired,
-};
 
 const DeepChild = withTheme(DeepChildRaw);
 

--- a/docs/src/pages/styles/basics/AdaptingHOC.js
+++ b/docs/src/pages/styles/basics/AdaptingHOC.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
@@ -26,11 +25,6 @@ function MyButtonRaw(props) {
   const { classes, color, ...other } = props;
   return <Button className={classes.root} {...other} />;
 }
-
-MyButtonRaw.propTypes = {
-  classes: PropTypes.object.isRequired,
-  color: PropTypes.oneOf(['blue', 'red']).isRequired,
-};
 
 const MyButton = withStyles(styles)(MyButtonRaw);
 

--- a/docs/src/pages/styles/basics/AdaptingHook.js
+++ b/docs/src/pages/styles/basics/AdaptingHook.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
@@ -27,10 +26,6 @@ function MyButton(props) {
   const classes = useStyles(props);
   return <Button className={classes.root} {...other} />;
 }
-
-MyButton.propTypes = {
-  color: PropTypes.oneOf(['blue', 'red']).isRequired,
-};
 
 export default function AdaptingHook() {
   return (

--- a/docs/src/pages/styles/basics/HigherOrderComponent.js
+++ b/docs/src/pages/styles/basics/HigherOrderComponent.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
@@ -19,9 +18,5 @@ function UnstyledComponent(props) {
   const { classes } = props;
   return <Button className={classes.root}>Styled with HOC API</Button>;
 }
-
-UnstyledComponent.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(UnstyledComponent);

--- a/docs/src/pages/styles/basics/StressTest.js
+++ b/docs/src/pages/styles/basics/StressTest.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { ThemeProvider, useTheme, makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
@@ -28,10 +27,6 @@ const Component = React.memo((props) => {
     </div>
   );
 });
-
-Component.propTypes = {
-  backgroundColor: PropTypes.string.isRequired,
-};
 
 export default function StressTest() {
   const [backgroundColor, setBackgroundColor] = React.useState('#2196f3');


### PR DESCRIPTION
With all of the demos available in TypeScript the prop-types don't provide us any value at the moment. prop-types are certainly helpful for runtime validation but the built-in types can all be solved with static analysis as far as I can tell

Their generation adds quite a bit of infra complexity. Seems like a good time to stop using them.

Curious to hear your thoughts.

Alternate to [`ed5ce00` (#22706)](https://github.com/mui-org/material-ui/pull/22706/commits/ed5ce00175482a33718e84acb3793eb0fc366f45) 