### PR TITLE
[docs] Remove wrong migration instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,15 +77,6 @@ Here are some highlights ✨:
   theme.spacing(2) => '16px'
   ```
 
-  You can restore the previous behavior with:
-
-  ```diff
-  -const theme = createMuiTheme();
-  +const theme = createMuiTheme({
-  +  spacing: x => x * 8,
-  +});
-  ```
-
 - [theme] Remove palette.text.hint key (#22537) @mbrookes
 
   The `theme.palette.text.hint` key was available but unused in Material-UI v4 components.

--- a/docs/src/pages/customization/spacing/spacing.md
+++ b/docs/src/pages/customization/spacing/spacing.md
@@ -7,7 +7,7 @@ Material-UI uses [a recommended 8px scaling factor](https://material.io/design/l
 ```js
 const theme = createMuiTheme();
 
-theme.spacing(2); // = 8 * 2
+theme.spacing(2); // = 8px * 2
 ```
 
 ## Custom spacing
@@ -21,7 +21,7 @@ const theme = createMuiTheme({
   spacing: 4,
 });
 
-theme.spacing(2); // = 4 * 2
+theme.spacing(2); // = 4px * 2
 ```
 
 - a function
@@ -41,7 +41,7 @@ const theme = createMuiTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 
-theme.spacing(2); // = 8
+theme.spacing(2); // = 8px
 ```
 
 ## Multiple arity

--- a/docs/src/pages/customization/spacing/spacing.md
+++ b/docs/src/pages/customization/spacing/spacing.md
@@ -21,7 +21,7 @@ const theme = createMuiTheme({
   spacing: 4,
 });
 
-theme.spacing(2); // = 4px * 2
+theme.spacing(2); // `${4 * 2}px` = '8px'
 ```
 
 - a function
@@ -41,7 +41,7 @@ const theme = createMuiTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 
-theme.spacing(2); // = 8px
+theme.spacing(2); // = '8px'
 ```
 
 ## Multiple arity

--- a/docs/src/pages/customization/spacing/spacing.md
+++ b/docs/src/pages/customization/spacing/spacing.md
@@ -7,7 +7,7 @@ Material-UI uses [a recommended 8px scaling factor](https://material.io/design/l
 ```js
 const theme = createMuiTheme();
 
-theme.spacing(2); // = 8px * 2
+theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
 
 ## Custom spacing

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -95,15 +95,6 @@ For a smoother transition, the `adaptV4Theme` helper allows you to iteratively u
   theme.spacing(2) => '16px'
   ```
 
-  You can restore the previous behavior with:
-
-  ```diff
-  -const theme = createMuiTheme();
-  +const theme = createMuiTheme({
-  +  spacing: x => x * 8,
-  +});
-  ```
-
 - The `theme.palette.text.hint` key was unused in Material-UI components, and has been removed.
 
 ```diff


### PR DESCRIPTION
A continuation of the discussion on https://github.com/mui-org/material-ui/commit/bc4582572e4126b58cde67a4f357089b33ac5b8d#r42461020. From what I understand, our best option is to no support the previous case. Happy to consider alternatives.