### PR TITLE
[Autocomplete] Fix accessibility issue with empty option set

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1338,6 +1338,22 @@ describe('<Autocomplete />', () => {
 
       expect(htmlOptions[0].innerHTML).to.equal('one');
     });
+
+    it('should display a no options message if no options are available', () => {
+      const { getByRole } = render(
+        <Autocomplete
+          {...defaultProps}
+          renderInput={(params) => <TextField autoFocus {...params} />}
+        />,
+      );
+
+      const combobox = getByRole('combobox');
+      const textbox = getByRole('textbox');
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+      expect(combobox).to.not.have.attribute('aria-owns');
+      expect(textbox).to.not.have.attribute('aria-controls');
+      expect(document.querySelector(`.${classes.paper}`)).to.have.text('No options');
+    });
   });
 
   describe('enter', () => {

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -206,6 +206,8 @@ export default function useAutocomplete(props) {
       )
     : [];
 
+  const listboxAvailable = open && filteredOptions.length > 0;
+
   if (process.env.NODE_ENV !== 'production') {
     if (value !== null && !freeSolo && options.length > 0) {
       const missingValue = (multiple ? value : [value]).filter(
@@ -932,9 +934,9 @@ export default function useAutocomplete(props) {
 
   return {
     getRootProps: (other = {}) => ({
-      'aria-owns': popupOpen ? `${id}-popup` : null,
+      'aria-owns': listboxAvailable ? `${id}-listbox` : null,
       role: 'combobox',
-      'aria-expanded': popupOpen,
+      'aria-expanded': listboxAvailable,
       ...other,
       onKeyDown: handleKeyDown(other),
       onMouseDown: handleMouseDown,
@@ -955,7 +957,7 @@ export default function useAutocomplete(props) {
       // only have an opinion about this when closed
       'aria-activedescendant': popupOpen ? '' : null,
       'aria-autocomplete': autoComplete ? 'both' : 'list',
-      'aria-controls': popupOpen ? `${id}-popup` : null,
+      'aria-controls': listboxAvailable ? `${id}-listbox` : null,
       // Disable browser's suggestion that might overlap with the popup.
       // Handle autocomplete but not autofill.
       autoComplete: 'off',
@@ -979,7 +981,7 @@ export default function useAutocomplete(props) {
     }),
     getListboxProps: () => ({
       role: 'listbox',
-      id: `${id}-popup`,
+      id: `${id}-listbox`,
       'aria-labelledby': `${id}-label`,
       ref: handleListboxRef,
       onMouseDown: (event) => {

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.test.js
@@ -24,6 +24,15 @@ describe('createFilterOptions', () => {
     expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([options[0]]);
   });
 
+  it('filters without error with empty option set', () => {
+    const filterOptions = createFilterOptions();
+
+    const getOptionLabel = (option) => option.name;
+    const options = [];
+
+    expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([]);
+  });
+
   describe('option: limit', () => {
     it('limits the number of suggested options to be shown', () => {
       const filterOptions = createFilterOptions({ limit: 2 });


### PR DESCRIPTION
I also added a sanity test for filtering without error on an empty option set

fix #22302

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
