### PR TITLE
[docs] Remove minimum-scale from meta viewport in docs

### DIFF
--- a/docs/src/modules/components/Head.js
+++ b/docs/src/modules/components/Head.js
@@ -11,7 +11,7 @@ export default function Head(props) {
   const router = useRouter();
 
   return (
-    <NextHead>      
+    <NextHead>
       <meta name="viewport" content="initial-scale=1, width=device-width" />
       <title>{title}</title>
       <meta name="description" content={description} />

--- a/docs/src/modules/components/Head.js
+++ b/docs/src/modules/components/Head.js
@@ -11,9 +11,8 @@ export default function Head(props) {
   const router = useRouter();
 
   return (
-    <NextHead>
-      {/* Use minimum-scale=1 to enable GPU rasterization. */}
-      <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+    <NextHead>      
+      <meta name="viewport" content="initial-scale=1, width=device-width" />
       <title>{title}</title>
       <meta name="description" content={description} />
       {/* Twitter */}

--- a/docs/src/pages/getting-started/usage/usage-de.md
+++ b/docs/src/pages/getting-started/usage/usage-de.md
@@ -41,7 +41,7 @@ Um eine korrektes Darstellen und Zoomen durch Berührungen für alle Geräte sic
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage-es.md
+++ b/docs/src/pages/getting-started/usage/usage-es.md
@@ -41,7 +41,7 @@ Para asegurar un renderizado adecuado y zoom táctil en todos los dispositivos, 
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage-fr.md
+++ b/docs/src/pages/getting-started/usage/usage-fr.md
@@ -41,7 +41,7 @@ Pour que le rendu et le zoom tactile soient corrects pour tous les périphériqu
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage-ja.md
+++ b/docs/src/pages/getting-started/usage/usage-ja.md
@@ -41,7 +41,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage-pt.md
+++ b/docs/src/pages/getting-started/usage/usage-pt.md
@@ -39,7 +39,7 @@ O Material-UI é desenvolvido com a estratégia mobile-first, uma estratégia na
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage-ru.md
+++ b/docs/src/pages/getting-started/usage/usage-ru.md
@@ -41,7 +41,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage-zh.md
+++ b/docs/src/pages/getting-started/usage/usage-zh.md
@@ -41,7 +41,7 @@ Material-UI 是先在移动设备上开发的，我们采用了首先为移动�
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage.md
+++ b/docs/src/pages/getting-started/usage/usage.md
@@ -41,7 +41,7 @@ To ensure proper rendering and touch zooming for all devices, add the responsive
 ```html
 <meta
   name="viewport"
-  content="minimum-scale=1, initial-scale=1, width=device-width"
+  content="initial-scale=1, width=device-width"
 />
 ```
 

--- a/docs/src/pages/getting-started/usage/usage.md
+++ b/docs/src/pages/getting-started/usage/usage.md
@@ -39,10 +39,7 @@ Material-UI is developed mobile-first, a strategy in which we first write code f
 To ensure proper rendering and touch zooming for all devices, add the responsive viewport meta tag to your `<head>` element.
 
 ```html
-<meta
-  name="viewport"
-  content="initial-scale=1, width=device-width"
-/>
+<meta name="viewport" content="initial-scale=1, width=device-width" />
 ```
 
 ### CssBaseline

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>My page</title>
     <meta charset="utf-8" />
-    <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <script src="https://unpkg.com/react@latest/umd/react.development.js" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/react-dom@latest/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@material-ui/core@latest/umd/material-ui.development.js" crossorigin="anonymous"></script>

--- a/examples/create-react-app-with-typescript/public/index.html
+++ b/examples/create-react-app-with-typescript/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/examples/create-react-app/public/index.html
+++ b/examples/create-react-app/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/examples/gatsby/plugins/gatsby-plugin-top-layout/TopLayout.js
+++ b/examples/gatsby/plugins/gatsby-plugin-top-layout/TopLayout.js
@@ -9,7 +9,7 @@ export default function TopLayout(props) {
   return (
     <React.Fragment>
       <Helmet>
-        <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
         <link
           href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap"
           rel="stylesheet"

--- a/examples/nextjs-with-typescript/pages/_app.tsx
+++ b/examples/nextjs-with-typescript/pages/_app.tsx
@@ -20,7 +20,7 @@ export default function MyApp(props: AppProps) {
     <React.Fragment>
       <Head>
         <title>My page</title>
-        <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
       <ThemeProvider theme={theme}>
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -20,7 +20,7 @@ export default function MyApp(props) {
     <React.Fragment>
       <Head>
         <title>My page</title>
-        <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
       <ThemeProvider theme={theme}>
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}

--- a/examples/preact/public/index.html
+++ b/examples/preact/public/index.html
@@ -5,7 +5,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width"
+      content="initial-scale=1, width=device-width"
     />
     <meta name="theme-color" content="#000000" />
     <!--

--- a/examples/ssr/server.js
+++ b/examples/ssr/server.js
@@ -13,7 +13,7 @@ function renderFullPage(html, css) {
       <head>
         <title>My page</title>
         <style id="jss-server-side">${css}</style>
-        <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
       </head>
       <body>

--- a/test/regressions/debug.html
+++ b/test/regressions/debug.html
@@ -3,7 +3,7 @@
   <head>
     <title>vrtest</title>
     <meta charset="utf-8" />
-    <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <style>body { background-color: white; }</style>
   </head>
   <body>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

This PR is in response to issue #22714, in which `minimum-scale` for the viewport can be an accessibility issue. This PR removes `minimum-scale` from all of the documentation and examples.

Closes #22714 