### PR TITLE
[docs] Prevent toolbar tooltips overlapping demos

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -454,7 +454,7 @@ function DemoToolbar(props) {
               open={showSourceHint && atLeastSmallViewport ? true : undefined}
               PopperProps={{ disablePortal: true }}
               title={showCodeLabel}
-              placement="top"
+              placement="bottom"
             >
               <IconButton
                 aria-controls={openDemoSource ? demoSourceId : null}
@@ -473,7 +473,7 @@ function DemoToolbar(props) {
               <Tooltip
                 classes={{ popper: classes.tooltip }}
                 title={t('codesandbox')}
-                placement="top"
+                placement="bottom"
               >
                 <IconButton
                   aria-label={t('codesandbox')}
@@ -487,7 +487,11 @@ function DemoToolbar(props) {
                 </IconButton>
               </Tooltip>
             )}
-            <Tooltip classes={{ popper: classes.tooltip }} title={t('copySource')} placement="top">
+            <Tooltip
+              classes={{ popper: classes.tooltip }}
+              title={t('copySource')}
+              placement="bottom"
+            >
               <IconButton
                 aria-label={t('copySource')}
                 data-ga-event-category="demo"
@@ -499,7 +503,11 @@ function DemoToolbar(props) {
                 <FileCopyIcon fontSize="small" />
               </IconButton>
             </Tooltip>
-            <Tooltip classes={{ popper: classes.tooltip }} title={t('resetFocus')} placement="top">
+            <Tooltip
+              classes={{ popper: classes.tooltip }}
+              title={t('resetFocus')}
+              placement="bottom"
+            >
               <IconButton
                 aria-label={t('resetFocus')}
                 data-ga-event-category="demo"
@@ -511,7 +519,11 @@ function DemoToolbar(props) {
                 <ResetFocusIcon fontSize="small" />
               </IconButton>
             </Tooltip>
-            <Tooltip classes={{ popper: classes.tooltip }} title={t('resetDemo')} placement="top">
+            <Tooltip
+              classes={{ popper: classes.tooltip }}
+              title={t('resetDemo')}
+              placement="bottom"
+            >
               <IconButton
                 aria-controls={demoId}
                 aria-label={t('resetDemo')}


### PR DESCRIPTION
Since #17831 the current Tooltip placement means tooltips will cover the demos. This is especially annoying if you get the source hint when first visiting the docs but tooltips hiding content is annoying generally. The space to the bottom fits a tooltip perfectly though it can hide potential ads and the source. In the case of ads I think visible demos are more important demos. For source code we only cover the first import line which is almost always the `react` import.

![tooltip fitting perfectly between demo toolbar and next heading](https://i.ibb.co/rQD2FST/demo-toolbar-tt-placement.png)

Aside: Bonus points for consistent formatting