### PR TITLE
[docs] Reference experimental slider demos correctly

### DIFF
--- a/docs/pages/api-docs/slider-styled.md
+++ b/docs/pages/api-docs/slider-styled.md
@@ -31,3 +31,7 @@ The `ref` is forwarded to the root element.
 
 Any other props supplied will be provided to the root element (native element).
 
+## Demos
+
+- [Slider Styled](/components/slider-styled/)
+

--- a/docs/pages/api-docs/slider-unstyled.md
+++ b/docs/pages/api-docs/slider-unstyled.md
@@ -56,3 +56,7 @@ The `ref` is forwarded to the root element.
 
 Any other props supplied will be provided to the root element (native element).
 
+## Demos
+
+- [Slider Styled](/components/slider-styled/)
+

--- a/docs/pages/api-docs/slider.md
+++ b/docs/pages/api-docs/slider.md
@@ -94,5 +94,4 @@ If that's not sufficient, you can check the [implementation of the component](ht
 ## Demos
 
 - [Slider](/components/slider/)
-- [Slider Styled](/components/slider-styled/)
 

--- a/docs/src/pages/components/slider-styled/slider-styled.md
+++ b/docs/src/pages/components/slider-styled/slider-styled.md
@@ -1,6 +1,6 @@
 ---
 title: Slider React component
-components: Slider
+components: SliderStyled, SliderUnstyled
 githubLabel: component: Slider
 materialDesign: https://material.io/components/sliders
 waiAria: https://www.w3.org/TR/wai-aria-practices/#slider

--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.d.ts
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.d.ts
@@ -25,6 +25,10 @@ export const SliderValueLabel: React.FC<SliderValueLabel>;
 
 /**
  *
+ * Demos:
+ *
+ * - [Slider Styled](https://material-ui.com/components/slider-styled/)
+ *
  * API:
  *
  * - [SliderStyled API](https://material-ui.com/api/slider-styled/)

--- a/packages/material-ui-lab/src/SliderUnstyled/SliderUnstyled.d.ts
+++ b/packages/material-ui-lab/src/SliderUnstyled/SliderUnstyled.d.ts
@@ -197,6 +197,10 @@ export interface SliderTypeMap<P = {}, D extends React.ElementType = 'span'> {
 
 /**
  *
+ * Demos:
+ *
+ * - [Slider Styled](https://material-ui.com/components/slider-styled/)
+ *
  * API:
  *
  * - [SliderUnstyled API](https://material-ui.com/api/slider-unstyled/)

--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -208,7 +208,6 @@ export interface SliderTypeMap<P = {}, D extends React.ElementType = 'span'> {
  * Demos:
  *
  * - [Slider](https://material-ui.com/components/slider/)
- * - [Slider Styled](https://material-ui.com/components/slider-styled/)
  *
  * API:
  *


### PR DESCRIPTION
We reference demos of a particula demo by manually declaring used components in front-matter blocks in the markdown pages.

The actual fix is just a one-liner: https://github.com/mui-org/material-ui/pull/22738/files#diff-b8af1751c5b229efa71dc077a7de41af. The rest is auto-generated.