### PR TITLE
[theme] convertLength does not work for fromUnit !== 'px'

### DIFF
--- a/packages/material-ui/src/styles/cssUtils.js
+++ b/packages/material-ui/src/styles/cssUtils.js
@@ -33,7 +33,6 @@ export function convertLength(baseFontSize) {
         pxLength = toUnitless(length) * toUnitless(baseFontSize);
       } else if (fromUnit === 'rem') {
         pxLength = toUnitless(length) * toUnitless(baseFontSize);
-        return length;
       }
     }
 

--- a/packages/material-ui/src/styles/cssUtils.test.js
+++ b/packages/material-ui/src/styles/cssUtils.test.js
@@ -41,6 +41,7 @@ describe('cssUtils', () => {
     it('should work as expected', () => {
       const convert = convertLength('16px');
       expect(convert('32px', 'rem')).to.equal('2rem');
+      expect(convert('2rem', 'px')).to.equal('32px');
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #22693

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).
