### PR TITLE
[Popper] Use placement viewport instead of window 

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -129,7 +129,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
           : {
               // It's using scrollParent by default, we can use the viewport when using a portal.
               preventOverflow: {
-                boundariesElement: 'window',
+                boundariesElement: 'viewport',
               },
             }),
         ...modifiers,

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -264,14 +264,14 @@ describe('<Popper />', () => {
       );
     });
 
-    it('sets preventOverflow to window when disablePortal is false', () => {
+    it('sets preventOverflow to viewport when disablePortal is false', () => {
       const popperRef = React.createRef();
       const { getByRole } = render(<Popper {...defaultProps} popperRef={popperRef} />);
       // renders
       expect(getByRole('tooltip')).to.not.equal(null);
       // correctly sets modifiers
       expect(popperRef.current.options.modifiers.preventOverflow.boundariesElement).to.equal(
-        'window',
+        'viewport',
       );
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

Closes #22708 