### PR TITLE
[test] Solve 2000ms timeout

### DIFF
--- a/packages/material-ui/src/Rating/Rating.test.js
+++ b/packages/material-ui/src/Rating/Rating.test.js
@@ -65,10 +65,9 @@ describe('<Rating />', () => {
 
   it('should clear the rating', () => {
     const handleChange = spy();
-    const { getByRole } = render(<Rating onChange={handleChange} value={2} />);
+    const { container } = render(<Rating name="rating-test" onChange={handleChange} value={2} />);
 
-    const input = getByRole('radio', { name: '2 Stars' });
-    fireEvent.click(input, {
+    fireEvent.click(container.querySelector('#rating-test-2'), {
       clientX: 1,
     });
 
@@ -78,12 +77,8 @@ describe('<Rating />', () => {
 
   it('should select the rating', () => {
     const handleChange = spy();
-    const { container, getByRole } = render(
-      <Rating name="rating-test" onChange={handleChange} value={2} />,
-    );
-
-    fireEvent.click(getByRole('radio', { name: '3 Stars' }));
-
+    const { container } = render(<Rating name="rating-test" onChange={handleChange} value={2} />);
+    fireEvent.click(container.querySelector('#rating-test-3'));
     expect(handleChange.callCount).to.equal(1);
     expect(handleChange.args[0][1]).to.deep.equal(3);
     const checked = container.querySelector('input[name="rating-test"]:checked');
@@ -91,20 +86,20 @@ describe('<Rating />', () => {
   });
 
   it('should select the empty input if value is null', () => {
-    const { container, getByRole } = render(<Rating name="rating-test" value={null} />);
-    const input = getByRole('radio', { name: 'Empty' });
+    const { container } = render(<Rating name="rating-test" value={null} />);
+    const input = container.querySelector('#rating-test-empty');
     const checked = container.querySelector('input[name="rating-test"]:checked');
     expect(input).to.equal(checked);
     expect(input.value).to.equal('');
   });
 
   it('should support a defaultValue', () => {
-    const { container, getByRole } = render(<Rating defaultValue={3} name="rating-test" />);
+    const { container } = render(<Rating defaultValue={3} name="rating-test" />);
     let checked;
     checked = container.querySelector('input[name="rating-test"]:checked');
     expect(checked.value).to.equal('3');
 
-    fireEvent.click(getByRole('radio', { name: '2 Stars' }));
+    fireEvent.click(container.querySelector('#rating-test-2'));
     checked = container.querySelector('input[name="rating-test"]:checked');
     expect(checked.value).to.equal('2');
   });


### PR DESCRIPTION
We have a bunch of tests that fail in the CI on the same test:

> Rating - should select the empty input if value is null

After a ssh on the CI and using the default reporter, I get:

<img width="825" alt="Capture d’écran 2020-09-27 à 17 46 51" src="https://user-images.githubusercontent.com/3165635/94369609-11bf5b00-00eb-11eb-8d50-27ef4114cb34.png">

As it turns out the tests are close to the 2,000 ms timeout. In the above screenshot, we run at 1,871ms.
In my local environment, the tests run much faster <50ms. If you add console.time on the different steps of the test, you will find (for one run):

- render: 5ms
- getByRole: 105ms
- querySelector: 0.2ms

The following change should fix the flakiness of the CI. The alternatives are to increase the timeout for all the tests or to upgrade the machines we use (to have more resources).
