### PR TITLE
[docs] Improve the left side-nav

### DIFF
--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -82,7 +82,7 @@ function renderNavItems(options) {
   const { pages, ...params } = options;
 
   return (
-    <List>
+    <List disablePadding>
       {pages.reduce(
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         (items, page) => reduceChildRoutes({ items, page, ...params }),

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -22,7 +22,7 @@ function PersistScroll(props) {
 
   React.useEffect(() => {
     const parent = rootRef.current ? rootRef.current.parentElement : null;
-    const activeElement = document.querySelector('.drawer-active');
+    const activeElement = document.querySelector('.app-drawer-active');
 
     if (!parent || !activeElement || !activeElement.scrollIntoView) {
       return undefined;

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -3,39 +3,47 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { makeStyles, fade } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
+import ButtonBase from '@material-ui/core/ButtonBase';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import Link from 'docs/src/modules/components/Link';
 
 const useStyles = makeStyles((theme) => ({
   li: {
+    padding: '1px 0',
     display: 'block',
-    paddingTop: 0,
-    paddingBottom: 0,
   },
-  liLeaf: {
+  liRoot: {
+    padding: '0 8px',
+  },
+  item: {
+    ...theme.typography.body2,
     display: 'flex',
-    padding: '0 12px',
+    borderRadius: theme.shape.borderRadius,
+    outline: 0,
+    width: '100%',
+    padding: '8px 0',
+    justifyContent: 'flex-start',
+    fontWeight: theme.typography.fontWeightMedium,
+    transition: theme.transitions.create(['color', 'background-color'], {
+      duration: theme.transitions.duration.shortest,
+    }),
+    '&:hover': {
+      color: theme.palette.text.primary,
+      backgroundColor: fade(theme.palette.text.primary, theme.palette.action.hoverOpacity),
+    },
+    '&.Mui-focusVisible': {
+      backgroundColor: theme.palette.action.focus,
+    },
+    [theme.breakpoints.up('md')]: {
+      padding: '6px 0',
+    },
   },
   button: {
-    ...theme.typography.body2,
-    cursor: 'pointer',
-    padding: '8px 0 6px',
-    display: 'flex',
     color: theme.palette.text.primary,
     fontWeight: theme.typography.fontWeightMedium,
-    WebkitTapHighlightColor: 'transparent',
-    backgroundColor: 'transparent', // Reset default value
-    outline: 0,
-    border: 0,
-    margin: 0, // Remove the margin in Safari
-    borderRadius: 0,
-    textAlign: 'left',
-    '-moz-appearance': 'none', // Reset
-    '-webkit-appearance': 'none', // Reset
-    width: '100%',
     '& svg': {
       fontSize: 18,
-      marginLeft: -6,
+      marginLeft: -19,
       color: theme.palette.text.secondary,
     },
     '& svg$open': {
@@ -47,23 +55,26 @@ const useStyles = makeStyles((theme) => ({
   },
   open: {},
   link: {
-    ...theme.typography.body2,
-    borderRadius: theme.shape.borderRadius,
-    width: '100%',
-    padding: '6px 0',
-    textDecoration: 'none',
     color: theme.palette.text.secondary,
-    fontWeight: theme.typography.fontWeightMedium,
-    transition: theme.transitions.create(['color', 'background-color'], {
-      duration: theme.transitions.duration.shortest,
-    }),
-    '&:hover': {
-      color: theme.palette.text.primary,
-      backgroundColor: fade(theme.palette.text.primary, theme.palette.action.hoverOpacity),
-    },
-    '&$active': {
+    '&.app-drawer-active': {
       color: theme.palette.primary.main,
       backgroundColor: fade(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+      '&:hover': {
+        backgroundColor: fade(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+        ),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: fade(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+        },
+      },
+      '&.Mui-focusVisible': {
+        backgroundColor: fade(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+        ),
+      },
     },
   },
   active: {},
@@ -89,17 +100,22 @@ export default function AppDrawerNavItem(props) {
   };
 
   const style = {
-    paddingLeft: 8 * (3 + 2 * depth),
+    paddingLeft: 8 * (3 + 1.5 * depth),
   };
 
   if (href) {
     return (
-      <li className={classes.liLeaf} {...other}>
+      <li
+        className={clsx(classes.li, {
+          [classes.liRoot]: depth === 0,
+        })}
+        {...other}
+      >
         <Link
-          naked
-          activeClassName={`drawer-active ${classes.active}`}
+          activeClassName="app-drawer-active"
           href={href}
-          className={clsx(classes.link, `depth-${depth}`)}
+          underline="none"
+          className={clsx(classes.item, classes.link)}
           onClick={onClick}
           style={style}
           {...linkProps}
@@ -111,10 +127,15 @@ export default function AppDrawerNavItem(props) {
   }
 
   return (
-    <li className={classes.li} {...other}>
-      <button
-        type="button"
-        className={clsx(classes.button, {
+    <li
+      className={clsx(classes.li, {
+        [classes.liRoot]: depth === 0,
+      })}
+      {...other}
+    >
+      <ButtonBase
+        disableRipple
+        className={clsx(classes.item, classes.button, {
           'algolia-lvl0': topLevel,
         })}
         onClick={handleClick}
@@ -122,7 +143,7 @@ export default function AppDrawerNavItem(props) {
       >
         <ArrowRightIcon className={open ? classes.open : ''} />
         {title}
-      </button>
+      </ButtonBase>
       <Collapse in={open} timeout="auto" unmountOnExit>
         {children}
       </Collapse>

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { makeStyles, fade } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
-import { createSvgIcon } from '@material-ui/core/utils';
+import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import Link from 'docs/src/modules/components/Link';
 
 const useStyles = makeStyles((theme) => ({
@@ -69,8 +69,6 @@ const useStyles = makeStyles((theme) => ({
   active: {},
 }));
 
-const ArrowRight = createSvgIcon(<path d="M10 17l5-5-5-5v10z" />, 'ArrowRight');
-
 export default function AppDrawerNavItem(props) {
   const {
     children,
@@ -122,7 +120,7 @@ export default function AppDrawerNavItem(props) {
         onClick={handleClick}
         style={style}
       >
-        <ArrowRight className={open ? classes.open : ''} />
+        <ArrowRightIcon className={open ? classes.open : ''} />
         {title}
       </button>
       <Collapse in={open} timeout="auto" unmountOnExit>

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -1,44 +1,71 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
-import ListItem from '@material-ui/core/ListItem';
-import Button from '@material-ui/core/Button';
+import { makeStyles, fade } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
+import { createSvgIcon } from '@material-ui/core/utils';
 import Link from 'docs/src/modules/components/Link';
 
 const useStyles = makeStyles((theme) => ({
-  item: {
+  li: {
     display: 'block',
     paddingTop: 0,
     paddingBottom: 0,
   },
-  itemLeaf: {
+  liLeaf: {
     display: 'flex',
-    paddingTop: 0,
-    paddingBottom: 0,
+    padding: '0 12px',
   },
   button: {
-    letterSpacing: 0,
-    justifyContent: 'flex-start',
-    textTransform: 'none',
+    ...theme.typography.body2,
+    cursor: 'pointer',
+    padding: '8px 0 6px',
+    display: 'flex',
+    color: theme.palette.text.primary,
+    fontWeight: theme.typography.fontWeightMedium,
+    WebkitTapHighlightColor: 'transparent',
+    backgroundColor: 'transparent', // Reset default value
+    outline: 0,
+    border: 0,
+    margin: 0, // Remove the margin in Safari
+    borderRadius: 0,
+    textAlign: 'left',
+    '-moz-appearance': 'none', // Reset
+    '-webkit-appearance': 'none', // Reset
     width: '100%',
-  },
-  buttonLeaf: {
-    letterSpacing: 0,
-    justifyContent: 'flex-start',
-    textTransform: 'none',
-    width: '100%',
-    fontWeight: theme.typography.fontWeightRegular,
-    '&.depth-0': {
-      fontWeight: theme.typography.fontWeightMedium,
+    '& svg': {
+      fontSize: 18,
+      marginLeft: -6,
+      color: theme.palette.text.secondary,
+    },
+    '&:hover svg': {
+      color: theme.palette.text.primary,
     },
   },
-  active: {
-    color: theme.palette.primary.main,
+  link: {
+    ...theme.typography.body2,
+    borderRadius: theme.shape.borderRadius,
+    width: '100%',
+    padding: '6px 0',
+    textDecoration: 'none',
+    color: theme.palette.text.secondary,
     fontWeight: theme.typography.fontWeightMedium,
+    transition: theme.transitions.create(['color', 'background-color'], {
+      duration: theme.transitions.duration.shortest,
+    }),
+    '&:hover': {
+      color: theme.palette.text.primary,
+      backgroundColor: fade(theme.palette.text.primary, theme.palette.action.hoverOpacity),
+    },
+    '&$active': {
+      color: theme.palette.primary.main,
+      backgroundColor: fade(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+    },
   },
+  active: {},
 }));
+
+const ArrowRight = createSvgIcon(<path d="M10 17l5-5-5-5v10z" />, 'ArrowRight');
 
 export default function AppDrawerNavItem(props) {
   const {
@@ -65,42 +92,39 @@ export default function AppDrawerNavItem(props) {
 
   if (href) {
     return (
-      <ListItem className={classes.itemLeaf} disableGutters {...other}>
-        <Button
-          color="inherit"
-          component={Link}
+      <li className={classes.liLeaf} {...other}>
+        <Link
           naked
           activeClassName={`drawer-active ${classes.active}`}
           href={href}
-          className={clsx(classes.buttonLeaf, `depth-${depth}`)}
-          disableTouchRipple
+          className={clsx(classes.link, `depth-${depth}`)}
           onClick={onClick}
           style={style}
           {...linkProps}
         >
           {title}
-        </Button>
-      </ListItem>
+        </Link>
+      </li>
     );
   }
 
   return (
-    <ListItem className={classes.item} disableGutters {...other}>
-      <Button
-        color="inherit"
-        classes={{
-          root: classes.button,
-          label: topLevel ? 'algolia-lvl0' : '',
-        }}
+    <li className={classes.li} {...other}>
+      <button
+        type="button"
+        className={clsx(classes.button, {
+          'algolia-lvl0': topLevel,
+        })}
         onClick={handleClick}
         style={style}
       >
+        <ArrowRight />
         {title}
-      </Button>
+      </button>
       <Collapse in={open} timeout="auto" unmountOnExit>
         {children}
       </Collapse>
-    </ListItem>
+    </li>
   );
 }
 

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -38,10 +38,14 @@ const useStyles = makeStyles((theme) => ({
       marginLeft: -6,
       color: theme.palette.text.secondary,
     },
+    '& svg$open': {
+      transform: 'rotate(90deg)',
+    },
     '&:hover svg': {
       color: theme.palette.text.primary,
     },
   },
+  open: {},
   link: {
     ...theme.typography.body2,
     borderRadius: theme.shape.borderRadius,
@@ -118,7 +122,7 @@ export default function AppDrawerNavItem(props) {
         onClick={handleClick}
         style={style}
       >
-        <ArrowRight />
+        <ArrowRight className={open ? classes.open : ''} />
         {title}
       </button>
       <Collapse in={open} timeout="auto" unmountOnExit>

--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -55,6 +55,10 @@ function Link(props) {
   const isExternal = href.indexOf('https:') === 0 || href.indexOf('mailto:') === 0;
 
   if (isExternal) {
+    if (naked) {
+      return <a className={className} href={href} ref={innerRef} role={role} {...other} />;
+    }
+
     return <MuiLink className={className} href={href} ref={innerRef} role={role} {...other} />;
   }
 

--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -275,7 +275,7 @@ const pages = [
       { pathname: '/discover-more/languages' },
     ],
   },
-  { pathname: '/versions', disableNav: true },
+  { pathname: '/versions', displayNav: false },
   { pathname: '/', displayNav: false, disableDrawer: true },
   { pathname: 'https://medium.com/material-ui', title: 'Blog' },
 ];


### PR DESCRIPTION
It was an opportunity to work on 3 problems at the same time:

### 1. Fix w3 validator

The warning was present on all the pages and was buried all the other issues (x81)

<img width="806" alt="Capture d’écran 2020-09-27 à 19 47 17" src="https://user-images.githubusercontent.com/3165635/94371918-4a1a6580-00fa-11eb-9e3b-48e508fcde9b.png">

https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext.material-ui.com%2Fcomponents%2Fslider-styled

There are still 3 issues related to navigation (edit page, previous page, and next page) but that's for another day.

### 2. Update the design

It's closer to the Material Design specification https://material.io/components/navigation-drawer. I also wanted the design to better support more levels of nesting and more items.

**Before**
<img width="260" alt="Capture d’écran 2020-09-27 à 19 45 22" src="https://user-images.githubusercontent.com/3165635/94371938-69b18e00-00fa-11eb-8507-39300820aaec.png">

**After**
<img width="248" alt="Capture d’écran 2020-10-04 à 14 10 01" src="https://user-images.githubusercontent.com/3165635/95015085-5c8d2580-064b-11eb-9551-7bb2b5c03602.png">

I have used the following as inspiration too:

- https://stripe.com/docs/api/accounts
- https://tailwindcss.com/docs/upgrading-to-v1
- https://next.vuetifyjs.com/en/styles/content/
- https://mail.google.com
- https://ionicframework.com/docs/api/input

### 3. Improve the rendering **performance**

I was getting frustrated at the time it takes to open the drawer on mobile and the time it takes to click on TOCs hash link. In the following benchmark in development, opening the drawer is about x2 faster. The main change is to use fewer React components.

**Before**
<img width="754" alt="Capture d’écran 2020-09-27 à 19 58 16" src="https://user-images.githubusercontent.com/3165635/94372181-f6a91700-00fb-11eb-8f31-7f679cc23c93.png">

**After**
<img width="755" alt="Capture d’écran 2020-09-27 à 19 59 04" src="https://user-images.githubusercontent.com/3165635/94372185-f9a40780-00fb-11eb-95ef-8264774be9b0.png">e

The performance for changing the hash is also improved but less significantly as the rendering time of the main body of the page stays the same. In dev:

**Before**
<img width="1349" alt="Capture d’écran 2020-09-27 à 20 03 02" src="https://user-images.githubusercontent.com/3165635/94372292-9b2b5900-00fc-11eb-952a-898b0dc0e3c7.png">

**After**
<img width="1348" alt="Capture d’écran 2020-09-27 à 20 02 28" src="https://user-images.githubusercontent.com/3165635/94372297-9e264980-00fc-11eb-8d0d-69ece76e6aac.png">
