### PR TITLE
[docs] Improve perf when opening the drawer

### DIFF
--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -92,7 +92,7 @@ function renderNavItems(options) {
   );
 }
 
-function reduceChildRoutes({ props, activePage, items, page, depth, t }) {
+function reduceChildRoutes({ onClose, activePage, items, page, depth, t }) {
   if (page.displayNav === false) {
     return items;
   }
@@ -110,7 +110,7 @@ function reduceChildRoutes({ props, activePage, items, page, depth, t }) {
         openImmediately={topLevel || Boolean(page.subheader)}
         title={title}
       >
-        {renderNavItems({ props, pages: page.children, activePage, depth: depth + 1, t })}
+        {renderNavItems({ onClose, pages: page.children, activePage, depth: depth + 1, t })}
       </AppDrawerNavItem>,
     );
   } else {
@@ -124,7 +124,7 @@ function reduceChildRoutes({ props, activePage, items, page, depth, t }) {
         key={title}
         title={title}
         href={page.pathname}
-        onClick={props.onClose}
+        onClick={onClose}
       />,
     );
   }
@@ -144,6 +144,10 @@ function AppDrawer(props) {
   const languagePrefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
   const t = useSelector((state) => state.options.t);
 
+  const navItems = React.useMemo(
+    () => renderNavItems({ onClose, pages, activePage, depth: 0, t }),
+    [activePage, pages, onClose, t],
+  );
   const drawer = (
     <PersistScroll>
       <div className={classes.toolbarIe11}>
@@ -168,7 +172,7 @@ function AppDrawer(props) {
       <Box mx={3} my={2}>
         <DiamondSponsors spot="drawer" />
       </Box>
-      {renderNavItems({ props, pages, activePage, depth: 0, t })}
+      {navItems}
     </PersistScroll>
   );
 

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -167,9 +167,9 @@ function AppFrame(props) {
   const handleDrawerOpen = () => {
     setMobileOpen(true);
   };
-  const handleDrawerClose = () => {
+  const handleDrawerClose = React.useCallback(() => {
     setMobileOpen(false);
-  };
+  }, []);
 
   const changeTheme = useChangeTheme();
   const handleTogglePaletteType = () => {


### PR DESCRIPTION
Alternate to the perf improvements of #22780.

Profiler marked the `AppDrawer` as expensive (30ms render duration is very slow). `renderNavItems` created a fairly big _tree_ of elements (the nav) which took almost all of the render duration of `AppDrawer`. Luckily we can memoize that tree fairly easily.

A single run show performance increase from 70ms down to 30ms when opening the drawer with 6x CPU throttling.

Before
![Profiler screenshot on `next`](https://i.ibb.co/mSDDHM4/drawer-perf-current.png)
After
![Profiler screenshot with this PR](https://i.ibb.co/VBrP11C/drawer-perf-pr.png)