### PR TITLE
[Autocomplete] Restrict component props in `renderInput`

### DIFF
--- a/docs/src/pages/components/autocomplete/CustomInputAutocomplete.js
+++ b/docs/src/pages/components/autocomplete/CustomInputAutocomplete.js
@@ -24,7 +24,6 @@ export default function CustomInputAutocomplete() {
           <input
             type="text"
             {...params.inputProps}
-            // @ts-expect-error TODO
             className={clsx(classes.input, params.inputProps.className)}
           />
         </div>

--- a/docs/src/pages/components/autocomplete/CustomInputAutocomplete.tsx
+++ b/docs/src/pages/components/autocomplete/CustomInputAutocomplete.tsx
@@ -26,7 +26,6 @@ export default function CustomInputAutocomplete() {
           <input
             type="text"
             {...params.inputProps}
-            // @ts-expect-error TODO
             className={clsx(classes.input, params.inputProps.className)}
           />
         </div>

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { InternalStandardProps as StandardProps } from '@material-ui/core';
+import { ChipProps, ChipTypeMap } from '@material-ui/core/Chip';
 import { PopperProps } from '@material-ui/core/Popper';
-import {
+import useAutocomplete, {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,
   AutocompleteCloseReason,
@@ -36,27 +37,28 @@ export interface AutocompleteRenderInputParams {
   disabled: boolean;
   fullWidth: boolean;
   size: 'small' | undefined;
-  InputLabelProps: object;
+  InputLabelProps: ReturnType<ReturnType<typeof useAutocomplete>['getInputLabelProps']>;
   InputProps: {
     ref: React.Ref<any>;
     className: string;
     startAdornment: React.ReactNode;
     endAdornment: React.ReactNode;
   };
-  inputProps: object;
+  inputProps: ReturnType<ReturnType<typeof useAutocomplete>['getInputProps']>;
 }
 
 export interface AutocompleteProps<
   T,
   Multiple extends boolean | undefined,
   DisableClearable extends boolean | undefined,
-  FreeSolo extends boolean | undefined
+  FreeSolo extends boolean | undefined,
+  ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent']
 > extends UseAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
     StandardProps<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange' | 'children'> {
   /**
    * Props applied to the [`Chip`](/api/chip/) element.
    */
-  ChipProps?: object;
+  ChipProps?: ChipProps<ChipComponent>;
   /**
    * Override or extend the styles applied to the component.
    */
@@ -165,7 +167,7 @@ export interface AutocompleteProps<
   /**
    * Props applied to the Listbox element.
    */
-  ListboxProps?: object;
+  ListboxProps?: ReturnType<ReturnType<typeof useAutocomplete>['getListboxProps']>;
   /**
    * If `true`, the component is in a loading state.
    * @default false

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { InputLabelProps } from '@material-ui/core';
 import { Autocomplete, AutocompleteProps } from '@material-ui/lab';
 import { expectType } from '@material-ui/types';
+import { HTMLAttributes } from 'enzyme';
 
 interface MyAutocomplete<
   T,

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { InputLabelProps } from '@material-ui/core';
 import { Autocomplete, AutocompleteProps } from '@material-ui/lab';
 import { expectType } from '@material-ui/types';
-import { HTMLAttributes } from 'enzyme';
 
 interface MyAutocomplete<
   T,

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -295,7 +295,8 @@ export default function useAutocomplete<
 ): {
   getRootProps: () => React.HTMLAttributes<HTMLDivElement>;
   getInputProps: () => React.HTMLAttributes<HTMLInputElement>;
-  getInputLabelProps: () => React.HTMLAttributes<HTMLLabelElement>;
+  // We pass `getInputLabelProps()` to `@material-ui/core/InputLabel` which does not implement HTMLLabelElement#color.
+  getInputLabelProps: () => Omit<React.HTMLAttributes<HTMLLabelElement>, 'color'>;
   getClearProps: () => React.HTMLAttributes<HTMLDivElement>;
   getPopupIndicatorProps: () => React.HTMLAttributes<HTMLDivElement>;
   getTagProps: ({ index }: { index: number }) => React.HTMLAttributes<HTMLDivElement>;


### PR DESCRIPTION
Removes need of `@ts-expect-error` introduce in #22711 by building on top of #22749