### PR TITLE
[Autocomplete] change 'autoComplete' to 'no'

### DIFF
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -960,7 +960,7 @@ export default function useAutocomplete(props) {
       'aria-controls': listboxAvailable ? `${id}-listbox` : null,
       // Disable browser's suggestion that might overlap with the popup.
       // Handle autocomplete but not autofill.
-      autoComplete: 'off',
+      autoComplete: 'no',
       ref: inputRef,
       autoCapitalize: 'none',
       spellCheck: 'false',


### PR DESCRIPTION
Fixes #22443: disables chrome autocomplete by setting `autoComplete` to `no` in `useAutocomplete` hook.
