### PR TITLE
[Accordion] Replace IconButton wrapper with div

### DIFF
--- a/docs/pages/api-docs/accordion-summary.md
+++ b/docs/pages/api-docs/accordion-summary.md
@@ -32,7 +32,6 @@ The `MuiAccordionSummary` name can be used for providing [default props](/custom
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node</span> |  | The icon to display as the expand indicator. |
 | <span class="prop-name">focusVisibleClassName</span> | <span class="prop-type">string</span> |  | This prop can help a person know which element has the keyboard focus. The class name will be applied when the element gain the focus through a keyboard interaction. It's a polyfill for the [CSS :focus-visible selector](https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo). The rationale for using this feature [is explained here](https://github.com/WICG/focus-visible/blob/master/explainer.md). A [polyfill can be used](https://github.com/WICG/focus-visible) to apply a `focus-visible` class to other components if needed. |
-| <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | Props applied to the `IconButton` element wrapping the expand icon. |
 
 The `ref` is forwarded to the root element.
 
@@ -47,7 +46,7 @@ Any other props supplied will be provided to the root element ([ButtonBase](/api
 | <span class="prop-name">focusVisible</span> | <span class="prop-name">.Mui-focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
 | <span class="prop-name">disabled</span> | <span class="prop-name">.Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">content</span> | <span class="prop-name">.MuiAccordionSummary-content</span> | Styles applied to the children wrapper element.
-| <span class="prop-name">expandIcon</span> | <span class="prop-name">.MuiAccordionSummary-expandIcon</span> | Styles applied to the `IconButton` component when `expandIcon` is supplied.
+| <span class="prop-name">expandIconWrapper</span> | <span class="prop-name">.MuiAccordionSummary-expandIconWrapper</span> | Styles applied to the `expandIcon`'s wrapper element.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -400,6 +400,9 @@ const theme = createMuiTheme({
   ```
 
 - Remove `display: flex` from AccordionDetails as its too opinionated.
+- Remove `IconButtonProps` prop from AccordionSummary.
+  The component renders a `<div>` element instead of an IconButton.
+  The prop is no longer necessary.
 
 ### Fab
 

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.d.ts
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
-import { IconButtonProps } from '../IconButton';
 import { OverrideProps } from '../OverridableComponent';
 
 export type AccordionSummaryTypeMap<
@@ -33,11 +32,6 @@ export type AccordionSummaryTypeMap<
      * The icon to display as the expand indicator.
      */
     expandIcon?: React.ReactNode;
-    /**
-     * Props applied to the `IconButton` element wrapping the expand icon.
-     * @default {}
-     */
-    IconButtonProps?: Partial<IconButtonProps>;
   };
   defaultComponent: D;
 }>;

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.d.ts
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.d.ts
@@ -25,8 +25,8 @@ export type AccordionSummaryTypeMap<
       disabled?: string;
       /** Styles applied to the children wrapper element. */
       content?: string;
-      /** Styles applied to the `IconButton` component when `expandIcon` is supplied. */
-      expandIcon?: string;
+      /** Styles applied to the `expandIcon`'s wrapper element. */
+      expandIconWrapper?: string;
     };
     /**
      * The icon to display as the expand indicator.

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -24,7 +24,7 @@ export const styles = (theme) => {
         minHeight: 64,
       },
       '&$focusVisible': {
-        backgroundColor: theme.palette.grey['200'],
+        backgroundColor: theme.palette.action.focus,
       },
       '&$disabled': {
         opacity: theme.palette.action.disabledOpacity,
@@ -48,8 +48,8 @@ export const styles = (theme) => {
     },
     /* Styles applied to the `expandIcon`'s wrapper element. */
     expandIconWrapper: {
-      height: '24px',
-      color: 'rgb(0, 0, 0, 0.38)',
+      display: 'flex',
+      color: theme.palette.action.active,
       transform: 'rotate(0deg)',
       transition: theme.transitions.create('transform', transition),
       '&$expanded': {
@@ -103,7 +103,6 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
       <div className={clsx(classes.content, { [classes.expanded]: expanded })}>{children}</div>
       {expandIcon && (
         <div
-          edge="end"
           className={clsx(classes.expandIconWrapper, {
             [classes.expanded]: expanded,
           })}

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -46,6 +46,7 @@ export const styles = (theme) => {
         margin: '20px 0',
       },
     },
+    /* Styles applied to the `expandIcon`'s wrapper element. */
     expandIconWrapper: {
       transform: 'rotate(0deg)',
       transition: theme.transitions.create('transform', transition),

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -47,8 +47,7 @@ export const styles = (theme) => {
         margin: '20px 0',
       },
     },
-    /* Styles applied to the `IconButton` component when `expandIcon` is supplied. */
-    expandIcon: {
+    expandIconWrapper: {
       transform: 'rotate(0deg)',
       transition: theme.transitions.create('transform', transition),
       '&$expanded': {
@@ -104,7 +103,7 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
         <div
           edge="end"
           className={clsx(
-            classes.expandIcon,
+            classes.expandIconWrapper,
             {
               [classes.expanded]: expanded,
             },

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import ButtonBase from '../ButtonBase';
-import IconButton from '../IconButton';
 import withStyles from '../styles/withStyles';
 import AccordionContext from '../Accordion/AccordionContext';
 
@@ -72,7 +71,6 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
     className,
     expandIcon,
     focusVisibleClassName,
-    IconButtonProps = {},
     onClick,
     ...other
   } = props;
@@ -109,23 +107,17 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
     >
       <div className={clsx(classes.content, { [classes.expanded]: expanded })}>{children}</div>
       {expandIcon && (
-        <IconButton
+        <div
           edge="end"
-          component="div"
-          tabIndex={null}
-          role={null}
-          aria-hidden
-          {...IconButtonProps}
           className={clsx(
             classes.expandIcon,
             {
               [classes.expanded]: expanded,
             },
-            IconButtonProps.className,
           )}
         >
           {expandIcon}
-        </IconButton>
+        </div>
       )}
     </ButtonBase>
   );
@@ -161,11 +153,6 @@ AccordionSummary.propTypes = {
    * if needed.
    */
   focusVisibleClassName: PropTypes.string,
-  /**
-   * Props applied to the `IconButton` element wrapping the expand icon.
-   * @default {}
-   */
-  IconButtonProps: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -24,7 +24,7 @@ export const styles = (theme) => {
         minHeight: 64,
       },
       '&$focusVisible': {
-        backgroundColor: theme.palette.action.focus,
+        backgroundColor: theme.palette.grey['200'],
       },
       '&$disabled': {
         opacity: theme.palette.action.disabledOpacity,
@@ -48,6 +48,8 @@ export const styles = (theme) => {
     },
     /* Styles applied to the `expandIcon`'s wrapper element. */
     expandIconWrapper: {
+      height: '24px',
+      color: 'rgb(0, 0, 0, 0.38)',
       transform: 'rotate(0deg)',
       transition: theme.transitions.create('transform', transition),
       '&$expanded': {

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -101,12 +101,9 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(props, ref) 
       {expandIcon && (
         <div
           edge="end"
-          className={clsx(
-            classes.expandIconWrapper,
-            {
-              [classes.expanded]: expanded,
-            },
-          )}
+          className={clsx(classes.expandIconWrapper, {
+            [classes.expanded]: expanded,
+          })}
         >
           {expandIcon}
         </div>

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -51,12 +51,6 @@ export const styles = (theme) => {
     expandIcon: {
       transform: 'rotate(0deg)',
       transition: theme.transitions.create('transform', transition),
-      '&:hover': {
-        // Disable the hover effect for the IconButton,
-        // because a hover effect should apply to the entire Expand button and
-        // not only to the IconButton.
-        backgroundColor: 'transparent',
-      },
       '&$expanded': {
         transform: 'rotate(180deg)',
       },

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/aria-role */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -46,7 +46,14 @@ describe('<AccordionSummary />', () => {
     expect(getByRole('button')).to.have.class(classes.disabled);
   });
 
-  it('when expanded adds the expanded class to the button and expandIcon', () => {
+  it('renders the content given in expandIcon prop inside the div.expandIconWrapper', () => {
+    const { container } = render(<AccordionSummary expandIcon="icon" />);
+
+    const expandIconWrapper = container.querySelector(`.${classes.expandIconWrapper}`);
+    expect(expandIconWrapper).to.have.text('Icon');
+  });
+
+  it('when expanded adds the expanded class to the button and .expandIconWrapper', () => {
     const { container, getByRole } = render(
       <Accordion expanded>
         <AccordionSummary expandIcon="expand" />
@@ -56,28 +63,7 @@ describe('<AccordionSummary />', () => {
     const button = getByRole('button');
     expect(button).to.have.class(classes.expanded);
     expect(button).to.have.attribute('aria-expanded', 'true');
-    expect(container.querySelector(`.${classes.expandIcon}`)).to.have.class(classes.expanded);
-  });
-
-  it('when expanded adds both the expanded class and the className provided with `IconButtonProps` to the expandIcon', () => {
-    const iconButtonProps = { className: 'icon' };
-    const { container } = render(
-      <Accordion expanded>
-        <AccordionSummary expandIcon="expand" IconButtonProps={iconButtonProps} />
-      </Accordion>,
-    );
-
-    const expandIcon = container.querySelector(`.${classes.expandIcon}`);
-    expect(expandIcon).to.have.class(classes.expanded);
-    expect(expandIcon).to.have.class(iconButtonProps.className);
-  });
-
-  it('should render with an inaccessible expand icon and have the expandIcon class', () => {
-    const { container } = render(<AccordionSummary expandIcon={<div>Icon</div>} />);
-
-    const expandIcon = container.querySelector(`.${classes.expandIcon}`);
-    expect(expandIcon).to.have.text('Icon');
-    expect(expandIcon).toBeInaccessible();
+    expect(container.querySelector(`.${classes.expandIconWrapper}`)).to.have.class(classes.expanded);
   });
 
   it('should fire onBlur when the button blurs', () => {

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -47,7 +47,7 @@ describe('<AccordionSummary />', () => {
   });
 
   it('renders the content given in expandIcon prop inside the div.expandIconWrapper', () => {
-    const { container } = render(<AccordionSummary expandIcon='iconElementContentExample' />);
+    const { container } = render(<AccordionSummary expandIcon="iconElementContentExample" />);
 
     const expandIconWrapper = container.querySelector(`.${classes.expandIconWrapper}`);
     expect(expandIconWrapper).to.have.text('iconElementContentExample');
@@ -63,7 +63,9 @@ describe('<AccordionSummary />', () => {
     const button = getByRole('button');
     expect(button).to.have.class(classes.expanded);
     expect(button).to.have.attribute('aria-expanded', 'true');
-    expect(container.querySelector(`.${classes.expandIconWrapper}`)).to.have.class(classes.expanded);
+    expect(container.querySelector(`.${classes.expandIconWrapper}`)).to.have.class(
+      classes.expanded,
+    );
   });
 
   it('should fire onBlur when the button blurs', () => {

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -47,10 +47,10 @@ describe('<AccordionSummary />', () => {
   });
 
   it('renders the content given in expandIcon prop inside the div.expandIconWrapper', () => {
-    const { container } = render(<AccordionSummary expandIcon="icon" />);
+    const { container } = render(<AccordionSummary expandIcon='iconElementContentExample' />);
 
     const expandIconWrapper = container.querySelector(`.${classes.expandIconWrapper}`);
-    expect(expandIconWrapper).to.have.text('Icon');
+    expect(expandIconWrapper).to.have.text('iconElementContentExample');
   });
 
   it('when expanded adds the expanded class to the button and .expandIconWrapper', () => {


### PR DESCRIPTION
### Breaking changes

- [Accordion] Remove `IconButtonProps` prop from AccordionSummary.
  The component renders a `<div>` element instead of an IconButton.
  The prop is no longer necessary.

---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#sending-a-pull-request).

As per https://github.com/mui-org/material-ui/issues/22804#issuecomment-701046569

---------------
@oliviertassinari 

> However for this demo: https://next.material-ui.com/components/accordion/#additional-actions, we likely want it.

I don't see that this demo is relevant to this change. This demo talks about interactive elements put in the children of the `AccordionSummary` not in the `iconElement`.

---------------------
I think the wrapping element around `iconElement` should still be present, but it's only function will be to fix the `iconElement` to the right and to rotate it around "z-axis" (top/bot), so I removed the wrapping element props completely. I think this is OK, but would like to hear if these wrapping element props should stay for some reason?

--------------------
If we agree to remove wrapping element's props (as per previous paragraph) I should complete the removal by removing the remaining stuff from docs/pages/api-docs/accordion-summary.md and packages/material-ui/src/AccordionSummary/AccordionSummary.test.js 