### PR TITLE
[Tabs] Fix RTL scrollbar with Chrome 85

### DIFF
--- a/packages/material-ui/src/utils/scrollLeft.js
+++ b/packages/material-ui/src/utils/scrollLeft.js
@@ -34,8 +34,8 @@ export function detectScrollType() {
   if (dummy.scrollLeft > 0) {
     cachedType = 'default';
   } else {
-    dummy.scrollLeft = 1;
-    if (dummy.scrollLeft === 0) {
+    dummy.scrollLeft = 2;
+    if (dummy.scrollLeft < 2) {
       cachedType = 'negative';
     }
   }

--- a/packages/material-ui/src/utils/scrollLeft.js
+++ b/packages/material-ui/src/utils/scrollLeft.js
@@ -4,13 +4,21 @@ let cachedType;
 /**
  * Based on the jquery plugin https://github.com/othree/jquery.rtl-scroll-type
  *
- * Types of scrollLeft, assiming scrollWidth=100 and direction is rtl.
+ * Types of scrollLeft, assuming scrollWidth=100 and direction is rtl.
  *
- * Browser        | Type          | <- Most Left | Most Right -> | Initial
- * -------------- | ------------- | ------------ | ------------- | -------
- * WebKit         | default       | 0            | 100           | 100
- * Firefox/Opera  | negative      | -100         | 0             | 0
- * IE/Edge        | reverse       | 100          | 0             | 0
+ * Type             | <- Most Left | Most Right -> | Initial
+ * ---------------- | ------------ | ------------- | -------
+ * default          | 0            | 100           | 100
+ * negative (spec*) | -100         | 0             | 0
+ * reverse          | 100          | 0             | 0
+ *
+ * Edge 85: default
+ * Safari 14: negative
+ * Chrome 85: negative
+ * Firefox 81: negative
+ * IE 11: reverse
+ *
+ * spec* https://drafts.csswg.org/cssom-view/#dom-window-scroll
  */
 export function detectScrollType() {
   if (cachedType) {
@@ -18,7 +26,10 @@ export function detectScrollType() {
   }
 
   const dummy = document.createElement('div');
-  dummy.appendChild(document.createTextNode('ABCD'));
+  const container = document.createElement('div');
+  container.style.width = '10px';
+  container.style.height = '1px';
+  dummy.appendChild(container);
   dummy.dir = 'rtl';
   dummy.style.fontSize = '14px';
   dummy.style.width = '4px';
@@ -34,8 +45,8 @@ export function detectScrollType() {
   if (dummy.scrollLeft > 0) {
     cachedType = 'default';
   } else {
-    dummy.scrollLeft = 2;
-    if (dummy.scrollLeft < 2) {
+    dummy.scrollLeft = 1;
+    if (dummy.scrollLeft === 0) {
       cachedType = 'negative';
     }
   }


### PR DESCRIPTION
Chrome 85 introduced a bug with how scrollLeft is computed for RTL. This was fixed in the original source of this module -- https://github.com/alitaheri/normalize-scroll-left/pull/6. The bug has been open for ~29 days, so not clear if it will be fixed anytime soon - https://bugs.chromium.org/p/chromium/issues/detail?id=1123301. This particular fix is backwards/forwards compatible according to the original PR. 

Example of bug's impact: This bug is actually causing the RTL implementation of Scrollable Tabs to be broken in production when using a right-to-left language: https://material-ui.com/components/tabs/#scrollable-tabs

A better longterm fix would be to actually import https://github.com/alitaheri/normalize-scroll-left as a dependency, but I didn't go that route since I wasn't sure if we are deliberately trying to reduce the number of third-party dependencies.

Is `master` the correct branch for a bugfix for 4.11? Will it be possible to publish a 4.11.1 release including this bugfix?
I can also open a separate PR for `next` branch. 

Thanks!