### PR TITLE
[docs] More robust description matcher

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -22,8 +22,7 @@ const workspaceRoot = path.join(__dirname, '../');
 const reactMode = 'legacy';
 // eslint-disable-next-line no-console
 console.log(`Using React '${reactMode}' mode.`);
-const l10nPRInNetlify = /l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
-console.log('head: "%s", netlify: %s', process.env.HEAD, process.env.NETLIFY);
+const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
 
 module.exports = {
   typescript: {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -22,8 +22,8 @@ const workspaceRoot = path.join(__dirname, '../');
 const reactMode = 'legacy';
 // eslint-disable-next-line no-console
 console.log(`Using React '${reactMode}' mode.`);
-const l10nPRInNetlify = /l10n_/.test(process.env.BRANCH) && process.env.NETLIFY === 'true';
-console.log('branch: "%s", netlify: %s', process.env.BRANCH, process.env.NETLIFY);
+const l10nPRInNetlify = /l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
+console.log('head: "%s", netlify: %s', process.env.HEAD, process.env.NETLIFY);
 
 module.exports = {
   typescript: {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -165,8 +165,11 @@ module.exports = {
       });
     }
 
+    const l10nPRInNetlify = /l10n_/.test(process.env.BRANCH) && process.env.NETLIFY === 'true';
+    console.log(process.env.BRANCH);
     // We want to speed-up the build of pull requests.
-    if (process.env.PULL_REQUEST === 'true') {
+    // For crowdin PRs we want to build all locales for testing.
+    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -166,7 +166,7 @@ module.exports = {
     }
 
     const l10nPRInNetlify = /l10n_/.test(process.env.BRANCH) && process.env.NETLIFY === 'true';
-    console.log(process.env.BRANCH);
+    console.log('branch: "%s"', process.env.BRANCH);
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
     if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify) {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -22,6 +22,8 @@ const workspaceRoot = path.join(__dirname, '../');
 const reactMode = 'legacy';
 // eslint-disable-next-line no-console
 console.log(`Using React '${reactMode}' mode.`);
+const l10nPRInNetlify = /l10n_/.test(process.env.BRANCH) && process.env.NETLIFY === 'true';
+console.log('branch: "%s", netlify: %s', process.env.BRANCH, process.env.NETLIFY);
 
 module.exports = {
   typescript: {
@@ -165,8 +167,6 @@ module.exports = {
       });
     }
 
-    const l10nPRInNetlify = /l10n_/.test(process.env.BRANCH) && process.env.NETLIFY === 'true';
-    console.log('branch: "%s"', process.env.BRANCH);
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
     if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify) {

--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -6,7 +6,7 @@ import prism from 'docs/src/modules/utils/prism';
 
 const headerRegExp = /---[\r\n]([\s\S]*)[\r\n]---/;
 const titleRegExp = /# (.*)[\r\n]/;
-const descriptionRegExp = /<p class="description">(.*)<\/p>[\r\n]/;
+const descriptionRegExp = /<p class="description">(.*)<\/p>/s;
 const headerKeyValueRegExp = /(.*?): (.*)/g;
 const emptyRegExp = /^\s*$/;
 const notEnglishMarkdownRegExp = /-([a-z]{2})\.md$/;
@@ -78,7 +78,7 @@ export function getTitle(markdown) {
 export function getDescription(markdown) {
   const matches = markdown.match(descriptionRegExp);
 
-  return matches?.[1];
+  return matches?.[1].trim();
 }
 
 /**

--- a/docs/src/modules/utils/parseMarkdown.test.js
+++ b/docs/src/modules/utils/parseMarkdown.test.js
@@ -1,7 +1,19 @@
 import { expect } from 'chai';
-import { getContents, getHeaders, prepareMarkdown } from './parseMarkdown';
+import { getContents, getDescription, getHeaders, prepareMarkdown } from './parseMarkdown';
 
 describe('parseMarkdown', () => {
+  describe('getDescription', () => {
+    it('trims the description', () => {
+      expect(
+        getDescription(`
+        <p class="description">
+          Some description
+        </p>
+      `),
+      ).to.equal('Some description');
+    });
+  });
+
   describe('getHeaders', () => {
     it('should return a correct result', () => {
       expect(


### PR DESCRIPTION
In crowdin PRs we should deploy all locales for testing. This would've prevented current deploy failures due to #22752.

Specifically, #22752 introduced page descriptions (`<p class="description" />`) that had whitespace around the text ([`docs/src/pages/components/rating/rating-zh.md`](https://github.com/mui-org/material-ui/blob/c04bdacdf9fae388f0ef4894ac3783037ceb670f/docs/src/pages/components/rating/rating-zh.md#L10-L11)). If that whitespace included newlines they couldn't be easily matched. Luckily ES 5 introduced the "dotall" flag (`s`) for that exact use case which is available as of node 8.10. The matched text is trimmed to retain the previous behavior.
