### PR TITLE
[Select] Add generic support for value

### DIFF
--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -4,9 +4,9 @@ import { InputProps } from '../Input';
 import { MenuProps } from '../Menu';
 import { SelectInputProps } from './SelectInput';
 
-export interface SelectProps
+export interface SelectProps<T = unknown>
   extends StandardProps<InputProps, 'value' | 'onChange'>,
-    Pick<SelectInputProps, 'onChange'> {
+    Pick<SelectInputProps<T>, 'onChange'> {
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.
@@ -115,7 +115,7 @@ export interface SelectProps
    * You can pull out the new value by accessing `event.target.value` (any).
    * @param {object} [child] The react element that was selected when `native` is `false` (default).
    */
-  onChange?: SelectInputProps['onChange'];
+  onChange?: SelectInputProps<T>['onChange'];
   /**
    * Callback fired when the component requests to be closed.
    * Use in controlled mode (see open).
@@ -142,7 +142,7 @@ export interface SelectProps
    * @param {any} value The `value` provided to the component.
    * @returns {ReactNode}
    */
-  renderValue?: (value: SelectProps['value']) => React.ReactNode;
+  renderValue?: (value: SelectProps<T>['value']) => React.ReactNode;
   /**
    * Props applied to the clickable div element.
    */
@@ -163,7 +163,7 @@ export interface SelectProps
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-export type SelectClassKey = keyof NonNullable<SelectProps['classes']>;
+export type SelectClassKey = keyof NonNullable<SelectProps<any>['classes']>;
 
 /**
  *
@@ -176,4 +176,4 @@ export type SelectClassKey = keyof NonNullable<SelectProps['classes']>;
  * - [Select API](https://material-ui.com/api/select/)
  * - inherits [Input API](https://material-ui.com/api/input/)
  */
-export default function Select(props: SelectProps): JSX.Element;
+export default function Select<T>(props: SelectProps<T>): JSX.Element;

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -142,7 +142,7 @@ export interface SelectProps<T = unknown>
    * @param {any} value The `value` provided to the component.
    * @returns {ReactNode}
    */
-  renderValue?: (value: SelectProps<T>['value']) => React.ReactNode;
+  renderValue?: (value: T) => React.ReactNode;
   /**
    * Props applied to the clickable div element.
    */
@@ -163,7 +163,7 @@ export interface SelectProps<T = unknown>
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-export type SelectClassKey = keyof NonNullable<SelectProps<any>['classes']>;
+export type SelectClassKey = keyof NonNullable<SelectProps['classes']>;
 
 /**
  *

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -50,7 +50,7 @@ export interface SelectProps<T = unknown>
   /**
    * The default element value. Use when the component is not controlled.
    */
-  defaultValue?: unknown;
+  defaultValue?: T;
   /**
    * If `true`, a value is displayed even if no items are selected.
    *
@@ -155,7 +155,7 @@ export interface SelectProps<T = unknown>
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    */
-  value?: unknown;
+  value?: T;
   /**
    * The variant to use.
    * @default 'standard'

--- a/packages/material-ui/src/Select/Select.spec.tsx
+++ b/packages/material-ui/src/Select/Select.spec.tsx
@@ -34,4 +34,10 @@ function genericValueTest() {
     }}
     value="1"
   />;
+
+  <Select onChange={(event) => console.log(event.target.value)} value="1">
+    <MenuItem value="1" />
+    {/* Whoops. The value in onChange won't be a string */}
+    <MenuItem value={2} />
+  </Select>;
 }

--- a/packages/material-ui/src/Select/Select.spec.tsx
+++ b/packages/material-ui/src/Select/Select.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
 
 function genericValueTest() {
   function handleChangeWithSameTypeAsSelect(
@@ -20,5 +21,17 @@ function genericValueTest() {
     defaultValue={1}
     // @ts-expect-error Value should be a string
     value={10}
+  />;
+
+  <Select
+    onChange={(event) => {
+      function testString(value: string) {}
+      function testNumber(value: number) {}
+
+      testString(event.target.value);
+      // @ts-expect-error
+      testNumber(event.target.value);
+    }}
+    value="1"
   />;
 }

--- a/packages/material-ui/src/Select/Select.spec.tsx
+++ b/packages/material-ui/src/Select/Select.spec.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Select from '@material-ui/core/Select';
+
+function genericValueTest() {
+  function handleChangeWithSameTypeAsSelect(
+    event: React.ChangeEvent<{ name?: string; value: number }>,
+  ) {}
+  <Select<number> onChange={handleChangeWithSameTypeAsSelect} />;
+
+  function handleChangeWithDifferentTypeFromSelect(
+    event: React.ChangeEvent<{ name?: string; value: string }>,
+  ) {}
+  <Select<number>
+    // @ts-expect-error
+    onChange={handleChangeWithDifferentTypeFromSelect}
+  />;
+
+  <Select<string>
+    // @ts-expect-error defaultValue should be a string
+    defaultValue={1}
+    // @ts-expect-error Value should be a string
+    value={10}
+  />;
+}

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MenuProps } from '../Menu';
 
-export interface SelectInputProps<T> {
+export interface SelectInputProps<T = unknown> {
   autoFocus?: boolean;
   autoWidth: boolean;
   disabled?: boolean;
@@ -30,6 +30,6 @@ export interface SelectInputProps<T> {
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-declare const SelectInput: React.ComponentType<SelectInputProps<any>>;
+declare const SelectInput: React.ComponentType<SelectInputProps>;
 
 export default SelectInput;

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { MenuProps } from '../Menu';
 
-export interface SelectInputProps {
+export interface SelectInputProps<T> {
   autoFocus?: boolean;
   autoWidth: boolean;
   disabled?: boolean;
   IconComponent?: React.ElementType;
   inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps['value'] }
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<T>['value'] }
   ) => void;
   MenuProps?: Partial<MenuProps>;
   multiple: boolean;
@@ -15,7 +15,7 @@ export interface SelectInputProps {
   native: boolean;
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (
-    event: React.ChangeEvent<{ name?: string; value: unknown }>,
+    event: React.ChangeEvent<{ name?: string; value: T }>,
     child: React.ReactNode
   ) => void;
   onClose?: (event: React.SyntheticEvent) => void;
@@ -23,13 +23,13 @@ export interface SelectInputProps {
   onOpen?: (event: React.SyntheticEvent) => void;
   open?: boolean;
   readOnly?: boolean;
-  renderValue?: (value: SelectInputProps['value']) => React.ReactNode;
+  renderValue?: (value: SelectInputProps<T>['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   tabIndex?: number;
-  value?: unknown;
+  value?: T;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-declare const SelectInput: React.ComponentType<SelectInputProps>;
+declare const SelectInput: React.ComponentType<SelectInputProps<any>>;
 
 export default SelectInput;


### PR DESCRIPTION
It adds the opportunity to type the value of the Select component.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
