### PR TITLE
[core] Batch small changes

### DIFF
--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -104,6 +104,28 @@ const pages = [
       },
       {
         pathname: '/components',
+        subheader: '/components/data-grid',
+        children: [
+          {
+            pathname: '/components/data-grid',
+            title: 'Overview',
+          },
+          { pathname: '/components/data-grid/getting-started' },
+          { pathname: '/components/data-grid/columns' },
+          { pathname: '/components/data-grid/rows' },
+          { pathname: '/components/data-grid/filtering', title: '🚧 Filtering' },
+          { pathname: '/components/data-grid/pagination' },
+          { pathname: '/components/data-grid/selection' },
+          { pathname: '/components/data-grid/editing', title: '🚧 Editing' },
+          { pathname: '/components/data-grid/rendering' },
+          { pathname: '/components/data-grid/export', title: '🚧 Export & Import' },
+          { pathname: '/components/data-grid/localization', title: '🚧 Localization' },
+          { pathname: '/components/data-grid/group-pivot', title: '🚧 Group & Pivot' },
+          { pathname: '/components/data-grid/accessibility' },
+        ],
+      },
+      {
+        pathname: '/components',
         subheader: '/components/utils',
         children: [
           { pathname: '/components/click-away-listener' },
@@ -128,48 +150,6 @@ const pages = [
           { pathname: '/components/trap-focus' },
           { pathname: '/components/tree-view' },
         ],
-      },
-      {
-        pathname: '/components',
-        subheader: '/components/data-grid',
-        children:
-          process.env.CONTEXT === 'production'
-            ? [
-                {
-                  pathname: '/components/data-grid',
-                  title: 'Overview',
-                },
-                { pathname: '/components/data-grid/getting-started' },
-                { pathname: '/components/data-grid/columns' },
-                { pathname: '/components/data-grid/rows' },
-                { pathname: '/components/data-grid/filtering', title: '🚧 Filtering' },
-                { pathname: '/components/data-grid/pagination' },
-                { pathname: '/components/data-grid/selection' },
-                { pathname: '/components/data-grid/editing', title: '🚧 Editing' },
-                { pathname: '/components/data-grid/rendering' },
-                { pathname: '/components/data-grid/export', title: '🚧 Export & Import' },
-                { pathname: '/components/data-grid/localization', title: '🚧 Localization' },
-                { pathname: '/components/data-grid/group-pivot', title: '🚧 Group & Pivot' },
-                { pathname: '/components/data-grid/accessibility' },
-              ]
-            : [
-                {
-                  pathname: '/components/data-grid',
-                  title: 'Overview',
-                },
-                { pathname: '/components/data-grid/getting-started' },
-                { pathname: '/components/data-grid/columns' },
-                { pathname: '/components/data-grid/rows' },
-                { pathname: '/components/data-grid/filtering', title: '🚧 Filtering' },
-                { pathname: '/components/data-grid/pagination' },
-                { pathname: '/components/data-grid/selection' },
-                { pathname: '/components/data-grid/editing', title: '🚧 Editing' },
-                { pathname: '/components/data-grid/rendering' },
-                { pathname: '/components/data-grid/export', title: '🚧 Export & Import' },
-                { pathname: '/components/data-grid/localization', title: '🚧 Localization' },
-                { pathname: '/components/data-grid/group-pivot', title: '🚧 Group & Pivot' },
-                { pathname: '/components/data-grid/accessibility' },
-              ],
       },
     ],
   },

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -207,7 +207,7 @@ const theme = createMuiTheme({
   +import AlertTitle from '@material-ui/core/AlertTitle';
   ```
 
-  ### Autocomplete
+### Autocomplete
 
 - Move the component from the lab to the core. The component is now stable.
 

--- a/examples/create-react-app-with-styled-components/README.md
+++ b/examples/create-react-app-with-styled-components/README.md
@@ -1,4 +1,4 @@
-# Create React App example
+# Create React App example with styled-components
 
 ## How to use
 

--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-material-ui",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "private": true,
   "description": "Custom eslint rules for Material-UI.",
   "main": "src/index.js",

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -26,7 +26,6 @@ describe('<Button />', () => {
     inheritComponent: ButtonBase,
     mount,
     refInstanceof: window.HTMLButtonElement,
-    skip: ['componentProp'],
   }));
 
   it('should render with the root, text, and textPrimary classes but no others', () => {

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -29,7 +29,7 @@ describe('<StepContent />', () => {
       return wrapper.find(Step).childAt(0).childAt(0).childAt(0);
     },
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'reactTestRenderer', 'refForwarding'],
+    skip: ['componentProp', 'reactTestRenderer'],
   }));
 
   it('renders children inside an Collapse component', () => {

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -18,7 +18,6 @@ describe('<TableSortLabel />', () => {
     classes,
     inheritComponent: ButtonBase,
     mount,
-
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],
   }));

--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentsPropsList } from '../styles/props';
 
 export interface Localization {
@@ -16,17 +15,14 @@ export interface Localization {
     MuiRating?: {
       defaultProps: Pick<ComponentsPropsList['MuiRating'], 'emptyLabelText' | 'getLabelText'>;
     };
+    MuiAutocomplete?: {
+      defaultProps: Pick<
+        ComponentsPropsList['MuiAutocomplete'],
+        'clearText' | 'closeText' | 'loadingText' | 'noOptionsText' | 'openText'
+      >;
+    };
     // The core package has no dependencies on the @material-ui/lab components.
     // We can't use ComponentsPropsList, we have to duplicate and inline the definitions.
-    MuiAutocomplete?: {
-      defaultProps: {
-        clearText?: string;
-        closeText?: string;
-        loadingText?: React.ReactNode;
-        noOptionsText?: React.ReactNode;
-        openText?: string;
-      };
-    };
     MuiPagination?: {
       defaultProps: Pick<ComponentsPropsList['MuiPagination'], 'aria-label' | 'getItemAriaLabel'>;
     };

--- a/packages/material-ui/src/styles/ThemeProvider.js
+++ b/packages/material-ui/src/styles/ThemeProvider.js
@@ -5,11 +5,11 @@ import { exactProp } from '@material-ui/utils';
 import { ThemeContext as StyledEngineThemeContext } from '@material-ui/styled-engine';
 import useTheme from './useTheme';
 
-function InnerThemeProvider({ children }) {
+function InnerThemeProvider(props) {
   const theme = useTheme();
   return (
     <StyledEngineThemeContext.Provider value={typeof theme === 'object' ? theme : {}}>
-      {children}
+      {props.children}
     </StyledEngineThemeContext.Provider>
   );
 }


### PR DESCRIPTION
- [examples] Include full name of the demo in h1 2adc4ce
- ~[core] Fix benchmark start command b57a5b3: Without the change, an error is raised: `Error: Cannot find module '../../material-ui-utils/src'`. The regression comes from the migration of @material-ui/utils to TypeScript.~
- We are working on v5 now ad0c8d8
- ~[test] Fix tests with react@next 8a81f44: an example of a fail: https://app.circleci.com/pipelines/github/mui-org/material-ui/22275/workflows/12c660da-1195-4e53-8413-06511fd5ead1/jobs/181874. The regression comes from moving the Autocomplete from the lab to the core.~
- [Autocomplete] Polish migration to core 65b8397
- [core] Keep 'props' explicit 77c07aa
- [docs] Improve position in the side nav of DataGrid 5f3a1bf: Move data grid right after data display.
- [test] Remove outdated skips 8272e8a: