### PR TITLE
[SliderStyled] Fix mark label alignment on coarse pointer devices

### DIFF
--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.js
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.js
@@ -173,16 +173,14 @@ const SliderRoot = muiStyled(
       ':hover': {
         boxShadow: 'none',
       },
+      ...(props.styleProps.orientation === 'vertical' && {
+        marginLeft: -3,
+        marginBottom: -4,
+      }),
     },
     ...(props.styleProps.orientation === 'vertical' && {
       marginLeft: -5,
       marginBottom: -6,
-    }),
-    ...(props.styleProps.orientation === 'vertical' && {
-      '&.Mui-disabled': {
-        marginLeft: -3,
-        marginBottom: -4,
-      },
     }),
     ...(props.styleProps.color === 'secondary' && {
       ':hover': {

--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.js
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.js
@@ -226,6 +226,7 @@ const SliderRoot = muiStyled(
     '@media (pointer: coarse)': {
       top: 40,
       ...(props.styleProps.orientation === 'vertical' && {
+        top: 'auto',
         left: 31,
       }),
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Noticed this when working on the new Slider spec.
Before:

![image](https://user-images.githubusercontent.com/12938082/94996513-0d88b700-059d-11eb-9b99-e30334adf906.png)

After:

![image](https://user-images.githubusercontent.com/12938082/94996526-21341d80-059d-11eb-8242-ed24e595c4ec.png)
