### PR TITLE
[test] Migrate more components to react-testing-library

### DIFF
--- a/packages/material-ui/src/Hidden/Hidden.test.js
+++ b/packages/material-ui/src/Hidden/Hidden.test.js
@@ -1,26 +1,22 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow } from 'test/utils';
+import { createClientRender } from 'test/utils';
 import Hidden from './Hidden';
-import HiddenJs from './HiddenJs';
-import HiddenCss from './HiddenCss';
 
 describe('<Hidden />', () => {
-  let shallow;
-
-  before(() => {
-    shallow = createShallow();
-  });
+  let render = createClientRender();
 
   describe('prop: implementation', () => {
     it('should use HiddenJs by default', () => {
-      const wrapper = shallow(<Hidden>Hello</Hidden>);
-      expect(wrapper.find(HiddenJs).length).to.equal(1);
+      const { container } = render(<Hidden>Hello</Hidden>);
+      // JS implementation doesn't requires wrapping <div />
+      expect(container.firstChild).to.equal(null);
     });
 
     it('should change the implementation', () => {
-      const wrapper = shallow(<Hidden implementation="css">Hello</Hidden>);
-      expect(wrapper.find(HiddenCss).length).to.equal(1);
+      const { container } = render(<Hidden implementation="css">Hello</Hidden>);
+      // CSS  implementation requires wrapping <div />
+      expect(container.firstChild).to.have.tagName('div');
     });
   });
 });

--- a/packages/material-ui/src/Hidden/Hidden.test.js
+++ b/packages/material-ui/src/Hidden/Hidden.test.js
@@ -4,18 +4,19 @@ import { createClientRender } from 'test/utils';
 import Hidden from './Hidden';
 
 describe('<Hidden />', () => {
-  let render = createClientRender();
+  const render = createClientRender();
+  const child = <span>Hello</span>;
 
   describe('prop: implementation', () => {
     it('should use HiddenJs by default', () => {
-      const { container } = render(<Hidden>Hello</Hidden>);
+      const { container } = render(<Hidden>{child}</Hidden>);
       // JS implementation doesn't requires wrapping <div />
-      expect(container.firstChild).to.equal(null);
+      expect(container.firstChild).to.have.tagName('span');
     });
 
     it('should change the implementation', () => {
-      const { container } = render(<Hidden implementation="css">Hello</Hidden>);
-      // CSS  implementation requires wrapping <div />
+      const { container } = render(<Hidden implementation="css">{child}</Hidden>);
+      // CSS implementation requires wrapping <div />
       expect(container.firstChild).to.have.tagName('div');
     });
   });

--- a/packages/material-ui/src/Hidden/Hidden.test.js
+++ b/packages/material-ui/src/Hidden/Hidden.test.js
@@ -9,7 +9,7 @@ describe('<Hidden />', () => {
 
   describe('prop: implementation', () => {
     it('should use HiddenJs by default', () => {
-      const { container } = render(<Hidden>{child}</Hidden>);
+      const { container } = render(<Hidden width="sm">{child}</Hidden>);
       // JS implementation doesn't requires wrapping <div />
       expect(container.firstChild).to.have.tagName('span');
     });

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -33,8 +33,8 @@ describe('<HiddenCss />', () => {
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.onlySm);
-      expect(root.firstElementChild).to.have.tagName('div');
-      expect(root.firstElementChild).to.have.class('foo');
+      expect(root.firstChild).to.have.tagName('div');
+      expect(root.firstChild).to.have.class('foo');
     });
 
     it('should be ok with only as an array', () => {
@@ -43,7 +43,7 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      const root = container.firstElementChild;
+      const root = container.firstChild;
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.onlyXs);
@@ -56,7 +56,7 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      const root = container.firstElementChild;
+      const root = container.firstChild;
 
       expect(root).to.have.tagName('div');
       Object.keys(classes).forEach((className) => expect(root).to.not.have.class(className));
@@ -68,9 +68,8 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      const root = container.firstElementChild;
 
-      expect(root).to.have.class(classes.mdDown);
+      expect(container.firstChild).to.have.class(classes.mdDown);
     });
 
     it('should be ok with mdUp', () => {
@@ -79,9 +78,8 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      const root = container.firstElementChild;
 
-      expect(root).to.have.class(classes.mdUp);
+      expect(container.firstChild).to.have.class(classes.mdUp);
     });
     it('should handle provided className prop', () => {
       const { container } = render(
@@ -89,9 +87,8 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      const root = container.firstElementChild;
 
-      expect(root).to.have.class('custom');
+      expect(container.firstChild).to.have.class('custom');
     });
 
     it('allows custom breakpoints', () => {
@@ -103,16 +100,15 @@ describe('<HiddenCss />', () => {
           </HiddenCss>
         </MuiThemeProvider>,
       );
-      const root = container.querySelector('.testid');
 
-      expect(root).to.have.class('xxlUp');
+      expect(container.querySelector('.testid')).to.have.class('xxlUp');
     });
   });
 
   describe('prop: children', () => {
     it('should work when text Node', () => {
       const { container, queryByText } = render(<HiddenCss mdUp>foo</HiddenCss>);
-      const root = container.firstElementChild;
+      const root = container.firstChild;
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
@@ -125,8 +121,7 @@ describe('<HiddenCss />', () => {
           <TestChild />
         </HiddenCss>,
       );
-
-      const root = container.firstElementChild;
+      const root = container.firstChild;
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
@@ -141,8 +136,7 @@ describe('<HiddenCss />', () => {
           foo
         </HiddenCss>,
       );
-
-      const root = container.firstElementChild;
+      const root = container.firstChild;
       const children = queryAllByTestId('test-child');
 
       expect(root).to.have.tagName('div');

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -111,16 +111,16 @@ describe('<HiddenCss />', () => {
 
   describe('prop: children', () => {
     it('should work when text Node', () => {
-      const { container, getByText } = render(<HiddenCss mdUp>foo</HiddenCss>);
+      const { container, queryByText } = render(<HiddenCss mdUp>foo</HiddenCss>);
       const root = container.firstElementChild;
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
-      expect(getByText('foo')).to.not.equal(null);
+      expect(queryByText('foo')).to.not.equal(null);
     });
 
     it('should work when Element', () => {
-      const { container, getByTestId } = render(
+      const { container, queryByTestId } = render(
         <HiddenCss mdUp>
           <TestChild />
         </HiddenCss>,
@@ -130,11 +130,11 @@ describe('<HiddenCss />', () => {
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
-      expect(getByTestId('test-child')).not.to.equal(null);
+      expect(queryByTestId('test-child')).to.not.equal(null);
     });
 
     it('should work when mixed ChildrenArray', () => {
-      const { container, getAllByTestId, getByText } = render(
+      const { container, queryAllByTestId, queryByText } = render(
         <HiddenCss mdUp>
           <TestChild />
           <TestChild />
@@ -143,12 +143,12 @@ describe('<HiddenCss />', () => {
       );
 
       const root = container.firstElementChild;
-      const children = getAllByTestId('test-child');
+      const children = queryAllByTestId('test-child');
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
       expect(children.length).to.equal(2);
-      expect(getByText('foo')).not.to.equal(null);
+      expect(queryByText('foo')).to.not.equal(null);
     });
   });
 

--- a/packages/material-ui/src/Hidden/HiddenJs.test.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.test.js
@@ -4,7 +4,7 @@ import { createClientRender } from 'test/utils';
 import HiddenJs from './HiddenJs';
 
 describe('<HiddenJs />', () => {
-  let render = createClientRender();
+  const render = createClientRender();
 
   function resolvePropName(upDownOnly, breakpoint) {
     if (upDownOnly === 'only') {

--- a/packages/material-ui/src/Hidden/HiddenJs.test.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.test.js
@@ -1,14 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow } from 'test/utils';
+import { createClientRender } from 'test/utils';
 import HiddenJs from './HiddenJs';
 
 describe('<HiddenJs />', () => {
-  let shallow;
-
-  before(() => {
-    shallow = createShallow({ dive: true });
-  });
+  let render = createClientRender();
 
   function resolvePropName(upDownOnly, breakpoint) {
     if (upDownOnly === 'only') {
@@ -29,12 +25,13 @@ describe('<HiddenJs />', () => {
       const props = { [prop]: upDownOnly === 'only' ? breakpoint : true };
 
       it(descriptions[upDownOnly], () => {
-        const wrapper = shallow(
+        const { container } = render(
           <HiddenJs width={width} {...props}>
             <div>foo</div>
           </HiddenJs>,
         );
-        expect(wrapper.type()).to.equal(null);
+
+        expect(container.firstElementChild).to.equal(null);
       });
     });
   }
@@ -50,14 +47,16 @@ describe('<HiddenJs />', () => {
       const props = { [prop]: upDownOnly === 'only' ? breakpoint : true };
 
       it(descriptions[upDownOnly], () => {
-        const wrapper = shallow(
+        const { container, getByText } = render(
           <HiddenJs width={width} {...props}>
             <div>foo</div>
           </HiddenJs>,
         );
-        expect(wrapper.type()).to.not.equal(null);
-        expect(wrapper.name()).to.equal('div');
-        expect(wrapper.first().text()).to.equal('foo');
+
+        const root = container.firstElementChild;
+
+        expect(root).to.have.tagName('div');
+        expect(getByText('foo')).not.to.equal(null);
       });
     });
   }

--- a/packages/material-ui/src/Hidden/HiddenJs.test.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.test.js
@@ -31,7 +31,7 @@ describe('<HiddenJs />', () => {
           </HiddenJs>,
         );
 
-        expect(container.firstElementChild).to.equal(null);
+        expect(container.firstChild).to.equal(null);
       });
     });
   }
@@ -53,9 +53,7 @@ describe('<HiddenJs />', () => {
           </HiddenJs>,
         );
 
-        const root = container.firstElementChild;
-
-        expect(root).to.have.tagName('div');
+        expect(container.firstChild).to.have.tagName('div');
         expect(queryByText('foo')).to.not.equal(null);
       });
     });

--- a/packages/material-ui/src/Hidden/HiddenJs.test.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.test.js
@@ -47,7 +47,7 @@ describe('<HiddenJs />', () => {
       const props = { [prop]: upDownOnly === 'only' ? breakpoint : true };
 
       it(descriptions[upDownOnly], () => {
-        const { container, getByText } = render(
+        const { container, queryByText } = render(
           <HiddenJs width={width} {...props}>
             <div>foo</div>
           </HiddenJs>,
@@ -56,7 +56,7 @@ describe('<HiddenJs />', () => {
         const root = container.firstElementChild;
 
         expect(root).to.have.tagName('div');
-        expect(getByText('foo')).not.to.equal(null);
+        expect(queryByText('foo')).to.not.equal(null);
       });
     });
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Replaces enzyme for react-testing-library in the `<HiddenJs/>` and `<HiddenCss/>`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
