### PR TITLE
styles(zIndex): add list subheader sticky

### DIFF
--- a/packages/material-ui/src/ListSubheader/ListSubheader.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.js
@@ -36,7 +36,7 @@ export const styles = (theme) => ({
   sticky: {
     position: 'sticky',
     top: 0,
-    zIndex: 1,
+    zIndex: theme.zIndex.listSubheaderSticky,
     backgroundColor: 'inherit',
   },
 });

--- a/packages/material-ui/src/styles/zIndex.js
+++ b/packages/material-ui/src/styles/zIndex.js
@@ -1,6 +1,7 @@
 // We need to centralize the zIndex definitions as they work
 // like global values in the browser.
 const zIndex = {
+  listSubheaderSticky: 1,
   mobileStepper: 1000,
   speedDial: 1050,
   appBar: 1100,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR aims to add `listSubheaderSticky` to the `zIndex` constants list.

resolve #22881 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
