### PR TITLE
[Button] Fix invalid type value

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -267,7 +267,7 @@ const Button = React.forwardRef(function Button(props, ref) {
     fullWidth = false,
     size = 'medium',
     startIcon: startIconProp,
-    type = 'button',
+    type,
     variant = 'text',
     ...other
   } = props;

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -367,4 +367,14 @@ describe('<Button />', () => {
       expect(markup.text()).to.equal('Hello World');
     });
   });
+
+  it('should automatically change the button to an anchor element when href is provided', () => {
+    const { container } = render(<Button href="https://google.com">Hello</Button>);
+    const button = container.firstChild;
+
+    expect(button).to.have.property('nodeName', 'A');
+    expect(button).not.to.have.attribute('role');
+    expect(button).not.to.have.attribute('type');
+    expect(button).to.have.attribute('href', 'https://google.com');
+  });
 });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -80,11 +80,12 @@ describe('<ButtonBase />', () => {
     });
 
     it('should automatically change the button to an anchor element when href is provided', () => {
-      const { getByText } = render(<ButtonBase href="https://google.com">Hello</ButtonBase>);
-      const button = getByText('Hello');
+      const { container } = render(<ButtonBase href="https://google.com">Hello</ButtonBase>);
+      const button = container.firstChild;
 
       expect(button).to.have.property('nodeName', 'A');
       expect(button).not.to.have.attribute('role');
+      expect(button).not.to.have.attribute('type');
       expect(button).to.have.attribute('href', 'https://google.com');
     });
 


### PR DESCRIPTION
You can observe the issue on https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext--material-ui.netlify.app%2Fcomponents%2Fslider-styled%2F.

<img width="995" alt="Capture d’écran 2020-10-05 à 12 52 39" src="https://user-images.githubusercontent.com/3165635/95071263-accabd00-0709-11eb-8ad8-1910204eeea3.png">

The first error (2.) originates from:

https://github.com/mui-org/material-ui/blob/4824c9e08dd665e2f2b1b04465a67101daca87a1/docs/src/modules/components/EditPage.js#L17-L32

The change fixes the three occurrences.

A bit related to #21924. I had a look [at Bootstrap](https://getbootstrap.com/docs/4.5/components/buttons/), they transition the same 4 CSS properties.