### PR TITLE
[Button] Improve loading transition

### DIFF
--- a/docs/src/pages/components/switches/CustomizedSwitches.js
+++ b/docs/src/pages/components/switches/CustomizedSwitches.js
@@ -56,7 +56,7 @@ const IOSSwitch = withStyles((theme) => ({
     border: `1px solid ${theme.palette.grey[400]}`,
     backgroundColor: theme.palette.grey[50],
     opacity: 1,
-    transition: theme.transitions.create(['background-color', 'border']),
+    transition: theme.transitions.create(['background-color', 'border-color']),
   },
   checked: {},
   focusVisible: {},

--- a/docs/src/pages/components/switches/CustomizedSwitches.tsx
+++ b/docs/src/pages/components/switches/CustomizedSwitches.tsx
@@ -72,7 +72,10 @@ const IOSSwitch = withStyles((theme: Theme) =>
       border: `1px solid ${theme.palette.grey[400]}`,
       backgroundColor: theme.palette.grey[50],
       opacity: 1,
-      transition: theme.transitions.create(['background-color', 'border']),
+      transition: theme.transitions.create([
+        'background-color',
+        'border-color',
+      ]),
     },
     checked: {},
     focusVisible: {},

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -14,9 +14,12 @@ export const styles = (theme) => ({
     minWidth: 64,
     padding: '6px 16px',
     borderRadius: theme.shape.borderRadius,
-    transition: theme.transitions.create(['background-color', 'box-shadow', 'border'], {
-      duration: theme.transitions.duration.short,
-    }),
+    transition: theme.transitions.create(
+      ['background-color', 'box-shadow', 'border-color', 'color'],
+      {
+        duration: theme.transitions.duration.short,
+      },
+    ),
     '&:hover': {
       textDecoration: 'none',
       backgroundColor: fade(theme.palette.text.primary, theme.palette.action.hoverOpacity),

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -11,7 +11,7 @@ export const styles = (theme) => ({
   root: {
     ...theme.typography.button,
     minHeight: 36,
-    transition: theme.transitions.create(['background-color', 'box-shadow', 'border'], {
+    transition: theme.transitions.create(['background-color', 'box-shadow', 'border-color'], {
       duration: theme.transitions.duration.short,
     }),
     borderRadius: '50%',


### PR DESCRIPTION
I have noticed the wrong synchronization in the transition looking at #22878.

**Before**
![before](https://user-images.githubusercontent.com/3165635/95027698-d00a5380-069a-11eb-9044-ad7d6676cd06.gif)

**After**
![after](https://user-images.githubusercontent.com/3165635/95027693-cc76cc80-069a-11eb-80cc-4f49a65515a9.gif)
