### PR TITLE
[test] Autocomplete drop "defaultProps" pattern

### DIFF
--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -19,16 +19,12 @@ describe('<Autocomplete />', () => {
   const mount = createMount();
   let classes;
   const render = createClientRender();
-  const defaultProps = {
-    options: [],
-    openOnFocus: true,
-  };
 
   before(() => {
-    classes = getClasses(<Autocomplete {...defaultProps} renderInput={() => null} />);
+    classes = getClasses(<Autocomplete options={[]} renderInput={() => null} />);
   });
 
-  describeConformance(<Autocomplete {...defaultProps} renderInput={() => null} />, () => ({
+  describeConformance(<Autocomplete options={[]} renderInput={() => null} />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
@@ -39,7 +35,7 @@ describe('<Autocomplete />', () => {
   describe('combobox', () => {
     it('should clear the input when blur', () => {
       const { getByRole } = render(
-        <Autocomplete {...defaultProps} renderInput={(params) => <TextField {...params} />} />,
+        <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
       );
       const input = getByRole('textbox');
 
@@ -58,7 +54,7 @@ describe('<Autocomplete />', () => {
 
     it('should apply the icon classes', () => {
       const { container } = render(
-        <Autocomplete {...defaultProps} renderInput={(params) => <TextField {...params} />} />,
+        <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
       );
       expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.hasClearIcon);
       expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.hasPopupIcon);
@@ -69,7 +65,7 @@ describe('<Autocomplete />', () => {
     it('should show a loading message when open', () => {
       render(
         <Autocomplete
-          {...defaultProps}
+          options={[]}
           freeSolo
           loading
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -85,9 +81,9 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           freeSolo
           autoHighlight
+          open
           options={options}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -107,9 +103,9 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           value="one"
           autoHighlight
+          open
           options={options}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -128,7 +124,7 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       const { getByRole, setProps } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={[]}
           autoHighlight
           loading
@@ -148,8 +144,8 @@ describe('<Autocomplete />', () => {
     it('should set the highlight on selected item when dropdown is expanded', () => {
       const { getByRole, setProps } = render(
         <Autocomplete
-          {...defaultProps}
           value="one"
+          open
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -167,9 +163,9 @@ describe('<Autocomplete />', () => {
     it('should keep the current highlight if possible', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           multiple
           defaultValue={['one']}
+          open
           options={['one', 'two', 'three']}
           disableCloseOnSelect
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -193,9 +189,9 @@ describe('<Autocomplete />', () => {
     it('should not update the highlight when multiple open and value change', () => {
       const { setProps, getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           value={['two']}
           multiple
+          open
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -217,7 +213,6 @@ describe('<Autocomplete />', () => {
     it('show all items on focus', () => {
       const { container, getAllByRole, getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           multiple
           limitTags={2}
           options={['one', 'two', 'three']}
@@ -243,7 +238,6 @@ describe('<Autocomplete />', () => {
     it('show 0 item on close when set 0 to limitTags', () => {
       const { container, getAllByRole, getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           multiple
           limitTags={0}
           options={['one', 'two', 'three']}
@@ -271,8 +265,8 @@ describe('<Autocomplete />', () => {
     it('when the last item is selected, highlights the new last item', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           filterSelectedOptions
+          openOnFocus
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -301,7 +295,6 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       render(
         <Autocomplete
-          {...defaultProps}
           freeSolo
           autoSelect
           options={options}
@@ -327,10 +320,10 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       render(
         <Autocomplete
-          {...defaultProps}
           autoSelect
           multiple
           value={[options[0]]}
+          openOnFocus
           options={options}
           onChange={handleChange}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -352,11 +345,11 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           autoSelect
           freeSolo
           multiple
           onChange={handleChange}
+          options={[]}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
@@ -375,7 +368,8 @@ describe('<Autocomplete />', () => {
     it('should not crash', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          openOnFocus
+          options={[]}
           renderInput={(params) => <TextField {...params} />}
           multiple
         />,
@@ -394,9 +388,8 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       const { getAllByTestId } = render(
         <Autocomplete
-          {...defaultProps}
+          options={[]}
           defaultValue={options}
-          options={options}
           onChange={handleChange}
           renderInput={(params) => <TextField {...params} />}
           multiple
@@ -412,7 +405,6 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       render(
         <Autocomplete
-          {...defaultProps}
           defaultValue={options}
           options={options}
           onChange={handleChange}
@@ -440,7 +432,6 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       render(
         <Autocomplete
-          {...defaultProps}
           defaultValue={options}
           options={options}
           value={options}
@@ -533,7 +524,6 @@ describe('<Autocomplete />', () => {
     const handleSubmit = spy();
     const { setProps } = render(
       <Autocomplete
-        {...defaultProps}
         options={['one', 'two']}
         onKeyDown={(event) => {
           if (!event.defaultPrevented && event.key === 'Enter') {
@@ -580,8 +570,6 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       const { getAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
-          options={['one', 'two', 'three']}
           disabledItemsFocusable
           getOptionDisabled={(option) => option === 'two'}
           onKeyDown={(event) => {
@@ -590,6 +578,8 @@ describe('<Autocomplete />', () => {
             }
           }}
           onChange={handleChange}
+          openOnFocus
+          options={['one', 'two', 'three']}
           renderInput={(props2) => <TextField {...props2} autoFocus />}
         />,
       );
@@ -620,7 +610,7 @@ describe('<Autocomplete />', () => {
   describe('WAI-ARIA conforming markup', () => {
     specify('when closed', () => {
       const { getAllByRole, getByRole, queryByRole } = render(
-        <Autocomplete {...defaultProps} renderInput={(params) => <TextField {...params} />} />,
+        <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
       );
 
       const combobox = getByRole('combobox');
@@ -658,7 +648,6 @@ describe('<Autocomplete />', () => {
     specify('when open', () => {
       const { getAllByRole, getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           open
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} />}
@@ -701,7 +690,6 @@ describe('<Autocomplete />', () => {
     it('should add and remove aria-activedescendant', () => {
       const { getAllByRole, getByRole, setProps } = render(
         <Autocomplete
-          {...defaultProps}
           open
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -723,12 +711,13 @@ describe('<Autocomplete />', () => {
   });
 
   describe('when popup closed', () => {
-    it('opens when the textbox is focused', () => {
+    it('opens when the textbox is focused when `openOnFocus`', () => {
       const handleOpen = spy();
       render(
         <Autocomplete
-          {...defaultProps}
+          options={[]}
           onOpen={handleOpen}
+          openOnFocus
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
@@ -741,7 +730,6 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       const { container } = render(
         <Autocomplete
-          {...defaultProps}
           onOpen={handleOpen}
           onChange={handleChange}
           open={false}
@@ -759,13 +747,14 @@ describe('<Autocomplete />', () => {
     });
 
     ['ArrowDown', 'ArrowUp'].forEach((key) => {
-      it(`opens on ${key} when focus is on the textbox without moving focus`, () => {
+      it(`opens on ${key} when focus is on the textbox and \`openOnFocus\` without moving focus`, () => {
         const handleOpen = spy();
         render(
           <Autocomplete
-            {...defaultProps}
-            open={false}
             onOpen={handleOpen}
+            open={false}
+            openOnFocus
+            options={[]}
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
@@ -783,7 +772,6 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           onChange={handleChange}
           open={false}
           options={['one', 'two']}
@@ -803,7 +791,6 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           onChange={handleChange}
           clearOnEscape
           multiple
@@ -813,7 +800,6 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
       fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal([]);
@@ -825,7 +811,6 @@ describe('<Autocomplete />', () => {
       const handleClose = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           onClose={handleClose}
           open
           options={['one', 'two']}
@@ -841,7 +826,6 @@ describe('<Autocomplete />', () => {
       const handleClose = spy();
       const { getAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
           onClose={handleClose}
           open
           options={['one', 'two']}
@@ -858,7 +842,6 @@ describe('<Autocomplete />', () => {
       const handleClose = spy();
       const { getAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
           onClose={handleClose}
           open
           options={['one', 'two']}
@@ -874,7 +857,7 @@ describe('<Autocomplete />', () => {
     it('moves focus to the first option on ArrowDown', () => {
       const { getAllByRole, getByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -890,7 +873,7 @@ describe('<Autocomplete />', () => {
     it('moves focus to the last option on ArrowUp', () => {
       const { getAllByRole, getByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -909,7 +892,6 @@ describe('<Autocomplete />', () => {
     it('enables open on input focus', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           options={['one', 'two', 'three']}
           openOnFocus
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -947,7 +929,6 @@ describe('<Autocomplete />', () => {
     it('wraps around when navigating the list by default', () => {
       const { getAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -968,7 +949,6 @@ describe('<Autocomplete />', () => {
     it('selects the first item if on the last item and pressing up by default', () => {
       render(
         <Autocomplete
-          {...defaultProps}
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -987,8 +967,8 @@ describe('<Autocomplete />', () => {
       it('considers the textbox the predessor of the first option when pressing Up', () => {
         render(
           <Autocomplete
-            {...defaultProps}
             includeInputInList
+            open
             options={['one', 'two', 'three']}
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
@@ -1005,8 +985,8 @@ describe('<Autocomplete />', () => {
       it('considers the textbox the successor of the last option when pressing Down', () => {
         render(
           <Autocomplete
-            {...defaultProps}
             includeInputInList
+            open
             options={['one', 'two', 'three']}
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
@@ -1025,8 +1005,8 @@ describe('<Autocomplete />', () => {
       it('keeps focus on the first item if focus is on the first item and pressing Up', () => {
         render(
           <Autocomplete
-            {...defaultProps}
             disableListWrap
+            open
             options={['one', 'two', 'three']}
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
@@ -1046,8 +1026,8 @@ describe('<Autocomplete />', () => {
       it('focuses the last item when pressing Up when no option is active', () => {
         render(
           <Autocomplete
-            {...defaultProps}
             disableListWrap
+            open
             options={['one', 'two', 'three']}
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
@@ -1067,8 +1047,8 @@ describe('<Autocomplete />', () => {
       it('keeps focus on the last item if focus is on the last item and pressing Down', () => {
         render(
           <Autocomplete
-            {...defaultProps}
             disableListWrap
+            open
             options={['one', 'two', 'three']}
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
@@ -1093,20 +1073,18 @@ describe('<Autocomplete />', () => {
     it('should disable the input', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           disabled
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} />}
         />,
       );
       const input = getByRole('textbox');
-      expect(input.disabled).to.equal(true);
+      expect(input).to.have.property('disabled', true);
     });
 
     it('should disable the popup button', () => {
       const { queryByTitle } = render(
         <Autocomplete
-          {...defaultProps}
           disabled
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} />}
@@ -1118,7 +1096,6 @@ describe('<Autocomplete />', () => {
     it('should not render the clear button', () => {
       const { queryByTitle } = render(
         <Autocomplete
-          {...defaultProps}
           disabled
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} />}
@@ -1130,7 +1107,6 @@ describe('<Autocomplete />', () => {
     it('should not apply the hasClearIcon class', () => {
       const { container } = render(
         <Autocomplete
-          {...defaultProps}
           disabled
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} />}
@@ -1145,7 +1121,6 @@ describe('<Autocomplete />', () => {
     it('should not render the clear button', () => {
       const { queryByTitle, container } = render(
         <Autocomplete
-          {...defaultProps}
           disableClearable
           options={['one', 'two', 'three']}
           renderInput={(params) => <TextField {...params} />}
@@ -1162,7 +1137,6 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           freeSolo
           onChange={handleChange}
           options={[{ name: 'one' }, { name: 'two ' }]}
@@ -1199,7 +1173,6 @@ describe('<Autocomplete />', () => {
 
       render(
         <Autocomplete
-          {...defaultProps}
           multiple
           options={options}
           value={value}
@@ -1225,7 +1198,6 @@ describe('<Autocomplete />', () => {
       expect(() => {
         render(
           <Autocomplete
-            {...defaultProps}
             value={value}
             options={options}
             renderInput={(params) => <TextField {...params} />}
@@ -1253,7 +1225,7 @@ describe('<Autocomplete />', () => {
       expect(() => {
         render(
           <Autocomplete
-            {...defaultProps}
+            openOnFocus
             options={data}
             getOptionLabel={(option) => option.value}
             renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1275,7 +1247,7 @@ describe('<Autocomplete />', () => {
     it('should keep focus on selected option and not reset to top option when options updated', () => {
       const { setProps } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -1301,8 +1273,8 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           onChange={handleChange}
+          openOnFocus
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} />}
         />,
@@ -1326,8 +1298,8 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           onChange={handleChange}
+          openOnFocus
           options={options}
           renderInput={(params) => <TextField {...params} />}
         />,
@@ -1344,10 +1316,7 @@ describe('<Autocomplete />', () => {
 
     it("should display a 'no options' message if no options are available", () => {
       const { getByRole } = render(
-        <Autocomplete
-          {...defaultProps}
-          renderInput={(params) => <TextField autoFocus {...params} />}
-        />,
+        <Autocomplete open options={[]} renderInput={(params) => <TextField {...params} />} />,
       );
 
       const combobox = getByRole('combobox');
@@ -1364,8 +1333,8 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           onChange={handleChange}
+          openOnFocus
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -1385,9 +1354,9 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'one' }, { name: 'two ' }];
       render(
         <Autocomplete
-          {...defaultProps}
           multiple
           onChange={handleChange}
+          openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1409,8 +1378,8 @@ describe('<Autocomplete />', () => {
     it('add a completion string', () => {
       render(
         <Autocomplete
-          {...defaultProps}
           autoComplete
+          openOnFocus
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -1436,10 +1405,10 @@ describe('<Autocomplete />', () => {
   });
 
   describe('click input', () => {
-    it('toggles if empty', () => {
+    it('when `openOnFocus` toggles if empty', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          openOnFocus
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} />}
         />,
@@ -1456,7 +1425,6 @@ describe('<Autocomplete />', () => {
     it('selects all the first time', () => {
       const { getByRole } = render(
         <Autocomplete
-          {...defaultProps}
           value="one"
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} />}
@@ -1471,7 +1439,6 @@ describe('<Autocomplete />', () => {
     it('should focus the input when clicking on the open action', () => {
       const { getByRole, queryByTitle } = render(
         <Autocomplete
-          {...defaultProps}
           value="one"
           options={['one', 'two']}
           renderInput={(params) => <TextField {...params} />}
@@ -1546,7 +1513,7 @@ describe('<Autocomplete />', () => {
         };
         return (
           <Autocomplete
-            {...defaultProps}
+            options={[]}
             inputValue=""
             onInputChange={handleInputChange}
             renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1568,9 +1535,9 @@ describe('<Autocomplete />', () => {
       const handleInputChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           onChange={handleChange}
           onInputChange={handleInputChange}
+          open
           options={['foo']}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -1588,7 +1555,7 @@ describe('<Autocomplete />', () => {
     it('should ignore object keys by default', () => {
       const { queryAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={[
             {
               value: 'one',
@@ -1620,9 +1587,9 @@ describe('<Autocomplete />', () => {
       const filterOptions = createFilterOptions({ limit: 2 });
       const { queryAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} />}
           filterOptions={filterOptions}
         />,
       );
@@ -1633,9 +1600,9 @@ describe('<Autocomplete />', () => {
       const filterOptions = createFilterOptions({});
       const { queryAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} />}
           filterOptions={filterOptions}
         />,
       );
@@ -1649,9 +1616,9 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'foo' }];
       render(
         <Autocomplete
-          {...defaultProps}
           freeSolo
           onChange={handleChange}
+          open
           options={options}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1675,7 +1642,6 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'two'];
       const { container } = render(
         <Autocomplete
-          {...defaultProps}
           defaultValue={options}
           options={options}
           onChange={handleChange}
@@ -1701,9 +1667,9 @@ describe('<Autocomplete />', () => {
       const handleChange = spy();
       render(
         <Autocomplete
-          {...defaultProps}
           freeSolo
           onChange={handleChange}
+          options={[]}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
@@ -1842,7 +1808,6 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'foo' }];
       render(
         <Autocomplete
-          {...defaultProps}
           onInputChange={handleInputChange}
           options={options}
           getOptionLabel={(option) => option.name}
@@ -1860,8 +1825,8 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'foo' }];
       render(
         <Autocomplete
-          {...defaultProps}
           onInputChange={handleInputChange}
+          openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1883,7 +1848,7 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'foo' }];
       const { getByRole, queryByTitle } = render(
         <Autocomplete
-          {...defaultProps}
+          openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1908,7 +1873,7 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'foo' }];
       const { getByRole, queryByTitle } = render(
         <Autocomplete
-          {...defaultProps}
+          openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1931,7 +1896,7 @@ describe('<Autocomplete />', () => {
       const options = [{ name: 'foo' }];
       const { getByRole, queryByTitle } = render(
         <Autocomplete
-          {...defaultProps}
+          openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
@@ -1955,10 +1920,10 @@ describe('<Autocomplete />', () => {
     it('is considered for falsy values when filtering the list of options', () => {
       const { getAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={[0, 10, 20]}
           getOptionLabel={(option) => (option === 0 ? 'Any' : option.toString())}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} />}
           value={0}
         />,
       );
@@ -1970,10 +1935,10 @@ describe('<Autocomplete />', () => {
     it('is not considered for nullish values when filtering the list of options', () => {
       const { getAllByRole } = render(
         <Autocomplete
-          {...defaultProps}
+          open
           options={[null, 10, 20]}
           getOptionLabel={(option) => (option === null ? 'Any' : option.toString())}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} />}
           value={null}
         />,
       );
@@ -1987,7 +1952,6 @@ describe('<Autocomplete />', () => {
     it('should have the fullWidth class', () => {
       const { container } = render(
         <Autocomplete
-          {...defaultProps}
           fullWidth
           options={[0, 10, 20]}
           renderInput={(params) => <TextField {...params} />}
@@ -2068,7 +2032,6 @@ describe('<Autocomplete />', () => {
       const options = ['one', 'three', 'onetwo'];
       render(
         <Autocomplete
-          {...defaultProps}
           onHighlightChange={handleHighlightChange}
           options={options}
           renderInput={(params) => <TextField {...params} autoFocus />}


### PR DESCRIPTION
Removes indirection of having to look up what props are set (motivated by having to check out what `openOnFocus` is supposed to do in #20286). It's apparent from the current state of the test suite that these props aren't actually default props anymore.