### PR TITLE
[docs] For non-SSR language, internal search fall back to English

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -8,6 +8,7 @@ import Input from '@material-ui/core/Input';
 import SearchIcon from '@material-ui/icons/Search';
 import { handleEvent } from 'docs/src/modules/components/MarkdownLinks';
 import docsearch from 'docsearch.js';
+import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -143,6 +144,9 @@ export default function AppSearch() {
 
   React.useEffect(() => {
     if (desktop) {
+      // In non-SSR languages, fall back to English.
+      const facetFilterLanguage = LANGUAGES_SSR.includes(userLanguage) ? `language:${userLanguage}` : `language:en`
+
       // This assumes that by the time this effect runs the Input component is committed
       // this holds true as long as the effect and the component are in the same
       // suspense boundary. If you move effect and component apart be sure to check
@@ -152,7 +156,7 @@ export default function AppSearch() {
         indexName: 'material-ui',
         inputSelector: '#docsearch-input',
         algoliaOptions: {
-          facetFilters: ['version:next', `language:${userLanguage}`],
+          facetFilters: ['version:next', facetFilterLanguage],
         },
         autocompleteOptions: {
           openOnFocus: true,

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -145,7 +145,8 @@ export default function AppSearch() {
   React.useEffect(() => {
     if (desktop) {
       // In non-SSR languages, fall back to English.
-      const facetFilterLanguage = LANGUAGES_SSR.includes(userLanguage) ? `language:${userLanguage}` : `language:en`
+      const facetFilterLanguage =
+        LANGUAGES_SSR.indexOf(userLanguage) !== -1 ? `language:${userLanguage}` : `language:en`;
 
       // This assumes that by the time this effect runs the Input component is committed
       // this holds true as long as the effect and the component are in the same


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #22901

For non-SSR language, internal search fall back to English.

in Japanese (non-SSR)
<img src="https://user-images.githubusercontent.com/47806818/95169538-01476880-07ee-11eb-9a53-f3dc48c909a7.png" width="300">

in Chinese (SSR)
<img src="https://user-images.githubusercontent.com/47806818/95169546-04425900-07ee-11eb-9549-d5ad8430d3a0.png" width="300">
