### PR TITLE
[test] Migrate TabIndicator to react-testing-library

### DIFF
--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -26,9 +26,11 @@ describe('<TabIndicator />', () => {
 
   describe('prop: style', () => {
     it('should be applied on the root element', () => {
-      const wrapper = mount(<TabIndicator {...defaultProps} style={style} />);
-      const modal = wrapper.find(TabIndicator);
-      expect(modal.props().style).to.equal(style);
+      const { container } = render(<TabIndicator {...defaultProps} style={style} />);
+      const tab = container.firstChild;
+      
+      expect(tab.style).to.have.property('left', '1px');
+      expect(tab.style).to.have.property('width', '2px');
     });
   });
 

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createClientRender, createMount } from 'test/utils';
+import { getClasses, createClientRender } from 'test/utils';
 import TabIndicator from './TabIndicator';
 
 describe('<TabIndicator />', () => {
-  const mount = createMount();
   const render = createClientRender();
   let classes;
   const defaultProps = {

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -28,7 +28,7 @@ describe('<TabIndicator />', () => {
     it('should be applied on the root element', () => {
       const { container } = render(<TabIndicator {...defaultProps} style={style} />);
       const tab = container.firstChild;
-      
+
       expect(tab.style).to.have.property('left', '1px');
       expect(tab.style).to.have.property('width', '2px');
     });

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
+import { getClasses, createClientRender, createMount } from 'test/utils';
 import TabIndicator from './TabIndicator';
 
 describe('<TabIndicator />', () => {
-  let shallow;
+  const mount = createMount();
+  const render = createClientRender();
   let classes;
   const defaultProps = {
     direction: 'left',
@@ -14,28 +15,28 @@ describe('<TabIndicator />', () => {
   const style = { left: 1, width: 2 };
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<TabIndicator {...defaultProps} />);
   });
 
   it('should render with the root class', () => {
-    const wrapper = shallow(<TabIndicator {...defaultProps} />);
-    expect(wrapper.name()).to.equal('span');
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    const { container } = render(<TabIndicator {...defaultProps} />);
+    expect(container.firstChild).to.have.tagName('span');
+    expect(container.firstChild).to.have.class(classes.root);
   });
 
   describe('prop: style', () => {
     it('should be applied on the root element', () => {
-      const wrapper = shallow(<TabIndicator {...defaultProps} style={style} />);
-      expect(wrapper.props().style).to.equal(style);
+      const wrapper = mount(<TabIndicator {...defaultProps} style={style} />);
+      const modal = wrapper.find(TabIndicator);
+      expect(modal.props().style).to.equal(style);
     });
   });
 
   describe('prop: className', () => {
     it('should append the className on the root element', () => {
-      const wrapper = shallow(<TabIndicator {...defaultProps} className="foo" />);
-      expect(wrapper.name()).to.equal('span');
-      expect(wrapper.hasClass('foo')).to.equal(true);
+      const { container } = render(<TabIndicator {...defaultProps} className="foo" />);
+      expect(container.firstChild).to.have.tagName('span');
+      expect(container.firstChild).to.have.class('foo');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

#22911