### PR TITLE
[test] Throw on console.(error|warn) outside of test

### DIFF
--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -7,6 +7,7 @@ import ThemeProvider from './ThemeProvider';
 
 describe('experimentalStyled', () => {
   const render = createClientRender();
+
   it('should work', () => {
     const Div = styled('div')({
       width: '200px',
@@ -91,6 +92,7 @@ describe('experimentalStyled', () => {
         ...(props.variant && styles[props.variant]),
       });
 
+      // FIXME: Should not error in DEV
       expect(() => {
         Test = styled(
           'div',

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -52,43 +52,59 @@ describe('experimentalStyled', () => {
   });
 
   describe('muiOptions', () => {
-    const theme = createMuiTheme({
-      components: {
-        MuiTest: {
-          variants: [
-            {
-              props: { variant: 'rect', size: 'large' },
-              style: {
-                width: '400px',
-                height: '400px',
+    /**
+     * @type {ReturnType<typeof createMuiTheme>}
+     */
+    let theme;
+    /**
+     * @type {ReturnType<typeof styled>}
+     */
+    let Test;
+
+    before(() => {
+      theme = createMuiTheme({
+        components: {
+          MuiTest: {
+            variants: [
+              {
+                props: { variant: 'rect', size: 'large' },
+                style: {
+                  width: '400px',
+                  height: '400px',
+                },
               },
-            },
-          ],
-          styleOverrides: {
-            root: {
-              width: '250px',
-            },
-            rect: {
-              height: '250px',
+            ],
+            styleOverrides: {
+              root: {
+                width: '250px',
+              },
+              rect: {
+                height: '250px',
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    const testOverridesResolver = (props, styles) => ({
-      ...styles.root,
-      ...(props.variant && styles[props.variant]),
-    });
+      const testOverridesResolver = (props, styles) => ({
+        ...styles.root,
+        ...(props.variant && styles[props.variant]),
+      });
 
-    const Test = styled(
-      'div',
-      { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' },
-      { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
-    )`
-      width: 200px;
-      height: 300px;
-    `;
+      expect(() => {
+        Test = styled(
+          'div',
+          { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' },
+          { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+        )`
+          width: 200px;
+          height: 300px;
+        `;
+      }).toErrorDev([
+        'You have illegal escape sequence in your template literal',
+        'You have illegal escape sequence in your template literal',
+      ]);
+    });
 
     it('should work with specified muiOptions', () => {
       render(<Test data-testid="component">Test</Test>);

--- a/test/utils/setupJSDOM.js
+++ b/test/utils/setupJSDOM.js
@@ -44,10 +44,6 @@ function throwOnUnexpectedConsoleMessages(methodName, expectedMatcher) {
     console[methodName] = logUnexpectedConsoleCalls;
   });
 
-  mochaHooks.beforeEach.push(function resetUnexpectedCalls() {
-    unexpectedCalls.length = 0;
-  });
-
   mochaHooks.afterEach.push(function flushUnexpectedCalls() {
     const hadUnexpectedCalls = unexpectedCalls.length > 0;
     const formattedCalls = unexpectedCalls.map(([stack, message]) => `${message}\n${stack}`);


### PR DESCRIPTION
Should be reviewed without whitespace diff.

1. ~Get rid of "You have illegal escape sequence in your template literal" console message~
   Leaving a FIXME
1. console.(warn|error) outside of if `it()` now throws
   I don't know anymore if this was intentional or not. 
1. Move work in `experimentalStyled.test` into `before`
   Tests should be side-effect free i.e. don't execute any code. 
   If they do you'll have a hard time locating the issue. 
   It also slows down the overall test suite when doing `--grep` because test runners have to evaluate the full test suite. But this is more of a "death-by-thousand-cuts" scenario

