### PR TITLE
[core] Misc dependency fixes

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -115,6 +115,7 @@
     "rimraf": "^3.0.0",
     "styled-components": "^5.0.0",
     "stylis-plugin-rtl": "^1.0.0",
+    "stylis": "^3.5.4",
     "webfontloader": "^1.6.28",
     "webpack": "^4.41.0",
     "webpack-bundle-analyzer": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "**/@babel/types": "^7.10.2",
     "**/cross-fetch": "^3.0.5",
     "**/dot-prop": "^5.2.0",
-    "**/hoist-non-react-statics": "^3.3.2",
     "**/react-docgen/ast-types": "^0.14.1",
     "**/webpack": "^4.44.1"
   },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
   "resolutions": {
     "**/@babel/core": "^7.10.2",
     "**/@babel/code-frame": "^7.10.4",
-    "**/@babel/parser": "7.10.5",
     "**/@babel/plugin-proposal-class-properties": "^7.10.1",
     "**/@babel/plugin-proposal-object-rest-spread": "^7.10.1",
     "**/@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
@@ -171,6 +170,7 @@
     "**/cross-fetch": "^3.0.5",
     "**/dot-prop": "^5.2.0",
     "**/hoist-non-react-statics": "^3.3.2",
+    "**/react-docgen/ast-types": "^0.14.1",
     "**/webpack": "^4.44.1"
   },
   "nyc": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15453,7 +15453,7 @@ stylis-rule-sheet@0.0.10:
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
-stylis@3.5.4:
+stylis@3.5.4, stylis@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,10 +354,10 @@
     resolve "^1.13.1"
     v8flags "^3.1.1"
 
-"@babel/parser@7.10.5", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.7.5":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.5.tgz#e7c6bf5a7deff957cec9f04b551e2762909d826b"
-  integrity sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==
+"@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.7.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
+  integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
@@ -3818,12 +3818,7 @@ ast-types@0.14.1:
   dependencies:
     tslib "^2.0.1"
 
-ast-types@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
-  integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
-
-ast-types@^0.14.1:
+ast-types@^0.13.2, ast-types@^0.14.1:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
   integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==


### PR DESCRIPTION
1. fixes missing peer warning for `stylis-plugin-rtl`
1. Less intrusive fix for https://github.com/reactjs/react-docgen/issues/463 (original fix: https://github.com/mui-org/material-ui/pull/22501#discussion_r484386396)
1. Remove unused resolution for `hoist-non-react-statics`
   All packages now pull in 3.x