### PR TITLE
[test] Migrate NativeSelectInput to react-testing-library

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount, describeConformance } from 'test/utils';
+import { createMount, describeConformance, createClientRender } from 'test/utils';
 import NativeSelectInput from './NativeSelectInput';
 
 describe('<NativeSelectInput />', () => {
-  let shallow;
   const mount = createMount();
+  const render = createClientRender();
   const defaultProps = {
     classes: { select: 'select' },
+    onChange: () => {},
     value: 10,
     IconComponent: 'div',
     children: [
@@ -24,10 +25,6 @@ describe('<NativeSelectInput />', () => {
     ],
   };
 
-  before(() => {
-    shallow = createShallow();
-  });
-
   describeConformance(<NativeSelectInput {...defaultProps} onChange={() => {}} />, () => ({
     mount,
     only: ['refForwarding'],
@@ -35,14 +32,15 @@ describe('<NativeSelectInput />', () => {
   }));
 
   it('should render a native select', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <NativeSelectInput {...defaultProps}>
         <option value={10}>Ten</option>
         <option value={20}>Twenty</option>
         <option value={30}>Thirty</option>
       </NativeSelectInput>,
     );
-    expect(wrapper.find('select').props().value).to.equal(10);
+
+    expect(container.firstChild.value).to.equal('10');
   });
 
   it('should respond to update event', () => {
@@ -61,8 +59,8 @@ describe('<NativeSelectInput />', () => {
   });
 
   it('should apply outlined class', () => {
-    const outlined = 'class for outlined variant';
-    const wrapper = shallow(
+    const outlined = '.outlined';
+    const { container } = render(
       <NativeSelectInput
         {...defaultProps}
         variant="outlined"
@@ -70,12 +68,12 @@ describe('<NativeSelectInput />', () => {
       />,
     );
 
-    expect(wrapper.find(`.${defaultProps.classes.select}`).hasClass(outlined)).to.equal(true);
+    expect(container.firstChild).to.have.class(outlined);
   });
 
   it('should apply filled class', () => {
-    const filled = 'class for filled variant';
-    const wrapper = shallow(
+    const filled = '.filled';
+    const { container } = render(
       <NativeSelectInput
         {...defaultProps}
         variant="filled"
@@ -83,6 +81,6 @@ describe('<NativeSelectInput />', () => {
       />,
     );
 
-    expect(wrapper.find(`.${defaultProps.classes.select}`).hasClass(filled)).to.equal(true);
+    expect(container.firstChild).to.have.class(filled);
   });
 });

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -72,7 +72,7 @@ describe('<NativeSelectInput />', () => {
   });
 
   it('should apply filled class', () => {
-    const filled = '.filled';
+    const filled = 'filled';
     const { container } = render(
       <NativeSelectInput
         {...defaultProps}

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -59,7 +59,7 @@ describe('<NativeSelectInput />', () => {
   });
 
   it('should apply outlined class', () => {
-    const outlined = '.outlined';
+    const outlined = 'outlined';
     const { container } = render(
       <NativeSelectInput
         {...defaultProps}

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -1,44 +1,41 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createClientRender } from 'test/utils';
+import { createShallow, getClasses } from 'test/utils';
 import TabIndicator from './TabIndicator';
 
 describe('<TabIndicator />', () => {
-  const render = createClientRender();
+  let shallow;
   let classes;
   const defaultProps = {
     direction: 'left',
     orientation: 'horizontal',
     color: 'secondary',
   };
-  const style = { left: '1px', width: '2px' };
+  const style = { left: 1, width: 2 };
 
   before(() => {
+    shallow = createShallow({ dive: true });
     classes = getClasses(<TabIndicator {...defaultProps} />);
   });
 
   it('should render with the root class', () => {
-    const { container } = render(<TabIndicator {...defaultProps} />);
-
-    expect(container.firstChild).to.have.tagName('span');
-    expect(container.firstChild).to.have.class(classes.root);
+    const wrapper = shallow(<TabIndicator {...defaultProps} />);
+    expect(wrapper.name()).to.equal('span');
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
   });
 
   describe('prop: style', () => {
     it('should be applied on the root element', () => {
-      const { container } = render(<TabIndicator {...defaultProps} style={style} />);
-
-      expect(container.firstChild.style).to.have.property('left', '1px');
-      expect(container.firstChild.style).to.have.property('width', '2px');
+      const wrapper = shallow(<TabIndicator {...defaultProps} style={style} />);
+      expect(wrapper.props().style).to.equal(style);
     });
   });
 
   describe('prop: className', () => {
     it('should append the className on the root element', () => {
-      const { container } = render(<TabIndicator {...defaultProps} className="foo" />);
-
-      expect(container.firstChild).to.have.tagName('span');
-      expect(container.firstChild).to.have.class('foo');
+      const wrapper = shallow(<TabIndicator {...defaultProps} className="foo" />);
+      expect(wrapper.name()).to.equal('span');
+      expect(wrapper.hasClass('foo')).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -1,41 +1,44 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createShallow, getClasses } from 'test/utils';
+import { getClasses, createClientRender } from 'test/utils';
 import TabIndicator from './TabIndicator';
 
 describe('<TabIndicator />', () => {
-  let shallow;
+  const render = createClientRender();
   let classes;
   const defaultProps = {
     direction: 'left',
     orientation: 'horizontal',
     color: 'secondary',
   };
-  const style = { left: 1, width: 2 };
+  const style = { left: '1px', width: '2px' };
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<TabIndicator {...defaultProps} />);
   });
 
   it('should render with the root class', () => {
-    const wrapper = shallow(<TabIndicator {...defaultProps} />);
-    expect(wrapper.name()).to.equal('span');
-    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    const { container } = render(<TabIndicator {...defaultProps} />);
+
+    expect(container.firstChild).to.have.tagName('span');
+    expect(container.firstChild).to.have.class(classes.root);
   });
 
   describe('prop: style', () => {
     it('should be applied on the root element', () => {
-      const wrapper = shallow(<TabIndicator {...defaultProps} style={style} />);
-      expect(wrapper.props().style).to.equal(style);
+      const { container } = render(<TabIndicator {...defaultProps} style={style} />);
+
+      expect(container.firstChild.style).to.have.property('left', '1px');
+      expect(container.firstChild.style).to.have.property('width', '2px');
     });
   });
 
   describe('prop: className', () => {
     it('should append the className on the root element', () => {
-      const wrapper = shallow(<TabIndicator {...defaultProps} className="foo" />);
-      expect(wrapper.name()).to.equal('span');
-      expect(wrapper.hasClass('foo')).to.equal(true);
+      const { container } = render(<TabIndicator {...defaultProps} className="foo" />);
+
+      expect(container.firstChild).to.have.tagName('span');
+      expect(container.firstChild).to.have.class('foo');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Replaces enzyme for react-testing-library in the `<NativeSelectInput/>`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


#22911