### PR TITLE
[Autocomplete] Don't display whole options list when input text is the same as selected value

### DIFF
--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -195,9 +195,7 @@ export default function useAutocomplete(props) {
           }
           return true;
         }),
-        // we use the empty string to manipulate `filterOptions` to not filter any options
-        // i.e. the filter predicate always returns true
-        { inputValue: inputValueIsSelectedValue ? '' : inputValue, getOptionLabel },
+        { inputValue, getOptionLabel },
       )
     : [];
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #22792 

**inputValueIsSelectedValue** is `true` when **multiple** is `false` and **selectedValue** equals **inputValue**. In this case, it's an unnecessary check since even if **selectedValue** equals **inputValue**, we'd want the filterOptions work correctly. 