### PR TITLE
[docs] Use demo name as codesandbox name

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -299,6 +299,9 @@ function DemoToolbar(props) {
             },
             main: demoConfig.main,
             scripts: demoConfig.scripts,
+            // We used `title` previously but only inference from `name` is documented.
+            // TODO revisit once https://github.com/codesandbox/codesandbox-client/issues/4983 is resolved.
+            title: demoConfig.title,
           },
         },
         ...Object.keys(demoConfig.files).reduce((files, name) => {

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -50,23 +50,29 @@ function getDemoName(location) {
   return location.replace(/(.+?)(\w+)\.\w+$$/, '$2');
 }
 
-function getDemoData(codeVariant, demo, githubLocation) {
+function useDemoData(codeVariant, demo, githubLocation) {
+  const userLanguage = useSelector((state) => state.options.userLanguage);
+  const title = `${getDemoName(githubLocation)} Material Demo`;
   if (codeVariant === CODE_VARIANTS.TS && demo.rawTS) {
     return {
       codeVariant: CODE_VARIANTS.TS,
       githubLocation: githubLocation.replace(/\.js$/, '.tsx'),
+      language: userLanguage,
       raw: demo.rawTS,
       Component: demo.tsx,
       sourceLanguage: 'tsx',
+      title,
     };
   }
 
   return {
     codeVariant: CODE_VARIANTS.JS,
     githubLocation,
+    language: userLanguage,
     raw: demo.raw,
     Component: demo.js,
     sourceLanguage: 'jsx',
+    title,
   };
 }
 
@@ -284,7 +290,7 @@ function DemoToolbar(props) {
       files: {
         'package.json': {
           content: {
-            title: demoConfig.title,
+            name: demoConfig.title,
             description: demoConfig.description,
             dependencies: demoConfig.dependencies,
             devDependencies: {
@@ -710,7 +716,7 @@ export default function Demo(props) {
   const classes = useStyles();
   const t = useSelector((state) => state.options.t);
   const codeVariant = useSelector((state) => state.options.codeVariant);
-  const demoData = getDemoData(codeVariant, demo, githubLocation);
+  const demoData = useDemoData(codeVariant, demo, githubLocation);
 
   const [demoHovered, setDemoHovered] = React.useState(false);
   const handleDemoHover = (event) => {

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -89,12 +89,12 @@ export default function getDemo(demoData) {
 <html lang="${demoData.language}">
   <head>
     <title>${demoData.title}</title>
-  </head>
-  <body>
     <!-- Fonts to support Material Design -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <!-- Icons to support Material Design -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+  </head>
+  <body>
     <div id="root"></div>
   </body>
 </html>

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -81,17 +81,23 @@ function getLanguageConfig(demoData) {
 
 export default function getDemo(demoData) {
   const baseConfig = {
-    title: 'Material demo',
+    title: demoData.title,
     description: demoData.githubLocation,
     files: {
-      'index.html': `
-<body>
-  <!-- Fonts to support Material Design -->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-  <!-- Icons to support Material Design -->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-  <div id="root"></div>
-</body>
+      'public/index.html': `
+<!DOCTYPE html>
+<html lang="${demoData.language}">
+  <head>
+    <title>${demoData.title}</title>
+  </head>
+  <body>
+    <!-- Fonts to support Material Design -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <!-- Icons to support Material Design -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <div id="root"></div>
+  </body>
+</html>
       `,
     },
   };

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -14,7 +14,7 @@ import ReactDOM from 'react-dom';
 import Demo from './demo';
 
 ReactDOM.render(<Demo />, document.querySelector('#root'));
-    `,
+    `.trim(),
     },
   };
 }
@@ -33,7 +33,7 @@ import ReactDOM from 'react-dom';
 import Demo from './demo';
 
 ReactDOM.render(<Demo />, document.querySelector('#root'));
-    `,
+    `.trim(),
       'tsconfig.json': `{
   "compilerOptions": {
     "target": "es5",
@@ -90,15 +90,21 @@ export default function getDemo(demoData) {
   <head>
     <title>${demoData.title}</title>
     <!-- Fonts to support Material Design -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
     <!-- Icons to support Material Design -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
   </head>
   <body>
     <div id="root"></div>
   </body>
 </html>
-      `,
+`.trim(),
     },
   };
   const languageConfig = getLanguageConfig(demoData);


### PR DESCRIPTION
Includes the demo name in the codesandbox and page title. Also includes the currently used docs language for more accurate repros.

Note that this only works when the sandbox is opened in a new window. The integrated view has a non-descriptive UUID-like title. Possibly due to https://github.com/codesandbox/codesandbox-client/issues/4983.