### PR TITLE
[Tooltip] Support tooltips for disabled buttons

### DIFF
--- a/docs/src/pages/components/tooltips/DisabledTooltips.js
+++ b/docs/src/pages/components/tooltips/DisabledTooltips.js
@@ -5,9 +5,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 export default function DisabledTooltips() {
   return (
     <Tooltip title="You don't have permission to do this">
-      <span>
-        <Button disabled>A Disabled Button</Button>
-      </span>
+      <Button disabled>A Disabled Button</Button>
     </Tooltip>
   );
 }

--- a/docs/src/pages/components/tooltips/DisabledTooltips.tsx
+++ b/docs/src/pages/components/tooltips/DisabledTooltips.tsx
@@ -5,9 +5,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 export default function DisabledTooltips() {
   return (
     <Tooltip title="You don't have permission to do this">
-      <span>
-        <Button disabled>A Disabled Button</Button>
-      </span>
+      <Button disabled>A Disabled Button</Button>
     </Tooltip>
   );
 }

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -36,7 +36,6 @@ export const styles = {
       borderStyle: 'none', // Remove Firefox dotted outline.
     },
     '&$disabled': {
-      pointerEvents: 'none', // Disable link interactions
       cursor: 'default',
     },
     '@media print': {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -387,14 +387,16 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   };
 
   const handleTouchStart = (event) => {
-    detectTouchStart(event);
-    clearTimeout(leaveTimer.current);
-    clearTimeout(closeTimer.current);
-    clearTimeout(touchTimer.current);
-    event.persist();
-    touchTimer.current = setTimeout(() => {
-      handleEnter()(event);
-    }, enterTouchDelay);
+    if (typeof PointerEvent === 'undefined') {
+      detectTouchStart(event);
+      clearTimeout(leaveTimer.current);
+      clearTimeout(closeTimer.current);
+      clearTimeout(touchTimer.current);
+      event.persist();
+      touchTimer.current = setTimeout(() => {
+        handleEnter()(event);
+      }, enterTouchDelay);
+    }
   };
 
   const handleTouchEnd = (event) => {
@@ -402,12 +404,14 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
       children.props.onTouchEnd(event);
     }
 
-    clearTimeout(touchTimer.current);
-    clearTimeout(leaveTimer.current);
-    event.persist();
-    leaveTimer.current = setTimeout(() => {
-      handleClose(event);
-    }, leaveTouchDelay);
+    if (typeof PointerEvent === 'undefined') {
+      clearTimeout(touchTimer.current);
+      clearTimeout(leaveTimer.current);
+      event.persist();
+      leaveTimer.current = setTimeout(() => {
+        handleClose(event);
+      }, leaveTouchDelay);
+    }
   };
 
   React.useEffect(() => {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -263,8 +263,8 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   const handleEnter = (forward = true) => (event) => {
     const childrenProps = children.props;
 
-    if (event.type === 'mouseover' && childrenProps.onMouseOver && forward) {
-      childrenProps.onMouseOver(event);
+    if (event.type === 'pointerenter' && childrenProps.onPointerEnter && forward) {
+      childrenProps.onPointerEnter(event);
     }
 
     if (ignoreNonTouchEvents.current && event.type !== 'touchstart') {
@@ -501,12 +501,12 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   }
 
   if (!disableHoverListener) {
-    childrenProps.onMouseOver = handleEnter();
-    childrenProps.onMouseLeave = handleLeave();
+    childrenProps.onPointerEnter = handleEnter();
+    childrenProps.onPointerLeave = handleLeave();
 
     if (!disableInteractive) {
-      interactiveWrapperListeners.onMouseOver = handleEnter(false);
-      interactiveWrapperListeners.onMouseLeave = handleLeave(false);
+      interactiveWrapperListeners.onPointerEnter = handleEnter(false);
+      interactiveWrapperListeners.onPointerLeave = handleLeave(false);
     }
   }
 


### PR DESCRIPTION
https://deploy-preview-22937--material-ui.netlify.app/components/tooltips/#disabled-elements

Use pointer events instead of mouse events. That way we don't have to deal with quirky mouseenter on disabled buttons (which should work by spec but is not implemented for historic reasons: https://github.com/w3c/pointerevents/issues/177). We can leverage pointer events even though we support Safari 12.1 on iOS because in that environment the tooltip is triggered by the touchstart event.

Needs:
1. [x] spec crawling
   1. Seems to be intended reading https://github.com/w3c/pointerevents/issues/177
      From that issue it sounds like mouseenter not firing is due to a historical misinterpretation of the spec.
      Since PointerEvents are new browsers had a chance to remedy this without breaking compat.
1. [ ] browser testing
   1. Linux
      1. [x] Chrome 85
      1. [ ] Firefox 
   1. MacOS
      1. [ ] Chrome 85
      1. [ ] Safari 13
   1. Windows
      1. [x] Chrome 85
      1. [x] Edge 85
      1. [x] Firefox 75
   1. iOS
      1. [ ] Safari 12
1. [ ] discuss how we reconcile the "anchor as a button" use case and whether we support disabled anchors.
   Right now we implement most of the expected behavior for disabled elements by adding `pointer-events: none;`.
   We do this for the anchor and `div[role="button"]` use case as well as to not apply hover styles.
   I would propose that we rather implement these behaviors properly so that we have better support for the default `<button type="button" />` use case e.g. allow `cursor: not-allowed`
1. [ ] fix tests

## Motivation

Wrapper elements for disabled buttons with tooltips are pretty hard since we only want event handlers on the wrapper. Everything else should go on the button e.g. `aria-label`.