### PR TITLE
[test] Use appropriate templates for csb CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -23,9 +23,9 @@
     "@material-ui/utils": "packages/material-ui-utils/build"
   },
   "sandboxes": [
-    "new",
-    "github/mui-org/material-ui/tree/master/examples/create-react-app",
-    "github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript"
+    "material-ui-issue-dh2yh",
+    "github/mui-org/material-ui/tree/HEAD/examples/create-react-app",
+    "github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-typescript"
   ],
   "silent": true
 }

--- a/examples/create-react-app-with-typescript/package.json
+++ b/examples/create-react-app-with-typescript/package.json
@@ -3,7 +3,9 @@
   "version": "4.0.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "latest",
+    "@emotion/core": "latest",
+    "@emotion/styled": "latest",
+    "@material-ui/core": "next",
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "react": "latest",


### PR DESCRIPTION
1. Replace bare react template with our issue template
   The react template isn't useful since you manually add the versions. Might as well start out with react.new
1. Use `HEAD` instead of `master`
   Continuation of #22801