### PR TITLE
[test] Migrate TextField to react-testing-library

### DIFF
--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -32,15 +32,19 @@ describe('<TextField />', () => {
     });
 
     it('should forward the multiline prop to Input', () => {
-      const wrapper = mount(<TextField multiline />);
+      const inputClasses = getClasses(<Input />);
+      const { getAllByRole } = render(<TextField multiline />);
 
-      expect(wrapper.find(Input).props()).to.have.property('multiline', true);
+      expect(getAllByRole('textbox')[0]).to.have.class(inputClasses.inputMultiline);
     });
 
     it('should forward the fullWidth prop to Input', () => {
-      const wrapper = mount(<TextField fullWidth />);
+      const inputClasses = getClasses(<Input />);
+      const { getByTestId } = render(
+        <TextField fullWidth InputProps={{ 'data-testid': 'mui-input-base-root' }} />,
+      );
 
-      expect(wrapper.find(Input).props()).to.have.property('fullWidth', true);
+      expect(getByTestId('mui-input-base-root')).to.have.class(inputClasses.fullWidth);
     });
   });
 
@@ -112,11 +116,12 @@ describe('<TextField />', () => {
     });
 
     it('should set shrink prop on outline from label', () => {
-      const wrapper = mount(
+      const outlinedInputClasses = getClasses(<OutlinedInput />);
+      const { getByRole } = render(
         <TextField variant="outlined" InputLabelProps={{ shrink: true }} classes={{}} />,
       );
 
-      expect(wrapper.find(OutlinedInput).props()).to.have.property('notched', true);
+      expect(getByRole('group')).to.have.class(outlinedInputClasses.notchedOutline);
     });
   });
 

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -117,11 +117,13 @@ describe('<TextField />', () => {
 
     it('should set shrink prop on outline from label', () => {
       const outlinedInputClasses = getClasses(<OutlinedInput />);
-      const { getByRole } = render(
+      const { container } = render(
         <TextField variant="outlined" InputLabelProps={{ shrink: true }} classes={{}} />,
       );
 
-      expect(getByRole('group')).to.have.class(outlinedInputClasses.notchedOutline);
+      expect(container.querySelector('fieldset')).to.have.class(
+        outlinedInputClasses.notchedOutline,
+      );
     });
   });
 

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -33,9 +33,9 @@ describe('<TextField />', () => {
 
     it('should forward the multiline prop to Input', () => {
       const inputClasses = getClasses(<Input />);
-      const { getAllByRole } = render(<TextField multiline />);
+      const { getByRole } = render(<TextField multiline />);
 
-      expect(getAllByRole('textbox')[0]).to.have.class(inputClasses.inputMultiline);
+      expect(getByRole('textbox', { hidden: false })).to.have.class(inputClasses.inputMultiline);
     });
 
     it('should forward the fullWidth prop to Input', () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

#22911 