### PR TITLE
[docs] Cache next build dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,7 @@ jobs:
 workflows:
   version: 2
   pipeline:
+    when: false
     jobs:
       - checkout
       - test_unit:

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,6 @@
 [build.environment]
   NODE_VERSION = "10"
   NODE_OPTIONS = "--max_old_space_size=4096"
+
+[[plugins]]
+  package = "./packages/netlify-plugin-cache-docs"

--- a/packages/netlify-plugin-cache-docs/index.js
+++ b/packages/netlify-plugin-cache-docs/index.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+const fse = require('fs-extra');
+const path = require('path');
+
+const CACHE_OUTPUT_FILE = 'cache-output.json';
+
+function generateAbsolutePaths(context) {
+  const { constants } = context;
+
+  const workspaceRoot = path.dirname(constants.CONFIG_PATH);
+  const docsWorkspacePath = path.join(workspaceRoot, 'docs');
+
+  const nextjsBuildDir = path.join(docsWorkspacePath, '.next');
+  const digests = [path.join(workspaceRoot, 'yarn.lock')];
+
+  return { digests, nextjsBuildDir };
+}
+
+module.exports = {
+  async onPreBuild(context) {
+    const { constants, utils } = context;
+    const { nextjsBuildDir } = generateAbsolutePaths({ constants });
+    const success = await utils.cache.restore(nextjsBuildDir);
+
+    console.log("'%s' exists: %s", nextjsBuildDir, String(fse.existsSync(nextjsBuildDir)));
+
+    console.log(
+      "Restored the cached 'docs/.next' folder at the location '%s': %s",
+      nextjsBuildDir,
+      String(success),
+    );
+  },
+  async onPostBuild(context) {
+    const { constants, utils } = context;
+    const { digests, nextjsBuildDir } = generateAbsolutePaths({ constants });
+
+    console.log("'%s' exists: %s", nextjsBuildDir, String(fse.existsSync(nextjsBuildDir)));
+
+    const success = await utils.cache.save(nextjsBuildDir, {
+      digests,
+    });
+
+    console.log(
+      "Cached 'docs/.next' folder at the location '%s': %s",
+      nextjsBuildDir,
+      String(success),
+    );
+  },
+  // debug
+  // based on: https://github.com/netlify-labs/netlify-plugin-debug-cache/blob/v1.0.3/index.js
+  async onEnd({ constants, utils }) {
+    const { PUBLISH_DIR } = constants;
+    const cacheManifestFileName = CACHE_OUTPUT_FILE;
+    const cacheManifestPath = path.join(PUBLISH_DIR, cacheManifestFileName);
+    console.log('Saving cache file manifest for debugging...');
+    const files = await utils.cache.list();
+    await fse.mkdirp(PUBLISH_DIR);
+    await fse.writeJSON(cacheManifestPath, files, { spaces: 2 });
+    console.log(`Cache file count: ${files.length}`);
+    console.log(`Cache manifest saved to ${cacheManifestPath}`);
+    console.log(`Please download the build files to inspect ${cacheManifestFileName}.`);
+    console.log('Instructions => http://bit.ly/netlify-dl-cache');
+  },
+};

--- a/packages/netlify-plugin-cache-docs/manifest.yml
+++ b/packages/netlify-plugin-cache-docs/manifest.yml
@@ -1,0 +1,1 @@
+name: netlify-plugin-cache-docs

--- a/packages/netlify-plugin-cache-docs/package.json
+++ b/packages/netlify-plugin-cache-docs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "netlify-plugin-cache-docs",
+  "version": "0.0.1",
+  "private": true,
+  "author": "Material-UI Team",
+  "description": "Alternative to netlify-plugin-cache-nextjs",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/netlify-plugin-cache-docs"
+  },
+  "license": "MIT",
+  "scripts": {},
+  "dependencies": {
+    "fs-extra": "^9.0.1"
+  },
+  "devDependencies": {},
+  "engines": {
+    "node": ">=10.0.0"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,7 +7919,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0:
+fs-extra@^9.0.0, fs-extra@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==


### PR DESCRIPTION
Another attempt at #20357.

Might be that this simply doesn't work for deploy previews (see https://github.com/pizzafox/netlify-cache-nextjs/issues/95 and https://github.com/netlify/build/issues/1225). We can test if it works on branch deploys which is where netlify is currently failing very often.