### PR TITLE
[test] Prevent nextjs build cache to grow indefinitely

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,10 +78,7 @@ steps:
 
   - task: Cache@2
     inputs:
-      key: 'yarn | "$(Agent.OS)" | yarn.lock'
-      restoreKeys: |
-        yarn | "$(Agent.OS)"
-        yarn
+      key: 'nextjs-build | yarn.lock'
       path: $(DOCS_NEXT_CACHE_FOLDER)
     displayName: Cache nextjs build
 


### PR DESCRIPTION
The cached size of `docs/.next/cache` in azure pipelines is now at 3GB (takes 2min to restore) while a fresh build only creates a cache of 23MB.

The issue is that ever time yarn.lock changed it fell back to any previous cache. Since nextjs does not remove any cache files the cache only ever increased. 

There might be an argument to be made that nextjs should remove every untouched cache file but that's hard to tell without knowing how they cache their files.

Completely clearing it when `yarn.lock` changes is a good enough approximation of "clear it occasionally".
