### PR TITLE
[test] Migrate Fab to react-testing-library

### DIFF
--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -6,10 +6,12 @@ import {
   createClientRender,
   createMount,
   createServerRender,
+  fireEvent,
 } from 'test/utils';
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';
+import TouchRipple from '../ButtonBase/TouchRipple';
 
 describe('<Fab />', () => {
   const mount = createMount();
@@ -90,27 +92,37 @@ describe('<Fab />', () => {
   });
 
   it('should have a ripple by default', () => {
-    const wrapper = mount(<Fab>Fab</Fab>);
+    const touchRippleClasses = getClasses(<TouchRipple />);
+    const { container } = render(<Fab>Fab</Fab>);
 
-    expect(wrapper.find(ButtonBase).props()).not.to.have.property('disableRipple');
+    expect(container.querySelector(`.${touchRippleClasses.root}`)).not.to.equal(null);
   });
 
   it('should pass disableRipple to ButtonBase', () => {
-    const wrapper = mount(<Fab disableRipple>Fab</Fab>);
+    const touchRippleClasses = getClasses(<TouchRipple />);
+    const { container } = render(<Fab disableRipple>Fab</Fab>);
 
-    expect(wrapper.find(ButtonBase).props()).to.have.property('disableRipple', true);
+    expect(container.querySelector(`.${touchRippleClasses.root}`)).to.equal(null);
   });
 
   it('should have a focusRipple by default', () => {
-    const wrapper = mount(<Fab>Fab</Fab>);
+    const touchRippleClasses = getClasses(<TouchRipple />);
+    const { container, getByRole } = render(<Fab>Fab</Fab>);
 
-    expect(wrapper.find(ButtonBase).props()).to.have.property('focusRipple', true);
+    fireEvent.focus(getByRole('button'));
+
+    expect(container.querySelector(`.${touchRippleClasses.root}`).firstChild).to.have.class(
+      touchRippleClasses.ripple,
+    );
   });
 
   it('should pass disableFocusRipple to ButtonBase', () => {
-    const wrapper = mount(<Fab disableFocusRipple>Fab</Fab>);
+    const touchRippleClasses = getClasses(<TouchRipple />);
+    const { container, getByRole } = render(<Fab disableFocusRipple>Fab</Fab>);
 
-    expect(wrapper.find(ButtonBase).props()).to.have.property('focusRipple', false);
+    fireEvent.focus(getByRole('button'));
+
+    expect(container.querySelector(`.${touchRippleClasses.root}`).firstChild).to.equal(null);
   });
 
   it('should render Icon children with right classes', () => {

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -42,7 +42,6 @@ describe('<Fab />', () => {
     expect(button).not.to.have.class(classes.focusVisible);
     expect(button).not.to.have.class(classes.disabled);
     expect(button).not.to.have.class(classes.colorInherit);
-    expect(button).not.to.have.class(classes.mini);
     expect(button).not.to.have.class(classes.fullWidth);
     expect(button).not.to.have.class(classes.sizeSmall);
     expect(button).not.to.have.class(classes.sizeMedium);

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -105,24 +105,29 @@ describe('<Fab />', () => {
     expect(container.querySelector(`.${touchRippleClasses.root}`)).to.equal(null);
   });
 
-  it('should have a focusRipple by default', () => {
+  it('should have a focusRipple by default', async () => {
     const touchRippleClasses = getClasses(<TouchRipple />);
-    const { container, getByRole } = render(<Fab>Fab</Fab>);
+    const { getByRole, findByTestId } = render(
+      <Fab TouchRippleProps={{ 'data-testid': 'mui-ripple-root' }}>Fab</Fab>,
+    );
 
     fireEvent.focus(getByRole('button'));
 
-    expect(container.querySelector(`.${touchRippleClasses.root}`).firstChild).to.have.class(
+    expect((await findByTestId('mui-ripple-root')).firstChild).to.have.class(
       touchRippleClasses.ripple,
     );
   });
 
-  it('should pass disableFocusRipple to ButtonBase', () => {
-    const touchRippleClasses = getClasses(<TouchRipple />);
-    const { container, getByRole } = render(<Fab disableFocusRipple>Fab</Fab>);
+  it('should pass disableFocusRipple to ButtonBase', async () => {
+    const { getByRole, findByTestId } = render(
+      <Fab TouchRippleProps={{ 'data-testid': 'mui-ripple-root' }} disableFocusRipple>
+        Fab
+      </Fab>,
+    );
 
     fireEvent.focus(getByRole('button'));
 
-    expect(container.querySelector(`.${touchRippleClasses.root}`).firstChild).to.equal(null);
+    expect((await findByTestId('mui-ripple-root')).firstChild).to.equal(null);
   });
 
   it('should render Icon children with right classes', () => {

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -6,6 +6,8 @@ import {
   createClientRender,
   createMount,
   createServerRender,
+  act,
+  fireEvent,
 } from 'test/utils';
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
@@ -105,30 +107,44 @@ describe('<Fab />', () => {
   });
 
   it('should have a focusRipple by default', async () => {
-    const touchRippleClasses = getClasses(<TouchRipple />);
-    const { getByRole, findByTestId } = render(
-      <Fab TouchRippleProps={{ 'data-testid': 'mui-ripple-root' }}>Fab</Fab>,
-    );
-
-    getByRole('button').focus();
-
-    expect(
-      (await findByTestId('mui-ripple-root', undefined, { timeout: 5000 })).firstChild,
-    ).to.have.class(touchRippleClasses.ripple);
-  });
-
-  it('should pass disableFocusRipple to ButtonBase', async () => {
-    const { getByRole, findByTestId } = render(
-      <Fab TouchRippleProps={{ 'data-testid': 'mui-ripple-root' }} disableFocusRipple>
+    const { getByRole } = render(
+      <Fab
+        TouchRippleProps={{
+          classes: { ripplePulsate: 'pulsate-focus-visible' },
+        }}
+      >
         Fab
       </Fab>,
     );
+    const button = getByRole('button');
 
-    getByRole('button').focus();
+    act(() => {
+      fireEvent.keyDown(document.body, { key: 'TAB' });
+      button.focus();
+    });
 
-    expect(
-      (await findByTestId('mui-ripple-root', undefined, { timeout: 5000 })).firstChild,
-    ).to.equal(null);
+    expect(button.querySelector('.pulsate-focus-visible')).not.to.equal(null);
+  });
+
+  it('should pass disableFocusRipple to ButtonBase', async () => {
+    const { getByRole } = render(
+      <Fab
+        TouchRippleProps={{
+          classes: { ripplePulsate: 'pulsate-focus-visible' },
+        }}
+        disableFocusRipple
+      >
+        Fab
+      </Fab>,
+    );
+    const button = getByRole('button');
+
+    act(() => {
+      fireEvent.keyDown(document.body, { key: 'TAB' });
+      button.focus();
+    });
+
+    expect(button.querySelector('.pulsate-focus-visible')).to.equal(null);
   });
 
   it('should render Icon children with right classes', () => {

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -6,7 +6,6 @@ import {
   createClientRender,
   createMount,
   createServerRender,
-  fireEvent,
 } from 'test/utils';
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
@@ -111,11 +110,11 @@ describe('<Fab />', () => {
       <Fab TouchRippleProps={{ 'data-testid': 'mui-ripple-root' }}>Fab</Fab>,
     );
 
-    fireEvent.focus(getByRole('button'));
+    getByRole('button').focus();
 
-    expect((await findByTestId('mui-ripple-root')).firstChild).to.have.class(
-      touchRippleClasses.ripple,
-    );
+    expect(
+      (await findByTestId('mui-ripple-root', undefined, { timeout: 5000 })).firstChild,
+    ).to.have.class(touchRippleClasses.ripple);
   });
 
   it('should pass disableFocusRipple to ButtonBase', async () => {
@@ -125,9 +124,11 @@ describe('<Fab />', () => {
       </Fab>,
     );
 
-    fireEvent.focus(getByRole('button'));
+    getByRole('button').focus();
 
-    expect((await findByTestId('mui-ripple-root')).firstChild).to.equal(null);
+    expect(
+      (await findByTestId('mui-ripple-root', undefined, { timeout: 5000 })).firstChild,
+    ).to.equal(null);
   });
 
   it('should render Icon children with right classes', () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I migrated the last old tests to rtl.
#22911
