### PR TITLE
[test] Migrate NativeSelect to react-testing-library

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -6,7 +6,7 @@ import NativeSelect from './NativeSelect';
 
 describe('<NativeSelect />', () => {
   let classes;
-  let classesInput;
+  let inputClasses;
   const mount = createMount();
   const render = createClientRender();
   const defaultProps = {
@@ -23,7 +23,7 @@ describe('<NativeSelect />', () => {
 
   before(() => {
     classes = getClasses(<NativeSelect {...defaultProps} />);
-    classesInput = getClasses(<Input />);
+    inputClasses = getClasses(<Input />);
   });
 
   describeConformance(<NativeSelect {...defaultProps} />, () => ({
@@ -35,7 +35,7 @@ describe('<NativeSelect />', () => {
   }));
 
   it('should render a native select', () => {
-    const { container } = render(
+    const { getByRole } = render(
       <NativeSelect {...defaultProps} value={10}>
         <option value="">empty</option>
         <option value={10}>Ten</option>
@@ -44,7 +44,7 @@ describe('<NativeSelect />', () => {
       </NativeSelect>,
     );
 
-    const select = container.querySelector('select');
+    const select = getByRole('combobox');
     const options = select.children;
     expect(select.value).to.equal('10');
     expect(options.length).to.equal(4);
@@ -61,11 +61,11 @@ describe('<NativeSelect />', () => {
 
   it('should provide the classes to the input component', () => {
     const { container } = render(<NativeSelect {...defaultProps} />);
-    expect(container.firstChild).to.have.class(classesInput.root);
+    expect(container.firstChild).to.have.class(inputClasses.root);
   });
 
   it('should provide the classes to the select component', () => {
-    const { container } = render(<NativeSelect {...defaultProps} />);
-    expect(container.querySelector('select')).to.have.class(classes.root);
+    const { getByRole } = render(<NativeSelect {...defaultProps} />);
+    expect(getByRole('combobox')).to.have.class(classes.root);
   });
 });

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, describeConformance } from 'test/utils';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
 import Input from '../Input';
 import NativeSelect from './NativeSelect';
 
 describe('<NativeSelect />', () => {
   let classes;
+  let classesInput;
   const mount = createMount();
+  const render = createClientRender();
   const defaultProps = {
     input: <Input />,
     children: [
@@ -21,6 +23,7 @@ describe('<NativeSelect />', () => {
 
   before(() => {
     classes = getClasses(<NativeSelect {...defaultProps} />);
+    classesInput = getClasses(<Input />);
   });
 
   describeConformance(<NativeSelect {...defaultProps} />, () => ({
@@ -31,20 +34,38 @@ describe('<NativeSelect />', () => {
     skip: ['componentProp', 'rootClass'],
   }));
 
-  it('should provide the classes to the input component', () => {
-    const wrapper = mount(<NativeSelect {...defaultProps} />);
-    expect(wrapper.find(Input).props().inputProps.classes).to.deep.equal(classes);
-  });
-
-  it('should be able to mount the component', () => {
-    const wrapper = mount(
+  it('should render a native select', () => {
+    const { container } = render(
       <NativeSelect {...defaultProps} value={10}>
         <option value="">empty</option>
         <option value={10}>Ten</option>
         <option value={20}>Twenty</option>
         <option value={30}>Thirty</option>
-      </NativeSelect>,
+      </NativeSelect>
     );
-    expect(wrapper.find('select').props().value).to.equal(10);
+
+    const select = container.querySelector('select');
+    const options = select.children;
+    expect(select.value).to.equal('10');
+    expect(options.length).to.equal(4);
+    expect(options[0].value).to.equal('');
+    expect(options[0].text).to.equal('empty');
+    expect(options[1].selected).to.equal(true);
+    expect(options[1].value).to.equal('10');
+    expect(options[1].text).to.equal('Ten');
+    expect(options[2].value).to.equal('20');
+    expect(options[2].text).to.equal('Twenty');
+    expect(options[3].value).to.equal('30');
+    expect(options[3].text).to.equal('Thirty');
+  });
+
+  it('should provide the classes to the input component', () => {
+    const { container } = render(<NativeSelect {...defaultProps} />);
+    expect(container.firstChild).to.have.class(classesInput.root);
+  });
+
+  it('should provide the classes to the select component', () => {
+    const { container } = render(<NativeSelect {...defaultProps} />);
+    expect(container.querySelector('select')).to.have.class(classes.root);
   });
 });

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -41,7 +41,7 @@ describe('<NativeSelect />', () => {
         <option value={10}>Ten</option>
         <option value={20}>Twenty</option>
         <option value={30}>Thirty</option>
-      </NativeSelect>
+      </NativeSelect>,
     );
 
     const select = container.querySelector('select');


### PR DESCRIPTION
This pull request migrates the unit tests of the NativeSelect component to use React Testing Library.

#22911