### PR TITLE
[docs] Improve icon preview color contrast

### DIFF
--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -164,12 +164,14 @@ const useDialogStyles = makeStyles((theme) => ({
   canvas: {
     fontSize: 210,
     marginTop: theme.spacing(2),
-    color: theme.palette.primary.dark,
+    color: theme.palette.text.primary,
     backgroundSize: '30px 30px',
-    backgroundColor: '#fff',
+    backgroundColor: 'transparent',
     backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0',
     backgroundImage:
-      'linear-gradient(45deg, #f4f4f4 25%, transparent 25%), linear-gradient(-45deg, #f4f4f4 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f4f4f4 75%), linear-gradient(-45deg, transparent 75%, #f4f4f4 75%)',
+      theme.palette.mode === 'light'
+        ? 'linear-gradient(45deg, #e6e6e6 25%, transparent 25%), linear-gradient(-45deg, #e6e6e6 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e6e6e6 75%), linear-gradient(-45deg, transparent 75%, #e6e6e6 75%)'
+        : 'linear-gradient(45deg, #595959 25%, transparent 25%), linear-gradient(-45deg, #595959 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #595959 75%), linear-gradient(-45deg, transparent 75%, #595959 75%)',
   },
   fontSize: {
     margin: theme.spacing(2),


### PR DESCRIPTION
I have found the issue opening the page inside VSCode. The light mosaic in a dark theme was really ugly.

**Before**
<img width="618" alt="Capture d’écran 2020-10-10 à 22 33 06" src="https://user-images.githubusercontent.com/3165635/95664500-ab095b00-0b48-11eb-9114-483abf3ea2a4.png">

**After**
<img width="626" alt="Capture d’écran 2020-10-10 à 22 32 03" src="https://user-images.githubusercontent.com/3165635/95664496-a80e6a80-0b48-11eb-8103-af6c02f847b5.png">

**Before**
<img width="622" alt="Capture d’écran 2020-10-10 à 22 33 01" src="https://user-images.githubusercontent.com/3165635/95664499-aa70c480-0b48-11eb-8c57-0f44325a4e5b.png">

**After**
<img width="619" alt="Capture d’écran 2020-10-10 à 22 32 08" src="https://user-images.githubusercontent.com/3165635/95664497-a9d82e00-0b48-11eb-94da-8adfc49d6914.png">