### PR TITLE
[TreeView] Use `alpha` color utility instead of deprecated `fade`

### DIFF
--- a/docs/src/pages/components/tree-view/BarTreeView.js
+++ b/docs/src/pages/components/tree-view/BarTreeView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, fade } from '@material-ui/core/styles';
+import { makeStyles, alpha } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
@@ -49,27 +49,27 @@ const useContentStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.action.focus,
     },
     '$root$selected &': {
-      backgroundColor: fade(
+      backgroundColor: alpha(
         theme.palette.primary.main,
         theme.palette.action.selectedOpacity,
       ),
     },
     '$root$selected:hover &': {
-      backgroundColor: fade(
+      backgroundColor: alpha(
         theme.palette.primary.main,
         theme.palette.action.selectedOpacity +
           theme.palette.action.hoverOpacity,
       ),
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
-        backgroundColor: fade(
+        backgroundColor: alpha(
           theme.palette.primary.main,
           theme.palette.action.selectedOpacity,
         ),
       },
     },
     '$root$selected$focused &': {
-      backgroundColor: fade(
+      backgroundColor: alpha(
         theme.palette.primary.main,
         theme.palette.action.selectedOpacity +
           theme.palette.action.focusOpacity,

--- a/docs/src/pages/components/tree-view/BarTreeView.tsx
+++ b/docs/src/pages/components/tree-view/BarTreeView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, fade, createStyles } from '@material-ui/core/styles';
+import { makeStyles, alpha, createStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
@@ -53,27 +53,27 @@ const useContentStyles = makeStyles((theme) =>
         backgroundColor: theme.palette.action.focus,
       },
       '$root$selected &': {
-        backgroundColor: fade(
+        backgroundColor: alpha(
           theme.palette.primary.main,
           theme.palette.action.selectedOpacity,
         ),
       },
       '$root$selected:hover &': {
-        backgroundColor: fade(
+        backgroundColor: alpha(
           theme.palette.primary.main,
           theme.palette.action.selectedOpacity +
             theme.palette.action.hoverOpacity,
         ),
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
-          backgroundColor: fade(
+          backgroundColor: alpha(
             theme.palette.primary.main,
             theme.palette.action.selectedOpacity,
           ),
         },
       },
       '$root$selected$focused &': {
-        backgroundColor: fade(
+        backgroundColor: alpha(
           theme.palette.primary.main,
           theme.palette.action.selectedOpacity +
             theme.palette.action.focusOpacity,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Missed this in the other PR.
