### PR TITLE
[docs] Enable StrictMode

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -19,7 +19,7 @@ const workspaceRoot = path.join(__dirname, '../');
  *
  * @type {ReactRenderMode | 'legacy-strict'}
  */
-const reactMode = 'legacy';
+const reactMode = 'legacy-strict';
 // eslint-disable-next-line no-console
 console.log(`Using React '${reactMode}' mode.`);
 const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';


### PR DESCRIPTION
I'm not eager to see other occurrences of https://github.com/mui-org/material-ui-x/issues/177 going forward. I couldn't notice any errors in development. I could test that the switch work with:

```diff
diff --git a/docs/src/pages/components/alert/BasicAlerts.tsx b/docs/src/pages/components/alert/BasicAlerts.tsx
index b0525db44c..bd9b09e0d8 100644
--- a/docs/src/pages/components/alert/BasicAlerts.tsx
+++ b/docs/src/pages/components/alert/BasicAlerts.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Alert from '@material-ui/core/Alert';

@@ -13,12 +14,23 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );

+class Foo extends React.Component {
+  render() {
+    return <div>hello</div>
+  }
+}
+
 export default function BasicAlerts() {
   const classes = useStyles();
+  const ref = React.useRef();
+
+  React.useEffect(() => {
+    ReactDOM.findDOMNode(ref.current);
+  });

   return (
     <div className={classes.root}>
-      <Alert severity="error">This is an error alert — check it out!</Alert>
+      <Foo ref={ref} severity="error">This is an error alert — check it out!</Foo>
       <Alert severity="warning">This is a warning alert — check it out!</Alert>
       <Alert severity="info">This is an info alert — check it out!</Alert>
       <Alert severity="success">This is a success alert — check it out!</Alert>
```

<img width="337" alt="Capture d’écran 2020-10-11 à 17 47 52" src="https://user-images.githubusercontent.com/3165635/95683176-e60f9b00-0be9-11eb-9799-cad843941ffb.png">
