### PR TITLE
[docs] Fix docs:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,8 +174,7 @@
     "**/cross-fetch": "^3.0.5",
     "**/dot-prop": "^5.2.0",
     "**/react-docgen/ast-types": "^0.14.1",
-    "**/webpack": "^4.44.1",
-    "**/webpack/acorn": "^7.4.0"
+    "**/webpack": "^4.44.1"
   },
   "nyc": {
     "include": [

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -97,11 +97,13 @@ async function getSizeLimitBundles() {
       webpack: true,
       path: 'packages/material-ui-utils/build/index.js',
     },
-    {
-      name: '@material-ui/core.modern',
-      webpack: true,
-      path: path.join(path.relative(workspaceRoot, corePackagePath), 'modern/index.js'),
-    },
+    // TODO: Requires webpack v5
+    // Resolution of webpack/acorn to 7.x is blocked by nextjs (https://github.com/vercel/next.js/issues/11947)
+    // {
+    //   name: '@material-ui/core.modern',
+    //   webpack: true,
+    //   path: path.join(path.relative(workspaceRoot, corePackagePath), 'modern/index.js'),
+    // },
     {
       name: '@material-ui/core.legacy',
       webpack: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,7 +3439,12 @@ acorn@^5.7.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
-acorn@^6.4.1, acorn@^7.1.1, acorn@^7.2.0, acorn@^7.4.0:
+acorn@^6.4.1:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
+acorn@^7.1.1, acorn@^7.2.0, acorn@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==


### PR DESCRIPTION
Resolves https://github.com/mui-org/material-ui/pull/22814#issuecomment-707362641

`yarn docs:dev` broke during work on https://github.com/mui-org/material-ui/pull/22814 when trying to track the modern bundle. We didn't used to track `/es` anyway. 

Don't mind the bundle size changes. They're noise from different chunking which results in changes of module concatenation.