### PR TITLE
Update typedefs to use boolean instead of true/false

### DIFF
--- a/docs/src/pages/components/lists/SimpleList.tsx
+++ b/docs/src/pages/components/lists/SimpleList.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function ListItemLink(props: ListItemProps<'a', { button?: true }>) {
+function ListItemLink(props: ListItemProps<'a', { button?: boolean }>) {
   return <ListItem button component="a" {...props} />;
 }
 

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -106,7 +106,7 @@ declare const ListItem: OverridableComponent<
        * for `ButtonBase` can then be applied to `ListItem`.
        * @default false
        */
-      button?: false;
+      button?: boolean;
     },
     'li'
   >
@@ -119,7 +119,7 @@ declare const ListItem: OverridableComponent<
          * for `ButtonBase` can then be applied to `ListItem`.
          * @default false
          */
-        button: true;
+        button: boolean;
       },
       'div'
     >

--- a/packages/material-ui/src/MenuItem/MenuItem.d.ts
+++ b/packages/material-ui/src/MenuItem/MenuItem.d.ts
@@ -44,9 +44,9 @@ export interface MenuItemTypeMap<P = {}, D extends React.ElementType = 'li'> {
  * - inherits [ListItem API](https://material-ui.com/api/list-item/)
  */
 declare const MenuItem: OverridableComponent<
-  MenuItemTypeMap<{ button: false }, MenuItemTypeMap['defaultComponent']>
+  MenuItemTypeMap<{ button: boolean }, MenuItemTypeMap['defaultComponent']>
 > &
-  ExtendButtonBase<MenuItemTypeMap<{ button?: true }, MenuItemTypeMap['defaultComponent']>>;
+  ExtendButtonBase<MenuItemTypeMap<{ button?: boolean }, MenuItemTypeMap['defaultComponent']>>;
 
 export type MenuItemProps<
   D extends React.ElementType = MenuItemTypeMap['defaultComponent'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Some type definitions were using `true` or `false` literals when it seems `boolean` was intended. This PR attempts to fix that.