### PR TITLE
[SwipeableDrawer] Decorrelate swipeAreaWidth and initial jumping amount

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -476,7 +476,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
       // The ref may be null when a parent component updates while swiping.
       setPosition(
         getMaxTranslate(horizontalSwipe, paperRef.current) +
-          (disableDiscovery ? 1 : -1) * DRAG_STARTED_SIGNAL,
+          (disableDiscovery ? 15 : -DRAG_STARTED_SIGNAL,
         {
           changeTransition: false,
         },

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -476,7 +476,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
       // The ref may be null when a parent component updates while swiping.
       setPosition(
         getMaxTranslate(horizontalSwipe, paperRef.current) +
-          (disableDiscovery ? 15 : -DRAG_STARTED_SIGNAL,
+          (disableDiscovery ? 15 : -DRAG_STARTED_SIGNAL),
         {
           changeTransition: false,
         },

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -16,6 +16,7 @@ import SwipeArea from './SwipeArea';
 // This value is closed to what browsers are using internally to
 // trigger a native scroll.
 const UNCERTAINTY_THRESHOLD = 3; // px
+const DRAG_STARTED_SIGNAL = 20; // px
 
 // We can only have one node at the time claiming ownership for handling the swipe.
 // Otherwise, the UX would be confusing.
@@ -351,9 +352,9 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
         // Compensate for the part of the drawer displayed on touch start.
         if (!disableDiscovery && !open) {
           if (horizontalSwipe) {
-            swipeInstance.current.startX -= swipeAreaWidth;
+            swipeInstance.current.startX -= DRAG_STARTED_SIGNAL;
           } else {
-            swipeInstance.current.startY -= swipeAreaWidth;
+            swipeInstance.current.startY -= DRAG_STARTED_SIGNAL;
           }
         }
       }
@@ -473,7 +474,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
       // The ref may be null when a parent component updates while swiping.
       setPosition(
         getMaxTranslate(horizontalSwipe, paperRef.current) +
-          (disableDiscovery ? 20 : -swipeAreaWidth),
+          (disableDiscovery ? 1 : -1) * DRAG_STARTED_SIGNAL,
         {
           changeTransition: false,
         },

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -16,6 +16,8 @@ import SwipeArea from './SwipeArea';
 // This value is closed to what browsers are using internally to
 // trigger a native scroll.
 const UNCERTAINTY_THRESHOLD = 3; // px
+
+// This is the part of the drawer displayed on touch start.
 const DRAG_STARTED_SIGNAL = 20; // px
 
 // We can only have one node at the time claiming ownership for handling the swipe.


### PR DESCRIPTION
This PR removes dependency between `swipeAreaWidth` prop and the ready-for-dragging signal of drawer related to 

Closes #23037