### PR TITLE
[docs] Change color to palette

### DIFF
--- a/docs/src/pages/styles/api/api.md
+++ b/docs/src/pages/styles/api/api.md
@@ -59,7 +59,7 @@ import { makeStyles, createStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
-    backgroundColor: theme.color.red,
+    backgroundColor: theme.palette.red,
   },
 }));
 


### PR DESCRIPTION
ThemeOptions contain "palette" instead of "color"

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [&check;] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
