### PR TITLE
[test] Introduce toHaveInlineStyle and toHaveComputedStyle matcher

### DIFF
--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
@@ -766,8 +766,9 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('background-color')).to.equal('rgb(255, 0, 0)');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        backgroundColor: 'rgb(255, 0, 0)',
+      });
     });
 
     it('variants should win over overrides', () => {
@@ -779,8 +780,9 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('background-color')).to.equal('rgb(0, 255, 0)');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        backgroundColor: 'rgb(0, 255, 0)',
+      });
     });
 
     it('styled wrapper should win over variants', () => {
@@ -796,8 +798,9 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('background-color')).to.equal('rgb(0, 0, 255)');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        backgroundColor: 'rgb(0, 0, 255)',
+      });
     });
   });
 });

--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
@@ -766,7 +766,7 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         backgroundColor: 'rgb(255, 0, 0)',
       });
     });
@@ -780,7 +780,7 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         backgroundColor: 'rgb(0, 255, 0)',
       });
     });
@@ -798,7 +798,7 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         backgroundColor: 'rgb(0, 0, 255)',
       });
     });

--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
@@ -766,8 +766,8 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
-        backgroundColor: 'rgb(255, 0, 0)',
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
+        backgroundColor: 'rgb(255, 1, 0)',
       });
     });
 
@@ -780,7 +780,7 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         backgroundColor: 'rgb(0, 255, 0)',
       });
     });
@@ -798,7 +798,7 @@ describe('<Slider />', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         backgroundColor: 'rgb(0, 0, 255)',
       });
     });

--- a/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
+++ b/packages/material-ui-lab/src/SliderStyled/SliderStyled.test.js
@@ -767,7 +767,7 @@ describe('<Slider />', () => {
       );
 
       expect(screen.getByTestId('component')).toHaveComputedStyle({
-        backgroundColor: 'rgb(255, 1, 0)',
+        backgroundColor: 'rgb(255, 0, 0)',
       });
     });
 

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -70,8 +70,8 @@ describe('<TouchRipple />', () => {
         );
       });
 
-      expect(queryRipple().style).to.have.property('height', '1px');
-      expect(queryRipple().style).to.have.property('width', '1px');
+      expect(queryRipple().style).toHaveStyle({ height: '1px' });
+      expect(queryRipple().style).toHaveStyle({ width: '1px' });
     });
   });
 
@@ -173,8 +173,8 @@ describe('<TouchRipple />', () => {
 
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
-      expect(queryRipple().style).to.have.property('top', '-0.5px');
-      expect(queryRipple().style).to.have.property('left', '-0.5px');
+      expect(queryRipple().style).toHaveStyle({ top: '-0.5px' });
+      expect(queryRipple().style).toHaveStyle({ left: '-0.5px' });
     });
   });
 

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -70,8 +70,8 @@ describe('<TouchRipple />', () => {
         );
       });
 
-      expect(queryRipple().style).toHaveStyle({ height: '1px' });
-      expect(queryRipple().style).toHaveStyle({ width: '1px' });
+      expect(queryRipple().style).toIncludeStyle({ height: '1px' });
+      expect(queryRipple().style).toIncludeStyle({ width: '1px' });
     });
   });
 
@@ -173,8 +173,8 @@ describe('<TouchRipple />', () => {
 
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
-      expect(queryRipple().style).toHaveStyle({ top: '-0.5px' });
-      expect(queryRipple().style).toHaveStyle({ left: '-0.5px' });
+      expect(queryRipple().style).toIncludeStyle({ top: '-0.5px' });
+      expect(queryRipple().style).toIncludeStyle({ left: '-0.5px' });
     });
   });
 

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -70,8 +70,8 @@ describe('<TouchRipple />', () => {
         );
       });
 
-      expect(queryRipple().style).toIncludeStyle({ height: '1px' });
-      expect(queryRipple().style).toIncludeStyle({ width: '1px' });
+      expect(queryRipple()).toHaveInlineStyle({ height: '1px' });
+      expect(queryRipple()).toHaveInlineStyle({ width: '1px' });
     });
   });
 
@@ -173,8 +173,8 @@ describe('<TouchRipple />', () => {
 
       expect(queryAllActiveRipples()).to.have.lengthOf(1);
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
-      expect(queryRipple().style).toIncludeStyle({ top: '-0.5px' });
-      expect(queryRipple().style).toIncludeStyle({ left: '-0.5px' });
+      expect(queryRipple()).toHaveInlineStyle({ top: '-0.5px' });
+      expect(queryRipple()).toHaveInlineStyle({ left: '-0.5px' });
     });
   });
 

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -103,8 +103,8 @@ describe('<Fade />', () => {
 
       const element = container.querySelector('div');
 
-      expect(element.style).toHaveStyle({ opacity: '0' });
-      expect(element.style).toHaveStyle({ visibility: 'hidden' });
+      expect(element.style).toIncludeStyle({ opacity: '0' });
+      expect(element.style).toIncludeStyle({ visibility: 'hidden' });
     });
 
     it('should work when initially hidden, appear=false', () => {
@@ -116,8 +116,8 @@ describe('<Fade />', () => {
 
       const element = container.querySelector('div');
 
-      expect(element.style).toHaveStyle({ opacity: '0' });
-      expect(element.style).toHaveStyle({ visibility: 'hidden' });
+      expect(element.style).toIncludeStyle({ opacity: '0' });
+      expect(element.style).toIncludeStyle({ visibility: 'hidden' });
     });
   });
 });

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -103,8 +103,8 @@ describe('<Fade />', () => {
 
       const element = container.querySelector('div');
 
-      expect(element.style).to.have.property('opacity', '0');
-      expect(element.style).to.have.property('visibility', 'hidden');
+      expect(element.style).toHaveStyle({ opacity: '0' });
+      expect(element.style).toHaveStyle({ visibility: 'hidden' });
     });
 
     it('should work when initially hidden, appear=false', () => {
@@ -116,8 +116,8 @@ describe('<Fade />', () => {
 
       const element = container.querySelector('div');
 
-      expect(element.style).to.have.property('opacity', '0');
-      expect(element.style).to.have.property('visibility', 'hidden');
+      expect(element.style).toHaveStyle({ opacity: '0' });
+      expect(element.style).toHaveStyle({ visibility: 'hidden' });
     });
   });
 });

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -103,8 +103,8 @@ describe('<Fade />', () => {
 
       const element = container.querySelector('div');
 
-      expect(element.style).toIncludeStyle({ opacity: '0' });
-      expect(element.style).toIncludeStyle({ visibility: 'hidden' });
+      expect(element).toHaveInlineStyle({ opacity: '0' });
+      expect(element).toHaveInlineStyle({ visibility: 'hidden' });
     });
 
     it('should work when initially hidden, appear=false', () => {
@@ -116,8 +116,8 @@ describe('<Fade />', () => {
 
       const element = container.querySelector('div');
 
-      expect(element.style).toIncludeStyle({ opacity: '0' });
-      expect(element.style).toIncludeStyle({ visibility: 'hidden' });
+      expect(element).toHaveInlineStyle({ opacity: '0' });
+      expect(element).toHaveInlineStyle({ visibility: 'hidden' });
     });
   });
 });

--- a/packages/material-ui/src/ImageList/ImageList.test.js
+++ b/packages/material-ui/src/ImageList/ImageList.test.js
@@ -117,7 +117,7 @@ describe('<ImageList />', () => {
         </ImageList>,
       );
 
-      expect(getByTestId('test-root').style).toHaveStyle({ backgroundColor: 'red' });
+      expect(getByTestId('test-root').style).toIncludeStyle({ backgroundColor: 'red' });
     });
   });
 
@@ -200,7 +200,7 @@ describe('<ImageList />', () => {
           </ImageList>,
         );
 
-        expect(window.getComputedStyle(getByTestId('test-root'))).toHaveStyle({
+        expect(window.getComputedStyle(getByTestId('test-root'))).toIncludeStyle({
           rowGap: '8px',
           columnGap: '8px',
         });
@@ -217,7 +217,9 @@ describe('<ImageList />', () => {
           </ImageList>,
         );
 
-        expect(window.getComputedStyle(getByTestId('test-root'))).toHaveStyle({ columnGap: '8px' });
+        expect(window.getComputedStyle(getByTestId('test-root'))).toIncludeStyle({
+          columnGap: '8px',
+        });
       });
     });
   });

--- a/packages/material-ui/src/ImageList/ImageList.test.js
+++ b/packages/material-ui/src/ImageList/ImageList.test.js
@@ -117,7 +117,7 @@ describe('<ImageList />', () => {
         </ImageList>,
       );
 
-      expect(getByTestId('test-root').style).to.have.property('backgroundColor', 'red');
+      expect(getByTestId('test-root').style).toHaveStyle({ backgroundColor: 'red' });
     });
   });
 
@@ -200,7 +200,7 @@ describe('<ImageList />', () => {
           </ImageList>,
         );
 
-        expect(window.getComputedStyle(getByTestId('test-root'))).to.include({
+        expect(window.getComputedStyle(getByTestId('test-root'))).toHaveStyle({
           rowGap: '8px',
           columnGap: '8px',
         });
@@ -217,10 +217,7 @@ describe('<ImageList />', () => {
           </ImageList>,
         );
 
-        expect(window.getComputedStyle(getByTestId('test-root'))).to.have.property(
-          'columnGap',
-          '8px',
-        );
+        expect(window.getComputedStyle(getByTestId('test-root'))).toHaveStyle({ columnGap: '8px' });
       });
     });
   });

--- a/packages/material-ui/src/ImageList/ImageList.test.js
+++ b/packages/material-ui/src/ImageList/ImageList.test.js
@@ -117,7 +117,7 @@ describe('<ImageList />', () => {
         </ImageList>,
       );
 
-      expect(getByTestId('test-root').style).toIncludeStyle({ backgroundColor: 'red' });
+      expect(getByTestId('test-root')).toHaveInlineStyle({ backgroundColor: 'red' });
     });
   });
 
@@ -200,7 +200,7 @@ describe('<ImageList />', () => {
           </ImageList>,
         );
 
-        expect(window.getComputedStyle(getByTestId('test-root'))).toIncludeStyle({
+        expect(getByTestId('test-root')).toHaveComputedStyle({
           rowGap: '8px',
           columnGap: '8px',
         });
@@ -217,7 +217,7 @@ describe('<ImageList />', () => {
           </ImageList>,
         );
 
-        expect(window.getComputedStyle(getByTestId('test-root'))).toIncludeStyle({
+        expect(getByTestId('test-root')).toHaveComputedStyle({
           columnGap: '8px',
         });
       });

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -14,7 +14,7 @@ describe('experimentalStyled', () => {
 
     render(<Div data-testid="component">Test</Div>);
 
-    expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+    expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
       width: '200px',
     });
   });
@@ -26,7 +26,9 @@ describe('experimentalStyled', () => {
 
     render(<Div data-testid="component">Test</Div>);
 
-    expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({ width: '8px' });
+    expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      width: '8px',
+    });
   });
 
   it('should use theme from context if available', () => {
@@ -44,7 +46,9 @@ describe('experimentalStyled', () => {
       </ThemeProvider>,
     );
 
-    expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({ width: '10px' });
+    expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      width: '10px',
+    });
   });
 
   describe('muiOptions', () => {
@@ -89,7 +93,7 @@ describe('experimentalStyled', () => {
     it('should work with specified muiOptions', () => {
       render(<Test data-testid="component">Test</Test>);
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         width: '200px',
         height: '300px',
       });
@@ -102,7 +106,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         width: '250px',
         height: '300px',
       });
@@ -117,7 +121,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         width: '250px',
         height: '250px',
       });
@@ -132,7 +136,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         width: '400px',
         height: '400px',
       });
@@ -151,7 +155,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
         width: '500px',
         height: '400px',
       });

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -14,8 +14,9 @@ describe('experimentalStyled', () => {
 
     render(<Div data-testid="component">Test</Div>);
 
-    const style = window.getComputedStyle(screen.getByTestId('component'));
-    expect(style.getPropertyValue('width')).to.equal('200px');
+    expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+      width: '200px',
+    });
   });
 
   it('should use defaultTheme if no theme is provided', () => {
@@ -25,8 +26,7 @@ describe('experimentalStyled', () => {
 
     render(<Div data-testid="component">Test</Div>);
 
-    const style = window.getComputedStyle(screen.getByTestId('component'));
-    expect(style.getPropertyValue('width')).to.equal('8px');
+    expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({ width: '8px' });
   });
 
   it('should use theme from context if available', () => {
@@ -44,8 +44,7 @@ describe('experimentalStyled', () => {
       </ThemeProvider>,
     );
 
-    const style = window.getComputedStyle(screen.getByTestId('component'));
-    expect(style.getPropertyValue('width')).to.equal('10px');
+    expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({ width: '10px' });
   });
 
   describe('muiOptions', () => {
@@ -90,9 +89,10 @@ describe('experimentalStyled', () => {
     it('should work with specified muiOptions', () => {
       render(<Test data-testid="component">Test</Test>);
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('width')).to.equal('200px');
-      expect(style.getPropertyValue('height')).to.equal('300px');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        width: '200px',
+        height: '300px',
+      });
     });
 
     it('overrides should be respected', () => {
@@ -102,9 +102,10 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('width')).to.equal('250px');
-      expect(style.getPropertyValue('height')).to.equal('300px');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        width: '250px',
+        height: '300px',
+      });
     });
 
     it('overrides should be respected when prop is specified', () => {
@@ -116,9 +117,10 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('width')).to.equal('250px');
-      expect(style.getPropertyValue('height')).to.equal('250px');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        width: '250px',
+        height: '250px',
+      });
     });
 
     it('variants should win over overrides', () => {
@@ -130,9 +132,10 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('width')).to.equal('400px');
-      expect(style.getPropertyValue('height')).to.equal('400px');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        width: '400px',
+        height: '400px',
+      });
     });
 
     it('styled wrapper should win over variants', () => {
@@ -148,9 +151,10 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      const style = window.getComputedStyle(screen.getByTestId('component'));
-      expect(style.getPropertyValue('width')).to.equal('500px');
-      expect(style.getPropertyValue('height')).to.equal('400px');
+      expect(window.getComputedStyle(screen.getByTestId('component'))).toHaveStyle({
+        width: '500px',
+        height: '400px',
+      });
     });
   });
 });

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -14,7 +14,7 @@ describe('experimentalStyled', () => {
 
     render(<Div data-testid="component">Test</Div>);
 
-    expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+    expect(screen.getByTestId('component')).toHaveComputedStyle({
       width: '200px',
     });
   });
@@ -26,7 +26,7 @@ describe('experimentalStyled', () => {
 
     render(<Div data-testid="component">Test</Div>);
 
-    expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+    expect(screen.getByTestId('component')).toHaveComputedStyle({
       width: '8px',
     });
   });
@@ -46,7 +46,7 @@ describe('experimentalStyled', () => {
       </ThemeProvider>,
     );
 
-    expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+    expect(screen.getByTestId('component')).toHaveComputedStyle({
       width: '10px',
     });
   });
@@ -93,7 +93,7 @@ describe('experimentalStyled', () => {
     it('should work with specified muiOptions', () => {
       render(<Test data-testid="component">Test</Test>);
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         width: '200px',
         height: '300px',
       });
@@ -106,7 +106,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         width: '250px',
         height: '300px',
       });
@@ -121,7 +121,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         width: '250px',
         height: '250px',
       });
@@ -136,7 +136,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         width: '400px',
         height: '400px',
       });
@@ -155,7 +155,7 @@ describe('experimentalStyled', () => {
         </ThemeProvider>,
       );
 
-      expect(window.getComputedStyle(screen.getByTestId('component'))).toIncludeStyle({
+      expect(screen.getByTestId('component')).toHaveComputedStyle({
         width: '500px',
         height: '400px',
       });

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -20,10 +20,10 @@ declare global {
       toBeAriaHidden(): void;
       /**
        * Checks `expectedStyle` is a subset of the given `CSSStyleDeclaration`.
-       * @example expect(element.style).toHaveStyle({ width: '200px' })
-       * @example expect(window.getComputedStyle(element)).toHaveStyle({ backgroundColor: 'rgb(255, 0, 0)' })
+       * @example expect(element.style).toIncludeStyle({ width: '200px' })
+       * @example expect(window.getComputedStyle(element)).toIncludeStyle({ backgroundColor: 'rgb(255, 0, 0)' })
        */
-      toHaveStyle(
+      toIncludeStyle(
         expectedStyle: Record<
           Exclude<
             keyof CSSStyleDeclaration,
@@ -292,7 +292,7 @@ chai.use((chaiAPI, utils) => {
     new chai.Assertion(this._obj).to.be.visible;
   });
 
-  chai.Assertion.addMethod('toHaveStyle', function toHaveComputedStyle(
+  chai.Assertion.addMethod('toIncludeStyle', function toHaveComputedStyle(
     expectedStyleUnnormalized: Record<string, string>,
   ) {
     // Compare objects using hyphen case.


### PR DESCRIPTION
Examples:
`expect(element).toHaveInlineStyle({ width: '200px' })`
`expect(element).toHaveComputedStyle({ backgroundColor: 'rgb(255, 0, 0)' })`

Existing solutions for custom style matchers like `expect(style).to.have.property` and `expect(style.getPropertyValue('width')).to.equal('200px')` have a couple of downsides:
1. poor failure messages (too verbose for `property` or not descriptive for `to.equal` (which is bad in general without a message).
1. provide little explanation why they're failing (JSDOM being the common problem)

The new matcher 
1. has a concise syntax (just match against a property bag)
1. has a descriptive message (what is mismatching? what is the actual value? what is the expected value? From which element is the style taken?)
1. explains why something might be failing with actionable advise (skip in JSDOM).

Motivate by having to go over old style matchers that were incomplete (grid `gap` and Safari) and future  extensive testing for `experimentalStyled`).

Example failure message in `yarn test:unit`:
![](https://i.ibb.co/NrZyXFS/Screenshot-from-2020-10-14-19-58-43.png)
-- https://app.circleci.com/pipelines/github/mui-org/material-ui/24135/workflows/b1567766-6adb-4596-878d-737182c5483e/jobs/186717
Example failure message in `yarn test:karma`:
![](https://i.ibb.co/HTXpNb6/Screenshot-from-2020-10-14-19-58-17.png)
-- https://app.circleci.com/pipelines/github/mui-org/material-ui/24135/workflows/b1567766-6adb-4596-878d-737182c5483e/jobs/186719