### PR TITLE
[test] Enable failing unexpected console warn|error in browser tests

### DIFF
--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -40,6 +40,10 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
   } = props;
   const clampedMax = max < 2 ? 2 : max;
 
+  if (max === 3) {
+    console.error('Testing unexpected errors');
+  }
+
   const children = React.Children.toArray(childrenProp).filter((child) => {
     if (process.env.NODE_ENV !== 'production') {
       if (isFragment(child)) {

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -40,10 +40,6 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
   } = props;
   const clampedMax = max < 2 ? 2 : max;
 
-  if (max === 3) {
-    console.error('Testing unexpected errors');
-  }
-
   const children = React.Children.toArray(childrenProp).filter((child) => {
     if (process.env.NODE_ENV !== 'production') {
       if (isFragment(child)) {

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,4 +1,32 @@
+/* eslint-env mocha */
 import './utils/init';
+import { createMochaHooks } from './utils/mochaHooks';
+
+const mochaHooks = createMochaHooks(window.Mocha);
+
+before(function beforeAllHook() {
+  mochaHooks.beforeAll.forEach((mochaHook) => {
+    mochaHook.call(this);
+  });
+});
+
+after(function afterAllHook() {
+  mochaHooks.afterAll.forEach((mochaHook) => {
+    mochaHook.call(this);
+  });
+});
+
+beforeEach(function beforeEachHook() {
+  mochaHooks.beforeEach.forEach((mochaHook) => {
+    mochaHook.call(this);
+  });
+});
+
+afterEach(function afterEachHook() {
+  mochaHooks.afterEach.forEach((mochaHook) => {
+    mochaHook.call(this);
+  });
+});
 
 const integrationContext = require.context(
   '../packages/material-ui/test/integration',

--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -1,0 +1,80 @@
+const formatUtil = require('format-util');
+
+function createUnexpectedConsoleMessagesHooks(Mocha, methodName, expectedMatcher) {
+  const mochaHooks = {
+    beforeAll: [],
+    afterAll: [],
+    beforeEach: [],
+    afterEach: [],
+  };
+  const unexpectedCalls = [];
+  const stackTraceFilter = Mocha.utils.stackTraceFilter();
+
+  function logUnexpectedConsoleCalls(format, ...args) {
+    const message = formatUtil(format, ...args);
+    // Safe stack so that test dev can track where the unexpected console message was created.
+    const { stack } = new Error();
+
+    unexpectedCalls.push([
+      // first line includes the (empty) error message
+      // i.e. Remove the `Error:` line
+      // second line is this frame
+      stackTraceFilter(stack.split('\n').slice(2).join('\n')),
+      message,
+    ]);
+  }
+
+  mochaHooks.beforeAll.push(function registerConsoleStub() {
+    // eslint-disable-next-line no-console
+    console[methodName] = logUnexpectedConsoleCalls;
+  });
+
+  mochaHooks.afterEach.push(function flushUnexpectedCalls() {
+    const hadUnexpectedCalls = unexpectedCalls.length > 0;
+    const formattedCalls = unexpectedCalls.map(([stack, message]) => `${message}\n${stack}`);
+    unexpectedCalls.length = 0;
+
+    // eslint-disable-next-line no-console
+    if (console[methodName] !== logUnexpectedConsoleCalls) {
+      throw new Error(`Did not tear down spy or stub of console.${methodName} in your test.`);
+    }
+    if (hadUnexpectedCalls) {
+      // In karma `file` is `null`.
+      // We still have the stacktrace though
+      const location = this.currentTest.file ?? '(unknown file)';
+      const testPath = `"${this.currentTest.parent
+        .titlePath()
+        .concat(this.currentTest.title)
+        .join('" -> "')}"`;
+      const message =
+        `Expected test not to call console.${methodName}()\n\n` +
+        'If the warning is expected, test for it explicitly by ' +
+        `using the ${expectedMatcher}() matcher.`;
+
+      const error = new Error(
+        `${location}: ${message}\n\n${formattedCalls.join('\n\n')}\n\n` +
+          `in ${testPath} (${location})`,
+      );
+      // The stack of `flushUnexpectedCalls` is irrelevant.
+      // It includes no clue where the test was triggered
+      error.stack = '';
+      throw error;
+    }
+  });
+
+  return mochaHooks;
+}
+
+function createMochaHooks(Mocha) {
+  const warnHooks = createUnexpectedConsoleMessagesHooks(Mocha, 'warn', 'toWarnDev');
+  const errorHooks = createUnexpectedConsoleMessagesHooks(Mocha, 'error', 'toErrorDev');
+
+  return {
+    beforeAll: [...warnHooks.beforeAll, ...errorHooks.beforeAll],
+    afterAll: [...warnHooks.afterAll, ...errorHooks.afterAll],
+    beforeEach: [...warnHooks.beforeEach, ...errorHooks.beforeEach],
+    afterEach: [...warnHooks.afterEach, ...errorHooks.afterEach],
+  };
+}
+
+module.exports = { createMochaHooks };


### PR DESCRIPTION
Should be safe now that we've dropped Safari < 13. Will start failing the test suite if we go back to Safari 10.

Polyfills root-level hooks for karma-mocha. We use dependency injection for `mocha` in the browser. Their browser build is not importable and from the issues I looked at in their repo (https://github.com/mochajs/mocha/issues/4278,  https://github.com/mochajs/mocha/issues/2448) they insist that this is fine.

Examples: 
- [test:unit](https://app.circleci.com/pipelines/github/mui-org/material-ui/24191/workflows/2563e702-c81d-495b-af0b-d571281f6e1a/jobs/186889)
- [test:browser](https://app.circleci.com/pipelines/github/mui-org/material-ui/24191/workflows/2563e702-c81d-495b-af0b-d571281f6e1a/jobs/186891)