### PR TITLE
[docs] Fix wrong variable characters in tooltips

### DIFF
--- a/docs/src/pages/components/tooltips/tooltips.md
+++ b/docs/src/pages/components/tooltips/tooltips.md
@@ -101,7 +101,7 @@ By default disabled elements like `<button>` do not trigger user interactions so
       disabled={disabled}
       style={disabled ? { pointerEvents: 'none' } : {}}
     >
-      {'A disabled button'}
+      A disabled button
     </button>
   </span>
 </Tooltip>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [*] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Crowdin issue: https://crowdin.com/translate/material-ui-docs/3380/en-zhcn?filter=basic&value=17#q=140834