### PR TITLE
[core] Add support for iOS Safari 12

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -9,22 +9,22 @@ node 14
 # `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, not IE 11"` when the last major is released.
 # #stable-snapshot
 [stable]
-and_chr 84
-and_ff 79
+and_chr 85
+and_ff 80
 and_qq 10.4
 and_uc 12.12
-android 84
+android 85
 baidu 7.12
-chrome 83
-edge 83
-firefox 68
-ios_saf 12.0
+chrome 84
+edge 85
+firefox 78
+ios_saf 12.2
 kaios 2.5
 op_mini all
-op_mob 69
-opera 69
-safari 13
-samsung 11.1
+op_mob 70
+opera 70
+safari 13.1
+samsung 11.1-11.2
 
 # Same as `stable` but with IE 11
 [legacy]

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -29,22 +29,22 @@ samsung 11.1-11.2
 # Same as `stable` but with IE 11
 [legacy]
 IE 11
-and_chr 84
-and_ff 79
+and_chr 85
+and_ff 80
 and_qq 10.4
 and_uc 12.12
-android 84
+android 85
 baidu 7.12
-chrome 83
-edge 83
-firefox 68
-ios_saf 12.0
+chrome 84
+edge 85
+firefox 78
+ios_saf 12.2
 kaios 2.5
 op_mini all
-op_mob 69
-opera 69
-safari 13
-samsung 11.1
+op_mob 70
+opera 70
+safari 13.1
+samsung 11.1-11.2
 
 # snapshot of `npx browserslist "maintained node versions"`
 [node]

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -7,7 +7,7 @@ node 14
 
 # Default/Fallback
 # `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, not IE 11"` when the last major is released.
-# #stable-snapshot
+# On update check all #stable-snapshot markers
 [stable]
 and_chr 85
 and_ff 80

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -9,10 +9,13 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 
 <!-- #stable-snapshot -->
 
-| Edge  | Firefox | Chrome | Safari |
-| :---- | :------ | :----- | :----- |
-| >= 83 | >= 68   | >= 83  | >= 13  |
+| Edge  | Firefox | Chrome | Safari (macOS) | Safari (iOS) |
+| :---- | :------ | :----- | :------------- | :----------- |
+| >= 85 | >= 78   | >= 84  | >= 13          | >= 12.2      |
 
+<!-- #default-branch-switch -->
+
+An extensive list can be found in our [.browserlistrc](https://github.com/mui-org/material-ui/blob/next/.browserslistrc#L12-L27) (check the `stable` entry).
 If you need to support IE 11, check out our [legacy bundle](/guides/minimizing-bundle-size/#legacy-bundle).
 
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that Material-UI supports it.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -55,10 +55,10 @@ The default bundle now supports:
 <!-- #stable-snapshot -->
 
 - Node 10 (up from 8)
-- Chrome 83 (up from 49)
-- Edge 83 (up from 14)
-- Firefox 68 (up from 52)
-- Safari 13 (up from 10)
+- Chrome 84 (up from 49)
+- Edge 85 (up from 14)
+- Firefox 78 (up from 52)
+- Safari 13 (macOS) and 12.2 (iOS) (up from 10)
 - and more (see [.browserslistrc (`stable` entry)](https://github.com/mui-org/material-ui/blob/HEAD/.browserslistrc#L11))
 
 It no longer supports IE 11.

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -119,28 +119,30 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'chrome',
-          browser_version: '83.0',
+          browser_version: '84.0',
         },
         BrowserStack_Firefox: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'firefox',
-          browser_version: '68.0',
+          browser_version: '78.0',
         },
         BrowserStack_Safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Mojave',
           browser: 'safari',
-          browser_version: '13.0',
+          // On desktop we support 13.1 but on mobile we support 12.2.
+          // Using desktop 12.1 (12.2 is not available) as an approximation for mobile 12.2.
+          browser_version: '12.1',
         },
         BrowserStack_Edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'edge',
-          browser_version: '83.0',
+          browser_version: '85.0',
         },
       },
     };


### PR DESCRIPTION
Seems like I forgot `ios_safari 12.2` in #22814. The other changes are due to new version releases (mainly Firefox ESR moving to 78).

[Safari 12 sits at 2% global usage](https://caniuse.com/usage-table). But other than IE 11 where we argue that this browser is mostly used in corporate enviornments (with an LTS license) iOS Safari 12 is used by actual people that would need to buy a new phone in order to upgrade to Safari 13. So I don't think the usage stats can solely be used as justification to drop it.

The unfortunate part is that this won't allow an all-in usage of PointerEvent. But we'll get there eventually.

The good part is that ImageList should function perfectly well in iOS Safari 12 looking at [`gap`](https://caniuse.com/mdn-css_properties_gap_grid_context) and [`column-gap`](https://caniuse.com/mdn-css_properties_column-gap_grid_context) support