### PR TITLE
[slider] Align value label text center

### DIFF
--- a/packages/material-ui-lab/src/SliderStyled/ValueLabelStyled.js
+++ b/packages/material-ui-lab/src/SliderStyled/ValueLabelStyled.js
@@ -50,7 +50,7 @@ const ValueLabelRoot = experimentalStyled(
   '& .MuiSlider-valueLabelLabel': {
     color: props.theme.palette.primary.contrastText,
     transform: 'rotate(45deg)',
-    align: 'center',
+    textAlign: 'center',
   },
 }));
 

--- a/packages/material-ui-lab/src/SliderStyled/ValueLabelStyled.js
+++ b/packages/material-ui-lab/src/SliderStyled/ValueLabelStyled.js
@@ -50,6 +50,7 @@ const ValueLabelRoot = experimentalStyled(
   '& .MuiSlider-valueLabelLabel': {
     color: props.theme.palette.primary.contrastText,
     transform: 'rotate(45deg)',
+    align: 'center',
   },
 }));
 

--- a/packages/material-ui/src/Slider/ValueLabel.js
+++ b/packages/material-ui/src/Slider/ValueLabel.js
@@ -37,6 +37,7 @@ const styles = (theme) => ({
   label: {
     color: theme.palette.primary.contrastText,
     transform: 'rotate(45deg)',
+    textAlign: 'center',
   },
 });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Slider value label was left aligned (default).
This PR changes the alignment to be `center`.

Before: 
![Bildschirmfoto am 2020-10-15 um 20 25 38](https://user-images.githubusercontent.com/10603631/96171257-f181ff80-0f24-11eb-9201-c22fcaecb037.png)

After:
![Bildschirmfoto am 2020-10-15 um 20 25 29](https://user-images.githubusercontent.com/10603631/96171254-f0e96900-0f24-11eb-8b09-5ff9ed9590a7.png)