### PR TITLE
[Tooltip] Refactor touch handling

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -377,17 +377,14 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }, leaveDelay);
   };
 
-  const detectTouchStart = (event) => {
+  const handleTouchStart = (event) => {
     ignoreNonTouchEvents.current = true;
 
     const childrenProps = children.props;
     if (childrenProps.onTouchStart) {
       childrenProps.onTouchStart(event);
     }
-  };
 
-  const handleTouchStart = (event) => {
-    detectTouchStart(event);
     clearTimeout(leaveTimer.current);
     clearTimeout(closeTimer.current);
     clearTimeout(touchTimer.current);
@@ -472,7 +469,6 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     ...other,
     ...children.props,
     className: clsx(other.className, children.props.className),
-    onTouchStart: detectTouchStart,
     ref: handleRef,
     ...(followCursor ? { onMouseMove: handleMouseMove } : {}),
   };


### PR DESCRIPTION
`detectTouch` was introduced in #20807. The added test still passes with this change so either the test is insufficient or the observed event order never actually happens (e.g. when emulating devices the events are sometimes wrong especially with Firefox).
