### PR TITLE
[Tooltip] Refactor event handling

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -283,12 +283,6 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   );
 
   const handleEnter = (forward = true) => (event) => {
-    const childrenProps = children.props;
-
-    if (event.type === 'mouseover' && childrenProps.onMouseOver && forward) {
-      childrenProps.onMouseOver(event);
-    }
-
     if (ignoreNonTouchEvents.current && event.type !== 'touchstart') {
       return;
     }
@@ -374,6 +368,16 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     if (childrenProps.onFocus && forward) {
       childrenProps.onFocus(event);
     }
+  };
+
+  const handleMouseOver = (forward = true) => (event) => {
+    const childrenProps = children.props;
+
+    if (childrenProps.onMouseOver && forward) {
+      childrenProps.onMouseOver(event);
+    }
+
+    handleEnter()(event);
   };
 
   const detectTouchStart = (event) => {
@@ -500,11 +504,11 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   }
 
   if (!disableHoverListener) {
-    childrenProps.onMouseOver = handleEnter();
+    childrenProps.onMouseOver = handleMouseOver();
     childrenProps.onMouseLeave = handleLeave();
 
     if (!disableInteractive) {
-      interactiveWrapperListeners.onMouseOver = handleEnter(false);
+      interactiveWrapperListeners.onMouseOver = handleMouseOver(false);
       interactiveWrapperListeners.onMouseLeave = handleLeave(false);
     }
   }

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -282,7 +282,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     },
   );
 
-  const handleEnter = (forward = true) => (event) => {
+  const handleEnter = (event) => {
     if (ignoreNonTouchEvents.current && event.type !== 'touchstart') {
       return;
     }
@@ -309,7 +309,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }
   };
 
-  const handleLeave = (forward = true) => (event) => {
+  const handleLeave = (event) => {
     clearTimeout(enterTimer.current);
     clearTimeout(leaveTimer.current);
     event.persist();
@@ -336,7 +336,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     handleBlurVisible(event);
     if (isFocusVisibleRef.current === false) {
       setChildIsFocusVisible(false);
-      handleLeave()(event);
+      handleLeave(event);
     }
   };
 
@@ -351,7 +351,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     handleFocusVisible(event);
     if (isFocusVisibleRef.current === true) {
       setChildIsFocusVisible(true);
-      handleEnter()(event);
+      handleEnter(event);
     }
 
     const childrenProps = children.props;
@@ -367,7 +367,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
       childrenProps.onMouseOver(event);
     }
 
-    handleEnter()(event);
+    handleEnter(event);
   };
 
   const handleMouseLeave = (forward = true) => (event) => {
@@ -377,7 +377,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
       childrenProps.onMouseLeave(event);
     }
 
-    handleLeave()(event);
+    handleLeave(event);
   };
 
   const detectTouchStart = (event) => {
@@ -396,7 +396,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     clearTimeout(touchTimer.current);
     event.persist();
     touchTimer.current = setTimeout(() => {
-      handleEnter()(event);
+      handleEnter(event);
     }, enterTouchDelay);
   };
 

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -310,16 +310,6 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   };
 
   const handleLeave = (forward = true) => (event) => {
-    const childrenProps = children.props;
-
-    if (
-      event.type === 'mouseleave' &&
-      childrenProps.onMouseLeave &&
-      event.currentTarget === childNode
-    ) {
-      childrenProps.onMouseLeave(event);
-    }
-
     clearTimeout(enterTimer.current);
     clearTimeout(leaveTimer.current);
     event.persist();
@@ -378,6 +368,16 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }
 
     handleEnter()(event);
+  };
+
+  const handleMouseLeave = (forward = true) => (event) => {
+    const childrenProps = children.props;
+
+    if (childrenProps.onMouseLeave && forward) {
+      childrenProps.onMouseLeave(event);
+    }
+
+    handleLeave()(event);
   };
 
   const detectTouchStart = (event) => {
@@ -505,11 +505,11 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
 
   if (!disableHoverListener) {
     childrenProps.onMouseOver = handleMouseOver();
-    childrenProps.onMouseLeave = handleLeave();
+    childrenProps.onMouseLeave = handleMouseLeave();
 
     if (!disableInteractive) {
       interactiveWrapperListeners.onMouseOver = handleMouseOver(false);
-      interactiveWrapperListeners.onMouseLeave = handleLeave(false);
+      interactiveWrapperListeners.onMouseLeave = handleMouseLeave(false);
     }
   }
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -880,7 +880,7 @@ describe('<Tooltip />', () => {
       focusVisible(getByRole('button'));
 
       expect(getByRole('tooltip')).toBeVisible();
-      expect(eventLog).to.deep.equal(['open', 'focus']);
+      expect(eventLog).to.deep.equal(['focus', 'open']);
 
       // TODO: Can be removed once Popper#update is sync.
       act(() => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -305,45 +305,47 @@ describe('<Tooltip />', () => {
   });
 
   it('should be controllable', () => {
-    const handleRequestOpen = spy();
-    const handleClose = spy();
+    const eventLog = [];
 
     const { getByRole } = render(
       <Tooltip
         enterDelay={100}
         title="Hello World"
-        onOpen={handleRequestOpen}
-        onClose={handleClose}
+        onOpen={() => eventLog.push('open')}
+        onClose={() => eventLog.push('close')}
         open
       >
-        <button id="testChild" type="submit">
+        <button
+          id="testChild"
+          onMouseLeave={() => eventLog.push('mouseleave')}
+          onMouseOver={() => eventLog.push('mouseover')}
+          type="submit"
+        >
           Hello World
         </button>
       </Tooltip>,
     );
 
-    expect(handleRequestOpen.callCount).to.equal(0);
-    expect(handleClose.callCount).to.equal(0);
+    expect(eventLog).to.deep.equal([]);
 
     fireEvent.mouseOver(getByRole('button'));
     act(() => {
       clock.tick(100);
     });
 
-    expect(handleRequestOpen.callCount).to.equal(1);
-    expect(handleClose.callCount).to.equal(0);
+    expect(eventLog).to.deep.equal(['mouseover', 'open']);
 
     fireEvent.mouseLeave(getByRole('button'));
     act(() => {
       clock.tick(0);
     });
 
-    expect(handleRequestOpen.callCount).to.equal(1);
-    expect(handleClose.callCount).to.equal(1);
+    expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
 
-    // TODO: Unclear why not running triggers microtasks but runAll does not trigger microtasks
-    // can be removed once Popper#update is sync
-    clock.runAll();
+    // TODO: Can be removed once Popper#update is sync.
+    act(() => {
+      clock.runAll();
+    });
   });
 
   it('is dismissable by pressing Escape', () => {
@@ -845,18 +847,12 @@ describe('<Tooltip />', () => {
   });
 
   describe('focus', () => {
-    function Test() {
-      return (
-        <Tooltip enterDelay={0} leaveDelay={0} title="Some information">
-          <button id="target" type="button">
-            Do something
-          </button>
-        </Tooltip>
-      );
-    }
-
     it('ignores base focus', () => {
-      const { getByRole, queryByRole } = render(<Test />);
+      const { getByRole, queryByRole } = render(
+        <Tooltip enterDelay={0} title="Some information">
+          <button />
+        </Tooltip>,
+      );
       simulatePointerDevice();
 
       expect(queryByRole('tooltip')).to.equal(null);
@@ -871,7 +867,12 @@ describe('<Tooltip />', () => {
     });
 
     it('opens on focus-visible', () => {
-      const { queryByRole, getByRole } = render(<Test />);
+      const eventLog = [];
+      const { queryByRole, getByRole } = render(
+        <Tooltip enterDelay={0} onOpen={() => eventLog.push('open')} title="Some information">
+          <button onFocus={() => eventLog.push('focus')} />
+        </Tooltip>,
+      );
       simulatePointerDevice();
 
       expect(queryByRole('tooltip')).to.equal(null);
@@ -879,10 +880,44 @@ describe('<Tooltip />', () => {
       focusVisible(getByRole('button'));
 
       expect(getByRole('tooltip')).toBeVisible();
+      expect(eventLog).to.deep.equal(['open', 'focus']);
 
-      // TOD: Unclear why not running triggers microtasks but runAll does not trigger microtasks
-      // can be removed once Popper#update is sync
-      clock.runAll();
+      // TODO: Can be removed once Popper#update is sync.
+      act(() => {
+        clock.runAll();
+      });
+    });
+
+    it('closes on blur', () => {
+      const eventLog = [];
+      const transitionTimeout = 0;
+      const { getByRole } = render(
+        <Tooltip
+          enterDelay={0}
+          leaveDelay={0}
+          onClose={() => eventLog.push('close')}
+          open
+          title="Some information"
+          TransitionProps={{ timeout: transitionTimeout }}
+        >
+          <button onBlur={() => eventLog.push('blur')} />
+        </Tooltip>,
+      );
+      const button = getByRole('button');
+
+      act(() => {
+        button.focus();
+        button.blur();
+        clock.tick(transitionTimeout);
+      });
+
+      expect(getByRole('tooltip')).toBeVisible();
+      expect(eventLog).to.deep.equal(['blur', 'close']);
+
+      // TODO: Can be removed once Popper#update is sync.
+      act(() => {
+        clock.runAll();
+      });
     });
 
     // https://github.com/mui-org/material-ui/issues/19883


### PR DESCRIPTION
Review by commit helps understand the refactoring process.

We're currently (sometimes) composing user-event handlers in the Tooltip event handlers. The current implementation is hard to parse (e.g. when coming back to the component after some time) and doesn't follow existing patterns.

I refactored it in a couple of steps:
1. Ignore event types in behavioral handlers (like `handleEnter` and `handleLeave`)
1. Actually handle events in `on*` props instead of handling behavior
1. compose handlers where appropriate (i.e. when overriding props in e.g. `children.props`) otherwise simply assign (e.g in `interactiveWrapperListeners`)

The only behavior that changed is the order of events for focus events (https://github.com/mui-org/material-ui/pull/23092/commits/cdbad40055504dfc3e769108833d3013b42ea1a9#diff-ec0479377a3497fa2a9c6db5b8a61bbd82b435648c4994ff7d6b9948c6d026a7L883-R883). Previously you'd see `onOpen` before `onFocus`. Now the order is reverse which is consistent with the other event triggers.

Curious about the size impact. I'd be fine with a couple of added bytes if this means that I don't have treat events differently when working with the Tooltip.
Edit: Size win as well.