### PR TITLE
[examples] Update gatsby-theme example to use @material-ui/* next 

### DIFF
--- a/examples/gatsby-theme/gatsby-config.js
+++ b/examples/gatsby-theme/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['gatsby-theme-material-ui'],
+  plugins: ['gatsby-theme-material-ui', 'gatsby-plugin-emotion'],
   siteMetadata: {
     title: 'My page',
   },

--- a/examples/gatsby-theme/package.json
+++ b/examples/gatsby-theme/package.json
@@ -1,10 +1,13 @@
 {
   "name": "gatsby-theme",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "latest",
+    "@emotion/core": "latest",
+    "@emotion/styled": "latest",
+    "@material-ui/core": "next",
     "gatsby": "latest",
+    "gatsby-plugin-emotion": "latest",
     "gatsby-theme-material-ui": "latest",
     "react": "latest",
     "react-dom": "latest",

--- a/examples/gatsby-theme/src/pages/about.js
+++ b/examples/gatsby-theme/src/pages/about.js
@@ -11,7 +11,7 @@ export default function About() {
     <Container maxWidth="sm">
       <Box my={4}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Gatsby v4-beta example
+          Gatsby v5-alpha example
         </Typography>
         <Link to="/">Go to the main page</Link>
         <ProTip />

--- a/examples/gatsby-theme/src/pages/index.js
+++ b/examples/gatsby-theme/src/pages/index.js
@@ -11,7 +11,7 @@ export default function Index() {
     <Container maxWidth="sm">
       <Box my={4}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Gatsby v4-beta example
+          Gatsby v5-alpha example
         </Typography>
         <Link to="/about" color="secondary">
           Go to the about page


### PR DESCRIPTION
This PR updates the gatsby-theme example project to use `next` version of @material-ui/* packages. It adds the @emotion/* packages and the `gatsby-plugin-emotion` plugin.