### PR TITLE
[docs] Improve docs for Table sticky column grouping

### DIFF
--- a/docs/src/pages/components/tables/ColumnGroupingTable.js
+++ b/docs/src/pages/components/tables/ColumnGroupingTable.js
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TablePagination from '@material-ui/core/TablePagination';
+import TableRow from '@material-ui/core/TableRow';
+
+const columns = [
+  { id: 'name', label: 'Name', minWidth: 170 },
+  { id: 'code', label: 'ISO\u00a0Code', minWidth: 100 },
+  {
+    id: 'population',
+    label: 'Population',
+    minWidth: 170,
+    align: 'right',
+    format: (value) => value.toLocaleString('en-US'),
+  },
+  {
+    id: 'size',
+    label: 'Size\u00a0(km\u00b2)',
+    minWidth: 170,
+    align: 'right',
+    format: (value) => value.toLocaleString('en-US'),
+  },
+  {
+    id: 'density',
+    label: 'Density',
+    minWidth: 170,
+    align: 'right',
+    format: (value) => value.toFixed(2),
+  },
+];
+
+function createData(name, code, population, size) {
+  const density = population / size;
+  return { name, code, population, size, density };
+}
+
+const rows = [
+  createData('India', 'IN', 1324171354, 3287263),
+  createData('China', 'CN', 1403500365, 9596961),
+  createData('Italy', 'IT', 60483973, 301340),
+  createData('United States', 'US', 327167434, 9833520),
+  createData('Canada', 'CA', 37602103, 9984670),
+  createData('Australia', 'AU', 25475400, 7692024),
+  createData('Germany', 'DE', 83019200, 357578),
+  createData('Ireland', 'IE', 4857000, 70273),
+  createData('Mexico', 'MX', 126577691, 1972550),
+  createData('Japan', 'JP', 126317000, 377973),
+  createData('France', 'FR', 67022000, 640679),
+  createData('United Kingdom', 'GB', 67545757, 242495),
+  createData('Russia', 'RU', 146793744, 17098246),
+  createData('Nigeria', 'NG', 200962417, 923768),
+  createData('Brazil', 'BR', 210147125, 8515767),
+];
+
+const useStyles = makeStyles({
+  root: {
+    width: '100%',
+  },
+  container: {
+    maxHeight: 440,
+  },
+});
+
+export default function ColumnGroupingTable() {
+  const classes = useStyles();
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(+event.target.value);
+    setPage(0);
+  };
+
+  return (
+    <Paper className={classes.root}>
+      <TableContainer className={classes.container}>
+        <Table stickyHeader aria-label="sticky table">
+          <TableHead>
+            <TableRow>
+              <TableCell align="center" colSpan={2}>
+                Country
+              </TableCell>
+              <TableCell align="center" colSpan={3}>
+                Details
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              {columns.map((column) => (
+                <TableCell
+                  key={column.id}
+                  align={column.align}
+                  style={{ top: 57, minWidth: column.minWidth }}
+                >
+                  {column.label}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((row) => {
+                return (
+                  <TableRow hover role="checkbox" tabIndex={-1} key={row.code}>
+                    {columns.map((column) => {
+                      const value = row[column.id];
+                      return (
+                        <TableCell key={column.id} align={column.align}>
+                          {column.format && typeof value === 'number'
+                            ? column.format(value)
+                            : value}
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                );
+              })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[10, 25, 100]}
+        component="div"
+        count={rows.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </Paper>
+  );
+}

--- a/docs/src/pages/components/tables/ColumnGroupingTable.tsx
+++ b/docs/src/pages/components/tables/ColumnGroupingTable.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TablePagination from '@material-ui/core/TablePagination';
+import TableRow from '@material-ui/core/TableRow';
+
+interface Column {
+  id: 'name' | 'code' | 'population' | 'size' | 'density';
+  label: string;
+  minWidth?: number;
+  align?: 'right';
+  format?: (value: number) => string;
+}
+
+const columns: Column[] = [
+  { id: 'name', label: 'Name', minWidth: 170 },
+  { id: 'code', label: 'ISO\u00a0Code', minWidth: 100 },
+  {
+    id: 'population',
+    label: 'Population',
+    minWidth: 170,
+    align: 'right',
+    format: (value: number) => value.toLocaleString('en-US'),
+  },
+  {
+    id: 'size',
+    label: 'Size\u00a0(km\u00b2)',
+    minWidth: 170,
+    align: 'right',
+    format: (value: number) => value.toLocaleString('en-US'),
+  },
+  {
+    id: 'density',
+    label: 'Density',
+    minWidth: 170,
+    align: 'right',
+    format: (value: number) => value.toFixed(2),
+  },
+];
+
+interface Data {
+  name: string;
+  code: string;
+  population: number;
+  size: number;
+  density: number;
+}
+
+function createData(
+  name: string,
+  code: string,
+  population: number,
+  size: number,
+): Data {
+  const density = population / size;
+  return { name, code, population, size, density };
+}
+
+const rows = [
+  createData('India', 'IN', 1324171354, 3287263),
+  createData('China', 'CN', 1403500365, 9596961),
+  createData('Italy', 'IT', 60483973, 301340),
+  createData('United States', 'US', 327167434, 9833520),
+  createData('Canada', 'CA', 37602103, 9984670),
+  createData('Australia', 'AU', 25475400, 7692024),
+  createData('Germany', 'DE', 83019200, 357578),
+  createData('Ireland', 'IE', 4857000, 70273),
+  createData('Mexico', 'MX', 126577691, 1972550),
+  createData('Japan', 'JP', 126317000, 377973),
+  createData('France', 'FR', 67022000, 640679),
+  createData('United Kingdom', 'GB', 67545757, 242495),
+  createData('Russia', 'RU', 146793744, 17098246),
+  createData('Nigeria', 'NG', 200962417, 923768),
+  createData('Brazil', 'BR', 210147125, 8515767),
+];
+
+const useStyles = makeStyles({
+  root: {
+    width: '100%',
+  },
+  container: {
+    maxHeight: 440,
+  },
+});
+
+export default function ColumnGroupingTable() {
+  const classes = useStyles();
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+
+  const handleChangePage = (event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setRowsPerPage(+event.target.value);
+    setPage(0);
+  };
+
+  return (
+    <Paper className={classes.root}>
+      <TableContainer className={classes.container}>
+        <Table stickyHeader aria-label="sticky table">
+          <TableHead>
+            <TableRow>
+              <TableCell align="center" colSpan={2}>
+                Country
+              </TableCell>
+              <TableCell align="center" colSpan={3}>
+                Details
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              {columns.map((column) => (
+                <TableCell
+                  key={column.id}
+                  align={column.align}
+                  style={{ top: 57, minWidth: column.minWidth }}
+                >
+                  {column.label}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((row) => {
+                return (
+                  <TableRow hover role="checkbox" tabIndex={-1} key={row.code}>
+                    {columns.map((column) => {
+                      const value = row[column.id];
+                      return (
+                        <TableCell key={column.id} align={column.align}>
+                          {column.format && typeof value === 'number'
+                            ? column.format(value)
+                            : value}
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                );
+              })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[10, 25, 100]}
+        component="div"
+        count={rows.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </Paper>
+  );
+}

--- a/docs/src/pages/components/tables/tables-pt.md
+++ b/docs/src/pages/components/tables/tables-pt.md
@@ -79,6 +79,31 @@ Um exemplo de uma tabela com linhas roláveis e cabeçalhos de coluna fixos. It 
 
 {{"demo": "pages/components/tables/StickyHeadTable.js", "bg": true}}
 
+##### Nota: Se a tabela tiver múltiplas linhas de cabeçalho, é necessário adicionar estilos adicionais para garantir que todas as linhas fiquem visíveis. Por defeito, as linhas irão acumular uma em cima da outra de forma a que apenas a última linha de cabeçalho ficará visível. Para evitar este comportamento, será necessário estilizar as linhas de cabeçalho adicionais com um valor de `top` para criar o espaçamento necessário.
+##### Exemplo:
+
+```jsx
+		<TableHead>
+      <TableRow>
+        <TableCell
+          align="center"
+          colSpan={columns.length}
+        >
+          First Header Row
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell
+          style={{ top: 57 }}
+          align="center"
+          colSpan={columns.length}
+        >
+          Another Header Row
+        </TableCell>
+      </TableRow>
+    </TableHead>
+```
+
 ## Tabela minimizável
 
 Um exemplo de uma tabela com linhas expansíveis, revelando mais informações. Ela utiliza o componente [`Collapse`](/api/collapse/).

--- a/docs/src/pages/components/tables/tables-pt.md
+++ b/docs/src/pages/components/tables/tables-pt.md
@@ -79,32 +79,6 @@ Um exemplo de uma tabela com linhas roláveis e cabeçalhos de coluna fixos. It 
 
 {{"demo": "pages/components/tables/StickyHeadTable.js", "bg": true}}
 
-##### Nota: Se a tabela tiver múltiplas linhas de cabeçalho, é necessário adicionar estilos adicionais para garantir que todas as linhas fiquem visíveis. Por defeito, as linhas irão acumular uma em cima da outra de forma a que apenas a última linha de cabeçalho ficará visível. Para evitar este comportamento, será necessário estilizar as linhas de cabeçalho adicionais com um valor de `top` para criar o espaçamento necessário.
-
-##### Exemplo:
-
-```jsx
-		<TableHead>
-      <TableRow>
-        <TableCell
-          align="center"
-          colSpan={columns.length}
-        >
-          First Header Row
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell
-          style={{ top: 57 }}
-          align="center"
-          colSpan={columns.length}
-        >
-          Another Header Row
-        </TableCell>
-      </TableRow>
-    </TableHead>
-```
-
 ## Tabela minimizável
 
 Um exemplo de uma tabela com linhas expansíveis, revelando mais informações. Ela utiliza o componente [`Collapse`](/api/collapse/).

--- a/docs/src/pages/components/tables/tables-pt.md
+++ b/docs/src/pages/components/tables/tables-pt.md
@@ -80,6 +80,7 @@ Um exemplo de uma tabela com linhas roláveis e cabeçalhos de coluna fixos. It 
 {{"demo": "pages/components/tables/StickyHeadTable.js", "bg": true}}
 
 ##### Nota: Se a tabela tiver múltiplas linhas de cabeçalho, é necessário adicionar estilos adicionais para garantir que todas as linhas fiquem visíveis. Por defeito, as linhas irão acumular uma em cima da outra de forma a que apenas a última linha de cabeçalho ficará visível. Para evitar este comportamento, será necessário estilizar as linhas de cabeçalho adicionais com um valor de `top` para criar o espaçamento necessário.
+
 ##### Exemplo:
 
 ```jsx

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -84,6 +84,31 @@ It leverages the `stickyHeader` prop (⚠️ no IE11 support).
 
 {{"demo": "pages/components/tables/StickyHeadTable.js", "bg": true}}
 
+##### Note: If the table has multiple header rows, additional styling must be added to ensure that all of them are visible. By default, they will be stacked together on the top and only the last one will be visible. To avoid this behavior, additional header rows must be styled with a `top` value to create the necessary spacing.
+##### Example:
+
+```jsx
+		<TableHead>
+      <TableRow>
+        <TableCell
+          align="center"
+          colSpan={columns.length}
+        >
+          First Header Row
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell
+          style={{ top: 57 }}
+          align="center"
+          colSpan={columns.length}
+        >
+          Another Header Row
+        </TableCell>
+      </TableRow>
+    </TableHead>
+```
+
 ## Collapsible table
 
 An example of a table with expandable rows, revealing more information.

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -80,35 +80,23 @@ The `ActionsComponent` prop of the `TablePagination` component allows the implem
 ## Fixed header
 
 An example of a table with scrollable rows and fixed column headers.
-It leverages the `stickyHeader` prop (⚠️ no IE11 support).
+It leverages the `stickyHeader` prop.<br />
+(⚠️ no IE11 support)
 
 {{"demo": "pages/components/tables/StickyHeadTable.js", "bg": true}}
 
-##### Note: If the table has multiple header rows, additional styling must be added to ensure that all of them are visible. By default, they will be stacked together on the top and only the last one will be visible. To avoid this behavior, additional header rows must be styled with a `top` value to create the necessary spacing.
+## Column grouping
 
-##### Example:
+You can group column header by rendering multiple table rows inside a table head:
 
 ```jsx
-		<TableHead>
-      <TableRow>
-        <TableCell
-          align="center"
-          colSpan={columns.length}
-        >
-          First Header Row
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell
-          style={{ top: 57 }}
-          align="center"
-          colSpan={columns.length}
-        >
-          Another Header Row
-        </TableCell>
-      </TableRow>
-    </TableHead>
+<TableHead>
+  <TableRow />
+  <TableRow />
+</TableHead>
 ```
+
+{{"demo": "pages/components/tables/ColumnGroupingTable.js", "bg": true}}
 
 ## Collapsible table
 

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -85,6 +85,7 @@ It leverages the `stickyHeader` prop (⚠️ no IE11 support).
 {{"demo": "pages/components/tables/StickyHeadTable.js", "bg": true}}
 
 ##### Note: If the table has multiple header rows, additional styling must be added to ensure that all of them are visible. By default, they will be stacked together on the top and only the last one will be visible. To avoid this behavior, additional header rows must be styled with a `top` value to create the necessary spacing.
+
 ##### Example:
 
 ```jsx

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -87,7 +87,7 @@ It leverages the `stickyHeader` prop.<br />
 
 ## Column grouping
 
-You can group column header by rendering multiple table rows inside a table head:
+You can group column headers by rendering multiple table rows inside a table head:
 
 ```jsx
 <TableHead>


### PR DESCRIPTION
Fixes #23090 
This update adds additional information about how to enable multiple sticky headers using `stickyHeader`.
Portuguese documentation has also been updated accordingly.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
