### PR TITLE
[Autocomplete] Replace `:first-child` class with `first-of-type`

### DIFF
--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -64,7 +64,7 @@ export const styles = (theme) => ({
       '& $input': {
         padding: 4,
       },
-      '& $input:first-child': {
+      '& $input:first-of-type': {
         padding: '6px 0',
       },
     },
@@ -72,7 +72,7 @@ export const styles = (theme) => ({
       '& $input': {
         padding: '2px 4px 3px',
       },
-      '& $input:first-child': {
+      '& $input:first-of-type': {
         padding: '1px 0 4px',
       },
     },
@@ -87,7 +87,7 @@ export const styles = (theme) => ({
       '& $input': {
         padding: '7.5px 4px',
       },
-      '& $input:first-child': {
+      '& $input:first-of-type': {
         paddingLeft: 6,
       },
       '& $endAdornment': {


### PR DESCRIPTION
In case of `startAdornment` in `MuiInput-root` we've `startAdornment` as first-child of the parent div. So in order to fix this issue #23051, I've replaced `input:first-child` pseudo class with `input:first-of-type`.