### PR TITLE
[Tooltip] Fix followCursor preventing onMouseMove on children

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -446,8 +446,8 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
 
   const handleMouseMove = (event) => {
     const childrenProps = children.props;
-    if (childrenProps.handleMouseMove) {
-      childrenProps.handleMouseMove(event);
+    if (childrenProps.onMouseMove) {
+      childrenProps.onMouseMove(event);
     }
 
     positionRef.current = { x: event.clientX, y: event.clientY };

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -598,23 +598,28 @@ describe('<Tooltip />', () => {
   });
 
   describe('prop: overrides', () => {
-    ['onTouchStart', 'onTouchEnd', 'onMouseEnter', 'onMouseOver', 'onMouseLeave'].forEach(
-      (name) => {
-        it(`should be transparent for the ${name} event`, () => {
-          const handler = spy();
-          const { getByRole } = render(
-            <Tooltip title="Hello World">
-              <button id="testChild" type="submit" {...{ [name]: handler }}>
-                Hello World
-              </button>
-            </Tooltip>,
-          );
-          const type = camelCase(name.slice(2));
-          fireEvent[type](getByRole('button'));
-          expect(handler.callCount).to.equal(1, `${name} should've been called`);
-        });
-      },
-    );
+    [
+      'onTouchStart',
+      'onTouchEnd',
+      'onMouseEnter',
+      'onMouseMove',
+      'onMouseOver',
+      'onMouseLeave',
+    ].forEach((name) => {
+      it(`should be transparent for the ${name} event`, () => {
+        const handler = spy();
+        const { getByRole } = render(
+          <Tooltip followCursor title="Hello World">
+            <button id="testChild" type="submit" {...{ [name]: handler }}>
+              Hello World
+            </button>
+          </Tooltip>,
+        );
+        const type = camelCase(name.slice(2));
+        fireEvent[type](getByRole('button'));
+        expect(handler.callCount).to.equal(1, `${name} should've been called`);
+      });
+    });
 
     it(`should be transparent for the focus and blur event`, () => {
       const handleBlur = spy();


### PR DESCRIPTION
Would've been funny if some component actually implemented `handleMouseMove`
