### PR TITLE
[core] Improve bundle size comment

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -12,9 +12,24 @@ on:
     branches:
       - master
       - next
-    types: [synchronize]
+    types: [opened, synchronize]
 
 jobs:
+  danger:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name === "opened" }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use node@10
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install dependencies
+        run: yarn install
+      - name: Run danger
+        run: yarn danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   main:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -12,24 +12,9 @@ on:
     branches:
       - master
       - next
-    types: [opened, synchronize]
+    types: [synchronize]
 
 jobs:
-  danger:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name === "opened" }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use node@10
-        uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
-      - name: Install dependencies
-        run: yarn install
-      - name: Run danger
-        run: yarn danger ci
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   main:
     runs-on: ubuntu-latest
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ steps:
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       AZURE_BUILD_ID: $(Build.BuildId)
-      AZURE_BUILD_URI: $(Build.BuildUri)
       DANGER_COMMAND: 'prepareBundleSizeReport'
       DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,7 @@ steps:
     displayName: 'prepare danger on PRs'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
+      AZURE_BUILD_ID: $(Build.BuildId)
       AZURE_BUILD_URI: $(Build.BuildUri)
       DANGER_COMMAND: 'prepareBundleSizeReport'
       DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,15 @@ steps:
     displayName: 'install dependencies'
 
   - script: |
+      yarn danger ci
+    displayName: 'prepare danger on PRs'
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      AZURE_BUILD_URI: $(Build.BuildUri)
+      DANGER_COMMAND: 'prepareBundleSizeReport'
+      DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
+
+  - script: |
       yarn lerna run --ignore @material-ui/icons --parallel --scope "@material-ui/*" build
     displayName: 'build @material-ui packages'
 
@@ -135,4 +144,5 @@ steps:
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       AZURE_BUILD_ID: $(Build.BuildId)
+      DANGER_COMMAND: 'reportBundleSize'
       DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -126,7 +126,7 @@ async function reportBundleSize() {
   await git(`fetch ${UPSTREAM_REMOTE}`);
   const mergeBaseCommit = await git(`merge-base HEAD ${UPSTREAM_REMOTE}/${upstreamRef}`);
 
-  const commitRange = `${mergeBaseCommit}...${danger.github.pr.head.sha}`;
+  const detailedComparisonUrl = `https://mui-dashboard.netlify.app/size-comparison?buildId=${azureBuildId}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number}`;
 
   const comparison = await loadComparison(mergeBaseCommit, upstreamRef);
 
@@ -144,13 +144,11 @@ async function reportBundleSize() {
       markdown(importantChanges.join('\n'));
     }
 
-    const details = `[Details of bundle changes](https://mui-dashboard.netlify.app/size-comparison?buildId=${azureBuildId}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number})`;
+    const details = `[Details of bundle changes](${detailedComparisonUrl})`;
 
     markdown(details);
   } else {
-    // this can later be removed to reduce PR noise. It is kept for now for debug
-    // purposes only. DangerJS will swallow console.logs if it completes successfully
-    markdown(`No bundle size changes comparing ${commitRange}`);
+    markdown(`[No bundle size changes](${detailedComparisonUrl})`);
   }
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -103,7 +103,13 @@ function sieveResults(results) {
   return { all: results, main, pages };
 }
 
-async function run() {
+function postInitialComment() {
+  markdown(`Bundle size changes will be reported soon.`);
+}
+
+async function postBundleSize(context) {
+  const { azureBuildId } = context;
+
   // Use git locally to grab the commit which represents the place
   // where the branches differ
   const upstreamRepo = danger.github.pr.base.repo.full_name;
@@ -134,13 +140,21 @@ async function run() {
       markdown(importantChanges.join('\n'));
     }
 
-    const details = `[Details of bundle changes](https://mui-dashboard.netlify.app/size-comparison?buildId=${process.env.AZURE_BUILD_ID}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number})`;
+    const details = `[Details of bundle changes](https://mui-dashboard.netlify.app/size-comparison?buildId=${azureBuildId}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number})`;
 
     markdown(details);
   } else {
     // this can later be removed to reduce PR noise. It is kept for now for debug
     // purposes only. DangerJS will swallow console.logs if it completes successfully
     markdown(`No bundle size changes comparing ${commitRange}`);
+  }
+}
+
+async function run() {
+  if (process.env.AZURE_BUILD_ID === undefined) {
+    postInitialComment();
+  } else {
+    await postBundleSize({ azureBuildId: process.env.AZURE_BUILD_ID });
   }
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -5,7 +5,7 @@ const { exec } = require('child_process');
 const { loadComparison } = require('./scripts/sizeSnapshot');
 
 const azureBuildId = process.env.AZURE_BUILD_ID;
-const azureBuildUri = process.env.AZURE_BUILD_URI;
+const azureBuildUrl = `https://dev.azure.com/mui-org/Material-UI/_build/results?buildId=${azureBuildId}`;
 const dangerCommand = process.env.DANGER_COMMAND;
 
 const parsedSizeChangeThreshold = 300;
@@ -109,7 +109,7 @@ function sieveResults(results) {
 
 function prepareBundleSizeReport() {
   markdown(
-    `Bundle size will be reported once [Azure build #${azureBuildId}](${azureBuildUri}) finishes.`,
+    `Bundle size will be reported once [Azure build #${azureBuildId}](${azureBuildUrl}) finishes.`,
   );
 }
 
@@ -153,7 +153,6 @@ async function reportBundleSize() {
 }
 
 async function run() {
-  console.log(process.env);
   switch (dangerCommand) {
     case 'prepareBundleSizeReport':
       prepareBundleSizeReport();

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -144,21 +144,11 @@ async function run() {
   }
 }
 
-(async () => {
-  let exitCode = 0;
-  try {
-    await run();
-  } catch (err) {
-    console.error(err);
-    exitCode = 1;
-  }
-
-  try {
-    await cleanup();
-  } catch (err) {
-    console.error(err);
-    exitCode = 1;
-  }
-
-  process.exit(exitCode);
-})();
+run()
+  .finally(() => {
+    return cleanup();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -34,7 +34,7 @@ const UPSTREAM_REMOTE = 'danger-upstream';
  * scripts exit to avoid adding internal remotes to the local machine. This is
  * not an issue in CI.
  */
-async function cleanup() {
+async function reportBundleSizeCleanup() {
   await git(`remote remove ${UPSTREAM_REMOTE}`);
 }
 
@@ -158,18 +158,18 @@ async function run() {
       prepareBundleSizeReport();
       break;
     case 'reportBundleSize':
-      await reportBundleSize();
+      try {
+        await reportBundleSize();
+      } finally {
+        await reportBundleSizeCleanup();
+      }
       break;
     default:
       throw new TypeError(`Unrecognized danger command '${dangerCommand}'`);
   }
 }
 
-run()
-  .finally(() => {
-    return cleanup();
-  })
-  .catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -153,6 +153,7 @@ async function reportBundleSize() {
 }
 
 async function run() {
+  console.log(process.env);
   switch (dangerCommand) {
     case 'prepareBundleSizeReport':
       prepareBundleSizeReport();


### PR DESCRIPTION
1. Comment before the size-snapshot is ready
   That way the actual conversation isn't interrupted and it's easier to find the reported bundle size.
   Especially on PRs that target the build setup (and fail on the first pushes) you sometimes find the comment very low in the conversation.
   Ideally we'd always have the very first comment be the bundle size changes. This change should improve it by commenting immediately after `yarn install` is done (1-2minutes after opening).
1. Always include the link 
   We don't report changes of docs pages but these are sometimes the target of a PR (e.g. #23108)