### PR TITLE
[utils] Don't warn about non-ref-forwarding components on the server

### DIFF
--- a/packages/material-ui-utils/src/elementAcceptingRef.ts
+++ b/packages/material-ui-utils/src/elementAcceptingRef.ts
@@ -18,7 +18,14 @@ function acceptingRef(
   const element = props[propName];
   const safePropName = propFullName || propName;
 
-  if (element == null) {
+  if (
+    element == null ||
+    // When server-side rendering React doesn't warn either.
+    // This is not an accurate check for SSR.
+    // This is only in place for emotion compat.
+    // TODO: Revisit once https://github.com/facebook/react/issues/20047 is resolved.
+    typeof window === 'undefined'
+  ) {
     return null;
   }
 

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.ts
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.ts
@@ -18,7 +18,14 @@ function elementTypeAcceptingRef(
   const propValue = props[propName];
   const safePropName = propFullName || propName;
 
-  if (propValue == null) {
+  if (
+    propValue == null ||
+    // When server-side rendering React doesn't warn either.
+    // This is not an accurate check for SSR.
+    // This is only in place for emotion compat.
+    // TODO: Revisit once https://github.com/facebook/react/issues/20047 is resolved.
+    typeof window === 'undefined'
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Getting this in before https://github.com/facebook/react/issues/20047 and v5 because we're affected by this warning as well: `/components/tooltips` already triggers this warning. 

Tested locally since we don't have a clean environment for node i.e. server rendering.

Related to #23070