### PR TITLE
[utils] Fix types of chainPropTypes

### DIFF
--- a/packages/material-ui-utils/src/chainPropTypes.ts
+++ b/packages/material-ui-utils/src/chainPropTypes.ts
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 
-export default function chainPropTypes(
-  propType1: PropTypes.Validator<unknown>,
-  propType2: PropTypes.Validator<unknown>,
-): PropTypes.Validator<unknown> {
+export default function chainPropTypes<A, B>(
+  propType1: PropTypes.Validator<A>,
+  propType2: PropTypes.Validator<B>,
+): PropTypes.Validator<A & B> {
   if (process.env.NODE_ENV === 'production') {
     return () => null;
   }

--- a/packages/material-ui-utils/src/chainpropTypes.spec.tsx
+++ b/packages/material-ui-utils/src/chainpropTypes.spec.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import chainPropTypes from './chainPropTypes';
+
+interface ChainProps {
+  foo?: boolean,
+};
+
+const Chain: React.FC<ChainProps> = (props) => {
+  return <div />;
+}
+
+Chain.propTypes = {
+  foo: chainPropTypes(PropTypes.bool, () => {
+    return null;
+  }),
+};

--- a/packages/material-ui-utils/src/chainpropTypes.spec.tsx
+++ b/packages/material-ui-utils/src/chainpropTypes.spec.tsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import chainPropTypes from './chainPropTypes';
 
 interface ChainProps {
-  foo?: boolean,
-};
+  foo?: boolean;
+}
 
 const Chain: React.FC<ChainProps> = (props) => {
   return <div />;
-}
+};
 
 Chain.propTypes = {
   foo: chainPropTypes(PropTypes.bool, () => {

--- a/packages/material-ui/src/Box/Box.spec.tsx
+++ b/packages/material-ui/src/Box/Box.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
 
-function responsiveTest() {
+function ResponsiveTest() {
   <Box p={[2, 3, 4]} />;
   <Box p={{ xs: 2, sm: 3, md: 4 }} />;
   // undesired

--- a/packages/material-ui/src/Grid/Grid.spec.tsx
+++ b/packages/material-ui/src/Grid/Grid.spec.tsx
@@ -2,6 +2,6 @@ import * as React from 'react';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-function responsiveTest() {
+function ResponsiveTest() {
   <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square />;
 }


### PR DESCRIPTION
Without the fix the new reproduction fail:

<img width="623" alt="Capture d’écran 2020-10-18 à 18 27 27" src="https://user-images.githubusercontent.com/3165635/96373936-e373ef00-116f-11eb-88ee-e10f365305d6.png">

I have first seen the issue in https://github.com/mui-org/material-ui-x/pull/455.

I have used https://github.com/DefinitelyTyped/DefinitelyTyped/blob/47120459d29b508f334db2957c1a962eb193d356/types/airbnb-prop-types/index.d.ts#L44 as inspiration for the solution.