### PR TITLE
[core] Fix bundles for packages without subpackages

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
 const childProcess = require('child_process');
+const fse = require('fs-extra');
 const path = require('path');
 const { promisify } = require('util');
 const yargs = require('yargs');
@@ -32,12 +33,27 @@ async function run(argv) {
   };
   const babelConfigPath = path.resolve(__dirname, '../babel.config.js');
   const srcDir = path.resolve('./src');
+
+  let topLevelPathImportsArePackages = true;
+  fse.readdirSync(srcDir, { withFileTypes: true }).forEach((dirEntry) => {
+    if (dirEntry.isFile() && !path.basename(dirEntry.name).startsWith('index.')) {
+      topLevelPathImportsArePackages = false;
+    }
+  });
+
   const outDir = path.resolve(
     relativeOutDir,
+    // We generally support top level path imports e.g.
+    // 1. `import ArrowDownIcon from '@material-ui/icons/ArrowDown'`.
+    // 2. `import Typography from '@material-ui/core/Typography'`.
+    // The first case resolves to a file while the second case resolves to a package first i.e. a package.json
+    // This means that only in the second case the bundler can decide whether it uses ES modules or CommonJS modules.
+    // Different extensions are not viable yet since they require additional bundler config for users and additional transpilation steps in our repo.
+    // Switch to `exports` field in v6.
     {
-      node: './node',
+      node: topLevelPathImportsArePackages ? './node' : './',
       modern: './modern',
-      stable: './',
+      stable: topLevelPathImportsArePackages ? './' : './esm',
       legacy: './legacy',
     }[bundle],
   );

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -69,8 +69,12 @@ async function createPackageFile() {
   const newPackageData = {
     ...packageDataOther,
     private: false,
-    main: './node/index.js',
-    module: './index.js',
+    main: fse.existsSync(path.resolve(buildPath, './node/index.js'))
+      ? './node/index.js'
+      : './index.js',
+    module: fse.existsSync(path.resolve(buildPath, './esm/index.js'))
+      ? './esm/index.js'
+      : './index.js',
     typings: './index.d.ts',
   };
   const targetPath = path.resolve(buildPath, './package.json');

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -63,7 +63,7 @@ async function getSizeLimitBundles() {
     {
       name: '@material-ui/system',
       webpack: true,
-      path: 'packages/material-ui-system/build/index.js',
+      path: 'packages/material-ui-system/build/esm/index.js',
     },
     ...coreComponents,
     {
@@ -95,7 +95,7 @@ async function getSizeLimitBundles() {
     {
       name: '@material-ui/utils',
       webpack: true,
-      path: 'packages/material-ui-utils/build/index.js',
+      path: 'packages/material-ui-utils/build/esm/index.js',
     },
     // TODO: Requires webpack v5
     // Resolution of webpack/acorn to 7.x is blocked by nextjs (https://github.com/vercel/next.js/issues/11947)


### PR DESCRIPTION
Affected packages:

- `@material-ui/icons`
- `@material-ui/system`
- `@material-ui/utils`

I had some assumptions about our packages that don't hold for all `@material-ui/*` packages. In a perfect world these would hold since it makes easier to work with them (as maintainer and, more importantly, app dev) but we have adjust for the way people consume Material-UI today.

This is not the ideal fix for #23120 but I'd rather get a working™ fix out soon as possible so that we can cut a release.

1. [x] Get deploy of new bundles
1. [X] Create test fixture covering (tracked in #23166)


Closes #23120