### PR TITLE
[examples] Remove reason example project

### DIFF
--- a/docs/src/pages/getting-started/example-projects/example-projects.md
+++ b/docs/src/pages/getting-started/example-projects/example-projects.md
@@ -14,7 +14,6 @@ You can find some example projects in the [GitHub repository](https://github.com
 - [CDN](https://github.com/mui-org/material-ui/tree/next/examples/cdn)
 - [Plain server-side](https://github.com/mui-org/material-ui/tree/next/examples/ssr)
 - [Use styled-components as style engine](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components)
-- [Reason React](https://github.com/mui-org/material-ui/tree/next/examples/reason)
 
 Create React App is an awesome project for learning React.
 Have a look at [the alternatives available](https://github.com/facebook/create-react-app/blob/master/README.md#popular-alternatives) to see which project best fits your needs.

--- a/examples/reason/README.md
+++ b/examples/reason/README.md
@@ -1,9 +1,0 @@
-# Reason example
-
-## How to use
-
-Download the example [or clone the repo](https://github.com/Tevinthuku/material-ui-reason-react-demo).
-
-## The idea behind the example
-
-[Reason](https://reasonml.github.io/) lets you write simple, fast and quality type safe code while leveraging both the JavaScript & OCaml ecosystems.


### PR DESCRIPTION
Based on the popularity https://www.similarweb.com/website/reasonml.github.io/?competitors=reactjs.org 

![image](https://user-images.githubusercontent.com/4512430/96440664-955efa00-1208-11eb-947d-f43604094e12.png)

we are removing the reason example project that we had for v4. If somebody migrates it to v5, we may add it again.