### PR TITLE
[docs] Remove unused style selectors `extendedIcon`

### DIFF
--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -9,9 +9,6 @@ const useStyles = makeStyles((theme) => ({
   margin: {
     margin: theme.spacing(1),
   },
-  extendedIcon: {
-    marginRight: theme.spacing(1),
-  },
 }));
 
 export default function ButtonSizes() {

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -10,9 +10,6 @@ const useStyles = makeStyles((theme: Theme) =>
     margin: {
       margin: theme.spacing(1),
     },
-    extendedIcon: {
-      marginRight: theme.spacing(1),
-    },
   }),
 );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR removes unused selector "extendedIcon" from the "Buttons -> Sizes" example.
See https://material-ui.com/components/buttons/#sizes

This selector is not used anywhere in the example.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
