### PR TITLE
[docs] Add Menu component example with explicit positioning prop values

### DIFF
--- a/docs/src/pages/components/menus/PositionedMenu.js
+++ b/docs/src/pages/components/menus/PositionedMenu.js
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+
+export default function PositionedMenu() {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        aria-controls="positioned-menu"
+        aria-haspopup="true"
+        onClick={handleClick}
+      >
+        Open Menu
+      </Button>
+      <Menu
+        id="positioned-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        <MenuItem onClick={handleClose}>Profile</MenuItem>
+        <MenuItem onClick={handleClose}>My account</MenuItem>
+        <MenuItem onClick={handleClose}>Logout</MenuItem>
+      </Menu>
+    </div>
+  );
+}

--- a/docs/src/pages/components/menus/PositionedMenu.tsx
+++ b/docs/src/pages/components/menus/PositionedMenu.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+
+export default function PositionedMenu() {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        aria-controls="positioned-menu"
+        aria-haspopup="true"
+        onClick={handleClick}
+      >
+        Open Menu
+      </Button>
+      <Menu
+        id="positioned-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        <MenuItem onClick={handleClose}>Profile</MenuItem>
+        <MenuItem onClick={handleClose}>My account</MenuItem>
+        <MenuItem onClick={handleClose}>Logout</MenuItem>
+      </Menu>
+    </div>
+  );
+}

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -16,7 +16,7 @@ A menu displays a list of choices on a temporary surface. It appears when the us
 
 ## Basic menu
 
-A basic menu opens over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, a basic menu vertically realigns to make sure that all menu items are completely visible.
+A basic menu opens over the anchor element by default (this option can be [changed](#menu-positioning) via props). When close to a screen edge, a basic menu vertically realigns to make sure that all menu items are completely visible.
 
 Choosing an option should immediately ideally commit the option and close the menu.
 
@@ -33,7 +33,7 @@ To use a selected menu item without impacting the initial focus or the vertical 
 
 {{"demo": "pages/components/menus/SimpleListMenu.js"}}
 
-## Positioned menus
+## Menu positioning
 
 Because the `Menu` component uses the `Popover` component to position itself, you can use the same [positioning props](/components/popover/#anchor-playground) to position it.
 For instance, you can display the menu below the anchor:

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -16,7 +16,7 @@ A Menu displays a list of choices on a temporary surface. It appears when the us
 
 ## Simple Menu
 
-Simple menus open over the anchor element by default (this option can be [changed](#positioned-menu) via props). When close to a screen edge, simple menus vertically realign to make sure that all menu items are completely visible.
+Simple menus open over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, simple menus vertically realign to make sure that all menu items are completely visible.
 
 Choosing an option should immediately ideally commit the option and close the menu.
 

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -10,13 +10,13 @@ waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
 
 <p class="description">Menus display a list of choices on temporary surfaces.</p>
 
-A Menu displays a list of choices on a temporary surface. It appears when the user interacts with a button, or other control.
+A menu displays a list of choices on a temporary surface. It appears when the user interacts with a button, or other control.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Basic menu
 
-Simple menus open over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, simple menus vertically realign to make sure that all menu items are completely visible.
+A basic menu open over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, a basic menu vertically realigns to make sure that all menu items are completely visible.
 
 Choosing an option should immediately ideally commit the option and close the menu.
 
@@ -36,7 +36,6 @@ To use a selected menu item without impacting the initial focus or the vertical 
 ## Positioned menus
 
 Because the `Menu` component uses the `Popover` component to position itself, you can use the same [positioning props](/components/popover/#anchor-playground) to position it.
-
 For instance, you can display the menu below the anchor:
 
 {{"demo": "pages/components/menus/PositionedMenu.js"}}

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -16,7 +16,7 @@ A Menu displays a list of choices on a temporary surface. It appears when the us
 
 ## Simple Menu
 
-Simple menus open over the anchor element by default (this option can be changed via props). When close to a screen edge, simple menus vertically realign to make sure that all menu items are completely visible.
+Simple menus open over the anchor element by default (this option can be [changed](#positioned-menu) via props). When close to a screen edge, simple menus vertically realign to make sure that all menu items are completely visible.
 
 Choosing an option should immediately ideally commit the option and close the menu.
 
@@ -32,6 +32,14 @@ The currently selected menu item is set using the `selected` prop (from [ListIte
 To use a selected menu item without impacting the initial focus or the vertical positioning of the menu, set the `variant` prop to "menu".
 
 {{"demo": "pages/components/menus/SimpleListMenu.js"}}
+
+## Positioned menus
+
+Because the `Menu` component uses the `Popover` component to position itself, you can use the same [positioning props](/components/popover/#anchor-playground) to position `Menu`s.
+
+For instance, you can display the menu below the anchor:
+
+{{"demo": "pages/components/menus/PositionedMenu.js"}}
 
 ## MenuList composition
 

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -16,7 +16,7 @@ A menu displays a list of choices on a temporary surface. It appears when the us
 
 ## Basic menu
 
-A basic menu open over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, a basic menu vertically realigns to make sure that all menu items are completely visible.
+A basic menu opens over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, a basic menu vertically realigns to make sure that all menu items are completely visible.
 
 Choosing an option should immediately ideally commit the option and close the menu.
 

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -6,7 +6,7 @@ materialDesign: https://material.io/components/menus
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
 ---
 
-# Menus
+# Menu
 
 <p class="description">Menus display a list of choices on temporary surfaces.</p>
 
@@ -14,7 +14,7 @@ A Menu displays a list of choices on a temporary surface. It appears when the us
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-## Simple Menu
+## Basic menu
 
 Simple menus open over the anchor element by default (this option can be [changed](#positioned-menus) via props). When close to a screen edge, simple menus vertically realign to make sure that all menu items are completely visible.
 
@@ -35,7 +35,7 @@ To use a selected menu item without impacting the initial focus or the vertical 
 
 ## Positioned menus
 
-Because the `Menu` component uses the `Popover` component to position itself, you can use the same [positioning props](/components/popover/#anchor-playground) to position `Menu`s.
+Because the `Menu` component uses the `Popover` component to position itself, you can use the same [positioning props](/components/popover/#anchor-playground) to position it.
 
 For instance, you can display the menu below the anchor:
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Summary

Closes https://github.com/mui-org/material-ui/issues/20755 by adding a `PositionedMenu` `Menu` component example to the documentation

![image](https://user-images.githubusercontent.com/8136030/96480142-dd315180-1207-11eb-9546-2682bea903c2.png)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
