### PR TITLE
[docs] Add Performance section for Modal

### DIFF
--- a/docs/src/pages/components/dialogs/dialogs.md
+++ b/docs/src/pages/components/dialogs/dialogs.md
@@ -126,6 +126,10 @@ Try the demo below to see what we mean:
 
 {{"demo": "pages/components/dialogs/ScrollDialog.js"}}
 
+## Performance
+
+Follow the [Modal performance section](/components/modal/#performance).
+
 ## Limitations
 
 Follow the [Modal limitations section](/components/modal/#limitations).

--- a/docs/src/pages/components/drawers/drawers.md
+++ b/docs/src/pages/components/drawers/drawers.md
@@ -50,7 +50,7 @@ const iOS = process.browser && /iPad|iPhone|iPod/.test(navigator.userAgent);
 
 ### Keep mounted
 
-To ensure a temporary drawer is not unmounted, specify the `ModalProps` prop like
+To ensure a temporary drawer is not unmounted, specify the `ModalProps` prop like:
 
 ```jsx
 <Drawer

--- a/docs/src/pages/components/drawers/drawers.md
+++ b/docs/src/pages/components/drawers/drawers.md
@@ -24,17 +24,6 @@ It closes when an item is selected, handled by controlling the `open` prop.
 
 {{"demo": "pages/components/drawers/TemporaryDrawer.js"}}
 
-To ensure a temporary drawer is not unmounted, specify the `ModalProps` prop like
-
-```jsx
-<Drawer
-  variant="temporary"
-  ModalProps={{
-    keepMounted: true,
-  }}
-/>
-```
-
 ### Swipeable
 
 You can make the drawer swipeable with the `SwipeableDrawer` component.
@@ -58,6 +47,21 @@ const iOS = process.browser && /iPad|iPhone|iPod/.test(navigator.userAgent);
 
 <SwipeableDrawer disableBackdropTransition={!iOS} disableDiscovery={iOS} />;
 ```
+
+### Keep mounted
+
+To ensure a temporary drawer is not unmounted, specify the `ModalProps` prop like
+
+```jsx
+<Drawer
+  variant="temporary"
+  ModalProps={{
+    keepMounted: true,
+  }}
+/>
+```
+
+More details in the [Modal performance section](/components/modal/#performance).
 
 ## Responsive drawer
 

--- a/docs/src/pages/components/drawers/drawers.md
+++ b/docs/src/pages/components/drawers/drawers.md
@@ -30,10 +30,10 @@ To ensure a temporary drawer is not unmounted, specify the `ModalProps` prop lik
 <Drawer
   variant="temporary"
   ModalProps={{
-    keepMounted: true
+    keepMounted: true,
   }}
 />
-````
+```
 
 ### Swipeable
 

--- a/docs/src/pages/components/drawers/drawers.md
+++ b/docs/src/pages/components/drawers/drawers.md
@@ -24,6 +24,17 @@ It closes when an item is selected, handled by controlling the `open` prop.
 
 {{"demo": "pages/components/drawers/TemporaryDrawer.js"}}
 
+To ensure a temporary drawer is not unmounted, specify the `ModalProps` prop like
+
+```jsx
+<Drawer
+  variant="temporary"
+  ModalProps={{
+    keepMounted: true
+  }}
+/>
+````
+
 ### Swipeable
 
 You can make the drawer swipeable with the `SwipeableDrawer` component.

--- a/docs/src/pages/components/modal/KeepMountedModal.js
+++ b/docs/src/pages/components/modal/KeepMountedModal.js
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Modal from '@material-ui/core/Modal';
+
+function rand() {
+  return Math.round(Math.random() * 20) - 10;
+}
+
+function getModalStyle() {
+  const top = 50 + rand();
+  const left = 50 + rand();
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`,
+  };
+}
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    position: 'absolute',
+    width: 400,
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+  },
+}));
+
+export default function KeepMountedModal() {
+  const classes = useStyles();
+  // getModalStyle is not a pure function, we roll the style only on the first render
+  const [modalStyle] = React.useState(getModalStyle);
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        Open Modal
+      </button>
+      <Modal
+        keepMounted
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="keep-mounted-modal-title"
+        aria-describedby="keep-mounted-modal-description"
+      >
+        <div style={modalStyle} className={classes.paper}>
+          <h2 id="keep-mounted-modal-title">Text in a modal</h2>
+          <p id="keep-mounted-modal-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/docs/src/pages/components/modal/KeepMountedModal.tsx
+++ b/docs/src/pages/components/modal/KeepMountedModal.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Modal from '@material-ui/core/Modal';
+
+function rand() {
+  return Math.round(Math.random() * 20) - 10;
+}
+
+function getModalStyle() {
+  const top = 50 + rand();
+  const left = 50 + rand();
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`,
+  };
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    paper: {
+      position: 'absolute',
+      width: 400,
+      backgroundColor: theme.palette.background.paper,
+      border: '2px solid #000',
+      boxShadow: theme.shadows[5],
+      padding: theme.spacing(2, 4, 3),
+    },
+  }),
+);
+
+export default function KeepMountedModal() {
+  const classes = useStyles();
+  // getModalStyle is not a pure function, we roll the style only on the first render
+  const [modalStyle] = React.useState(getModalStyle);
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        Open Modal
+      </button>
+      <Modal
+        keepMounted
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="keep-mounted-modal-title"
+        aria-describedby="keep-mounted-modal-description"
+      >
+        <div style={modalStyle} className={classes.paper}>
+          <h2 id="keep-mounted-modal-title">Text in a modal</h2>
+          <p id="keep-mounted-modal-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -59,6 +59,21 @@ Alternatively, you can use [react-spring](https://github.com/react-spring/react-
 
 {{"demo": "pages/components/modal/SpringModal.js"}}
 
+## Performance
+
+The content of modal is unmounted when closed.
+If you need to make the content available to search engines or render expensive component trees inside your modal while optimizing for interaction responsiveness
+it might be a good idea to change this default behavior by enabling the `keepMounted` prop:
+
+```jsx
+<Modal keepMounted />
+```
+
+{{"demo": "pages/components/modal/KeepMountedModal.js", "defaultCodeOpen": false}}
+
+As with any performance optimization this is not a silver bullet. Be sure to identify
+bottlenecks first and then try out these optimization strategies.
+
 ## Server-side modal
 
 React [doesn't support](https://github.com/facebook/react/issues/13097) the [`createPortal()`](https://reactjs.org/docs/portals.html) API on the server.

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -59,7 +59,7 @@ const blacklist = [
   'docs-components-modal/SimpleModal.png', // Needs interaction
   'docs-components-modal/SpringModal.png', // Needs interaction
   'docs-components-modal/TransitionsModal.png', // Needs interaction
-  'docs-components-modal/TransitionsModal.png', // Needs interaction
+  'docs-components-modal/KeepMountedModal.png', // Needs interaction
   'docs-components-no-ssr/FrameDeferring.png', // Needs interaction
   'docs-components-popover/AnchorPlayground.png', // Redux isolation
   'docs-components-popover/MouseOverPopover.png', // Needs interaction


### PR DESCRIPTION
### Summary

Closes https://github.com/mui-org/material-ui/issues/21987.

I did not add a `Performance` section as mentioned in the discussion in the issue, but rather, simply added some guidance in the `Temporary drawer` section.

Happy to move this around and adjust as needed (like adding an explicit demo).

![image](https://user-images.githubusercontent.com/8136030/96488299-c0971880-120b-11eb-8ca4-354fe8b06aac.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
