### PR TITLE
[Card] Use flex display for CardHeader.avatar

### DIFF
--- a/packages/material-ui/src/CardHeader/CardHeader.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.js
@@ -13,6 +13,7 @@ export const styles = {
   },
   /* Styles applied to the avatar element. */
   avatar: {
+    display: 'flex',
     flex: '0 0 auto',
     marginRight: 16,
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I noticed the avatar is not properly aligned with the title when using an icon (it was fine if I used the Avatar component to wrap the icon). Inspecting the element I noticed the flex properties being set but the display wasn't set to flex. Changing this fixed the issue.