### PR TITLE
[Container] Fix support of custom breakpoint units

### DIFF
--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -44,25 +44,25 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `maxWidth="sm"`. */
   maxWidthSm: {
     [theme.breakpoints.up('sm')]: {
-      maxWidth: theme.breakpoints.values.sm,
+      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
     },
   },
   /* Styles applied to the root element if `maxWidth="md"`. */
   maxWidthMd: {
     [theme.breakpoints.up('md')]: {
-      maxWidth: theme.breakpoints.values.md,
+      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
     },
   },
   /* Styles applied to the root element if `maxWidth="lg"`. */
   maxWidthLg: {
     [theme.breakpoints.up('lg')]: {
-      maxWidth: theme.breakpoints.values.lg,
+      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
     },
   },
   /* Styles applied to the root element if `maxWidth="xl"`. */
   maxWidthXl: {
     [theme.breakpoints.up('xl')]: {
-      maxWidth: theme.breakpoints.values.xl,
+      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
     },
   },
 });

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -30,30 +30,40 @@ export const styles = (theme) => ({
 
     if (value !== 0) {
       acc[theme.breakpoints.up(breakpoint)] = {
-        maxWidth: value,
+        maxWidth: `${value}${theme.breakpoints.unit}`,
       };
     }
     return acc;
   }, {}),
   /* Styles applied to the root element if `maxWidth="xs"`. */
   maxWidthXs: {
-    maxWidth: Math.max(theme.breakpoints.values.xs, 444),
+    [theme.breakpoints.up('xs')]: {
+      maxWidth: Math.max(`${theme.breakpoints.values.xs}${theme.breakpoints.unit}`, 444),
+    },
   },
   /* Styles applied to the root element if `maxWidth="sm"`. */
   maxWidthSm: {
-    maxWidth: `${theme.breakpoints.values.sm}${theme.breakpoints.unit}`,
+    [theme.breakpoints.up('sm')]: {
+      maxWidth: `${theme.breakpoints.values.sm}${theme.breakpoints.unit}`,
+    },
   },
   /* Styles applied to the root element if `maxWidth="md"`. */
   maxWidthMd: {
-    maxWidth: `${theme.breakpoints.values.md}${theme.breakpoints.unit}`,
+    [theme.breakpoints.up('md')]: {
+      maxWidth: `${theme.breakpoints.values.md}${theme.breakpoints.unit}`,
+    },
   },
   /* Styles applied to the root element if `maxWidth="lg"`. */
   maxWidthLg: {
-    maxWidth: `${theme.breakpoints.values.lg}${theme.breakpoints.unit}`,
+    [theme.breakpoints.up('lg')]: {
+      maxWidth: `${theme.breakpoints.values.lg}${theme.breakpoints.unit}`,
+    },
   },
   /* Styles applied to the root element if `maxWidth="xl"`. */
   maxWidthXl: {
-    maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
+    [theme.breakpoints.up('xl')]: {
+      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
+    },
   },
 });
 

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -44,19 +44,19 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `maxWidth="sm"`. */
   maxWidthSm: {
     [theme.breakpoints.up('sm')]: {
-      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
+      maxWidth: `${theme.breakpoints.values.sm}${theme.breakpoints.unit}`,
     },
   },
   /* Styles applied to the root element if `maxWidth="md"`. */
   maxWidthMd: {
     [theme.breakpoints.up('md')]: {
-      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
+      maxWidth: `${theme.breakpoints.values.md}${theme.breakpoints.unit}`,
     },
   },
   /* Styles applied to the root element if `maxWidth="lg"`. */
   maxWidthLg: {
     [theme.breakpoints.up('lg')]: {
-      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
+      maxWidth: `${theme.breakpoints.values.lg}${theme.breakpoints.unit}`,
     },
   },
   /* Styles applied to the root element if `maxWidth="xl"`. */

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -37,33 +37,23 @@ export const styles = (theme) => ({
   }, {}),
   /* Styles applied to the root element if `maxWidth="xs"`. */
   maxWidthXs: {
-    [theme.breakpoints.up('xs')]: {
-      maxWidth: Math.max(theme.breakpoints.values.xs, 444),
-    },
+    maxWidth: Math.max(theme.breakpoints.values.xs, 444),
   },
   /* Styles applied to the root element if `maxWidth="sm"`. */
   maxWidthSm: {
-    [theme.breakpoints.up('sm')]: {
-      maxWidth: `${theme.breakpoints.values.sm}${theme.breakpoints.unit}`,
-    },
+    maxWidth: `${theme.breakpoints.values.sm}${theme.breakpoints.unit}`,
   },
   /* Styles applied to the root element if `maxWidth="md"`. */
   maxWidthMd: {
-    [theme.breakpoints.up('md')]: {
-      maxWidth: `${theme.breakpoints.values.md}${theme.breakpoints.unit}`,
-    },
+    maxWidth: `${theme.breakpoints.values.md}${theme.breakpoints.unit}`,
   },
   /* Styles applied to the root element if `maxWidth="lg"`. */
   maxWidthLg: {
-    [theme.breakpoints.up('lg')]: {
-      maxWidth: `${theme.breakpoints.values.lg}${theme.breakpoints.unit}`,
-    },
+    maxWidth: `${theme.breakpoints.values.lg}${theme.breakpoints.unit}`,
   },
   /* Styles applied to the root element if `maxWidth="xl"`. */
   maxWidthXl: {
-    [theme.breakpoints.up('xl')]: {
-      maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
-    },
+    maxWidth: `${theme.breakpoints.values.xl}${theme.breakpoints.unit}`,
   },
 });
 

--- a/packages/material-ui/src/styles/createBreakpoints.js
+++ b/packages/material-ui/src/styles/createBreakpoints.js
@@ -67,6 +67,7 @@ export default function createBreakpoints(breakpoints) {
     between,
     only,
     width,
+    unit,
     ...other,
   };
 }


### PR DESCRIPTION
When setting breakpoints in different units (like for example `em`) the media-query/breakpoints get created properly and they use the units defined.
However, the Container component is still using no units at all (defaults to pixels) which makes everything break apart.
![image](https://user-images.githubusercontent.com/12865914/96719202-02a59300-13a1-11eb-8d71-30da09cb6388.png)

This PR should fix it, but I've found out another bug on the ThemeProvider which I may need help with. The units set are not showing up on it at `theme.breakpoints.unit` so on the generated CSS it shows up like `undefined`:
![image](https://user-images.githubusercontent.com/12865914/96718510-097fd600-13a0-11eb-972b-2800dd4948fb.png)
On the React DevTools the Theme provider doesn't show units defined...
![image](https://user-images.githubusercontent.com/12865914/96718713-4f3c9e80-13a0-11eb-9a25-96776657d644.png)

If I manually set `unit: "em"` under breakpoints through the DevTools, it magically works after that!
![image](https://user-images.githubusercontent.com/12865914/96718898-94f96700-13a0-11eb-8f47-e2211362c4a4.png)

So basically some tweaks need to be made to the ThemeProvider to make it work, but I can't find where (need some guidance).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
