### PR TITLE
[test] Try to reduce safari flakyness

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function setKarmaConfig(config) {
     browsers: ['ChromeHeadlessNoSandbox'],
     browserDisconnectTimeout: 120 * 1000, // default 2 * 1000
     browserDisconnectTolerance: 3, // default 0
-    browserNoActivityTimeout: 60 * 1000, // default 10 * 1000
+    browserNoActivityTimeout: 120 * 1000, // default 10 * 1000
     colors: true,
     frameworks: ['mocha'],
     files: [

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,9 +13,9 @@ module.exports = function setKarmaConfig(config) {
   const baseConfig = {
     basePath: '../',
     browsers: ['ChromeHeadlessNoSandbox'],
-    browserDisconnectTimeout: 120000, // default 2000
-    browserDisconnectTolerance: 1, // default 0
-    browserNoActivityTimeout: 300000, // default 10000
+    browserDisconnectTimeout: 120 * 1000, // default 2 * 1000
+    browserDisconnectTolerance: 3, // default 0
+    browserNoActivityTimeout: 60 * 1000, // default 10 * 1000
     colors: true,
     frameworks: ['mocha'],
     files: [


### PR DESCRIPTION
Safari 12 is quite flaky right now. Keeping this PR open for a while with the occasional re-run to see if this change reduces flakyness.

1. Increased disconnect tolerance to 3 (up from 1)
2. Reduced no activity timeout to 10s (down from 5 minutes)