### PR TITLE
[docs] Use Box sx prop on all Slider examples

### DIFF
--- a/docs/src/pages/components/slider-styled/ContinuousSlider.js
+++ b/docs/src/pages/components/slider-styled/ContinuousSlider.js
@@ -14,7 +14,7 @@ export default function ContinuousSlider() {
   };
 
   return (
-    <Box width={200}>
+    <Box sx={{ width: 200 }}>
       <Typography id="continuous-slider" gutterBottom>
         Volume
       </Typography>

--- a/docs/src/pages/components/slider-styled/ContinuousSlider.tsx
+++ b/docs/src/pages/components/slider-styled/ContinuousSlider.tsx
@@ -17,7 +17,7 @@ export default function ContinuousSlider() {
   };
 
   return (
-    <Box width={200}>
+    <Box sx={{ width: 200 }}>
       <Typography id="continuous-slider" gutterBottom>
         Volume
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSlider.js
+++ b/docs/src/pages/components/slider-styled/DiscreteSlider.js
@@ -9,7 +9,7 @@ function valuetext(value) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider" gutterBottom>
         Temperature
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSlider.tsx
+++ b/docs/src/pages/components/slider-styled/DiscreteSlider.tsx
@@ -9,7 +9,7 @@ function valuetext(value: number) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider" gutterBottom>
         Temperature
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderLabel.js
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderLabel.js
@@ -28,7 +28,7 @@ function valuetext(value) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-always" gutterBottom>
         Always visible
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderLabel.tsx
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderLabel.tsx
@@ -28,7 +28,7 @@ function valuetext(value: number) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-always" gutterBottom>
         Always visible
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderMarks.js
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderMarks.js
@@ -28,7 +28,7 @@ function valuetext(value) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-custom" gutterBottom>
         Custom marks
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderMarks.tsx
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderMarks.tsx
@@ -28,7 +28,7 @@ function valuetext(value: number) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-custom" gutterBottom>
         Custom marks
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderSteps.js
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderSteps.js
@@ -9,7 +9,7 @@ function valuetext(value) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-small-steps" gutterBottom>
         Small steps
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderSteps.tsx
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderSteps.tsx
@@ -9,7 +9,7 @@ function valuetext(value: number) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-small-steps" gutterBottom>
         Small steps
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderValues.js
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderValues.js
@@ -32,7 +32,7 @@ function valueLabelFormat(value) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-restrict" gutterBottom>
         Restricted values
       </Typography>

--- a/docs/src/pages/components/slider-styled/DiscreteSliderValues.tsx
+++ b/docs/src/pages/components/slider-styled/DiscreteSliderValues.tsx
@@ -32,7 +32,7 @@ function valueLabelFormat(value: number) {
 
 export default function DiscreteSlider() {
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="discrete-slider-restrict" gutterBottom>
         Restricted values
       </Typography>

--- a/docs/src/pages/components/slider-styled/InputSlider.js
+++ b/docs/src/pages/components/slider-styled/InputSlider.js
@@ -31,7 +31,7 @@ export default function InputSlider() {
   };
 
   return (
-    <Box width={250}>
+    <Box sx={{ width: 250 }}>
       <Typography id="input-slider" gutterBottom>
         Volume
       </Typography>

--- a/docs/src/pages/components/slider-styled/InputSlider.tsx
+++ b/docs/src/pages/components/slider-styled/InputSlider.tsx
@@ -36,7 +36,7 @@ export default function InputSlider() {
   };
 
   return (
-    <Box width={250}>
+    <Box sx={{ width: 250 }}>
       <Typography id="input-slider" gutterBottom>
         Volume
       </Typography>

--- a/docs/src/pages/components/slider-styled/NonLinearSlider.js
+++ b/docs/src/pages/components/slider-styled/NonLinearSlider.js
@@ -1,13 +1,7 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
-
-const useStyles = makeStyles({
-  root: {
-    width: 250,
-  },
-});
 
 function valueLabelFormat(value) {
   const units = ['KB', 'MB', 'GB', 'TB'];
@@ -36,10 +30,8 @@ export default function NonLinearSlider() {
     }
   };
 
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 250 }}>
       <Typography id="non-linear-slider" gutterBottom>
         Storage: {valueLabelFormat(calculateValue(value))}
       </Typography>
@@ -55,6 +47,6 @@ export default function NonLinearSlider() {
         valueLabelDisplay="auto"
         aria-labelledby="non-linear-slider"
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider-styled/NonLinearSlider.tsx
+++ b/docs/src/pages/components/slider-styled/NonLinearSlider.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
-
-const useStyles = makeStyles({
-  root: {
-    width: 250,
-  },
-});
 
 function valueLabelFormat(value: number) {
   const units = ['KB', 'MB', 'GB', 'TB'];
@@ -39,10 +33,8 @@ export default function NonLinearSlider() {
     }
   };
 
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 250 }}>
       <Typography id="non-linear-slider" gutterBottom>
         Storage: {valueLabelFormat(calculateValue(value))}
       </Typography>
@@ -58,6 +50,6 @@ export default function NonLinearSlider() {
         valueLabelDisplay="auto"
         aria-labelledby="non-linear-slider"
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider-styled/RangeSlider.js
+++ b/docs/src/pages/components/slider-styled/RangeSlider.js
@@ -15,7 +15,7 @@ export default function RangeSlider() {
   };
 
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="range-slider-demo" gutterBottom>
         Temperature range
       </Typography>

--- a/docs/src/pages/components/slider-styled/RangeSlider.tsx
+++ b/docs/src/pages/components/slider-styled/RangeSlider.tsx
@@ -18,7 +18,7 @@ export default function RangeSlider() {
   };
 
   return (
-    <Box width={300}>
+    <Box sx={{ width: 300 }}>
       <Typography id="range-slider-demo" gutterBottom>
         Temperature range
       </Typography>

--- a/docs/src/pages/components/slider-styled/TrackFalseSlider.js
+++ b/docs/src/pages/components/slider-styled/TrackFalseSlider.js
@@ -35,7 +35,7 @@ function valuetext(value) {
 
 export default function TrackFalseSlider() {
   return (
-    <Box width={250}>
+    <Box sx={{ width: 250 }}>
       <Typography id="track-false-slider" gutterBottom>
         Removed track
       </Typography>

--- a/docs/src/pages/components/slider-styled/TrackFalseSlider.tsx
+++ b/docs/src/pages/components/slider-styled/TrackFalseSlider.tsx
@@ -35,7 +35,7 @@ function valuetext(value: number) {
 
 export default function TrackFalseSlider() {
   return (
-    <Box width={250}>
+    <Box sx={{ width: 250 }}>
       <Typography id="track-false-slider" gutterBottom>
         Removed track
       </Typography>

--- a/docs/src/pages/components/slider-styled/TrackInvertedSlider.js
+++ b/docs/src/pages/components/slider-styled/TrackInvertedSlider.js
@@ -35,7 +35,7 @@ function valuetext(value) {
 
 export default function TrackInvertedSlider() {
   return (
-    <Box width={250}>
+    <Box sx={{ width: 250 }}>
       <Typography id="track-inverted-slider" gutterBottom>
         Inverted track
       </Typography>

--- a/docs/src/pages/components/slider-styled/TrackInvertedSlider.tsx
+++ b/docs/src/pages/components/slider-styled/TrackInvertedSlider.tsx
@@ -35,7 +35,7 @@ function valuetext(value: number) {
 
 export default function TrackInvertedSlider() {
   return (
-    <Box width={250}>
+    <Box sx={{ width: 250 }}>
       <Typography id="track-inverted-slider" gutterBottom>
         Inverted track
       </Typography>

--- a/docs/src/pages/components/slider-styled/VerticalSlider.js
+++ b/docs/src/pages/components/slider-styled/VerticalSlider.js
@@ -32,7 +32,7 @@ export default function VerticalSlider() {
       <Typography id="vertical-slider" gutterBottom>
         Temperature
       </Typography>
-      <Box height={300}>
+      <Box sx={{ height: 300 }}>
         <Slider
           orientation="vertical"
           getAriaValueText={valuetext}

--- a/docs/src/pages/components/slider-styled/VerticalSlider.tsx
+++ b/docs/src/pages/components/slider-styled/VerticalSlider.tsx
@@ -32,7 +32,7 @@ export default function VerticalSlider() {
       <Typography id="vertical-slider" gutterBottom>
         Temperature
       </Typography>
-      <Box height={300}>
+      <Box sx={{ height: 300 }}>
         <Slider
           orientation="vertical"
           getAriaValueText={valuetext}


### PR DESCRIPTION
This PR simply replaces Box system props usages on the Slider docs page which will be used as a base for converting other components to the new styled engine.