### PR TITLE
[Transition] Document default appear value

### DIFF
--- a/docs/pages/api-docs/fade.md
+++ b/docs/pages/api-docs/fade.md
@@ -27,6 +27,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">appear</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Perform the enter transition when it first mounts if `in` is also `true`. Set this to `false` to disable this behavior. |
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |

--- a/docs/pages/api-docs/grow.md
+++ b/docs/pages/api-docs/grow.md
@@ -28,6 +28,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">appear</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Perform the enter transition when it first mounts if `in` is also `true`. Set this to `false` to disable this behavior. |
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">'auto'</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |

--- a/docs/pages/api-docs/slide.md
+++ b/docs/pages/api-docs/slide.md
@@ -27,6 +27,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">appear</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Perform the enter transition when it first mounts if `in` is also `true`. Set this to `false` to disable this behavior. |
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
 | <span class="prop-name">direction</span> | <span class="prop-type">'down'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'up'</span> | <span class="prop-default">'down'</span> | Direction the child node will enter from. |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |

--- a/docs/pages/api-docs/zoom.md
+++ b/docs/pages/api-docs/zoom.md
@@ -28,6 +28,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">appear</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Perform the enter transition when it first mounts if `in` is also `true`. Set this to `false` to disable this behavior. |
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -21,6 +21,12 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    * }
    */
   timeout?: TransitionProps['timeout'];
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -4,6 +4,12 @@ import { TransitionProps } from '../transitions/transition';
 
 export interface FadeProps extends Omit<TransitionProps, 'children'> {
   /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
+  /**
    * A single child content element.
    */
   children?: React.ReactElement<any, any>;
@@ -21,12 +27,6 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    * }
    */
   timeout?: TransitionProps['timeout'];
-  /**
-   * Perform the enter transition when it first mounts if `in` is also `true`.
-   * Set this to `false` to disable this behavior.
-   * @default true
-   */
-  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -36,6 +36,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     onExited,
     onExiting,
     style,
+    appear = true,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     timeout = defaultTimeout,
@@ -105,7 +106,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
 
   return (
     <TransitionComponent
-      appear
+      appear={appear}
       in={inProp}
       nodeRef={enableStrictModeCompat ? nodeRef : undefined}
       onEnter={handleEnter}
@@ -139,6 +140,12 @@ Fade.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear: PropTypes.bool,
   /**
    * A single child content element.
    */

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -27,6 +27,7 @@ const defaultTimeout = {
  */
 const Fade = React.forwardRef(function Fade(props, ref) {
   const {
+    appear = true,
     children,
     in: inProp,
     onEnter,
@@ -36,7 +37,6 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     onExited,
     onExiting,
     style,
-    appear = true,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     timeout = defaultTimeout,

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -4,6 +4,12 @@ import { TransitionProps } from '../transitions/transition';
 
 export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
   /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
+  /**
    * A single child content element.
    */
   children?: React.ReactElement<any, any>;
@@ -20,12 +26,6 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
    * @default 'auto'
    */
   timeout?: TransitionProps['timeout'] | 'auto';
-  /**
-   * Perform the enter transition when it first mounts if `in` is also `true`.
-   * Set this to `false` to disable this behavior.
-   * @default true
-   */
-  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -20,6 +20,12 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
    * @default 'auto'
    */
   timeout?: TransitionProps['timeout'] | 'auto';
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -38,6 +38,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
     onExiting,
     style,
     timeout = 'auto',
+    appear = true,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -154,7 +155,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
 
   return (
     <TransitionComponent
-      appear
+      appear={appear}
       in={inProp}
       nodeRef={nodeRef}
       onEnter={handleEnter}
@@ -190,6 +191,12 @@ Grow.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear: PropTypes.bool,
   /**
    * A single child content element.
    */

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -28,6 +28,7 @@ const styles = {
  */
 const Grow = React.forwardRef(function Grow(props, ref) {
   const {
+    appear = true,
     children,
     in: inProp,
     onEnter,
@@ -38,7 +39,6 @@ const Grow = React.forwardRef(function Grow(props, ref) {
     onExiting,
     style,
     timeout = 'auto',
-    appear = true,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -3,6 +3,12 @@ import { TransitionProps } from '../transitions/transition';
 
 export interface SlideProps extends TransitionProps {
   /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
+  /**
    * A single child content element.
    */
   children?: React.ReactElement<any, any>;
@@ -25,12 +31,6 @@ export interface SlideProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
-  /**
-   * Perform the enter transition when it first mounts if `in` is also `true`.
-   * Set this to `false` to disable this behavior.
-   * @default true
-   */
-  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -25,6 +25,12 @@ export interface SlideProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -81,6 +81,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     onExited,
     onExiting,
     style,
+    appear = true,
     timeout = defaultTimeout,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
@@ -218,7 +219,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
       onExit={handleExit}
       onExited={handleExited}
       onExiting={handleExiting}
-      appear
+      appear={appear}
       in={inProp}
       timeout={timeout}
       {...other}
@@ -243,6 +244,12 @@ Slide.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear: PropTypes.bool,
   /**
    * A single child content element.
    */

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -71,6 +71,7 @@ const defaultTimeout = {
  */
 const Slide = React.forwardRef(function Slide(props, ref) {
   const {
+    appear = true,
     children,
     direction = 'down',
     in: inProp,
@@ -81,7 +82,6 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     onExited,
     onExiting,
     style,
-    appear = true,
     timeout = defaultTimeout,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -20,6 +20,12 @@ export interface ZoomProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -3,6 +3,12 @@ import { TransitionProps } from '../transitions/transition';
 
 export interface ZoomProps extends TransitionProps {
   /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear?: boolean;
+  /**
    * A single child content element.
    */
   children?: React.ReactElement<any, any>;
@@ -20,12 +26,6 @@ export interface ZoomProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
-  /**
-   * Perform the enter transition when it first mounts if `in` is also `true`.
-   * Set this to `false` to disable this behavior.
-   * @default true
-   */
-  appear?: boolean;
 }
 
 /**

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -37,6 +37,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     onExited,
     onExiting,
     style,
+    appear = true,
     timeout = defaultTimeout,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
@@ -106,7 +107,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
 
   return (
     <TransitionComponent
-      appear
+      appear={appear}
       in={inProp}
       nodeRef={nodeRef}
       onEnter={handleEnter}
@@ -140,6 +141,12 @@ Zoom.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * Perform the enter transition when it first mounts if `in` is also `true`.
+   * Set this to `false` to disable this behavior.
+   * @default true
+   */
+  appear: PropTypes.bool,
   /**
    * A single child content element.
    */

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -28,6 +28,7 @@ const defaultTimeout = {
  */
 const Zoom = React.forwardRef(function Zoom(props, ref) {
   const {
+    appear = true,
     children,
     in: inProp,
     onEnter,
@@ -37,7 +38,6 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     onExited,
     onExiting,
     style,
-    appear = true,
     timeout = defaultTimeout,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,


### PR DESCRIPTION
## Breaking changes

- Bug fix: Setting `appear={undefined}` on a transition component would set the transition component's `appear` to `false`. This now sets it to `true`, matching the behavior of omitting the prop

----

Document the default value of the `appear` prop on transition components.
This resolves #22162 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
