### PR TITLE
[theme] Fix spacing string arguments

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -176,9 +176,9 @@ export type SpacingProps = PropsFor<typeof spacing>;
 export function createUnarySpacing<Spacing>(theme: {
   spacing: Spacing;
 }): Spacing extends number
-  ? (abs: number) => number
+  ? (abs: number | string) => number | number
   : Spacing extends any[]
-  ? <Index extends number>(abs: Index) => Spacing[Index]
+  ? <Index extends number>(abs: Index | string) => Spacing[Index] | string
   : Spacing extends (...args: unknown[]) => unknown
   ? Spacing
   : // warns in Dev

--- a/packages/material-ui-system/src/spacing.js
+++ b/packages/material-ui-system/src/spacing.js
@@ -79,9 +79,15 @@ export function createUnarySpacing(theme) {
 
   if (typeof themeSpacing === 'number') {
     return (abs) => {
+      if (typeof abs === 'string') {
+        return abs;
+      }
+
       if (process.env.NODE_ENV !== 'production') {
         if (typeof abs !== 'number') {
-          console.error(`Material-UI: Expected spacing argument to be a number, got ${abs}.`);
+          console.error(
+            `Material-UI: Expected spacing argument to be a number or a string, got ${abs}.`,
+          );
         }
       }
       return themeSpacing * abs;
@@ -90,6 +96,10 @@ export function createUnarySpacing(theme) {
 
   if (Array.isArray(themeSpacing)) {
     return (abs) => {
+      if (typeof abs === 'string') {
+        return abs;
+      }
+
       if (process.env.NODE_ENV !== 'production') {
         if (abs > themeSpacing.length - 1) {
           console.error(

--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -17,7 +17,9 @@ export interface Spacing {
 
 export type SpacingOptions =
   | number
+  | Spacing
   | ((factor: number) => string | number)
+  | ((factor: number | string) => string | number)
   | Array<string | number>;
 
 export default function createSpacing(spacing: SpacingOptions): Spacing;

--- a/packages/material-ui/src/styles/createSpacing.test.ts
+++ b/packages/material-ui/src/styles/createSpacing.test.ts
@@ -12,9 +12,9 @@ describe('createSpacing', () => {
     expect(spacing(2)).to.equal('16px');
     spacing = createSpacing(['0rem', '8rem', '16rem']);
     expect(spacing(2)).to.equal('16rem');
-    spacing = createSpacing((factor) => factor ** 2);
+    spacing = createSpacing((factor: number) => factor ** 2);
     expect(spacing(2)).to.equal('4px');
-    spacing = createSpacing((factor) => `${0.25 * factor}rem`);
+    spacing = createSpacing((factor: number) => `${0.25 * factor}rem`);
     expect(spacing(2)).to.equal('0.5rem');
   });
 
@@ -27,7 +27,7 @@ describe('createSpacing', () => {
     let spacing;
     spacing = createSpacing();
     expect(spacing()).to.equal('8px');
-    spacing = createSpacing((factor) => `${0.25 * factor}rem`);
+    spacing = createSpacing((factor: number) => `${0.25 * factor}rem`);
     expect(spacing()).to.equal('0.25rem');
   });
 
@@ -35,7 +35,7 @@ describe('createSpacing', () => {
     let spacing;
     spacing = createSpacing();
     expect(spacing(1, 2)).to.equal('8px 16px');
-    spacing = createSpacing((factor) => `${0.25 * factor}rem`);
+    spacing = createSpacing((factor: number) => `${0.25 * factor}rem`);
     expect(spacing(1, 2)).to.equal('0.25rem 0.5rem');
   });
 
@@ -43,7 +43,9 @@ describe('createSpacing', () => {
     let spacing;
     spacing = createSpacing();
     expect(spacing(1, 'auto')).to.equal('8px auto');
-    spacing = createSpacing((factor) => `${0.25 * factor}rem`);
+    spacing = createSpacing((factor: number | string) =>
+      typeof factor === 'string' ? factor : `${0.25 * factor}rem`,
+    );
     expect(spacing(1, 'auto', 2, 3)).to.equal('0.25rem auto 0.5rem 0.75rem');
   });
 

--- a/packages/material-ui/src/styles/createSpacing.ts
+++ b/packages/material-ui/src/styles/createSpacing.ts
@@ -4,6 +4,7 @@ export type SpacingOptions =
   | number
   | Spacing
   | ((abs: number) => number | string)
+  | ((abs: number | string) => number | string)
   | Array<string | number>;
 
 export type SpacingArgument = number | string;
@@ -53,9 +54,6 @@ export default function createSpacing(spacingInput: SpacingOptions = 8): Spacing
 
     return args
       .map((argument) => {
-        if (typeof argument === 'string') {
-          return argument;
-        }
         const output = transform(argument);
         return typeof output === 'number' ? `${output}px` : output;
       })


### PR DESCRIPTION
This resolves #21278. The change gives more control to the developers that choose to provide a function to the unit.

When passing a function to `createSpacing`, only number arguments were passed to the function, while strings were not.

Before:
```js
const spacing = createSpacing((factor) => `${0.25 * factor}rem`);
expect(spacing(1, 'auto', 2, 3)).to.equal('0.25rem auto 0.5rem 0.75rem');
```
After:
With this PR we pass the strings to the function and expect the function to handle them:
```js
spacing = createSpacing((factor) =>
  typeof factor === 'string' ? factor : `${0.25 * factor}rem`,
);
expect(spacing(1, 'auto', 2, 3)).to.equal('0.25rem auto 0.5rem 0.75rem');
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
