### PR TITLE
Hackfix for safari infinite drawer flicker

### DIFF
--- a/packages/material-ui/src/Modal/ModalManager.ts
+++ b/packages/material-ui/src/Modal/ModalManager.ts
@@ -78,7 +78,7 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
   const scrollbarSize = getScrollbarSize(ownerDocument(container));
   const lg = 1280;
   const clientWidth = ownerDocument(container).documentElement.clientWidth;
-  const epilepsyZone =  isSafari() && lg >= clientWidth && clientWidth >= (lg - scrollbarSize);
+  const epilepsyZone = isSafari() && lg >= clientWidth && clientWidth >= lg - scrollbarSize;
   if (!props.disableScrollLock && !epilepsyZone) {
     if (isOverflowing(container)) {
       restoreStyle.push({

--- a/packages/material-ui/src/Modal/ModalManager.ts
+++ b/packages/material-ui/src/Modal/ModalManager.ts
@@ -58,6 +58,11 @@ function findIndexOf<T>(items: T[], callback: (item: T) => boolean): number {
   return idx;
 }
 
+function isSafari() {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.includes('safari') && !ua.includes('chrome');
+}
+
 function handleContainer(containerInfo: Container, props: ManagedModalProps) {
   const restoreStyle: Array<{
     /**
@@ -69,11 +74,13 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
   }> = [];
   const container = containerInfo.container;
 
-  if (!props.disableScrollLock) {
+  // Compute the size before applying overflow hidden to avoid any scroll jumps.
+  const scrollbarSize = getScrollbarSize(ownerDocument(container));
+  const lg = 1280;
+  const clientWidth = ownerDocument(container).documentElement.clientWidth;
+  const epilepsyZone =  isSafari() && lg >= clientWidth && clientWidth >= (lg - scrollbarSize);
+  if (!props.disableScrollLock && !epilepsyZone) {
     if (isOverflowing(container)) {
-      // Compute the size before applying overflow hidden to avoid any scroll jumps.
-      const scrollbarSize = getScrollbarSize(ownerDocument(container));
-
       restoreStyle.push({
         value: container.style.paddingRight,
         property: 'padding-right',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Related to #22812 

I narrowed down the conditions under which the undesired behavior is triggered.
Basically, the problem is caused by a Safari bug @oliviertassinari mentioned here: https://github.com/mui-org/material-ui/issues/20947#issuecomment-625725872

This PR offers a temporary solution that disables scrollLocking in case of:
- Browser is Safari &
- Viewport size is a bit smaller (scrollbar size) than the point where the breakpoint is triggered

This is my first PR here, all comments are welcome.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
