### PR TITLE
[Icon] Disable translation, e.g Google Translate

### DIFF
--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -76,7 +76,6 @@ const Icon = React.forwardRef(function Icon(props, ref) {
         className,
       )}
       aria-hidden
-      translate="no"
       ref={ref}
       {...other}
     />

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -66,6 +66,7 @@ const Icon = React.forwardRef(function Icon(props, ref) {
     <Component
       className={clsx(
         'material-icons',
+        'notranslate',
         classes.root,
         {
           [classes[`color${capitalize(color)}`]]: color !== 'inherit',

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -66,6 +66,7 @@ const Icon = React.forwardRef(function Icon(props, ref) {
     <Component
       className={clsx(
         'material-icons',
+        // Prevent translations of the content which breaks the CSS logic.
         'notranslate',
         classes.root,
         {
@@ -75,6 +76,7 @@ const Icon = React.forwardRef(function Icon(props, ref) {
         className,
       )}
       aria-hidden
+      translate="no"
       ref={ref}
       {...other}
     />

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -66,7 +66,8 @@ const Icon = React.forwardRef(function Icon(props, ref) {
     <Component
       className={clsx(
         'material-icons',
-        // Prevent translations of the content which breaks the CSS logic.
+        // Prevent the translation of the text content.
+        // The font relies on the exact text content to render the icon.
         'notranslate',
         classes.root,
         {


### PR DESCRIPTION
Make the Icons avoid Google Chrome translation since it make it stop showing the Icon.

Resolves #23236 


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Resources:

- https://stackoverflow.com/questions/9628507/how-can-i-tell-google-translate-to-not-translate-a-section-of-a-website
- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate

Related to #22719