### PR TITLE
[Radio] Fix dot misalignment in Safari

### DIFF
--- a/packages/material-ui/src/Radio/RadioButtonIcon.js
+++ b/packages/material-ui/src/Radio/RadioButtonIcon.js
@@ -9,7 +9,7 @@ export const styles = (theme) => ({
   root: {
     position: 'relative',
     display: 'flex',
-    '&$checked $layer': {
+    '&$checked $dot': {
       transform: 'scale(1)',
       transition: theme.transitions.create('transform', {
         easing: theme.transitions.easing.easeOut,
@@ -17,7 +17,12 @@ export const styles = (theme) => ({
       }),
     },
   },
-  layer: {
+  checked: {},
+  background: {
+    // Scale applied to prevent dot misalignment in Safari
+    transform: 'scale(1)',
+  },
+  dot: {
     left: 0,
     position: 'absolute',
     transform: 'scale(0)',
@@ -26,7 +31,6 @@ export const styles = (theme) => ({
       duration: theme.transitions.duration.shortest,
     }),
   },
-  checked: {},
 });
 
 /**
@@ -37,8 +41,8 @@ function RadioButtonIcon(props) {
 
   return (
     <div className={clsx(classes.root, { [classes.checked]: checked })}>
-      <RadioButtonUncheckedIcon fontSize={fontSize} />
-      <RadioButtonCheckedIcon fontSize={fontSize} className={classes.layer} />
+      <RadioButtonUncheckedIcon fontSize={fontSize} className={classes.background} />
+      <RadioButtonCheckedIcon fontSize={fontSize} className={classes.dot} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Added `scale(1)` to `RadioButtonUncheckedIcon` which centres the dot on Safari different screen sizes and on window zoom. 

Resolves #19846  

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
