### PR TITLE
[Autocomplete] Use Popper with when disablePortal

### DIFF
--- a/docs/src/pages/components/autocomplete/ComboBox.js
+++ b/docs/src/pages/components/autocomplete/ComboBox.js
@@ -6,11 +6,12 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 export default function ComboBox() {
   return (
     <Autocomplete
+      disablePortal
       id="combo-box-demo"
       options={top100Films}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Combo box" variant="outlined" />
+        <TextField {...params} label="Movie" variant="outlined" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/ComboBox.js
+++ b/docs/src/pages/components/autocomplete/ComboBox.js
@@ -5,17 +5,15 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 
 export default function ComboBox() {
   return (
-    <div>
-      <Autocomplete
-        disablePortal
-        id="combo-box-demo"
-        options={top100Films}
-        style={{ width: 300 }}
-        renderInput={(params) => (
-          <TextField {...params} label="Movie" variant="outlined" />
-        )}
-      />
-    </div>
+    <Autocomplete
+      disablePortal
+      id="combo-box-demo"
+      options={top100Films}
+      style={{ width: 300 }}
+      renderInput={(params) => (
+        <TextField {...params} label="Movie" variant="outlined" />
+      )}
+    />
   );
 }
 

--- a/docs/src/pages/components/autocomplete/ComboBox.js
+++ b/docs/src/pages/components/autocomplete/ComboBox.js
@@ -5,15 +5,17 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 
 export default function ComboBox() {
   return (
-    <Autocomplete
-      disablePortal
-      id="combo-box-demo"
-      options={top100Films}
-      style={{ width: 300 }}
-      renderInput={(params) => (
-        <TextField {...params} label="Movie" variant="outlined" />
-      )}
-    />
+    <div>
+      <Autocomplete
+        disablePortal
+        id="combo-box-demo"
+        options={top100Films}
+        style={{ width: 300 }}
+        renderInput={(params) => (
+          <TextField {...params} label="Movie" variant="outlined" />
+        )}
+      />
+    </div>
   );
 }
 

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx
@@ -6,11 +6,12 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 export default function ComboBox() {
   return (
     <Autocomplete
+      disablePortal
       id="combo-box-demo"
       options={top100Films}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Combo box" variant="outlined" />
+        <TextField {...params} label="Movie" variant="outlined" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx
@@ -5,17 +5,15 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 
 export default function ComboBox() {
   return (
-    <div>
-      <Autocomplete
-        disablePortal
-        id="combo-box-demo"
-        options={top100Films}
-        style={{ width: 300 }}
-        renderInput={(params) => (
-          <TextField {...params} label="Movie" variant="outlined" />
-        )}
-      />
-    </div>
+    <Autocomplete
+      disablePortal
+      id="combo-box-demo"
+      options={top100Films}
+      style={{ width: 300 }}
+      renderInput={(params) => (
+        <TextField {...params} label="Movie" variant="outlined" />
+      )}
+    />
   );
 }
 

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx
@@ -5,15 +5,17 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 
 export default function ComboBox() {
   return (
-    <Autocomplete
-      disablePortal
-      id="combo-box-demo"
-      options={top100Films}
-      style={{ width: 300 }}
-      renderInput={(params) => (
-        <TextField {...params} label="Movie" variant="outlined" />
-      )}
-    />
+    <div>
+      <Autocomplete
+        disablePortal
+        id="combo-box-demo"
+        options={top100Films}
+        style={{ width: 300 }}
+        renderInput={(params) => (
+          <TextField {...params} label="Movie" variant="outlined" />
+        )}
+      />
+    </div>
   );
 }
 

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -254,12 +254,6 @@ export const styles = (theme) => ({
   },
 });
 
-function DisablePortal(props) {
-  // eslint-disable-next-line react/prop-types
-  const { anchorEl, open, ...other } = props;
-  return <div {...other} />;
-}
-
 const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
@@ -314,7 +308,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     openText = 'Open',
     options,
     PaperComponent = Paper,
-    PopperComponent: PopperComponentProp = Popper,
+    PopperComponent = Popper,
     popupIcon = <ArrowDropDownIcon />,
     renderGroup: renderGroupProp,
     renderInput,
@@ -326,8 +320,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     ...other
   } = props;
   /* eslint-enable @typescript-eslint/no-unused-vars */
-
-  const PopperComponent = disablePortal ? DisablePortal : PopperComponentProp;
 
   const {
     getRootProps,
@@ -481,6 +473,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
           className={clsx(classes.popper, {
             [classes.popperDisablePortal]: disablePortal,
           })}
+          disablePortal={disablePortal}
           style={{
             width: anchorEl ? anchorEl.clientWidth : null,
           }}


### PR DESCRIPTION
By using the `Popper` we can use `<Autocomplete disablePortal />` in a flex container and resolve the misleading naming issue i.e. `disablePortal` now only disables the portal instead of disabling the Popper.

`disablePortal` is important for a11y on VO

Other minor fixes:
1. Avoid role in label
  The UI already communicates what kind of interactions are allowed. We don't need to repeat that in the label.
   It's especially annoying with screen readers which announced "combobox combobox"

Preview: https://deploy-preview-23263--material-ui.netlify.app/components/autocomplete/

Closes #23471