### PR TITLE
[types] Moved types from OverridableComponent.d.ts to @material-ui/types

### DIFF
--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector, ClassNameMap, StyledComponentProps } from '@material-ui/types';
+import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 import { DefaultTheme } from '../defaultTheme';
@@ -80,7 +80,7 @@ export interface WithStylesOptions<Theme = DefaultTheme> extends JSS.StyleSheetF
   name?: string;
 }
 
-export { ClassNameMap } from '@material-ui/types';
+export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
 /**
  * @internal
@@ -112,7 +112,13 @@ export type WithStyles<
   innerRef?: React.Ref<any>;
 } & PropsOfStyles<StylesType>;
 
-export { StyledComponentProps } from '@material-ui/types';
+export interface StyledComponentProps<ClassKey extends string = string> {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<ClassNameMap<ClassKey>>;
+  innerRef?: React.Ref<any>;
+}
 
 export default function withStyles<
   StylesType extends Styles<any, any>,

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector } from '@material-ui/types';
+import { PropInjector, ClassNameMap, StyledComponentProps } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 import { DefaultTheme } from '../defaultTheme';
@@ -80,7 +80,7 @@ export interface WithStylesOptions<Theme = DefaultTheme> extends JSS.StyleSheetF
   name?: string;
 }
 
-export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
+export { ClassNameMap } from '@material-ui/types';
 
 /**
  * @internal
@@ -112,13 +112,7 @@ export type WithStyles<
   innerRef?: React.Ref<any>;
 } & PropsOfStyles<StylesType>;
 
-export interface StyledComponentProps<ClassKey extends string = string> {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<ClassNameMap<ClassKey>>;
-  innerRef?: React.Ref<any>;
-}
+export { StyledComponentProps } from '@material-ui/types';
 
 export default function withStyles<
   StylesType extends Styles<any, any>,

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -82,3 +82,84 @@ type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) ext
  * @param actual
  */
 export function expectType<Expected, Actual>(actual: IfEquals<Actual, Expected, Actual>): void;
+
+export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
+
+export interface StyledComponentProps<ClassKey extends string = string> {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<ClassNameMap<ClassKey>>;
+  innerRef?: React.Ref<any>;
+}
+
+/**
+ * A component whose root component can be controlled via a `component` prop.
+ *
+ * Adjusts valid props based on the type of `component`.
+ */
+export interface OverridableComponent<M extends OverridableTypeMap> {
+  <C extends React.ElementType>(
+    props: {
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      component: C;
+    } & OverrideProps<M, C>
+  ): JSX.Element;
+  (props: DefaultComponentProps<M>): JSX.Element;
+}
+
+/**
+ * Props of the component if `component={Component}` is used.
+ */
+// prettier-ignore
+export type OverrideProps<
+  M extends OverridableTypeMap,
+  C extends React.ElementType
+> = (
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<C>, keyof BaseProps<M>>
+);
+
+/**
+ * Props if `component={Component}` is NOT used.
+ */
+// prettier-ignore
+export type DefaultComponentProps<M extends OverridableTypeMap> =
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
+
+/**
+ * Props defined on the component (+ common material-ui props).
+ */
+// prettier-ignore
+export type BaseProps<M extends OverridableTypeMap> =
+  & M['props']
+  & CommonProps;
+
+/**
+ * Props that are valid for material-ui components.
+ */
+// each component declares it's classes in a separate interface for proper JSDOC.
+export interface CommonProps extends StyledComponentProps<never> {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export interface OverridableTypeMap {
+  props: {};
+  defaultComponent: React.ElementType;
+}
+
+/**
+ * @deprecated Not used in this library.
+ */
+export type Simplify<T> = T extends any ? { [K in keyof T]: T[K] } : never;
+
+/**
+ * @deprecated Not used in this library.
+ */
+// tslint:disable-next-line: deprecation
+export type SimplifiedPropsOf<C extends React.ElementType> = Simplify<React.ComponentProps<C>>;

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -122,20 +122,10 @@ export type DefaultComponentProps<M extends OverridableTypeMap> =
   & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
 
 /**
- * Props defined on the component (+ common material-ui props).
+ * Props defined on the component.
  */
 // prettier-ignore
-export type BaseProps<M extends OverridableTypeMap> =
-& M['props']
-& CommonProps;
-
-/**
- * Props that are valid for material-ui components.
- */
-export interface CommonProps {
-  className?: string;
-  style?: React.CSSProperties;
-}
+export type BaseProps<M extends OverridableTypeMap> = M['props'];
 
 export interface OverridableTypeMap {
   props: {};

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -83,16 +83,6 @@ type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) ext
  */
 export function expectType<Expected, Actual>(actual: IfEquals<Actual, Expected, Actual>): void;
 
-export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
-
-export interface StyledComponentProps<ClassKey extends string = string> {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<ClassNameMap<ClassKey>>;
-  innerRef?: React.Ref<any>;
-}
-
 /**
  * A component whose root component can be controlled via a `component` prop.
  *
@@ -136,14 +126,13 @@ export type DefaultComponentProps<M extends OverridableTypeMap> =
  */
 // prettier-ignore
 export type BaseProps<M extends OverridableTypeMap> =
-  & M['props']
-  & CommonProps;
+& M['props']
+& CommonProps;
 
 /**
  * Props that are valid for material-ui components.
  */
-// each component declares it's classes in a separate interface for proper JSDOC.
-export interface CommonProps extends StyledComponentProps<never> {
+export interface CommonProps {
   className?: string;
   style?: React.CSSProperties;
 }

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -1,74 +1,10 @@
-import * as React from 'react';
-import { Omit } from '@material-ui/types';
-import { StyledComponentProps } from './styles';
-
-/**
- * A component whose root component can be controlled via a `component` prop.
- *
- * Adjusts valid props based on the type of `component`.
- */
-export interface OverridableComponent<M extends OverridableTypeMap> {
-  <C extends React.ElementType>(
-    props: {
-      /**
-       * The component used for the root node.
-       * Either a string to use a HTML element or a component.
-       */
-      component: C;
-    } & OverrideProps<M, C>
-  ): JSX.Element;
-  (props: DefaultComponentProps<M>): JSX.Element;
-}
-
-/**
- * Props of the component if `component={Component}` is used.
- */
-// prettier-ignore
-export type OverrideProps<
-  M extends OverridableTypeMap,
-  C extends React.ElementType
-> = (
-  & BaseProps<M>
-  & Omit<React.ComponentPropsWithRef<C>, keyof BaseProps<M>>
-);
-
-/**
- * Props if `component={Component}` is NOT used.
- */
-// prettier-ignore
-export type DefaultComponentProps<M extends OverridableTypeMap> =
-  & BaseProps<M>
-  & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
-
-/**
- * Props defined on the component (+ common material-ui props).
- */
-// prettier-ignore
-export type BaseProps<M extends OverridableTypeMap> =
-  & M['props']
-  & CommonProps;
-
-/**
- * Props that are valid for material-ui components.
- */
-// each component declares it's classes in a separate interface for proper JSDOC.
-export interface CommonProps extends StyledComponentProps<never> {
-  className?: string;
-  style?: React.CSSProperties;
-}
-
-export interface OverridableTypeMap {
-  props: {};
-  defaultComponent: React.ElementType;
-}
-
-/**
- * @deprecated Not used in this library.
- */
-export type Simplify<T> = T extends any ? { [K in keyof T]: T[K] } : never;
-
-/**
- * @deprecated Not used in this library.
- */
-// tslint:disable-next-line: deprecation
-export type SimplifiedPropsOf<C extends React.ElementType> = Simplify<React.ComponentProps<C>>;
+export {
+  OverridableComponent,
+  OverrideProps,
+  DefaultComponentProps,
+  BaseProps,
+  CommonProps,
+  OverridableTypeMap,
+  Simplify,
+  SimplifiedPropsOf,
+} from '@material-ui/types';

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Omit, OverridableTypeMap } from '@material-ui/types';
 import { StyledComponentProps } from './styles';
 
-export { Simplify, SimplifiedPropsOf } from '@material-ui/types';
+export { OverridableTypeMap, Simplify, SimplifiedPropsOf } from '@material-ui/types';
 
 /**
  * A component whose root component can be controlled via a `component` prop.

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -1,10 +1,60 @@
-export {
-  OverridableComponent,
-  OverrideProps,
-  DefaultComponentProps,
-  BaseProps,
-  CommonProps,
-  OverridableTypeMap,
-  Simplify,
-  SimplifiedPropsOf,
-} from '@material-ui/types';
+import * as React from 'react';
+import { Omit, OverridableTypeMap } from '@material-ui/types';
+import { StyledComponentProps } from './styles';
+
+export { Simplify, SimplifiedPropsOf } from '@material-ui/types';
+
+/**
+ * A component whose root component can be controlled via a `component` prop.
+ *
+ * Adjusts valid props based on the type of `component`.
+ */
+export interface OverridableComponent<M extends OverridableTypeMap> {
+  <C extends React.ElementType>(
+    props: {
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      component: C;
+    } & OverrideProps<M, C>
+  ): JSX.Element;
+  (props: DefaultComponentProps<M>): JSX.Element;
+}
+
+/**
+ * Props of the component if `component={Component}` is used.
+ */
+// prettier-ignore
+export type OverrideProps<
+  M extends OverridableTypeMap,
+  C extends React.ElementType
+> = (
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<C>, keyof BaseProps<M>>
+);
+
+/**
+ * Props if `component={Component}` is NOT used.
+ */
+// prettier-ignore
+export type DefaultComponentProps<M extends OverridableTypeMap> =
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
+
+/**
+ * Props defined on the component (+ common material-ui props).
+ */
+// prettier-ignore
+export type BaseProps<M extends OverridableTypeMap> =
+  & M['props']
+  & CommonProps;
+
+/**
+ * Props that are valid for material-ui components.
+ */
+// each component declares it's classes in a separate interface for proper JSDOC.
+export interface CommonProps extends StyledComponentProps<never> {
+  className?: string;
+  style?: React.CSSProperties;
+}


### PR DESCRIPTION
Another PR that prepares unnecessary changes for introducing the `@material-ui/unstyled` package. It moves the typings from `@material-ui/core/OverridableComponent` to `@material-ui/types` so that those can be reused in the new package. All previous typings from `@material-ui/core/OverridableComponent` are now just re-exported from `@material-ui/types`