### PR TITLE
[styled-engine] Fix tagged template syntax with multiple expressions

### DIFF
--- a/packages/material-ui-styled-engine-sc/src/index.js
+++ b/packages/material-ui-styled-engine-sc/src/index.js
@@ -1,21 +1,14 @@
 import scStyled from 'styled-components';
 
 export default function styled(tag, options) {
-  let scStyledPrepared;
-
   if (options) {
-    scStyledPrepared = scStyled(tag).withConfig({
+    return scStyled(tag).withConfig({
       displayName: options.label,
       shouldForwardProp: options.shouldForwardProp,
     });
-  } else {
-    scStyledPrepared = scStyled(tag);
   }
 
-  // TODO: This should not be required once we solve the warning `You have illegal escape sequence in your template literal`
-  return (styles) => {
-    return scStyledPrepared(...styles);
-  };
+  return scStyled(tag);
 }
 
 export { ThemeContext } from 'styled-components';

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -64,34 +64,51 @@ const shouldForwardProp = (prop) => prop !== 'styleProps' && prop !== 'theme' &&
 const experimentalStyled = (tag, options, muiOptions = {}) => {
   const name = muiOptions.muiName;
   const defaultStyledResolver = styled(tag, { shouldForwardProp, label: name, ...options });
-  const muiStyledResolver = (...styles) => {
-    const stylesWithDefaultTheme = styles.map((stylesArg) => {
-      return typeof stylesArg === 'function'
-        ? ({ theme: themeInput, ...rest }) =>
-            stylesArg({ theme: isEmpty(themeInput) ? defaultTheme : themeInput, ...rest })
-        : stylesArg;
-    });
+  const muiStyledResolver = (styleArg, ...expressions) => {
+    const expressionsWithDefaultTheme = expressions
+      ? expressions.map((stylesArg) => {
+          return typeof stylesArg === 'function'
+            ? ({ theme: themeInput, ...rest }) => {
+              return stylesArg({ theme: isEmpty(themeInput) ? defaultTheme : themeInput, ...rest });
+            }
+            : stylesArg;
+        })
+      : [];
 
-    if (name && muiOptions.overridesResolver) {
-      stylesWithDefaultTheme.push((props) => {
+    let transformedStyleArg = styleArg;
+
+    if (Array.isArray(styleArg)) {
+      // If the type is array, than we need to add placeholders in the template for the overrides, variants and the sx styles
+      transformedStyleArg = [...styleArg, '', '', ''];
+      transformedStyleArg.raw = [...styleArg.raw, '', '', ''];
+    } else if (typeof styleArg === 'function') {
+      // If the type is function, we need to define the default theme
+      transformedStyleArg = ({ theme: themeInput, ...rest }) =>
+        styleArg({ theme: isEmpty(themeInput) ? defaultTheme : themeInput, ...rest });
+    }
+
+    expressionsWithDefaultTheme.push((props) => {
+      if (name && muiOptions.overridesResolver) {
         const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
         return muiOptions.overridesResolver(props, getStyleOverrides(name, theme), name);
-      });
-    }
+      }
+      return '';
+    });
 
-    if (name) {
-      stylesWithDefaultTheme.push((props) => {
+    expressionsWithDefaultTheme.push((props) => {
+      if (name) {
         const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
         return variantsResolver(props, getVariantStyles(name, theme), theme, name);
-      });
-    }
+      }
+      return '';
+    });
 
-    stylesWithDefaultTheme.push((props) => {
+    expressionsWithDefaultTheme.push((props) => {
       const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
       return styleFunctionSx(props.sx, theme);
     });
 
-    return defaultStyledResolver(...stylesWithDefaultTheme);
+    return defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
   };
   return muiStyledResolver;
 };

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -69,8 +69,11 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
       ? expressions.map((stylesArg) => {
           return typeof stylesArg === 'function'
             ? ({ theme: themeInput, ...rest }) => {
-              return stylesArg({ theme: isEmpty(themeInput) ? defaultTheme : themeInput, ...rest });
-            }
+                return stylesArg({
+                  theme: isEmpty(themeInput) ? defaultTheme : themeInput,
+                  ...rest,
+                });
+              }
             : stylesArg;
         })
       : [];

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -91,7 +91,7 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
       return styleFunctionSx(props.sx, theme);
     });
 
-    return defaultStyledResolver(stylesWithDefaultTheme);
+    return defaultStyledResolver(...stylesWithDefaultTheme);
   };
   return muiStyledResolver;
 };

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -52,15 +52,29 @@ describe('experimentalStyled', () => {
     });
   });
 
-  it('can adapt styles to props', () => {
-    const Div = styled('div')`
-      font-size: ${(props) => props.scale * 8}px;
-      padding: ${(props) => props.scale * 2}px;
-    `;
+  describe('dynamic styles', () => {
+    /**
+     * @type {ReturnType<typeof styled>}
+     */
+    let Div;
 
-    render(<Div scale={4} data-testid="target" />);
+    before(() => {
+      // FIXME: Should not error in DEV
+      expect(() => {
+        Div = styled('div')`
+          font-size: ${(props) => props.scale * 8}px;
+          padding: ${(props) => props.scale * 2}px;
+        `;
+      }).toErrorDev(['You have illegal escape sequence in your template literal']);
+    });
 
-    expect(screen.getByTestId('target')).toHaveComputedStyle({ fontSize: '32px', padding: '8px' });
+    it('can adapt styles to props', () => {
+      render(<Div scale={4} data-testid="target" />);
+      expect(screen.getByTestId('target')).toHaveComputedStyle({
+        fontSize: '32px',
+        padding: '8px',
+      });
+    });
   });
 
   describe('muiOptions', () => {
@@ -108,14 +122,21 @@ describe('experimentalStyled', () => {
         ...(props.variant && styles[props.variant]),
       });
 
-      Test = styled(
-        'div',
-        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
-      )`
-        width: 200px;
-        height: 300px;
-      `;
+      // FIXME: Should not error in DEV
+      expect(() => {
+        Test = styled(
+          'div',
+          { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+          { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+        )`
+          width: 200px;
+          height: 300px;
+        `;
+      }).toErrorDev([
+        'You have illegal escape sequence in your template literal',
+        'You have illegal escape sequence in your template literal',
+        'You have illegal escape sequence in your template literal',
+      ]);
     });
 
     it('should work with specified muiOptions', () => {
@@ -169,9 +190,13 @@ describe('experimentalStyled', () => {
     });
 
     it('styled wrapper should win over variants', () => {
-      const CustomTest = styled(Test)`
-        width: 500px;
-      `;
+      let CustomTest;
+      // FIXME: Should not error in DEV
+      expect(() => {
+        CustomTest = styled(Test)`
+          width: 500px;
+        `;
+      }).toErrorDev(['You have illegal escape sequence in your template literal']);
 
       const { container } = render(
         <ThemeProvider theme={theme}>

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils';
+import { createClientRender, screen } from 'test/utils';
 import createMuiTheme from './createMuiTheme';
 import styled from './experimentalStyled';
 import ThemeProvider from './ThemeProvider';
@@ -50,6 +50,17 @@ describe('experimentalStyled', () => {
     expect(container.firstChild).toHaveComputedStyle({
       width: '10px',
     });
+  });
+
+  it('can adapt styles to props', () => {
+    const Div = styled('div')`
+      font-size: ${(props) => props.scale * 8}px;
+      padding: ${(props) => props.scale * 2}px;
+    `;
+
+    render(<Div scale={4} data-testid="target" />);
+
+    expect(screen.getByTestId('target')).toHaveComputedStyle({ fontSize: '32px', padding: '8px' });
   });
 
   describe('muiOptions', () => {

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -9,6 +9,18 @@ describe('experimentalStyled', () => {
   const render = createClientRender();
 
   it('should work', () => {
+    const Div = styled('div')`
+      width: 200px;
+    `;
+
+    const { container } = render(<Div>Test</Div>);
+
+    expect(container.firstChild).toHaveComputedStyle({
+      width: '200px',
+    });
+  });
+
+  it('should work when styles are object', () => {
     const Div = styled('div')({
       width: '200px',
     });
@@ -21,6 +33,18 @@ describe('experimentalStyled', () => {
   });
 
   it('should use defaultTheme if no theme is provided', () => {
+    const Div = styled('div')`
+      width: ${(props) => props.theme.spacing(1)};
+    `;
+
+    const { container } = render(<Div>Test</Div>);
+
+    expect(container.firstChild).toHaveComputedStyle({
+      width: '8px',
+    });
+  });
+
+  it('should use defaultTheme if no theme is provided when styles are object', () => {
     const Div = styled('div')((props) => ({
       width: props.theme.spacing(1),
     }));
@@ -33,6 +57,26 @@ describe('experimentalStyled', () => {
   });
 
   it('should use theme from context if available', () => {
+    const Div = styled('div')`
+      width: ${(props) => props.theme.spacing(1)}
+    `;
+
+    const theme = createMuiTheme({
+      spacing: 10,
+    });
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Div>Test</Div>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toHaveComputedStyle({
+      width: '10px',
+    });
+  });
+
+  it('should use theme from context if available when styles are object', () => {
     const Div = styled('div')((props) => ({
       width: props.theme.spacing(1),
     }));
@@ -58,15 +102,34 @@ describe('experimentalStyled', () => {
      */
     let Div;
 
+    /**
+     * @type {ReturnType<typeof styled>}
+     */
+    let DivObj;
+
+
     before(() => {
       Div = styled('div')`
         font-size: ${(props) => props.scale * 8}px;
         padding-left: ${(props) => props.scale * 2}px;
       `;
+
+      DivObj = styled('div')((props) => ({
+        fontSize: `${props.scale * 8}px`,
+        paddingLeft: `${props.scale * 2}px`,
+      }));
     });
 
     it('can adapt styles to props', () => {
       render(<Div scale={4} data-testid="target" />);
+      expect(screen.getByTestId('target')).toHaveComputedStyle({
+        fontSize: '32px',
+        paddingLeft: '8px',
+      });
+    });
+
+    it('can adapt styles to props when styles are object', () => {
+      render(<DivObj scale={4} data-testid="target" />);
       expect(screen.getByTestId('target')).toHaveComputedStyle({
         fontSize: '32px',
         paddingLeft: '8px',
@@ -83,6 +146,10 @@ describe('experimentalStyled', () => {
      * @type {ReturnType<typeof styled>}
      */
     let Test;
+    /**
+     * @type {ReturnType<typeof styled>}
+     */
+    let TestObj;
 
     before(() => {
       theme = createMuiTheme({
@@ -127,6 +194,15 @@ describe('experimentalStyled', () => {
         width: 200px;
         height: 300px;
       `;
+
+      TestObj = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+      )({
+        width: '200px',
+        height: '300px',
+      })
     });
 
     it('should work with specified muiOptions', () => {
@@ -138,10 +214,32 @@ describe('experimentalStyled', () => {
       });
     });
 
+    it('should work with specified muiOptions when styles are object', () => {
+      const { container } = render(<TestObj>Test</TestObj>);
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '200px',
+        height: '300px',
+      });
+    });
+
     it('overrides should be respected', () => {
       const { container } = render(
         <ThemeProvider theme={theme}>
           <Test>Test</Test>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '250px',
+        height: '300px',
+      });
+    });
+
+    it('overrides should be respected when styles are object', () => {
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestObj>Test</TestObj>
         </ThemeProvider>,
       );
 
@@ -164,12 +262,40 @@ describe('experimentalStyled', () => {
       });
     });
 
+    it('overrides should be respected when prop is specified when styles are object', () => {
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestObj variant="rect">Test</TestObj>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '250px',
+        height: '250px',
+      });
+    });
+
     it('variants should win over overrides', () => {
       const { container } = render(
         <ThemeProvider theme={theme}>
           <Test variant="rect" size="large">
             Test
           </Test>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '400px',
+        height: '400px',
+      });
+    });
+
+    it('variants should win over overrides when styles are object', () => {
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestObj variant="rect" size="large">
+            Test
+          </TestObj>
         </ThemeProvider>,
       );
 
@@ -198,10 +324,42 @@ describe('experimentalStyled', () => {
       });
     });
 
+    it('styled wrapper should win over variants when styles are object', () => {
+      const CustomTest = styled(TestObj)({
+        width: '500px',
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <CustomTest variant="rect" size="large">
+            Test
+          </CustomTest>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '500px',
+        height: '400px',
+      });
+    });
+
     it('should resolve the sx prop', () => {
       const { container } = render(
         <ThemeProvider theme={theme}>
           <Test sx={{ color: 'primary.main' }}>Test</Test>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        color: 'rgb(0, 0, 255)',
+      });
+    });
+
+    
+    it('should resolve the sx prop when styles are object', () => {
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestObj sx={{ color: 'primary.main' }}>Test</TestObj>
         </ThemeProvider>,
       );
 

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -59,13 +59,10 @@ describe('experimentalStyled', () => {
     let Div;
 
     before(() => {
-      // FIXME: Should not error in DEV
-      expect(() => {
-        Div = styled('div')`
-          font-size: ${(props) => props.scale * 8}px;
-          padding-left: ${(props) => props.scale * 2}px;
-        `;
-      }).toErrorDev(['You have illegal escape sequence in your template literal']);
+      Div = styled('div')`
+        font-size: ${(props) => props.scale * 8}px;
+        padding-left: ${(props) => props.scale * 2}px;
+      `;
     });
 
     it('can adapt styles to props', () => {
@@ -122,21 +119,14 @@ describe('experimentalStyled', () => {
         ...(props.variant && styles[props.variant]),
       });
 
-      // FIXME: Should not error in DEV
-      expect(() => {
-        Test = styled(
-          'div',
-          { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-          { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
-        )`
-          width: 200px;
-          height: 300px;
-        `;
-      }).toErrorDev([
-        'You have illegal escape sequence in your template literal',
-        'You have illegal escape sequence in your template literal',
-        'You have illegal escape sequence in your template literal',
-      ]);
+      Test = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
     });
 
     it('should work with specified muiOptions', () => {
@@ -190,13 +180,9 @@ describe('experimentalStyled', () => {
     });
 
     it('styled wrapper should win over variants', () => {
-      let CustomTest;
-      // FIXME: Should not error in DEV
-      expect(() => {
-        CustomTest = styled(Test)`
-          width: 500px;
-        `;
-      }).toErrorDev(['You have illegal escape sequence in your template literal']);
+      const CustomTest = styled(Test)`
+        width: 500px;
+      `;
 
       const { container } = render(
         <ThemeProvider theme={theme}>

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -97,30 +97,13 @@ describe('experimentalStyled', () => {
   });
 
   describe('dynamic styles', () => {
-    /**
-     * @type {ReturnType<typeof styled>}
-     */
-    let Div;
-
-    /**
-     * @type {ReturnType<typeof styled>}
-     */
-    let DivObj;
-
-    before(() => {
-      Div = styled('div')`
+    it('can adapt styles to props', () => {
+      const Div = styled('div')`
         font-size: ${(props) => props.scale * 8}px;
         padding-left: ${(props) => props.scale * 2}px;
       `;
-
-      DivObj = styled('div')((props) => ({
-        fontSize: `${props.scale * 8}px`,
-        paddingLeft: `${props.scale * 2}px`,
-      }));
-    });
-
-    it('can adapt styles to props', () => {
       render(<Div scale={4} data-testid="target" />);
+
       expect(screen.getByTestId('target')).toHaveComputedStyle({
         fontSize: '32px',
         paddingLeft: '8px',
@@ -128,7 +111,12 @@ describe('experimentalStyled', () => {
     });
 
     it('can adapt styles to props when styles are object', () => {
+      const DivObj = styled('div')((props) => ({
+        fontSize: `${props.scale * 8}px`,
+        paddingLeft: `${props.scale * 2}px`,
+      }));
       render(<DivObj scale={4} data-testid="target" />);
+
       expect(screen.getByTestId('target')).toHaveComputedStyle({
         fontSize: '32px',
         paddingLeft: '8px',

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -58,7 +58,7 @@ describe('experimentalStyled', () => {
 
   it('should use theme from context if available', () => {
     const Div = styled('div')`
-      width: ${(props) => props.theme.spacing(1)}
+      width: ${(props) => props.theme.spacing(1)};
     `;
 
     const theme = createMuiTheme({
@@ -106,7 +106,6 @@ describe('experimentalStyled', () => {
      * @type {ReturnType<typeof styled>}
      */
     let DivObj;
-
 
     before(() => {
       Div = styled('div')`
@@ -202,7 +201,7 @@ describe('experimentalStyled', () => {
       )({
         width: '200px',
         height: '300px',
-      })
+      });
     });
 
     it('should work with specified muiOptions', () => {
@@ -355,7 +354,6 @@ describe('experimentalStyled', () => {
       });
     });
 
-    
     it('should resolve the sx prop when styles are object', () => {
       const { container } = render(
         <ThemeProvider theme={theme}>

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -63,7 +63,7 @@ describe('experimentalStyled', () => {
       expect(() => {
         Div = styled('div')`
           font-size: ${(props) => props.scale * 8}px;
-          padding: ${(props) => props.scale * 2}px;
+          padding-left: ${(props) => props.scale * 2}px;
         `;
       }).toErrorDev(['You have illegal escape sequence in your template literal']);
     });
@@ -72,7 +72,7 @@ describe('experimentalStyled', () => {
       render(<Div scale={4} data-testid="target" />);
       expect(screen.getByTestId('target')).toHaveComputedStyle({
         fontSize: '32px',
-        padding: '8px',
+        paddingLeft: '8px',
       });
     });
   });


### PR DESCRIPTION
Assuming that `@emotion/styled` and `@material-ui/core/styles#experimentalStyled` implement the same API the added test fails unexpectedly.

Comparison between emotion and styled-engine: https://codesandbox.io/s/experimentalstyled-dynamic-styling-ubozu

Aside but not as severe: `styled.div` is not available. Only `styled()`. 