### PR TITLE
[docs] Avoid confusing nav items with disabled items

### DIFF
--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -23,7 +23,6 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     padding: '8px 0',
     justifyContent: 'flex-start',
-    fontWeight: theme.typography.fontWeightMedium,
     transition: theme.transitions.create(['color', 'background-color'], {
       duration: theme.transitions.duration.shortest,
     }),
@@ -55,7 +54,7 @@ const useStyles = makeStyles((theme) => ({
   },
   open: {},
   link: {
-    color: theme.palette.text.secondary,
+    color: theme.palette.text.primary,
     '&.app-drawer-active': {
       color: theme.palette.primary.main,
       backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),


### PR DESCRIPTION
Reverts the redesign of links in #22780 until #23444 is resolved.

The new styling of the nav items make them indistinguishable from disabled items. This is especially noticeable on top level links like "premium themes" and "blog". It doesn't really make sense to go against an existing design system.

[`next`](https://5f989306fe4fc800073aa58a--material-ui.netlify.app/):
![screenshot of "premium themes"-link next to collapsible menu buttons](https://i.ibb.co/r0WgKdS/Screenshot-from-2020-10-27-23-06-57.png)


It's less noticeable on dark themes but the general issue exists there as well.

The argument for the redesign was that it's closer to the drawer in material.io but it was not specified why that is desired. Especially because it's simply used as an inspiration from a site that is black and white and therefore is not suited to copy only certain features. Maybe material.io is never using disabled items and can therefore appropriate those styles. Maybe the use a different styling for disabled items. But I don't think they intended to use "disabled"-styles for "inactive"-styles. The actual demos of a drawer do not grey-out inactive items.