### PR TITLE
[Avatar] Fix usage of srcset property

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -70,7 +70,9 @@ function useLoaded({ src, srcSet }) {
     let active = true;
     const image = new Image();
     image.src = src;
-    image.srcSet = srcSet;
+    if (srcSet) {
+      image.srcset = srcSet;
+    }
     image.onload = () => {
       if (!active) {
         return;


### PR DESCRIPTION
According to the [HTMLImageElement API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) the correct property is `srcset`, not `srcSet`... and it cannot be `undefined`, otherwise it will trigger the `onerror` event.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
