### PR TITLE
[test] Run with Safari 13

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -142,11 +142,11 @@ module.exports = function setKarmaConfig(config) {
         BrowserStack_Safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Mojave',
+          os_version: 'Catalina',
           browser: 'safari',
-          // On desktop we support 13.1 but on mobile we support 12.2.
-          // Using desktop 12.1 (12.2 is not available) as an approximation for mobile 12.2.
-          browser_version: '12.1',
+          // We support 12.2 on iOS.
+          // However, 12.1 is very flaky on desktop (mobile is always flaky).
+          browser_version: '13.0',
         },
         BrowserStack_Edge: {
           base: 'BrowserStack',


### PR DESCRIPTION
Safari 12 is fairly flaky in `test_browser` (feels like >50% failure, probably around 10%) so let's try Safari 13 instead.

This makes Safari 12 effectively our new IE 11 (on which we don't test either) so let's hope we don't break it too often.