### PR TITLE
[Select] Replace displayNode state with displayRef for ref value 

### DIFF
--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1086,4 +1086,21 @@ describe('<Select />', () => {
     fireEvent.click(container.querySelector('button[type=submit]'));
     expect(handleSubmit.callCount).to.equal(1);
   });
+
+  it('should programmatically focus the select', () => {
+    const { getByRole } = render(
+      <Select
+        value={1}
+        inputRef={(input) => {
+          if (input !== null) {
+            input.focus();
+          }
+        }}
+      >
+        <MenuItem value={1}>1</MenuItem>
+        <MenuItem value={2}>2</MenuItem>
+      </Select>,
+    );
+    expect(document.activeElement).to.equal(getByRole('button'));
+  });
 });

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -67,48 +67,54 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   });
 
   const inputRef = React.useRef(null);
+  const displayRef = React.useRef(null);
   const [displayNode, setDisplayNode] = React.useState(null);
   const { current: isOpenControlled } = React.useRef(openProp != null);
   const [menuMinWidthState, setMenuMinWidthState] = React.useState();
   const [openState, setOpenState] = React.useState(false);
   const handleRef = useForkRef(ref, inputRefProp);
 
+  const handleDisplayRef = React.useCallback((node) => {
+    displayRef.current = node;
+
+    if (node) {
+      setDisplayNode(node);
+    }
+  }, []);
+
   React.useImperativeHandle(
     handleRef,
     () => ({
       focus: () => {
-        displayNode.focus();
+        displayRef.current.focus();
       },
       node: inputRef.current,
       value,
     }),
-    [displayNode, value],
+    [value],
   );
 
   React.useEffect(() => {
-    if (autoFocus && displayNode) {
-      displayNode.focus();
+    if (autoFocus) {
+      displayRef.current.focus();
     }
-  }, [autoFocus, displayNode]);
+  }, [autoFocus]);
 
   React.useEffect(() => {
-    if (displayNode) {
-      const label = ownerDocument(displayNode).getElementById(labelId);
-      if (label) {
-        const handler = () => {
-          if (getSelection().isCollapsed) {
-            displayNode.focus();
-          }
-        };
-        label.addEventListener('click', handler);
-        return () => {
-          label.removeEventListener('click', handler);
-        };
-      }
-    }
-
-    return undefined;
-  }, [labelId, displayNode]);
+    const label = ownerDocument(displayRef.current).getElementById(labelId);
+    if (label) {
+      const handler = () => {
+        if (getSelection().isCollapsed) {
+          displayRef.current.focus();
+        }
+      };
+      label.addEventListener('click', handler);
+      return () => {
+        label.removeEventListener('click', handler);
+      };
+    } 
+    
+  }, [labelId]);
 
   const update = (open, event) => {
     if (open) {
@@ -132,7 +138,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     }
     // Hijack the default focus behavior.
     event.preventDefault();
-    displayNode.focus();
+    displayRef.current.focus();
 
     update(true, event);
   };
@@ -353,7 +359,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   return (
     <React.Fragment>
       <div
-        ref={setDisplayNode}
+        ref={handleDisplayRef}
         tabIndex={tabIndex}
         role="button"
         aria-disabled={disabled ? 'true' : undefined}

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -113,7 +113,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         label.removeEventListener('click', handler);
       };
     } 
-    
+    return undefined;
   }, [labelId]);
 
   const update = (open, event) => {

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -112,7 +112,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       return () => {
         label.removeEventListener('click', handler);
       };
-    } 
+    }
     return undefined;
   }, [labelId]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is an attempt to close [#21441](https://github.com/mui-org/material-ui/issues/21441). I used the second proposed solution from [#21441 (comment)](https://github.com/mui-org/material-ui/issues/21441#issuecomment-685940576).

There was quite a bit of discussion about the best solution. The motivation for this pull request is described as the third possibility in [#21441 (comment)](https://github.com/mui-org/material-ui/issues/21441#issuecomment-689497020). 

Note, when using the proposed solution, I received an error in `yarn lint` that `103:22  error  Expected to return a value at the end of arrow function`, so I modified the solution as follows:

```diff
diff --git a/packages/material-ui/src/Select/SelectInput.js b/packages/material-ui/src/Select/SelectInput.js
index cce92efcc..6eb7bac63 100644
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -113,7 +113,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         label.removeEventListener('click', handler);
       };
     } 
-    
+    return undefined;
   }, [labelId]);
 
   const update = (open, event) => {
```
