### PR TITLE
[test] Fix unexpected console warn/error spy swallowing unrelated messages 

### DIFF
--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -26,9 +26,17 @@ function createUnexpectedConsoleMessagesHooks(Mocha, methodName, expectedMatcher
     ]);
   }
 
+  let originalConsoleMethod;
   mochaHooks.beforeAll.push(function registerConsoleStub() {
     // eslint-disable-next-line no-console
+    originalConsoleMethod = console[methodName];
+    // eslint-disable-next-line no-console
     console[methodName] = logUnexpectedConsoleCalls;
+  });
+
+  mochaHooks.afterAll.push(function registerConsoleStub() {
+    // eslint-disable-next-line no-console
+    console[methodName] = originalConsoleMethod;
   });
 
   mochaHooks.afterEach.push(function flushUnexpectedCalls() {


### PR DESCRIPTION
Mocha makes use of console error for watchmode for notifications in the terminal which resulted in "unexpected console.error calls" errors being thrown on subsequent watchmode runs.

By restoring the console methods we now get to see these messages and don't throw on unrelated errors.