### PR TITLE
allow the wrapping component to be passed in

### DIFF
--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -81,12 +81,12 @@ export const styles = (theme) => {
 };
 
 const AppBar = React.forwardRef(function AppBar(props, ref) {
-  const { classes, className, color = 'primary', position = 'fixed', ...other } = props;
+  const { classes, className, color = 'primary', position = 'fixed', component = 'header', ...other } = props;
 
   return (
     <Paper
       square
-      component="header"
+      component={component}
       elevation={4}
       className={clsx(
         classes.root,
@@ -125,6 +125,10 @@ AppBar.propTypes = {
    * @default 'primary'
    */
   color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary', 'transparent']),
+  /**
+   * The component to wrap the content in
+   */
+  component: PropTypes.string,
   /**
    * The positioning type. The behavior of the different options is described
    * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I have one AppBar within another and am getting failures in my accessibility tests because it is one header inside another (specifically 'landmark-banner-is-top-level on 2 Nodes' and 'landmark-unique on 1 Node')

This change allows the calling component to set what the wrapper component will be example call:
`<AppBar position="static" component="div"></AppBar>`

Default component is header so change is not breaking.