### PR TITLE
[test] Prevent growing call stack in custom keyDown/keyUp

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -933,7 +933,7 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
 
-        fireEvent.keyDown(document.querySelector('input'), {
+        fireEvent.keyDown(screen.getByRole('textbox'), {
           key: 'Enter',
         });
 
@@ -950,7 +950,7 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
 
-        fireEvent.keyUp(document.querySelector('input'), {
+        fireEvent.keyUp(screen.getByRole('textbox'), {
           key: ' ',
         });
 

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -156,9 +156,14 @@ export function createClientRender(globalOptions = {}) {
   };
 }
 
+/**
+ * @type {typeof rtlFireEvent}
+ */
+const fireEvent = (...args) => rtlFireEvent(...args);
+
 const originalFireEventKeyDown = rtlFireEvent.keyDown;
 const originalFireEventKeyUp = rtlFireEvent.keyUp;
-const fireEvent = Object.assign(rtlFireEvent, {
+Object.assign(fireEvent, rtlFireEvent, {
   keyDown(element, options = {}) {
     // `element` shouldn't be `document` but we catch this later anyway
     const document = element.ownerDocument || element;

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -156,13 +156,12 @@ export function createClientRender(globalOptions = {}) {
   };
 }
 
+const originalFireEventKeyDown = rtlFireEvent.keyDown;
+const originalFireEventKeyUp = rtlFireEvent.keyUp;
 /**
  * @type {typeof rtlFireEvent}
  */
 const fireEvent = (...args) => rtlFireEvent(...args);
-
-const originalFireEventKeyDown = rtlFireEvent.keyDown;
-const originalFireEventKeyUp = rtlFireEvent.keyUp;
 Object.assign(fireEvent, rtlFireEvent, {
   keyDown(element, options = {}) {
     // `element` shouldn't be `document` but we catch this later anyway


### PR DESCRIPTION
In watchmode these files are re-evaluate so every run wraps the composed `fireEvent` again.

With 5 re-reruns
Before (see 4x the `keyDown` stackframe in addition to 1 Function.keyDown frame):
![screenshot of callstack without the change](https://i.ibb.co/R6VQ2w8/Screenshot-from-2020-10-30-15-09-12.png)
After (1 stackframe for Function.keyDown):
![screenshot of callstack with the change](https://i.ibb.co/kHBgKKy/Screenshot-from-2020-10-30-15-11-01.png)