### PR TITLE
[core] Use boolean type for ListItem prop instead of 'false'

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -98,7 +98,7 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
  *
  * - [ListItem API](https://material-ui.com/api/list-item/)
  */
-declare const ListItem: OverridableComponent<
+declare const ListItem: ExtendButtonBase<
   ListItemTypeMap<
     {
       /**
@@ -106,12 +106,12 @@ declare const ListItem: OverridableComponent<
        * for `ButtonBase` can then be applied to `ListItem`.
        * @default false
        */
-      button?: boolean;
+      button: true;
     },
-    'li'
+    'div'
   >
 > &
-  ExtendButtonBase<
+  OverridableComponent<
     ListItemTypeMap<
       {
         /**
@@ -119,9 +119,9 @@ declare const ListItem: OverridableComponent<
          * for `ButtonBase` can then be applied to `ListItem`.
          * @default false
          */
-        button: true;
+        button?: boolean;
       },
-      'div'
+      'li'
     >
   >;
 

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -106,7 +106,7 @@ declare const ListItem: OverridableComponent<
        * for `ButtonBase` can then be applied to `ListItem`.
        * @default false
        */
-      button?: false;
+      button?: boolean;
     },
     'li'
   >

--- a/packages/material-ui/src/ListItem/ListItem.spec.tsx
+++ b/packages/material-ui/src/ListItem/ListItem.spec.tsx
@@ -7,7 +7,6 @@ function BooleanButtonTest() {
 
   function EditableItemFail(props: { editable: boolean }) {
     const { editable } = props;
-    // @ts-expect-error 'boolean' is not assignable to type 'true'
     return <ListItem button={editable}>Editable? {editable}</ListItem>;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Sometimes, we might need to assign button type as boolean. Last time i tried conditional variable passed to button prop. Something like this
```tsx
<ListItem button={!!item.onClick} />
```
But i got an error type caused type boolean isn't assignable to type `true` or `false`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

For #14971