### PR TITLE
[test] Improve test debugging

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -10,4 +10,13 @@ module.exports = {
   recursive: true,
   reporter: 'dot',
   require: [require.resolve('./test/utils/setupBabel'), require.resolve('./test/utils/setupJSDOM')],
+  'watch-ignore': [
+    // default
+    '.git',
+    // node_modules can be nested with workspaces
+    '**/node_modules/**',
+    // Unrelated directories with a large number of files
+    '**/build/**',
+    'docs/.next/**',
+  ],
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -22,6 +22,9 @@ async function run(argv) {
   if (argv.bail) {
     args.push('--bail');
   }
+  if (argv.inspectBrk) {
+    args.push('--inspect-brk');
+  }
   if (!argv.single) {
     args.push('--watch');
   }
@@ -60,6 +63,11 @@ yargs
           type: 'string',
         })
         .option('bail', {
+          alias: 'b',
+          description: 'Stop on first error.',
+          type: 'boolean',
+        })
+        .option('inspect-brk', {
           alias: 'b',
           description: 'Stop on first error.',
           type: 'boolean',


### PR DESCRIPTION
- reduce boot times (stable and experimental CLIs)
  This was noticeable in "old" repositories that accumulated a lot of ignored files. I got a 8s bootstrap time reduction in watchmode since it went from watching ~60k files to ~10k files.
- Add `--inspect-brk` to `yarn t`
  Works exactly like `node --inspect-brk` but by adding the flag to our CLI we can control where the debugger should start. `node --inspect-brk test/cli.js` would not debug the tests.