### PR TITLE
[TextField] Fix disabled color in Safari 

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -50,6 +50,7 @@ export const styles = (theme) => {
       '&$disabled': {
         color: theme.palette.text.disabled,
         cursor: 'default',
+        WebkitTextFillColor: theme.palette.text.disabled, // Fix opacity Safari bug
       },
     },
     /* Styles applied to the root element if the component is a descendant of `FormControl`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

this PR is created base on an issue https://github.com/mui-org/material-ui/issues/23332
it fixes the opacity of disable color on the safari browser.

Closes #23332