### PR TITLE
[test] Make sure system properties are in the same order when generating CSS

### DIFF
--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { createClientRender, createMount, describeConformance } from 'test/utils';
 import Box from './Box';
 
@@ -72,37 +71,16 @@ describe('<Box />', () => {
       this.skip();
     }
 
-    const theme = createMuiTheme({
-      palette: {
-        primary: {
-          // light: will be calculated from palette.primary.main,
-          main: 'rgb(0, 0, 255)',
-          // dark: will be calculated from palette.primary.main,
-          // contrastText: will be calculated to contrast with palette.primary.main
-        },
-      },
-    });
-
-    const testCaseBorderColorWins = render(
-      <ThemeProvider theme={theme}>
-        <Box border={1} borderColor="primary.main" />
-      </ThemeProvider>,
-    );
+    const testCaseBorderColorWins = render(<Box border={1} borderColor="rgb(0, 0, 255)" />);
 
     expect(testCaseBorderColorWins.container.firstChild).toHaveComputedStyle({
       border: '1px solid rgb(0, 0, 255)',
-      'border-color': 'rgb(0, 0, 255)',
     });
 
-    const testCaseBorderWins = render(
-      <ThemeProvider theme={theme}>
-        <Box borderColor="primary.main" border={1} />
-      </ThemeProvider>,
-    );
+    const testCaseBorderWins = render(<Box borderColor="rgb(0, 0, 255)" border={1} />);
 
     expect(testCaseBorderWins.container.firstChild).toHaveComputedStyle({
       border: '1px solid rgb(0, 0, 0)',
-      'border-color': 'rgb(0, 0, 0)',
     });
   });
 
@@ -119,37 +97,18 @@ describe('<Box />', () => {
       this.skip();
     }
 
-    const theme = createMuiTheme({
-      palette: {
-        primary: {
-          // light: will be calculated from palette.primary.main,
-          main: 'rgb(0, 0, 255)',
-          // dark: will be calculated from palette.primary.main,
-          // contrastText: will be calculated to contrast with palette.primary.main
-        },
-      },
-    });
-
     const testCaseBorderColorWins = render(
-      <ThemeProvider theme={theme}>
-        <Box sx={{ border: 1, borderColor: 'primary.main' }} />
-      </ThemeProvider>,
+      <Box sx={{ border: 1, borderColor: 'rgb(0, 0, 255)' }} />,
     );
 
     expect(testCaseBorderColorWins.container.firstChild).toHaveComputedStyle({
       border: '1px solid rgb(0, 0, 255)',
-      'border-color': 'rgb(0, 0, 255)',
     });
 
-    const testCaseBorderWins = render(
-      <ThemeProvider theme={theme}>
-        <Box sx={{ borderColor: 'primary.main', border: 1 }} />
-      </ThemeProvider>,
-    );
+    const testCaseBorderWins = render(<Box sx={{ borderColor: 'rgb(0, 0, 255)', border: 1 }} />);
 
     expect(testCaseBorderWins.container.firstChild).toHaveComputedStyle({
       border: '1px solid rgb(0, 0, 0)',
-      'border-color': 'rgb(0, 0, 0)',
     });
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, createMount, describeConformance } from 'test/utils';
 import Box from './Box';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 
 describe('<Box />', () => {
   const mount = createMount();
@@ -56,5 +57,42 @@ describe('<Box />', () => {
     expect(element.getAttribute('color')).to.equal(null);
     expect(element.getAttribute('font-family')).to.equal(null);
     expect(element.getAttribute('font-size')).to.equal(null);
+  });
+
+  it('respect properties order when generating the CSS', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) this.skip();
+
+    const theme = createMuiTheme({
+      palette: {
+        primary: {
+          // light: will be calculated from palette.primary.main,
+          main: 'rgb(0, 0, 255)',
+          // dark: will be calculated from palette.primary.main,
+          // contrastText: will be calculated to contrast with palette.primary.main
+        },
+      },
+    });
+
+    const testCaseBorderColorWins = render(
+      <ThemeProvider theme={theme}>
+        <Box border={1} borderColor="primary.main" />
+      </ThemeProvider>,
+    );
+
+    expect(testCaseBorderColorWins.container.firstChild).toHaveComputedStyle({
+      border: '1px solid rgb(0, 0, 255)',
+      'border-color': 'rgb(0, 0, 255)',
+    });
+
+    const testCaseBorderWins = render(
+      <ThemeProvider theme={theme}>
+        <Box borderColor="primary.main" border={1} />
+      </ThemeProvider>,
+    );
+
+    expect(testCaseBorderWins.container.firstChild).toHaveComputedStyle({
+      border: '1px solid rgb(0, 0, 0)',
+      'border-color': 'rgb(0, 0, 0)',
+    });
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -60,15 +60,15 @@ describe('<Box />', () => {
   });
 
   it('respect properties order when generating the CSS', function test() {
-    const isMozilla = window.navigator.userAgent.indexOf("Firefox") > -1
+    const isMozilla = window.navigator.userAgent.indexOf('Firefox') > -1;
     const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
     if (isJSDOM || isMozilla) {
       // Test fails on Mozilla with just:
 
-	    // "border": "",
-	    // "border-color": "",
-      
+      // "border": "",
+      // "border-color": "",
+
       this.skip();
     }
 
@@ -107,15 +107,15 @@ describe('<Box />', () => {
   });
 
   it('respect properties order when generating the CSS from the sx prop', function test() {
-    const isMozilla = window.navigator.userAgent.indexOf("Firefox") > -1
+    const isMozilla = window.navigator.userAgent.indexOf('Firefox') > -1;
     const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
     if (isJSDOM || isMozilla) {
       // Test fails on Mozilla with just:
 
-	    // "border": "",
-	    // "border-color": "",
-      
+      // "border": "",
+      // "border-color": "",
+
       this.skip();
     }
 

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { createClientRender, createMount, describeConformance } from 'test/utils';
 import Box from './Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 
 describe('<Box />', () => {
   const mount = createMount();

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -95,4 +95,41 @@ describe('<Box />', () => {
       'border-color': 'rgb(0, 0, 0)',
     });
   });
+
+  it('respect properties order when generating the CSS from the sx prop', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) this.skip();
+
+    const theme = createMuiTheme({
+      palette: {
+        primary: {
+          // light: will be calculated from palette.primary.main,
+          main: 'rgb(0, 0, 255)',
+          // dark: will be calculated from palette.primary.main,
+          // contrastText: will be calculated to contrast with palette.primary.main
+        },
+      },
+    });
+
+    const testCaseBorderColorWins = render(
+      <ThemeProvider theme={theme}>
+        <Box sx={{ border: 1, borderColor: 'primary.main' }} />
+      </ThemeProvider>,
+    );
+
+    expect(testCaseBorderColorWins.container.firstChild).toHaveComputedStyle({
+      border: '1px solid rgb(0, 0, 255)',
+      'border-color': 'rgb(0, 0, 255)',
+    });
+
+    const testCaseBorderWins = render(
+      <ThemeProvider theme={theme}>
+        <Box sx={{ borderColor: 'primary.main', border: 1 }} />
+      </ThemeProvider>,
+    );
+
+    expect(testCaseBorderWins.container.firstChild).toHaveComputedStyle({
+      border: '1px solid rgb(0, 0, 0)',
+      'border-color': 'rgb(0, 0, 0)',
+    });
+  });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -60,7 +60,17 @@ describe('<Box />', () => {
   });
 
   it('respect properties order when generating the CSS', function test() {
-    if (/jsdom/.test(window.navigator.userAgent)) this.skip();
+    const isMozilla = window.navigator.userAgent.indexOf("Firefox") > -1
+    const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
+    if (isJSDOM || isMozilla) {
+      // Test fails on Mozilla with just:
+
+	    // "border": "",
+	    // "border-color": "",
+      
+      this.skip();
+    }
 
     const theme = createMuiTheme({
       palette: {
@@ -97,7 +107,17 @@ describe('<Box />', () => {
   });
 
   it('respect properties order when generating the CSS from the sx prop', function test() {
-    if (/jsdom/.test(window.navigator.userAgent)) this.skip();
+    const isMozilla = window.navigator.userAgent.indexOf("Firefox") > -1
+    const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
+    if (isJSDOM || isMozilla) {
+      // Test fails on Mozilla with just:
+
+	    // "border": "",
+	    // "border-color": "",
+      
+      this.skip();
+    }
 
     const theme = createMuiTheme({
       palette: {


### PR DESCRIPTION
This PR adds necessary tests to ensure that the bug https://github.com/mui-org/material-ui/issues/16995 won't happen again. We are testing that the rules in the generated CSS corresponds with the correct expected CSS depending on the order of the properties defined on the `Box` component

Closes #16995 