### PR TITLE
[docs] Allow to host code in a different repo

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -29,7 +29,7 @@ import Link from 'docs/src/modules/components/Link';
 import AppDrawer from 'docs/src/modules/components/AppDrawer';
 import Notifications from 'docs/src/modules/components/Notifications';
 import MarkdownLinks from 'docs/src/modules/components/MarkdownLinks';
-import { LANGUAGES_LABEL } from 'docs/src/modules/constants';
+import { LANGUAGES_LABEL, SOURCE_CODE_REPO } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import RtlContext from 'docs/src/modules/utils/RtlContext';
 import { useChangeTheme } from 'docs/src/modules/components/ThemeContext';
@@ -296,7 +296,7 @@ function AppFrame(props) {
             <IconButton
               component="a"
               color="inherit"
-              href="https://github.com/mui-org/material-ui"
+              href={SOURCE_CODE_REPO}
               data-ga-event-category="header"
               data-ga-event-action="github"
             >

--- a/docs/src/modules/constants.js
+++ b/docs/src/modules/constants.js
@@ -54,7 +54,9 @@ const LANGUAGES_LABEL = [
 ];
 
 // #default-branch-switch
-const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/blob/next';
+const SOURCE_CODE_ROOT_URL =
+  process.env.SOURCE_CODE_ROOT_URL || 'https://github.com/mui-org/material-ui/blob/next';
+const SOURCE_CODE_REPO = process.env.SOURCE_CODE_REPO || 'https://github.com/mui-org/material-ui';
 
 module.exports = {
   CODE_VARIANTS,
@@ -64,4 +66,5 @@ module.exports = {
   LANGUAGES_LABEL,
   LANGUAGES_IN_PROGRESS,
   SOURCE_CODE_ROOT_URL,
+  SOURCE_CODE_REPO,
 };


### PR DESCRIPTION
Aim to fix the links on https://material-ui-x.netlify.app/components/data-grid/pagination/ that don't work.

e.g.

<img width="392" alt="Capture d’écran 2020-11-04 à 13 22 18" src="https://user-images.githubusercontent.com/3165635/98111371-c8f48200-1ea0-11eb-820a-aa2ad235d78a.png">
