### PR TITLE
[Table] Relax IconComponent type in TableSortLabel

### DIFF
--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -45,7 +45,7 @@ export type TableSortLabelTypeMap<
      * Sort icon to use.
      * @default ArrowDownwardIcon
      */
-    IconComponent?: React.ComponentType<{ className: string }>;
+    IconComponent?: React.ComponentType<{ className?: string }>;
   };
   defaultComponent: D;
 }>;

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.spec.tsx
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.spec.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { SvgIconProps } from '@material-ui/core/SvgIcon/SvgIcon';
+import TableSortLabel from '@material-ui/core/TableSortLabel';
+import ArrowDownwardIcon from '../internal/svg-icons/ArrowDownward';
+
+const Icon: React.FunctionComponent<SvgIconProps> = (props) => <ArrowDownwardIcon {...props} />;
+
+function TestTableSortLabel() {
+  return <TableSortLabel active direction="desc" IconComponent={Icon} />;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related previous PR: https://github.com/mui-org/material-ui/pull/18936

Currently passing an element typed as `React.ComponentType<SvgIconProps>` (as IconComponent was originally typed) gives an error, as `className` is not required in `SvgIconProps`.