### PR TITLE
[Stepper] Fix the icon prop support in StepLabel

### DIFF
--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -79,6 +79,7 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
     classes,
     className,
     error = false,
+    icon: iconProp,
     optional,
     StepIconComponent: StepIconComponentProp,
     StepIconProps,
@@ -86,7 +87,8 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
   } = props;
 
   const { alternativeLabel, orientation } = React.useContext(StepperContext);
-  const { active, disabled, completed, icon } = React.useContext(StepContext);
+  const { active, disabled, completed, icon: iconContext } = React.useContext(StepContext);
+  const icon = iconProp || iconContext;
 
   let StepIconComponent = StepIconComponentProp;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is a PR for issue #23392 .   The StepLabel icon prop was not being used at all. Now the icon prop, if provided, will override whatever was passed via the StepContext.  I'm applying the fix proposed by @oliviertassinari.

Closes #23392.