### PR TITLE
[theme] Add htmlFontSize to Typography interface

### DIFF
--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -25,10 +25,10 @@ export interface FontStyle
     fontWeightRegular: React.CSSProperties['fontWeight'];
     fontWeightMedium: React.CSSProperties['fontWeight'];
     fontWeightBold: React.CSSProperties['fontWeight'];
+    htmlFontSize: number;
   }> {}
 
 export interface FontStyleOptions extends Partial<FontStyle> {
-  htmlFontSize?: number;
   allVariants?: React.CSSProperties;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Typography interface, the type returned by createTypography, doesn't
contain the property htmlFontSize. This property is always present in
the object returned by createTypography. As a result of htmlFontSize not
existing on the Typography interface, the htmlFontSize property does not
exist on the Theme type returned by createMuiTheme either.

This fix moves the htmlFontSize from FontStyleOptions back into
FontStyle where it previously existed (see: https://github.com/mui-org/material-ui/pull/11456)

By moving to FontStyle, the htmlFontSize property is now present on
Typography and Theme, as well as on TypographyOptions and ThemeOptions.