### PR TITLE
[docs] Fix usage of palette.type instead of palette.mode in docs

### DIFF
--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -227,7 +227,7 @@ function App() {
     () =>
       createMuiTheme({
         palette: {
-          type: prefersDarkMode ? 'dark' : 'light',
+          mode: prefersDarkMode ? 'dark' : 'light',
         },
       }),
     [prefersDarkMode],


### PR DESCRIPTION
Change one more instance of `palette.type` to `palette.mode` in the Palette examples, following on from #22844