### PR TITLE
[Tooltip] Use media queries for applying "mobile styles"

### DIFF
--- a/docs/pages/api-docs/tooltip.md
+++ b/docs/pages/api-docs/tooltip.md
@@ -67,7 +67,6 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">tooltip</span> | <span class="prop-name">.MuiTooltip-tooltip</span> | Styles applied to the tooltip (label wrapper) element.
 | <span class="prop-name">tooltipArrow</span> | <span class="prop-name">.MuiTooltip-tooltipArrow</span> | Styles applied to the tooltip (label wrapper) element if `arrow={true}`.
 | <span class="prop-name">arrow</span> | <span class="prop-name">.MuiTooltip-arrow</span> | Styles applied to the arrow element.
-| <span class="prop-name">touch</span> | <span class="prop-name">.MuiTooltip-touch</span> | Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch.
 | <span class="prop-name">tooltipPlacementLeft</span> | <span class="prop-name">.MuiTooltip-tooltipPlacementLeft</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "left".
 | <span class="prop-name">tooltipPlacementRight</span> | <span class="prop-name">.MuiTooltip-tooltipPlacementRight</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "right".
 | <span class="prop-name">tooltipPlacementTop</span> | <span class="prop-name">.MuiTooltip-tooltipPlacementTop</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "top".

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -29,8 +29,6 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
     tooltipArrow?: string;
     /** Styles applied to the arrow element. */
     arrow?: string;
-    /** Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch. */
-    touch?: string;
     /** Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
     tooltipPlacementLeft?: string;
     /** Styles applied to the tooltip (label wrapper) element if `placement` contains "right". */

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -80,6 +80,12 @@ export const styles = (theme) => ({
     maxWidth: 300,
     wordWrap: 'break-word',
     fontWeight: theme.typography.fontWeightMedium,
+    '@media (pointer: coarse)': {
+      padding: '8px 16px',
+      fontSize: theme.typography.pxToRem(14),
+      lineHeight: `${round(16 / 14)}em`,
+      fontWeight: theme.typography.fontWeightRegular,
+    },
   },
   /* Styles applied to the tooltip (label wrapper) element if `arrow={true}`. */
   tooltipArrow: {
@@ -103,13 +109,6 @@ export const styles = (theme) => ({
       backgroundColor: 'currentColor',
       transform: 'rotate(45deg)',
     },
-  },
-  /* Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch. */
-  touch: {
-    padding: '8px 16px',
-    fontSize: theme.typography.pxToRem(14),
-    lineHeight: `${round(16 / 14)}em`,
-    fontWeight: theme.typography.fontWeightRegular,
   },
   /* Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
   tooltipPlacementLeft: {
@@ -353,20 +352,17 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }
   };
 
-  const detectTouchStart = (event) => {
+  const handleMouseOver = handleEnter;
+  const handleMouseLeave = handleLeave;
+
+  const handleTouchStart = (event) => {
     ignoreNonTouchEvents.current = true;
 
     const childrenProps = children.props;
     if (childrenProps.onTouchStart) {
       childrenProps.onTouchStart(event);
     }
-  };
 
-  const handleMouseOver = handleEnter;
-  const handleMouseLeave = handleLeave;
-
-  const handleTouchStart = (event) => {
-    detectTouchStart(event);
     clearTimeout(leaveTimer.current);
     clearTimeout(closeTimer.current);
     clearTimeout(touchTimer.current);
@@ -451,7 +447,6 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     ...other,
     ...children.props,
     className: clsx(other.className, children.props.className),
-    onTouchStart: detectTouchStart,
     ref: handleRef,
     ...(followCursor ? { onMouseMove: handleMouseMove } : {}),
   };
@@ -573,7 +568,6 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
               className={clsx(
                 classes.tooltip,
                 {
-                  [classes.touch]: ignoreNonTouchEvents.current,
                   [classes.tooltipArrow]: arrow,
                 },
                 classes[`tooltipPlacement${capitalize(placementInner.split('-')[0])}`],


### PR DESCRIPTION
Replaces `.touch` class with `@media (pointer: coarse) .MuiTooltip-tooltip`.

Instead of applying the mobile styles depending on the input modality we apply them by the pointer granularity. That way we use less JS and are sure we don't have any CM problems (reading from a ref during render should be safe here but not trivial to determine).

[caniuse data](https://caniuse.com/mdn-css_at-rules_media_pointer)