### PR TITLE
[docs] Remove redundant aria-label when wrapped in Tooltip

### DIFF
--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -237,13 +237,13 @@ const EnhancedTableToolbar = (props) => {
 
       {numSelected > 0 ? (
         <Tooltip title="Delete">
-          <IconButton aria-label="delete">
+          <IconButton>
             <DeleteIcon />
           </IconButton>
         </Tooltip>
       ) : (
         <Tooltip title="Filter list">
-          <IconButton aria-label="filter list">
+          <IconButton>
             <FilterListIcon />
           </IconButton>
         </Tooltip>
@@ -328,7 +328,6 @@ export default function EnhancedTable() {
             className={classes.table}
             aria-labelledby="tableTitle"
             size={dense ? 'small' : 'medium'}
-            aria-label="enhanced table"
           >
             <EnhancedTableHead
               classes={classes}

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -283,13 +283,13 @@ const EnhancedTableToolbar = (props: EnhancedTableToolbarProps) => {
       )}
       {numSelected > 0 ? (
         <Tooltip title="Delete">
-          <IconButton aria-label="delete">
+          <IconButton>
             <DeleteIcon />
           </IconButton>
         </Tooltip>
       ) : (
         <Tooltip title="Filter list">
-          <IconButton aria-label="filter list">
+          <IconButton>
             <FilterListIcon />
           </IconButton>
         </Tooltip>
@@ -375,7 +375,6 @@ export default function EnhancedTable() {
             className={classes.table}
             aria-labelledby="tableTitle"
             size={dense ? 'small' : 'medium'}
-            aria-label="enhanced table"
           >
             <EnhancedTableHead
               classes={classes}

--- a/docs/src/pages/components/tooltips/SimpleTooltips.js
+++ b/docs/src/pages/components/tooltips/SimpleTooltips.js
@@ -23,16 +23,16 @@ export default function SimpleTooltips() {
   return (
     <div>
       <Tooltip title="Delete">
-        <IconButton aria-label="delete">
+        <IconButton>
           <DeleteIcon />
         </IconButton>
       </Tooltip>
-      <Tooltip title="Add" aria-label="add">
+      <Tooltip title="Add">
         <Fab color="primary" className={classes.fab}>
           <AddIcon />
         </Fab>
       </Tooltip>
-      <Tooltip title="Add" aria-label="add">
+      <Tooltip title="Add">
         <Fab color="secondary" className={classes.absolute}>
           <AddIcon />
         </Fab>

--- a/docs/src/pages/components/tooltips/SimpleTooltips.tsx
+++ b/docs/src/pages/components/tooltips/SimpleTooltips.tsx
@@ -25,16 +25,16 @@ export default function SimpleTooltips() {
   return (
     <div>
       <Tooltip title="Delete">
-        <IconButton aria-label="delete">
+        <IconButton>
           <DeleteIcon />
         </IconButton>
       </Tooltip>
-      <Tooltip title="Add" aria-label="add">
+      <Tooltip title="Add">
         <Fab color="primary" className={classes.fab}>
           <AddIcon />
         </Fab>
       </Tooltip>
-      <Tooltip title="Add" aria-label="add">
+      <Tooltip title="Add">
         <Fab color="secondary" className={classes.absolute}>
           <AddIcon />
         </Fab>


### PR DESCRIPTION
These became redundant with #22729