### PR TITLE
[docs] Redirect legacy GridList pages to ImageList

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -128,6 +128,11 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /customization/themes/ /customization/theming/ 301
 https://v1-5-0.material-ui.com/* https://v1.material-ui.com/:splat 301!
 https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
+# v5: GridList -> ImageList
+/components/grid-list/ /components/image-list/ 301
+/api/grid-list/ /api/image-list/ 301
+/api/grid-list-tile/ /api/image-list-tile/ 301
+/api/grid-list-tile-bar/ /api/image-list-tile-bar/ 301
 
 # Proxies
 

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -131,8 +131,8 @@ https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 # v5: GridList -> ImageList
 /components/grid-list/ /components/image-list/ 301
 /api/grid-list/ /api/image-list/ 301
-/api/grid-list-tile/ /api/image-list-tile/ 301
-/api/grid-list-tile-bar/ /api/image-list-tile-bar/ 301
+/api/grid-list-tile/ /api/image-list-item/ 301
+/api/grid-list-tile-bar/ /api/image-list-item-bar/ 301
 
 # Proxies
 


### PR DESCRIPTION
Noticed some 404s in mui-scripts-incubator. Considering ExpansionPanel also has redirects and Grid is way more popular we should redirect them as well. At least until we have a proper 404 page.