### PR TITLE
Ripple overflow on Lists with padding disabled

### DIFF
--- a/packages/material-ui/src/List/List.js
+++ b/packages/material-ui/src/List/List.js
@@ -8,6 +8,7 @@ export const styles = {
   /* Styles applied to the root element. */
   root: {
     listStyle: 'none',
+    overflow: 'hidden',
     margin: 0,
     padding: 0,
     position: 'relative',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Currently, Lists with disablePadding attribute, allow the ripple effect of ListItem to overflow past the rounded corner

![Screenshot_20201110-120116~2](https://user-images.githubusercontent.com/63855941/98659191-8f15f680-234c-11eb-86d6-f3e146a0bd2b.png)

My fix only adds overflow hidden on the List component

