### PR TITLE
[test] Increase timeout threshold for slow Firefox tests

### DIFF
--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -888,7 +888,11 @@ describe('<Autocomplete />', () => {
       );
     });
 
-    it('should ignore keydown event until the IME is confirmed', () => {
+    it('should ignore keydown event until the IME is confirmed', function test() {
+      // TODO: Often times out in Firefox 78.
+      // Is this slow because of testing-library or because of the implementation?
+      this.timeout(4000);
+
       const { getByRole } = render(
         <Autocomplete
           open


### PR DESCRIPTION
The test frequently timed out. Increasing the threshold until further investigation. If it also times out with 4s it's more likely to be caused by implementation.
