### PR TITLE
[test] Use fake timers in visual regression tests

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { useFakeTimers } from 'sinon';
 import vrtest from 'vrtest-mui/client';
 import webfontloader from 'webfontloader';
 import TestViewer from './TestViewer';
@@ -259,12 +260,19 @@ tests.forEach((test) => {
   }
 
   suite.createTest(test.name, () => {
-    ReactDOM.render(
-      <TestViewer>
-        <TestCase />
-      </TestViewer>,
-      rootEl,
-    );
+    // Use a "real timestamp" so that we see a useful date instead of "00:00"
+    const clock = useFakeTimers(new Date('Mon Aug 18 14:11:54 2014 -0500'));
+
+    try {
+      ReactDOM.render(
+        <TestViewer>
+          <TestCase />
+        </TestViewer>,
+        rootEl,
+      );
+    } finally {
+      clock.restore();
+    }
   });
 });
 

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -261,8 +261,7 @@ tests.forEach((test) => {
 
   suite.createTest(test.name, () => {
     // Use a "real timestamp" so that we see a useful date instead of "00:00"
-    // A hardcoded timezone leads to inconsistent dates if they're constructed without a hardcoded timezone.
-    const clock = useFakeTimers(new Date(`Mon Aug 18 14:11:54 2014 ${Date.getTimezoneOffset()}`));
+    const clock = useFakeTimers(new Date('Mon Aug 18 14:11:54 2014 -0500'));
 
     try {
       ReactDOM.render(

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -261,7 +261,8 @@ tests.forEach((test) => {
 
   suite.createTest(test.name, () => {
     // Use a "real timestamp" so that we see a useful date instead of "00:00"
-    const clock = useFakeTimers(new Date('Mon Aug 18 14:11:54 2014 -0500'));
+    // A hardcoded timezone leads to inconsistent dates if they're constructed without a hardcoded timezone.
+    const clock = useFakeTimers(new Date(`Mon Aug 18 14:11:54 2014 ${Date.getTimezoneOffset()}`));
 
     try {
       ReactDOM.render(


### PR DESCRIPTION
With #22692 we now have visual regression tests relying on `Date` which means they produce different output depending on the time they're run.

Using `sinon#useFakeTimers` to run the tests with the same (mocked) time. This also mocks all other timer related things so the tests should be even "more stable" though we haven't had any timer related flakyness. But it could still mean that we run less timer related stuff (e.g. passive effects?).

We'll see if this works. Otherwise I'll just stub the `Date` constructor.