### PR TITLE
[core] Fix skipped ignore patterns

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,7 +12,7 @@
 /framer/Material-UI.framerfx/design/document.json
 /packages/babel-plugin-unwrap-createStyles/test/__fixtures__/
 /packages/material-ui-codemod/lib
-/packages/material-ui-codemod/src/*/*.test
+/packages/material-ui-codemod/src/*/*.test/*
 /packages/material-ui-codemod/src/*/*.test.js
 /packages/material-ui-icons/fixtures
 /packages/material-ui-icons/legacy

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -12,7 +12,8 @@ const yargs = require('yargs');
 const { LANGUAGES } = require('docs/src/modules/constants');
 const listChangedFiles = require('./listChangedFiles');
 
-const workspaceRoot = path.resolve(__dirname, '../');
+// FIXME: Incorrect assumption
+const workspaceRoot = process.cwd();
 
 function isTranslatedDocument(filename) {
   // markdown files from crowdin end with a 2 letter locale
@@ -70,7 +71,7 @@ function runPrettier(options) {
     return;
   }
 
-  const prettierConfigPath = path.join(process.cwd(), 'prettier.config.js');
+  const prettierConfigPath = path.join(workspaceRoot, 'prettier.config.js');
 
   files.forEach((file) => {
     const prettierOptions = prettier.resolveConfig.sync(file, {

--- a/test/cli.js
+++ b/test/cli.js
@@ -8,10 +8,19 @@ async function run(argv) {
   const workspaceRoot = path.resolve(__dirname, '../');
 
   const gitignore = fs.readFileSync(path.join(workspaceRoot, '.gitignore'), { encoding: 'utf-8' });
-  const eol = gitignore.match(/\r?\n/)[0];
-  const ignore = gitignore.split(eol).filter((pattern) => {
-    return pattern.length > 0 && !pattern.startsWith('#');
-  });
+  const ignore = gitignore
+    .split(/\r?\n/)
+    .filter((pattern) => {
+      return pattern.length > 0 && !pattern.startsWith('#');
+    })
+    .map((line) => {
+      if (line.startsWith('/')) {
+        // "/" marks the cwd of the ignore file.
+        // Since we declare the dirname of the gitignore the cwd we can prepend "." as a shortcut.
+        return `.${line}`;
+      }
+      return line;
+    });
   const globPattern = `**/*${argv.testFilePattern}*.test.{js,ts,tsx}`;
   const spec = glob.sync(globPattern, {
     cwd: workspaceRoot,


### PR DESCRIPTION
`globby`'s patterns don't work the same as gitignore patterns so we have to map them accordingly.

Loosely based off of https://github.com/sindresorhus/globby/blob/52d02bb9d776a898097dbe76400d9dd8bfeca7e9/gitignore.js#L26-L46