### PR TITLE
[test] Use adapter instead of native Date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,6 @@ workflows:
     jobs:
       - checkout
       - test_unit:
-          test-gate: experimental-timezones
           requires:
             - checkout
       - test_static:
@@ -253,7 +252,6 @@ workflows:
           requires:
             - checkout
       - test_browser:
-          test-gate: experimental-timezones
           requires:
             - checkout
       - test_regressions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,7 @@ workflows:
     jobs:
       - checkout
       - test_unit:
+          test-gate: experimental-timezones
           requires:
             - checkout
       - test_static:
@@ -252,6 +253,7 @@ workflows:
           requires:
             - checkout
       - test_browser:
+          test-gate: experimental-timezones
           requires:
             - checkout
       - test_regressions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ workflows:
   timezone-tests:
     triggers:
       - schedule:
-          cron: '0 0 0 * *'
+          cron: '23 * * * *'
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,5 +301,7 @@ workflows:
               only:
                 - next
     jobs:
+      - test_unit:
+          test-gate: experimental-timezones
       - test_browser:
           test-gate: experimental-timezones

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,14 @@ defaults: &defaults
       description: The dist-tag of react to be used
       type: string
       default: stable
+    test-gate:
+      description: A particular type of tests that should be run
+      type: string
+      default: null
   environment:
     # expose it globally otherwise we have to thread it from each job to the install command
     REACT_DIST_TAG: << parameters.react-dist-tag >>
+    TEST_GATE: << parameters.test-gate >>
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:10
@@ -285,3 +290,14 @@ workflows:
                 - next
     jobs:
       - test_types_next
+  timezone-tests:
+    triggers:
+      - schedule:
+          cron: '0 0 0 * *'
+          filters:
+            branches:
+              only:
+                - next
+    jobs:
+      - test_browser:
+          test-gate: experimental-timezones

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     test-gate:
       description: A particular type of tests that should be run
       type: string
-      default: null
+      default: undefined
   environment:
     # expose it globally otherwise we have to thread it from each job to the install command
     REACT_DIST_TAG: << parameters.react-dist-tag >>

--- a/packages/material-ui-lab/src/ClockPicker/ClockPickerStandalone.test.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPickerStandalone.test.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { createMount, describeConformance } from 'test/utils';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
-import DateFnsAdapter from '@material-ui/lab/dateAdapter/date-fns';
 import ClockPicker from '@material-ui/lab/ClockPicker';
+import { adapterToUse, AdapterClassToUse } from '../internal/pickers/test-utils';
 
 describe('<ClockPickerStandalone />', () => {
   const mount = createMount();
 
   const localizedMount = (node: React.ReactNode) => {
-    return mount(<LocalizationProvider dateAdapter={DateFnsAdapter}>{node}</LocalizationProvider>);
+    return mount(
+      <LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>,
+    );
   };
 
-  describeConformance(<ClockPicker date={new Date()} onChange={() => {}} />, () => ({
+  describeConformance(<ClockPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
     classes: {},
     inheritComponent: 'div',
     mount: localizedMount,

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.test.tsx
@@ -23,9 +23,10 @@ import {
 describe('<DatePicker />', () => {
   const render = createPickerRender({ strict: false });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('render proper month', () => {
+  it('render proper month', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <StaticDatePicker
         value={adapterToUse.date('2019-01-01T00:00:00.000')}
@@ -39,9 +40,10 @@ describe('<DatePicker />', () => {
     expect(getAllByMuiTest('day')).to.have.length(31);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('desktop Mode – Accepts date on day button click', () => {
+  it('desktop Mode – Accepts date on day button click', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const onChangeMock = spy();
 
     render(
@@ -61,9 +63,10 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('mobile mode – Accepts date on `OK` button click', () => {
+  it('mobile mode – Accepts date on `OK` button click', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const onChangeMock = spy();
     render(
       <MobileDatePicker
@@ -86,9 +89,10 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('switches between months', () => {
+  it('switches between months', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <StaticDatePicker
         reduceAnimations
@@ -110,9 +114,10 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('calendar-month-text')).to.have.text('December');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('selects the closest enabled date if selected date is disabled', () => {
+  it('selects the closest enabled date if selected date is disabled', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const onChangeMock = spy();
 
     render(
@@ -150,9 +155,10 @@ describe('<DatePicker />', () => {
     expect(onChangeMock.callCount).to.equal(1);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('allows to select edge years from list', () => {
+  it('allows to select edge years from list', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <MobileDatePicker
         open
@@ -160,8 +166,8 @@ describe('<DatePicker />', () => {
         value={null}
         onChange={() => {}}
         openTo="year"
-        minDate={new Date('2000-01-01T00:00:00.000')}
-        maxDate={new Date('2010-01-01T00:00:00.000')}
+        minDate={adapterToUse.date('2000-01-01T00:00:00.000')}
+        maxDate={adapterToUse.date('2010-01-01T00:00:00.000')}
         renderInput={(params) => <TextField {...params} />}
       />,
     );
@@ -170,12 +176,13 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('datepicker-toolbar-date')).to.have.text('Fri, Jan 1');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip("doesn't close picker on selection in Mobile mode", () => {
+  it("doesn't close picker on selection in Mobile mode", function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <MobileDatePicker
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
       />,
@@ -187,13 +194,14 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).toBeVisible();
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('closes picker on selection in Desktop mode', async () => {
+  it('closes picker on selection in Desktop mode', async function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <DesktopDatePicker
         TransitionComponent={FakeTransitionComponent}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
       />,
@@ -212,7 +220,7 @@ describe('<DatePicker />', () => {
     render(
       <MobileDatePicker
         clearable
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
         onChange={onChangeMock}
         DialogProps={{ TransitionComponent: FakeTransitionComponent }}
         renderInput={(params) => <TextField {...params} />}
@@ -226,9 +234,10 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip("prop `disableCloseOnSelect` – if `true` doesn't close picker", () => {
+  it("prop `disableCloseOnSelect` – if `true` doesn't close picker", function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <DesktopDatePicker
         TransitionComponent={FakeTransitionComponent}
@@ -245,9 +254,10 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).toBeVisible();
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('does not call onChange if same date selected', async () => {
+  it('does not call onChange if same date selected', async function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const onChangeMock = spy();
 
     render(
@@ -273,7 +283,7 @@ describe('<DatePicker />', () => {
         renderInput={(props) => <TextField placeholder="10/10/2018" {...props} />}
         label="Masked input"
         inputFormat="dd/MM/yyyy"
-        value={new Date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
         onChange={onChangeMock}
         InputAdornmentProps={{
           disableTypography: true,
@@ -335,9 +345,10 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('picker-toolbar-title').textContent).to.equal('Default label');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('prop `toolbarFormat` – should format toolbar according to passed format', () => {
+  it('prop `toolbarFormat` – should format toolbar according to passed format', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -361,7 +372,7 @@ describe('<DatePicker />', () => {
         cancelText="stream"
         onClose={onCloseMock}
         onChange={onChangeMock}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
         DialogProps={{ TransitionComponent: FakeTransitionComponent }}
       />,
     );
@@ -411,9 +422,9 @@ describe('<DatePicker />', () => {
         openTo="year"
         onChange={() => {}}
         // getByRole() with name attribute is too slow, so restrict the number of rendered years
-        minDate={new Date('2025-01-01T00:00:00.000')}
-        maxDate={new Date('2035-01-01T00:00:00.000')}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        minDate={adapterToUse.date('2025-01-01T00:00:00.000')}
+        maxDate={adapterToUse.date('2035-01-01T00:00:00.000')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
         shouldDisableYear={(year) => adapterToUse.getYear(year) === 2030}
       />,
     );
@@ -434,7 +445,7 @@ describe('<DatePicker />', () => {
         renderInput={(params) => <TextField {...params} />}
         onChange={() => {}}
         onMonthChange={onMonthChangeMock}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -449,7 +460,7 @@ describe('<DatePicker />', () => {
         loading
         renderInput={(params) => <TextField {...params} />}
         onChange={() => {}}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -465,7 +476,7 @@ describe('<DatePicker />', () => {
         open
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -478,7 +489,7 @@ describe('<DatePicker />', () => {
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
         open
-        value={new Date()}
+        value={adapterToUse.date()}
         onChange={() => {}}
         ToolbarComponent={() => <div data-testid="custom-toolbar" />}
       />,
@@ -503,16 +514,17 @@ describe('<DatePicker />', () => {
     expect(screen.getAllByTestId('test-day')).to.have.length(31);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('prop `defaultCalendarMonth` – opens on provided month if date is `null`', () => {
+  it('prop `defaultCalendarMonth` – opens on provided month if date is `null`', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
         open
         value={null}
         onChange={() => {}}
-        defaultCalendarMonth={new Date('2018-07-01T00:00:00.000')}
+        defaultCalendarMonth={adapterToUse.date('2018-07-01T00:00:00.000')}
       />,
     );
 

--- a/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
@@ -6,14 +6,14 @@ import TextField from '@material-ui/core/TextField';
 import { fireEvent, screen, act } from 'test/utils';
 import DesktopDatePicker, { DesktopDatePickerProps } from '@material-ui/lab/DesktopDatePicker';
 import StaticDatePicker from '@material-ui/lab/StaticDatePicker';
-import { createPickerRender } from '../internal/pickers/test-utils';
+import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
 import { MakeOptional } from '../internal/pickers/typings/helpers';
 
 function TestKeyboardDatePicker(
   PickerProps: MakeOptional<DesktopDatePickerProps, 'value' | 'onChange' | 'renderInput'>,
 ) {
   const [value, setValue] = React.useState<unknown>(
-    PickerProps.value ?? new Date('2019-01-01T00:00:00.000'),
+    PickerProps.value ?? adapterToUse.date('2019-01-01T00:00:00.000'),
   );
 
   return (
@@ -121,23 +121,23 @@ describe('<DatePicker /> keyboard interactions', () => {
     });
   });
 
-  context('Calendar keyboard navigation', () => {
-    beforeEach(() => {
+  describe('Calendar keyboard navigation', () => {
+    it('autofocus selected day on mount', function test() {
+      if (process.env.TEST_GATE !== 'experimental-timezones') {
+        this.skip();
+      }
+
       // Important: Use <StaticDatePicker /> here in order to avoid async waiting for focus because of packages/material-ui-lab/src/internal/pickers/hooks/useCanAutoFocus.tsx logic
       render(
         <StaticDatePicker
           allowKeyboardControl // required to enable focus management in static mode
           displayStaticWrapperAs="desktop"
-          value={new Date('2020-08-13T00:00:00.000')}
+          value={adapterToUse.date('2020-08-13T00:00:00.000')}
           onChange={() => {}}
           renderInput={(params) => <TextField placeholder="10/10/2018" {...params} />}
         />,
       );
-    });
 
-    // TODO
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('autofocus selected day on mount', () => {
       expect(screen.getByLabelText('Aug 13, 2020')).toHaveFocus();
     });
 
@@ -149,9 +149,22 @@ describe('<DatePicker /> keyboard interactions', () => {
       { keyCode: 39, key: 'ArrowRight', expectFocusedDay: 'Aug 14, 2020' },
       { keyCode: 40, key: 'ArrowDown', expectFocusedDay: 'Aug 20, 2020' },
     ].forEach(({ key, keyCode, expectFocusedDay }) => {
-      // TODO
-      // eslint-disable-next-line mocha/no-skipped-tests
-      it.skip(key, () => {
+      it(key, function test() {
+        if (process.env.TEST_GATE !== 'experimental-timezones') {
+          this.skip();
+        }
+
+        // Important: Use <StaticDatePicker /> here in order to avoid async waiting for focus because of packages/material-ui-lab/src/internal/pickers/hooks/useCanAutoFocus.tsx logic
+        render(
+          <StaticDatePicker
+            allowKeyboardControl // required to enable focus management in static mode
+            displayStaticWrapperAs="desktop"
+            value={adapterToUse.date('2020-08-13T00:00:00.000')}
+            onChange={() => {}}
+            renderInput={(params) => <TextField placeholder="10/10/2018" {...params} />}
+          />,
+        );
+
         fireEvent.keyDown(document.body, { force: true, keyCode, key });
 
         expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);
@@ -159,15 +172,16 @@ describe('<DatePicker /> keyboard interactions', () => {
     });
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip("doesn't allow to select disabled date from keyboard", async () => {
+  it("doesn't allow to select disabled date from keyboard", async function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <StaticDatePicker
         allowKeyboardControl
         displayStaticWrapperAs="desktop"
-        value={new Date('2020-08-13T00:00:00.000')}
-        minDate={new Date('2020-08-13T00:00:00.000')}
+        value={adapterToUse.date('2020-08-13T00:00:00.000')}
+        minDate={adapterToUse.date('2020-08-13T00:00:00.000')}
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
       />,
@@ -191,9 +205,11 @@ describe('<DatePicker /> keyboard interactions', () => {
       { keyCode: 39, key: 'ArrowRight', expectFocusedYear: '2021' },
       { keyCode: 40, key: 'ArrowDown', expectFocusedYear: '2024' },
     ].forEach(({ key, keyCode, expectFocusedYear }) => {
-      // TODO
-      // eslint-disable-next-line mocha/no-skipped-tests
-      it.skip(key, () => {
+      it(key, function test() {
+        if (process.env.TEST_GATE !== 'experimental-timezones') {
+          this.skip();
+        }
+
         render(
           <StaticDatePicker
             open
@@ -201,7 +217,7 @@ describe('<DatePicker /> keyboard interactions', () => {
             reduceAnimations
             allowKeyboardControl
             displayStaticWrapperAs="desktop"
-            value={new Date('2020-08-13T00:00:00.000')}
+            value={adapterToUse.date('2020-08-13T00:00:00.000')}
             onChange={() => {}}
             renderInput={(params) => <TextField {...params} />}
           />,
@@ -219,8 +235,16 @@ describe('<DatePicker /> keyboard interactions', () => {
       { expectedError: 'invalidDate', props: {}, input: 'invalidText' },
       { expectedError: 'disablePast', props: { disablePast: true }, input: '01/01/1900' },
       { expectedError: 'disableFuture', props: { disableFuture: true }, input: '01/01/2050' },
-      { expectedError: 'minDate', props: { minDate: new Date('01/01/2000') }, input: '01/01/1990' },
-      { expectedError: 'maxDate', props: { maxDate: new Date('01/01/2000') }, input: '01/01/2010' },
+      {
+        expectedError: 'minDate',
+        props: { minDate: adapterToUse.date('2000-01-01') },
+        input: '01/01/1990',
+      },
+      {
+        expectedError: 'maxDate',
+        props: { maxDate: adapterToUse.date('2000-01-01') },
+        input: '01/01/2010',
+      },
       {
         expectedError: 'shouldDisableDate',
         props: { shouldDisableDate: isWeekend },

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -22,6 +22,8 @@ describe('<DatePicker /> localization', () => {
         views={['year']}
       />,
     );
+    console.log(value);
+    console.log(value.getFullYear());
 
     expect(screen.getByRole('textbox')).to.have.value(value.getFullYear().toString());
     expect(screen.getByRole('textbox')).to.have.value('2018');
@@ -30,18 +32,19 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('datePicker localized format for year+month view', () => {
+  it.only('datePicker localized format for year+month view', () => {
+    const value = adapterToUse.date('2018-01-01T00:00:00.000');
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000')}
+        value={value}
         onChange={() => {}}
         views={['year', 'month']}
       />,
     );
 
+    console.log(value);
+    console.log(value.getFullYear());
     expect(screen.getByRole('textbox')).to.have.value('janvier 2018');
 
     fireEvent.click(screen.getByLabelText(/Choose date/));

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -12,7 +12,9 @@ import { adapterToUse, getByMuiTest, createPickerRender } from '../internal/pick
 describe('<DatePicker /> localization', () => {
   const render = createPickerRender({ strict: false, locale: fr });
 
-  it.only('datePicker localized format for year view', () => {
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('datePicker localized format for year view', () => {
     const value = adapterToUse.date('2018-01-01T00:00:00.000');
     render(
       <MobileDatePicker
@@ -22,8 +24,6 @@ describe('<DatePicker /> localization', () => {
         views={['year']}
       />,
     );
-    console.log(value);
-    console.log(value.getFullYear());
 
     expect(screen.getByRole('textbox')).to.have.value(value.getFullYear().toString());
     expect(screen.getByRole('textbox')).to.have.value('2018');
@@ -32,7 +32,12 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
-  it.only('datePicker localized format for year+month view', () => {
+  it('datePicker localized format for year+month view', function test() {
+    // TODO
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
+
     const value = adapterToUse.date('2018-01-01T00:00:00.000');
     render(
       <MobileDatePicker
@@ -43,8 +48,10 @@ describe('<DatePicker /> localization', () => {
       />,
     );
 
-    console.log(value);
-    console.log(value.getFullYear());
+    // eslint-disable-next-line no-console
+    console.log(adapterToUse.date('2018-01-01T00:00:00.000'));
+    // eslint-disable-next-line no-console
+    console.log(adapterToUse.date('2018-01-01T00:00:00.000Z'));
     expect(screen.getByRole('textbox')).to.have.value('janvier 2018');
 
     fireEvent.click(screen.getByLabelText(/Choose date/));

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -46,12 +46,12 @@ describe('<DatePicker /> localization', () => {
       />,
     );
 
-    // eslint-disable-next-line no-console
     console.log(adapterToUse.localDate('2018-01-01T00:00:00.000'));
-    // eslint-disable-next-line no-console
+    console.log(adapterToUse.localDate('2018-01-01T00:00:00.000').getFullYear());
     console.log(adapterToUse.date('2018-01-01T00:00:00.000'));
-    // eslint-disable-next-line no-console
+    console.log(adapterToUse.date('2018-01-01T00:00:00.000').getFullYear());
     console.log(adapterToUse.date('2018-01-01T00:00:00.000Z'));
+    console.log(adapterToUse.date('2018-01-01T00:00:00.000Z').getFullYear());
     expect(screen.getByRole('textbox')).to.have.value('janvier 2018');
 
     fireEvent.click(screen.getByLabelText(/Choose date/));

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -15,17 +15,15 @@ describe('<DatePicker /> localization', () => {
   // TODO
   // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('datePicker localized format for year view', () => {
-    const value = adapterToUse.date('2018-01-01T00:00:00.000');
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
-        value={value}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
         onChange={() => {}}
         views={['year']}
       />,
     );
 
-    expect(screen.getByRole('textbox')).to.have.value(value.getFullYear().toString());
     expect(screen.getByRole('textbox')).to.have.value('2018');
 
     fireEvent.click(screen.getByLabelText(/Choose date/));

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -12,9 +12,10 @@ import { adapterToUse, getByMuiTest, createPickerRender } from '../internal/pick
 describe('<DatePicker /> localization', () => {
   const render = createPickerRender({ strict: false, locale: fr });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('datePicker localized format for year view', () => {
+  it('datePicker localized format for year view', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -30,13 +31,12 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
-  it.only('datePicker localized format for year+month view', function test() {
-    // TODO
+  it('datePicker localized format for year+month view', function test() {
     if (process.env.TEST_GATE !== 'experimental-timezones') {
       this.skip();
     }
 
-    const value = adapterToUse.localDate(`2018-01-01T00:00:00.000`);
+    const value = adapterToUse.date(`2018-01-01T00:00:00.000`);
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -46,21 +46,16 @@ describe('<DatePicker /> localization', () => {
       />,
     );
 
-    console.log(adapterToUse.localDate('2018-01-01T00:00:00.000'));
-    console.log(adapterToUse.localDate('2018-01-01T00:00:00.000').getFullYear());
-    console.log(adapterToUse.date('2018-01-01T00:00:00.000'));
-    console.log(adapterToUse.date('2018-01-01T00:00:00.000').getFullYear());
-    console.log(adapterToUse.date('2018-01-01T00:00:00.000Z'));
-    console.log(adapterToUse.date('2018-01-01T00:00:00.000Z').getFullYear());
     expect(screen.getByRole('textbox')).to.have.value('janvier 2018');
 
     fireEvent.click(screen.getByLabelText(/Choose date/));
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('janvier');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('datePicker localized format for year+month+date view', () => {
+  it('datePicker localized format for year+month+date view', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <MobileDatePicker
         onChange={() => {}}
@@ -84,7 +79,7 @@ describe('<DatePicker /> localization', () => {
 
     const Form = (props: FormProps) => {
       const { Picker, PickerProps } = props;
-      const [value, setValue] = React.useState<unknown>(new Date('01/01/2020'));
+      const [value, setValue] = React.useState<unknown>(adapterToUse.date('01/01/2020'));
 
       return (
         <Picker

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -30,7 +30,7 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
-  it('datePicker localized format for year+month view', function test() {
+  it.only('datePicker localized format for year+month view', function test() {
     // TODO
     if (process.env.TEST_GATE !== 'experimental-timezones') {
       this.skip();

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -12,18 +12,18 @@ import { adapterToUse, getByMuiTest, createPickerRender } from '../internal/pick
 describe('<DatePicker /> localization', () => {
   const render = createPickerRender({ strict: false, locale: fr });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('datePicker localized format for year view', () => {
+  it.only('datePicker localized format for year view', () => {
+    const value = adapterToUse.date('2018-01-01T00:00:00.000');
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000')}
+        value={value}
         onChange={() => {}}
         views={['year']}
       />,
     );
 
+    expect(screen.getByRole('textbox')).to.have.value(value.getFullYear().toString());
     expect(screen.getByRole('textbox')).to.have.value('2018');
 
     fireEvent.click(screen.getByLabelText(/Choose date/));

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -36,7 +36,7 @@ describe('<DatePicker /> localization', () => {
       this.skip();
     }
 
-    const value = adapterToUse.date('2018-01-01T00:00:00.000');
+    const value = adapterToUse.localDate(`2018-01-01T00:00:00.000`);
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -46,6 +46,8 @@ describe('<DatePicker /> localization', () => {
       />,
     );
 
+    // eslint-disable-next-line no-console
+    console.log(adapterToUse.localDate('2018-01-01T00:00:00.000'));
     // eslint-disable-next-line no-console
     console.log(adapterToUse.date('2018-01-01T00:00:00.000'));
     // eslint-disable-next-line no-console

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
@@ -34,8 +34,8 @@ describe('<DateRangePicker />', () => {
   it('allows to select date range end-to-end', () => {
     function RangePickerTest() {
       const [range, changeRange] = React.useState<DateRange<Date>>([
-        new Date('2019-01-01T00:00:00.000'),
-        new Date('2019-01-01T00:00:00.000'),
+        adapterToUse.date('2019-01-01T00:00:00.000'),
+        adapterToUse.date('2019-01-01T00:00:00.000'),
       ]);
 
       return (
@@ -65,8 +65,8 @@ describe('<DateRangePicker />', () => {
         renderInput={defaultRangeRenderInput}
         onChange={() => {}}
         value={[
-          adapterToUse.date(new Date('2018-01-01T00:00:00.000Z')),
-          adapterToUse.date(new Date('2018-01-31T00:00:00.000Z')),
+          adapterToUse.date(adapterToUse.date('2018-01-01T00:00:00.000')),
+          adapterToUse.date(adapterToUse.date('2018-01-31T00:00:00.000')),
         ]}
       />,
     );
@@ -81,7 +81,7 @@ describe('<DateRangePicker />', () => {
         open
         renderInput={defaultRangeRenderInput}
         onChange={onChangeMock}
-        value={[new Date('2019-01-01T00:00:00.000'), null]}
+        value={[adapterToUse.date('2019-01-01T00:00:00.000'), null]}
       />,
     );
 
@@ -93,8 +93,8 @@ describe('<DateRangePicker />', () => {
 
     expect(onChangeMock.callCount).to.equal(2);
     const [changedRange] = onChangeMock.lastCall.args;
-    expect(changedRange[0]).to.toEqualDateTime(new Date('2019-01-01T00:00:00.000'));
-    expect(changedRange[1]).to.toEqualDateTime(new Date('2019-03-19T00:00:00.000'));
+    expect(changedRange[0]).to.toEqualDateTime(adapterToUse.date('2019-01-01T00:00:00.000'));
+    expect(changedRange[1]).to.toEqualDateTime(adapterToUse.date('2019-03-19T00:00:00.000'));
   });
 
   it('continues start selection if selected "end" date is before start', () => {
@@ -104,7 +104,7 @@ describe('<DateRangePicker />', () => {
         open
         renderInput={defaultRangeRenderInput}
         onChange={onChangeMock}
-        defaultCalendarMonth={new Date('2019-01-01T00:00:00.000')}
+        defaultCalendarMonth={adapterToUse.date('2019-01-01T00:00:00.000')}
         value={[null, null]}
       />,
     );
@@ -118,8 +118,8 @@ describe('<DateRangePicker />', () => {
 
     expect(onChangeMock.callCount).to.equal(3);
     const [changedRange] = onChangeMock.lastCall.args;
-    expect(changedRange[0]).to.toEqualDateTime(new Date('2019-01-19T00:00:00.000'));
-    expect(changedRange[1]).to.toEqualDateTime(new Date('2019-01-30T00:00:00.000'));
+    expect(changedRange[0]).to.toEqualDateTime(adapterToUse.date('2019-01-19T00:00:00.000'));
+    expect(changedRange[1]).to.toEqualDateTime(adapterToUse.date('2019-01-30T00:00:00.000'));
   });
 
   it('starts selection from end if end text field was focused', function test() {
@@ -128,7 +128,7 @@ describe('<DateRangePicker />', () => {
       <DesktopDateRangePicker
         renderInput={defaultRangeRenderInput}
         onChange={onChangeMock}
-        defaultCalendarMonth={new Date('2019-01-01T00:00:00.000')}
+        defaultCalendarMonth={adapterToUse.date('2019-01-01T00:00:00.000')}
         value={[null, null]}
       />,
     );
@@ -141,8 +141,8 @@ describe('<DateRangePicker />', () => {
     expect(getAllByMuiTest('DateRangeHighlight')).to.have.length(12);
     expect(onChangeMock.callCount).to.equal(2);
     const [changedRange] = onChangeMock.lastCall.args;
-    expect(changedRange[0]).toEqualDateTime(new Date('2019-01-19T00:00:00.000'));
-    expect(changedRange[1]).toEqualDateTime(new Date('2019-01-30T00:00:00.000'));
+    expect(changedRange[0]).toEqualDateTime(adapterToUse.date('2019-01-19T00:00:00.000'));
+    expect(changedRange[1]).toEqualDateTime(adapterToUse.date('2019-01-30T00:00:00.000'));
   });
 
   it('closes on focus out of fields', () => {
@@ -165,9 +165,10 @@ describe('<DateRangePicker />', () => {
     expect(screen.getByRole('tooltip')).not.toBeVisible();
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('allows pure keyboard selection of range', () => {
+  it('allows pure keyboard selection of range', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const onChangeMock = spy();
     render(
       <DesktopDateRangePicker
@@ -194,8 +195,8 @@ describe('<DateRangePicker />', () => {
 
     expect(
       onChangeMock.calledWith([
-        new Date('2019-06-06T00:00:00.000'),
-        new Date('2019-06-06T00:00:00.000'),
+        adapterToUse.date('2019-06-06T00:00:00.000'),
+        adapterToUse.date('2019-06-06T00:00:00.000'),
       ]),
     ).to.equal(true);
   });
@@ -204,7 +205,10 @@ describe('<DateRangePicker />', () => {
     render(
       <DesktopDateRangePicker
         reduceAnimations
-        value={[new Date('2019-05-19T00:00:00.000'), new Date('2019-10-30T00:00:00.000')]}
+        value={[
+          adapterToUse.date('2019-05-19T00:00:00.000'),
+          adapterToUse.date('2019-10-30T00:00:00.000'),
+        ]}
         renderInput={defaultRangeRenderInput}
         onChange={() => {}}
         TransitionComponent={FakeTransitionComponent}
@@ -226,7 +230,7 @@ describe('<DateRangePicker />', () => {
     render(
       <StaticDateRangePicker
         renderInput={defaultRangeRenderInput}
-        minDate={new Date('2005-01-01T00:00:00.000')}
+        minDate={adapterToUse.date('2005-01-01T00:00:00.000')}
         shouldDisableDate={isWeekend}
         onChange={() => {}}
         value={[
@@ -248,7 +252,10 @@ describe('<DateRangePicker />', () => {
         calendars={3}
         onChange={() => {}}
         TransitionComponent={FakeTransitionComponent}
-        value={[adapterToUse.date(new Date(NaN)), adapterToUse.date('2018-01-31T00:00:00.000')]}
+        value={[
+          adapterToUse.date(adapterToUse.date(NaN)),
+          adapterToUse.date('2018-01-31T00:00:00.000'),
+        ]}
       />,
     );
 

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
@@ -165,10 +165,9 @@ describe('<DateRangePicker />', () => {
     expect(screen.getByRole('tooltip')).not.toBeVisible();
   });
 
-  it('allows pure keyboard selection of range', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('allows pure keyboard selection of range', () => {
     const onChangeMock = spy();
     render(
       <DesktopDateRangePicker

--- a/packages/material-ui-lab/src/DateRangePicker/date-range-manager.test.ts
+++ b/packages/material-ui-lab/src/DateRangePicker/date-range-manager.test.ts
@@ -3,9 +3,9 @@ import { calculateRangeChange, calculateRangePreview } from './date-range-manage
 import { adapterToUse } from '../internal/pickers/test-utils';
 import { DateRange } from './RangeTypes';
 
-const start2018 = new Date('2018-01-01T00:00:00.000Z');
-const mid2018 = new Date('2018-06-01T00:00:00.000Z');
-const end2019 = new Date('2019-01-01T00:00:00.000Z');
+const start2018 = adapterToUse.date('2018-01-01T00:00:00.000');
+const mid2018 = adapterToUse.date('2018-06-01T00:00:00.000');
+const end2019 = adapterToUse.date('2019-01-01T00:00:00.000');
 
 describe('date-range-manager', () => {
   [

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
-import DateFnsAdapter from '@material-ui/lab/dateAdapter/date-fns';
 import DateRangePickerDay from '@material-ui/lab/DateRangePickerDay';
+import { adapterToUse, AdapterClassToUse } from '../internal/pickers/test-utils';
 
 describe('<DateRangePickeryarDay />', () => {
   const mount = createMount();
   let classes: Record<string, string>;
 
   const localizedMount = (node: React.ReactNode) => {
-    return mount(<LocalizationProvider dateAdapter={DateFnsAdapter}>{node}</LocalizationProvider>);
+    return mount(
+      <LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>,
+    );
   };
 
   before(() => {
     classes = getClasses(
       <DateRangePickerDay
-        day={new Date()}
+        day={adapterToUse.date()}
         outsideCurrentMonth={false}
         selected
         focused
@@ -32,7 +34,7 @@ describe('<DateRangePickeryarDay />', () => {
 
   describeConformance(
     <DateRangePickerDay
-      day={new Date()}
+      day={adapterToUse.date()}
       outsideCurrentMonth={false}
       selected
       focused

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.test.tsx
@@ -15,7 +15,7 @@ describe('<DateTimePicker />', () => {
   let clock: SinonFakeTimers;
 
   beforeEach(() => {
-    clock = useFakeTimers(new Date('2018-01-01T00:00:00.000').getTime());
+    clock = useFakeTimers(adapterToUse.date('2018-01-01T00:00:00.000').getTime());
   });
 
   afterEach(() => {
@@ -110,7 +110,7 @@ describe('<DateTimePicker />', () => {
     expect(getByMuiTest('minutes')).to.have.text('53');
 
     fireEvent.click(screen.getByText(/ok/i));
-    expect(onChangeMock.calledWith(new Date('2010-01-15T11:53:00.000'))).to.be.equal(true);
+    expect(onChangeMock.calledWith(adapterToUse.date('2010-01-15T11:53:00.000'))).to.be.equal(true);
   });
 
   it('prop: open – overrides open state', () => {
@@ -119,7 +119,7 @@ describe('<DateTimePicker />', () => {
         renderInput={(params) => <TextField {...params} />}
         open
         onChange={() => {}}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -134,7 +134,7 @@ describe('<DateTimePicker />', () => {
         open
         onClose={onCloseMock}
         onChange={() => {}}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -150,7 +150,7 @@ describe('<DateTimePicker />', () => {
         onChange={() => {}}
         dateAdapter={new DayJsAdapter({ locale: 'ru' })}
         disableMaskedInput
-        value={dayjs('2018-01-15T00:00:00.000Z')}
+        value={dayjs('2018-01-15T00:00:00.000')}
       />,
     );
 
@@ -179,17 +179,18 @@ describe('<DateTimePicker />', () => {
     expect(textbox.value).to.equal('12.');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('prop: maxDateTime – minutes is disabled by date part', () => {
+  it('prop: maxDateTime – minutes is disabled by date part', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
       <DesktopDateTimePicker
         open
         openTo="minutes"
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T12:00:00.000Z')}
-        minDateTime={adapterToUse.date('2018-01-01T12:30:00.000Z')}
+        value={adapterToUse.date('2018-01-01T12:00:00.000')}
+        minDateTime={adapterToUse.date('2018-01-01T12:30:00.000')}
       />,
     );
 
@@ -205,8 +206,8 @@ describe('<DateTimePicker />', () => {
         onChange={() => {}}
         ampm={false}
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
-        minDateTime={adapterToUse.date('2018-01-01T12:30:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
+        minDateTime={adapterToUse.date('2018-01-01T12:30:00.000')}
       />,
     );
 
@@ -220,7 +221,7 @@ describe('<DateTimePicker />', () => {
         openTo="hours"
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -234,7 +235,7 @@ describe('<DateTimePicker />', () => {
         openTo="hours"
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 
@@ -242,15 +243,16 @@ describe('<DateTimePicker />', () => {
     expect(screen.getByLabelText('open next view')).to.have.attribute('disabled');
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('allows to select the same day and move to the next view', () => {
+  it('allows to select the same day and move to the next view', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const onChangeMock = spy();
     render(
       <StaticDateTimePicker
         onChange={onChangeMock}
         renderInput={(params) => <TextField {...params} />}
-        value={adapterToUse.date('2018-01-01T00:00:00.000Z')}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
       />,
     );
 

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
@@ -39,10 +39,9 @@ describe('<DayPicker />', () => {
     expect(getAllByMuiTest('day')).to.have.length(31);
   });
 
-  it('renders year selection  standalone', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('renders year selection  standalone', () => {
     render(
       <DayPicker
         date={adapterToUse.date('2019-01-01T00:00:00.000')}

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
@@ -4,7 +4,7 @@ import { getClasses, createMount, fireEvent, screen, describeConformance } from 
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateFnsAdapter from '@material-ui/lab/dateAdapter/date-fns';
 import DayPicker from '@material-ui/lab/DayPicker';
-import { createPickerRender, getAllByMuiTest } from '../internal/pickers/test-utils';
+import { adapterToUse, createPickerRender, getAllByMuiTest } from '../internal/pickers/test-utils';
 
 describe('<DayPicker />', () => {
   const mount = createMount();
@@ -16,10 +16,10 @@ describe('<DayPicker />', () => {
   };
 
   before(() => {
-    classes = getClasses(<DayPicker date={new Date()} onChange={() => {}} />);
+    classes = getClasses(<DayPicker date={adapterToUse.date()} onChange={() => {}} />);
   });
 
-  describeConformance(<DayPicker date={new Date()} onChange={() => {}} />, () => ({
+  describeConformance(<DayPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
     classes,
     inheritComponent: 'div',
     mount: localizedMount,
@@ -28,28 +28,34 @@ describe('<DayPicker />', () => {
     skip: ['componentProp', 'propsSpread', 'reactTestRenderer'],
   }));
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('renders calendar standalone', () => {
-    render(<DayPicker date={new Date('2019-01-01T00:00:00.000')} onChange={() => {}} />);
+  it('renders calendar standalone', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
+    render(<DayPicker date={adapterToUse.date('2019-01-01T00:00:00.000')} onChange={() => {}} />);
 
     expect(screen.getByText('January')).toBeVisible();
     expect(screen.getByText('2019')).toBeVisible();
     expect(getAllByMuiTest('day')).to.have.length(31);
   });
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('renders year selection  standalone', () => {
+  it('renders year selection  standalone', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     render(
-      <DayPicker date={new Date('2019-01-01T00:00:00.000')} openTo="year" onChange={() => {}} />,
+      <DayPicker
+        date={adapterToUse.date('2019-01-01T00:00:00.000')}
+        openTo="year"
+        onChange={() => {}}
+      />,
     );
 
     expect(getAllByMuiTest('year')).to.have.length(200);
   });
 
   it('switches between views uncontrolled', () => {
-    render(<DayPicker date={new Date('2019-01-01T00:00:00.000')} onChange={() => {}} />);
+    render(<DayPicker date={adapterToUse.date('2019-01-01T00:00:00.000')} onChange={() => {}} />);
 
     fireEvent.click(screen.getByLabelText(/switch to year view/i));
 

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
@@ -5,7 +5,7 @@ import { getClasses, createMount, fireEvent, screen, describeConformance } from 
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateFnsAdapter from '@material-ui/lab/dateAdapter/date-fns';
 import MonthPicker from '@material-ui/lab/MonthPicker';
-import { createPickerRender } from '../internal/pickers/test-utils';
+import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<MonthPicker />', () => {
   const mount = createMount();
@@ -19,9 +19,9 @@ describe('<MonthPicker />', () => {
   before(() => {
     classes = getClasses(
       <MonthPicker
-        minDate={new Date('2019-01-01T00:00:00.000')}
-        maxDate={new Date('2029-01-01T00:00:00.000')}
-        date={new Date()}
+        minDate={adapterToUse.date('2019-01-01T00:00:00.000')}
+        maxDate={adapterToUse.date('2029-01-01T00:00:00.000')}
+        date={adapterToUse.date()}
         onChange={() => {}}
       />,
     );
@@ -29,9 +29,9 @@ describe('<MonthPicker />', () => {
 
   describeConformance(
     <MonthPicker
-      minDate={new Date('2019-01-01T00:00:00.000')}
-      maxDate={new Date('2029-01-01T00:00:00.000')}
-      date={new Date()}
+      minDate={adapterToUse.date('2019-01-01T00:00:00.000')}
+      maxDate={adapterToUse.date('2029-01-01T00:00:00.000')}
+      date={adapterToUse.date()}
       onChange={() => {}}
     />,
     () => ({
@@ -48,9 +48,9 @@ describe('<MonthPicker />', () => {
     const onChangeMock = spy();
     render(
       <MonthPicker
-        minDate={new Date('2019-01-01T00:00:00.000')}
-        maxDate={new Date('2029-01-01T00:00:00.000')}
-        date={new Date('2019-02-02T00:00:00.000')}
+        minDate={adapterToUse.date('2019-01-01T00:00:00.000')}
+        maxDate={adapterToUse.date('2029-01-01T00:00:00.000')}
+        date={adapterToUse.date('2019-02-02T00:00:00.000')}
         onChange={onChangeMock}
       />,
     );

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
 import { getClasses, createMount, describeConformance } from 'test/utils';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
-import DateFnsAdapter from '@material-ui/lab/dateAdapter/date-fns';
 import PickersDay from '@material-ui/lab/PickersDay';
+import { adapterToUse, AdapterClassToUse } from '../internal/pickers/test-utils';
 
 describe('<PickersDay />', () => {
   const mount = createMount();
   let classes: Record<string, string>;
 
   const localizedMount = (node: React.ReactNode) => {
-    return mount(<LocalizationProvider dateAdapter={DateFnsAdapter}>{node}</LocalizationProvider>);
+    return mount(
+      <LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>,
+    );
   };
 
   before(() => {
     classes = getClasses(
       <PickersDay
-        day={new Date()}
+        day={adapterToUse.date()}
         outsideCurrentMonth={false}
         selected
         focused
@@ -26,7 +28,7 @@ describe('<PickersDay />', () => {
 
   describeConformance(
     <PickersDay
-      day={new Date()}
+      day={adapterToUse.date()}
       outsideCurrentMonth={false}
       selected
       focused

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.test.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.test.tsx
@@ -190,8 +190,8 @@ describe('<TimePicker />', () => {
           onChange={() => {}}
           views={['hours', 'minutes', 'seconds']}
           value={adapterToUse.date('2018-01-01T00:00:00.000')}
-          minTime={new Date(0, 0, 0, 12, 15, 15)}
-          maxTime={new Date(0, 0, 0, 15, 45, 30)}
+          minTime={adapterToUse.date('2018-01-01T12:15:00.000')}
+          maxTime={adapterToUse.date('2018-01-01T15:45:30.000')}
         />,
       );
     });
@@ -243,13 +243,20 @@ describe('<TimePicker />', () => {
   });
 
   context('input validation', () => {
-    const createTime = (time: string) => new Date(`01/01/2000 ${time}`);
     const shouldDisableTime: TimePickerProps['shouldDisableTime'] = (value) => value === 10;
 
     [
       { expectedError: 'invalidDate', props: {}, input: 'invalidText' },
-      { expectedError: 'minTime', props: { minTime: createTime('08:00') }, input: '03:00' },
-      { expectedError: 'maxTime', props: { maxTime: createTime('08:00') }, input: '12:00' },
+      {
+        expectedError: 'minTime',
+        props: { minTime: adapterToUse.date(`2000-01-01T08:00:00.000`) },
+        input: '03:00',
+      },
+      {
+        expectedError: 'maxTime',
+        props: { maxTime: adapterToUse.date(`2000-01-01T08:00:00.000`) },
+        input: '12:00',
+      },
       { expectedError: 'shouldDisableTime-hours', props: { shouldDisableTime }, input: '10:00' },
       { expectedError: 'shouldDisableTime-minutes', props: { shouldDisableTime }, input: '00:10' },
     ].forEach(({ props, input, expectedError }) => {

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
@@ -5,7 +5,7 @@ import { getClasses, createMount, fireEvent, screen, describeConformance } from 
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateFnsAdapter from '@material-ui/lab/dateAdapter/date-fns';
 import YearPicker from '@material-ui/lab/YearPicker';
-import { createPickerRender } from '../internal/pickers/test-utils';
+import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<YearPicker />', () => {
   const mount = createMount();
@@ -19,10 +19,10 @@ describe('<YearPicker />', () => {
   before(() => {
     classes = getClasses(
       <YearPicker
-        minDate={new Date('2019-01-01T00:00:00.000')}
-        maxDate={new Date('2029-01-01T00:00:00.000')}
+        minDate={adapterToUse.date('2019-01-01T00:00:00.000')}
+        maxDate={adapterToUse.date('2029-01-01T00:00:00.000')}
         isDateDisabled={() => false}
-        date={new Date()}
+        date={adapterToUse.date()}
         onChange={() => {}}
       />,
     );
@@ -30,10 +30,10 @@ describe('<YearPicker />', () => {
 
   describeConformance(
     <YearPicker
-      minDate={new Date('2019-01-01T00:00:00.000')}
-      maxDate={new Date('2029-01-01T00:00:00.000')}
+      minDate={adapterToUse.date('2019-01-01T00:00:00.000')}
+      maxDate={adapterToUse.date('2029-01-01T00:00:00.000')}
       isDateDisabled={() => false}
-      date={new Date()}
+      date={adapterToUse.date()}
       onChange={() => {}}
     />,
     () => ({
@@ -50,15 +50,15 @@ describe('<YearPicker />', () => {
     const onChangeMock = spy();
     render(
       <YearPicker
-        minDate={new Date('2019-01-01T00:00:00.000')}
-        maxDate={new Date('2029-01-01T00:00:00.000')}
+        minDate={adapterToUse.date('2019-01-01T00:00:00.000')}
+        maxDate={adapterToUse.date('2029-01-01T00:00:00.000')}
         isDateDisabled={() => false}
-        date={new Date('2019-02-02T00:00:00.000')}
+        date={adapterToUse.date('2019-02-02T00:00:00.000')}
         onChange={onChangeMock}
       />,
     );
 
     fireEvent.click(screen.getByText('2025', { selector: 'button' }));
-    expect(onChangeMock.calledWith(new Date('2025-02-02T00:00:00.000'))).to.equal(true);
+    expect(onChangeMock.calledWith(adapterToUse.date('2025-02-02T00:00:00.000'))).to.equal(true);
   });
 });

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.test.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.test.ts
@@ -9,10 +9,9 @@ describe('findClosestEnabledDate', () => {
   );
   const only18th = (date: any) => adapterToUse.format(date, 'dayOfMonth') !== day18thText;
 
-  it('should fallback to today if all dates are disabled', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('should fallback to today if all dates are disabled', () => {
     const result = findClosestEnabledDate({
       date: adapterToUse.date('2000-01-01T00:00:00.000'),
       minDate: adapterToUse.date('1999-01-01T00:00:00.000'), // Use close-by min/max dates to reduce the test runtime.
@@ -184,7 +183,9 @@ describe('findClosestEnabledDate', () => {
     );
   });
 
-  it('should fallback to today if minDate is after maxDate', () => {
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('should fallback to today if minDate is after maxDate', () => {
     const result = findClosestEnabledDate({
       date: adapterToUse.date('2000-01-01T00:00:00.000'),
       minDate: adapterToUse.date('2000-01-01T00:00:00.000'),

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.test.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.test.ts
@@ -9,9 +9,10 @@ describe('findClosestEnabledDate', () => {
   );
   const only18th = (date: any) => adapterToUse.format(date, 'dayOfMonth') !== day18thText;
 
-  // TODO
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('should fallback to today if all dates are disabled', () => {
+  it('should fallback to today if all dates are disabled', function test() {
+    if (process.env.TEST_GATE !== 'experimental-timezones') {
+      this.skip();
+    }
     const result = findClosestEnabledDate({
       date: adapterToUse.date('2000-01-01T00:00:00.000'),
       minDate: adapterToUse.date('1999-01-01T00:00:00.000'), // Use close-by min/max dates to reduce the test runtime.

--- a/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
@@ -14,7 +14,7 @@ export class AdapterClassToUse extends DateFnsAdapter {
   localDate(isoDateWithoutTimezone: string): Date {
     const timezoneOffset = this.date().getTimezoneOffset();
     const absTimezoneOffset = Math.abs(timezoneOffset);
-    const localIsoTimezone = `${timezoneOffset < 0 ? '-' : '+'}${Math.floor(absTimezoneOffset / 60)
+    const localIsoTimezone = `${timezoneOffset > 0 ? '-' : '+'}${Math.floor(absTimezoneOffset / 60)
       .toString()
       .padStart(2, '0')}:${(absTimezoneOffset % 60).toString().padStart(2, '0')}`;
 

--- a/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
@@ -6,7 +6,22 @@ import DateFnsAdapter from '../../dateAdapter/date-fns';
 import LocalizationProvider from '../../LocalizationProvider';
 
 // TODO make possible to pass here any utils using cli
-export const AdapterClassToUse = DateFnsAdapter;
+export class AdapterClassToUse extends DateFnsAdapter {
+  /**
+   * @param isoDateWithoutTimezone The date in ISO 8601 format without the timezone.
+   * @example adapterToUse.localDate('2018-01-01T00:00:00.000')
+   */
+  localDate(isoDateWithoutTimezone: string): Date {
+    const timezoneOffset = this.date().getTimezoneOffset();
+    const absTimezoneOffset = Math.abs(timezoneOffset);
+    const localIsoTimezone = `${timezoneOffset < 0 ? '-' : '+'}${Math.floor(absTimezoneOffset / 60)
+      .toString()
+      .padStart(2, '0')}:${(absTimezoneOffset % 60).toString().padStart(2, '0')}`;
+
+    const isoDateWithTimezone = `${isoDateWithoutTimezone}${localIsoTimezone}`;
+    return this.date(isoDateWithTimezone);
+  }
+}
 export const adapterToUse = new AdapterClassToUse();
 
 export const FakeTransitionComponent = React.forwardRef<HTMLDivElement, TransitionProps>(

--- a/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
@@ -21,6 +21,14 @@ export class AdapterClassToUse extends DateFnsAdapter {
     const isoDateWithTimezone = `${isoDateWithoutTimezone}${localIsoTimezone}`;
     return this.date(isoDateWithTimezone);
   }
+
+  /**
+   * WARNING: Only use with an explicit timezone. For local dates prefer `localDate`.
+   * @param value
+   */
+  date(value?: any): Date {
+    return super.date(value);
+  }
 }
 export const adapterToUse = new AdapterClassToUse();
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -60,6 +60,7 @@ module.exports = function setKarmaConfig(config) {
             NODE_ENV: JSON.stringify('test'),
             CI: JSON.stringify(process.env.CI),
             KARMA: JSON.stringify(true),
+            TEST_GATE: JSON.stringify(process.env.TEST_GATE),
           },
         }),
       ],


### PR DESCRIPTION
In Safari `new Date('2018-01-01T00:00:00.000')` is the same as `new Date('2018-01-01T00:00:00.000Z')` i.e. the default timezone is GMT not the local timezone. GMT is assumed because the date uses ISO 8601 format. Oddly enough, Safari is the only browser in our roster spec compliant here. But the first date should use the local timezone because `date.getFullYear()` returns the value in the current timezone.

MDN actually warns about this and says relying on Date.parse is discouraged:

> Note: Parsing of date strings with the Date constructor (and Date.parse, they are equivalent) is strongly discouraged due to browser differences and inconsistencies.

--https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
 
Periodically runs the datepicker tests that were skipped previously. I'm confident that the fix to `adater.date` should fix the tests but in order to not block main development I'm running them behind a flag.

There are still some tests skipped unconditionally. These failures might have the same underlying issue but probably require a different fix.

Default: https://app.circleci.com/pipelines/github/mui-org/material-ui/26388/workflows/9274fe34-e7c4-43fc-b9a5-2aa940bcdcdb/jobs/194419
With `test-gate: https://app.circleci.com/pipelines/github/mui-org/material-ui/26390/workflows/e44089f9-fc25-4e6a-a222-65dc3d10a49e/jobs/194430