### PR TITLE
[DatePicker] Skip flaky tests

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
@@ -149,7 +149,9 @@ describe('<DatePicker /> keyboard interactions', () => {
       { keyCode: 39, key: 'ArrowRight', expectFocusedDay: 'Aug 14, 2020' },
       { keyCode: 40, key: 'ArrowDown', expectFocusedDay: 'Aug 20, 2020' },
     ].forEach(({ key, keyCode, expectFocusedDay }) => {
-      it(key, () => {
+      // TODO
+      // eslint-disable-next-line mocha/no-skipped-tests
+      it.skip(key, () => {
         fireEvent.keyDown(document.body, { force: true, keyCode, key });
 
         expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -30,7 +30,9 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
-  it('datePicker localized format for year+month view', () => {
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('datePicker localized format for year+month view', () => {
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -46,7 +48,9 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('janvier');
   });
 
-  it('datePicker localized format for year+month+date view', () => {
+  // TODO
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('datePicker localized format for year+month+date view', () => {
     render(
       <MobileDatePicker
         onChange={() => {}}


### PR DESCRIPTION
- https://app.circleci.com/pipelines/github/mui-org/material-ui/26324/workflows/6a9f040c-75f0-4420-b12a-c8c4ef4caa48/jobs/194193
- https://app.circleci.com/pipelines/github/mui-org/material-ui/26326/workflows/e97d412d-c696-4100-99fd-c5cd5d621c4d/jobs/194203

<img width="538" alt="Capture d’écran 2020-11-10 à 22 15 07" src="https://user-images.githubusercontent.com/3165635/98734462-40934700-23a2-11eb-8f6c-f412994a6c83.png">

#23475 might solve the root issue, until then, optimize for stability.