### PR TITLE
[docs] Fix links being opened when dismissing context menus

### DIFF
--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -28,11 +28,18 @@ export async function handleEvent(event, as) {
   document.body.focus();
 }
 
+/**
+ * @param {MouseEvent} event
+ */
 function handleClick(event) {
-  const activeElement = document.activeElement;
+  let activeElement = event.target;
+  while (activeElement?.nodeType === Node.ELEMENT_NODE && activeElement.nodeName !== 'A') {
+    activeElement = activeElement.parentElement;
+  }
 
   // Ignore non link clicks
   if (
+    activeElement === null ||
     activeElement.nodeName !== 'A' ||
     activeElement.getAttribute('target') === '_blank' ||
     activeElement.getAttribute('data-no-link') === 'true' ||
@@ -41,7 +48,7 @@ function handleClick(event) {
     return;
   }
 
-  handleEvent(event, document.activeElement.getAttribute('href'));
+  handleEvent(event, activeElement.getAttribute('href'));
 }
 
 let bound = false;


### PR DESCRIPTION
With Chrome 86, Ubuntu 20.04:

1. right-click link
1. left-click outside of opened context menu

Behavior with native `<a />`: context menu is dismissed
Behavior in https://next--material-ui.netlify.app/: context menu is dismissed and link that was previously right clicked is opened

The current implementation uses `document.activeElement` as the link target (assuming that the link target becomes the activeElement upon activation). However, the link target becomes the active element on mousedown (any button) not on click. So if the click event is interrupted (context menu) the next click will target the link for which the event was actually interrupted.

Fixed it by finding the first parent `<a />` of the click target and using that. Also gets rid of potential platform inconsistencies from unspecified mousedown+focus.