### PR TITLE
[TextField] Change default variant from standard to outlined

### DIFF
--- a/docs/pages/api-docs/text-field.md
+++ b/docs/pages/api-docs/text-field.md
@@ -87,7 +87,7 @@ The `MuiTextField` name can be used for providing [default props](/customization
 | <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | The size of the text field. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'outlined'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/src/modules/components/MarkdownDocsFooter.js
+++ b/docs/src/modules/components/MarkdownDocsFooter.js
@@ -296,7 +296,8 @@ function MarkdownDocsFooter(props) {
                   'aria-label': t('feedbackCommentLabel'),
                   'aria-describedby': 'feedback-description',
                   ref: inputRef,
-                }} />
+                }}
+              />
             </div>
             <DialogActions>
               <Button type="reset">{t('cancel')}</Button>

--- a/docs/src/modules/components/MarkdownDocsFooter.js
+++ b/docs/src/modules/components/MarkdownDocsFooter.js
@@ -286,7 +286,6 @@ function MarkdownDocsFooter(props) {
               </Typography>
               <TextField
                 multiline
-                variant="outlined"
                 margin="dense"
                 name="comment"
                 fullWidth
@@ -297,8 +296,7 @@ function MarkdownDocsFooter(props) {
                   'aria-label': t('feedbackCommentLabel'),
                   'aria-describedby': 'feedback-description',
                   ref: inputRef,
-                }}
-              />
+                }} />
             </div>
             <DialogActions>
               <Button type="reset">{t('cancel')}</Button>

--- a/docs/src/modules/utils/i18n.js
+++ b/docs/src/modules/utils/i18n.js
@@ -20,7 +20,7 @@ export function useTranslate() {
 
   return React.useMemo(
     () =>
-      (function translate(key, options = {}) {
+      function translate(key, options = {}) {
         const { ignoreWarning = false } = options;
         const wordings = translations[userLanguage];
 
@@ -42,7 +42,7 @@ export function useTranslate() {
         }
 
         return translation;
-      }),
+      },
     [userLanguage],
   );
 }

--- a/docs/src/modules/utils/i18n.js
+++ b/docs/src/modules/utils/i18n.js
@@ -20,7 +20,7 @@ export function useTranslate() {
 
   return React.useMemo(
     () =>
-      function translate(key, options = {}) {
+      (function translate(key, options = {}) {
         const { ignoreWarning = false } = options;
         const wordings = translations[userLanguage];
 
@@ -42,7 +42,7 @@ export function useTranslate() {
         }
 
         return translation;
-      },
+      }),
     [userLanguage],
   );
 }

--- a/docs/src/pages/components/autocomplete/Asynchronous.js
+++ b/docs/src/pages/components/autocomplete/Asynchronous.js
@@ -65,7 +65,6 @@ export default function Asynchronous() {
         <TextField
           {...params}
           label="Asynchronous"
-          variant="outlined"
           InputProps={{
             ...params.InputProps,
             endAdornment: (
@@ -76,8 +75,7 @@ export default function Asynchronous() {
                 {params.InputProps.endAdornment}
               </React.Fragment>
             ),
-          }}
-        />
+          }} />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Asynchronous.js
+++ b/docs/src/pages/components/autocomplete/Asynchronous.js
@@ -75,7 +75,8 @@ export default function Asynchronous() {
                 {params.InputProps.endAdornment}
               </React.Fragment>
             ),
-          }} />
+          }}
+        />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Asynchronous.tsx
+++ b/docs/src/pages/components/autocomplete/Asynchronous.tsx
@@ -82,7 +82,8 @@ export default function Asynchronous() {
                 {params.InputProps.endAdornment}
               </React.Fragment>
             ),
-          }} />
+          }}
+        />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Asynchronous.tsx
+++ b/docs/src/pages/components/autocomplete/Asynchronous.tsx
@@ -72,7 +72,6 @@ export default function Asynchronous() {
         <TextField
           {...params}
           label="Asynchronous"
-          variant="outlined"
           InputProps={{
             ...params.InputProps,
             endAdornment: (
@@ -83,8 +82,7 @@ export default function Asynchronous() {
                 {params.InputProps.endAdornment}
               </React.Fragment>
             ),
-          }}
-        />
+          }} />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/CheckboxesTags.js
+++ b/docs/src/pages/components/autocomplete/CheckboxesTags.js
@@ -30,12 +30,7 @@ export default function CheckboxesTags() {
       )}
       style={{ width: 500 }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="outlined"
-          label="Checkboxes"
-          placeholder="Favorites"
-        />
+        <TextField {...params} label="Checkboxes" placeholder="Favorites" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/CheckboxesTags.tsx
+++ b/docs/src/pages/components/autocomplete/CheckboxesTags.tsx
@@ -30,12 +30,7 @@ export default function CheckboxesTags() {
       )}
       style={{ width: 500 }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="outlined"
-          label="Checkboxes"
-          placeholder="Favorites"
-        />
+        <TextField {...params} label="Checkboxes" placeholder="Favorites" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/ComboBox.js
+++ b/docs/src/pages/components/autocomplete/ComboBox.js
@@ -11,7 +11,7 @@ export default function ComboBox() {
       options={top100Films}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Movie" variant="outlined" />
+        <TextField {...params} label="Movie" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/ComboBox.js
+++ b/docs/src/pages/components/autocomplete/ComboBox.js
@@ -10,9 +10,7 @@ export default function ComboBox() {
       id="combo-box-demo"
       options={top100Films}
       style={{ width: 300 }}
-      renderInput={(params) => (
-        <TextField {...params} label="Movie" />
-      )}
+      renderInput={(params) => <TextField {...params} label="Movie" />}
     />
   );
 }

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx
@@ -11,7 +11,7 @@ export default function ComboBox() {
       options={top100Films}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Movie" variant="outlined" />
+        <TextField {...params} label="Movie" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx
@@ -10,9 +10,7 @@ export default function ComboBox() {
       id="combo-box-demo"
       options={top100Films}
       style={{ width: 300 }}
-      renderInput={(params) => (
-        <TextField {...params} label="Movie" />
-      )}
+      renderInput={(params) => <TextField {...params} label="Movie" />}
     />
   );
 }

--- a/docs/src/pages/components/autocomplete/ControllableStates.js
+++ b/docs/src/pages/components/autocomplete/ControllableStates.js
@@ -26,7 +26,7 @@ export default function ControllableStates() {
         options={options}
         style={{ width: 300 }}
         renderInput={(params) => (
-          <TextField {...params} label="Controllable" variant="outlined" />
+          <TextField {...params} label="Controllable" />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/ControllableStates.js
+++ b/docs/src/pages/components/autocomplete/ControllableStates.js
@@ -25,9 +25,7 @@ export default function ControllableStates() {
         id="controllable-states-demo"
         options={options}
         style={{ width: 300 }}
-        renderInput={(params) => (
-          <TextField {...params} label="Controllable" />
-        )}
+        renderInput={(params) => <TextField {...params} label="Controllable" />}
       />
     </div>
   );

--- a/docs/src/pages/components/autocomplete/ControllableStates.tsx
+++ b/docs/src/pages/components/autocomplete/ControllableStates.tsx
@@ -26,7 +26,7 @@ export default function ControllableStates() {
         options={options}
         style={{ width: 300 }}
         renderInput={(params) => (
-          <TextField {...params} label="Controllable" variant="outlined" />
+          <TextField {...params} label="Controllable" />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/ControllableStates.tsx
+++ b/docs/src/pages/components/autocomplete/ControllableStates.tsx
@@ -25,9 +25,7 @@ export default function ControllableStates() {
         id="controllable-states-demo"
         options={options}
         style={{ width: 300 }}
-        renderInput={(params) => (
-          <TextField {...params} label="Controllable" />
-        )}
+        renderInput={(params) => <TextField {...params} label="Controllable" />}
       />
     </div>
   );

--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -52,7 +52,8 @@ export default function CountrySelect() {
           inputProps={{
             ...params.inputProps,
             autoComplete: 'new-password', // disable autocomplete and autofill
-          }} />
+          }}
+        />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -49,12 +49,10 @@ export default function CountrySelect() {
         <TextField
           {...params}
           label="Choose a country"
-          variant="outlined"
           inputProps={{
             ...params.inputProps,
             autoComplete: 'new-password', // disable autocomplete and autofill
-          }}
-        />
+          }} />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -52,7 +52,8 @@ export default function CountrySelect() {
           inputProps={{
             ...params.inputProps,
             autoComplete: 'new-password', // disable autocomplete and autofill
-          }} />
+          }}
+        />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -49,12 +49,10 @@ export default function CountrySelect() {
         <TextField
           {...params}
           label="Choose a country"
-          variant="outlined"
           inputProps={{
             ...params.inputProps,
             autoComplete: 'new-password', // disable autocomplete and autofill
-          }}
-        />
+          }} />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/DisabledOptions.js
+++ b/docs/src/pages/components/autocomplete/DisabledOptions.js
@@ -13,7 +13,7 @@ export default function DisabledOptions() {
       }
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Disabled options" variant="outlined" />
+        <TextField {...params} label="Disabled options" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/DisabledOptions.tsx
+++ b/docs/src/pages/components/autocomplete/DisabledOptions.tsx
@@ -13,7 +13,7 @@ export default function DisabledOptions() {
       }
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Disabled options" variant="outlined" />
+        <TextField {...params} label="Disabled options" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Filter.js
+++ b/docs/src/pages/components/autocomplete/Filter.js
@@ -18,9 +18,7 @@ export default function Filter() {
       getOptionLabel={(option) => option.title}
       filterOptions={filterOptions}
       style={{ width: 300 }}
-      renderInput={(params) => (
-        <TextField {...params} label="Custom filter" />
-      )}
+      renderInput={(params) => <TextField {...params} label="Custom filter" />}
     />
   );
 }

--- a/docs/src/pages/components/autocomplete/Filter.js
+++ b/docs/src/pages/components/autocomplete/Filter.js
@@ -19,7 +19,7 @@ export default function Filter() {
       filterOptions={filterOptions}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Custom filter" variant="outlined" />
+        <TextField {...params} label="Custom filter" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Filter.tsx
+++ b/docs/src/pages/components/autocomplete/Filter.tsx
@@ -18,9 +18,7 @@ export default function Filter() {
       getOptionLabel={(option) => option.title}
       filterOptions={filterOptions}
       style={{ width: 300 }}
-      renderInput={(params) => (
-        <TextField {...params} label="Custom filter" />
-      )}
+      renderInput={(params) => <TextField {...params} label="Custom filter" />}
     />
   );
 }

--- a/docs/src/pages/components/autocomplete/Filter.tsx
+++ b/docs/src/pages/components/autocomplete/Filter.tsx
@@ -19,7 +19,7 @@ export default function Filter() {
       filterOptions={filterOptions}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="Custom filter" variant="outlined" />
+        <TextField {...params} label="Custom filter" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/FixedTags.js
+++ b/docs/src/pages/components/autocomplete/FixedTags.js
@@ -32,12 +32,7 @@ export default function FixedTags() {
       }
       style={{ width: 500 }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Fixed tag"
-          variant="outlined"
-          placeholder="Favorites"
-        />
+        <TextField {...params} label="Fixed tag" placeholder="Favorites" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/FixedTags.tsx
+++ b/docs/src/pages/components/autocomplete/FixedTags.tsx
@@ -32,12 +32,7 @@ export default function FixedTags() {
       }
       style={{ width: 500 }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Fixed tag"
-          variant="outlined"
-          placeholder="Favorites"
-        />
+        <TextField {...params} label="Fixed tag" placeholder="Favorites" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/FreeSolo.js
+++ b/docs/src/pages/components/autocomplete/FreeSolo.js
@@ -27,7 +27,8 @@ export default function FreeSolo() {
             InputProps={{
               ...params.InputProps,
               type: 'search',
-            }} />
+            }}
+          />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSolo.js
+++ b/docs/src/pages/components/autocomplete/FreeSolo.js
@@ -11,12 +11,7 @@ export default function FreeSolo() {
         freeSolo
         options={top100Films.map((option) => option.title)}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            label="freeSolo"
-            margin="normal"
-            variant="outlined"
-          />
+          <TextField {...params} label="freeSolo" margin="normal" />
         )}
       />
       <Autocomplete
@@ -29,12 +24,10 @@ export default function FreeSolo() {
             {...params}
             label="Search input"
             margin="normal"
-            variant="outlined"
             InputProps={{
               ...params.InputProps,
               type: 'search',
-            }}
-          />
+            }} />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSolo.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSolo.tsx
@@ -27,7 +27,8 @@ export default function FreeSolo() {
             InputProps={{
               ...params.InputProps,
               type: 'search',
-            }} />
+            }}
+          />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSolo.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSolo.tsx
@@ -11,12 +11,7 @@ export default function FreeSolo() {
         freeSolo
         options={top100Films.map((option) => option.title)}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            label="freeSolo"
-            margin="normal"
-            variant="outlined"
-          />
+          <TextField {...params} label="freeSolo" margin="normal" />
         )}
       />
       <Autocomplete
@@ -29,12 +24,10 @@ export default function FreeSolo() {
             {...params}
             label="Search input"
             margin="normal"
-            variant="outlined"
             InputProps={{
               ...params.InputProps,
               type: 'search',
-            }}
-          />
+            }} />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
@@ -61,11 +61,7 @@ export default function FreeSoloCreateOption() {
       style={{ width: 300 }}
       freeSolo
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Free solo with text demo"
-          variant="outlined"
-        />
+        <TextField {...params} label="Free solo with text demo" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.tsx
@@ -61,11 +61,7 @@ export default function FreeSoloCreateOption() {
       style={{ width: 300 }}
       freeSolo
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Free solo with text demo"
-          variant="outlined"
-        />
+        <TextField {...params} label="Free solo with text demo" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
@@ -96,7 +96,7 @@ export default function FreeSoloCreateOptionDialog() {
         style={{ width: 300 }}
         freeSolo
         renderInput={(params) => (
-          <TextField {...params} label="Free solo dialog" variant="outlined" />
+          <TextField {...params} label="Free solo dialog" />
         )}
       />
       <Dialog
@@ -123,7 +123,7 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="title"
               type="text"
-            />
+              variant="standard" />
             <TextField
               margin="dense"
               id="name"
@@ -136,7 +136,7 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="year"
               type="number"
-            />
+              variant="standard" />
           </DialogContent>
           <DialogActions>
             <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
@@ -123,7 +123,8 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="title"
               type="text"
-              variant="standard" />
+              variant="standard"
+            />
             <TextField
               margin="dense"
               id="name"
@@ -136,7 +137,8 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="year"
               type="number"
-              variant="standard" />
+              variant="standard"
+            />
           </DialogContent>
           <DialogActions>
             <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
@@ -94,7 +94,7 @@ export default function FreeSoloCreateOptionDialog() {
         style={{ width: 300 }}
         freeSolo
         renderInput={(params) => (
-          <TextField {...params} label="Free solo dialog" variant="outlined" />
+          <TextField {...params} label="Free solo dialog" />
         )}
       />
       <Dialog
@@ -121,7 +121,7 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="title"
               type="text"
-            />
+              variant="standard" />
             <TextField
               margin="dense"
               id="name"
@@ -134,7 +134,7 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="year"
               type="number"
-            />
+              variant="standard" />
           </DialogContent>
           <DialogActions>
             <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
@@ -121,7 +121,8 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="title"
               type="text"
-              variant="standard" />
+              variant="standard"
+            />
             <TextField
               margin="dense"
               id="name"
@@ -134,7 +135,8 @@ export default function FreeSoloCreateOptionDialog() {
               }
               label="year"
               type="number"
-              variant="standard" />
+              variant="standard"
+            />
           </DialogContent>
           <DialogActions>
             <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/autocomplete/GoogleMaps.js
+++ b/docs/src/pages/components/autocomplete/GoogleMaps.js
@@ -113,12 +113,7 @@ export default function GoogleMaps() {
         setInputValue(newInputValue);
       }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Add a location"
-          variant="outlined"
-          fullWidth
-        />
+        <TextField {...params} label="Add a location" fullWidth />
       )}
       renderOption={(props, option) => {
         const matches =

--- a/docs/src/pages/components/autocomplete/GoogleMaps.tsx
+++ b/docs/src/pages/components/autocomplete/GoogleMaps.tsx
@@ -136,12 +136,7 @@ export default function GoogleMaps() {
         setInputValue(newInputValue);
       }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Add a location"
-          variant="outlined"
-          fullWidth
-        />
+        <TextField {...params} label="Add a location" fullWidth />
       )}
       renderOption={(props, option) => {
         const matches =

--- a/docs/src/pages/components/autocomplete/Grouped.js
+++ b/docs/src/pages/components/autocomplete/Grouped.js
@@ -22,7 +22,7 @@ export default function Grouped() {
       getOptionLabel={(option) => option.title}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="With categories" variant="outlined" />
+        <TextField {...params} label="With categories" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Grouped.tsx
+++ b/docs/src/pages/components/autocomplete/Grouped.tsx
@@ -22,7 +22,7 @@ export default function Grouped() {
       getOptionLabel={(option) => option.title}
       style={{ width: 300 }}
       renderInput={(params) => (
-        <TextField {...params} label="With categories" variant="outlined" />
+        <TextField {...params} label="With categories" />
       )}
     />
   );

--- a/docs/src/pages/components/autocomplete/Highlights.js
+++ b/docs/src/pages/components/autocomplete/Highlights.js
@@ -13,12 +13,7 @@ export default function Highlights() {
       options={top100Films}
       getOptionLabel={(option) => option.title}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Highlights"
-          variant="outlined"
-          margin="normal"
-        />
+        <TextField {...params} label="Highlights" margin="normal" />
       )}
       renderOption={(props, option, { inputValue }) => {
         const matches = match(option.title, inputValue);

--- a/docs/src/pages/components/autocomplete/Highlights.tsx
+++ b/docs/src/pages/components/autocomplete/Highlights.tsx
@@ -13,12 +13,7 @@ export default function Highlights() {
       options={top100Films}
       getOptionLabel={(option) => option.title}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Highlights"
-          variant="outlined"
-          margin="normal"
-        />
+        <TextField {...params} label="Highlights" margin="normal" />
       )}
       renderOption={(props, option, { inputValue }) => {
         const matches = match(option.title, inputValue);

--- a/docs/src/pages/components/autocomplete/LimitTags.js
+++ b/docs/src/pages/components/autocomplete/LimitTags.js
@@ -26,12 +26,7 @@ export default function LimitTags() {
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="limitTags"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="limitTags" placeholder="Favorites" />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/LimitTags.tsx
+++ b/docs/src/pages/components/autocomplete/LimitTags.tsx
@@ -28,12 +28,7 @@ export default function LimitTags() {
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="limitTags"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="limitTags" placeholder="Favorites" />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/Playground.js
+++ b/docs/src/pages/components/autocomplete/Playground.js
@@ -22,7 +22,11 @@ export default function Playground() {
         id="disable-close-on-select"
         disableCloseOnSelect
         renderInput={(params) => (
-          <TextField {...params} label="disableCloseOnSelect" margin="normal" />
+          <TextField
+            {...params}
+            label="disableCloseOnSelect"
+            margin="normal"
+            variant="standard" />
         )}
       />
       <Autocomplete
@@ -30,7 +34,7 @@ export default function Playground() {
         id="clear-on-escape"
         clearOnEscape
         renderInput={(params) => (
-          <TextField {...params} label="clearOnEscape" margin="normal" />
+          <TextField {...params} label="clearOnEscape" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -38,7 +42,7 @@ export default function Playground() {
         id="disable-clearable"
         disableClearable
         renderInput={(params) => (
-          <TextField {...params} label="disableClearable" margin="normal" />
+          <TextField {...params} label="disableClearable" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -46,14 +50,14 @@ export default function Playground() {
         id="include-input-in-list"
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="includeInputInList" margin="normal" />
+          <TextField {...params} label="includeInputInList" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
         {...flatProps}
         id="flat-demo"
         renderInput={(params) => (
-          <TextField {...params} label="flat" margin="normal" />
+          <TextField {...params} label="flat" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -64,7 +68,7 @@ export default function Playground() {
           setValue(newValue);
         }}
         renderInput={(params) => (
-          <TextField {...params} label="controlled" margin="normal" />
+          <TextField {...params} label="controlled" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -73,7 +77,7 @@ export default function Playground() {
         autoComplete
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="autoComplete" margin="normal" />
+          <TextField {...params} label="autoComplete" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -81,7 +85,7 @@ export default function Playground() {
         id="disable-list-wrap"
         disableListWrap
         renderInput={(params) => (
-          <TextField {...params} label="disableListWrap" margin="normal" />
+          <TextField {...params} label="disableListWrap" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -89,7 +93,7 @@ export default function Playground() {
         id="open-on-focus"
         openOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="openOnFocus" margin="normal" />
+          <TextField {...params} label="openOnFocus" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -97,7 +101,7 @@ export default function Playground() {
         id="auto-highlight"
         autoHighlight
         renderInput={(params) => (
-          <TextField {...params} label="autoHighlight" margin="normal" />
+          <TextField {...params} label="autoHighlight" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -105,7 +109,7 @@ export default function Playground() {
         id="auto-select"
         autoSelect
         renderInput={(params) => (
-          <TextField {...params} label="autoSelect" margin="normal" />
+          <TextField {...params} label="autoSelect" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -113,7 +117,7 @@ export default function Playground() {
         id="disabled"
         disabled
         renderInput={(params) => (
-          <TextField {...params} label="disabled" margin="normal" />
+          <TextField {...params} label="disabled" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -121,7 +125,7 @@ export default function Playground() {
         id="disable-portal"
         disablePortal
         renderInput={(params) => (
-          <TextField {...params} label="disablePortal" margin="normal" />
+          <TextField {...params} label="disablePortal" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -129,7 +133,7 @@ export default function Playground() {
         id="blur-on-select"
         blurOnSelect
         renderInput={(params) => (
-          <TextField {...params} label="blurOnSelect" margin="normal" />
+          <TextField {...params} label="blurOnSelect" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -137,7 +141,7 @@ export default function Playground() {
         id="clear-on-blur"
         clearOnBlur
         renderInput={(params) => (
-          <TextField {...params} label="clearOnBlur" margin="normal" />
+          <TextField {...params} label="clearOnBlur" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -145,7 +149,7 @@ export default function Playground() {
         id="select-on-focus"
         selectOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="selectOnFocus" margin="normal" />
+          <TextField {...params} label="selectOnFocus" margin="normal" variant="standard" />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/Playground.js
+++ b/docs/src/pages/components/autocomplete/Playground.js
@@ -26,7 +26,8 @@ export default function Playground() {
             {...params}
             label="disableCloseOnSelect"
             margin="normal"
-            variant="standard" />
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -34,7 +35,12 @@ export default function Playground() {
         id="clear-on-escape"
         clearOnEscape
         renderInput={(params) => (
-          <TextField {...params} label="clearOnEscape" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="clearOnEscape"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -42,7 +48,12 @@ export default function Playground() {
         id="disable-clearable"
         disableClearable
         renderInput={(params) => (
-          <TextField {...params} label="disableClearable" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disableClearable"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -50,14 +61,24 @@ export default function Playground() {
         id="include-input-in-list"
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="includeInputInList" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="includeInputInList"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
         {...flatProps}
         id="flat-demo"
         renderInput={(params) => (
-          <TextField {...params} label="flat" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="flat"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -68,7 +89,12 @@ export default function Playground() {
           setValue(newValue);
         }}
         renderInput={(params) => (
-          <TextField {...params} label="controlled" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="controlled"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -77,7 +103,12 @@ export default function Playground() {
         autoComplete
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="autoComplete" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="autoComplete"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -85,7 +116,12 @@ export default function Playground() {
         id="disable-list-wrap"
         disableListWrap
         renderInput={(params) => (
-          <TextField {...params} label="disableListWrap" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disableListWrap"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -93,7 +129,12 @@ export default function Playground() {
         id="open-on-focus"
         openOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="openOnFocus" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="openOnFocus"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -101,7 +142,12 @@ export default function Playground() {
         id="auto-highlight"
         autoHighlight
         renderInput={(params) => (
-          <TextField {...params} label="autoHighlight" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="autoHighlight"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -109,7 +155,12 @@ export default function Playground() {
         id="auto-select"
         autoSelect
         renderInput={(params) => (
-          <TextField {...params} label="autoSelect" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="autoSelect"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -117,7 +168,12 @@ export default function Playground() {
         id="disabled"
         disabled
         renderInput={(params) => (
-          <TextField {...params} label="disabled" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disabled"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -125,7 +181,12 @@ export default function Playground() {
         id="disable-portal"
         disablePortal
         renderInput={(params) => (
-          <TextField {...params} label="disablePortal" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disablePortal"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -133,7 +194,12 @@ export default function Playground() {
         id="blur-on-select"
         blurOnSelect
         renderInput={(params) => (
-          <TextField {...params} label="blurOnSelect" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="blurOnSelect"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -141,7 +207,12 @@ export default function Playground() {
         id="clear-on-blur"
         clearOnBlur
         renderInput={(params) => (
-          <TextField {...params} label="clearOnBlur" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="clearOnBlur"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -149,7 +220,12 @@ export default function Playground() {
         id="select-on-focus"
         selectOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="selectOnFocus" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="selectOnFocus"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/Playground.tsx
+++ b/docs/src/pages/components/autocomplete/Playground.tsx
@@ -24,7 +24,8 @@ export default function Playground() {
             {...params}
             label="disableCloseOnSelect"
             margin="normal"
-            variant="standard" />
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -32,7 +33,12 @@ export default function Playground() {
         id="clear-on-escape"
         clearOnEscape
         renderInput={(params) => (
-          <TextField {...params} label="clearOnEscape" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="clearOnEscape"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -40,7 +46,12 @@ export default function Playground() {
         id="disable-clearable"
         disableClearable
         renderInput={(params) => (
-          <TextField {...params} label="disableClearable" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disableClearable"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -48,14 +59,24 @@ export default function Playground() {
         id="include-input-in-list"
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="includeInputInList" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="includeInputInList"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
         {...flatProps}
         id="flat-demo"
         renderInput={(params) => (
-          <TextField {...params} label="flat" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="flat"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -66,7 +87,12 @@ export default function Playground() {
           setValue(newValue);
         }}
         renderInput={(params) => (
-          <TextField {...params} label="controlled" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="controlled"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -75,7 +101,12 @@ export default function Playground() {
         autoComplete
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="autoComplete" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="autoComplete"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -83,7 +114,12 @@ export default function Playground() {
         id="disable-list-wrap"
         disableListWrap
         renderInput={(params) => (
-          <TextField {...params} label="disableListWrap" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disableListWrap"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -91,7 +127,12 @@ export default function Playground() {
         id="open-on-focus"
         openOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="openOnFocus" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="openOnFocus"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -99,7 +140,12 @@ export default function Playground() {
         id="auto-highlight"
         autoHighlight
         renderInput={(params) => (
-          <TextField {...params} label="autoHighlight" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="autoHighlight"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -107,7 +153,12 @@ export default function Playground() {
         id="auto-select"
         autoSelect
         renderInput={(params) => (
-          <TextField {...params} label="autoSelect" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="autoSelect"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -115,7 +166,12 @@ export default function Playground() {
         id="disabled"
         disabled
         renderInput={(params) => (
-          <TextField {...params} label="disabled" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disabled"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -123,7 +179,12 @@ export default function Playground() {
         id="disable-portal"
         disablePortal
         renderInput={(params) => (
-          <TextField {...params} label="disablePortal" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="disablePortal"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -131,7 +192,12 @@ export default function Playground() {
         id="blur-on-select"
         blurOnSelect
         renderInput={(params) => (
-          <TextField {...params} label="blurOnSelect" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="blurOnSelect"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -139,7 +205,12 @@ export default function Playground() {
         id="clear-on-blur"
         clearOnBlur
         renderInput={(params) => (
-          <TextField {...params} label="clearOnBlur" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="clearOnBlur"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
       <Autocomplete
@@ -147,7 +218,12 @@ export default function Playground() {
         id="select-on-focus"
         selectOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="selectOnFocus" margin="normal" variant="standard" />
+          <TextField
+            {...params}
+            label="selectOnFocus"
+            margin="normal"
+            variant="standard"
+          />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/Playground.tsx
+++ b/docs/src/pages/components/autocomplete/Playground.tsx
@@ -20,7 +20,11 @@ export default function Playground() {
         id="disable-close-on-select"
         disableCloseOnSelect
         renderInput={(params) => (
-          <TextField {...params} label="disableCloseOnSelect" margin="normal" />
+          <TextField
+            {...params}
+            label="disableCloseOnSelect"
+            margin="normal"
+            variant="standard" />
         )}
       />
       <Autocomplete
@@ -28,7 +32,7 @@ export default function Playground() {
         id="clear-on-escape"
         clearOnEscape
         renderInput={(params) => (
-          <TextField {...params} label="clearOnEscape" margin="normal" />
+          <TextField {...params} label="clearOnEscape" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -36,7 +40,7 @@ export default function Playground() {
         id="disable-clearable"
         disableClearable
         renderInput={(params) => (
-          <TextField {...params} label="disableClearable" margin="normal" />
+          <TextField {...params} label="disableClearable" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -44,14 +48,14 @@ export default function Playground() {
         id="include-input-in-list"
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="includeInputInList" margin="normal" />
+          <TextField {...params} label="includeInputInList" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
         {...flatProps}
         id="flat-demo"
         renderInput={(params) => (
-          <TextField {...params} label="flat" margin="normal" />
+          <TextField {...params} label="flat" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -62,7 +66,7 @@ export default function Playground() {
           setValue(newValue);
         }}
         renderInput={(params) => (
-          <TextField {...params} label="controlled" margin="normal" />
+          <TextField {...params} label="controlled" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -71,7 +75,7 @@ export default function Playground() {
         autoComplete
         includeInputInList
         renderInput={(params) => (
-          <TextField {...params} label="autoComplete" margin="normal" />
+          <TextField {...params} label="autoComplete" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -79,7 +83,7 @@ export default function Playground() {
         id="disable-list-wrap"
         disableListWrap
         renderInput={(params) => (
-          <TextField {...params} label="disableListWrap" margin="normal" />
+          <TextField {...params} label="disableListWrap" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -87,7 +91,7 @@ export default function Playground() {
         id="open-on-focus"
         openOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="openOnFocus" margin="normal" />
+          <TextField {...params} label="openOnFocus" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -95,7 +99,7 @@ export default function Playground() {
         id="auto-highlight"
         autoHighlight
         renderInput={(params) => (
-          <TextField {...params} label="autoHighlight" margin="normal" />
+          <TextField {...params} label="autoHighlight" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -103,7 +107,7 @@ export default function Playground() {
         id="auto-select"
         autoSelect
         renderInput={(params) => (
-          <TextField {...params} label="autoSelect" margin="normal" />
+          <TextField {...params} label="autoSelect" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -111,7 +115,7 @@ export default function Playground() {
         id="disabled"
         disabled
         renderInput={(params) => (
-          <TextField {...params} label="disabled" margin="normal" />
+          <TextField {...params} label="disabled" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -119,7 +123,7 @@ export default function Playground() {
         id="disable-portal"
         disablePortal
         renderInput={(params) => (
-          <TextField {...params} label="disablePortal" margin="normal" />
+          <TextField {...params} label="disablePortal" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -127,7 +131,7 @@ export default function Playground() {
         id="blur-on-select"
         blurOnSelect
         renderInput={(params) => (
-          <TextField {...params} label="blurOnSelect" margin="normal" />
+          <TextField {...params} label="blurOnSelect" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -135,7 +139,7 @@ export default function Playground() {
         id="clear-on-blur"
         clearOnBlur
         renderInput={(params) => (
-          <TextField {...params} label="clearOnBlur" margin="normal" />
+          <TextField {...params} label="clearOnBlur" margin="normal" variant="standard" />
         )}
       />
       <Autocomplete
@@ -143,7 +147,7 @@ export default function Playground() {
         id="select-on-focus"
         selectOnFocus
         renderInput={(params) => (
-          <TextField {...params} label="selectOnFocus" margin="normal" />
+          <TextField {...params} label="selectOnFocus" margin="normal" variant="standard" />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/Sizes.js
+++ b/docs/src/pages/components/autocomplete/Sizes.js
@@ -57,12 +57,7 @@ export default function Sizes() {
         getOptionLabel={(option) => option.title}
         defaultValue={top100Films[13]}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="Size small"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="Size small" placeholder="Favorites" />
         )}
       />
       <Autocomplete
@@ -73,12 +68,7 @@ export default function Sizes() {
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="Size small"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="Size small" placeholder="Favorites" />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Sizes.tsx
+++ b/docs/src/pages/components/autocomplete/Sizes.tsx
@@ -59,12 +59,7 @@ export default function Sizes() {
         getOptionLabel={(option) => option.title}
         defaultValue={top100Films[13]}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="Size small"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="Size small" placeholder="Favorites" />
         )}
       />
       <Autocomplete
@@ -75,12 +70,7 @@ export default function Sizes() {
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="Size small"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="Size small" placeholder="Favorites" />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Tags.js
+++ b/docs/src/pages/components/autocomplete/Tags.js
@@ -42,7 +42,11 @@ export default function Tags() {
         defaultValue={[top100Films[13]]}
         filterSelectedOptions
         renderInput={(params) => (
-          <TextField {...params} label="filterSelectedOptions" placeholder="Favorites" />
+          <TextField
+            {...params}
+            label="filterSelectedOptions"
+            placeholder="Favorites"
+          />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Tags.js
+++ b/docs/src/pages/components/autocomplete/Tags.js
@@ -42,12 +42,7 @@ export default function Tags() {
         defaultValue={[top100Films[13]]}
         filterSelectedOptions
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="filterSelectedOptions"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="filterSelectedOptions" placeholder="Favorites" />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Tags.tsx
+++ b/docs/src/pages/components/autocomplete/Tags.tsx
@@ -44,7 +44,11 @@ export default function Tags() {
         defaultValue={[top100Films[13]]}
         filterSelectedOptions
         renderInput={(params) => (
-          <TextField {...params} label="filterSelectedOptions" placeholder="Favorites" />
+          <TextField
+            {...params}
+            label="filterSelectedOptions"
+            placeholder="Favorites"
+          />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Tags.tsx
+++ b/docs/src/pages/components/autocomplete/Tags.tsx
@@ -44,12 +44,7 @@ export default function Tags() {
         defaultValue={[top100Films[13]]}
         filterSelectedOptions
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="filterSelectedOptions"
-            placeholder="Favorites"
-          />
+          <TextField {...params} label="filterSelectedOptions" placeholder="Favorites" />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -141,7 +141,7 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => (
-        <TextField {...params} variant="outlined" label="10,000 options" />
+        <TextField {...params} label="10,000 options" />
       )}
       renderOption={(props, option) => (
         <li {...props}>

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -140,9 +140,7 @@ export default function Virtualize() {
       renderGroup={renderGroup}
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
-      renderInput={(params) => (
-        <TextField {...params} label="10,000 options" />
-      )}
+      renderInput={(params) => <TextField {...params} label="10,000 options" />}
       renderOption={(props, option) => (
         <li {...props}>
           <Typography noWrap>{option}</Typography>

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -141,9 +141,7 @@ export default function Virtualize() {
       renderGroup={renderGroup}
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
-      renderInput={(params) => (
-        <TextField {...params} label="10,000 options" />
-      )}
+      renderInput={(params) => <TextField {...params} label="10,000 options" />}
       renderOption={(props, option) => (
         <li {...props}>
           <Typography noWrap>{option}</Typography>

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -142,7 +142,7 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => (
-        <TextField {...params} variant="outlined" label="10,000 options" />
+        <TextField {...params} label="10,000 options" />
       )}
       renderOption={(props, option) => (
         <li {...props}>

--- a/docs/src/pages/components/date-picker/BasicDatePicker.js
+++ b/docs/src/pages/components/date-picker/BasicDatePicker.js
@@ -15,7 +15,7 @@ export default function BasicDatePicker() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/BasicDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/BasicDatePicker.tsx
@@ -15,7 +15,7 @@ export default function BasicDatePicker() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/CustomDay.js
+++ b/docs/src/pages/components/date-picker/CustomDay.js
@@ -70,7 +70,7 @@ export default function CustomDay() {
         value={selectedDate}
         onChange={handleDateChange}
         renderDay={renderWeekPickerDay}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
         inputFormat="'Week of' MMM d"
       />
     </LocalizaitonProvider>

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -72,7 +72,7 @@ export default function CustomDay() {
         value={selectedDate}
         onChange={handleDateChange}
         renderDay={renderWeekPickerDay as any}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
         inputFormat="'Week of' MMM d"
       />
     </LocalizaitonProvider>

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.js
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.js
@@ -42,7 +42,9 @@ export default function LocalizedDatePicker() {
           mask={maskMap[locale]}
           value={selectedDate}
           onChange={(date) => handleDateChange(date)}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <ToggleButtonGroup value={locale} exclusive>
           {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.js
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.js
@@ -42,7 +42,7 @@ export default function LocalizedDatePicker() {
           mask={maskMap[locale]}
           value={selectedDate}
           onChange={(date) => handleDateChange(date)}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <ToggleButtonGroup value={locale} exclusive>
           {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
@@ -44,7 +44,7 @@ export default function LocalizedDatePicker() {
           mask={maskMap[locale]}
           value={selectedDate}
           onChange={(date) => handleDateChange(date)}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <ToggleButtonGroup value={locale} exclusive>
           {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
@@ -44,7 +44,9 @@ export default function LocalizedDatePicker() {
           mask={maskMap[locale]}
           value={selectedDate}
           onChange={(date) => handleDateChange(date)}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <ToggleButtonGroup value={locale} exclusive>
           {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
@@ -18,7 +18,9 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DesktopDatePicker
           label="For desktop"
@@ -27,7 +29,9 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DatePicker
           disableFuture
@@ -38,7 +42,9 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
@@ -18,7 +18,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DesktopDatePicker
           label="For desktop"
@@ -27,7 +27,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DatePicker
           disableFuture
@@ -38,7 +38,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
@@ -18,7 +18,9 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DesktopDatePicker
           label="For desktop"
@@ -27,7 +29,9 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DatePicker
           disableFuture
@@ -38,7 +42,9 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
@@ -18,7 +18,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DesktopDatePicker
           label="For desktop"
@@ -27,7 +27,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DatePicker
           disableFuture
@@ -38,7 +38,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/ServerRequestDatePicker.js
+++ b/docs/src/pages/components/date-picker/ServerRequestDatePicker.js
@@ -83,7 +83,7 @@ export default function ServerRequestDatePicker() {
           setValue(newValue);
         }}
         onMonthChange={handleMonthChange}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
         renderLoading={() => <PickersCalendarSkeleton />}
         renderDay={(day, _value, DayComponentProps) => {
           const isSelected =

--- a/docs/src/pages/components/date-picker/ServerRequestDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/ServerRequestDatePicker.tsx
@@ -83,7 +83,7 @@ export default function ServerRequestDatePicker() {
           setValue(newValue);
         }}
         onMonthChange={handleMonthChange}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
         renderLoading={() => <PickersCalendarSkeleton />}
         renderDay={(day, _value, DayComponentProps) => {
           const isSelected =

--- a/docs/src/pages/components/date-picker/StaticDatePickerDemo.js
+++ b/docs/src/pages/components/date-picker/StaticDatePickerDemo.js
@@ -16,7 +16,7 @@ export default function StaticDatePickerDemo() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizaitonProvider>
   );

--- a/docs/src/pages/components/date-picker/StaticDatePickerDemo.tsx
+++ b/docs/src/pages/components/date-picker/StaticDatePickerDemo.tsx
@@ -16,7 +16,7 @@ export default function StaticDatePickerDemo() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizaitonProvider>
   );

--- a/docs/src/pages/components/date-picker/StaticDatePickerLandscape.js
+++ b/docs/src/pages/components/date-picker/StaticDatePickerLandscape.js
@@ -18,7 +18,7 @@ export default function StaticDatePickerLandscape() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizaitonProvider>
   );

--- a/docs/src/pages/components/date-picker/StaticDatePickerLandscape.tsx
+++ b/docs/src/pages/components/date-picker/StaticDatePickerLandscape.tsx
@@ -18,7 +18,7 @@ export default function StaticDatePickerLandscape() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizaitonProvider>
   );

--- a/docs/src/pages/components/date-picker/ViewsDatePicker.js
+++ b/docs/src/pages/components/date-picker/ViewsDatePicker.js
@@ -18,7 +18,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -31,7 +31,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -43,7 +43,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -54,7 +54,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -65,7 +65,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-picker/ViewsDatePicker.js
+++ b/docs/src/pages/components/date-picker/ViewsDatePicker.js
@@ -18,7 +18,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -31,7 +36,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -43,7 +53,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -54,7 +69,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -65,7 +85,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-picker/ViewsDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/ViewsDatePicker.tsx
@@ -18,7 +18,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -31,7 +31,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -43,7 +43,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -54,7 +54,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
         <DatePicker
@@ -65,7 +65,7 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} />
+            <TextField {...params} margin="normal" helperText={null} variant="standard" />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-picker/ViewsDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/ViewsDatePicker.tsx
@@ -18,7 +18,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -31,7 +36,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -43,7 +53,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -54,7 +69,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
         <DatePicker
@@ -65,7 +85,12 @@ export default function ViewsDatePicker() {
             setValue(newValue);
           }}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText={null} variant="standard" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText={null}
+              variant="standard"
+            />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-range-picker/BasicDateRangePicker.js
+++ b/docs/src/pages/components/date-range-picker/BasicDateRangePicker.js
@@ -19,9 +19,9 @@ export default function BasicDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/BasicDateRangePicker.tsx
+++ b/docs/src/pages/components/date-range-picker/BasicDateRangePicker.tsx
@@ -19,9 +19,9 @@ export default function BasicDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/CalendarsDateRangePicker.js
+++ b/docs/src/pages/components/date-range-picker/CalendarsDateRangePicker.js
@@ -22,9 +22,9 @@ export default function CalendarsDateRangePicker() {
           }}
           renderInput={(startProps, endProps) => (
             <React.Fragment>
-              <TextField {...startProps} />
+              <TextField {...startProps} variant="standard" />
               <DateRangeDelimiter> to </DateRangeDelimiter>
-              <TextField {...endProps} />
+              <TextField {...endProps} variant="standard" />
             </React.Fragment>
           )}
         />
@@ -37,9 +37,9 @@ export default function CalendarsDateRangePicker() {
           }}
           renderInput={(startProps, endProps) => (
             <React.Fragment>
-              <TextField {...startProps} />
+              <TextField {...startProps} variant="standard" />
               <DateRangeDelimiter> to </DateRangeDelimiter>
-              <TextField {...endProps} />
+              <TextField {...endProps} variant="standard" />
             </React.Fragment>
           )}
         />
@@ -52,9 +52,9 @@ export default function CalendarsDateRangePicker() {
           }}
           renderInput={(startProps, endProps) => (
             <React.Fragment>
-              <TextField {...startProps} />
+              <TextField {...startProps} variant="standard" />
               <DateRangeDelimiter> to </DateRangeDelimiter>
-              <TextField {...endProps} />
+              <TextField {...endProps} variant="standard" />
             </React.Fragment>
           )}
         />

--- a/docs/src/pages/components/date-range-picker/CalendarsDateRangePicker.tsx
+++ b/docs/src/pages/components/date-range-picker/CalendarsDateRangePicker.tsx
@@ -22,9 +22,9 @@ export default function CalendarsDateRangePicker() {
           }}
           renderInput={(startProps, endProps) => (
             <React.Fragment>
-              <TextField {...startProps} />
+              <TextField {...startProps} variant="standard" />
               <DateRangeDelimiter> to </DateRangeDelimiter>
-              <TextField {...endProps} />
+              <TextField {...endProps} variant="standard" />
             </React.Fragment>
           )}
         />
@@ -37,9 +37,9 @@ export default function CalendarsDateRangePicker() {
           }}
           renderInput={(startProps, endProps) => (
             <React.Fragment>
-              <TextField {...startProps} />
+              <TextField {...startProps} variant="standard" />
               <DateRangeDelimiter> to </DateRangeDelimiter>
-              <TextField {...endProps} />
+              <TextField {...endProps} variant="standard" />
             </React.Fragment>
           )}
         />
@@ -52,9 +52,9 @@ export default function CalendarsDateRangePicker() {
           }}
           renderInput={(startProps, endProps) => (
             <React.Fragment>
-              <TextField {...startProps} />
+              <TextField {...startProps} variant="standard" />
               <DateRangeDelimiter> to </DateRangeDelimiter>
-              <TextField {...endProps} />
+              <TextField {...endProps} variant="standard" />
             </React.Fragment>
           )}
         />

--- a/docs/src/pages/components/date-range-picker/MinMaxDateRangePicker.js
+++ b/docs/src/pages/components/date-range-picker/MinMaxDateRangePicker.js
@@ -24,9 +24,9 @@ export default function MinMaxDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/MinMaxDateRangePicker.tsx
+++ b/docs/src/pages/components/date-range-picker/MinMaxDateRangePicker.tsx
@@ -24,9 +24,9 @@ export default function MinMaxDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/ResponsiveDateRangePicker.js
+++ b/docs/src/pages/components/date-range-picker/ResponsiveDateRangePicker.js
@@ -19,9 +19,9 @@ export default function ResponsiveDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />
@@ -33,9 +33,9 @@ export default function ResponsiveDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/ResponsiveDateRangePicker.tsx
+++ b/docs/src/pages/components/date-range-picker/ResponsiveDateRangePicker.tsx
@@ -21,9 +21,9 @@ export default function ResponsiveDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />
@@ -35,9 +35,9 @@ export default function ResponsiveDateRangePicker() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/StaticDateRangePicker.js
+++ b/docs/src/pages/components/date-range-picker/StaticDateRangePicker.js
@@ -18,9 +18,9 @@ export default function StaticDateRangePickerExample() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-range-picker/StaticDateRangePicker.tsx
+++ b/docs/src/pages/components/date-range-picker/StaticDateRangePicker.tsx
@@ -20,9 +20,9 @@ export default function StaticDateRangePickerExample() {
         }}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
-            <TextField {...startProps} />
+            <TextField {...startProps} variant="standard" />
             <DateRangeDelimiter> to </DateRangeDelimiter>
-            <TextField {...endProps} />
+            <TextField {...endProps} variant="standard" />
           </React.Fragment>
         )}
       />

--- a/docs/src/pages/components/date-time-picker/BasicDateTimePicker.js
+++ b/docs/src/pages/components/date-time-picker/BasicDateTimePicker.js
@@ -10,7 +10,7 @@ export default function BasicDateTimePicker() {
   return (
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <DateTimePicker
-        renderInput={(props) => <TextField variant="outlined" {...props} />}
+        renderInput={(props) => <TextField {...props} />}
         label="DateTimePicker"
         value={selectedDate}
         onChange={handleDateChange}

--- a/docs/src/pages/components/date-time-picker/BasicDateTimePicker.tsx
+++ b/docs/src/pages/components/date-time-picker/BasicDateTimePicker.tsx
@@ -12,7 +12,7 @@ export default function BasicDateTimePicker() {
   return (
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <DateTimePicker
-        renderInput={(props) => <TextField variant="outlined" {...props} />}
+        renderInput={(props) => <TextField {...props} />}
         label="DateTimePicker"
         value={selectedDate}
         onChange={handleDateChange}

--- a/docs/src/pages/components/date-time-picker/CustomDateTimePicker.js
+++ b/docs/src/pages/components/date-time-picker/CustomDateTimePicker.js
@@ -34,7 +34,11 @@ export default function CustomDateTimePicker() {
           minTime={new Date(0, 0, 0, 9)}
           maxTime={new Date(0, 0, 0, 20)}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText="Hardcoded helper text" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText="Hardcoded helper text"
+            />
           )}
         />
         <MobileDateTimePicker
@@ -47,9 +51,7 @@ export default function CustomDateTimePicker() {
           minDate={new Date('2018-01-01T00:00')}
           inputFormat="yyyy/MM/dd hh:mm a"
           mask="___/__/__ __:__ _M"
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DateTimePicker
           clearable
@@ -60,7 +62,8 @@ export default function CustomDateTimePicker() {
               {...params}
               margin="normal"
               helperText="Clear Initial State"
-              variant="standard" />
+              variant="standard"
+            />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-time-picker/CustomDateTimePicker.js
+++ b/docs/src/pages/components/date-time-picker/CustomDateTimePicker.js
@@ -34,12 +34,7 @@ export default function CustomDateTimePicker() {
           minTime={new Date(0, 0, 0, 9)}
           maxTime={new Date(0, 0, 0, 20)}
           renderInput={(params) => (
-            <TextField
-              {...params}
-              margin="normal"
-              variant="outlined"
-              helperText="Hardcoded helper text"
-            />
+            <TextField {...params} margin="normal" helperText="Hardcoded helper text" />
           )}
         />
         <MobileDateTimePicker
@@ -53,7 +48,7 @@ export default function CustomDateTimePicker() {
           inputFormat="yyyy/MM/dd hh:mm a"
           mask="___/__/__ __:__ _M"
           renderInput={(params) => (
-            <TextField variant="outlined" {...params} margin="normal" />
+            <TextField {...params} margin="normal" />
           )}
         />
         <DateTimePicker
@@ -65,7 +60,7 @@ export default function CustomDateTimePicker() {
               {...params}
               margin="normal"
               helperText="Clear Initial State"
-            />
+              variant="standard" />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-time-picker/CustomDateTimePicker.tsx
+++ b/docs/src/pages/components/date-time-picker/CustomDateTimePicker.tsx
@@ -36,12 +36,7 @@ export default function CustomDateTimePicker() {
           minTime={new Date(0, 0, 0, 9)}
           maxTime={new Date(0, 0, 0, 20)}
           renderInput={(params) => (
-            <TextField
-              {...params}
-              margin="normal"
-              variant="outlined"
-              helperText="Hardcoded helper text"
-            />
+            <TextField {...params} margin="normal" helperText="Hardcoded helper text" />
           )}
         />
         <MobileDateTimePicker
@@ -55,7 +50,7 @@ export default function CustomDateTimePicker() {
           inputFormat="yyyy/MM/dd hh:mm a"
           mask="___/__/__ __:__ _M"
           renderInput={(params) => (
-            <TextField variant="outlined" {...params} margin="normal" />
+            <TextField {...params} margin="normal" />
           )}
         />
         <DateTimePicker
@@ -67,7 +62,7 @@ export default function CustomDateTimePicker() {
               {...params}
               margin="normal"
               helperText="Clear Initial State"
-            />
+              variant="standard" />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-time-picker/CustomDateTimePicker.tsx
+++ b/docs/src/pages/components/date-time-picker/CustomDateTimePicker.tsx
@@ -36,7 +36,11 @@ export default function CustomDateTimePicker() {
           minTime={new Date(0, 0, 0, 9)}
           maxTime={new Date(0, 0, 0, 20)}
           renderInput={(params) => (
-            <TextField {...params} margin="normal" helperText="Hardcoded helper text" />
+            <TextField
+              {...params}
+              margin="normal"
+              helperText="Hardcoded helper text"
+            />
           )}
         />
         <MobileDateTimePicker
@@ -49,9 +53,7 @@ export default function CustomDateTimePicker() {
           minDate={new Date('2018-01-01T00:00')}
           inputFormat="yyyy/MM/dd hh:mm a"
           mask="___/__/__ __:__ _M"
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DateTimePicker
           clearable
@@ -62,7 +64,8 @@ export default function CustomDateTimePicker() {
               {...params}
               margin="normal"
               helperText="Clear Initial State"
-              variant="standard" />
+              variant="standard"
+            />
           )}
         />
       </div>

--- a/docs/src/pages/components/date-time-picker/DateTimeValidation.js
+++ b/docs/src/pages/components/date-time-picker/DateTimeValidation.js
@@ -11,7 +11,9 @@ export default function DateTimeValidation() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           label="Ignore date and time"
           value={value}
           onChange={(newValue) => {
@@ -20,7 +22,9 @@ export default function DateTimeValidation() {
           minDateTime={new Date()}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           label="Ignore time in each day"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/date-time-picker/DateTimeValidation.js
+++ b/docs/src/pages/components/date-time-picker/DateTimeValidation.js
@@ -11,7 +11,7 @@ export default function DateTimeValidation() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           label="Ignore date and time"
           value={value}
           onChange={(newValue) => {
@@ -20,7 +20,7 @@ export default function DateTimeValidation() {
           minDateTime={new Date()}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           label="Ignore time in each day"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/date-time-picker/DateTimeValidation.tsx
+++ b/docs/src/pages/components/date-time-picker/DateTimeValidation.tsx
@@ -11,7 +11,9 @@ export default function DateTimeValidation() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           label="Ignore date and time"
           value={value}
           onChange={(newValue) => {
@@ -20,7 +22,9 @@ export default function DateTimeValidation() {
           minDateTime={new Date()}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           label="Ignore time in each day"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/date-time-picker/DateTimeValidation.tsx
+++ b/docs/src/pages/components/date-time-picker/DateTimeValidation.tsx
@@ -11,7 +11,7 @@ export default function DateTimeValidation() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           label="Ignore date and time"
           value={value}
           onChange={(newValue) => {
@@ -20,7 +20,7 @@ export default function DateTimeValidation() {
           minDateTime={new Date()}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           label="Ignore time in each day"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.js
+++ b/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.js
@@ -19,17 +19,17 @@ export default function ResponsiveDateTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DesktopDateTimePicker
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);

--- a/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.js
+++ b/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.js
@@ -19,17 +19,23 @@ export default function ResponsiveDateTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DesktopDateTimePicker
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);

--- a/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.tsx
+++ b/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.tsx
@@ -19,17 +19,17 @@ export default function ResponsiveDateTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DesktopDateTimePicker
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);

--- a/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.tsx
+++ b/docs/src/pages/components/date-time-picker/ResponsiveDateTimePickers.tsx
@@ -19,17 +19,23 @@ export default function ResponsiveDateTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DesktopDateTimePicker
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DateTimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);

--- a/docs/src/pages/components/dialogs/FormDialog.js
+++ b/docs/src/pages/components/dialogs/FormDialog.js
@@ -41,7 +41,8 @@ export default function FormDialog() {
             label="Email Address"
             type="email"
             fullWidth
-            variant="standard" />
+            variant="standard"
+          />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/dialogs/FormDialog.js
+++ b/docs/src/pages/components/dialogs/FormDialog.js
@@ -41,7 +41,7 @@ export default function FormDialog() {
             label="Email Address"
             type="email"
             fullWidth
-          />
+            variant="standard" />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/dialogs/FormDialog.tsx
+++ b/docs/src/pages/components/dialogs/FormDialog.tsx
@@ -41,7 +41,8 @@ export default function FormDialog() {
             label="Email Address"
             type="email"
             fullWidth
-            variant="standard" />
+            variant="standard"
+          />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/dialogs/FormDialog.tsx
+++ b/docs/src/pages/components/dialogs/FormDialog.tsx
@@ -41,7 +41,7 @@ export default function FormDialog() {
             label="Email Address"
             type="email"
             fullWidth
-          />
+            variant="standard" />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>

--- a/docs/src/pages/components/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.js
@@ -28,7 +28,7 @@ export default function DateAndTimePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-      />
+        variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.js
@@ -28,7 +28,8 @@ export default function DateAndTimePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DateAndTimePickers.tsx
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.tsx
@@ -30,7 +30,8 @@ export default function DateAndTimePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DateAndTimePickers.tsx
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.tsx
@@ -30,7 +30,7 @@ export default function DateAndTimePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-      />
+        variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DatePickers.js
+++ b/docs/src/pages/components/pickers/DatePickers.js
@@ -28,7 +28,7 @@ export default function DatePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-      />
+        variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DatePickers.js
+++ b/docs/src/pages/components/pickers/DatePickers.js
@@ -28,7 +28,8 @@ export default function DatePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DatePickers.tsx
+++ b/docs/src/pages/components/pickers/DatePickers.tsx
@@ -30,7 +30,7 @@ export default function DatePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-      />
+        variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/DatePickers.tsx
+++ b/docs/src/pages/components/pickers/DatePickers.tsx
@@ -30,7 +30,8 @@ export default function DatePickers() {
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/MaterialUIPickers.js
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.js
@@ -25,7 +25,12 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-desktop" margin="normal" {...params} variant="standard" />
+            <TextField
+              id="date-picker-desktop"
+              margin="normal"
+              {...params}
+              variant="standard"
+            />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -37,7 +42,12 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-mobile" margin="normal" {...params} variant="standard" />
+            <TextField
+              id="date-picker-mobile"
+              margin="normal"
+              {...params}
+              variant="standard"
+            />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -47,7 +57,9 @@ export default function MaterialUIPickers() {
           label="Time picker"
           value={selectedDate}
           onChange={handleDateChange}
-          renderInput={(params) => <TextField margin="normal" {...params} variant="standard" />}
+          renderInput={(params) => (
+            <TextField margin="normal" {...params} variant="standard" />
+          )}
           OpenPickerButtonProps={{
             'aria-label': 'change time',
           }}

--- a/docs/src/pages/components/pickers/MaterialUIPickers.js
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.js
@@ -25,7 +25,7 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-desktop" margin="normal" {...params} />
+            <TextField id="date-picker-desktop" margin="normal" {...params} variant="standard" />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -37,7 +37,7 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-mobile" margin="normal" {...params} />
+            <TextField id="date-picker-mobile" margin="normal" {...params} variant="standard" />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -47,7 +47,7 @@ export default function MaterialUIPickers() {
           label="Time picker"
           value={selectedDate}
           onChange={handleDateChange}
-          renderInput={(params) => <TextField margin="normal" {...params} />}
+          renderInput={(params) => <TextField margin="normal" {...params} variant="standard" />}
           OpenPickerButtonProps={{
             'aria-label': 'change time',
           }}

--- a/docs/src/pages/components/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.tsx
@@ -25,7 +25,12 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-desktop" margin="normal" {...params} variant="standard" />
+            <TextField
+              id="date-picker-desktop"
+              margin="normal"
+              {...params}
+              variant="standard"
+            />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -37,7 +42,12 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-mobile" margin="normal" {...params} variant="standard" />
+            <TextField
+              id="date-picker-mobile"
+              margin="normal"
+              {...params}
+              variant="standard"
+            />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -47,7 +57,9 @@ export default function MaterialUIPickers() {
           label="Time picker"
           value={selectedDate}
           onChange={handleDateChange}
-          renderInput={(params) => <TextField margin="normal" {...params} variant="standard" />}
+          renderInput={(params) => (
+            <TextField margin="normal" {...params} variant="standard" />
+          )}
           OpenPickerButtonProps={{
             'aria-label': 'change time',
           }}

--- a/docs/src/pages/components/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.tsx
@@ -25,7 +25,7 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-desktop" margin="normal" {...params} />
+            <TextField id="date-picker-desktop" margin="normal" {...params} variant="standard" />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -37,7 +37,7 @@ export default function MaterialUIPickers() {
           value={selectedDate}
           onChange={handleDateChange}
           renderInput={(params) => (
-            <TextField id="date-picker-mobile" margin="normal" {...params} />
+            <TextField id="date-picker-mobile" margin="normal" {...params} variant="standard" />
           )}
           OpenPickerButtonProps={{
             'aria-label': 'change date',
@@ -47,7 +47,7 @@ export default function MaterialUIPickers() {
           label="Time picker"
           value={selectedDate}
           onChange={handleDateChange}
-          renderInput={(params) => <TextField margin="normal" {...params} />}
+          renderInput={(params) => <TextField margin="normal" {...params} variant="standard" />}
           OpenPickerButtonProps={{
             'aria-label': 'change time',
           }}

--- a/docs/src/pages/components/pickers/TimePickers.js
+++ b/docs/src/pages/components/pickers/TimePickers.js
@@ -31,7 +31,7 @@ export default function TimePickers() {
         inputProps={{
           step: 300, // 5 min
         }}
-      />
+        variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/TimePickers.js
+++ b/docs/src/pages/components/pickers/TimePickers.js
@@ -31,7 +31,8 @@ export default function TimePickers() {
         inputProps={{
           step: 300, // 5 min
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/TimePickers.tsx
+++ b/docs/src/pages/components/pickers/TimePickers.tsx
@@ -33,7 +33,8 @@ export default function TimePickers() {
         inputProps={{
           step: 300, // 5 min
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/pickers/TimePickers.tsx
+++ b/docs/src/pages/components/pickers/TimePickers.tsx
@@ -33,7 +33,7 @@ export default function TimePickers() {
         inputProps={{
           step: 300, // 5 min
         }}
-      />
+        variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/popper/ScrollPlayground.js
+++ b/docs/src/pages/components/popper/ScrollPlayground.js
@@ -281,7 +281,8 @@ export default function ScrollPlayground() {
               onChange={(event) => {
                 setPlacement(event.target.value);
               }}
-              variant="standard">
+              variant="standard"
+            >
               <option value="top-start">top-start</option>
               <option value="top">top</option>
               <option value="top-end">top-end</option>
@@ -405,7 +406,8 @@ export default function ScrollPlayground() {
                     rootBoundary: event.target.value,
                   }));
                 }}
-                variant="standard">
+                variant="standard"
+              >
                 <option value="document">document</option>
                 <option value="viewport">viewport</option>
               </TextField>
@@ -465,7 +467,8 @@ export default function ScrollPlayground() {
                     rootBoundary: event.target.value,
                   }));
                 }}
-                variant="standard">
+                variant="standard"
+              >
                 <option value="document">document</option>
                 <option value="viewport">viewport</option>
               </TextField>

--- a/docs/src/pages/components/popper/ScrollPlayground.js
+++ b/docs/src/pages/components/popper/ScrollPlayground.js
@@ -281,7 +281,7 @@ export default function ScrollPlayground() {
               onChange={(event) => {
                 setPlacement(event.target.value);
               }}
-            >
+              variant="standard">
               <option value="top-start">top-start</option>
               <option value="top">top</option>
               <option value="top-end">top-end</option>
@@ -405,7 +405,7 @@ export default function ScrollPlayground() {
                     rootBoundary: event.target.value,
                   }));
                 }}
-              >
+                variant="standard">
                 <option value="document">document</option>
                 <option value="viewport">viewport</option>
               </TextField>
@@ -465,7 +465,7 @@ export default function ScrollPlayground() {
                     rootBoundary: event.target.value,
                   }));
                 }}
-              >
+                variant="standard">
                 <option value="document">document</option>
                 <option value="viewport">viewport</option>
               </TextField>

--- a/docs/src/pages/components/text-fields/BasicTextFields.js
+++ b/docs/src/pages/components/text-fields/BasicTextFields.js
@@ -16,9 +16,9 @@ export default function BasicTextFields() {
 
   return (
     <form className={classes.root} noValidate autoComplete="off">
-      <TextField id="standard-basic" label="Standard" />
+      <TextField id="standard-basic" label="Standard" variant="standard" />
       <TextField id="filled-basic" label="Filled" variant="filled" />
-      <TextField id="outlined-basic" label="Outlined" variant="outlined" />
+      <TextField id="outlined-basic" label="Outlined" />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/BasicTextFields.js
+++ b/docs/src/pages/components/text-fields/BasicTextFields.js
@@ -16,9 +16,9 @@ export default function BasicTextFields() {
 
   return (
     <form className={classes.root} noValidate autoComplete="off">
-      <TextField id="standard-basic" label="Standard" variant="standard" />
-      <TextField id="filled-basic" label="Filled" variant="filled" />
       <TextField id="outlined-basic" label="Outlined" />
+      <TextField id="filled-basic" label="Filled" variant="filled" />
+      <TextField id="standard-basic" label="Standard" variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/BasicTextFields.tsx
+++ b/docs/src/pages/components/text-fields/BasicTextFields.tsx
@@ -18,9 +18,9 @@ export default function BasicTextFields() {
 
   return (
     <form className={classes.root} noValidate autoComplete="off">
-      <TextField id="standard-basic" label="Standard" />
+      <TextField id="standard-basic" label="Standard" variant="standard" />
       <TextField id="filled-basic" label="Filled" variant="filled" />
-      <TextField id="outlined-basic" label="Outlined" variant="outlined" />
+      <TextField id="outlined-basic" label="Outlined" />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/BasicTextFields.tsx
+++ b/docs/src/pages/components/text-fields/BasicTextFields.tsx
@@ -18,9 +18,9 @@ export default function BasicTextFields() {
 
   return (
     <form className={classes.root} noValidate autoComplete="off">
-      <TextField id="standard-basic" label="Standard" variant="standard" />
-      <TextField id="filled-basic" label="Filled" variant="filled" />
       <TextField id="outlined-basic" label="Outlined" />
+      <TextField id="filled-basic" label="Filled" variant="filled" />
+      <TextField id="standard-basic" label="Standard" variant="standard" />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/ColorTextFields.js
+++ b/docs/src/pages/components/text-fields/ColorTextFields.js
@@ -20,14 +20,19 @@ export default function ColorTextFields() {
         id="standard-secondary"
         label="Standard secondary"
         color="secondary"
-        variant="standard" />
+        variant="standard"
+      />
       <TextField
         id="filled-secondary"
         label="Filled secondary"
         variant="filled"
         color="secondary"
       />
-      <TextField id="outlined-secondary" label="Outlined secondary" color="secondary" />
+      <TextField
+        id="outlined-secondary"
+        label="Outlined secondary"
+        color="secondary"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/ColorTextFields.js
+++ b/docs/src/pages/components/text-fields/ColorTextFields.js
@@ -17,10 +17,9 @@ export default function ColorTextFields() {
   return (
     <form className={classes.root} noValidate autoComplete="off">
       <TextField
-        id="standard-secondary"
-        label="Standard secondary"
+        id="outlined-secondary"
+        label="Outlined secondary"
         color="secondary"
-        variant="standard"
       />
       <TextField
         id="filled-secondary"
@@ -29,9 +28,10 @@ export default function ColorTextFields() {
         color="secondary"
       />
       <TextField
-        id="outlined-secondary"
-        label="Outlined secondary"
+        id="standard-secondary"
+        label="Standard secondary"
         color="secondary"
+        variant="standard"
       />
     </form>
   );

--- a/docs/src/pages/components/text-fields/ColorTextFields.js
+++ b/docs/src/pages/components/text-fields/ColorTextFields.js
@@ -20,19 +20,14 @@ export default function ColorTextFields() {
         id="standard-secondary"
         label="Standard secondary"
         color="secondary"
-      />
+        variant="standard" />
       <TextField
         id="filled-secondary"
         label="Filled secondary"
         variant="filled"
         color="secondary"
       />
-      <TextField
-        id="outlined-secondary"
-        label="Outlined secondary"
-        variant="outlined"
-        color="secondary"
-      />
+      <TextField id="outlined-secondary" label="Outlined secondary" color="secondary" />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/ColorTextFields.tsx
+++ b/docs/src/pages/components/text-fields/ColorTextFields.tsx
@@ -22,19 +22,14 @@ export default function ColorTextFields() {
         id="standard-secondary"
         label="Standard secondary"
         color="secondary"
-      />
+        variant="standard" />
       <TextField
         id="filled-secondary"
         label="Filled secondary"
         variant="filled"
         color="secondary"
       />
-      <TextField
-        id="outlined-secondary"
-        label="Outlined secondary"
-        variant="outlined"
-        color="secondary"
-      />
+      <TextField id="outlined-secondary" label="Outlined secondary" color="secondary" />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/ColorTextFields.tsx
+++ b/docs/src/pages/components/text-fields/ColorTextFields.tsx
@@ -19,10 +19,9 @@ export default function ColorTextFields() {
   return (
     <form className={classes.root} noValidate autoComplete="off">
       <TextField
-        id="standard-secondary"
-        label="Standard secondary"
+        id="outlined-secondary"
+        label="Outlined secondary"
         color="secondary"
-        variant="standard"
       />
       <TextField
         id="filled-secondary"
@@ -31,9 +30,10 @@ export default function ColorTextFields() {
         color="secondary"
       />
       <TextField
-        id="outlined-secondary"
-        label="Outlined secondary"
+        id="standard-secondary"
+        label="Standard secondary"
         color="secondary"
+        variant="standard"
       />
     </form>
   );

--- a/docs/src/pages/components/text-fields/ColorTextFields.tsx
+++ b/docs/src/pages/components/text-fields/ColorTextFields.tsx
@@ -22,14 +22,19 @@ export default function ColorTextFields() {
         id="standard-secondary"
         label="Standard secondary"
         color="secondary"
-        variant="standard" />
+        variant="standard"
+      />
       <TextField
         id="filled-secondary"
         label="Filled secondary"
         variant="filled"
         color="secondary"
       />
-      <TextField id="outlined-secondary" label="Outlined secondary" color="secondary" />
+      <TextField
+        id="outlined-secondary"
+        label="Outlined secondary"
+        color="secondary"
+      />
     </form>
   );
 }

--- a/docs/src/pages/components/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.js
@@ -104,7 +104,8 @@ function RedditTextField(props) {
     <TextField
       InputProps={{ classes, disableUnderline: true }}
       {...props}
-      variant="standard" />
+      variant="standard"
+    />
   );
 }
 
@@ -164,11 +165,13 @@ export default function CustomizedInputs() {
           className={classes.margin}
           label="ThemeProvider"
           id="mui-theme-provider-standard-input"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           className={classes.margin}
           label="ThemeProvider"
-          id="mui-theme-provider-outlined-input" />
+          id="mui-theme-provider-outlined-input"
+        />
       </ThemeProvider>
       <FormControl className={classes.margin}>
         <InputLabel shrink htmlFor="bootstrap-input">

--- a/docs/src/pages/components/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.js
@@ -101,10 +101,7 @@ function RedditTextField(props) {
   const classes = useStylesReddit();
 
   return (
-    <TextField
-      InputProps={{ classes, disableUnderline: true }}
-      {...props}
-    />
+    <TextField InputProps={{ classes, disableUnderline: true }} {...props} />
   );
 }
 
@@ -194,6 +191,7 @@ export default function CustomizedInputs() {
         className={classes.margin}
         label="CSS validation style"
         required
+        variant="outlined"
         defaultValue="Success"
         id="validation-outlined-input"
       />

--- a/docs/src/pages/components/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.js
@@ -101,7 +101,10 @@ function RedditTextField(props) {
   const classes = useStylesReddit();
 
   return (
-    <TextField InputProps={{ classes, disableUnderline: true }} {...props} />
+    <TextField
+      InputProps={{ classes, disableUnderline: true }}
+      {...props}
+      variant="standard" />
   );
 }
 
@@ -161,13 +164,11 @@ export default function CustomizedInputs() {
           className={classes.margin}
           label="ThemeProvider"
           id="mui-theme-provider-standard-input"
-        />
+          variant="standard" />
         <TextField
           className={classes.margin}
           label="ThemeProvider"
-          variant="outlined"
-          id="mui-theme-provider-outlined-input"
-        />
+          id="mui-theme-provider-outlined-input" />
       </ThemeProvider>
       <FormControl className={classes.margin}>
         <InputLabel shrink htmlFor="bootstrap-input">

--- a/docs/src/pages/components/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.js
@@ -104,7 +104,6 @@ function RedditTextField(props) {
     <TextField
       InputProps={{ classes, disableUnderline: true }}
       {...props}
-      variant="standard"
     />
   );
 }
@@ -153,11 +152,11 @@ export default function CustomizedInputs() {
         className={classes.margin}
         id="custom-css-standard-input"
         label="Custom CSS"
+        variant="standard"
       />
       <CssTextField
         className={classes.margin}
         label="Custom CSS"
-        variant="outlined"
         id="custom-css-outlined-input"
       />
       <ThemeProvider theme={newTheme}>
@@ -195,7 +194,6 @@ export default function CustomizedInputs() {
         className={classes.margin}
         label="CSS validation style"
         required
-        variant="outlined"
         defaultValue="Success"
         id="validation-outlined-input"
       />

--- a/docs/src/pages/components/text-fields/CustomizedInputs.tsx
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.tsx
@@ -113,7 +113,8 @@ function RedditTextField(props: TextFieldProps) {
         { classes, disableUnderline: true } as Partial<OutlinedInputProps>
       }
       {...props}
-      variant="standard" />
+      variant="standard"
+    />
   );
 }
 
@@ -175,11 +176,13 @@ export default function CustomizedInputs() {
           className={classes.margin}
           label="ThemeProvider"
           id="mui-theme-provider-standard-input"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           className={classes.margin}
           label="ThemeProvider"
-          id="mui-theme-provider-outlined-input" />
+          id="mui-theme-provider-outlined-input"
+        />
       </ThemeProvider>
       <FormControl className={classes.margin}>
         <InputLabel shrink htmlFor="bootstrap-input">

--- a/docs/src/pages/components/text-fields/CustomizedInputs.tsx
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.tsx
@@ -113,7 +113,6 @@ function RedditTextField(props: TextFieldProps) {
         { classes, disableUnderline: true } as Partial<OutlinedInputProps>
       }
       {...props}
-      variant="standard"
     />
   );
 }
@@ -164,11 +163,11 @@ export default function CustomizedInputs() {
         className={classes.margin}
         id="custom-css-standard-input"
         label="Custom CSS"
+        variant="standard"
       />
       <CssTextField
         className={classes.margin}
         label="Custom CSS"
-        variant="outlined"
         id="custom-css-outlined-input"
       />
       <ThemeProvider theme={newTheme}>

--- a/docs/src/pages/components/text-fields/CustomizedInputs.tsx
+++ b/docs/src/pages/components/text-fields/CustomizedInputs.tsx
@@ -113,7 +113,7 @@ function RedditTextField(props: TextFieldProps) {
         { classes, disableUnderline: true } as Partial<OutlinedInputProps>
       }
       {...props}
-    />
+      variant="standard" />
   );
 }
 
@@ -175,13 +175,11 @@ export default function CustomizedInputs() {
           className={classes.margin}
           label="ThemeProvider"
           id="mui-theme-provider-standard-input"
-        />
+          variant="standard" />
         <TextField
           className={classes.margin}
           label="ThemeProvider"
-          variant="outlined"
-          id="mui-theme-provider-outlined-input"
-        />
+          id="mui-theme-provider-outlined-input" />
       </ThemeProvider>
       <FormControl className={classes.margin}>
         <InputLabel shrink htmlFor="bootstrap-input">

--- a/docs/src/pages/components/text-fields/FormPropsTextFields.js
+++ b/docs/src/pages/components/text-fields/FormPropsTextFields.js
@@ -19,55 +19,44 @@ export default function FormPropsTextFields() {
       <div>
         <TextField
           required
-          id="standard-required"
+          id="outlined-required"
           label="Required"
           defaultValue="Hello World"
-          variant="standard"
         />
         <TextField
           disabled
-          id="standard-disabled"
+          id="outlined-disabled"
           label="Disabled"
           defaultValue="Hello World"
-          variant="standard"
         />
         <TextField
-          id="standard-password-input"
+          id="outlined-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
-          variant="standard"
         />
         <TextField
-          id="standard-read-only-input"
+          id="outlined-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
           }}
-          variant="standard"
         />
         <TextField
-          id="standard-number"
+          id="outlined-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard"
         />
+        <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
-          id="standard-search"
-          label="Search field"
-          type="search"
-          variant="standard"
-        />
-        <TextField
-          id="standard-helperText"
+          id="outlined-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
-          variant="standard"
         />
       </div>
       <div>
@@ -127,44 +116,55 @@ export default function FormPropsTextFields() {
       <div>
         <TextField
           required
-          id="outlined-required"
+          id="standard-required"
           label="Required"
           defaultValue="Hello World"
+          variant="standard"
         />
         <TextField
           disabled
-          id="outlined-disabled"
+          id="standard-disabled"
           label="Disabled"
           defaultValue="Hello World"
+          variant="standard"
         />
         <TextField
-          id="outlined-password-input"
+          id="standard-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
+          variant="standard"
         />
         <TextField
-          id="outlined-read-only-input"
+          id="standard-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
           }}
+          variant="standard"
         />
         <TextField
-          id="outlined-number"
+          id="standard-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
           }}
+          variant="standard"
         />
-        <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
-          id="outlined-helperText"
+          id="standard-search"
+          label="Search field"
+          type="search"
+          variant="standard"
+        />
+        <TextField
+          id="standard-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/FormPropsTextFields.js
+++ b/docs/src/pages/components/text-fields/FormPropsTextFields.js
@@ -22,19 +22,19 @@ export default function FormPropsTextFields() {
           id="standard-required"
           label="Required"
           defaultValue="Hello World"
-        />
+          variant="standard" />
         <TextField
           disabled
           id="standard-disabled"
           label="Disabled"
           defaultValue="Hello World"
-        />
+          variant="standard" />
         <TextField
           id="standard-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
-        />
+          variant="standard" />
         <TextField
           id="standard-read-only-input"
           label="Read Only"
@@ -42,7 +42,7 @@ export default function FormPropsTextFields() {
           InputProps={{
             readOnly: true,
           }}
-        />
+          variant="standard" />
         <TextField
           id="standard-number"
           label="Number"
@@ -50,14 +50,18 @@ export default function FormPropsTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-        />
-        <TextField id="standard-search" label="Search field" type="search" />
+          variant="standard" />
+        <TextField
+          id="standard-search"
+          label="Search field"
+          type="search"
+          variant="standard" />
         <TextField
           id="standard-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -118,54 +122,37 @@ export default function FormPropsTextFields() {
           required
           id="outlined-required"
           label="Required"
-          defaultValue="Hello World"
-          variant="outlined"
-        />
+          defaultValue="Hello World" />
         <TextField
           disabled
           id="outlined-disabled"
           label="Disabled"
-          defaultValue="Hello World"
-          variant="outlined"
-        />
+          defaultValue="Hello World" />
         <TextField
           id="outlined-password-input"
           label="Password"
           type="password"
-          autoComplete="current-password"
-          variant="outlined"
-        />
+          autoComplete="current-password" />
         <TextField
           id="outlined-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
-          }}
-          variant="outlined"
-        />
+          }} />
         <TextField
           id="outlined-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
-          }}
-          variant="outlined"
-        />
-        <TextField
-          id="outlined-search"
-          label="Search field"
-          type="search"
-          variant="outlined"
-        />
+          }} />
+        <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
           id="outlined-helperText"
           label="Helper text"
           defaultValue="Default Value"
-          helperText="Some important text"
-          variant="outlined"
-        />
+          helperText="Some important text" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/FormPropsTextFields.js
+++ b/docs/src/pages/components/text-fields/FormPropsTextFields.js
@@ -22,19 +22,22 @@ export default function FormPropsTextFields() {
           id="standard-required"
           label="Required"
           defaultValue="Hello World"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           disabled
           id="standard-disabled"
           label="Disabled"
           defaultValue="Hello World"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-read-only-input"
           label="Read Only"
@@ -42,7 +45,8 @@ export default function FormPropsTextFields() {
           InputProps={{
             readOnly: true,
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-number"
           label="Number"
@@ -50,18 +54,21 @@ export default function FormPropsTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-search"
           label="Search field"
           type="search"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -122,37 +129,43 @@ export default function FormPropsTextFields() {
           required
           id="outlined-required"
           label="Required"
-          defaultValue="Hello World" />
+          defaultValue="Hello World"
+        />
         <TextField
           disabled
           id="outlined-disabled"
           label="Disabled"
-          defaultValue="Hello World" />
+          defaultValue="Hello World"
+        />
         <TextField
           id="outlined-password-input"
           label="Password"
           type="password"
-          autoComplete="current-password" />
+          autoComplete="current-password"
+        />
         <TextField
           id="outlined-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
-          }} />
+          }}
+        />
         <TextField
           id="outlined-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
-          }} />
+          }}
+        />
         <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
           id="outlined-helperText"
           label="Helper text"
           defaultValue="Default Value"
-          helperText="Some important text" />
+          helperText="Some important text"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/FormPropsTextFields.tsx
+++ b/docs/src/pages/components/text-fields/FormPropsTextFields.tsx
@@ -21,55 +21,44 @@ export default function FormPropsTextFields() {
       <div>
         <TextField
           required
-          id="standard-required"
+          id="outlined-required"
           label="Required"
           defaultValue="Hello World"
-          variant="standard"
         />
         <TextField
           disabled
-          id="standard-disabled"
+          id="outlined-disabled"
           label="Disabled"
           defaultValue="Hello World"
-          variant="standard"
         />
         <TextField
-          id="standard-password-input"
+          id="outlined-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
-          variant="standard"
         />
         <TextField
-          id="standard-read-only-input"
+          id="outlined-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
           }}
-          variant="standard"
         />
         <TextField
-          id="standard-number"
+          id="outlined-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard"
         />
+        <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
-          id="standard-search"
-          label="Search field"
-          type="search"
-          variant="standard"
-        />
-        <TextField
-          id="standard-helperText"
+          id="outlined-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
-          variant="standard"
         />
       </div>
       <div>
@@ -129,44 +118,55 @@ export default function FormPropsTextFields() {
       <div>
         <TextField
           required
-          id="outlined-required"
+          id="standard-required"
           label="Required"
           defaultValue="Hello World"
+          variant="standard"
         />
         <TextField
           disabled
-          id="outlined-disabled"
+          id="standard-disabled"
           label="Disabled"
           defaultValue="Hello World"
+          variant="standard"
         />
         <TextField
-          id="outlined-password-input"
+          id="standard-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
+          variant="standard"
         />
         <TextField
-          id="outlined-read-only-input"
+          id="standard-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
           }}
+          variant="standard"
         />
         <TextField
-          id="outlined-number"
+          id="standard-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
           }}
+          variant="standard"
         />
-        <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
-          id="outlined-helperText"
+          id="standard-search"
+          label="Search field"
+          type="search"
+          variant="standard"
+        />
+        <TextField
+          id="standard-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/FormPropsTextFields.tsx
+++ b/docs/src/pages/components/text-fields/FormPropsTextFields.tsx
@@ -24,19 +24,19 @@ export default function FormPropsTextFields() {
           id="standard-required"
           label="Required"
           defaultValue="Hello World"
-        />
+          variant="standard" />
         <TextField
           disabled
           id="standard-disabled"
           label="Disabled"
           defaultValue="Hello World"
-        />
+          variant="standard" />
         <TextField
           id="standard-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
-        />
+          variant="standard" />
         <TextField
           id="standard-read-only-input"
           label="Read Only"
@@ -44,7 +44,7 @@ export default function FormPropsTextFields() {
           InputProps={{
             readOnly: true,
           }}
-        />
+          variant="standard" />
         <TextField
           id="standard-number"
           label="Number"
@@ -52,14 +52,18 @@ export default function FormPropsTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-        />
-        <TextField id="standard-search" label="Search field" type="search" />
+          variant="standard" />
+        <TextField
+          id="standard-search"
+          label="Search field"
+          type="search"
+          variant="standard" />
         <TextField
           id="standard-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -120,54 +124,37 @@ export default function FormPropsTextFields() {
           required
           id="outlined-required"
           label="Required"
-          defaultValue="Hello World"
-          variant="outlined"
-        />
+          defaultValue="Hello World" />
         <TextField
           disabled
           id="outlined-disabled"
           label="Disabled"
-          defaultValue="Hello World"
-          variant="outlined"
-        />
+          defaultValue="Hello World" />
         <TextField
           id="outlined-password-input"
           label="Password"
           type="password"
-          autoComplete="current-password"
-          variant="outlined"
-        />
+          autoComplete="current-password" />
         <TextField
           id="outlined-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
-          }}
-          variant="outlined"
-        />
+          }} />
         <TextField
           id="outlined-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
-          }}
-          variant="outlined"
-        />
-        <TextField
-          id="outlined-search"
-          label="Search field"
-          type="search"
-          variant="outlined"
-        />
+          }} />
+        <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
           id="outlined-helperText"
           label="Helper text"
           defaultValue="Default Value"
-          helperText="Some important text"
-          variant="outlined"
-        />
+          helperText="Some important text" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/FormPropsTextFields.tsx
+++ b/docs/src/pages/components/text-fields/FormPropsTextFields.tsx
@@ -24,19 +24,22 @@ export default function FormPropsTextFields() {
           id="standard-required"
           label="Required"
           defaultValue="Hello World"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           disabled
           id="standard-disabled"
           label="Disabled"
           defaultValue="Hello World"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-password-input"
           label="Password"
           type="password"
           autoComplete="current-password"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-read-only-input"
           label="Read Only"
@@ -44,7 +47,8 @@ export default function FormPropsTextFields() {
           InputProps={{
             readOnly: true,
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-number"
           label="Number"
@@ -52,18 +56,21 @@ export default function FormPropsTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-search"
           label="Search field"
           type="search"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-helperText"
           label="Helper text"
           defaultValue="Default Value"
           helperText="Some important text"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -124,37 +131,43 @@ export default function FormPropsTextFields() {
           required
           id="outlined-required"
           label="Required"
-          defaultValue="Hello World" />
+          defaultValue="Hello World"
+        />
         <TextField
           disabled
           id="outlined-disabled"
           label="Disabled"
-          defaultValue="Hello World" />
+          defaultValue="Hello World"
+        />
         <TextField
           id="outlined-password-input"
           label="Password"
           type="password"
-          autoComplete="current-password" />
+          autoComplete="current-password"
+        />
         <TextField
           id="outlined-read-only-input"
           label="Read Only"
           defaultValue="Hello World"
           InputProps={{
             readOnly: true,
-          }} />
+          }}
+        />
         <TextField
           id="outlined-number"
           label="Number"
           type="number"
           InputLabelProps={{
             shrink: true,
-          }} />
+          }}
+        />
         <TextField id="outlined-search" label="Search field" type="search" />
         <TextField
           id="outlined-helperText"
           label="Helper text"
           defaultValue="Default Value"
-          helperText="Some important text" />
+          helperText="Some important text"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -123,7 +123,8 @@ export default function FormattedInputs() {
         InputProps={{
           inputComponent: NumberFormatCustom,
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -123,7 +123,7 @@ export default function FormattedInputs() {
         InputProps={{
           inputComponent: NumberFormatCustom,
         }}
-      />
+        variant="standard" />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/FormattedInputs.tsx
+++ b/docs/src/pages/components/text-fields/FormattedInputs.tsx
@@ -132,7 +132,8 @@ export default function FormattedInputs() {
         InputProps={{
           inputComponent: NumberFormatCustom as any,
         }}
-        variant="standard" />
+        variant="standard"
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/FormattedInputs.tsx
+++ b/docs/src/pages/components/text-fields/FormattedInputs.tsx
@@ -132,7 +132,7 @@ export default function FormattedInputs() {
         InputProps={{
           inputComponent: NumberFormatCustom as any,
         }}
-      />
+        variant="standard" />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextAligned.js
+++ b/docs/src/pages/components/text-fields/HelperTextAligned.js
@@ -13,7 +13,11 @@ export default function HelperTextAligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField
+        helperText="Please enter your name"
+        label="Name"
+        variant="standard"
+      />
       <TextField helperText=" " label="Name" variant="standard" />
     </div>
   );

--- a/docs/src/pages/components/text-fields/HelperTextAligned.js
+++ b/docs/src/pages/components/text-fields/HelperTextAligned.js
@@ -13,8 +13,8 @@ export default function HelperTextAligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" />
-      <TextField helperText=" " label="Name" />
+      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField helperText=" " label="Name" variant="standard" />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextAligned.tsx
+++ b/docs/src/pages/components/text-fields/HelperTextAligned.tsx
@@ -13,7 +13,11 @@ export default function HelperTextAligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField
+        helperText="Please enter your name"
+        label="Name"
+        variant="standard"
+      />
       <TextField helperText=" " label="Name" variant="standard" />
     </div>
   );

--- a/docs/src/pages/components/text-fields/HelperTextAligned.tsx
+++ b/docs/src/pages/components/text-fields/HelperTextAligned.tsx
@@ -13,8 +13,8 @@ export default function HelperTextAligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" />
-      <TextField helperText=" " label="Name" />
+      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField helperText=" " label="Name" variant="standard" />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextMisaligned.js
+++ b/docs/src/pages/components/text-fields/HelperTextMisaligned.js
@@ -13,8 +13,8 @@ export default function HelperTextMisaligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" />
-      <TextField label="Name" />
+      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField label="Name" variant="standard" />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextMisaligned.js
+++ b/docs/src/pages/components/text-fields/HelperTextMisaligned.js
@@ -13,7 +13,11 @@ export default function HelperTextMisaligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField
+        helperText="Please enter your name"
+        label="Name"
+        variant="standard"
+      />
       <TextField label="Name" variant="standard" />
     </div>
   );

--- a/docs/src/pages/components/text-fields/HelperTextMisaligned.tsx
+++ b/docs/src/pages/components/text-fields/HelperTextMisaligned.tsx
@@ -13,8 +13,8 @@ export default function HelperTextMisaligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" />
-      <TextField label="Name" />
+      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField label="Name" variant="standard" />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextMisaligned.tsx
+++ b/docs/src/pages/components/text-fields/HelperTextMisaligned.tsx
@@ -13,7 +13,11 @@ export default function HelperTextMisaligned() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <TextField helperText="Please enter your name" label="Name" variant="standard" />
+      <TextField
+        helperText="Please enter your name"
+        label="Name"
+        variant="standard"
+      />
       <TextField label="Name" variant="standard" />
     </div>
   );

--- a/docs/src/pages/components/text-fields/InputAdornments.js
+++ b/docs/src/pages/components/text-fields/InputAdornments.js
@@ -59,42 +59,42 @@ export default function InputAdornments() {
       <div>
         <TextField
           label="With normal TextField"
-          id="standard-start-adornment"
+          id="outlined-start-adornment"
           className={clsx(classes.margin, classes.textField)}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
-          variant="standard"
         />
         <FormControl
-          className={clsx(
-            classes.margin,
-            classes.withoutLabel,
-            classes.textField,
-          )}
+          className={clsx(classes.margin, classes.textField)}
+          variant="outlined"
         >
-          <Input
-            id="standard-adornment-weight"
+          <OutlinedInput
+            id="outlined-adornment-weight"
             value={values.weight}
             onChange={handleChange('weight')}
             endAdornment={<InputAdornment position="end">Kg</InputAdornment>}
-            aria-describedby="standard-weight-helper-text"
+            aria-describedby="outlined-weight-helper-text"
             inputProps={{
               'aria-label': 'weight',
             }}
+            labelWidth={0}
           />
-          <FormHelperText id="standard-weight-helper-text">
+          <FormHelperText id="outlined-weight-helper-text">
             Weight
           </FormHelperText>
         </FormControl>
-        <FormControl className={clsx(classes.margin, classes.textField)}>
-          <InputLabel htmlFor="standard-adornment-password">
+        <FormControl
+          className={clsx(classes.margin, classes.textField)}
+          variant="outlined"
+        >
+          <InputLabel htmlFor="outlined-adornment-password">
             Password
           </InputLabel>
-          <Input
-            id="standard-adornment-password"
+          <OutlinedInput
+            id="outlined-adornment-password"
             type={values.showPassword ? 'text' : 'password'}
             value={values.password}
             onChange={handleChange('password')}
@@ -104,20 +104,23 @@ export default function InputAdornments() {
                   aria-label="toggle password visibility"
                   onClick={handleClickShowPassword}
                   onMouseDown={handleMouseDownPassword}
+                  edge="end"
                 >
                   {values.showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }
+            labelWidth={70}
           />
         </FormControl>
-        <FormControl fullWidth className={classes.margin}>
-          <InputLabel htmlFor="standard-adornment-amount">Amount</InputLabel>
-          <Input
-            id="standard-adornment-amount"
+        <FormControl fullWidth className={classes.margin} variant="outlined">
+          <InputLabel htmlFor="outlined-adornment-amount">Amount</InputLabel>
+          <OutlinedInput
+            id="outlined-adornment-amount"
             value={values.amount}
             onChange={handleChange('amount')}
             startAdornment={<InputAdornment position="start">$</InputAdornment>}
+            labelWidth={60}
           />
         </FormControl>
       </div>
@@ -186,42 +189,42 @@ export default function InputAdornments() {
       <div>
         <TextField
           label="With normal TextField"
-          id="outlined-start-adornment"
+          id="standard-start-adornment"
           className={clsx(classes.margin, classes.textField)}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
+          variant="standard"
         />
         <FormControl
-          className={clsx(classes.margin, classes.textField)}
-          variant="outlined"
+          className={clsx(
+            classes.margin,
+            classes.withoutLabel,
+            classes.textField,
+          )}
         >
-          <OutlinedInput
-            id="outlined-adornment-weight"
+          <Input
+            id="standard-adornment-weight"
             value={values.weight}
             onChange={handleChange('weight')}
             endAdornment={<InputAdornment position="end">Kg</InputAdornment>}
-            aria-describedby="outlined-weight-helper-text"
+            aria-describedby="standard-weight-helper-text"
             inputProps={{
               'aria-label': 'weight',
             }}
-            labelWidth={0}
           />
-          <FormHelperText id="outlined-weight-helper-text">
+          <FormHelperText id="standard-weight-helper-text">
             Weight
           </FormHelperText>
         </FormControl>
-        <FormControl
-          className={clsx(classes.margin, classes.textField)}
-          variant="outlined"
-        >
-          <InputLabel htmlFor="outlined-adornment-password">
+        <FormControl className={clsx(classes.margin, classes.textField)}>
+          <InputLabel htmlFor="standard-adornment-password">
             Password
           </InputLabel>
-          <OutlinedInput
-            id="outlined-adornment-password"
+          <Input
+            id="standard-adornment-password"
             type={values.showPassword ? 'text' : 'password'}
             value={values.password}
             onChange={handleChange('password')}
@@ -231,23 +234,20 @@ export default function InputAdornments() {
                   aria-label="toggle password visibility"
                   onClick={handleClickShowPassword}
                   onMouseDown={handleMouseDownPassword}
-                  edge="end"
                 >
                   {values.showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }
-            labelWidth={70}
           />
         </FormControl>
-        <FormControl fullWidth className={classes.margin} variant="outlined">
-          <InputLabel htmlFor="outlined-adornment-amount">Amount</InputLabel>
-          <OutlinedInput
-            id="outlined-adornment-amount"
+        <FormControl fullWidth className={classes.margin}>
+          <InputLabel htmlFor="standard-adornment-amount">Amount</InputLabel>
+          <Input
+            id="standard-adornment-amount"
             value={values.amount}
             onChange={handleChange('amount')}
             startAdornment={<InputAdornment position="start">$</InputAdornment>}
-            labelWidth={60}
           />
         </FormControl>
       </div>

--- a/docs/src/pages/components/text-fields/InputAdornments.js
+++ b/docs/src/pages/components/text-fields/InputAdornments.js
@@ -66,7 +66,7 @@ export default function InputAdornments() {
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
-        />
+          variant="standard" />
         <FormControl
           className={clsx(
             classes.margin,
@@ -191,9 +191,7 @@ export default function InputAdornments() {
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
-          }}
-          variant="outlined"
-        />
+          }} />
         <FormControl
           className={clsx(classes.margin, classes.textField)}
           variant="outlined"

--- a/docs/src/pages/components/text-fields/InputAdornments.js
+++ b/docs/src/pages/components/text-fields/InputAdornments.js
@@ -66,7 +66,8 @@ export default function InputAdornments() {
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <FormControl
           className={clsx(
             classes.margin,
@@ -191,7 +192,8 @@ export default function InputAdornments() {
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
-          }} />
+          }}
+        />
         <FormControl
           className={clsx(classes.margin, classes.textField)}
           variant="outlined"

--- a/docs/src/pages/components/text-fields/InputAdornments.tsx
+++ b/docs/src/pages/components/text-fields/InputAdornments.tsx
@@ -80,7 +80,8 @@ export default function InputAdornments() {
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <FormControl
           className={clsx(
             classes.margin,
@@ -205,7 +206,8 @@ export default function InputAdornments() {
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
-          }} />
+          }}
+        />
         <FormControl
           className={clsx(classes.margin, classes.textField)}
           variant="outlined"

--- a/docs/src/pages/components/text-fields/InputAdornments.tsx
+++ b/docs/src/pages/components/text-fields/InputAdornments.tsx
@@ -73,42 +73,42 @@ export default function InputAdornments() {
       <div>
         <TextField
           label="With normal TextField"
-          id="standard-start-adornment"
+          id="outlined-start-adornment"
           className={clsx(classes.margin, classes.textField)}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
-          variant="standard"
         />
         <FormControl
-          className={clsx(
-            classes.margin,
-            classes.withoutLabel,
-            classes.textField,
-          )}
+          className={clsx(classes.margin, classes.textField)}
+          variant="outlined"
         >
-          <Input
-            id="standard-adornment-weight"
+          <OutlinedInput
+            id="outlined-adornment-weight"
             value={values.weight}
             onChange={handleChange('weight')}
             endAdornment={<InputAdornment position="end">Kg</InputAdornment>}
-            aria-describedby="standard-weight-helper-text"
+            aria-describedby="outlined-weight-helper-text"
             inputProps={{
               'aria-label': 'weight',
             }}
+            labelWidth={0}
           />
-          <FormHelperText id="standard-weight-helper-text">
+          <FormHelperText id="outlined-weight-helper-text">
             Weight
           </FormHelperText>
         </FormControl>
-        <FormControl className={clsx(classes.margin, classes.textField)}>
-          <InputLabel htmlFor="standard-adornment-password">
+        <FormControl
+          className={clsx(classes.margin, classes.textField)}
+          variant="outlined"
+        >
+          <InputLabel htmlFor="outlined-adornment-password">
             Password
           </InputLabel>
-          <Input
-            id="standard-adornment-password"
+          <OutlinedInput
+            id="outlined-adornment-password"
             type={values.showPassword ? 'text' : 'password'}
             value={values.password}
             onChange={handleChange('password')}
@@ -118,20 +118,23 @@ export default function InputAdornments() {
                   aria-label="toggle password visibility"
                   onClick={handleClickShowPassword}
                   onMouseDown={handleMouseDownPassword}
+                  edge="end"
                 >
                   {values.showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }
+            labelWidth={70}
           />
         </FormControl>
-        <FormControl fullWidth className={classes.margin}>
-          <InputLabel htmlFor="standard-adornment-amount">Amount</InputLabel>
-          <Input
-            id="standard-adornment-amount"
+        <FormControl fullWidth className={classes.margin} variant="outlined">
+          <InputLabel htmlFor="outlined-adornment-amount">Amount</InputLabel>
+          <OutlinedInput
+            id="outlined-adornment-amount"
             value={values.amount}
             onChange={handleChange('amount')}
             startAdornment={<InputAdornment position="start">$</InputAdornment>}
+            labelWidth={60}
           />
         </FormControl>
       </div>
@@ -200,42 +203,42 @@ export default function InputAdornments() {
       <div>
         <TextField
           label="With normal TextField"
-          id="outlined-start-adornment"
+          id="standard-start-adornment"
           className={clsx(classes.margin, classes.textField)}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
+          variant="standard"
         />
         <FormControl
-          className={clsx(classes.margin, classes.textField)}
-          variant="outlined"
+          className={clsx(
+            classes.margin,
+            classes.withoutLabel,
+            classes.textField,
+          )}
         >
-          <OutlinedInput
-            id="outlined-adornment-weight"
+          <Input
+            id="standard-adornment-weight"
             value={values.weight}
             onChange={handleChange('weight')}
             endAdornment={<InputAdornment position="end">Kg</InputAdornment>}
-            aria-describedby="outlined-weight-helper-text"
+            aria-describedby="standard-weight-helper-text"
             inputProps={{
               'aria-label': 'weight',
             }}
-            labelWidth={0}
           />
-          <FormHelperText id="outlined-weight-helper-text">
+          <FormHelperText id="standard-weight-helper-text">
             Weight
           </FormHelperText>
         </FormControl>
-        <FormControl
-          className={clsx(classes.margin, classes.textField)}
-          variant="outlined"
-        >
-          <InputLabel htmlFor="outlined-adornment-password">
+        <FormControl className={clsx(classes.margin, classes.textField)}>
+          <InputLabel htmlFor="standard-adornment-password">
             Password
           </InputLabel>
-          <OutlinedInput
-            id="outlined-adornment-password"
+          <Input
+            id="standard-adornment-password"
             type={values.showPassword ? 'text' : 'password'}
             value={values.password}
             onChange={handleChange('password')}
@@ -245,23 +248,20 @@ export default function InputAdornments() {
                   aria-label="toggle password visibility"
                   onClick={handleClickShowPassword}
                   onMouseDown={handleMouseDownPassword}
-                  edge="end"
                 >
                   {values.showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }
-            labelWidth={70}
           />
         </FormControl>
-        <FormControl fullWidth className={classes.margin} variant="outlined">
-          <InputLabel htmlFor="outlined-adornment-amount">Amount</InputLabel>
-          <OutlinedInput
-            id="outlined-adornment-amount"
+        <FormControl fullWidth className={classes.margin}>
+          <InputLabel htmlFor="standard-adornment-amount">Amount</InputLabel>
+          <Input
+            id="standard-adornment-amount"
             value={values.amount}
             onChange={handleChange('amount')}
             startAdornment={<InputAdornment position="start">$</InputAdornment>}
-            labelWidth={60}
           />
         </FormControl>
       </div>

--- a/docs/src/pages/components/text-fields/InputAdornments.tsx
+++ b/docs/src/pages/components/text-fields/InputAdornments.tsx
@@ -80,7 +80,7 @@ export default function InputAdornments() {
               <InputAdornment position="start">Kg</InputAdornment>
             ),
           }}
-        />
+          variant="standard" />
         <FormControl
           className={clsx(
             classes.margin,
@@ -205,9 +205,7 @@ export default function InputAdornments() {
             startAdornment: (
               <InputAdornment position="start">Kg</InputAdornment>
             ),
-          }}
-          variant="outlined"
-        />
+          }} />
         <FormControl
           className={clsx(classes.margin, classes.textField)}
           variant="outlined"

--- a/docs/src/pages/components/text-fields/InputWithIcon.js
+++ b/docs/src/pages/components/text-fields/InputWithIcon.js
@@ -43,14 +43,19 @@ export default function InputWithIcon() {
             </InputAdornment>
           ),
         }}
-        variant="standard" />
+        variant="standard"
+      />
       <div className={classes.margin}>
         <Grid container spacing={1} alignItems="flex-end">
           <Grid item>
             <AccountCircle />
           </Grid>
           <Grid item>
-            <TextField id="input-with-icon-grid" label="With a grid" variant="standard" />
+            <TextField
+              id="input-with-icon-grid"
+              label="With a grid"
+              variant="standard"
+            />
           </Grid>
         </Grid>
       </div>

--- a/docs/src/pages/components/text-fields/InputWithIcon.js
+++ b/docs/src/pages/components/text-fields/InputWithIcon.js
@@ -43,14 +43,14 @@ export default function InputWithIcon() {
             </InputAdornment>
           ),
         }}
-      />
+        variant="standard" />
       <div className={classes.margin}>
         <Grid container spacing={1} alignItems="flex-end">
           <Grid item>
             <AccountCircle />
           </Grid>
           <Grid item>
-            <TextField id="input-with-icon-grid" label="With a grid" />
+            <TextField id="input-with-icon-grid" label="With a grid" variant="standard" />
           </Grid>
         </Grid>
       </div>

--- a/docs/src/pages/components/text-fields/InputWithIcon.tsx
+++ b/docs/src/pages/components/text-fields/InputWithIcon.tsx
@@ -45,14 +45,14 @@ export default function InputWithIcon() {
             </InputAdornment>
           ),
         }}
-      />
+        variant="standard" />
       <div className={classes.margin}>
         <Grid container spacing={1} alignItems="flex-end">
           <Grid item>
             <AccountCircle />
           </Grid>
           <Grid item>
-            <TextField id="input-with-icon-grid" label="With a grid" />
+            <TextField id="input-with-icon-grid" label="With a grid" variant="standard" />
           </Grid>
         </Grid>
       </div>

--- a/docs/src/pages/components/text-fields/InputWithIcon.tsx
+++ b/docs/src/pages/components/text-fields/InputWithIcon.tsx
@@ -45,14 +45,19 @@ export default function InputWithIcon() {
             </InputAdornment>
           ),
         }}
-        variant="standard" />
+        variant="standard"
+      />
       <div className={classes.margin}>
         <Grid container spacing={1} alignItems="flex-end">
           <Grid item>
             <AccountCircle />
           </Grid>
           <Grid item>
-            <TextField id="input-with-icon-grid" label="With a grid" variant="standard" />
+            <TextField
+              id="input-with-icon-grid"
+              label="With a grid"
+              variant="standard"
+            />
           </Grid>
         </Grid>
       </div>

--- a/docs/src/pages/components/text-fields/LayoutTextFields.js
+++ b/docs/src/pages/components/text-fields/LayoutTextFields.js
@@ -21,7 +21,7 @@ export default function LayoutTextFields() {
     <div className={classes.root}>
       <div>
         <TextField
-          id="standard-full-width"
+          id="outlined-full-width"
           label="Label"
           style={{ margin: 8 }}
           placeholder="Placeholder"
@@ -31,33 +31,29 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard"
         />
         <TextField
           label="None"
-          id="margin-none"
+          id="outlined-margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          variant="standard"
         />
         <TextField
           label="Dense"
-          id="margin-dense"
+          id="outlined-margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
-          variant="standard"
         />
         <TextField
           label="Normal"
-          id="margin-normal"
+          id="outlined-margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
-          variant="standard"
         />
       </div>
       <div>
@@ -103,7 +99,7 @@ export default function LayoutTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-full-width"
+          id="standard-full-width"
           label="Label"
           style={{ margin: 8 }}
           placeholder="Placeholder"
@@ -113,29 +109,33 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
+          variant="standard"
         />
         <TextField
           label="None"
-          id="outlined-margin-none"
+          id="margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
+          variant="standard"
         />
         <TextField
           label="Dense"
-          id="outlined-margin-dense"
+          id="margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
+          variant="standard"
         />
         <TextField
           label="Normal"
-          id="outlined-margin-normal"
+          id="margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
+          variant="standard"
         />
       </div>
     </div>

--- a/docs/src/pages/components/text-fields/LayoutTextFields.js
+++ b/docs/src/pages/components/text-fields/LayoutTextFields.js
@@ -31,14 +31,14 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-        />
+          variant="standard" />
         <TextField
           label="None"
           id="margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-        />
+          variant="standard" />
         <TextField
           label="Dense"
           id="margin-dense"
@@ -46,7 +46,7 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
-        />
+          variant="standard" />
         <TextField
           label="Normal"
           id="margin-normal"
@@ -54,7 +54,7 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -108,35 +108,27 @@ export default function LayoutTextFields() {
           margin="normal"
           InputLabelProps={{
             shrink: true,
-          }}
-          variant="outlined"
-        />
+          }} />
         <TextField
           label="None"
           id="outlined-margin-none"
           defaultValue="Default Value"
           className={classes.textField}
-          helperText="Some important text"
-          variant="outlined"
-        />
+          helperText="Some important text" />
         <TextField
           label="Dense"
           id="outlined-margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="dense"
-          variant="outlined"
-        />
+          margin="dense" />
         <TextField
           label="Normal"
           id="outlined-margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="normal"
-          variant="outlined"
-        />
+          margin="normal" />
       </div>
     </div>
   );

--- a/docs/src/pages/components/text-fields/LayoutTextFields.js
+++ b/docs/src/pages/components/text-fields/LayoutTextFields.js
@@ -31,14 +31,16 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="None"
           id="margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="Dense"
           id="margin-dense"
@@ -46,7 +48,8 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="Normal"
           id="margin-normal"
@@ -54,7 +57,8 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -108,27 +112,31 @@ export default function LayoutTextFields() {
           margin="normal"
           InputLabelProps={{
             shrink: true,
-          }} />
+          }}
+        />
         <TextField
           label="None"
           id="outlined-margin-none"
           defaultValue="Default Value"
           className={classes.textField}
-          helperText="Some important text" />
+          helperText="Some important text"
+        />
         <TextField
           label="Dense"
           id="outlined-margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="dense" />
+          margin="dense"
+        />
         <TextField
           label="Normal"
           id="outlined-margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="normal" />
+          margin="normal"
+        />
       </div>
     </div>
   );

--- a/docs/src/pages/components/text-fields/LayoutTextFields.tsx
+++ b/docs/src/pages/components/text-fields/LayoutTextFields.tsx
@@ -33,14 +33,14 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-        />
+          variant="standard" />
         <TextField
           label="None"
           id="margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-        />
+          variant="standard" />
         <TextField
           label="Dense"
           id="margin-dense"
@@ -48,7 +48,7 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
-        />
+          variant="standard" />
         <TextField
           label="Normal"
           id="margin-normal"
@@ -56,7 +56,7 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -110,35 +110,27 @@ export default function LayoutTextFields() {
           margin="normal"
           InputLabelProps={{
             shrink: true,
-          }}
-          variant="outlined"
-        />
+          }} />
         <TextField
           label="None"
           id="outlined-margin-none"
           defaultValue="Default Value"
           className={classes.textField}
-          helperText="Some important text"
-          variant="outlined"
-        />
+          helperText="Some important text" />
         <TextField
           label="Dense"
           id="outlined-margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="dense"
-          variant="outlined"
-        />
+          margin="dense" />
         <TextField
           label="Normal"
           id="outlined-margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="normal"
-          variant="outlined"
-        />
+          margin="normal" />
       </div>
     </div>
   );

--- a/docs/src/pages/components/text-fields/LayoutTextFields.tsx
+++ b/docs/src/pages/components/text-fields/LayoutTextFields.tsx
@@ -23,7 +23,7 @@ export default function LayoutTextFields() {
     <div className={classes.root}>
       <div>
         <TextField
-          id="standard-full-width"
+          id="outlined-full-width"
           label="Label"
           style={{ margin: 8 }}
           placeholder="Placeholder"
@@ -33,33 +33,29 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard"
         />
         <TextField
           label="None"
-          id="margin-none"
+          id="outlined-margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          variant="standard"
         />
         <TextField
           label="Dense"
-          id="margin-dense"
+          id="outlined-margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
-          variant="standard"
         />
         <TextField
           label="Normal"
-          id="margin-normal"
+          id="outlined-margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
-          variant="standard"
         />
       </div>
       <div>
@@ -105,7 +101,7 @@ export default function LayoutTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-full-width"
+          id="standard-full-width"
           label="Label"
           style={{ margin: 8 }}
           placeholder="Placeholder"
@@ -115,29 +111,33 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
+          variant="standard"
         />
         <TextField
           label="None"
-          id="outlined-margin-none"
+          id="margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
+          variant="standard"
         />
         <TextField
           label="Dense"
-          id="outlined-margin-dense"
+          id="margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
+          variant="standard"
         />
         <TextField
           label="Normal"
-          id="outlined-margin-normal"
+          id="margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
+          variant="standard"
         />
       </div>
     </div>

--- a/docs/src/pages/components/text-fields/LayoutTextFields.tsx
+++ b/docs/src/pages/components/text-fields/LayoutTextFields.tsx
@@ -33,14 +33,16 @@ export default function LayoutTextFields() {
           InputLabelProps={{
             shrink: true,
           }}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="None"
           id="margin-none"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="Dense"
           id="margin-dense"
@@ -48,7 +50,8 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="dense"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="Normal"
           id="margin-normal"
@@ -56,7 +59,8 @@ export default function LayoutTextFields() {
           className={classes.textField}
           helperText="Some important text"
           margin="normal"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -110,27 +114,31 @@ export default function LayoutTextFields() {
           margin="normal"
           InputLabelProps={{
             shrink: true,
-          }} />
+          }}
+        />
         <TextField
           label="None"
           id="outlined-margin-none"
           defaultValue="Default Value"
           className={classes.textField}
-          helperText="Some important text" />
+          helperText="Some important text"
+        />
         <TextField
           label="Dense"
           id="outlined-margin-dense"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="dense" />
+          margin="dense"
+        />
         <TextField
           label="Normal"
           id="outlined-margin-normal"
           defaultValue="Default Value"
           className={classes.textField}
           helperText="Some important text"
-          margin="normal" />
+          margin="normal"
+        />
       </div>
     </div>
   );

--- a/docs/src/pages/components/text-fields/MultilineTextFields.js
+++ b/docs/src/pages/components/text-fields/MultilineTextFields.js
@@ -29,20 +29,23 @@ export default function MultilineTextFields() {
           maxRows={4}
           value={value}
           onChange={handleChange}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -77,18 +80,21 @@ export default function MultilineTextFields() {
           multiline
           maxRows={4}
           value={value}
-          onChange={handleChange} />
+          onChange={handleChange}
+        />
         <TextField
           id="outlined-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
-          multiline />
+          multiline
+        />
         <TextField
           id="outlined-multiline-static"
           label="Multiline"
           multiline
           rows={4}
-          defaultValue="Default Value" />
+          defaultValue="Default Value"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/MultilineTextFields.js
+++ b/docs/src/pages/components/text-fields/MultilineTextFields.js
@@ -23,28 +23,25 @@ export default function MultilineTextFields() {
     <form className={classes.root} noValidate autoComplete="off">
       <div>
         <TextField
-          id="standard-multiline-flexible"
+          id="outlined-multiline-flexible"
           label="Multiline"
           multiline
           maxRows={4}
           value={value}
           onChange={handleChange}
-          variant="standard"
         />
         <TextField
-          id="standard-textarea"
+          id="outlined-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
-          variant="standard"
         />
         <TextField
-          id="standard-multiline-static"
+          id="outlined-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
-          variant="standard"
         />
       </div>
       <div>
@@ -75,25 +72,28 @@ export default function MultilineTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-multiline-flexible"
+          id="standard-multiline-flexible"
           label="Multiline"
           multiline
           maxRows={4}
           value={value}
           onChange={handleChange}
+          variant="standard"
         />
         <TextField
-          id="outlined-textarea"
+          id="standard-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
+          variant="standard"
         />
         <TextField
-          id="outlined-multiline-static"
+          id="standard-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/MultilineTextFields.js
+++ b/docs/src/pages/components/text-fields/MultilineTextFields.js
@@ -29,20 +29,20 @@ export default function MultilineTextFields() {
           maxRows={4}
           value={value}
           onChange={handleChange}
-        />
+          variant="standard" />
         <TextField
           id="standard-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
-        />
+          variant="standard" />
         <TextField
           id="standard-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -77,24 +77,18 @@ export default function MultilineTextFields() {
           multiline
           maxRows={4}
           value={value}
-          onChange={handleChange}
-          variant="outlined"
-        />
+          onChange={handleChange} />
         <TextField
           id="outlined-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
-          multiline
-          variant="outlined"
-        />
+          multiline />
         <TextField
           id="outlined-multiline-static"
           label="Multiline"
           multiline
           rows={4}
-          defaultValue="Default Value"
-          variant="outlined"
-        />
+          defaultValue="Default Value" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/MultilineTextFields.tsx
+++ b/docs/src/pages/components/text-fields/MultilineTextFields.tsx
@@ -31,20 +31,23 @@ export default function MultilineTextFields() {
           maxRows={4}
           value={value}
           onChange={handleChange}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -79,18 +82,21 @@ export default function MultilineTextFields() {
           multiline
           maxRows={4}
           value={value}
-          onChange={handleChange} />
+          onChange={handleChange}
+        />
         <TextField
           id="outlined-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
-          multiline />
+          multiline
+        />
         <TextField
           id="outlined-multiline-static"
           label="Multiline"
           multiline
           rows={4}
-          defaultValue="Default Value" />
+          defaultValue="Default Value"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/MultilineTextFields.tsx
+++ b/docs/src/pages/components/text-fields/MultilineTextFields.tsx
@@ -25,28 +25,25 @@ export default function MultilineTextFields() {
     <form className={classes.root} noValidate autoComplete="off">
       <div>
         <TextField
-          id="standard-multiline-flexible"
+          id="outlined-multiline-flexible"
           label="Multiline"
           multiline
           maxRows={4}
           value={value}
           onChange={handleChange}
-          variant="standard"
         />
         <TextField
-          id="standard-textarea"
+          id="outlined-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
-          variant="standard"
         />
         <TextField
-          id="standard-multiline-static"
+          id="outlined-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
-          variant="standard"
         />
       </div>
       <div>
@@ -77,25 +74,28 @@ export default function MultilineTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-multiline-flexible"
+          id="standard-multiline-flexible"
           label="Multiline"
           multiline
           maxRows={4}
           value={value}
           onChange={handleChange}
+          variant="standard"
         />
         <TextField
-          id="outlined-textarea"
+          id="standard-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
+          variant="standard"
         />
         <TextField
-          id="outlined-multiline-static"
+          id="standard-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/MultilineTextFields.tsx
+++ b/docs/src/pages/components/text-fields/MultilineTextFields.tsx
@@ -31,20 +31,20 @@ export default function MultilineTextFields() {
           maxRows={4}
           value={value}
           onChange={handleChange}
-        />
+          variant="standard" />
         <TextField
           id="standard-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
           multiline
-        />
+          variant="standard" />
         <TextField
           id="standard-multiline-static"
           label="Multiline"
           multiline
           rows={4}
           defaultValue="Default Value"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -79,24 +79,18 @@ export default function MultilineTextFields() {
           multiline
           maxRows={4}
           value={value}
-          onChange={handleChange}
-          variant="outlined"
-        />
+          onChange={handleChange} />
         <TextField
           id="outlined-textarea"
           label="Multiline Placeholder"
           placeholder="Placeholder"
-          multiline
-          variant="outlined"
-        />
+          multiline />
         <TextField
           id="outlined-multiline-static"
           label="Multiline"
           multiline
           rows={4}
-          defaultValue="Default Value"
-          variant="outlined"
-        />
+          defaultValue="Default Value" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/SelectTextFields.js
+++ b/docs/src/pages/components/text-fields/SelectTextFields.js
@@ -49,7 +49,7 @@ export default function MultilineTextFields() {
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
-        >
+          variant="standard">
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -66,7 +66,7 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
-        >
+          variant="standard">
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
@@ -116,9 +116,7 @@ export default function MultilineTextFields() {
           label="Select"
           value={currency}
           onChange={handleChange}
-          helperText="Please select your currency"
-          variant="outlined"
-        >
+          helperText="Please select your currency">
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -134,9 +132,7 @@ export default function MultilineTextFields() {
           SelectProps={{
             native: true,
           }}
-          helperText="Please select your currency"
-          variant="outlined"
-        >
+          helperText="Please select your currency">
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}

--- a/docs/src/pages/components/text-fields/SelectTextFields.js
+++ b/docs/src/pages/components/text-fields/SelectTextFields.js
@@ -49,7 +49,8 @@ export default function MultilineTextFields() {
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
-          variant="standard">
+          variant="standard"
+        >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -66,7 +67,8 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
-          variant="standard">
+          variant="standard"
+        >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
@@ -116,7 +118,8 @@ export default function MultilineTextFields() {
           label="Select"
           value={currency}
           onChange={handleChange}
-          helperText="Please select your currency">
+          helperText="Please select your currency"
+        >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -132,7 +135,8 @@ export default function MultilineTextFields() {
           SelectProps={{
             native: true,
           }}
-          helperText="Please select your currency">
+          helperText="Please select your currency"
+        >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}

--- a/docs/src/pages/components/text-fields/SelectTextFields.js
+++ b/docs/src/pages/components/text-fields/SelectTextFields.js
@@ -43,13 +43,12 @@ export default function MultilineTextFields() {
     <form className={classes.root} noValidate autoComplete="off">
       <div>
         <TextField
-          id="standard-select-currency"
+          id="outlined-select-currency"
           select
           label="Select"
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
-          variant="standard"
         >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
@@ -58,7 +57,7 @@ export default function MultilineTextFields() {
           ))}
         </TextField>
         <TextField
-          id="standard-select-currency-native"
+          id="outlined-select-currency-native"
           select
           label="Native select"
           value={currency}
@@ -67,7 +66,6 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
-          variant="standard"
         >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
@@ -113,12 +111,13 @@ export default function MultilineTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-select-currency"
+          id="standard-select-currency"
           select
           label="Select"
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
+          variant="standard"
         >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
@@ -127,7 +126,7 @@ export default function MultilineTextFields() {
           ))}
         </TextField>
         <TextField
-          id="outlined-select-currency-native"
+          id="standard-select-currency-native"
           select
           label="Native select"
           value={currency}
@@ -136,6 +135,7 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
+          variant="standard"
         >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>

--- a/docs/src/pages/components/text-fields/SelectTextFields.tsx
+++ b/docs/src/pages/components/text-fields/SelectTextFields.tsx
@@ -45,13 +45,12 @@ export default function MultilineTextFields() {
     <form className={classes.root} noValidate autoComplete="off">
       <div>
         <TextField
-          id="standard-select-currency"
+          id="outlined-select-currency"
           select
           label="Select"
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
-          variant="standard"
         >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
@@ -60,7 +59,7 @@ export default function MultilineTextFields() {
           ))}
         </TextField>
         <TextField
-          id="standard-select-currency-native"
+          id="outlined-select-currency-native"
           select
           label="Native select"
           value={currency}
@@ -69,7 +68,6 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
-          variant="standard"
         >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
@@ -115,12 +113,13 @@ export default function MultilineTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-select-currency"
+          id="standard-select-currency"
           select
           label="Select"
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
+          variant="standard"
         >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
@@ -129,7 +128,7 @@ export default function MultilineTextFields() {
           ))}
         </TextField>
         <TextField
-          id="outlined-select-currency-native"
+          id="standard-select-currency-native"
           select
           label="Native select"
           value={currency}
@@ -138,6 +137,7 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
+          variant="standard"
         >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>

--- a/docs/src/pages/components/text-fields/SelectTextFields.tsx
+++ b/docs/src/pages/components/text-fields/SelectTextFields.tsx
@@ -51,7 +51,8 @@ export default function MultilineTextFields() {
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
-          variant="standard">
+          variant="standard"
+        >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -68,7 +69,8 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
-          variant="standard">
+          variant="standard"
+        >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
@@ -118,7 +120,8 @@ export default function MultilineTextFields() {
           label="Select"
           value={currency}
           onChange={handleChange}
-          helperText="Please select your currency">
+          helperText="Please select your currency"
+        >
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -134,7 +137,8 @@ export default function MultilineTextFields() {
           SelectProps={{
             native: true,
           }}
-          helperText="Please select your currency">
+          helperText="Please select your currency"
+        >
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}

--- a/docs/src/pages/components/text-fields/SelectTextFields.tsx
+++ b/docs/src/pages/components/text-fields/SelectTextFields.tsx
@@ -51,7 +51,7 @@ export default function MultilineTextFields() {
           value={currency}
           onChange={handleChange}
           helperText="Please select your currency"
-        >
+          variant="standard">
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -68,7 +68,7 @@ export default function MultilineTextFields() {
             native: true,
           }}
           helperText="Please select your currency"
-        >
+          variant="standard">
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
@@ -118,9 +118,7 @@ export default function MultilineTextFields() {
           label="Select"
           value={currency}
           onChange={handleChange}
-          helperText="Please select your currency"
-          variant="outlined"
-        >
+          helperText="Please select your currency">
           {currencies.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
@@ -136,9 +134,7 @@ export default function MultilineTextFields() {
           SelectProps={{
             native: true,
           }}
-          helperText="Please select your currency"
-          variant="outlined"
-        >
+          helperText="Please select your currency">
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}

--- a/docs/src/pages/components/text-fields/StateTextFields.js
+++ b/docs/src/pages/components/text-fields/StateTextFields.js
@@ -22,17 +22,15 @@ export default function StateTextFields() {
     <form className={classes.root} noValidate autoComplete="off">
       <div>
         <TextField
-          id="standard-name"
+          id="outlined-name"
           label="Name"
           value={name}
           onChange={handleChange}
-          variant="standard"
         />
         <TextField
-          id="standard-uncontrolled"
+          id="outlined-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-          variant="standard"
         />
       </div>
       <div>
@@ -52,15 +50,17 @@ export default function StateTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-name"
+          id="standard-name"
           label="Name"
           value={name}
           onChange={handleChange}
+          variant="standard"
         />
         <TextField
-          id="outlined-uncontrolled"
+          id="standard-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/StateTextFields.js
+++ b/docs/src/pages/components/text-fields/StateTextFields.js
@@ -26,12 +26,14 @@ export default function StateTextFields() {
           label="Name"
           value={name}
           onChange={handleChange}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -49,8 +51,17 @@ export default function StateTextFields() {
         />
       </div>
       <div>
-        <TextField id="outlined-name" label="Name" value={name} onChange={handleChange} />
-        <TextField id="outlined-uncontrolled" label="Uncontrolled" defaultValue="foo" />
+        <TextField
+          id="outlined-name"
+          label="Name"
+          value={name}
+          onChange={handleChange}
+        />
+        <TextField
+          id="outlined-uncontrolled"
+          label="Uncontrolled"
+          defaultValue="foo"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/StateTextFields.js
+++ b/docs/src/pages/components/text-fields/StateTextFields.js
@@ -26,12 +26,12 @@ export default function StateTextFields() {
           label="Name"
           value={name}
           onChange={handleChange}
-        />
+          variant="standard" />
         <TextField
           id="standard-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -49,19 +49,8 @@ export default function StateTextFields() {
         />
       </div>
       <div>
-        <TextField
-          id="outlined-name"
-          label="Name"
-          value={name}
-          onChange={handleChange}
-          variant="outlined"
-        />
-        <TextField
-          id="outlined-uncontrolled"
-          label="Uncontrolled"
-          defaultValue="foo"
-          variant="outlined"
-        />
+        <TextField id="outlined-name" label="Name" value={name} onChange={handleChange} />
+        <TextField id="outlined-uncontrolled" label="Uncontrolled" defaultValue="foo" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/StateTextFields.tsx
+++ b/docs/src/pages/components/text-fields/StateTextFields.tsx
@@ -28,12 +28,12 @@ export default function StateTextFields() {
           label="Name"
           value={name}
           onChange={handleChange}
-        />
+          variant="standard" />
         <TextField
           id="standard-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -51,19 +51,8 @@ export default function StateTextFields() {
         />
       </div>
       <div>
-        <TextField
-          id="outlined-name"
-          label="Name"
-          value={name}
-          onChange={handleChange}
-          variant="outlined"
-        />
-        <TextField
-          id="outlined-uncontrolled"
-          label="Uncontrolled"
-          defaultValue="foo"
-          variant="outlined"
-        />
+        <TextField id="outlined-name" label="Name" value={name} onChange={handleChange} />
+        <TextField id="outlined-uncontrolled" label="Uncontrolled" defaultValue="foo" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/StateTextFields.tsx
+++ b/docs/src/pages/components/text-fields/StateTextFields.tsx
@@ -24,17 +24,15 @@ export default function StateTextFields() {
     <form className={classes.root} noValidate autoComplete="off">
       <div>
         <TextField
-          id="standard-name"
+          id="outlined-name"
           label="Name"
           value={name}
           onChange={handleChange}
-          variant="standard"
         />
         <TextField
-          id="standard-uncontrolled"
+          id="outlined-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-          variant="standard"
         />
       </div>
       <div>
@@ -54,15 +52,17 @@ export default function StateTextFields() {
       </div>
       <div>
         <TextField
-          id="outlined-name"
+          id="standard-name"
           label="Name"
           value={name}
           onChange={handleChange}
+          variant="standard"
         />
         <TextField
-          id="outlined-uncontrolled"
+          id="standard-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/StateTextFields.tsx
+++ b/docs/src/pages/components/text-fields/StateTextFields.tsx
@@ -28,12 +28,14 @@ export default function StateTextFields() {
           label="Name"
           value={name}
           onChange={handleChange}
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           id="standard-uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -51,8 +53,17 @@ export default function StateTextFields() {
         />
       </div>
       <div>
-        <TextField id="outlined-name" label="Name" value={name} onChange={handleChange} />
-        <TextField id="outlined-uncontrolled" label="Uncontrolled" defaultValue="foo" />
+        <TextField
+          id="outlined-name"
+          label="Name"
+          value={name}
+          onChange={handleChange}
+        />
+        <TextField
+          id="outlined-uncontrolled"
+          label="Uncontrolled"
+          defaultValue="foo"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/TextFieldSizes.js
+++ b/docs/src/pages/components/text-fields/TextFieldSizes.js
@@ -22,12 +22,14 @@ export default function TextFieldSizes() {
           id="standard-size-small"
           defaultValue="Small"
           size="small"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="Size"
           id="standard-size-normal"
           defaultValue="Normal"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -45,8 +47,17 @@ export default function TextFieldSizes() {
         />
       </div>
       <div>
-        <TextField label="Size" id="outlined-size-small" defaultValue="Small" size="small" />
-        <TextField label="Size" id="outlined-size-normal" defaultValue="Normal" />
+        <TextField
+          label="Size"
+          id="outlined-size-small"
+          defaultValue="Small"
+          size="small"
+        />
+        <TextField
+          label="Size"
+          id="outlined-size-normal"
+          defaultValue="Normal"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/TextFieldSizes.js
+++ b/docs/src/pages/components/text-fields/TextFieldSizes.js
@@ -19,16 +19,14 @@ export default function TextFieldSizes() {
       <div>
         <TextField
           label="Size"
-          id="standard-size-small"
+          id="outlined-size-small"
           defaultValue="Small"
           size="small"
-          variant="standard"
         />
         <TextField
           label="Size"
-          id="standard-size-normal"
+          id="outlined-size-normal"
           defaultValue="Normal"
-          variant="standard"
         />
       </div>
       <div>
@@ -49,14 +47,16 @@ export default function TextFieldSizes() {
       <div>
         <TextField
           label="Size"
-          id="outlined-size-small"
+          id="standard-size-small"
           defaultValue="Small"
           size="small"
+          variant="standard"
         />
         <TextField
           label="Size"
-          id="outlined-size-normal"
+          id="standard-size-normal"
           defaultValue="Normal"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/TextFieldSizes.js
+++ b/docs/src/pages/components/text-fields/TextFieldSizes.js
@@ -22,12 +22,12 @@ export default function TextFieldSizes() {
           id="standard-size-small"
           defaultValue="Small"
           size="small"
-        />
+          variant="standard" />
         <TextField
           label="Size"
           id="standard-size-normal"
           defaultValue="Normal"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -45,19 +45,8 @@ export default function TextFieldSizes() {
         />
       </div>
       <div>
-        <TextField
-          label="Size"
-          id="outlined-size-small"
-          defaultValue="Small"
-          variant="outlined"
-          size="small"
-        />
-        <TextField
-          label="Size"
-          id="outlined-size-normal"
-          defaultValue="Normal"
-          variant="outlined"
-        />
+        <TextField label="Size" id="outlined-size-small" defaultValue="Small" size="small" />
+        <TextField label="Size" id="outlined-size-normal" defaultValue="Normal" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/TextFieldSizes.tsx
+++ b/docs/src/pages/components/text-fields/TextFieldSizes.tsx
@@ -24,12 +24,14 @@ export default function TextFieldSizes() {
           id="standard-size-small"
           defaultValue="Small"
           size="small"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           label="Size"
           id="standard-size-normal"
           defaultValue="Normal"
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -47,8 +49,17 @@ export default function TextFieldSizes() {
         />
       </div>
       <div>
-        <TextField label="Size" id="outlined-size-small" defaultValue="Small" size="small" />
-        <TextField label="Size" id="outlined-size-normal" defaultValue="Normal" />
+        <TextField
+          label="Size"
+          id="outlined-size-small"
+          defaultValue="Small"
+          size="small"
+        />
+        <TextField
+          label="Size"
+          id="outlined-size-normal"
+          defaultValue="Normal"
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/TextFieldSizes.tsx
+++ b/docs/src/pages/components/text-fields/TextFieldSizes.tsx
@@ -24,12 +24,12 @@ export default function TextFieldSizes() {
           id="standard-size-small"
           defaultValue="Small"
           size="small"
-        />
+          variant="standard" />
         <TextField
           label="Size"
           id="standard-size-normal"
           defaultValue="Normal"
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -47,19 +47,8 @@ export default function TextFieldSizes() {
         />
       </div>
       <div>
-        <TextField
-          label="Size"
-          id="outlined-size-small"
-          defaultValue="Small"
-          variant="outlined"
-          size="small"
-        />
-        <TextField
-          label="Size"
-          id="outlined-size-normal"
-          defaultValue="Normal"
-          variant="outlined"
-        />
+        <TextField label="Size" id="outlined-size-small" defaultValue="Small" size="small" />
+        <TextField label="Size" id="outlined-size-normal" defaultValue="Normal" />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/TextFieldSizes.tsx
+++ b/docs/src/pages/components/text-fields/TextFieldSizes.tsx
@@ -21,16 +21,14 @@ export default function TextFieldSizes() {
       <div>
         <TextField
           label="Size"
-          id="standard-size-small"
+          id="outlined-size-small"
           defaultValue="Small"
           size="small"
-          variant="standard"
         />
         <TextField
           label="Size"
-          id="standard-size-normal"
+          id="outlined-size-normal"
           defaultValue="Normal"
-          variant="standard"
         />
       </div>
       <div>
@@ -51,14 +49,16 @@ export default function TextFieldSizes() {
       <div>
         <TextField
           label="Size"
-          id="outlined-size-small"
+          id="standard-size-small"
           defaultValue="Small"
           size="small"
+          variant="standard"
         />
         <TextField
           label="Size"
-          id="outlined-size-normal"
+          id="standard-size-normal"
           defaultValue="Normal"
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/ValidationTextFields.js
+++ b/docs/src/pages/components/text-fields/ValidationTextFields.js
@@ -22,14 +22,16 @@ export default function ValidationTextFields() {
           id="standard-error"
           label="Error"
           defaultValue="Hello World"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           error
           id="standard-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -49,13 +51,19 @@ export default function ValidationTextFields() {
         />
       </div>
       <div>
-        <TextField error id="outlined-error" label="Error" defaultValue="Hello World" />
+        <TextField
+          error
+          id="outlined-error"
+          label="Error"
+          defaultValue="Hello World"
+        />
         <TextField
           error
           id="outlined-error-helper-text"
           label="Error"
           defaultValue="Hello World"
-          helperText="Incorrect entry." />
+          helperText="Incorrect entry."
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/ValidationTextFields.js
+++ b/docs/src/pages/components/text-fields/ValidationTextFields.js
@@ -22,14 +22,14 @@ export default function ValidationTextFields() {
           id="standard-error"
           label="Error"
           defaultValue="Hello World"
-        />
+          variant="standard" />
         <TextField
           error
           id="standard-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -49,21 +49,13 @@ export default function ValidationTextFields() {
         />
       </div>
       <div>
-        <TextField
-          error
-          id="outlined-error"
-          label="Error"
-          defaultValue="Hello World"
-          variant="outlined"
-        />
+        <TextField error id="outlined-error" label="Error" defaultValue="Hello World" />
         <TextField
           error
           id="outlined-error-helper-text"
           label="Error"
           defaultValue="Hello World"
-          helperText="Incorrect entry."
-          variant="outlined"
-        />
+          helperText="Incorrect entry." />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/ValidationTextFields.js
+++ b/docs/src/pages/components/text-fields/ValidationTextFields.js
@@ -19,18 +19,16 @@ export default function ValidationTextFields() {
       <div>
         <TextField
           error
-          id="standard-error"
+          id="outlined-error"
           label="Error"
           defaultValue="Hello World"
-          variant="standard"
         />
         <TextField
           error
-          id="standard-error-helper-text"
+          id="outlined-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
-          variant="standard"
         />
       </div>
       <div>
@@ -53,16 +51,18 @@ export default function ValidationTextFields() {
       <div>
         <TextField
           error
-          id="outlined-error"
+          id="standard-error"
           label="Error"
           defaultValue="Hello World"
+          variant="standard"
         />
         <TextField
           error
-          id="outlined-error-helper-text"
+          id="standard-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/ValidationTextFields.tsx
+++ b/docs/src/pages/components/text-fields/ValidationTextFields.tsx
@@ -24,14 +24,14 @@ export default function ValidationTextFields() {
           id="standard-error"
           label="Error"
           defaultValue="Hello World"
-        />
+          variant="standard" />
         <TextField
           error
           id="standard-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
-        />
+          variant="standard" />
       </div>
       <div>
         <TextField
@@ -51,21 +51,13 @@ export default function ValidationTextFields() {
         />
       </div>
       <div>
-        <TextField
-          error
-          id="outlined-error"
-          label="Error"
-          defaultValue="Hello World"
-          variant="outlined"
-        />
+        <TextField error id="outlined-error" label="Error" defaultValue="Hello World" />
         <TextField
           error
           id="outlined-error-helper-text"
           label="Error"
           defaultValue="Hello World"
-          helperText="Incorrect entry."
-          variant="outlined"
-        />
+          helperText="Incorrect entry." />
       </div>
     </form>
   );

--- a/docs/src/pages/components/text-fields/ValidationTextFields.tsx
+++ b/docs/src/pages/components/text-fields/ValidationTextFields.tsx
@@ -21,18 +21,16 @@ export default function ValidationTextFields() {
       <div>
         <TextField
           error
-          id="standard-error"
+          id="outlined-error"
           label="Error"
           defaultValue="Hello World"
-          variant="standard"
         />
         <TextField
           error
-          id="standard-error-helper-text"
+          id="outlined-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
-          variant="standard"
         />
       </div>
       <div>
@@ -55,16 +53,18 @@ export default function ValidationTextFields() {
       <div>
         <TextField
           error
-          id="outlined-error"
+          id="standard-error"
           label="Error"
           defaultValue="Hello World"
+          variant="standard"
         />
         <TextField
           error
-          id="outlined-error-helper-text"
+          id="standard-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
+          variant="standard"
         />
       </div>
     </form>

--- a/docs/src/pages/components/text-fields/ValidationTextFields.tsx
+++ b/docs/src/pages/components/text-fields/ValidationTextFields.tsx
@@ -24,14 +24,16 @@ export default function ValidationTextFields() {
           id="standard-error"
           label="Error"
           defaultValue="Hello World"
-          variant="standard" />
+          variant="standard"
+        />
         <TextField
           error
           id="standard-error-helper-text"
           label="Error"
           defaultValue="Hello World"
           helperText="Incorrect entry."
-          variant="standard" />
+          variant="standard"
+        />
       </div>
       <div>
         <TextField
@@ -51,13 +53,19 @@ export default function ValidationTextFields() {
         />
       </div>
       <div>
-        <TextField error id="outlined-error" label="Error" defaultValue="Hello World" />
+        <TextField
+          error
+          id="outlined-error"
+          label="Error"
+          defaultValue="Hello World"
+        />
         <TextField
           error
           id="outlined-error-helper-text"
           label="Error"
           defaultValue="Hello World"
-          helperText="Incorrect entry." />
+          helperText="Incorrect entry."
+        />
       </div>
     </form>
   );

--- a/docs/src/pages/components/time-picker/BasicTimePicker.js
+++ b/docs/src/pages/components/time-picker/BasicTimePicker.js
@@ -16,7 +16,9 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <TimePicker
           ampm={false}
@@ -25,7 +27,9 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/BasicTimePicker.js
+++ b/docs/src/pages/components/time-picker/BasicTimePicker.js
@@ -16,7 +16,7 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <TimePicker
           ampm={false}
@@ -25,7 +25,7 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/BasicTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/BasicTimePicker.tsx
@@ -16,7 +16,9 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <TimePicker
           ampm={false}
@@ -25,7 +27,9 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/BasicTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/BasicTimePicker.tsx
@@ -16,7 +16,7 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <TimePicker
           ampm={false}
@@ -25,7 +25,7 @@ export default function BasicTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.js
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.js
@@ -36,7 +36,9 @@ export default function LocalizedTimePicker() {
           <TimePicker
             value={selectedDate}
             onChange={(date) => handleDateChange(date)}
-            renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+            renderInput={(params) => (
+              <TextField {...params} margin="normal" variant="standard" />
+            )}
           />
           <ToggleButtonGroup value={locale} exclusive>
             {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.js
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.js
@@ -36,7 +36,7 @@ export default function LocalizedTimePicker() {
           <TimePicker
             value={selectedDate}
             onChange={(date) => handleDateChange(date)}
-            renderInput={(params) => <TextField {...params} margin="normal" />}
+            renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           />
           <ToggleButtonGroup value={locale} exclusive>
             {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
@@ -38,7 +38,7 @@ export default function LocalizedTimePicker() {
           <TimePicker
             value={selectedDate}
             onChange={(date) => handleDateChange(date)}
-            renderInput={(params) => <TextField {...params} margin="normal" />}
+            renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           />
           <ToggleButtonGroup value={locale} exclusive>
             {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
@@ -38,7 +38,9 @@ export default function LocalizedTimePicker() {
           <TimePicker
             value={selectedDate}
             onChange={(date) => handleDateChange(date)}
-            renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+            renderInput={(params) => (
+              <TextField {...params} margin="normal" variant="standard" />
+            )}
           />
           <ToggleButtonGroup value={locale} exclusive>
             {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
@@ -20,7 +20,7 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -28,12 +28,12 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
@@ -20,7 +20,9 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -28,12 +30,16 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
@@ -20,7 +20,7 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -28,12 +28,12 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
@@ -20,7 +20,9 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -28,12 +30,16 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.js
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.js
@@ -21,7 +21,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <TimePicker
           ampmInClock
@@ -33,7 +33,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.js
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.js
@@ -21,7 +21,9 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <TimePicker
           ampmInClock
@@ -33,7 +35,9 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
@@ -21,7 +21,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
         <TimePicker
           ampmInClock
@@ -33,7 +33,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
@@ -21,7 +21,9 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
         <TimePicker
           ampmInClock
@@ -33,7 +35,9 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/StaticTimePickerDemo.js
+++ b/docs/src/pages/components/time-picker/StaticTimePickerDemo.js
@@ -15,7 +15,7 @@ export default function StaticTimePickerDemo() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/time-picker/StaticTimePickerDemo.tsx
+++ b/docs/src/pages/components/time-picker/StaticTimePickerDemo.tsx
@@ -15,7 +15,7 @@ export default function StaticTimePickerDemo() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/time-picker/StaticTimePickerLandscape.js
+++ b/docs/src/pages/components/time-picker/StaticTimePickerLandscape.js
@@ -17,7 +17,7 @@ export default function StaticTimePickerLandscape() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/time-picker/StaticTimePickerLandscape.tsx
+++ b/docs/src/pages/components/time-picker/StaticTimePickerLandscape.tsx
@@ -17,7 +17,7 @@ export default function StaticTimePickerLandscape() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} />}
+        renderInput={(params) => <TextField {...params} variant="standard" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
@@ -11,7 +11,9 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -21,7 +23,9 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
@@ -11,7 +11,7 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -21,7 +21,7 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
@@ -13,7 +13,7 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -23,7 +23,7 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" />}
+          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
@@ -13,7 +13,9 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -23,7 +25,9 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => <TextField {...params} margin="normal" variant="standard" />}
+          renderInput={(params) => (
+            <TextField {...params} margin="normal" variant="standard" />
+          )}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/getting-started/templates/checkout/AddressForm.js
+++ b/docs/src/pages/getting-started/templates/checkout/AddressForm.js
@@ -20,7 +20,7 @@ export default function AddressForm() {
             label="First name"
             fullWidth
             autoComplete="given-name"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -30,7 +30,7 @@ export default function AddressForm() {
             label="Last name"
             fullWidth
             autoComplete="family-name"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -40,7 +40,7 @@ export default function AddressForm() {
             label="Address line 1"
             fullWidth
             autoComplete="shipping address-line1"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -49,7 +49,7 @@ export default function AddressForm() {
             label="Address line 2"
             fullWidth
             autoComplete="shipping address-line2"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -59,7 +59,7 @@ export default function AddressForm() {
             label="City"
             fullWidth
             autoComplete="shipping address-level2"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -67,7 +67,7 @@ export default function AddressForm() {
             name="state"
             label="State/Province/Region"
             fullWidth
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -77,7 +77,7 @@ export default function AddressForm() {
             label="Zip / Postal code"
             fullWidth
             autoComplete="shipping postal-code"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -87,7 +87,7 @@ export default function AddressForm() {
             label="Country"
             fullWidth
             autoComplete="shipping country"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/AddressForm.js
+++ b/docs/src/pages/getting-started/templates/checkout/AddressForm.js
@@ -20,7 +20,8 @@ export default function AddressForm() {
             label="First name"
             fullWidth
             autoComplete="given-name"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -30,7 +31,8 @@ export default function AddressForm() {
             label="Last name"
             fullWidth
             autoComplete="family-name"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -40,7 +42,8 @@ export default function AddressForm() {
             label="Address line 1"
             fullWidth
             autoComplete="shipping address-line1"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -49,7 +52,8 @@ export default function AddressForm() {
             label="Address line 2"
             fullWidth
             autoComplete="shipping address-line2"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -59,7 +63,8 @@ export default function AddressForm() {
             label="City"
             fullWidth
             autoComplete="shipping address-level2"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -67,7 +72,8 @@ export default function AddressForm() {
             name="state"
             label="State/Province/Region"
             fullWidth
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -77,7 +83,8 @@ export default function AddressForm() {
             label="Zip / Postal code"
             fullWidth
             autoComplete="shipping postal-code"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -87,7 +94,8 @@ export default function AddressForm() {
             label="Country"
             fullWidth
             autoComplete="shipping country"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/AddressForm.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/AddressForm.tsx
@@ -20,7 +20,7 @@ export default function AddressForm() {
             label="First name"
             fullWidth
             autoComplete="given-name"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -30,7 +30,7 @@ export default function AddressForm() {
             label="Last name"
             fullWidth
             autoComplete="family-name"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -40,7 +40,7 @@ export default function AddressForm() {
             label="Address line 1"
             fullWidth
             autoComplete="shipping address-line1"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -49,7 +49,7 @@ export default function AddressForm() {
             label="Address line 2"
             fullWidth
             autoComplete="shipping address-line2"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -59,7 +59,7 @@ export default function AddressForm() {
             label="City"
             fullWidth
             autoComplete="shipping address-level2"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -67,7 +67,7 @@ export default function AddressForm() {
             name="state"
             label="State/Province/Region"
             fullWidth
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -77,7 +77,7 @@ export default function AddressForm() {
             label="Zip / Postal code"
             fullWidth
             autoComplete="shipping postal-code"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -87,7 +87,7 @@ export default function AddressForm() {
             label="Country"
             fullWidth
             autoComplete="shipping country"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/AddressForm.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/AddressForm.tsx
@@ -20,7 +20,8 @@ export default function AddressForm() {
             label="First name"
             fullWidth
             autoComplete="given-name"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -30,7 +31,8 @@ export default function AddressForm() {
             label="Last name"
             fullWidth
             autoComplete="family-name"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -40,7 +42,8 @@ export default function AddressForm() {
             label="Address line 1"
             fullWidth
             autoComplete="shipping address-line1"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <TextField
@@ -49,7 +52,8 @@ export default function AddressForm() {
             label="Address line 2"
             fullWidth
             autoComplete="shipping address-line2"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -59,7 +63,8 @@ export default function AddressForm() {
             label="City"
             fullWidth
             autoComplete="shipping address-level2"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -67,7 +72,8 @@ export default function AddressForm() {
             name="state"
             label="State/Province/Region"
             fullWidth
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -77,7 +83,8 @@ export default function AddressForm() {
             label="Zip / Postal code"
             fullWidth
             autoComplete="shipping postal-code"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} sm={6}>
           <TextField
@@ -87,7 +94,8 @@ export default function AddressForm() {
             label="Country"
             fullWidth
             autoComplete="shipping country"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/PaymentForm.js
+++ b/docs/src/pages/getting-started/templates/checkout/PaymentForm.js
@@ -19,7 +19,8 @@ export default function PaymentForm() {
             label="Name on card"
             fullWidth
             autoComplete="cc-name"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -28,7 +29,8 @@ export default function PaymentForm() {
             label="Card number"
             fullWidth
             autoComplete="cc-number"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -37,7 +39,8 @@ export default function PaymentForm() {
             label="Expiry date"
             fullWidth
             autoComplete="cc-exp"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -47,7 +50,8 @@ export default function PaymentForm() {
             helperText="Last three digits on signature strip"
             fullWidth
             autoComplete="cc-csc"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/PaymentForm.js
+++ b/docs/src/pages/getting-started/templates/checkout/PaymentForm.js
@@ -19,7 +19,7 @@ export default function PaymentForm() {
             label="Name on card"
             fullWidth
             autoComplete="cc-name"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -28,7 +28,7 @@ export default function PaymentForm() {
             label="Card number"
             fullWidth
             autoComplete="cc-number"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -37,7 +37,7 @@ export default function PaymentForm() {
             label="Expiry date"
             fullWidth
             autoComplete="cc-exp"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -47,7 +47,7 @@ export default function PaymentForm() {
             helperText="Last three digits on signature strip"
             fullWidth
             autoComplete="cc-csc"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/PaymentForm.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/PaymentForm.tsx
@@ -19,7 +19,8 @@ export default function PaymentForm() {
             label="Name on card"
             fullWidth
             autoComplete="cc-name"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -28,7 +29,8 @@ export default function PaymentForm() {
             label="Card number"
             fullWidth
             autoComplete="cc-number"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -37,7 +39,8 @@ export default function PaymentForm() {
             label="Expiry date"
             fullWidth
             autoComplete="cc-exp"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -47,7 +50,8 @@ export default function PaymentForm() {
             helperText="Last three digits on signature strip"
             fullWidth
             autoComplete="cc-csc"
-            variant="standard" />
+            variant="standard"
+          />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/checkout/PaymentForm.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/PaymentForm.tsx
@@ -19,7 +19,7 @@ export default function PaymentForm() {
             label="Name on card"
             fullWidth
             autoComplete="cc-name"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -28,7 +28,7 @@ export default function PaymentForm() {
             label="Card number"
             fullWidth
             autoComplete="cc-number"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -37,7 +37,7 @@ export default function PaymentForm() {
             label="Expiry date"
             fullWidth
             autoComplete="cc-exp"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12} md={6}>
           <TextField
@@ -47,7 +47,7 @@ export default function PaymentForm() {
             helperText="Last three digits on signature strip"
             fullWidth
             autoComplete="cc-csc"
-          />
+            variant="standard" />
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
@@ -83,7 +83,8 @@ export default function SignInSide() {
               label="Email Address"
               name="email"
               autoComplete="email"
-              autoFocus />
+              autoFocus
+            />
             <TextField
               margin="normal"
               required
@@ -92,7 +93,8 @@ export default function SignInSide() {
               label="Password"
               type="password"
               id="password"
-              autoComplete="current-password" />
+              autoComplete="current-password"
+            />
             <FormControlLabel
               control={<Checkbox value="remember" color="primary" />}
               label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.js
@@ -76,7 +76,6 @@ export default function SignInSide() {
           </Typography>
           <form className={classes.form} noValidate>
             <TextField
-              variant="outlined"
               margin="normal"
               required
               fullWidth
@@ -84,10 +83,8 @@ export default function SignInSide() {
               label="Email Address"
               name="email"
               autoComplete="email"
-              autoFocus
-            />
+              autoFocus />
             <TextField
-              variant="outlined"
               margin="normal"
               required
               fullWidth
@@ -95,8 +92,7 @@ export default function SignInSide() {
               label="Password"
               type="password"
               id="password"
-              autoComplete="current-password"
-            />
+              autoComplete="current-password" />
             <FormControlLabel
               control={<Checkbox value="remember" color="primary" />}
               label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.tsx
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.tsx
@@ -83,7 +83,8 @@ export default function SignInSide() {
               label="Email Address"
               name="email"
               autoComplete="email"
-              autoFocus />
+              autoFocus
+            />
             <TextField
               margin="normal"
               required
@@ -92,7 +93,8 @@ export default function SignInSide() {
               label="Password"
               type="password"
               id="password"
-              autoComplete="current-password" />
+              autoComplete="current-password"
+            />
             <FormControlLabel
               control={<Checkbox value="remember" color="primary" />}
               label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.tsx
+++ b/docs/src/pages/getting-started/templates/sign-in-side/SignInSide.tsx
@@ -76,7 +76,6 @@ export default function SignInSide() {
           </Typography>
           <form className={classes.form} noValidate>
             <TextField
-              variant="outlined"
               margin="normal"
               required
               fullWidth
@@ -84,10 +83,8 @@ export default function SignInSide() {
               label="Email Address"
               name="email"
               autoComplete="email"
-              autoFocus
-            />
+              autoFocus />
             <TextField
-              variant="outlined"
               margin="normal"
               required
               fullWidth
@@ -95,8 +92,7 @@ export default function SignInSide() {
               label="Password"
               type="password"
               id="password"
-              autoComplete="current-password"
-            />
+              autoComplete="current-password" />
             <FormControlLabel
               control={<Checkbox value="remember" color="primary" />}
               label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.js
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.js
@@ -68,7 +68,8 @@ export default function SignIn() {
             label="Email Address"
             name="email"
             autoComplete="email"
-            autoFocus />
+            autoFocus
+          />
           <TextField
             margin="normal"
             required
@@ -77,7 +78,8 @@ export default function SignIn() {
             label="Password"
             type="password"
             id="password"
-            autoComplete="current-password" />
+            autoComplete="current-password"
+          />
           <FormControlLabel
             control={<Checkbox value="remember" color="primary" />}
             label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.js
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.js
@@ -61,7 +61,6 @@ export default function SignIn() {
         </Typography>
         <form className={classes.form} noValidate>
           <TextField
-            variant="outlined"
             margin="normal"
             required
             fullWidth
@@ -69,10 +68,8 @@ export default function SignIn() {
             label="Email Address"
             name="email"
             autoComplete="email"
-            autoFocus
-          />
+            autoFocus />
           <TextField
-            variant="outlined"
             margin="normal"
             required
             fullWidth
@@ -80,8 +77,7 @@ export default function SignIn() {
             label="Password"
             type="password"
             id="password"
-            autoComplete="current-password"
-          />
+            autoComplete="current-password" />
           <FormControlLabel
             control={<Checkbox value="remember" color="primary" />}
             label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.tsx
@@ -68,7 +68,8 @@ export default function SignIn() {
             label="Email Address"
             name="email"
             autoComplete="email"
-            autoFocus />
+            autoFocus
+          />
           <TextField
             margin="normal"
             required
@@ -77,7 +78,8 @@ export default function SignIn() {
             label="Password"
             type="password"
             id="password"
-            autoComplete="current-password" />
+            autoComplete="current-password"
+          />
           <FormControlLabel
             control={<Checkbox value="remember" color="primary" />}
             label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.tsx
@@ -61,7 +61,6 @@ export default function SignIn() {
         </Typography>
         <form className={classes.form} noValidate>
           <TextField
-            variant="outlined"
             margin="normal"
             required
             fullWidth
@@ -69,10 +68,8 @@ export default function SignIn() {
             label="Email Address"
             name="email"
             autoComplete="email"
-            autoFocus
-          />
+            autoFocus />
           <TextField
-            variant="outlined"
             margin="normal"
             required
             fullWidth
@@ -80,8 +77,7 @@ export default function SignIn() {
             label="Password"
             type="password"
             id="password"
-            autoComplete="current-password"
-          />
+            autoComplete="current-password" />
           <FormControlLabel
             control={<Checkbox value="remember" color="primary" />}
             label="Remember me"

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.js
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.js
@@ -69,7 +69,8 @@ export default function SignUp() {
                 fullWidth
                 id="firstName"
                 label="First Name"
-                autoFocus />
+                autoFocus
+              />
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -78,7 +79,8 @@ export default function SignUp() {
                 id="lastName"
                 label="Last Name"
                 name="lastName"
-                autoComplete="lname" />
+                autoComplete="lname"
+              />
             </Grid>
             <Grid item xs={12}>
               <TextField
@@ -87,7 +89,8 @@ export default function SignUp() {
                 id="email"
                 label="Email Address"
                 name="email"
-                autoComplete="email" />
+                autoComplete="email"
+              />
             </Grid>
             <Grid item xs={12}>
               <TextField
@@ -97,7 +100,8 @@ export default function SignUp() {
                 label="Password"
                 type="password"
                 id="password"
-                autoComplete="current-password" />
+                autoComplete="current-password"
+              />
             </Grid>
             <Grid item xs={12}>
               <FormControlLabel

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.js
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.js
@@ -65,47 +65,39 @@ export default function SignUp() {
               <TextField
                 autoComplete="fname"
                 name="firstName"
-                variant="outlined"
                 required
                 fullWidth
                 id="firstName"
                 label="First Name"
-                autoFocus
-              />
+                autoFocus />
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
-                variant="outlined"
                 required
                 fullWidth
                 id="lastName"
                 label="Last Name"
                 name="lastName"
-                autoComplete="lname"
-              />
+                autoComplete="lname" />
             </Grid>
             <Grid item xs={12}>
               <TextField
-                variant="outlined"
                 required
                 fullWidth
                 id="email"
                 label="Email Address"
                 name="email"
-                autoComplete="email"
-              />
+                autoComplete="email" />
             </Grid>
             <Grid item xs={12}>
               <TextField
-                variant="outlined"
                 required
                 fullWidth
                 name="password"
                 label="Password"
                 type="password"
                 id="password"
-                autoComplete="current-password"
-              />
+                autoComplete="current-password" />
             </Grid>
             <Grid item xs={12}>
               <FormControlLabel

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
@@ -69,7 +69,8 @@ export default function SignUp() {
                 fullWidth
                 id="firstName"
                 label="First Name"
-                autoFocus />
+                autoFocus
+              />
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -78,7 +79,8 @@ export default function SignUp() {
                 id="lastName"
                 label="Last Name"
                 name="lastName"
-                autoComplete="lname" />
+                autoComplete="lname"
+              />
             </Grid>
             <Grid item xs={12}>
               <TextField
@@ -87,7 +89,8 @@ export default function SignUp() {
                 id="email"
                 label="Email Address"
                 name="email"
-                autoComplete="email" />
+                autoComplete="email"
+              />
             </Grid>
             <Grid item xs={12}>
               <TextField
@@ -97,7 +100,8 @@ export default function SignUp() {
                 label="Password"
                 type="password"
                 id="password"
-                autoComplete="current-password" />
+                autoComplete="current-password"
+              />
             </Grid>
             <Grid item xs={12}>
               <FormControlLabel

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
@@ -65,47 +65,39 @@ export default function SignUp() {
               <TextField
                 autoComplete="fname"
                 name="firstName"
-                variant="outlined"
                 required
                 fullWidth
                 id="firstName"
                 label="First Name"
-                autoFocus
-              />
+                autoFocus />
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
-                variant="outlined"
                 required
                 fullWidth
                 id="lastName"
                 label="Last Name"
                 name="lastName"
-                autoComplete="lname"
-              />
+                autoComplete="lname" />
             </Grid>
             <Grid item xs={12}>
               <TextField
-                variant="outlined"
                 required
                 fullWidth
                 id="email"
                 label="Email Address"
                 name="email"
-                autoComplete="email"
-              />
+                autoComplete="email" />
             </Grid>
             <Grid item xs={12}>
               <TextField
-                variant="outlined"
                 required
                 fullWidth
                 name="password"
                 label="Password"
                 type="password"
                 id="password"
-                autoComplete="current-password"
-              />
+                autoComplete="current-password" />
             </Grid>
             <Grid item xs={12}>
               <FormControlLabel

--- a/docs/src/pages/guides/localization/Locales.js
+++ b/docs/src/pages/guides/localization/Locales.js
@@ -25,12 +25,7 @@ export default function Locales() {
             setLocale(newValue);
           }}
           renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Locale"
-              variant="outlined"
-              fullWidth
-            />
+            <TextField {...params} label="Locale" fullWidth />
           )}
         />
         <TablePagination

--- a/docs/src/pages/guides/localization/Locales.tsx
+++ b/docs/src/pages/guides/localization/Locales.tsx
@@ -27,12 +27,7 @@ export default function Locales() {
             setLocale(newValue as SupportedLocales);
           }}
           renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Locale"
-              variant="outlined"
-              fullWidth
-            />
+            <TextField {...params} label="Locale" fullWidth />
           )}
         />
         <TablePagination

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -331,7 +331,7 @@ const classes = makeStyles(theme => ({
   +<BottomNavigation onChange={(event: React.SyntheticEvent) => {}} />
   ```
 
-  ### Box
+### Box
 
 - The system props have been deprecated in v5, and replaced with the `sx` prop.
 
@@ -862,19 +862,30 @@ const classes = makeStyles(theme => ({
 
 ### TextField
 
-- Better isolate the fixed textarea height behavior to the dynamic one.
-  You need to use the `minRows` prop in the following case:
+- Change the default variant from `standard` to `outlined`. Standard has been removed from the Material Design Guidelines.
 
   ```diff
-  -<TextField rows={2} maxRows={5} />
-  +<TextField minRows={2} maxRows={5} />
+  -<TextField value="Standard" />
+  -<TextField value="Outlined" variant="outlined" />
+  +<TextField value="Standard" variant="standard" />
+  +<TextField value="Outlined" />
   ```
+
+[This codemod](https://github.com/mui-org/material-ui/tree/next/packages/material-ui-codemod#textfield-variant-prop) will automatically update your code.
 
 - Rename `rowsMax` prop with `maxRows` for consistency with HTML attributes.
 
   ```diff
   -<TextField rowsMax={6}>
   +<TextField maxRows={6}>
+  ```
+
+- Better isolate the fixed textarea height behavior to the dynamic one.
+  You need to use the `minRows` prop in the following case:
+
+  ```diff
+  -<TextField rows={2} maxRows={5} />
+  +<TextField minRows={2} maxRows={5} />
   ```
 
 - Change ref forwarding expections on custom `inputComponent`.

--- a/docs/src/pages/guides/right-to-left/Direction.js
+++ b/docs/src/pages/guides/right-to-left/Direction.js
@@ -10,7 +10,7 @@ export default function Direction() {
   return (
     <ThemeProvider theme={theme}>
       <div dir="rtl">
-        <TextField placeholder="Name" />
+        <TextField placeholder="Name" variant="standard" />
         <input type="text" placeholder="Name" />
       </div>
     </ThemeProvider>

--- a/docs/src/pages/guides/right-to-left/Direction.tsx
+++ b/docs/src/pages/guides/right-to-left/Direction.tsx
@@ -10,7 +10,7 @@ export default function Direction() {
   return (
     <ThemeProvider theme={theme}>
       <div dir="rtl">
-        <TextField placeholder="Name" />
+        <TextField placeholder="Name" variant="standard" />
         <input type="text" placeholder="Name" />
       </div>
     </ThemeProvider>

--- a/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
@@ -24,7 +24,8 @@ function RFTextField(props) {
         ...InputProps,
       }}
       helperText={touched ? error || submitError : ''}
-      variant="standard" />
+      variant="standard"
+    />
   );
 }
 

--- a/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
@@ -24,7 +24,7 @@ function RFTextField(props) {
         ...InputProps,
       }}
       helperText={touched ? error || submitError : ''}
-    />
+      variant="standard" />
   );
 }
 

--- a/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.tsx
@@ -25,7 +25,8 @@ function RFTextField(
         ...InputProps,
       }}
       helperText={touched ? error || submitError : ''}
-      variant="standard" />
+      variant="standard"
+    />
   );
 }
 

--- a/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.tsx
@@ -25,7 +25,7 @@ function RFTextField(
         ...InputProps,
       }}
       helperText={touched ? error || submitError : ''}
-    />
+      variant="standard" />
   );
 }
 

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.js
@@ -133,7 +133,8 @@ export default function AppFooter() {
                 native: true,
               }}
               className={classes.language}
-              variant="standard">
+              variant="standard"
+            >
               {LANGUAGES.map((language) => (
                 <option value={language.code} key={language.code}>
                   {language.name}

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.js
@@ -133,7 +133,7 @@ export default function AppFooter() {
                 native: true,
               }}
               className={classes.language}
-            >
+              variant="standard">
               {LANGUAGES.map((language) => (
                 <option value={language.code} key={language.code}>
                   {language.name}

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.tsx
@@ -133,7 +133,8 @@ export default function AppFooter() {
                 native: true,
               }}
               className={classes.language}
-              variant="standard">
+              variant="standard"
+            >
               {LANGUAGES.map((language) => (
                 <option value={language.code} key={language.code}>
                   {language.name}

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppFooter.tsx
@@ -133,7 +133,7 @@ export default function AppFooter() {
                 native: true,
               }}
               className={classes.language}
-            >
+              variant="standard">
               {LANGUAGES.map((language) => (
                 <option value={language.code} key={language.code}>
                   {language.name}

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
@@ -87,7 +87,7 @@ function ProductCTA(props) {
                 noBorder
                 className={classes.textField}
                 placeholder="Your email"
-              />
+                variant="standard" />
               <Button
                 type="submit"
                 color="primary"

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
@@ -87,7 +87,8 @@ function ProductCTA(props) {
                 noBorder
                 className={classes.textField}
                 placeholder="Your email"
-                variant="standard" />
+                variant="standard"
+              />
               <Button
                 type="submit"
                 color="primary"

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.tsx
@@ -92,7 +92,8 @@ function ProductCTA(props: WithStyles<typeof styles>) {
                 noBorder
                 className={classes.textField}
                 placeholder="Your email"
-                variant="standard" />
+                variant="standard"
+              />
               <Button
                 type="submit"
                 color="primary"

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.tsx
@@ -92,7 +92,7 @@ function ProductCTA(props: WithStyles<typeof styles>) {
                 noBorder
                 className={classes.textField}
                 placeholder="Your email"
-              />
+                variant="standard" />
               <Button
                 type="submit"
                 color="primary"

--- a/docs/src/pages/premium-themes/paperbase/Content.js
+++ b/docs/src/pages/premium-themes/paperbase/Content.js
@@ -60,7 +60,8 @@ function Content(props) {
                   disableUnderline: true,
                   className: classes.searchInput,
                 }}
-                variant="standard" />
+                variant="standard"
+              />
             </Grid>
             <Grid item>
               <Button variant="contained" className={classes.addUser}>

--- a/docs/src/pages/premium-themes/paperbase/Content.js
+++ b/docs/src/pages/premium-themes/paperbase/Content.js
@@ -60,7 +60,7 @@ function Content(props) {
                   disableUnderline: true,
                   className: classes.searchInput,
                 }}
-              />
+                variant="standard" />
             </Grid>
             <Grid item>
               <Button variant="contained" className={classes.addUser}>

--- a/docs/src/pages/premium-themes/paperbase/Content.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Content.tsx
@@ -67,7 +67,8 @@ function Content(props: ContentProps) {
                   disableUnderline: true,
                   className: classes.searchInput,
                 }}
-                variant="standard" />
+                variant="standard"
+              />
             </Grid>
             <Grid item>
               <Button variant="contained" className={classes.addUser}>

--- a/docs/src/pages/premium-themes/paperbase/Content.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Content.tsx
@@ -67,7 +67,7 @@ function Content(props: ContentProps) {
                   disableUnderline: true,
                   className: classes.searchInput,
                 }}
-              />
+                variant="standard" />
             </Grid>
             <Grid item>
               <Button variant="contained" className={classes.addUser}>

--- a/framer/Material-UI.framerfx/code/TextField.tsx
+++ b/framer/Material-UI.framerfx/code/TextField.tsx
@@ -36,7 +36,7 @@ TextField.defaultProps = {
   label: 'TextField',
   multiline: false,
   required: false,
-  variant: 'standard' as 'standard',
+  variant: 'outlined' as 'outlined',
   width: 280,
   height: 56,
 };

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -35,6 +35,24 @@ The diff should look like this:
 find src -name '*.js' -print | xargs npx jscodeshift -t node_modules/@material-ui/codemod/lib/v5.0.0/box-sx-prop.js
 ```
 
+#### `textfield-variant-prop`
+
+Add the TextField `variant="standard` prop when `variant` is undefined.
+The diff should look like this:
+
+```diff
+  -<TextField value="Standard" />
+  -<TextField value="Outlined" variant="outlined" />
+  +<TextField value="Standard" variant="standard" />
+  +<TextField value="Outlined" />
+```
+
+This codemod is non-idempotent (`variant="standard"` would be added on a subsequent run, where `variant="outlined"` was removed), so should only be run once against any particular codebase.
+
+```sh
+find src -name '*.js' -print | xargs npx jscodeshift -t node_modules/@material-ui/codemod/lib/v5.0.0/textfield-variant-prop.js
+```
+
 ### v4.0.0
 
 #### `theme-spacing-api`

--- a/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.js
+++ b/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.js
@@ -1,0 +1,25 @@
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+
+  return j(file.source)
+    .findJSXElements('TextField')
+    .forEach((path) => {
+      const attributes = path.node.openingElement.attributes;
+      const variant = attributes.find(
+        (node) => node.type === 'JSXAttribute' && node.name.name === 'variant',
+      );
+
+      if (variant && variant.value.value === 'outlined') {
+        delete attributes[
+          attributes.findIndex(
+            (node) => node.type === 'JSXAttribute' && node.name.name === 'variant',
+          )
+        ];
+      }
+
+      if (!variant) {
+        attributes.push(j.jsxAttribute(j.jsxIdentifier('variant'), j.literal('standard')));
+      }
+    })
+    .toSource();
+}

--- a/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test.js
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from './textfield-variant-prop';
+
+function read(fileName) {
+  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+}
+
+describe('@material-ui/codemod', () => {
+  describe('v5.0.0', () => {
+    describe('textfield-variant-prop', () => {
+      it('transforms props as needed', () => {
+        const actual = transform(
+          {
+            source: read('./textfield-variant-prop.test/actual.js'),
+            path: require.resolve('./textfield-variant-prop.test/actual.js'),
+          },
+          { jscodeshift: jscodeshift },
+          {},
+        );
+
+        const expected = read('./textfield-variant-prop.test/expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
+  });
+});

--- a/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test/actual.js
+++ b/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test/actual.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+
+export default function TextFieldComponent(props) {
+  return (
+    <div>
+      <TextField {...props} />
+      <TextField variant="outlined" />
+      <TextField variant="standard" />
+      <TextField variant="filled" />
+    </div>
+  );
+}

--- a/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test/expected.js
+++ b/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test/expected.js
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+
+export default function TextFieldComponent(props) {
+  return (
+    <div>
+      <TextField {...props} variant="standard" />
+      <TextField />
+      <TextField variant="standard" />
+      <TextField variant="filled" />
+    </div>
+  );
+}
+  

--- a/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test/expected.js
+++ b/packages/material-ui-codemod/src/v5.0.0/textfield-variant-prop.test/expected.js
@@ -11,4 +11,3 @@ export default function TextFieldComponent(props) {
     </div>
   );
 }
-  

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -43,7 +43,10 @@ describe('<Autocomplete />', () => {
   describe('combobox', () => {
     it('should clear the input when blur', () => {
       const { getByRole } = render(
-        <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
+        <Autocomplete
+          options={[]}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
+        />,
       );
       const input = getByRole('textbox');
 
@@ -65,7 +68,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           value={'one'}
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.hasClearIcon);
@@ -80,7 +83,7 @@ describe('<Autocomplete />', () => {
           options={[]}
           freeSolo
           loading
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
@@ -97,7 +100,7 @@ describe('<Autocomplete />', () => {
           autoHighlight
           open
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -115,7 +118,7 @@ describe('<Autocomplete />', () => {
           autoHighlight
           open
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -132,7 +135,7 @@ describe('<Autocomplete />', () => {
           options={[]}
           autoHighlight
           loading
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -151,7 +154,7 @@ describe('<Autocomplete />', () => {
           value="one"
           open
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -168,7 +171,7 @@ describe('<Autocomplete />', () => {
           open
           options={['one', 'two', 'three']}
           disableCloseOnSelect
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -189,7 +192,7 @@ describe('<Autocomplete />', () => {
           autoHighlight
           value={options.slice(0, 1)}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -212,7 +215,7 @@ describe('<Autocomplete />', () => {
           multiple
           open
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -232,7 +235,7 @@ describe('<Autocomplete />', () => {
           limitTags={2}
           options={['one', 'two', 'three']}
           defaultValue={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
 
@@ -257,7 +260,7 @@ describe('<Autocomplete />', () => {
           limitTags={0}
           options={['one', 'two', 'three']}
           defaultValue={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
 
@@ -283,7 +286,7 @@ describe('<Autocomplete />', () => {
           filterSelectedOptions
           openOnFocus
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -310,7 +313,7 @@ describe('<Autocomplete />', () => {
           autoSelect
           options={options}
           onChange={handleChange}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -337,7 +340,7 @@ describe('<Autocomplete />', () => {
           openOnFocus
           options={options}
           onChange={handleChange}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -361,7 +364,7 @@ describe('<Autocomplete />', () => {
           multiple
           onChange={handleChange}
           options={[]}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -381,7 +384,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           openOnFocus
           options={[]}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           multiple
         />,
       );
@@ -402,7 +405,7 @@ describe('<Autocomplete />', () => {
           options={[]}
           defaultValue={options}
           onChange={handleChange}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           multiple
         />,
       );
@@ -419,7 +422,7 @@ describe('<Autocomplete />', () => {
           defaultValue={options}
           options={options}
           onChange={handleChange}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           multiple
         />,
       );
@@ -452,7 +455,7 @@ describe('<Autocomplete />', () => {
               .map((option, index) => <Chip label={option.title} {...getTagProps({ index })} />)
           }
           onChange={handleChange}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           multiple
         />,
       );
@@ -471,7 +474,7 @@ describe('<Autocomplete />', () => {
       render(
         <Autocomplete
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           multiple
           value={['one', 'two']}
         />,
@@ -492,7 +495,7 @@ describe('<Autocomplete />', () => {
           <Autocomplete
             multiple
             options={['one', 'two']}
-            renderInput={(params) => <TextField {...params} required />}
+            renderInput={(params) => <TextField {...params} required variant="standard" />}
             value={[]}
           />
           <button type="submit">Submit</button>
@@ -518,7 +521,7 @@ describe('<Autocomplete />', () => {
           <Autocomplete
             multiple
             options={['one', 'two']}
-            renderInput={(params) => <TextField {...params} required />}
+            renderInput={(params) => <TextField {...params} required variant="standard" />}
             value={['one']}
           />
           <button type="submit">Submit</button>
@@ -541,7 +544,7 @@ describe('<Autocomplete />', () => {
             handleSubmit();
           }
         }}
-        renderInput={(props2) => <TextField {...props2} autoFocus />}
+        renderInput={(props2) => <TextField {...props2} autoFocus variant="standard" />}
       />,
     );
     let textbox = screen.getByRole('textbox');
@@ -591,7 +594,7 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           openOnFocus
           options={['one', 'two', 'three']}
-          renderInput={(props2) => <TextField {...props2} autoFocus />}
+          renderInput={(props2) => <TextField {...props2} autoFocus variant="standard" />}
         />,
       );
 
@@ -621,7 +624,10 @@ describe('<Autocomplete />', () => {
   describe('WAI-ARIA conforming markup', () => {
     specify('when closed', () => {
       const { getAllByRole, getByRole, queryByRole } = render(
-        <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
+        <Autocomplete
+          options={[]}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
+        />,
       );
 
       const combobox = getByRole('combobox');
@@ -656,7 +662,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
 
@@ -693,7 +699,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -719,7 +725,7 @@ describe('<Autocomplete />', () => {
           options={[]}
           onOpen={handleOpen}
           openOnFocus
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -736,7 +742,7 @@ describe('<Autocomplete />', () => {
           open={false}
           options={['one', 'two']}
           value="one"
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
 
@@ -756,7 +762,7 @@ describe('<Autocomplete />', () => {
             open={false}
             openOnFocus
             options={[]}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />,
         );
         const textbox = screen.getByRole('textbox');
@@ -777,7 +783,7 @@ describe('<Autocomplete />', () => {
           open={false}
           options={['one', 'two']}
           value="one"
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -797,7 +803,7 @@ describe('<Autocomplete />', () => {
           multiple
           value={['one']}
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -815,7 +821,7 @@ describe('<Autocomplete />', () => {
           onClose={handleClose}
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -830,7 +836,7 @@ describe('<Autocomplete />', () => {
           onClose={handleClose}
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -846,7 +852,7 @@ describe('<Autocomplete />', () => {
           onClose={handleClose}
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -860,7 +866,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -876,7 +882,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -897,7 +903,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['가1', '가2']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -917,7 +923,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           options={['one', 'two', 'three']}
           openOnFocus
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -953,7 +959,7 @@ describe('<Autocomplete />', () => {
       const { getAllByRole } = render(
         <Autocomplete
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -973,7 +979,7 @@ describe('<Autocomplete />', () => {
       render(
         <Autocomplete
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -993,7 +999,7 @@ describe('<Autocomplete />', () => {
             includeInputInList
             open
             options={['one', 'two', 'three']}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />,
         );
         const textbox = screen.getByRole('textbox');
@@ -1011,7 +1017,7 @@ describe('<Autocomplete />', () => {
             includeInputInList
             open
             options={['one', 'two', 'three']}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />,
         );
         const textbox = screen.getByRole('textbox');
@@ -1031,7 +1037,7 @@ describe('<Autocomplete />', () => {
             disableListWrap
             open
             options={['one', 'two', 'three']}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />,
         );
         const textbox = screen.getByRole('textbox');
@@ -1052,7 +1058,7 @@ describe('<Autocomplete />', () => {
             disableListWrap
             open
             options={['one', 'two', 'three']}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />,
         );
         const textbox = screen.getByRole('textbox');
@@ -1073,7 +1079,7 @@ describe('<Autocomplete />', () => {
             disableListWrap
             open
             options={['one', 'two', 'three']}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />,
         );
         const textbox = screen.getByRole('textbox');
@@ -1098,7 +1104,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           disabled
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       const input = getByRole('textbox');
@@ -1110,7 +1116,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           disabled
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       expect(queryByTitle('Open').disabled).to.equal(true);
@@ -1121,7 +1127,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           disabled
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       expect(queryByTitle('Clear')).to.equal(null);
@@ -1132,7 +1138,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           disabled
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       expect(container.querySelector(`.${classes.root}`)).not.to.have.class(classes.hasClearIcon);
@@ -1146,7 +1152,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           disableClearable
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       expect(queryByTitle('Clear')).to.equal(null);
@@ -1164,7 +1170,7 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           options={[{ name: 'one' }, { name: 'two ' }]}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1201,7 +1207,7 @@ describe('<Autocomplete />', () => {
           value={value}
           getOptionLabel={(option) => option.text}
           getOptionSelected={(option) => value.find((v) => v.id === option.id)}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1223,7 +1229,7 @@ describe('<Autocomplete />', () => {
           <Autocomplete
             value={value}
             options={options}
-            renderInput={(params) => <TextField {...params} />}
+            renderInput={(params) => <TextField {...params} variant="standard" />}
           />,
         );
       }).toWarnDev([
@@ -1251,7 +1257,7 @@ describe('<Autocomplete />', () => {
             openOnFocus
             options={data}
             getOptionLabel={(option) => option.value}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
             groupBy={(option) => option.group}
           />,
         );
@@ -1272,7 +1278,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1295,7 +1301,7 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           openOnFocus
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       const input = getByRole('textbox');
@@ -1320,7 +1326,7 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           openOnFocus
           options={options}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
 
@@ -1335,7 +1341,11 @@ describe('<Autocomplete />', () => {
 
     it("should display a 'no options' message if no options are available", () => {
       const { getByRole } = render(
-        <Autocomplete open options={[]} renderInput={(params) => <TextField {...params} />} />,
+        <Autocomplete
+          open
+          options={[]}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
+        />,
       );
 
       const combobox = getByRole('combobox');
@@ -1355,7 +1365,7 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           openOnFocus
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1378,7 +1388,7 @@ describe('<Autocomplete />', () => {
           openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1400,7 +1410,7 @@ describe('<Autocomplete />', () => {
           autoComplete
           openOnFocus
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1429,7 +1439,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           openOnFocus
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -1446,7 +1456,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           value="one"
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       const textbox = getByRole('textbox');
@@ -1460,7 +1470,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           value="one"
           options={['one', 'two']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
 
@@ -1482,7 +1492,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           onHighlightChange={handleHighlightChange}
           options={['one']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       const combobox = getByRole('combobox');
@@ -1507,7 +1517,7 @@ describe('<Autocomplete />', () => {
           value="one"
           onHighlightChange={handleHighlightChange}
           options={['one']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
         />,
       );
       const combobox = getByRole('combobox');
@@ -1535,7 +1545,7 @@ describe('<Autocomplete />', () => {
             options={[]}
             inputValue=""
             onInputChange={handleInputChange}
-            renderInput={(params) => <TextField {...params} autoFocus />}
+            renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           />
         );
       }
@@ -1558,7 +1568,7 @@ describe('<Autocomplete />', () => {
           onInputChange={handleInputChange}
           open
           options={['foo']}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1586,7 +1596,7 @@ describe('<Autocomplete />', () => {
             },
           ]}
           getOptionLabel={(option) => option.label}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       let options;
@@ -1608,7 +1618,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           filterOptions={filterOptions}
         />,
       );
@@ -1621,7 +1631,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           open
           options={['one', 'two', 'three']}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           filterOptions={filterOptions}
         />,
       );
@@ -1640,7 +1650,7 @@ describe('<Autocomplete />', () => {
           open
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1665,7 +1675,7 @@ describe('<Autocomplete />', () => {
           options={options}
           onChange={handleChange}
           freeSolo
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           multiple
         />,
       );
@@ -1689,7 +1699,7 @@ describe('<Autocomplete />', () => {
           freeSolo
           onChange={handleChange}
           options={[]}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1716,7 +1726,7 @@ describe('<Autocomplete />', () => {
           freeSolo
           onChange={handleChange}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1737,7 +1747,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           onChange={handleChange}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1761,7 +1771,7 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           value={options}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1782,7 +1792,7 @@ describe('<Autocomplete />', () => {
           autoSelect
           onChange={handleChange}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1808,7 +1818,7 @@ describe('<Autocomplete />', () => {
           value={options}
           onChange={handleChange}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
 
@@ -1830,7 +1840,7 @@ describe('<Autocomplete />', () => {
           onInputChange={handleInputChange}
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       fireEvent.change(document.activeElement, { target: { value: 'a' } });
@@ -1848,7 +1858,7 @@ describe('<Autocomplete />', () => {
           openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -1870,7 +1880,7 @@ describe('<Autocomplete />', () => {
           openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           blurOnSelect
         />,
       );
@@ -1895,7 +1905,7 @@ describe('<Autocomplete />', () => {
           openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           blurOnSelect="touch"
         />,
       );
@@ -1918,7 +1928,7 @@ describe('<Autocomplete />', () => {
           openOnFocus
           options={options}
           getOptionLabel={(option) => option.name}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
           blurOnSelect="mouse"
         />,
       );
@@ -1942,7 +1952,7 @@ describe('<Autocomplete />', () => {
           open
           options={[0, 10, 20]}
           getOptionLabel={(option) => (option === 0 ? 'Any' : option.toString())}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           value={0}
         />,
       );
@@ -1957,7 +1967,7 @@ describe('<Autocomplete />', () => {
           open
           options={[null, 10, 20]}
           getOptionLabel={(option) => (option === null ? 'Any' : option.toString())}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           value={null}
         />,
       );
@@ -1973,7 +1983,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           fullWidth
           options={[0, 10, 20]}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} variant="standard" />}
           value={null}
         />,
       );
@@ -1992,7 +2002,7 @@ describe('<Autocomplete />', () => {
           onHighlightChange={handleHighlightChange}
           options={options}
           open
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       expect(handleHighlightChange.callCount).to.equal(1);
@@ -2009,7 +2019,7 @@ describe('<Autocomplete />', () => {
           onHighlightChange={handleHighlightChange}
           options={options}
           open
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -2035,7 +2045,7 @@ describe('<Autocomplete />', () => {
           onHighlightChange={handleHighlightChange}
           options={options}
           open
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const firstOption = getAllByRole('option')[0];
@@ -2053,7 +2063,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           onHighlightChange={handleHighlightChange}
           options={options}
-          renderInput={(params) => <TextField {...params} autoFocus />}
+          renderInput={(params) => <TextField {...params} autoFocus variant="standard" />}
         />,
       );
       const textbox = screen.getByRole('textbox');
@@ -2076,7 +2086,7 @@ describe('<Autocomplete />', () => {
         openOnFocus
         options={['one', 'two']}
         onChange={handleChange}
-        renderInput={(params) => <TextField autoFocus {...params} />}
+        renderInput={(params) => <TextField autoFocus {...params} variant="standard" />}
       />,
     );
     const textbox = getByRole('textbox');

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -622,6 +622,7 @@ describe('<InputBase />', () => {
               </InputAdornment>
             ),
           }}
+          variant="standard"
         />,
       );
     });

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -160,7 +160,7 @@ export interface StandardTextFieldProps extends BaseTextFieldProps {
   onChange?: StandardInputProps['onChange'];
   /**
    * The variant to use.
-   * @default 'standard'
+   * @default 'outlined'
    */
   variant?: 'standard';
   /**
@@ -182,7 +182,7 @@ export interface FilledTextFieldProps extends BaseTextFieldProps {
   onChange?: FilledInputProps['onChange'];
   /**
    * The variant to use.
-   * @default 'standard'
+   * @default 'outlined'
    */
   variant: 'filled';
   /**
@@ -204,7 +204,7 @@ export interface OutlinedTextFieldProps extends BaseTextFieldProps {
   onChange?: OutlinedInputProps['onChange'];
   /**
    * The variant to use.
-   * @default 'standard'
+   * @default 'outlined'
    */
   variant: 'outlined';
   /**

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -88,7 +88,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     SelectProps,
     type,
     value,
-    variant = 'standard',
+    variant = 'outlined',
     ...other
   } = props;
 
@@ -356,7 +356,7 @@ TextField.propTypes = {
   value: PropTypes.any,
   /**
    * The variant to use.
-   * @default 'standard'
+   * @default 'outlined'
    */
   variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
 };

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -13,10 +13,10 @@ describe('<TextField />', () => {
   const render = createClientRender();
 
   before(() => {
-    classes = getClasses(<TextField />);
+    classes = getClasses(<TextField variant="standard" />);
   });
 
-  describeConformance(<TextField />, () => ({
+  describeConformance(<TextField variant="standard" />, () => ({
     classes,
     inheritComponent: FormControl,
     mount,
@@ -26,7 +26,7 @@ describe('<TextField />', () => {
 
   describe('structure', () => {
     it('should have an input as the only child', () => {
-      const { getAllByRole } = render(<TextField />);
+      const { getAllByRole } = render(<TextField variant="standard" />);
 
       expect(getAllByRole('textbox')).to.have.lengthOf(1);
     });
@@ -54,14 +54,19 @@ describe('<TextField />', () => {
 
   describe('with a label', () => {
     it('label the input', () => {
-      const { getByRole } = render(<TextField id="labelled" label="Foo bar" />);
+      const { getByRole } = render(<TextField id="labelled" label="Foo bar" variant="standard" />);
 
       expect(getByRole('textbox', { name: 'Foo bar' })).not.to.equal(null);
     });
 
     it('should apply the className to the label', () => {
       const { container } = render(
-        <TextField id="labelled" label="Foo bar" InputLabelProps={{ className: 'foo' }} />,
+        <TextField
+          id="labelled"
+          label="Foo bar"
+          InputLabelProps={{ className: 'foo' }}
+          variant="standard"
+        />,
       );
 
       expect(container.querySelector('label')).to.have.class('foo');
@@ -69,7 +74,7 @@ describe('<TextField />', () => {
 
     ['', undefined].forEach((label) => {
       it(`should not render empty (${label}) label element`, () => {
-        const { container } = render(<TextField id="labelled" label={label} />);
+        const { container } = render(<TextField id="labelled" label={label} variant="standard" />);
 
         expect(container.querySelector('label')).to.equal(null);
       });
@@ -83,6 +88,7 @@ describe('<TextField />', () => {
           id="aria-test"
           helperText="Foo bar"
           FormHelperTextProps={{ className: 'foo' }}
+          variant="standard"
         />,
       );
 
@@ -95,6 +101,7 @@ describe('<TextField />', () => {
           id="aria-test"
           helperText="Foo bar"
           FormHelperTextProps={{ className: 'foo' }}
+          variant="standard"
         />,
       );
 
@@ -109,7 +116,6 @@ describe('<TextField />', () => {
           InputProps={{ classes: { notchedOutline: 'notch' } }}
           label={<div data-testid="label">label</div>}
           required
-          variant="outlined"
         />,
       );
 
@@ -121,9 +127,7 @@ describe('<TextField />', () => {
 
     it('should set shrink prop on outline from label', () => {
       const outlinedInputClasses = getClasses(<OutlinedInput />);
-      const { container } = render(
-        <TextField variant="outlined" InputLabelProps={{ shrink: true }} classes={{}} />,
-      );
+      const { container } = render(<TextField InputLabelProps={{ shrink: true }} classes={{}} />);
 
       expect(container.querySelector('fieldset')).to.have.class(
         outlinedInputClasses.notchedOutline,
@@ -134,7 +138,7 @@ describe('<TextField />', () => {
   describe('prop: InputProps', () => {
     it('should apply additional props to the Input component', () => {
       const { getByTestId } = render(
-        <TextField InputProps={{ 'data-testid': 'InputComponent' }} />,
+        <TextField InputProps={{ 'data-testid': 'InputComponent' }} variant="standard" />,
       );
 
       expect(getByTestId('InputComponent')).not.to.equal(null);
@@ -149,7 +153,7 @@ describe('<TextField />', () => {
       ];
 
       const { container } = render(
-        <TextField select SelectProps={{ native: true }}>
+        <TextField select SelectProps={{ native: true }} variant="standard">
           {currencies.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
@@ -171,6 +175,7 @@ describe('<TextField />', () => {
           select
           SelectProps={{ native: true }}
           value="$"
+          variant="standard"
         >
           <option value="dollar">$</option>
         </TextField>,
@@ -181,7 +186,7 @@ describe('<TextField />', () => {
 
     it('renders a combobox with the appropriate accessible name', () => {
       const { getByRole } = render(
-        <TextField select id="my-select" label="Release: " value="stable">
+        <TextField select id="my-select" label="Release: " value="stable" variant="standard">
           <MenuItem value="alpha">Alpha</MenuItem>
           <MenuItem value="beta">Beta</MenuItem>
           <MenuItem value="stable">Stable</MenuItem>
@@ -193,7 +198,7 @@ describe('<TextField />', () => {
 
     it('creates an input[hidden] that has no accessible properties', () => {
       const { container } = render(
-        <TextField select id="my-select" label="Release: " value="stable">
+        <TextField select id="my-select" label="Release: " value="stable" variant="standard">
           <MenuItem value="stable">Stable</MenuItem>
         </TextField>,
       );

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -33,7 +33,7 @@ describe('<TextField />', () => {
 
     it('should forward the multiline prop to Input', () => {
       const inputClasses = getClasses(<Input />);
-      const { getByRole } = render(<TextField multiline />);
+      const { getByRole } = render(<TextField variant="standard" multiline />);
 
       expect(getByRole('textbox', { hidden: false })).to.have.class(inputClasses.inputMultiline);
     });
@@ -41,7 +41,7 @@ describe('<TextField />', () => {
     it('should forward the fullWidth prop to Input', () => {
       const inputClasses = getClasses(<Input />);
       const { getByTestId } = render(
-        <TextField fullWidth InputProps={{ 'data-testid': 'mui-input-base-root' }} />,
+        <TextField variant="standard" fullWidth InputProps={{ 'data-testid': 'mui-input-base-root' }} />,
       );
 
       expect(getByTestId('mui-input-base-root')).to.have.class(inputClasses.fullWidth);

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -41,7 +41,11 @@ describe('<TextField />', () => {
     it('should forward the fullWidth prop to Input', () => {
       const inputClasses = getClasses(<Input />);
       const { getByTestId } = render(
-        <TextField variant="standard" fullWidth InputProps={{ 'data-testid': 'mui-input-base-root' }} />,
+        <TextField
+          variant="standard"
+          fullWidth
+          InputProps={{ 'data-testid': 'mui-input-base-root' }}
+        />,
       );
 
       expect(getByTestId('mui-input-base-root')).to.have.class(inputClasses.fullWidth);

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -945,7 +945,7 @@ describe('<Tooltip />', () => {
       });
       const { getByRole } = render(
         <Tooltip open title="test">
-          <TextField onFocus={handleFocus} />
+          <TextField onFocus={handleFocus} variant="standard" />
         </Tooltip>,
       );
       const input = getByRole('textbox');


### PR DESCRIPTION
### Breaking changes

- [TextField] Change the default variant from `standard` to `outlined`. Standard has been removed from the Material Design guidelines. [This codemod](https://github.com/mui-org/material-ui/tree/next/packages/material-ui-codemod#textfield-variant-prop) will automatically update your code.

  ```diff
  -<TextField value="Standard" />
  -<TextField value="Outlined" variant="outlined" />
  +<TextField value="Standard" variant="standard" />
  +<TextField value="Outlined" />
  ```

---

Contributes to: #20012
