### PR TITLE
[docs] Prevent layout jumps from img loading in system demo

### DIFF
--- a/docs/src/pages/system/basics/Demo.js
+++ b/docs/src/pages/system/basics/Demo.js
@@ -3,10 +3,6 @@ import Box from '@material-ui/core/Box';
 import { alpha } from '@material-ui/core/styles';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 
-function Img(props) {
-  return <Box component="img" {...props} />;
-}
-
 export default function Demo() {
   return (
     <Box
@@ -21,11 +17,21 @@ export default function Demo() {
         fontWeight: 'fontWeightBold',
       }}
     >
-      <Img
-        sx={{ width: '100%', maxWidth: { xs: 350, md: 250 } }}
-        alt="The house from the offer."
-        src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=400&dpr=2"
-      />
+      <Box
+        sx={{
+          width: '100%',
+          maxHeight: { xs: 233, md: 167 },
+          maxWidth: { xs: 350, md: 250 },
+        }}
+        clone
+      >
+        <img
+          alt="The house from the offer."
+          height="233"
+          width="350"
+          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=400&dpr=2"
+        />
+      </Box>
       <Box
         sx={{
           display: 'flex',

--- a/docs/src/pages/system/basics/Demo.js
+++ b/docs/src/pages/system/basics/Demo.js
@@ -19,7 +19,6 @@ export default function Demo() {
     >
       <Box
         sx={{
-          width: '100%',
           maxHeight: { xs: 233, md: 167 },
           maxWidth: { xs: 350, md: 250 },
         }}

--- a/docs/src/pages/system/basics/Demo.js
+++ b/docs/src/pages/system/basics/Demo.js
@@ -29,7 +29,7 @@ export default function Demo() {
           alt="The house from the offer."
           height="233"
           width="350"
-          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=400&dpr=2"
+          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
         />
       </Box>
       <Box

--- a/docs/src/pages/system/basics/Demo.tsx
+++ b/docs/src/pages/system/basics/Demo.tsx
@@ -19,7 +19,6 @@ export default function Demo() {
     >
       <Box
         sx={{
-          width: '100%',
           maxHeight: { xs: 233, md: 167 },
           maxWidth: { xs: 350, md: 250 },
         }}

--- a/docs/src/pages/system/basics/Demo.tsx
+++ b/docs/src/pages/system/basics/Demo.tsx
@@ -29,7 +29,7 @@ export default function Demo() {
           alt="The house from the offer."
           height="233"
           width="350"
-          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=400&dpr=2"
+          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
         />
       </Box>
       <Box

--- a/docs/src/pages/system/basics/Demo.tsx
+++ b/docs/src/pages/system/basics/Demo.tsx
@@ -1,16 +1,7 @@
 import * as React from 'react';
-import Box, { BoxProps } from '@material-ui/core/Box';
+import Box from '@material-ui/core/Box';
 import { alpha } from '@material-ui/core/styles';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
-
-interface ImgProps extends BoxProps {
-  src?: string;
-  alt?: string;
-}
-
-function Img(props: ImgProps) {
-  return <Box component="img" {...props} />;
-}
 
 export default function Demo() {
   return (
@@ -26,11 +17,21 @@ export default function Demo() {
         fontWeight: 'fontWeightBold',
       }}
     >
-      <Img
-        sx={{ width: '100%', maxWidth: { xs: 350, md: 250 } }}
-        alt="The house from the offer."
-        src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=400&dpr=2"
-      />
+      <Box
+        sx={{
+          width: '100%',
+          maxHeight: { xs: 233, md: 167 },
+          maxWidth: { xs: 350, md: 250 },
+        }}
+        clone
+      >
+        <img
+          alt="The house from the offer."
+          height="233"
+          width="350"
+          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=400&dpr=2"
+        />
+      </Box>
       <Box
         sx={{
           display: 'flex',


### PR DESCRIPTION
Most  likely not the best solution but better than documenting images with layout shiift. That's a gap a dedicated `Image` component could solve (https://github.com/mui-org/material-ui/issues/22470).
