### PR TITLE
[Tabs] Remove duplicate styles

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -916,9 +916,6 @@ const classes = makeStyles(theme => ({
 
 ### Tabs
 
-- Updates to match the Material Design guidelines:
-  - Remove min-width
-  - Improve padding
 - TypeScript: The `event` in `onChange` is no longer typed as a `React.ChangeEvent` but `React.SyntheticEvent`.
 
   ```diff

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -916,6 +916,9 @@ const classes = makeStyles(theme => ({
 
 ### Tabs
 
+- Updates to match the Material Design guidelines:
+  - Remove min-width
+  - Improve padding
 - TypeScript: The `event` in `onChange` is no longer typed as a `React.ChangeEvent` but `React.SyntheticEvent`.
 
   ```diff

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -11,13 +11,17 @@ export const styles = (theme) => ({
   root: {
     ...theme.typography.button,
     maxWidth: 264,
+    minWidth: 72,
     position: 'relative',
     minHeight: 48,
     flexShrink: 0,
-    padding: '6px 24px',
+    padding: '6px 12px',
     overflow: 'hidden',
     whiteSpace: 'normal',
     textAlign: 'center',
+    [theme.breakpoints.up('sm')]: {
+      minWidth: 160,
+    },
   },
   /* Styles applied to the root element if both `icon` and `label` are provided. */
   labelIcon: {

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -11,7 +11,6 @@ export const styles = (theme) => ({
   root: {
     ...theme.typography.button,
     maxWidth: 264,
-    minWidth: 72,
     position: 'relative',
     minHeight: 48,
     flexShrink: 0,

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -18,13 +18,11 @@ export const styles = (theme) => ({
     padding: '6px 12px',
     [theme.breakpoints.up('sm')]: {
       padding: '6px 24px',
+      minWidth: 160,
     },
     overflow: 'hidden',
     whiteSpace: 'normal',
     textAlign: 'center',
-    [theme.breakpoints.up('sm')]: {
-      minWidth: 160,
-    },
   },
   /* Styles applied to the root element if both `icon` and `label` are provided. */
   labelIcon: {

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -15,11 +15,7 @@ export const styles = (theme) => ({
     position: 'relative',
     minHeight: 48,
     flexShrink: 0,
-    padding: '6px 12px',
-    [theme.breakpoints.up('sm')]: {
-      padding: '6px 24px',
-      minWidth: 160,
-    },
+    padding: '6px 24px',
     overflow: 'hidden',
     whiteSpace: 'normal',
     textAlign: 'center',

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -348,9 +348,9 @@ describe('<Tabs />', () => {
     let clock;
     const tabs = (
       <Tabs value={0} style={{ width: 200 }} variant="scrollable">
-        <Tab />
-        <Tab />
-        <Tab />
+        <Tab style={{ width: 120 }} />
+        <Tab style={{ width: 120 }} />
+        <Tab style={{ width: 120 }} />
       </Tabs>
     );
 
@@ -376,7 +376,7 @@ describe('<Tabs />', () => {
       const { container, setProps, getByRole } = render(tabs);
       const tablistContainer = getByRole('tablist').parentElement;
 
-      Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+      Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
       tablistContainer.scrollLeft = 10;
       Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
       Object.defineProperty(tablistContainer, 'getBoundingClientRect', {
@@ -475,7 +475,7 @@ describe('<Tabs />', () => {
 
       const tablistContainer = getByRole('tablist').parentElement;
 
-      Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+      Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
       tablistContainer.scrollLeft = 10;
       Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
       Object.defineProperty(tablistContainer, 'getBoundingClientRect', {
@@ -518,14 +518,14 @@ describe('<Tabs />', () => {
       it('should set only left scroll button state', () => {
         const { container, setProps, getByRole } = render(
           <Tabs value={0} variant="scrollable" scrollButtons style={{ width: 200 }}>
-            <Tab />
-            <Tab />
-            <Tab />
+            <Tab style={{ width: 120 }} />
+            <Tab style={{ width: 120 }} />
+            <Tab style={{ width: 120 }} />
           </Tabs>,
         );
         const tablistContainer = getByRole('tablist').parentElement;
 
-        Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+        Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
         Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
         tablistContainer.scrollLeft = 96;
 
@@ -544,7 +544,7 @@ describe('<Tabs />', () => {
         );
         const tablistContainer = getByRole('tablist').parentElement;
 
-        Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+        Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
         Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
         tablistContainer.scrollLeft = 0;
 
@@ -556,13 +556,13 @@ describe('<Tabs />', () => {
       it('should set both left and right scroll button state', () => {
         const { container, setProps, getByRole } = render(
           <Tabs value={0} variant="scrollable" scrollButtons style={{ width: 200 }}>
-            <Tab />
-            <Tab />
+            <Tab style={{ width: 120 }} />
+            <Tab style={{ width: 120 }} />
           </Tabs>,
         );
         const tablistContainer = getByRole('tablist').parentElement;
 
-        Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+        Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
         Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
         tablistContainer.scrollLeft = 5;
 
@@ -587,18 +587,18 @@ describe('<Tabs />', () => {
     it('should scroll visible items', () => {
       const { container, setProps, getByRole, getAllByRole } = render(
         <Tabs value={0} variant="scrollable" scrollButtons style={{ width: 200 }}>
-          <Tab />
-          <Tab />
-          <Tab />
+          <Tab style={{ width: 100 }} />
+          <Tab style={{ width: 50 }} />
+          <Tab style={{ width: 100 }} />
         </Tabs>,
       );
       const tablistContainer = getByRole('tablist').parentElement;
       const tabs = getAllByRole('tab');
-      Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
-      Object.defineProperty(tabs[0], 'clientWidth', { value: 60 });
+      Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
+      Object.defineProperty(tabs[0], 'clientWidth', { value: 100 });
       Object.defineProperty(tabs[1], 'clientWidth', { value: 50 });
-      Object.defineProperty(tabs[2], 'clientWidth', { value: 60 });
-      Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
+      Object.defineProperty(tabs[2], 'clientWidth', { value: 100 });
+      Object.defineProperty(tablistContainer, 'scrollWidth', { value: 100 + 50 + 100 });
       tablistContainer.scrollLeft = 20;
       setProps();
       clock.tick(1000);
@@ -612,7 +612,7 @@ describe('<Tabs />', () => {
       tablistContainer.scrollLeft = 0;
       fireEvent.click(findScrollButton(container, 'right'));
       clock.tick(1000);
-      expect(tablistContainer.scrollLeft).equal(60 + 50);
+      expect(tablistContainer.scrollLeft).equal(100);
     });
   });
 
@@ -634,16 +634,16 @@ describe('<Tabs />', () => {
 
       const { setProps, getByRole } = render(
         <Tabs value={0} variant="scrollable" style={{ width: 200 }}>
-          <Tab />
-          <Tab />
-          <Tab />
+          <Tab style={{ width: 120 }} />
+          <Tab style={{ width: 120 }} />
+          <Tab style={{ width: 120 }} />
         </Tabs>,
       );
       const tablist = getByRole('tablist');
       const tablistContainer = tablist.parentElement;
       const tab = tablist.children[0];
 
-      Object.defineProperty(tablistContainer, 'clientWidth', { value: 120 });
+      Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 - 40 * 2 });
       Object.defineProperty(tablistContainer, 'scrollWidth', { value: 216 });
       tablistContainer.scrollLeft = 20;
       tablistContainer.getBoundingClientRect = () => ({


### PR DESCRIPTION
It looks like the first `[theme.breakpoints.up('sm')]` was being overwritten by the second `theme.breakpoints.up('sm')`, therefore the intended increased padding on `sm` and bigger screens did not take effect.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


(Note that I am not sure whether we actually want the padding or whether the Material Design spec has changed over the years and the padding should be different. However, the current state is clearly a bug)