### PR TITLE
 [docs] Explicitly set page-content properties

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console, no-shadow */
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import * as babel from '@babel/core';
@@ -464,7 +463,7 @@ async function annotateClassesDefinition(context: {
 /**
  * Substitute CSS class description conditions with placeholder
  */
-function extractClassConditions(classDescriptions: { [key: string]: { [key: string]: string } }) {
+function extractClassConditions() {
   const classConditions: any = {};
   const stylesRegex = /(if |unless )(`.*)./;
 
@@ -675,7 +674,7 @@ async function buildDocs(options: {
   try {
     checkProps(reactAPI);
   } catch (err) {
-    console.log('Error checking props for', componentObject.filename);
+    console.error('Error checking props for', componentObject.filename);
     throw err;
   }
 
@@ -786,6 +785,7 @@ Page.getInitialProps = async () => {
 `.replace(/\r?\n/g, reactAPI.EOL),
   );
 
+  // eslint-disable-next-line no-console
   console.log('Built API docs for', reactAPI.name);
 
   await annotateComponentDefinition({ api: reactAPI, component: componentObject });
@@ -890,7 +890,7 @@ function run(argv: { componentDirectories?: string[]; grep?: string; outputDirec
 
     writePrettifiedFile(
       path.resolve('docs/translations', 'class-descriptions.json'),
-      JSON.stringify(sortObject(extractClassConditions(classDescriptions))),
+      JSON.stringify(sortObject(extractClassConditions())),
       prettierConfigPath,
     );
 


### PR DESCRIPTION
No actual fix yet.

Just on refactoring pass from removing unwanted, internal properties to explicitly setting them. This way we control the order in the JSON output (for git-diff hygiene) and don't accidentally leak implementation details.

Inlined some files that were only used in one place to prevent premature abstraction.

Removed some global eslint-disables. We have them for a reason.

Closes #23577