### PR TITLE
[test] Enable experimental-timezone tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,16 +290,3 @@ workflows:
                 - next
     jobs:
       - test_types_next
-  timezone-tests:
-    triggers:
-      - schedule:
-          cron: '23 * * * *'
-          filters:
-            branches:
-              only:
-                - next
-    jobs:
-      - test_unit:
-          test-gate: experimental-timezones
-      - test_browser:
-          test-gate: experimental-timezones

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.test.tsx
@@ -23,10 +23,7 @@ import {
 describe('<DatePicker />', () => {
   const render = createPickerRender({ strict: false });
 
-  it('render proper month', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('render proper month', () => {
     render(
       <StaticDatePicker
         value={adapterToUse.date('2019-01-01T00:00:00.000')}
@@ -40,10 +37,7 @@ describe('<DatePicker />', () => {
     expect(getAllByMuiTest('day')).to.have.length(31);
   });
 
-  it('desktop Mode – Accepts date on day button click', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('desktop Mode – Accepts date on day button click', () => {
     const onChangeMock = spy();
 
     render(
@@ -63,10 +57,7 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
-  it('mobile mode – Accepts date on `OK` button click', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('mobile mode – Accepts date on `OK` button click', () => {
     const onChangeMock = spy();
     render(
       <MobileDatePicker
@@ -89,10 +80,7 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
-  it('switches between months', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('switches between months', () => {
     render(
       <StaticDatePicker
         reduceAnimations
@@ -114,10 +102,7 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('calendar-month-text')).to.have.text('December');
   });
 
-  it('selects the closest enabled date if selected date is disabled', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('selects the closest enabled date if selected date is disabled', () => {
     const onChangeMock = spy();
 
     render(
@@ -155,10 +140,7 @@ describe('<DatePicker />', () => {
     expect(onChangeMock.callCount).to.equal(1);
   });
 
-  it('allows to select edge years from list', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('allows to select edge years from list', () => {
     render(
       <MobileDatePicker
         open
@@ -176,10 +158,7 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('datepicker-toolbar-date')).to.have.text('Fri, Jan 1');
   });
 
-  it("doesn't close picker on selection in Mobile mode", function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it("doesn't close picker on selection in Mobile mode", () => {
     render(
       <MobileDatePicker
         value={adapterToUse.date('2018-01-01T00:00:00.000')}
@@ -194,10 +173,7 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).toBeVisible();
   });
 
-  it('closes picker on selection in Desktop mode', async function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('closes picker on selection in Desktop mode', async () => {
     render(
       <DesktopDatePicker
         TransitionComponent={FakeTransitionComponent}
@@ -234,10 +210,7 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
-  it("prop `disableCloseOnSelect` – if `true` doesn't close picker", function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it("prop `disableCloseOnSelect` – if `true` doesn't close picker", () => {
     render(
       <DesktopDatePicker
         TransitionComponent={FakeTransitionComponent}
@@ -254,10 +227,7 @@ describe('<DatePicker />', () => {
     expect(screen.queryByRole('dialog')).toBeVisible();
   });
 
-  it('does not call onChange if same date selected', async function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('does not call onChange if same date selected', async () => {
     const onChangeMock = spy();
 
     render(
@@ -345,10 +315,7 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('picker-toolbar-title').textContent).to.equal('Default label');
   });
 
-  it('prop `toolbarFormat` – should format toolbar according to passed format', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('prop `toolbarFormat` – should format toolbar according to passed format', () => {
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -514,10 +481,7 @@ describe('<DatePicker />', () => {
     expect(screen.getAllByTestId('test-day')).to.have.length(31);
   });
 
-  it('prop `defaultCalendarMonth` – opens on provided month if date is `null`', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('prop `defaultCalendarMonth` – opens on provided month if date is `null`', () => {
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}

--- a/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
@@ -122,11 +122,7 @@ describe('<DatePicker /> keyboard interactions', () => {
   });
 
   describe('Calendar keyboard navigation', () => {
-    it('autofocus selected day on mount', function test() {
-      if (process.env.TEST_GATE !== 'experimental-timezones') {
-        this.skip();
-      }
-
+    it('autofocus selected day on mount', () => {
       // Important: Use <StaticDatePicker /> here in order to avoid async waiting for focus because of packages/material-ui-lab/src/internal/pickers/hooks/useCanAutoFocus.tsx logic
       render(
         <StaticDatePicker
@@ -149,11 +145,7 @@ describe('<DatePicker /> keyboard interactions', () => {
       { keyCode: 39, key: 'ArrowRight', expectFocusedDay: 'Aug 14, 2020' },
       { keyCode: 40, key: 'ArrowDown', expectFocusedDay: 'Aug 20, 2020' },
     ].forEach(({ key, keyCode, expectFocusedDay }) => {
-      it(key, function test() {
-        if (process.env.TEST_GATE !== 'experimental-timezones') {
-          this.skip();
-        }
-
+      it(key, () => {
         // Important: Use <StaticDatePicker /> here in order to avoid async waiting for focus because of packages/material-ui-lab/src/internal/pickers/hooks/useCanAutoFocus.tsx logic
         render(
           <StaticDatePicker
@@ -174,10 +166,7 @@ describe('<DatePicker /> keyboard interactions', () => {
     });
   });
 
-  it("doesn't allow to select disabled date from keyboard", async function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it("doesn't allow to select disabled date from keyboard", async () => {
     render(
       <StaticDatePicker
         allowKeyboardControl
@@ -208,11 +197,7 @@ describe('<DatePicker /> keyboard interactions', () => {
       { keyCode: 39, key: 'ArrowRight', expectFocusedYear: '2021' },
       { keyCode: 40, key: 'ArrowDown', expectFocusedYear: '2024' },
     ].forEach(({ key, keyCode, expectFocusedYear }) => {
-      it(key, function test() {
-        if (process.env.TEST_GATE !== 'experimental-timezones') {
-          this.skip();
-        }
-
+      it(key, () => {
         render(
           <StaticDatePicker
             open

--- a/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerLocalization.test.tsx
@@ -12,10 +12,7 @@ import { adapterToUse, getByMuiTest, createPickerRender } from '../internal/pick
 describe('<DatePicker /> localization', () => {
   const render = createPickerRender({ strict: false, locale: fr });
 
-  it('datePicker localized format for year view', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('datePicker localized format for year view', () => {
     render(
       <MobileDatePicker
         renderInput={(params) => <TextField {...params} />}
@@ -31,11 +28,7 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
-  it('datePicker localized format for year+month view', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
-
+  it('datePicker localized format for year+month view', () => {
     const value = adapterToUse.date(`2018-01-01T00:00:00.000`);
     render(
       <MobileDatePicker
@@ -52,10 +45,7 @@ describe('<DatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('janvier');
   });
 
-  it('datePicker localized format for year+month+date view', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('datePicker localized format for year+month+date view', () => {
     render(
       <MobileDatePicker
         onChange={() => {}}

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.test.tsx
@@ -179,10 +179,7 @@ describe('<DateTimePicker />', () => {
     expect(textbox.value).to.equal('12.');
   });
 
-  it('prop: maxDateTime – minutes is disabled by date part', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('prop: maxDateTime – minutes is disabled by date part', () => {
     render(
       <DesktopDateTimePicker
         open
@@ -243,10 +240,7 @@ describe('<DateTimePicker />', () => {
     expect(screen.getByLabelText('open next view')).to.have.attribute('disabled');
   });
 
-  it('allows to select the same day and move to the next view', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('allows to select the same day and move to the next view', () => {
     const onChangeMock = spy();
     render(
       <StaticDateTimePicker

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
@@ -28,10 +28,7 @@ describe('<DayPicker />', () => {
     skip: ['componentProp', 'propsSpread', 'reactTestRenderer'],
   }));
 
-  it('renders calendar standalone', function test() {
-    if (process.env.TEST_GATE !== 'experimental-timezones') {
-      this.skip();
-    }
+  it('renders calendar standalone', () => {
     render(<DayPicker date={adapterToUse.date('2019-01-01T00:00:00.000')} onChange={() => {}} />);
 
     expect(screen.getByText('January')).toBeVisible();


### PR DESCRIPTION
These tests did not fail during the experiment (https://github.com/mui-org/material-ui/pull/23475). All failures on the experimental pipeline were due to other tests (e.g. ["checkMaskIsValid"](https://app.circleci.com/pipelines/github/mui-org/material-ui/26775/workflows/0b1a4c14-a94d-448f-8932-3d0ca6a4d7eb/jobs/195587) or ["should use hysteresis with the enterDelay:"](https://app.circleci.com/pipelines/github/mui-org/material-ui/26921/workflows/582eb550-3760-4765-8d5a-8d25ef651e01/jobs/196111).). I'll investigate the unrelated failures in a separate PRs.

I'm leaving the `test-gate` parameter in the CircleCI config to signal how we would run tests to the codebase that should only run under certain conditions (e.g. with feature flags, React experimental, periodically etc).