### PR TITLE
[DatePicker] Fix false-positive when validating mask in Safari

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
+++ b/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
@@ -39,8 +39,8 @@ export function pick12hOr24hFormat(
 }
 
 const MASK_USER_INPUT_SYMBOL = '_';
-export const staticDateWith2DigitTokens = new Date('2019-11-21T22:30:00.000');
-export const staticDateWith1DigitTokens = new Date('2019-01-01T09:00:00.000');
+export const staticDateWith2DigitTokens = '2019-11-21T22:30:00.000';
+export const staticDateWith1DigitTokens = '2019-01-01T09:00:00.000';
 
 export function checkMaskIsValidForCurrentFormat(
   mask: string,

--- a/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
+++ b/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
@@ -39,8 +39,8 @@ export function pick12hOr24hFormat(
 }
 
 const MASK_USER_INPUT_SYMBOL = '_';
-export const staticDateWith2DigitTokens = '2019-11-21T22:30:00.000';
-export const staticDateWith1DigitTokens = '2019-01-01T09:00:00.000';
+const staticDateWith2DigitTokens = '2019-11-21T22:30:00.000';
+const staticDateWith1DigitTokens = '2019-01-01T09:00:00.000';
 
 export function checkMaskIsValidForCurrentFormat(
   mask: string,


### PR DESCRIPTION
false-positive was observed periodically during https://github.com/mui-org/material-ui/pull/23475 (e.g. https://app.circleci.com/pipelines/github/mui-org/material-ui/26775/workflows/0b1a4c14-a94d-448f-8932-3d0ca6a4d7eb/jobs/195587).

The underlying issue is the same that required https://github.com/mui-org/material-ui/pull/23475: Safari assumes UTC if the timezone is omitted in iso 8601 date formats. We're fixing it by deferring to the date adapters. This means that date-fns still has this false positive until `@date-io/date-fns#date` uses `date-fns#parseISO` under the hood (or rather fixes the Safari quirk). See https://github.com/dmtrKovalenko/date-io/issues/479#issuecomment-725394784