### PR TITLE
[Icon] Allow customizing the 'material-icons' base class name

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -233,7 +233,7 @@ function loadDependencies() {
   dependenciesLoaded = true;
 
   loadCSS(
-    'https://fonts.googleapis.com/icon?family=Material+Icons',
+    'https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Round',
     document.querySelector('#material-icon-font'),
   );
 }

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -233,7 +233,7 @@ function loadDependencies() {
   dependenciesLoaded = true;
 
   loadCSS(
-    'https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Round',
+    'https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Two+Tone',
     document.querySelector('#material-icon-font'),
   );
 }

--- a/docs/pages/api-docs/icon.md
+++ b/docs/pages/api-docs/icon.md
@@ -28,7 +28,7 @@ The `MuiIcon` name can be used for providing [default props](/customization/glob
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">baseClass</span> | <span class="prop-type">string</span> | <span class="prop-default">'material-icons'</span> | The base class applied to the icon. Defaults to material-icons, but can be changed to any other base class that suits the icon font you're (e.g. material-icons-rounded, fas) or set to blank to omit "material-icons" and then use the className prop to apply the desired classes (e.g. &lt;Icon baseClass="" className="fas fa-user" ... />) |
+| <span class="prop-name">baseClassName</span> | <span class="prop-type">string</span> | <span class="prop-default">'material-icons'</span> | The base class applied to the icon. Defaults to 'material-icons', but can be changed to any other base class that suits the icon font you're using (e.g. material-icons-rounded, fas, etc). |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The name of the icon font ligature. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">'action'<br>&#124;&nbsp;'disabled'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'inherit'</span> | The color of the component. It supports those theme colors that make sense for this component. |

--- a/docs/pages/api-docs/icon.md
+++ b/docs/pages/api-docs/icon.md
@@ -28,6 +28,7 @@ The `MuiIcon` name can be used for providing [default props](/customization/glob
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">baseClass</span> | <span class="prop-type">string</span> | <span class="prop-default">'material-icons'</span> | The base class applied to the icon. Defaults to material-icons, but can be changed to any other base class that suits the icon font you're (e.g. material-icons-rounded, fas) or set to blank to omit "material-icons" and then use the className prop to apply the desired classes (e.g. &lt;Icon baseClass="" className="fas fa-user" ... />) |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The name of the icon font ligature. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">'action'<br>&#124;&nbsp;'disabled'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'inherit'</span> | The color of the component. It supports those theme colors that make sense for this component. |

--- a/docs/src/pages/components/icons/FontAwesomeIcon.js
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.js
@@ -31,7 +31,6 @@ export default function FontAwesomeIcon() {
     <div className={classes.root}>
       <Icon baseClassName="fas" className="fa-plus-circle" />
       <Icon baseClassName="fas" className="fa-plus-circle" color="primary" />
-      <Icon baseClassName="fas" className="fa-plus-circle" color="secondary" />
       <Icon
         baseClassName="fas"
         className="fa-plus-circle"

--- a/docs/src/pages/components/icons/FontAwesomeIcon.js
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.js
@@ -29,14 +29,20 @@ export default function FontAwesomeIcon() {
 
   return (
     <div className={classes.root}>
-      <Icon className="fas fa-plus-circle" />
-      <Icon className="fas fa-plus-circle" color="primary" />
-      <Icon className="fas fa-plus-circle" color="secondary" />
-      <Icon className="fas fa-plus-circle" style={{ color: green[500] }} />
-      <Icon className="fas fa-plus-circle" fontSize="small" />
-      <Icon className="fas fa-plus-circle" style={{ fontSize: 30 }} />
-      {/* Use `baseClass` to omit the material-icons class */}
-      <Icon baseClass="fas" className="fa-plus-circle" />
+      <Icon baseClassName="fas" className="fa-plus-circle" />
+      <Icon baseClassName="fas" className="fa-plus-circle" color="primary" />
+      <Icon baseClassName="fas" className="fa-plus-circle" color="secondary" />
+      <Icon
+        baseClassName="fas"
+        className="fa-plus-circle"
+        style={{ color: green[500] }}
+      />
+      <Icon baseClassName="fas" className="fa-plus-circle" fontSize="small" />
+      <Icon
+        baseClassName="fas"
+        className="fa-plus-circle"
+        style={{ fontSize: 30 }}
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.js
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.js
@@ -35,6 +35,8 @@ export default function FontAwesomeIcon() {
       <Icon className="fas fa-plus-circle" style={{ color: green[500] }} />
       <Icon className="fas fa-plus-circle" fontSize="small" />
       <Icon className="fas fa-plus-circle" style={{ fontSize: 30 }} />
+      {/* Use `baseClass` to omit the material-icons class */}
+      <Icon baseClass="fas" className="fa-plus-circle" />
     </div>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.tsx
@@ -31,14 +31,20 @@ export default function FontAwesomeIcon() {
 
   return (
     <div className={classes.root}>
-      <Icon className="fas fa-plus-circle" />
-      <Icon className="fas fa-plus-circle" color="primary" />
-      <Icon className="fas fa-plus-circle" color="secondary" />
-      <Icon className="fas fa-plus-circle" style={{ color: green[500] }} />
-      <Icon className="fas fa-plus-circle" fontSize="small" />
-      <Icon className="fas fa-plus-circle" style={{ fontSize: 30 }} />
-      {/* Use `baseClass` to omit the material-icons class */}
-      <Icon baseClass="fas" className="fa-plus-circle" />
+      <Icon baseClassName="fas" className="fa-plus-circle" />
+      <Icon baseClassName="fas" className="fa-plus-circle" color="primary" />
+      <Icon baseClassName="fas" className="fa-plus-circle" color="secondary" />
+      <Icon
+        baseClassName="fas"
+        className="fa-plus-circle"
+        style={{ color: green[500] }}
+      />
+      <Icon baseClassName="fas" className="fa-plus-circle" fontSize="small" />
+      <Icon
+        baseClassName="fas"
+        className="fa-plus-circle"
+        style={{ fontSize: 30 }}
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.tsx
@@ -33,7 +33,6 @@ export default function FontAwesomeIcon() {
     <div className={classes.root}>
       <Icon baseClassName="fas" className="fa-plus-circle" />
       <Icon baseClassName="fas" className="fa-plus-circle" color="primary" />
-      <Icon baseClassName="fas" className="fa-plus-circle" color="secondary" />
       <Icon
         baseClassName="fas"
         className="fa-plus-circle"

--- a/docs/src/pages/components/icons/FontAwesomeIcon.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.tsx
@@ -37,6 +37,8 @@ export default function FontAwesomeIcon() {
       <Icon className="fas fa-plus-circle" style={{ color: green[500] }} />
       <Icon className="fas fa-plus-circle" fontSize="small" />
       <Icon className="fas fa-plus-circle" style={{ fontSize: 30 }} />
+      {/* Use `baseClass` to omit the material-icons class */}
+      <Icon baseClass="fas" className="fa-plus-circle" />
     </div>
   );
 }

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -18,12 +18,9 @@ export default function Icons() {
     <div className={classes.root}>
       <Icon>add_circle</Icon>
       <Icon color="primary">add_circle</Icon>
-      <Icon color="secondary">add_circle</Icon>
       <Icon style={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
-      {/* Use the round variant */}
-      <Icon baseClassName="material-icons-round">add_circle</Icon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -22,6 +22,8 @@ export default function Icons() {
       <Icon style={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
+      {/* Use the round variant */}
+      <Icon baseClass="material-icons-round">add_circle</Icon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -23,7 +23,7 @@ export default function Icons() {
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
       {/* Use the round variant */}
-      <Icon baseClass="material-icons-round">add_circle</Icon>
+      <Icon baseClassName="material-icons-round">add_circle</Icon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -24,6 +24,8 @@ export default function Icons() {
       <Icon style={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
+      {/* Use the round variant */}
+      <Icon baseClass="material-icons-round">add_circle</Icon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -25,7 +25,7 @@ export default function Icons() {
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
       {/* Use the round variant */}
-      <Icon baseClass="material-icons-round">add_circle</Icon>
+      <Icon baseClassName="material-icons-round">add_circle</Icon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -20,12 +20,9 @@ export default function Icons() {
     <div className={classes.root}>
       <Icon>add_circle</Icon>
       <Icon color="primary">add_circle</Icon>
-      <Icon color="secondary">add_circle</Icon>
       <Icon style={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
-      {/* Use the round variant */}
-      <Icon baseClassName="material-icons-round">add_circle</Icon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/TwoToneIcons.js
+++ b/docs/src/pages/components/icons/TwoToneIcons.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Icon from '@material-ui/core/Icon';
+
+export default function TwoToneIcons() {
+  return <Icon baseClassName="material-icons-two-tone">add_circle</Icon>;
+}

--- a/docs/src/pages/components/icons/TwoToneIcons.tsx
+++ b/docs/src/pages/components/icons/TwoToneIcons.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Icon from '@material-ui/core/Icon';
+
+export default function TwoToneIcons() {
+  return <Icon baseClassName="material-icons-two-tone">add_circle</Icon>;
+}

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -200,7 +200,7 @@ Optionally, you can set the icon color using one of the theme color properties: 
 
 ### Font Material icons
 
-`Icon` will by default set the correct class name for the Material Icons font (filled variant).
+`Icon` will by default set the correct base class name for the Material Icons font (filled variant).
 All you need to do is load the font, for instance, via Google Web Fonts:
 
 ```html
@@ -229,6 +229,30 @@ import Icon from '@material-ui/core/Icon';
 
 {{"demo": "pages/components/icons/TwoToneIcons.js"}}
 
+#### Global base class name
+
+Modifying the `baseClassName` prop for each component usage is repetitive.
+You can change the default prop globally with the theme
+
+```js
+const theme = createMuiTheme({
+  components: {
+    MuiIcon: {
+      defaultProps: {
+        // Replace the `material-icons` default value.
+        baseClassName: 'material-icons-two-tone',
+      },
+    },
+  },
+});
+```
+
+Then, you can use the two-tone font directly:
+
+```jsx
+<Icon>add_circle</Icon>
+```
+
 ### Font Awesome
 
 [Font Awesome](https://fontawesome.com/icons) can be used with the `Icon` component as follows:
@@ -238,7 +262,7 @@ import Icon from '@material-ui/core/Icon';
 Note that the Font Awesome icons weren't designed like the Material Design icons (compare the two previous demos).
 The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
-```jsx
+```js
 const theme = createMuiTheme({
   components: {
     MuiIcon: {

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -185,17 +185,7 @@ Note: [mdi-material-ui](https://github.com/TeamWertarbyte/mdi-material-ui) has a
 
 The `Icon` component will display an icon from any icon font that supports ligatures.
 As a prerequisite, you must include one, such as the
-[Material icon font](https://google.github.io/material-design-icons/#icon-font-for-the-web) in your project, for instance, via Google Web Fonts:
-
-```html
-<link
-  rel="stylesheet"
-  href="https://fonts.googleapis.com/icon?family=Material+Icons"
-/>
-```
-
-`Icon` will by default set the correct class name for the Material Icons font (filled variant).
-
+[Material icon font](https://google.github.io/material-design-icons/#icon-font-for-the-web) in your project.
 To use an icon simply wrap the icon name (font ligature) with the `Icon` component,
 for example:
 
@@ -208,23 +198,36 @@ import Icon from '@material-ui/core/Icon';
 By default, an Icon will inherit the current text color.
 Optionally, you can set the icon color using one of the theme color properties: `primary`, `secondary`, `action`, `error` & `disabled`.
 
-For other fonts, you must supply the class name using the Icon component's `baseClass` prop.
+### Font Material icons
+
+`Icon` will by default set the correct class name for the Material Icons font (filled variant).
+All you need to do is load the font, for instance, via Google Web Fonts:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/icon?family=Material+Icons"
+/>
+```
+
+{{"demo": "pages/components/icons/Icons.js"}}
+
+### Custom font
+
+For other fonts, you can customize the baseline class name using the `baseClassName` prop.
+For instance, you can display two-tone icons with Material Design:
 
 ```jsx
 import Icon from '@material-ui/core/Icon';
 
 <link
   rel="stylesheet"
-  href="https://fonts.googleapis.com/css?family=Material+Icons+Round"
-  // Import the round MDI variant                             ^^^^^^
-/>
-
-<Icon baseClass="material-icons-round">star</Icon>;
+  href="https://fonts.googleapis.com/css?family=Material+Icons+Two+Tone"
+  // Import the two tones MD variant                           ^^^^^^^^
+/>;
 ```
 
-### Font Material icons
-
-{{"demo": "pages/components/icons/Icons.js"}}
+{{"demo": "pages/components/icons/TwoToneIcons.js"}}
 
 ### Font Awesome
 

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -194,8 +194,7 @@ As a prerequisite, you must include one, such as the
 />
 ```
 
-`Icon` will set the correct class name for the Material Icons font. For other fonts, you must supply the
-class name using the Icon component's `className` prop.
+`Icon` will by default set the correct class name for the Material Icons font (filled variant).
 
 To use an icon simply wrap the icon name (font ligature) with the `Icon` component,
 for example:
@@ -208,6 +207,20 @@ import Icon from '@material-ui/core/Icon';
 
 By default, an Icon will inherit the current text color.
 Optionally, you can set the icon color using one of the theme color properties: `primary`, `secondary`, `action`, `error` & `disabled`.
+
+For other fonts, you must supply the class name using the Icon component's `baseClass` prop.
+
+```jsx
+import Icon from '@material-ui/core/Icon';
+
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css?family=Material+Icons+Round"
+  // Import the round MDI variant                             ^^^^^^
+/>
+
+<Icon baseClass="material-icons-round">star</Icon>;
+```
 
 ### Font Material icons
 

--- a/framer/Material-UI.framerfx/code/Icon.tsx
+++ b/framer/Material-UI.framerfx/code/Icon.tsx
@@ -5,6 +5,7 @@ import { SvgIconProps } from '@material-ui/core/SvgIcon';
 import { pascalCase } from './utils';
 
 interface Props extends SvgIconProps {
+  baseClassName: string;
   color: 'action' | 'disabled' | 'error' | 'inherit' | 'primary' | 'secondary';
   icon: string;
   theme: 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
@@ -23,6 +24,7 @@ export function Icon(props: Props): JSX.Element | null {
 }
 
 Icon.defaultProps = {
+  baseClassName: 'material-icons',
   color: 'inherit' as 'inherit',
   icon: 'add',
   theme: 'Filled' as 'Filled',
@@ -31,6 +33,10 @@ Icon.defaultProps = {
 };
 
 addPropertyControls(Icon, {
+  baseClassName: {
+    type: ControlType.String,
+    title: 'Base class name',
+  },
   color: {
     type: ControlType.Enum,
     title: 'Color',

--- a/packages/material-ui/src/Icon/Icon.d.ts
+++ b/packages/material-ui/src/Icon/Icon.d.ts
@@ -41,6 +41,14 @@ export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
      * @default 'default'
      */
     fontSize?: 'inherit' | 'default' | 'small' | 'large';
+    /**
+     * The base class applied to the icon. Defaults to material-icons, but can be changed to any
+     * other base class that suits the icon font you're (e.g. material-icons-rounded, fas) or set
+     * to blank to omit "material-icons" and then use the className prop to apply the desired classes
+     * (e.g. <Icon baseClass="" className="fas fa-user" ... />)
+     * @default 'material-icons'
+     */
+    baseClass?: string;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Icon/Icon.d.ts
+++ b/packages/material-ui/src/Icon/Icon.d.ts
@@ -5,6 +5,12 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P & {
     /**
+     * The base class applied to the icon. Defaults to 'material-icons', but can be changed to any
+     * other base class that suits the icon font you're using (e.g. material-icons-rounded, fas, etc).
+     * @default 'material-icons'
+     */
+    baseClassName?: string;
+    /**
      * The name of the icon font ligature.
      */
     children?: React.ReactNode;
@@ -41,14 +47,6 @@ export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
      * @default 'default'
      */
     fontSize?: 'inherit' | 'default' | 'small' | 'large';
-    /**
-     * The base class applied to the icon. Defaults to material-icons, but can be changed to any
-     * other base class that suits the icon font you're (e.g. material-icons-rounded, fas) or set
-     * to blank to omit "material-icons" and then use the className prop to apply the desired classes
-     * (e.g. <Icon baseClass="" className="fas fa-user" ... />)
-     * @default 'material-icons'
-     */
-    baseClass?: string;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -56,6 +56,7 @@ const Icon = React.forwardRef(function Icon(props, ref) {
   const {
     classes,
     className,
+    baseClass = 'material-icons',
     color = 'inherit',
     component: Component = 'span',
     fontSize = 'default',
@@ -65,7 +66,7 @@ const Icon = React.forwardRef(function Icon(props, ref) {
   return (
     <Component
       className={clsx(
-        'material-icons',
+        baseClass,
         // Prevent the translation of the text content.
         // The font relies on the exact text content to render the icon.
         'notranslate',
@@ -88,6 +89,14 @@ Icon.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * The base class applied to the icon. Defaults to material-icons, but can be changed to any
+   * other base class that suits the icon font you're (e.g. material-icons-rounded, fas) or set
+   * to blank to omit "material-icons" and then use the className prop to apply the desired classes
+   * (e.g. <Icon baseClass="" className="fas fa-user" ... />)
+   * @default 'material-icons'
+   */
+  baseClass: PropTypes.string,
   /**
    * The name of the icon font ligature.
    */

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -54,9 +54,9 @@ export const styles = (theme) => ({
 
 const Icon = React.forwardRef(function Icon(props, ref) {
   const {
+    baseClassName = 'material-icons',
     classes,
     className,
-    baseClass = 'material-icons',
     color = 'inherit',
     component: Component = 'span',
     fontSize = 'default',
@@ -66,7 +66,7 @@ const Icon = React.forwardRef(function Icon(props, ref) {
   return (
     <Component
       className={clsx(
-        baseClass,
+        baseClassName,
         // Prevent the translation of the text content.
         // The font relies on the exact text content to render the icon.
         'notranslate',
@@ -90,13 +90,11 @@ Icon.propTypes = {
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
   /**
-   * The base class applied to the icon. Defaults to material-icons, but can be changed to any
-   * other base class that suits the icon font you're (e.g. material-icons-rounded, fas) or set
-   * to blank to omit "material-icons" and then use the className prop to apply the desired classes
-   * (e.g. <Icon baseClass="" className="fas fa-user" ... />)
+   * The base class applied to the icon. Defaults to 'material-icons', but can be changed to any
+   * other base class that suits the icon font you're using (e.g. material-icons-rounded, fas, etc).
    * @default 'material-icons'
    */
-  baseClass: PropTypes.string,
+  baseClassName: PropTypes.string,
   /**
    * The name of the icon font ligature.
    */

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -66,6 +66,26 @@ describe('<Icon />', () => {
 
       expect(getByTestId('root')).to.have.class(classes.colorPrimary);
     });
+
+    it('should render without the default class', () => {
+      const { getByTestId } = render(
+        <Icon data-testid="root" baseClass="material-icons-round">
+          account_circle
+        </Icon>,
+      );
+
+      expect(getByTestId('root')).to.not.have.class('material-icons');
+    });
+
+    it('should render with the supplied base class', () => {
+      const { getByTestId } = render(
+        <Icon data-testid="root" baseClass="material-icons-round">
+          account_circle
+        </Icon>,
+      );
+
+      expect(getByTestId('root')).to.have.class('material-icons-round');
+    });
   });
 
   describe('prop: fontSize', () => {

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -69,7 +69,7 @@ describe('<Icon />', () => {
 
     it('should render without the default class', () => {
       const { getByTestId } = render(
-        <Icon data-testid="root" baseClass="material-icons-round">
+        <Icon data-testid="root" baseClassName="material-icons-round">
           account_circle
         </Icon>,
       );
@@ -79,7 +79,7 @@ describe('<Icon />', () => {
 
     it('should render with the supplied base class', () => {
       const { getByTestId } = render(
-        <Icon data-testid="root" baseClass="material-icons-round">
+        <Icon data-testid="root" baseClassName="material-icons-round">
           account_circle
         </Icon>,
       );


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `Icon` component always adds the `material-icons` class to the element; however, per the docs, you may use other icon fonts with this component so always having this base class doesn't make sense in all cases. Best case scenario, the class is ignored but if someone is mixing two icon fonts (material-icons + some other), this may cause issues.

Also, [now that the different Material Icon variants can be used via icon font](https://stackoverflow.com/questions/50303454/how-to-use-the-new-material-design-icon-themes-outlined-rounded-two-tone-and), it would be convenient to be able to swap out `material-icons` for `material-icons-round`, for example.