### PR TITLE
[core] Fix transpilation target of UMD bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,20 +4,17 @@ const errorCodesPath = path.resolve(__dirname, './docs/public/static/error-codes
 const missingError = process.env.MUI_EXTRACT_ERROR_CODES === 'true' ? 'write' : 'annotate';
 
 const defaultAlias = {
-  '@material-ui/core': path.resolve(__dirname, './packages/material-ui/src'),
-  '@material-ui/docs': path.resolve(__dirname, './packages/material-ui-docs/src'),
-  '@material-ui/icons': path.resolve(__dirname, './packages/material-ui-icons/src'),
-  '@material-ui/lab': path.resolve(__dirname, './packages/material-ui-lab/src'),
-  '@material-ui/styled-engine': path.resolve(__dirname, './packages/material-ui-styled-engine/src'),
-  '@material-ui/styled-engine-sc': path.resolve(
-    __dirname,
-    './packages/material-ui-styled-engine-sc/src',
-  ),
-  '@material-ui/styles': path.resolve(__dirname, './packages/material-ui-styles/src'),
-  '@material-ui/system': path.resolve(__dirname, './packages/material-ui-system/src'),
-  '@material-ui/unstyled': path.resolve(__dirname, './packages/material-ui-unstyled/src'),
-  '@material-ui/utils': path.resolve(__dirname, './packages/material-ui-utils/src'),
-  'typescript-to-proptypes': path.resolve(__dirname, './packages/typescript-to-proptypes/src'),
+  '@material-ui/core': './packages/material-ui/src',
+  '@material-ui/docs': './packages/material-ui-docs/src',
+  '@material-ui/icons': './packages/material-ui-icons/src',
+  '@material-ui/lab': './packages/material-ui-lab/src',
+  '@material-ui/styled-engine': './packages/material-ui-styled-engine/src',
+  '@material-ui/styled-engine-sc': './packages/material-ui-styled-engine-sc/src',
+  '@material-ui/styles': './packages/material-ui-styles/src',
+  '@material-ui/system': './packages/material-ui-system/src',
+  '@material-ui/unstyled': './packages/material-ui-unstyled/src',
+  '@material-ui/utils': './packages/material-ui-utils/src',
+  'typescript-to-proptypes': './packages/typescript-to-proptypes/src',
 };
 
 const productionPlugins = [
@@ -112,18 +109,6 @@ module.exports = function getBabelConfig(api) {
             {
               alias: {
                 modules: './modules',
-              },
-            },
-          ],
-        ],
-      },
-      rollup: {
-        plugins: [
-          [
-            'babel-plugin-module-resolver',
-            {
-              alias: {
-                '@material-ui/unstyled': defaultAlias['@material-ui/unstyled'],
               },
             },
           ],

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -31,7 +31,7 @@
     "build:modern": "node ../../scripts/build modern",
     "build:node": "node ../../scripts/build node",
     "build:stable": "node ../../scripts/build stable",
-    "build:umd": "cross-env BABEL_ENV=rollup rollup -c scripts/rollup.config.js",
+    "build:umd": "cross-env BABEL_ENV=stable rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "tsc -p tsconfig.build.json",
     "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true yarn build:modern",

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -1,16 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { chainPropTypes } from '@material-ui/utils';
-import SliderUnstyled, {
-  SliderValueLabelUnstyled,
-  sliderClasses,
-} from '@material-ui/unstyled/SliderUnstyled';
+import { SliderUnstyled, SliderValueLabelUnstyled, sliderClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { alpha, lighten, darken } from '../styles/colorManipulator';
 import capitalize from '../utils/capitalize';
 
-export { sliderClasses } from '@material-ui/unstyled/SliderUnstyled';
+export { sliderClasses };
 
 const overridesResolver = (props, styles) => {
   const {


### PR DESCRIPTION
1. UMD bundle is not transpiled with the proper target (from .browserslistrc)
1. `yarn test:karma` issues warnings about imports not being resolved 
   This is not severe since tests pass fine but is noisy

This was introduced in https://github.com/mui-org/material-ui/commit/4b71794462d65cb43ac6e42917772c18cb8a0bfb#diff-09c56b2bf95de2a608a36afef3b6893146a959d6739be0a154dc9c9f02d80f24L7-R20 in order to let `yarn workspace @material-ui/core build:umd` pass. However, we can use existing patterns (use named imports over path imports) without having to change infra. Changing build infra is always scary since we don't (and likely never have) a proper coverage for that output.