### PR TITLE
[docs] Remove controlled Tooltip example in Slider

### DIFF
--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -18,10 +18,10 @@ const Separator = styled('div')(
 );
 
 function ValueLabelComponent(props) {
-  const { children, open, value } = props;
+  const { children, value } = props;
 
   return (
-    <Tooltip open={open} enterTouchDelay={0} placement="top" title={value}>
+    <Tooltip enterTouchDelay={0} placement="top" title={value}>
       {children}
     </Tooltip>
   );
@@ -29,7 +29,6 @@ function ValueLabelComponent(props) {
 
 ValueLabelComponent.propTypes = {
   children: PropTypes.element.isRequired,
-  open: PropTypes.bool.isRequired,
   value: PropTypes.number.isRequired,
 };
 

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -18,15 +18,14 @@ const Separator = styled('div')(
 
 interface Props {
   children: React.ReactElement;
-  open: boolean;
   value: number;
 }
 
 function ValueLabelComponent(props: Props) {
-  const { children, open, value } = props;
+  const { children, value } = props;
 
   return (
-    <Tooltip open={open} enterTouchDelay={0} placement="top" title={value}>
+    <Tooltip enterTouchDelay={0} placement="top" title={value}>
       {children}
     </Tooltip>
   );


### PR DESCRIPTION
As recommended in the issue #18679 I've removed controlled example from the docs.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #18679.