### PR TITLE
[core] Add support for TypeScript 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:umd": "node packages/material-ui/test/umd/run.js",
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:watch": "yarn test:unit --watch",
-    "typescript": "lerna run typescript --parallel"
+    "typescript": "lerna run --no-bail --parallel typescript"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "stylelint-processor-styled-components": "^1.10.0",
     "terser-webpack-plugin": "^4.2.2",
     "tslint": "5.14.0",
-    "typescript": "^4.0.2",
+    "typescript": "^4.1.2",
     "unist-util-visit": "^2.0.2",
     "url-loader": "^4.1.0",
     "webpack": "^4.41.0",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "stylelint-processor-styled-components": "^1.10.0",
     "terser-webpack-plugin": "^4.2.2",
     "tslint": "5.14.0",
-    "typescript": "^4.1.2",
+    "typescript": "^4.0.2",
     "unist-util-visit": "^2.0.2",
     "url-loader": "^4.1.0",
     "webpack": "^4.41.0",

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -2,22 +2,15 @@ import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/wit
 import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
-/**
- * `makeStyles` where the passed `styles` do not depend on props
- */
-export default function makeStyles<Theme = DefaultTheme, ClassKey extends string = string>(
-  style: Styles<Theme, {}, ClassKey>,
-  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props?: any) => ClassNameMap<ClassKey>;
-
-/**
- * `makeStyles` where the passed `styles` do depend on props
- */
 export default function makeStyles<
   Theme = DefaultTheme,
-  Props extends {} = {},
+  Props extends object = {},
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props: Props) => ClassNameMap<ClassKey>;
+): keyof Props extends never
+  ? // `makeStyles` where the passed `styles` do not depend on props
+    (props?: any) => ClassNameMap<ClassKey>
+  : // `makeStyles` where the passed `styles` do depend on props
+    (props: Props) => ClassNameMap<ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -81,7 +81,7 @@ import { createStyles, makeStyles } from '@material-ui/styles';
   );
 
   const UnsafeProps = (props: StyleProps) => {
-    // would be nice to have at least a compile time error because we forgot the argument
+    // @ts-expect-error
     const classes = useUnsafeProps(); // runtime: Can't read property color of undefined
     // but this would pass anyway
     const alsoClasses = useUnsafeProps(undefined); // runtime: Can't read property color of undefined

--- a/packages/material-ui-utils/src/deepmerge.ts
+++ b/packages/material-ui-utils/src/deepmerge.ts
@@ -1,5 +1,11 @@
 export function isPlainObject(item: unknown): item is Record<keyof any, unknown> {
-  return item && typeof item === 'object' && item.constructor === Object;
+  return (
+    item !== null &&
+    typeof item === 'object' &&
+    // TS thinks `item is possibly null` even though this was our first guard.
+    // @ts-expect-error
+    item.constructor === Object
+  );
 }
 
 export interface DeepmergeOptions {

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -2,21 +2,15 @@ import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/wit
 import { Omit } from '@material-ui/types';
 import { Theme as DefaultTheme } from './createMuiTheme';
 
-/**
- * `makeStyles` where the passed `styles` do not depend on props
- */
-export default function makeStyles<Theme = DefaultTheme, ClassKey extends string = string>(
-  style: Styles<Theme, {}, ClassKey>,
-  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props?: any) => ClassNameMap<ClassKey>;
-/**
- * `makeStyles` where the passed `styles` do depend on props
- */
 export default function makeStyles<
   Theme = DefaultTheme,
-  Props extends {} = {},
+  Props extends object = {},
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
-): (props: Props) => ClassNameMap<ClassKey>;
+): keyof Props extends never
+  ? // `makeStyles` where the passed `styles` do not depend on props
+    (props?: any) => ClassNameMap<ClassKey>
+  : // `makeStyles` where the passed `styles` do depend on props
+    (props: Props) => ClassNameMap<ClassKey>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16907,10 +16907,10 @@ typescript@3.5.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
-typescript@^4.0.2:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16907,10 +16907,10 @@ typescript@3.5.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.0.2:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
1. [core] Don't bail on monorepo typescript task
   Right now we're exiting on the very first error.
   This is not in line with other test-like tasks we have (e.g. `yarn lint` or `yarn test:unit`).
   It also hid a more severe issue https://github.com/mui-org/material-ui/issues/23627.
1. [styles] Fix useStyles requiring props in TS 4.1
   > docs: src/pages/components/drawers/PersistentDrawerLeft.tsx(88,19): error TS2554: Expected 1 arguments, but got 0.

   -- https://app.circleci.com/pipelines/github/mui-org/material-ui/27542/workflows/e3a4c4a4-19dc-4c38-84d9-044fc34a6fd3/jobs/197844
1. [utils] Fix deepmerge return type for falsy inputs
   > @material-ui/core: ../material-ui-utils/src/deepmerge.ts(2,3): error TS2322: Type 'unknown' is not assignable to type 'boolean'.

   -- https://app.circleci.com/pipelines/github/mui-org/material-ui/27542/workflows/e3a4c4a4-19dc-4c38-84d9-044fc34a6fd3/jobs/197844

Closes #23627