### PR TITLE
[docs] Allow codesandbox deploy for demos in X

### DIFF
--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -79,7 +79,7 @@ function getLanguageConfig(demoData) {
   }
 }
 
-export default function getDemo(demoData) {
+export default function getDemoConfig(demoData) {
   const baseConfig = {
     title: demoData.title,
     description: demoData.githubLocation,

--- a/docs/src/modules/utils/helpers.js
+++ b/docs/src/modules/utils/helpers.js
@@ -1,6 +1,6 @@
 const upperFirst = require('lodash/upperFirst');
 const camelCase = require('lodash/camelCase');
-const { CODE_VARIANTS, LANGUAGES } = require('../constants');
+const { CODE_VARIANTS, SOURCE_CODE_REPO, LANGUAGES } = require('../constants');
 
 /**
  * Mapping from the date adapter sub-packages to the npm packages they require.
@@ -116,12 +116,25 @@ function includePeerDependencies(deps, versions) {
  * @return string - A valid version for a dependency entry in a package.json
  */
 function getMuiPackageVersion(packageName, commitRef) {
-  if (commitRef === undefined) {
+  if (commitRef === undefined || SOURCE_CODE_REPO !== 'https://github.com/mui-org/material-ui') {
     // TODO: change 'next' to 'latest' once next is merged into master.
     return 'next';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui-org/material-ui/commit/${shortSha}/@material-ui/${packageName}`;
+}
+
+/**
+ * @param {string} packageName - The name of a package living inside this repository.
+ * @param {string} [commitRef]
+ * @return string - A valid version for a dependency entry in a package.json
+ */
+function getMuiXPackageVersion(packageName, commitRef) {
+  if (commitRef === undefined || SOURCE_CODE_REPO !== 'https://github.com/mui-org/material-ui-x') {
+    return 'latest';
+  }
+  const shortSha = commitRef.slice(0, 8);
+  return `https://pkg.csb.dev/mui-org/material-ui-x/commit/${shortSha}/@material-ui/${packageName}`;
 }
 
 /**
@@ -150,6 +163,13 @@ function getDependencies(raw, options = {}) {
     '@material-ui/system': getMuiPackageVersion('system', muiCommitRef),
     '@material-ui/unstyled': getMuiPackageVersion('unstyled', muiCommitRef),
     '@material-ui/utils': getMuiPackageVersion('utils', muiCommitRef),
+    '@material-ui/data-grid': getMuiXPackageVersion('data-grid', muiCommitRef),
+    '@material-ui/x-grid': getMuiXPackageVersion('x-grid', muiCommitRef),
+    '@material-ui/x-license': getMuiXPackageVersion('x-license', muiCommitRef),
+    '@material-ui/x-grid-data-generator': getMuiXPackageVersion(
+      'x-grid-data-generator',
+      muiCommitRef,
+    ),
   };
 
   const re = /^import\s'([^']+)'|import\s[\s\S]*?\sfrom\s+'([^']+)/gm;

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -62,19 +62,6 @@ const suggestions = [
     });
   });
 
-  it('should support next dependencies', () => {
-    expect(getDependencies(s1, { reactVersion: 'next' })).to.deep.equal({
-      react: 'next',
-      'react-dom': 'next',
-      '@emotion/react': 'latest',
-      '@emotion/styled': 'latest',
-      '@foo-bar/bip': 'latest',
-      '@material-ui/core': 'next',
-      '@material-ui/unstyled': 'next',
-      'prop-types': 'latest',
-    });
-  });
-
   it('should support direct import', () => {
     const source = `
 import * as React from 'react';
@@ -149,29 +136,6 @@ import lab from '@material-ui/lab';
       '@emotion/styled': 'latest',
       '@material-ui/core': 'next',
       '@material-ui/lab': 'next',
-    });
-  });
-
-  it('should support the data-grid component', () => {
-    const source = `
-import * as React from 'react';
-import { DataGrid } from '@material-ui/data-grid';
-import { useDemoData } from '@material-ui/x-grid-data-generator';
-    `;
-
-    expect(getDependencies(source, { codeLanguage: 'TS' })).to.deep.equal({
-      react: 'latest',
-      'react-dom': 'latest',
-      '@emotion/react': 'latest',
-      '@emotion/styled': 'latest',
-      '@material-ui/core': 'next',
-      '@material-ui/lab': 'next',
-      '@material-ui/icons': 'next',
-      '@material-ui/data-grid': 'latest',
-      '@material-ui/x-grid-data-generator': 'latest',
-      '@types/react': 'latest',
-      '@types/react-dom': 'latest',
-      typescript: 'latest',
     });
   });
 


### PR DESCRIPTION
The objective of this pull request is to get the same great DX of #22616 but for Material-UI X. Over the last few weeks, I have found myself going to the codesandbox-ci UI to get the published package many times. The workflow is especially useful when reviewing.

Once the changes are merged, I will cherry-pick it to `master` and complete the integration on https://github.com/mui-org/material-ui-x/pull/613.