### PR TITLE
[docs] Improve format for system' demos

### DIFF
--- a/docs/src/pages/system/basics/Why.js
+++ b/docs/src/pages/system/basics/Why.js
@@ -14,9 +14,7 @@ export default function Why() {
       }}
     >
       <Box sx={{ color: 'text.secondary' }}>Sessions</Box>
-      <Box sx={{ color: 'text.primary', fontSize: 34, fontWeight: 'fontWeightMedium' }}>
-        98.3 K
-      </Box>
+      <Box sx={{ color: 'text.primary', fontSize: 34, fontWeight: 'fontWeightMedium' }}>98.3 K</Box>
       <Box
         component={TrendingUpIcon}
         sx={{ color: 'success.dark', fontSize: 16, verticalAlign: 'sub' }}
@@ -31,9 +29,7 @@ export default function Why() {
       >
         18.77%
       </Box>
-      <Box sx={{ color: 'text.secondary', display: 'inline', fontSize: 12 }}>
-        vs last week
-      </Box>
+      <Box sx={{ color: 'text.secondary', display: 'inline', fontSize: 12 }}>vs last week</Box>
     </Box>
   );
 }

--- a/docs/src/pages/system/basics/Why.tsx
+++ b/docs/src/pages/system/basics/Why.tsx
@@ -14,9 +14,7 @@ export default function Why() {
       }}
     >
       <Box sx={{ color: 'text.secondary' }}>Sessions</Box>
-      <Box sx={{ color: 'text.primary', fontSize: 34, fontWeight: 'fontWeightMedium' }}>
-        98.3 K
-      </Box>
+      <Box sx={{ color: 'text.primary', fontSize: 34, fontWeight: 'fontWeightMedium' }}>98.3 K</Box>
       <Box
         component={TrendingUpIcon}
         sx={{ color: 'success.dark', fontSize: 16, verticalAlign: 'sub' }}
@@ -31,9 +29,7 @@ export default function Why() {
       >
         18.77%
       </Box>
-      <Box sx={{ color: 'text.secondary', display: 'inline', fontSize: 12 }}>
-        vs last week
-      </Box>
+      <Box sx={{ color: 'text.secondary', display: 'inline', fontSize: 12 }}>vs last week</Box>
     </Box>
   );
 }

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -106,9 +106,7 @@ return (
   }}
 >
   <Box sx={{ color: 'text.secondary' }}>Sessions</Box>
-  <Box sx={{ color: 'text.primary', fontSize: 34, fontWeight: 'fontWeightMedium' }}>
-    98.3 K
-  </Box>
+  <Box sx={{ color: 'text.primary', fontSize: 34, fontWeight: 'fontWeightMedium' }}>98.3 K</Box>
   <Box
     component={TrendingUpIcon}
     sx={{ color: 'success.dark', fontSize: 16, verticalAlign: 'sub' }}
@@ -123,9 +121,7 @@ return (
   >
     18.77%
   </Box>
-  <Box sx={{ color: 'text.secondary', display: 'inline', fontSize: 12 }}>
-    vs last week
-  </Box>
+  <Box sx={{ color: 'text.secondary', display: 'inline', fontSize: 12 }}>vs last week</Box>
 </Box>
 ```
 

--- a/docs/src/pages/system/display/Overflow.js
+++ b/docs/src/pages/system/display/Overflow.js
@@ -10,7 +10,10 @@ export default function Overflow() {
       >
         Overflow Hidden. Overflow Hidden. Overflow Hidden.
       </Box>
-      <Box component="div" sx={{ overflow: 'auto', my: 2, bgcolor: 'background.paper' }}>
+      <Box
+        component="div"
+        sx={{ overflow: 'auto', my: 2, bgcolor: 'background.paper' }}
+      >
         Overflow Auto. Overflow Auto. Overflow Auto.
       </Box>
     </div>

--- a/docs/src/pages/system/display/Overflow.tsx
+++ b/docs/src/pages/system/display/Overflow.tsx
@@ -10,7 +10,10 @@ export default function Overflow() {
       >
         Overflow Hidden. Overflow Hidden. Overflow Hidden.
       </Box>
-      <Box component="div" sx={{ overflow: 'auto', my: 2, bgcolor: 'background.paper' }}>
+      <Box
+        component="div"
+        sx={{ overflow: 'auto', my: 2, bgcolor: 'background.paper' }}
+      >
         Overflow Auto. Overflow Auto. Overflow Auto.
       </Box>
     </div>

--- a/docs/src/pages/system/flexbox/AlignSelf.js
+++ b/docs/src/pages/system/flexbox/AlignSelf.js
@@ -15,7 +15,9 @@ export default function AlignSelf() {
         }}
       >
         <Box sx={{ p: 1, bgcolor: 'grey.300' }}>Item 1</Box>
-        <Box sx={{ p: 1, bgcolor: 'grey.300', alignSelf: 'flex-end' }}>Item 2</Box>
+        <Box sx={{ p: 1, bgcolor: 'grey.300', alignSelf: 'flex-end' }}>
+          Item 2
+        </Box>
         <Box sx={{ p: 1, bgcolor: 'grey.300' }}>Item 3</Box>
       </Box>
     </div>

--- a/docs/src/pages/system/flexbox/AlignSelf.tsx
+++ b/docs/src/pages/system/flexbox/AlignSelf.tsx
@@ -15,7 +15,9 @@ export default function AlignSelf() {
         }}
       >
         <Box sx={{ p: 1, bgcolor: 'grey.300' }}>Item 1</Box>
-        <Box sx={{ p: 1, bgcolor: 'grey.300', alignSelf: 'flex-end' }}>Item 2</Box>
+        <Box sx={{ p: 1, bgcolor: 'grey.300', alignSelf: 'flex-end' }}>
+          Item 2
+        </Box>
         <Box sx={{ p: 1, bgcolor: 'grey.300' }}>Item 3</Box>
       </Box>
     </div>

--- a/docs/src/pages/system/palette/BackgroundColor.js
+++ b/docs/src/pages/system/palette/BackgroundColor.js
@@ -6,7 +6,9 @@ export default function BackgroundColor() {
   return (
     <Grid container spacing={1}>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', p: 2 }}
+        >
           primary.main
         </Box>
       </Grid>
@@ -27,7 +29,9 @@ export default function BackgroundColor() {
         </Box>
       </Grid>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'warning.main', color: 'warning.contrastText', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'warning.main', color: 'warning.contrastText', p: 2 }}
+        >
           warning.main
         </Box>
       </Grid>
@@ -37,7 +41,9 @@ export default function BackgroundColor() {
         </Box>
       </Grid>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'success.main', color: 'success.contrastText', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'success.main', color: 'success.contrastText', p: 2 }}
+        >
           success.main
         </Box>
       </Grid>
@@ -47,7 +53,9 @@ export default function BackgroundColor() {
         </Box>
       </Grid>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'text.secondary', color: 'background.paper', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'text.secondary', color: 'background.paper', p: 2 }}
+        >
           text.secondary
         </Box>
       </Grid>

--- a/docs/src/pages/system/palette/BackgroundColor.tsx
+++ b/docs/src/pages/system/palette/BackgroundColor.tsx
@@ -6,7 +6,9 @@ export default function BackgroundColor() {
   return (
     <Grid container spacing={1}>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', p: 2 }}
+        >
           primary.main
         </Box>
       </Grid>
@@ -27,7 +29,9 @@ export default function BackgroundColor() {
         </Box>
       </Grid>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'warning.main', color: 'warning.contrastText', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'warning.main', color: 'warning.contrastText', p: 2 }}
+        >
           warning.main
         </Box>
       </Grid>
@@ -37,7 +41,9 @@ export default function BackgroundColor() {
         </Box>
       </Grid>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'success.main', color: 'success.contrastText', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'success.main', color: 'success.contrastText', p: 2 }}
+        >
           success.main
         </Box>
       </Grid>
@@ -47,7 +53,9 @@ export default function BackgroundColor() {
         </Box>
       </Grid>
       <Grid item xs={12} sm={4}>
-        <Box sx={{ bgcolor: 'text.secondary', color: 'background.paper', p: 2 }}>
+        <Box
+          sx={{ bgcolor: 'text.secondary', color: 'background.paper', p: 2 }}
+        >
           text.secondary
         </Box>
       </Grid>

--- a/docs/src/pages/system/sizing/Values.js
+++ b/docs/src/pages/system/sizing/Values.js
@@ -4,9 +4,15 @@ import Box from '@material-ui/core/Box';
 export default function Values() {
   return (
     <Box sx={{ width: '100%' }}>
-      <Box sx={{ width: 1 / 4, bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 1/4</Box>
-      <Box sx={{ width: 300, bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 300</Box>
-      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 75%</Box>
+      <Box sx={{ width: 1 / 4, bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 1/4
+      </Box>
+      <Box sx={{ width: 300, bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 300
+      </Box>
+      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 75%
+      </Box>
       <Box sx={{ width: 1, bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 1</Box>
     </Box>
   );

--- a/docs/src/pages/system/sizing/Values.tsx
+++ b/docs/src/pages/system/sizing/Values.tsx
@@ -4,9 +4,15 @@ import Box from '@material-ui/core/Box';
 export default function Values() {
   return (
     <Box sx={{ width: '100%' }}>
-      <Box sx={{ width: 1 / 4, bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 1/4</Box>
-      <Box sx={{ width: 300, bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 300</Box>
-      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 75%</Box>
+      <Box sx={{ width: 1 / 4, bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 1/4
+      </Box>
+      <Box sx={{ width: 300, bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 300
+      </Box>
+      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 75%
+      </Box>
       <Box sx={{ width: 1, bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 1</Box>
     </Box>
   );

--- a/docs/src/pages/system/sizing/Width.js
+++ b/docs/src/pages/system/sizing/Width.js
@@ -4,11 +4,21 @@ import Box from '@material-ui/core/Box';
 export default function Width() {
   return (
     <Box sx={{ width: '100%' }}>
-      <Box sx={{ width: '25%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 25%</Box>
-      <Box sx={{ width: '50%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 50%</Box>
-      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 75%</Box>
-      <Box sx={{ width: '100%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 100%</Box>
-      <Box sx={{ width: 'auto', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width auto</Box>
+      <Box sx={{ width: '25%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 25%
+      </Box>
+      <Box sx={{ width: '50%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 50%
+      </Box>
+      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 75%
+      </Box>
+      <Box sx={{ width: '100%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 100%
+      </Box>
+      <Box sx={{ width: 'auto', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width auto
+      </Box>
     </Box>
   );
 }

--- a/docs/src/pages/system/sizing/Width.tsx
+++ b/docs/src/pages/system/sizing/Width.tsx
@@ -4,11 +4,21 @@ import Box from '@material-ui/core/Box';
 export default function Width() {
   return (
     <Box sx={{ width: '100%' }}>
-      <Box sx={{ width: '25%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 25%</Box>
-      <Box sx={{ width: '50%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 50%</Box>
-      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 75%</Box>
-      <Box sx={{ width: '100%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width 100%</Box>
-      <Box sx={{ width: 'auto', bgcolor: 'grey.300', p: 1, my: 0.5 }}>Width auto</Box>
+      <Box sx={{ width: '25%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 25%
+      </Box>
+      <Box sx={{ width: '50%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 50%
+      </Box>
+      <Box sx={{ width: '75%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 75%
+      </Box>
+      <Box sx={{ width: '100%', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width 100%
+      </Box>
+      <Box sx={{ width: 'auto', bgcolor: 'grey.300', p: 1, my: 0.5 }}>
+        Width auto
+      </Box>
     </Box>
   );
 }

--- a/docs/src/pages/system/spacing/HorizontalCentering.js
+++ b/docs/src/pages/system/spacing/HorizontalCentering.js
@@ -4,7 +4,9 @@ import Box from '@material-ui/core/Box';
 export default function HorizontalCentering() {
   return (
     <div>
-      <Box sx={{ mx: 'auto', bgcolor: 'background.paper', p: 1 }}>Centered element</Box>
+      <Box sx={{ mx: 'auto', bgcolor: 'background.paper', p: 1 }}>
+        Centered element
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/system/spacing/HorizontalCentering.tsx
+++ b/docs/src/pages/system/spacing/HorizontalCentering.tsx
@@ -4,7 +4,9 @@ import Box from '@material-ui/core/Box';
 export default function HorizontalCentering() {
   return (
     <div>
-      <Box sx={{ mx: 'auto', bgcolor: 'background.paper', p: 1 }}>Centered element</Box>
+      <Box sx={{ mx: 'auto', bgcolor: 'background.paper', p: 1 }}>
+        Centered element
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/system/typography/FontFamily.js
+++ b/docs/src/pages/system/typography/FontFamily.js
@@ -6,7 +6,9 @@ export default function FontFamily() {
   return (
     <Typography component="div">
       <Box sx={{ fontFamily: 'fontFamily', m: 1 }}>Default</Box>
-      <Box sx={{ fontFamily: 'Monospace', fontSize: 'h6.fontSize', m: 1 }}>Monospace</Box>
+      <Box sx={{ fontFamily: 'Monospace', fontSize: 'h6.fontSize', m: 1 }}>
+        Monospace
+      </Box>
     </Typography>
   );
 }

--- a/docs/src/pages/system/typography/FontFamily.tsx
+++ b/docs/src/pages/system/typography/FontFamily.tsx
@@ -6,7 +6,9 @@ export default function FontFamily() {
   return (
     <Typography component="div">
       <Box sx={{ fontFamily: 'fontFamily', m: 1 }}>Default</Box>
-      <Box sx={{ fontFamily: 'Monospace', fontSize: 'h6.fontSize', m: 1 }}>Monospace</Box>
+      <Box sx={{ fontFamily: 'Monospace', fontSize: 'h6.fontSize', m: 1 }}>
+        Monospace
+      </Box>
     </Typography>
   );
 }

--- a/docs/src/pages/system/typography/TextAlignment.js
+++ b/docs/src/pages/system/typography/TextAlignment.js
@@ -6,8 +6,8 @@ export default function TextAlignment() {
   return (
     <Typography component="div">
       <Box sx={{ textAlign: 'justify', m: 1 }}>
-        Ambitioni dedisse scripsisse iudicaretur. Cras mattis iudicium purus sit amet
-        fermentum. Donec sed odio operae, eu vulputate felis rhoncus.
+        Ambitioni dedisse scripsisse iudicaretur. Cras mattis iudicium purus sit
+        amet fermentum. Donec sed odio operae, eu vulputate felis rhoncus.
       </Box>
       <Box sx={{ textAlign: 'left', m: 1 }}>Left aligned text.</Box>
       <Box sx={{ textAlign: 'center', m: 1 }}>Center aligned text.</Box>

--- a/docs/src/pages/system/typography/TextAlignment.tsx
+++ b/docs/src/pages/system/typography/TextAlignment.tsx
@@ -6,8 +6,8 @@ export default function TextAlignment() {
   return (
     <Typography component="div">
       <Box sx={{ textAlign: 'justify', m: 1 }}>
-        Ambitioni dedisse scripsisse iudicaretur. Cras mattis iudicium purus sit amet
-        fermentum. Donec sed odio operae, eu vulputate felis rhoncus.
+        Ambitioni dedisse scripsisse iudicaretur. Cras mattis iudicium purus sit
+        amet fermentum. Donec sed odio operae, eu vulputate felis rhoncus.
       </Box>
       <Box sx={{ textAlign: 'left', m: 1 }}>Left aligned text.</Box>
       <Box sx={{ textAlign: 'center', m: 1 }}>Center aligned text.</Box>

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -18,10 +18,10 @@ module.exports = {
       },
     },
     {
-      files: ['docs/src/pages/system/**/*.{js,tsx,md}'],
+      files: ['docs/src/pages/system/basics/*.{js,tsx,md}'],
       options: {
-        // allow more space for the system
-        printWidth: 90,
+        // allow more space for the system' demo
+        printWidth: 100,
       },
     },
   ],


### PR DESCRIPTION
Complementary to #23512.

- Reduce the scope of the change of formating. I should only have changed https://next.material-ui.com/system/basics/ in #23509
- Horizontal scrollbar isn't a concern for this page, instead, use the same configuration as our sources for reproduction a similar result to what developers will get in their codebase (assuming 100 and above is more common than 90 or 80).