### PR TITLE
[docs] Fix the Box section title on migration-v4 guide

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -342,7 +342,7 @@ const classes = makeStyles(theme => ({
   +<BottomNavigation onChange={(event: React.SyntheticEvent) => {}} />
   ```
 
-### Box
+### Box
 
 - The system props have been deprecated in v5, and replaced with the `sx` prop.
 


### PR DESCRIPTION
Fixes the Box section title under https://next.material-ui.com/guides/migration-v4

Before:
![image](https://user-images.githubusercontent.com/298793/99920299-563d3080-2d01-11eb-94b9-bf40de16f394.png)

After:
![image](https://user-images.githubusercontent.com/298793/99920314-6d7c1e00-2d01-11eb-9663-4585b5026480.png)

Only happens on the English guide preview, in other languages, the markdown preview for the Box section looks ok

This is my first PR here, so just let me know if I did something wrong while fixing it or while opening the PR.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
