### PR TITLE
[Box] Fix TypeScript issue when component prop is used

### DIFF
--- a/docs/src/pages/system/basics/Demo.js
+++ b/docs/src/pages/system/basics/Demo.js
@@ -18,19 +18,16 @@ export default function Demo() {
       }}
     >
       <Box
+        component="img"
         sx={{
           maxHeight: { xs: 233, md: 167 },
           maxWidth: { xs: 350, md: 250 },
         }}
-        clone
-      >
-        <img
-          alt="The house from the offer."
-          height="233"
-          width="350"
-          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
-        />
-      </Box>
+        alt="The house from the offer."
+        height="233"
+        width="350"
+        src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
+      />
       <Box
         sx={{
           display: 'flex',

--- a/docs/src/pages/system/basics/Demo.js
+++ b/docs/src/pages/system/basics/Demo.js
@@ -20,12 +20,12 @@ export default function Demo() {
       <Box
         component="img"
         sx={{
+          height: 233,
+          width: 350,
           maxHeight: { xs: 233, md: 167 },
           maxWidth: { xs: 350, md: 250 },
         }}
         alt="The house from the offer."
-        height="233"
-        width="350"
         src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
       />
       <Box

--- a/docs/src/pages/system/basics/Demo.tsx
+++ b/docs/src/pages/system/basics/Demo.tsx
@@ -18,19 +18,16 @@ export default function Demo() {
       }}
     >
       <Box
+        component="img"
         sx={{
           maxHeight: { xs: 233, md: 167 },
           maxWidth: { xs: 350, md: 250 },
         }}
-        clone
-      >
-        <img
-          alt="The house from the offer."
-          height="233"
-          width="350"
-          src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
-        />
-      </Box>
+        alt="The house from the offer."
+        height="233"
+        width="350"
+        src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
+      />
       <Box
         sx={{
           display: 'flex',

--- a/docs/src/pages/system/basics/Demo.tsx
+++ b/docs/src/pages/system/basics/Demo.tsx
@@ -20,12 +20,12 @@ export default function Demo() {
       <Box
         component="img"
         sx={{
+          height: 233,
+          width: 350,
           maxHeight: { xs: 233, md: 167 },
           maxWidth: { xs: 350, md: 250 },
         }}
         alt="The house from the offer."
-        height="233"
-        width="350"
         src="https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&w=350&dpr=2"
       />
       <Box

--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -36,12 +36,11 @@ export type BoxStyleFunction = ComposedStyleFunction<
 type SystemProps = PropsFor<BoxStyleFunction>;
 type ElementProps = Omit<React.HTMLAttributes<HTMLElement>, keyof SystemProps>;
 
-export interface BoxTypeMap<P = {}, D extends React.ElementType = 'span'> {
+export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &
     ElementProps &
     SystemProps & {
       children?: React.ReactNode | ((props: ElementProps) => React.ReactNode);
-      // styled API
       component?: React.ElementType;
       clone?: boolean;
       ref?: React.Ref<unknown>;

--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -14,6 +14,7 @@ import {
   PropsFor,
   SxProps,
 } from '@material-ui/system';
+import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Theme } from '../styles/createMuiTheme';
 import { Omit } from '..';
 
@@ -35,15 +36,25 @@ export type BoxStyleFunction = ComposedStyleFunction<
 type SystemProps = PropsFor<BoxStyleFunction>;
 type ElementProps = Omit<React.HTMLAttributes<HTMLElement>, keyof SystemProps>;
 
-export interface BoxProps extends ElementProps, SystemProps {
-  children?: React.ReactNode | ((props: ElementProps) => React.ReactNode);
-  // styled API
-  component?: React.ElementType;
-  clone?: boolean;
-  ref?: React.Ref<unknown>;
-  sx?: SxProps<Theme>;
+export interface BoxTypeMap<P = {}, D extends React.ElementType = 'span'> {
+  props: P &
+    ElementProps &
+    SystemProps & {
+      children?: React.ReactNode | ((props: ElementProps) => React.ReactNode);
+      // styled API
+      component?: React.ElementType;
+      clone?: boolean;
+      ref?: React.Ref<unknown>;
+      sx?: SxProps<Theme>;
+    };
+  defaultComponent: D;
 }
 
-declare const Box: React.ComponentType<BoxProps>;
+declare const Box: OverridableComponent<BoxTypeMap>;
+
+export type BoxProps<
+  D extends React.ElementType = BoxTypeMap['defaultComponent'],
+  P = {}
+> = OverrideProps<BoxTypeMap<P, D>, D>;
 
 export default Box;

--- a/packages/material-ui/src/Box/Box.js
+++ b/packages/material-ui/src/Box/Box.js
@@ -63,7 +63,8 @@ Box.propTypes = {
    */
   clone: PropTypes.bool,
   /**
-   * @ignore
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
   /**

--- a/packages/material-ui/src/Box/Box.spec.tsx
+++ b/packages/material-ui/src/Box/Box.spec.tsx
@@ -8,7 +8,7 @@ interface TestProps {
 function Test(props: TestProps) {
   const { test, ...rest } = props;
   return <span {...rest}>{test}</span>;
-};
+}
 
 function ResponsiveTest() {
   <Box p={[2, 3, 4]} />;

--- a/packages/material-ui/src/Box/Box.spec.tsx
+++ b/packages/material-ui/src/Box/Box.spec.tsx
@@ -5,8 +5,9 @@ interface TestProps {
   test?: string;
 }
 
-const Test: React.FC<TestProps> = (props) => {
-  return <span {...props} />;
+function Test(props: TestProps) {
+  const { test, ...rest } = props;
+  return <span {...rest}>{test}</span>;
 };
 
 function ResponsiveTest() {

--- a/packages/material-ui/src/Box/Box.spec.tsx
+++ b/packages/material-ui/src/Box/Box.spec.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
 
+interface TestProps {
+  test?: string;
+}
+
+const Test: React.FC<TestProps> = (props) => {
+  return <span {...props} />
+}
+
 function ResponsiveTest() {
   <Box p={[2, 3, 4]} />;
   <Box p={{ xs: 2, sm: 3, md: 4 }} />;
@@ -16,4 +24,9 @@ function ResponsiveTest() {
   >
     Object API
   </Box>;
+}
+
+function ComponentPropTest() {
+  <Box component="img" src="https://material-ui.com/" alt="Material UI" />;
+  <Box component={Test} test="Test string" />;
 }

--- a/packages/material-ui/src/Box/Box.spec.tsx
+++ b/packages/material-ui/src/Box/Box.spec.tsx
@@ -6,8 +6,8 @@ interface TestProps {
 }
 
 const Test: React.FC<TestProps> = (props) => {
-  return <span {...props} />
-}
+  return <span {...props} />;
+};
 
 function ResponsiveTest() {
   <Box p={[2, 3, 4]} />;


### PR DESCRIPTION
Fixes ts issue with Box not respecting the props of the component used under the `component` prop. Examples:

```jsx
<Box 
  component={Paper} 
  minHeight={320} // <Box /> prop
  square // <Paper /> prop throws
/>
```

```jsx
<Box 
  component="img" 
  src="HTTP://material-ui.com" // img prop throws
  alt="Material-UI" // img prop throws
/>
```

Closes https://github.com/mui-org/material-ui/issues/16843 