### PR TITLE
[test] Misc improvements to experimental and browser test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "playwright": "^1.6.1",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.0.1",
-    "pretty-format-v24": "npm:pretty-format@24",
     "prop-types": "^15.7.2",
     "puppeteer": "^5.0.0",
     "react": "^16.14.0",

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -5,11 +5,10 @@ import Divider from './Divider';
 
 describe('<Divider />', () => {
   const mount = createMount();
-  let render;
+  const render = createClientRender();
   let classes;
 
   before(() => {
-    render = createClientRender();
     classes = getClasses(<Divider />);
   });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -48,7 +48,8 @@ async function run(argv) {
   const mochaProcess = childProcess.spawn('yarn', args, {
     env: {
       ...process.env,
-      NODE_ENV: 'test',
+      BABEL_ENV: 'test',
+      NODE_ENV: argv.production ? 'production' : 'test',
     },
     shell: true,
     stdio: ['inherit', 'inherit', 'inherit'],
@@ -84,6 +85,12 @@ yargs
         .option('inspect-brk', {
           alias: 'd',
           description: 'Stop on first error.',
+          type: 'boolean',
+        })
+        .option('production', {
+          alias: 'p',
+          description:
+            'Run tests in production environment. WARNING: Will not work with most tests.',
           type: 'boolean',
         })
         .option('single', {

--- a/test/cli.js
+++ b/test/cli.js
@@ -82,7 +82,7 @@ yargs
           type: 'boolean',
         })
         .option('inspect-brk', {
-          alias: 'b',
+          alias: 'd',
           description: 'Stop on first error.',
           type: 'boolean',
         })

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -85,10 +85,6 @@ module.exports = function setKarmaConfig(config) {
           // https://github.com/sinonjs/sinon/issues/1951
           // use the cdn main field. Neither module nor main are supported for browserbuilds
           sinon: 'sinon/pkg/sinon.js',
-          // https://github.com/testing-library/react-testing-library/issues/486
-          // "default" bundles are not browser compatible
-          '@testing-library/react/pure':
-            '@testing-library/react/dist/@testing-library/react.pure.esm',
         },
         extensions: ['.js', '.ts', '.tsx'],
       },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -82,11 +82,6 @@ module.exports = function setKarmaConfig(config) {
       },
       resolve: {
         alias: {
-          // yarn alias for `pretty-format@3`
-          // @testing-library/dom -> pretty-format@25
-          // which uses Object.entries which isn't implemented in all browsers
-          // we support
-          'pretty-format': require.resolve('pretty-format-v24'),
           // https://github.com/sinonjs/sinon/issues/1951
           // use the cdn main field. Neither module nor main are supported for browserbuilds
           sinon: 'sinon/pkg/sinon.js',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -12,7 +12,7 @@ process.env.CHROME_BIN = require('puppeteer').executablePath();
 module.exports = function setKarmaConfig(config) {
   const baseConfig = {
     basePath: '../',
-    browsers: ['ChromeHeadlessNoSandbox'],
+    browsers: ['chromeHeadless'],
     browserDisconnectTimeout: 120000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 300000, // default 10000
@@ -87,7 +87,7 @@ module.exports = function setKarmaConfig(config) {
       writeToDisk: Boolean(process.env.CI),
     },
     customLaunchers: {
-      ChromeHeadlessNoSandbox: {
+      chromeHeadless: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox'],
       },
@@ -101,30 +101,25 @@ module.exports = function setKarmaConfig(config) {
     newConfig = {
       ...baseConfig,
       browserStack,
-      browsers: baseConfig.browsers.concat([
-        'BrowserStack_Chrome',
-        'BrowserStack_Firefox',
-        'BrowserStack_Safari',
-        'BrowserStack_Edge',
-      ]),
+      browsers: baseConfig.browsers.concat(['chrome', 'firefox', 'safar', 'edge']),
       plugins: baseConfig.plugins.concat(['karma-browserstack-launcher']),
       customLaunchers: {
         ...baseConfig.customLaunchers,
-        BrowserStack_Chrome: {
+        chrome: {
           base: 'BrowserStack',
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'chrome',
           browser_version: '84.0',
         },
-        BrowserStack_Firefox: {
+        firefox: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'firefox',
           browser_version: '78.0',
         },
-        BrowserStack_Safari: {
+        safar: {
           base: 'BrowserStack',
           os: 'OS X',
           os_version: 'Catalina',
@@ -133,7 +128,7 @@ module.exports = function setKarmaConfig(config) {
           // However, 12.1 is very flaky on desktop (mobile is always flaky).
           browser_version: '13.0',
         },
-        BrowserStack_Edge: {
+        edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -81,11 +81,6 @@ module.exports = function setKarmaConfig(config) {
         fs: 'empty',
       },
       resolve: {
-        alias: {
-          // https://github.com/sinonjs/sinon/issues/1951
-          // use the cdn main field. Neither module nor main are supported for browserbuilds
-          sinon: 'sinon/pkg/sinon.js',
-        },
         extensions: ['.js', '.ts', '.tsx'],
       },
     },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -56,12 +56,10 @@ module.exports = function setKarmaConfig(config) {
       devtool: 'inline-source-map',
       plugins: [
         new webpack.DefinePlugin({
-          'process.env': {
-            NODE_ENV: JSON.stringify('test'),
-            CI: JSON.stringify(process.env.CI),
-            KARMA: JSON.stringify(true),
-            TEST_GATE: JSON.stringify(process.env.TEST_GATE),
-          },
+          'process.env.NODE_ENV': JSON.stringify('test'),
+          'process.env.CI': JSON.stringify(process.env.CI),
+          'process.env.KARMA': JSON.stringify(true),
+          'process.env.TEST_GATE': JSON.stringify(process.env.TEST_GATE),
         }),
       ],
       module: {

--- a/test/utils/createMount.js
+++ b/test/utils/createMount.js
@@ -57,6 +57,28 @@ export default function createMount(options = {}) {
     return titles.filter(Boolean).reverse().join(' -> ');
   }
 
+  // save stack to re-use in test-hooks
+  const { stack: createMountStack } = new Error();
+
+  /**
+   * Flag whether `createMount` was called in a suite i.e. describe() block.
+   * For legacy reasons `createMount` might accidentally be called in a before(Each) hook.
+   */
+  let wasCalledInSuite = false;
+  before(() => {
+    wasCalledInSuite = true;
+  });
+
+  beforeEach(() => {
+    if (!wasCalledInSuite) {
+      const error = new Error(
+        'Unable to run `before` hook for `createMount`. This usually indicates that `createMount` was called in a `before` hook instead of in a `describe()` block.',
+      );
+      error.stack = createMountStack;
+      throw error;
+    }
+  });
+
   beforeEach(function beforeEachMountTest() {
     container = document.createElement('div');
     container.setAttribute('data-test', computeTestName(this.currentTest));

--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -17,6 +17,13 @@ function createUnexpectedConsoleMessagesHooks(Mocha, methodName, expectedMatcher
     // Safe stack so that test dev can track where the unexpected console message was created.
     const { stack } = new Error();
 
+    if (process.env.NODE_ENV === 'production') {
+      // TODO: mock scheduler
+      if (message.indexOf('act(...) is not supported in production builds of React') !== -1) {
+        return;
+      }
+    }
+
     unexpectedCalls.push([
       // first line includes the (empty) error message
       // i.e. Remove the `Error:` line

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,15 +1586,6 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -2961,14 +2952,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
-  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/istanbul-reports@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
@@ -3309,13 +3292,6 @@
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
-  integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0", "@types/yargs@^15.0.5":
   version "15.0.10"
@@ -3848,7 +3824,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -13408,16 +13384,6 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-"pretty-format-v24@npm:pretty-format@24":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^26.0.1, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
@@ -13858,7 +13824,7 @@ react-final-form@^6.3.0:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-react-is@16.13.1, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, "react-is@^16.8.0 || ^17.0.0", react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^17.0.1:
+react-is@16.13.1, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, "react-is@^16.8.0 || ^17.0.0", react-is@^16.8.1, react-is@^16.8.6, react-is@^17.0.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
1. `test:karma`: More ergonomic approach to running `test:karma` with specified browsers
   ```diff
   -`yarn test:karma --browsers BrowserStack_Chrome,ChromeHeadlessNoSandBox,BrowserStack_Safari,BrowserStack_Firefox,BrowserStack_Firefox`
   +`yarn test:karma --browsers chrome,chromeHeadless,safari,firefox,edge`
1. `t` (experimental cli): Fix shorthand for `--bail` (`-b`) and `--inspect-brk` (`-d`)
   Both used `-b`.
1. Explicitly throw if `createClientRender` or `createMount` are mistakenly called in test hooks
   This is not problematic right now as far as I can tell but any potential `before` hook called from within `createClientRender` would be dropped if `createClientRender` is called within a `before` hook.
   Only `Divider.test` violated this.
1. `t`: Allow testing in production environment. 
   Does not work for all tests. Adding it now to gradually works towards enabling tests in prod.
   Tests should not do/assert something that actual users will never see. By only running in development we risk moving away from the "real world".
1. `test:karma`: Remove outdated aliases 
   These are no longer needed with https://github.com/mui-org/material-ui/pull/22814
1. `test:karma`: Fix known `process.env.*` variables being replaced with an object instead of their hardcoded (string) values
    This currently defeats dead-code-elimination and gets into some weird edge cases if we read from `process.env` which becomes truthy in browser tests.