### PR TITLE
[styles] Update mergeClasses types to more closely match its implementation

### DIFF
--- a/packages/material-ui-styles/src/mergeClasses/mergeClasses.d.ts
+++ b/packages/material-ui-styles/src/mergeClasses/mergeClasses.d.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 export interface Classes {
-  [k: string]: string;
+  [k: string]: string | undefined | null;
 }
 
 export interface MergeClassesOption {
   baseClasses: Classes;
-  newClasses: Classes;
-  Component: React.ElementType;
+  newClasses?: Classes;
+  Component?: React.ElementType | null;
 }
 
 export default function mergeClasses(options?: MergeClassesOption): Classes;

--- a/packages/material-ui-styles/src/mergeClasses/mergeClasses.test.js
+++ b/packages/material-ui-styles/src/mergeClasses/mergeClasses.test.js
@@ -15,6 +15,7 @@ describe('mergeClasses', () => {
       root: 'foo bar',
     });
   });
+
   it('should allow newClasses to be partial', () => {
     const output = mergeClasses({
       baseClasses: {
@@ -30,6 +31,7 @@ describe('mergeClasses', () => {
       child: 'baz',
     });
   });
+
   it('should allow newClasses to be optional', () => {
     const baseClasses = {
       root: 'foo',

--- a/packages/material-ui-styles/src/mergeClasses/mergeClasses.test.js
+++ b/packages/material-ui-styles/src/mergeClasses/mergeClasses.test.js
@@ -15,4 +15,26 @@ describe('mergeClasses', () => {
       root: 'foo bar',
     });
   });
+  it('should allow newClasses to be partial', () => {
+    const output = mergeClasses({
+      baseClasses: {
+        root: 'foo',
+        child: 'baz',
+      },
+      newClasses: {
+        root: 'bar',
+      },
+    });
+    expect(output).to.deep.equal({
+      root: 'foo bar',
+      child: 'baz',
+    });
+  });
+  it('should allow newClasses to be optional', () => {
+    const baseClasses = {
+      root: 'foo',
+    };
+    expect(mergeClasses({ baseClasses })).to.equal(baseClasses);
+    expect(mergeClasses({ baseClasses, newClasses: null })).to.equal(baseClasses);
+  });
 });


### PR DESCRIPTION
The types for `mergeClasses` didn't quite match its implementation. In particular, `newClasses` and `Component` are optional, and the values in `newClasses` should also be allowed to be optional.
 
This showed up in practice when you are using the `classes` prop directly from a `StyledComponentProps<ClassKey>` interface which is a `undefined | Partial<ClassNameMap<ClassKey>>` so if set, all of the props in `classes` are optional.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
