### PR TITLE
[l10n] Translate 'more than' in pt locales

### DIFF
--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -1855,7 +1855,7 @@ export const ptBR: Localization = {
         },
         labelRowsPerPage: 'Linhas por página:',
         labelDisplayedRows: ({ from, to, count }) =>
-          `${from}-${to} de ${count !== -1 ? count : `more than ${to}`}`,
+          `${from}-${to} de ${count !== -1 ? count : `mais de ${to}`}`,
       },
     },
     MuiRating: {

--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -1926,7 +1926,7 @@ export const ptPT: Localization = {
         },
         labelRowsPerPage: 'Linhas por página:',
         labelDisplayedRows: ({ from, to, count }) =>
-          `${from}-${to} de ${count !== -1 ? count : `more than ${to}`}`,
+          `${from}-${to} de ${count !== -1 ? count : `mais de ${to}`}`,
       },
     },
     MuiRating: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hey there! Just a translation of the "more than" phrase for the Portuguese locales. 

(figured it would be no problem to bundle them in one PR as they are the same; do let me know otherwise!)