### PR TITLE
[experimentalStyled] Make sx style fn optional

### DIFF
--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -182,6 +182,7 @@ export interface StyledOptions {
 interface MuiStyledOptions<Theme extends object = any> {
   muiName: string;
   overridesResolver?: (props: any, styles: string | object, name: string) => string | object;
+  skipSx?: boolean;
 }
 
 export interface CreateMUIStyled<Theme extends object = DefaultTheme> {

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -107,7 +107,7 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
       return '';
     });
 
-    if(!skipSx) {
+    if (!skipSx) {
       expressionsWithDefaultTheme.push((props) => {
         const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
         return styleFunctionSx({ ...props, theme });

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -63,6 +63,7 @@ const shouldForwardProp = (prop) => prop !== 'styleProps' && prop !== 'theme' &&
 
 const experimentalStyled = (tag, options, muiOptions = {}) => {
   const name = muiOptions.muiName;
+  const skipSx = muiOptions.skipSx || false;
   const defaultStyledResolver = styled(tag, { shouldForwardProp, label: name, ...options });
   const muiStyledResolver = (styleArg, ...expressions) => {
     const expressionsWithDefaultTheme = expressions
@@ -82,8 +83,8 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
 
     if (Array.isArray(styleArg)) {
       // If the type is array, than we need to add placeholders in the template for the overrides, variants and the sx styles
-      transformedStyleArg = [...styleArg, '', '', ''];
-      transformedStyleArg.raw = [...styleArg.raw, '', '', ''];
+      transformedStyleArg = [...styleArg, ...(skipSx ? ['', ''] : ['', '', ''])];
+      transformedStyleArg.raw = [...styleArg.raw, ...(skipSx ? ['', ''] : ['', '', ''])];
     } else if (typeof styleArg === 'function') {
       // If the type is function, we need to define the default theme
       transformedStyleArg = ({ theme: themeInput, ...rest }) =>
@@ -106,10 +107,12 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
       return '';
     });
 
-    expressionsWithDefaultTheme.push((props) => {
-      const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
-      return styleFunctionSx({ ...props, theme });
-    });
+    if(!skipSx) {
+      expressionsWithDefaultTheme.push((props) => {
+        const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
+        return styleFunctionSx({ ...props, theme });
+      });
+    }
 
     return defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
   };

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -365,20 +365,20 @@ describe('experimentalStyled', () => {
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
         { muiName: 'MuiTest', overridesResolver: testOverridesResolver, skipSx: true },
       )(({ sx = {} }) => ({
-        ...(sx.m && {
-          margin: `${sx.m * -1}px`,
+        ...(sx.mt && {
+          marginTop: `${sx.mt * -1}px`,
         }),
       }));
 
       const { container: containerNoSx } = render(
         <ThemeProvider theme={theme}>
-          <TestNoSx sx={{ m: 1 }}>Test</TestNoSx>
+          <TestNoSx sx={{ mt: 1 }}>Test</TestNoSx>
         </ThemeProvider>,
       );
 
       // sx prop ignored, custom function takes place
       expect(containerNoSx.firstChild).toHaveComputedStyle({
-        margin: '-1px',
+        marginTop: '-1px',
       });
 
       const TestWithSx = styled(
@@ -386,20 +386,20 @@ describe('experimentalStyled', () => {
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
         { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
       )(({ sx = {} }) => ({
-        ...(sx.m && {
-          margin: `${sx.m * -1}px`,
+        ...(sx.mt && {
+          marginTop: `${sx.m * -1}px`,
         }),
       }));
 
       const { container: containerSxProp } = render(
         <ThemeProvider theme={theme}>
-          <TestWithSx sx={{ m: 1 }}>Test</TestWithSx>
+          <TestWithSx sx={{ mt: 1 }}>Test</TestWithSx>
         </ThemeProvider>,
       );
 
       // default sx props takes place
       expect(containerSxProp.firstChild).toHaveComputedStyle({
-        margin: '8px',
+        marginTop: '8px',
       });
     });
   });

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -353,5 +353,54 @@ describe('experimentalStyled', () => {
         color: 'rgb(0, 0, 255)',
       });
     });
+
+    it('should respect the skipSx option', () => {
+      const testOverridesResolver = (props, styles) => ({
+        ...styles.root,
+        ...(props.variant && styles[props.variant]),
+      });
+
+      const TestNoSx = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { muiName: 'MuiTest', overridesResolver: testOverridesResolver, skipSx: true },
+      )(({ sx = {} }) => ({
+        ...(sx.m && {
+          margin: `${sx.m * -1}px`,
+        }),
+      }));
+
+      const { container: containerNoSx } = render(
+        <ThemeProvider theme={theme}>
+          <TestNoSx sx={{ m: 1 }}>Test</TestNoSx>
+        </ThemeProvider>,
+      );
+
+      // sx prop ignored, custom function takes place
+      expect(containerNoSx.firstChild).toHaveComputedStyle({
+        margin: '-1px',
+      });
+
+      const TestWithSx = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+      )(({ sx = {} }) => ({
+        ...(sx.m && {
+          margin: `${sx.m * -1}px`,
+        }),
+      }));
+
+      const { container: containerSxProp } = render(
+        <ThemeProvider theme={theme}>
+          <TestWithSx sx={{ m: 1 }}>Test</TestWithSx>
+        </ThemeProvider>,
+      );
+
+      // default sx props takes place
+      expect(containerSxProp.firstChild).toHaveComputedStyle({
+        margin: '8px',
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds an option for making the `sx` prop optional as part of the `experimentalStyled` utility. This could unblock developers to customize the behavior of the resolver for the `sx` prop, depending on their needs. A simple example of how it could be used can be found here - https://codesandbox.io/s/confident-bush-346hb?file=/src/App.js (the value for the `m` prop is always the negative value of the resolved one).

Discussion around this issue can be found here - https://github.com/mui-org/material-ui/issues/23496