### PR TITLE
[test] Cleanup skipped tests

### DIFF
--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -54,10 +54,12 @@ describe('StylesProvider', () => {
   });
 
   describe('server-side', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     const useStyles = makeStyles({ root: { display: 'flex' } });
     const Button = (props) => {

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -90,11 +90,6 @@ describe('ThemeProvider', () => {
   });
 
   it('does not allow setting mui.nested manually', () => {
-    if (typeof Symbol === 'undefined') {
-      // skip in IE11
-      return;
-    }
-
     const useStyles = makeStyles({ root: {} }, { name: 'MuiTest' });
     function Component(props) {
       const classes = useStyles();

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
@@ -113,15 +113,14 @@ describe('createGenerateClassName', () => {
   });
 
   describe('production', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
-
     let nodeEnv;
     const env = process.env;
 
-    before(() => {
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
       nodeEnv = env.NODE_ENV;
       env.NODE_ENV = 'production';
     });

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.test.js
@@ -4,9 +4,11 @@ import { createMount, createClientRender, describeConformance } from 'test/utils
 import SliderUnstyled from './SliderUnstyled';
 
 describe('<SliderUnstyled />', () => {
-  if (typeof Touch === 'undefined') {
-    return;
-  }
+  before(function beforeHook() {
+    if (typeof Touch === 'undefined') {
+      this.skip();
+    }
+  });
 
   const mount = createMount();
   const render = createClientRender();

--- a/packages/material-ui-utils/src/useIsFocusVisible.test.js
+++ b/packages/material-ui-utils/src/useIsFocusVisible.test.js
@@ -57,11 +57,13 @@ describe('focus-visible polyfill', () => {
   });
 
   describe('focus inside shadowRoot', () => {
-    // Only run on HeadlessChrome which has native shadowRoot support.
-    // And jsdom which has limited support for shadowRoot (^12.0.0).
-    if (!/HeadlessChrome|jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
+    before(function beforeHook() {
+      // Only run on HeadlessChrome which has native shadowRoot support.
+      // And jsdom which has limited support for shadowRoot (^12.0.0).
+      if (!/HeadlessChrome|jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     let rootElement;
 

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -354,12 +354,14 @@ describe('<Button />', () => {
   });
 
   describe('server-side', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
-
     const serverRender = createServerRender({ expectUseLayoutEffectWarning: true });
+
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     it('should server-side render', () => {
       const markup = serverRender(<Button>Hello World</Button>);

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -479,13 +479,6 @@ describe('<ButtonBase />', () => {
   });
 
   describe('focusRipple', () => {
-    before(function beforeHook() {
-      if (/Version\/10\.\d+\.\d+ Safari/.test(window.navigator.userAgent)) {
-        // browserstack quirk
-        this.skip();
-      }
-    });
-
     it('should pulsate the ripple when focusVisible', () => {
       const { getByRole } = render(
         <ButtonBase
@@ -1031,10 +1024,10 @@ describe('<ButtonBase />', () => {
       PropTypes.resetWarningCache();
     });
 
-    it('warns on invalid `component` prop: ref forward', () => {
+    it('warns on invalid `component` prop: ref forward', function test() {
       // Only run the test on node. On the browser the thrown error is not caught
       if (!/jsdom/.test(window.navigator.userAgent)) {
-        return;
+        this.skip();
       }
 
       /**

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -157,11 +157,14 @@ describe('<Fab />', () => {
   });
 
   describe('server-side', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
     const serverRender = createServerRender({ expectUseLayoutEffectWarning: true });
+
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     it('should server-side render', () => {
       const markup = serverRender(<Fab>Fab</Fab>);

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -9,10 +9,12 @@ describe('<Portal />', () => {
   const render = createClientRender();
 
   describe('server-side', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     it('render nothing on the server', () => {
       const markup1 = serverRender(<div>Bar</div>);

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -20,10 +20,12 @@ function createTouches(touches) {
 }
 
 describe('<Slider />', () => {
-  // only run in supported browsers
-  if (typeof Touch === 'undefined') {
-    return;
-  }
+  before(function beforeHook() {
+    // only run in supported browsers
+    if (typeof Touch === 'undefined') {
+      this.skip();
+    }
+  });
 
   const mount = createMount();
   const render = createClientRender();

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -41,23 +41,24 @@ function hasRightScrollButton(container) {
 }
 
 describe('<Tabs />', () => {
-  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   // tests mocking getBoundingClientRect prevent mocha to exit
   const isJSDOM = navigator.userAgent === 'node.js';
-
-  // The test fails on Safari with just:
-  //
-  // container.scrollLeft = 200;
-  // expect(container.scrollLeft).to.equal(200); 💥
-  if (isSafari) {
-    return;
-  }
 
   const mount = createMount();
   let classes;
   const render = createClientRender();
 
-  before(() => {
+  before(function beforeHook() {
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+    // The test fails on Safari with just:
+    //
+    // container.scrollLeft = 200;
+    // expect(container.scrollLeft).to.equal(200); 💥
+    if (isSafari) {
+      this.skip();
+    }
+
     classes = getClasses(<Tabs value={0} />);
   });
 

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -16,13 +16,7 @@ describe('<TextareaAutosize />', () => {
   }));
 
   describe('layout', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
-
     const getComputedStyleStub = {};
-
     function setLayout(
       input,
       shadow,
@@ -39,7 +33,12 @@ describe('<TextareaAutosize />', () => {
       });
     }
 
-    before(() => {
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
       stub(window, 'getComputedStyle').value((node) => getComputedStyleStub[node] || {});
     });
 

--- a/packages/material-ui/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.test.js
@@ -121,10 +121,12 @@ describe('<ToggleButton />', () => {
   });
 
   describe('server-side', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     const serverRender = createServerRender({ expectUseLayoutEffectWarning: true });
 

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -33,11 +33,13 @@ function createMatchMedia(width, ref) {
 }
 
 describe('useMediaQuery', () => {
-  // Only run the test on node.
-  // Waiting for https://github.com/facebook/react/issues/14050
-  if (!/jsdom/.test(window.navigator.userAgent)) {
-    return;
-  }
+  before(function beforeHook() {
+    // Only run the test on node.
+    // Waiting for https://github.com/facebook/react/issues/14050
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+  });
 
   const render = createClientRender();
   let values;

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -83,10 +83,12 @@ describe('useScrollTrigger', () => {
   });
 
   describe('scroll', () => {
-    // Only run the test on node.
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
+    before(function beforeHook() {
+      // Only run the test on node.
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+    });
 
     function dispatchScroll(offset, element = window) {
       act(() => {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -15,12 +15,6 @@ import {
 describe('<MenuList> integration', () => {
   const render = createClientRender();
 
-  if (/Chrome\/49\.0/.test(window.navigator.userAgent)) {
-    // fails repeatedly on chrome 49 in karma but works when manually testing
-    // the same component tree (-TrackCommitCountMenuItem) in isolation in browserstack
-    return;
-  }
-
   specify('the MenuItems have the `menuitem` role', () => {
     const { getAllByRole } = render(
       <MenuList>


### PR DESCRIPTION
1. Remove unused skip conditions
   Became obsolete with https://github.com/mui-org/material-ui/pull/22814
1. [test] Prefer skip() over return
   This can be abused up until adding a test becomes a balancing act. For example, in SwipeableDrawer where we return in the middle of the test file (not touching that test for now because it seems too brittle). This is the old problem of "optimizing for the current test suite". A test suite needs to scale and every addition needs to start from a clean slate. And a change to existing tests should not affect existing one.
   By using skip() we can also better monitor which tests are skipped across environments. This was only possible implicitly. Now we have an explicit signal in test runners.