### PR TITLE
[core] Fix error handling on upload

### DIFF
--- a/patches/argos-cli+0.3.0.patch
+++ b/patches/argos-cli+0.3.0.patch
@@ -1,16 +1,17 @@
 diff --git a/node_modules/argos-cli/lib/index.js b/node_modules/argos-cli/lib/index.js
-index 9260e62..2a59c7e 100644
+index 9260e62..c0c80bc 100644
 --- a/node_modules/argos-cli/lib/index.js
 +++ b/node_modules/argos-cli/lib/index.js
-@@ -51,7 +51,11 @@ _commander.default.command('upload <directory>').description('Upload screenshots
+@@ -51,7 +51,12 @@ _commander.default.command('upload <directory>').description('Upload screenshots
      const res = await (0, _upload.default)(_objectSpread({
        directory
      }, command));
 -    json = await res.json();
++    const text = await res.text();
 +    try {
-+      json = await res.json();
++      json = JSON.parse(text)
 +    } catch (error) {
-+      throw new Error(`Failed to parse response body as JSON:\n\n${await res.text()}`)
++      throw new Error(`${res.status}: Failed to parse response body as JSON:\n\n${text}`)
 +    }
  
      if (json.error) {


### PR DESCRIPTION
If `.json()` failed then the body is already used and we can't flush it again e.g. by using `.text()`. So just flush it once and then manually pipe it to JSON.parse or the error handler.

Previous failure: https://app.circleci.com/pipelines/github/mui-org/material-ui/28253/workflows/bf0933ce-ae1a-447e-975c-94305cad4b3a/jobs/199676

Closes #23725