### PR TITLE
Add Memory (user of MUI) to showcase

### DIFF
--- a/docs/src/pages/discover-more/showcase/appList.js
+++ b/docs/src/pages/discover-more/showcase/appList.js
@@ -639,6 +639,16 @@ const appList = [
     similarWebVisits: 534,
     dateAdded: '2020-09-11',
   },
+  {
+    title: 'Memory',
+    description:
+      'Memory offers free learning tools including flashcards.  Front ends built exclusively' +
+      ' upon MUI (with some other packages, e.g. react-spring for the game area) and even uses' +
+      ' MUI for superquick SQL to React adhoc reports.',
+    image: 'https://markdown.memory.com/flags/memory-screenshot.png',
+    link: 'https://www.memory.com',
+    dateAdded: '2020-11-27',
+  },
 ];
 
 export default appList;


### PR DESCRIPTION
Hi, I would like to submit my site for consideration:

Memory is an young (startup) educational learning app using MUI.  Pure MUI framework - although not a traditional MUI look - with minimal CSS overrides.

- I couldn't figure out where to upload the image.  The link is a hosted on a CDN.
- I spent time trying to figure out the similarweb visits, but the numbers of others in the list didn't tally up with what I found, so I'm not sure what number to use.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
