### PR TITLE
[docs] Improve SEO structure

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -145,6 +145,8 @@ MyDocument.getInitialProps = async (ctx) => {
       css = cleanCSS.minify(css).styles;
     }
 
+    // All the URLs should have a leading /.
+    // This is missing in the Next.js static export.
     let url = ctx.req.url;
     if (url[url.length - 1] !== '/') {
       url += '/';

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -52,16 +52,18 @@ export default class MyDocument extends Document {
           {/* SEO */}
           <link
             rel="canonical"
-            href={`https://material-ui.com${userLanguage === 'en' ? '' : `/${userLanguage}`
-              }${canonical}`}
+            href={`https://material-ui.com${
+              userLanguage === 'en' ? '' : `/${userLanguage}`
+            }${canonical}`}
           />
           <link rel="alternate" href={`https://material-ui.com${canonical}`} hrefLang="x-default" />
           {LANGUAGES_SSR.map((userLanguage2) => (
             <link
               key={userLanguage2}
               rel="alternate"
-              href={`https://material-ui.com${userLanguage2 === 'en' ? '' : `/${userLanguage2}`
-                }${canonical}`}
+              href={`https://material-ui.com${
+                userLanguage2 === 'en' ? '' : `/${userLanguage2}`
+              }${canonical}`}
               hrefLang={userLanguage2}
             />
           ))}

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -52,18 +52,16 @@ export default class MyDocument extends Document {
           {/* SEO */}
           <link
             rel="canonical"
-            href={`https://material-ui.com${
-              userLanguage === 'en' ? '/' : `/${userLanguage}`
-            }${canonical}`}
+            href={`https://material-ui.com${userLanguage === 'en' ? '' : `/${userLanguage}`
+              }${canonical}`}
           />
           <link rel="alternate" href={`https://material-ui.com${canonical}`} hrefLang="x-default" />
           {LANGUAGES_SSR.map((userLanguage2) => (
             <link
               key={userLanguage2}
               rel="alternate"
-              href={`https://material-ui.com${
-                userLanguage2 === 'en' ? '/' : `/${userLanguage2}`
-              }${canonical}`}
+              href={`https://material-ui.com${userLanguage2 === 'en' ? '' : `/${userLanguage2}`
+                }${canonical}`}
               hrefLang={userLanguage2}
             />
           ))}
@@ -145,9 +143,14 @@ MyDocument.getInitialProps = async (ctx) => {
       css = cleanCSS.minify(css).styles;
     }
 
+    let url = ctx.req.url;
+    if (url[url.length - 1] !== '/') {
+      url += '/';
+    }
+
     return {
       ...initialProps,
-      canonical: pathnameToLanguage(ctx.req.url).canonical,
+      canonical: pathnameToLanguage(url).canonical,
       userLanguage: ctx.query.userLanguage || 'en',
       // Styles fragment is rendered after the app and page rendering finish.
       styles: [

--- a/docs/src/pages/components/timeline/CustomizedTimeline.js
+++ b/docs/src/pages/components/timeline/CustomizedTimeline.js
@@ -47,7 +47,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Eat
           </Typography>
           <Typography>Because you need strength</Typography>
@@ -69,7 +69,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Code
           </Typography>
           <Typography>Because it&apos;s awesome!</Typography>
@@ -84,7 +84,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector className={classes.secondaryTail} />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Sleep
           </Typography>
           <Typography>Because you need rest</Typography>
@@ -99,7 +99,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Repeat
           </Typography>
           <Typography>Because this is the life you love!</Typography>

--- a/docs/src/pages/components/timeline/CustomizedTimeline.tsx
+++ b/docs/src/pages/components/timeline/CustomizedTimeline.tsx
@@ -47,7 +47,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Eat
           </Typography>
           <Typography>Because you need strength</Typography>
@@ -69,7 +69,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Code
           </Typography>
           <Typography>Because it&apos;s awesome!</Typography>
@@ -84,7 +84,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector className={classes.secondaryTail} />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Sleep
           </Typography>
           <Typography>Because you need rest</Typography>
@@ -99,7 +99,7 @@ export default function CustomizedTimeline() {
           <TimelineConnector />
         </TimelineSeparator>
         <TimelineContent className={classes.timelineContent}>
-          <Typography variant="h6" component="h1">
+          <Typography variant="h6" component="span">
             Repeat
           </Typography>
           <Typography>Because this is the life you love!</Typography>

--- a/docs/src/pages/components/timeline/timeline.md
+++ b/docs/src/pages/components/timeline/timeline.md
@@ -19,7 +19,7 @@ A basic timeline showing list of events.
 
 {{"demo": "pages/components/timeline/BasicTimeline.js"}}
 
-## Right aligned timeline
+## Right-aligned timeline
 
 The timeline can be positioned on the right side of the events.
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -48,7 +48,7 @@ In general, you can expect the following release cycle:
 | May 2018       | v1.0.0  | Released |
 | September 2018 | v3.0.0  | Released |
 | May 2019       | v4.0.0  | Released |
-| Q4 2020        | v5.0.0  | ⏳       |
+| Q1 2021        | v5.0.0  | ⏳       |
 
 You can follow the [milestones](https://github.com/mui-org/material-ui/milestones) for a more detailed overview.
 


### PR DESCRIPTION
- Fix double h1 by this demo: https://next.material-ui.com/components/timeline/#customized-timeline
- Fix double // on the canonical link of https://next.material-ui.com/components/timeline/#customized-timeline
<img width="587" alt="Capture d’écran 2020-11-28 à 00 17 53" src="https://user-images.githubusercontent.com/3165635/100488551-321d8d00-310f-11eb-94b2-cdcd38e1a863.png">

- Fix missing leading / on the canonical link of https://next.material-ui.com/components/timeline/#customized-timeline
<img width="587" alt="Capture d’écran 2020-11-28 à 00 17 53" src="https://user-images.githubusercontent.com/3165635/100488551-321d8d00-310f-11eb-94b2-cdcd38e1a863.png">
