### PR TITLE
[Select] Add disabled attribute in input element when disabled

### DIFF
--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -424,6 +424,12 @@ describe('<Select />', () => {
       expect(getByRole('button')).to.have.attribute('aria-disabled', 'true');
     });
 
+    it('sets disabled attribute in input when component is disabled', () => {
+      const { container } = render(<Select disabled value="" />);
+
+      expect(container.querySelector('input')).to.have.property('disabled', true);
+    });
+
     specify('aria-disabled is not present if component is not disabled', () => {
       const { getByRole } = render(<Select disabled={false} value="" />);
 

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -401,6 +401,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         aria-hidden
         onChange={handleChange}
         tabIndex={-1}
+        disabled={disabled}
         className={classes.nativeInput}
         autoFocus={autoFocus}
         {...other}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Add disabled attribute to the input element, when disabled prop is true and select is disabled.

### Why is it needed?
The disabled attribute is used to make the control non-interactive and to prevent its value from being submitted.

### Related issue(s)/PR(s)
Closes #23693
