### PR TITLE
[Switch] Add preventDefault check for state change

### DIFF
--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -84,6 +84,7 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
   };
 
   const handleInputChange = (event) => {
+    // Workaround for https://github.com/facebook/react/issues/9023
     if (event.nativeEvent.defaultPrevented) {
       return;
     }

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -84,6 +84,10 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
   };
 
   const handleInputChange = (event) => {
+    if (event.nativeEvent.defaultPrevented) {
+      return;
+    }
+
     const newChecked = event.target.checked;
 
     setCheckedState(newChecked);

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -214,6 +214,33 @@ describe('<SwitchBase />', () => {
       expect(handleChange.firstCall.returnValue).to.equal(!checked);
     });
 
+    it('should not change checkbox state when event is default prevented', () => {
+      const handleChange = spy((event) => event.target.checked);
+      const handleClick = spy((event) => event.preventDefault());
+      const { container, getByRole } = render(
+        <SwitchBase
+          icon="checkbox"
+          checkedIcon="checkbox"
+          type="checkbox"
+          defaultChecked
+          onChange={handleChange}
+          onClick={handleClick}
+        />,
+      );
+      const checkbox = getByRole('checkbox');
+
+      expect(container.firstChild).to.have.class(classes.checked);
+      expect(checkbox).to.have.property('checked', true);
+
+      act(() => {
+        checkbox.click();
+      });
+
+      expect(handleChange.callCount).to.equal(0);
+      expect(container.firstChild).to.have.class(classes.checked);
+      expect(checkbox).to.have.property('checked', true);
+    });
+
     describe('prop: inputProps', () => {
       it('should be able to add aria', () => {
         const { getByRole } = render(


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Checks whether the default behaviour is prevented, if yes, restricts the state change of the checkbox element.

### Why is it needed?
`preventDefault` should restrict the default behaviour of the input element and stop the element from updating.

Related issue(s)/PR(s)
Closes #23709 
