### PR TITLE
[docs] Fix various a11y issues reported by lighthouse

### DIFF
--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -175,7 +175,6 @@ ${headers.components
       const headingHashesFallbackTranslated = {};
       let headingIndex = -1;
 
-      console.log('----');
       const rendered = contents.map((content) => {
         if (/^"(demo|component)": "(.*)"/.test(content)) {
           try {

--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -175,6 +175,7 @@ ${headers.components
       const headingHashesFallbackTranslated = {};
       let headingIndex = -1;
 
+      console.log('----');
       const rendered = contents.map((content) => {
         if (/^"(demo|component)": "(.*)"/.test(content)) {
           try {
@@ -250,7 +251,7 @@ ${headers.components
               `<h${level}>`,
               `<a class="anchor-link" id="${hash}"></a>`,
               headingHtml,
-              `<a class="anchor-link-style" aria-hidden="true" aria-label="anchor" href="#${hash}">`,
+              `<a class="anchor-link-style" aria-hidden="true" href="#${hash}">`,
               '<svg><use xlink:href="#anchor-link-icon" /></svg>',
               '</a>',
               `</h${level}>`,

--- a/docs/src/pages/components/app-bar/BackToTop.js
+++ b/docs/src/pages/components/app-bar/BackToTop.js
@@ -69,7 +69,9 @@ export default function BackToTop(props) {
       <CssBaseline />
       <AppBar>
         <Toolbar>
-          <Typography variant="h6">Scroll to see button</Typography>
+          <Typography variant="h6" component="div">
+            Scroll to see button
+          </Typography>
         </Toolbar>
       </AppBar>
       <Toolbar id="back-to-top-anchor" />

--- a/docs/src/pages/components/app-bar/BackToTop.tsx
+++ b/docs/src/pages/components/app-bar/BackToTop.tsx
@@ -70,7 +70,9 @@ export default function BackToTop(props: Props) {
       <CssBaseline />
       <AppBar>
         <Toolbar>
-          <Typography variant="h6">Scroll to see button</Typography>
+          <Typography variant="h6" component="div">
+            Scroll to see button
+          </Typography>
         </Toolbar>
       </AppBar>
       <Toolbar id="back-to-top-anchor" />

--- a/docs/src/pages/components/app-bar/BottomAppBar.js
+++ b/docs/src/pages/components/app-bar/BottomAppBar.js
@@ -104,7 +104,12 @@ export default function BottomAppBar() {
     <React.Fragment>
       <CssBaseline />
       <Paper square className={classes.paper}>
-        <Typography className={classes.text} variant="h5" gutterBottom>
+        <Typography
+          className={classes.text}
+          variant="h5"
+          gutterBottom
+          component="div"
+        >
           Inbox
         </Typography>
         <List className={classes.list}>

--- a/docs/src/pages/components/app-bar/BottomAppBar.tsx
+++ b/docs/src/pages/components/app-bar/BottomAppBar.tsx
@@ -106,7 +106,12 @@ export default function BottomAppBar() {
     <React.Fragment>
       <CssBaseline />
       <Paper square className={classes.paper}>
-        <Typography className={classes.text} variant="h5" gutterBottom>
+        <Typography
+          className={classes.text}
+          variant="h5"
+          gutterBottom
+          component="div"
+        >
           Inbox
         </Typography>
         <List className={classes.list}>

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -34,7 +34,7 @@ export default function ButtonAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             News
           </Typography>
           <Button color="inherit">Login</Button>

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -36,7 +36,7 @@ export default function ButtonAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             News
           </Typography>
           <Button color="inherit">Login</Button>

--- a/docs/src/pages/components/app-bar/DenseAppBar.js
+++ b/docs/src/pages/components/app-bar/DenseAppBar.js
@@ -30,7 +30,7 @@ export default function DenseAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" color="inherit">
+          <Typography variant="h6" color="inherit" component="div">
             Photos
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/app-bar/DenseAppBar.tsx
+++ b/docs/src/pages/components/app-bar/DenseAppBar.tsx
@@ -32,7 +32,7 @@ export default function DenseAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" color="inherit">
+          <Typography variant="h6" color="inherit" component="div">
             Photos
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/app-bar/ElevateAppBar.js
+++ b/docs/src/pages/components/app-bar/ElevateAppBar.js
@@ -40,7 +40,9 @@ export default function ElevateAppBar(props) {
       <ElevationScroll {...props}>
         <AppBar>
           <Toolbar>
-            <Typography variant="h6">Scroll to Elevate App Bar</Typography>
+            <Typography variant="h6" component="div">
+              Scroll to Elevate App Bar
+            </Typography>
           </Toolbar>
         </AppBar>
       </ElevationScroll>

--- a/docs/src/pages/components/app-bar/ElevateAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ElevateAppBar.tsx
@@ -39,7 +39,9 @@ export default function ElevateAppBar(props: Props) {
       <ElevationScroll {...props}>
         <AppBar>
           <Toolbar>
-            <Typography variant="h6">Scroll to Elevate App Bar</Typography>
+            <Typography variant="h6" component="div">
+              Scroll to Elevate App Bar
+            </Typography>
           </Toolbar>
         </AppBar>
       </ElevationScroll>

--- a/docs/src/pages/components/app-bar/HideAppBar.js
+++ b/docs/src/pages/components/app-bar/HideAppBar.js
@@ -41,7 +41,9 @@ export default function HideAppBar(props) {
       <HideOnScroll {...props}>
         <AppBar>
           <Toolbar>
-            <Typography variant="h6">Scroll to Hide App Bar</Typography>
+            <Typography variant="h6" component="div">
+              Scroll to Hide App Bar
+            </Typography>
           </Toolbar>
         </AppBar>
       </HideOnScroll>

--- a/docs/src/pages/components/app-bar/HideAppBar.tsx
+++ b/docs/src/pages/components/app-bar/HideAppBar.tsx
@@ -40,7 +40,9 @@ export default function HideAppBar(props: Props) {
       <HideOnScroll {...props}>
         <AppBar>
           <Toolbar>
-            <Typography variant="h6">Scroll to Hide App Bar</Typography>
+            <Typography variant="h6" component="div">
+              Scroll to Hide App Bar
+            </Typography>
           </Toolbar>
         </AppBar>
       </HideOnScroll>

--- a/docs/src/pages/components/app-bar/MenuAppBar.js
+++ b/docs/src/pages/components/app-bar/MenuAppBar.js
@@ -65,7 +65,7 @@ export default function MenuAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Photos
           </Typography>
           {auth && (

--- a/docs/src/pages/components/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/components/app-bar/MenuAppBar.tsx
@@ -67,7 +67,7 @@ export default function MenuAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Photos
           </Typography>
           {auth && (

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
@@ -185,7 +185,7 @@ export default function PrimarySearchAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography className={classes.title} variant="h6" noWrap>
+          <Typography className={classes.title} variant="h6" noWrap component="div">
             Material-UI
           </Typography>
           <div className={classes.search}>

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
@@ -190,7 +190,7 @@ export default function PrimarySearchAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography className={classes.title} variant="h6" noWrap>
+          <Typography className={classes.title} variant="h6" noWrap component="div">
             Material-UI
           </Typography>
           <div className={classes.search}>

--- a/docs/src/pages/components/app-bar/ProminentAppBar.js
+++ b/docs/src/pages/components/app-bar/ProminentAppBar.js
@@ -42,7 +42,7 @@ export default function ProminentAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography className={classes.title} variant="h5" noWrap>
+          <Typography className={classes.title} variant="h5" noWrap component="div">
             Material-UI
           </Typography>
           <IconButton aria-label="search" color="inherit">

--- a/docs/src/pages/components/app-bar/ProminentAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ProminentAppBar.tsx
@@ -42,7 +42,7 @@ export default function ProminentAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography className={classes.title} variant="h5" noWrap>
+          <Typography className={classes.title} variant="h5" noWrap component="div">
             Material-UI
           </Typography>
           <IconButton aria-label="search" color="inherit">

--- a/docs/src/pages/components/app-bar/SearchAppBar.js
+++ b/docs/src/pages/components/app-bar/SearchAppBar.js
@@ -78,7 +78,7 @@ export default function SearchAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography className={classes.title} variant="h6" noWrap>
+          <Typography className={classes.title} variant="h6" noWrap component="div">
             Material-UI
           </Typography>
           <div className={classes.search}>

--- a/docs/src/pages/components/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/SearchAppBar.tsx
@@ -80,7 +80,7 @@ export default function SearchAppBar() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography className={classes.title} variant="h6" noWrap>
+          <Typography className={classes.title} variant="h6" noWrap component="div">
             Material-UI
           </Typography>
           <div className={classes.search}>

--- a/docs/src/pages/components/autocomplete/CustomInputAutocomplete.js
+++ b/docs/src/pages/components/autocomplete/CustomInputAutocomplete.js
@@ -4,6 +4,9 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
+  autocomplete: {
+    display: 'inline-block',
+  },
   input: {
     width: 200,
     backgroundColor: theme.palette.background.paper,
@@ -16,18 +19,22 @@ const options = ['Option 1', 'Option 2'];
 export default function CustomInputAutocomplete() {
   const classes = useStyles();
   return (
-    <Autocomplete
-      id="custom-input-demo"
-      options={options}
-      renderInput={(params) => (
-        <div ref={params.InputProps.ref}>
-          <input
-            type="text"
-            {...params.inputProps}
-            className={clsx(classes.input, params.inputProps.className)}
-          />
-        </div>
-      )}
-    />
+    <label>
+      Value:{' '}
+      <Autocomplete
+        className={classes.autocomplete}
+        id="custom-input-demo"
+        options={options}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input
+              type="text"
+              {...params.inputProps}
+              className={clsx(classes.input, params.inputProps.className)}
+            />
+          </div>
+        )}
+      />
+    </label>
   );
 }

--- a/docs/src/pages/components/autocomplete/CustomInputAutocomplete.tsx
+++ b/docs/src/pages/components/autocomplete/CustomInputAutocomplete.tsx
@@ -5,6 +5,9 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    autocomplete: {
+      display: 'inline-block',
+    },
     input: {
       width: 200,
       backgroundColor: theme.palette.background.paper,
@@ -18,18 +21,22 @@ const options = ['Option 1', 'Option 2'];
 export default function CustomInputAutocomplete() {
   const classes = useStyles();
   return (
-    <Autocomplete
-      id="custom-input-demo"
-      options={options}
-      renderInput={(params) => (
-        <div ref={params.InputProps.ref}>
-          <input
-            type="text"
-            {...params.inputProps}
-            className={clsx(classes.input, params.inputProps.className)}
-          />
-        </div>
-      )}
-    />
+    <label>
+      Value:{' '}
+      <Autocomplete
+        className={classes.autocomplete}
+        id="custom-input-demo"
+        options={options}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input
+              type="text"
+              {...params.inputProps}
+              className={clsx(classes.input, params.inputProps.className)}
+            />
+          </div>
+        )}
+      />
+    </label>
   );
 }

--- a/docs/src/pages/components/cards/ActionAreaCard.js
+++ b/docs/src/pages/components/cards/ActionAreaCard.js
@@ -27,7 +27,7 @@ export default function ActionAreaCard() {
           title="Contemplative Reptile"
         />
         <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
+          <Typography gutterBottom variant="h5" component="div">
             Lizard
           </Typography>
           <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/ActionAreaCard.tsx
+++ b/docs/src/pages/components/cards/ActionAreaCard.tsx
@@ -27,7 +27,7 @@ export default function ActionAreaCard() {
           title="Contemplative Reptile"
         />
         <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
+          <Typography gutterBottom variant="h5" component="div">
             Lizard
           </Typography>
           <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/ImgMediaCard.js
+++ b/docs/src/pages/components/cards/ImgMediaCard.js
@@ -26,7 +26,7 @@ export default function ImgMediaCard() {
         title="Contemplative Reptile"
       />
       <CardContent>
-        <Typography gutterBottom variant="h5" component="h2">
+        <Typography gutterBottom variant="h5" component="div">
           Lizard
         </Typography>
         <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/ImgMediaCard.tsx
+++ b/docs/src/pages/components/cards/ImgMediaCard.tsx
@@ -26,7 +26,7 @@ export default function ImgMediaCard() {
         title="Contemplative Reptile"
       />
       <CardContent>
-        <Typography gutterBottom variant="h5" component="h2">
+        <Typography gutterBottom variant="h5" component="div">
           Lizard
         </Typography>
         <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/MediaCard.js
+++ b/docs/src/pages/components/cards/MediaCard.js
@@ -27,7 +27,7 @@ export default function MediaCard() {
         title="Contemplative Reptile"
       />
       <CardContent>
-        <Typography gutterBottom variant="h5" component="h2">
+        <Typography gutterBottom variant="h5" component="div">
           Lizard
         </Typography>
         <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/MediaCard.tsx
+++ b/docs/src/pages/components/cards/MediaCard.tsx
@@ -27,7 +27,7 @@ export default function MediaCard() {
         title="Contemplative Reptile"
       />
       <CardContent>
-        <Typography gutterBottom variant="h5" component="h2">
+        <Typography gutterBottom variant="h5" component="div">
           Lizard
         </Typography>
         <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/MediaControlCard.js
+++ b/docs/src/pages/components/cards/MediaControlCard.js
@@ -46,7 +46,7 @@ export default function MediaControlCard() {
           <Typography component="div" variant="h5">
             Live From Space
           </Typography>
-          <Typography variant="subtitle1" color="textSecondary">
+          <Typography variant="subtitle1" color="textSecondary" component="div">
             Mac Miller
           </Typography>
         </CardContent>

--- a/docs/src/pages/components/cards/MediaControlCard.js
+++ b/docs/src/pages/components/cards/MediaControlCard.js
@@ -43,7 +43,7 @@ export default function MediaControlCard() {
     <Card className={classes.root}>
       <div className={classes.details}>
         <CardContent className={classes.content}>
-          <Typography component="h5" variant="h5">
+          <Typography component="div" variant="h5">
             Live From Space
           </Typography>
           <Typography variant="subtitle1" color="textSecondary">

--- a/docs/src/pages/components/cards/MediaControlCard.tsx
+++ b/docs/src/pages/components/cards/MediaControlCard.tsx
@@ -45,7 +45,7 @@ export default function MediaControlCard() {
     <Card className={classes.root}>
       <div className={classes.details}>
         <CardContent className={classes.content}>
-          <Typography component="h5" variant="h5">
+          <Typography component="div" variant="h5">
             Live From Space
           </Typography>
           <Typography variant="subtitle1" color="textSecondary">

--- a/docs/src/pages/components/cards/MediaControlCard.tsx
+++ b/docs/src/pages/components/cards/MediaControlCard.tsx
@@ -48,7 +48,7 @@ export default function MediaControlCard() {
           <Typography component="div" variant="h5">
             Live From Space
           </Typography>
-          <Typography variant="subtitle1" color="textSecondary">
+          <Typography variant="subtitle1" color="textSecondary" component="div">
             Mac Miller
           </Typography>
         </CardContent>

--- a/docs/src/pages/components/cards/MultiActionAreaCard.js
+++ b/docs/src/pages/components/cards/MultiActionAreaCard.js
@@ -27,7 +27,7 @@ export default function MultiActionAreaCard() {
           title="Contemplative Reptile"
         />
         <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
+          <Typography gutterBottom variant="h5" component="div">
             Lizard
           </Typography>
           <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/MultiActionAreaCard.tsx
+++ b/docs/src/pages/components/cards/MultiActionAreaCard.tsx
@@ -27,7 +27,7 @@ export default function MultiActionAreaCard() {
           title="Contemplative Reptile"
         />
         <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
+          <Typography gutterBottom variant="h5" component="div">
             Lizard
           </Typography>
           <Typography variant="body2" color="textSecondary" component="p">

--- a/docs/src/pages/components/cards/OutlinedCard.js
+++ b/docs/src/pages/components/cards/OutlinedCard.js
@@ -33,7 +33,7 @@ export default function OutlinedCard() {
         <Typography className={classes.title} color="textSecondary" gutterBottom>
           Word of the Day
         </Typography>
-        <Typography variant="h5" component="h2">
+        <Typography variant="h5" component="div">
           be{bull}nev{bull}o{bull}lent
         </Typography>
         <Typography className={classes.pos} color="textSecondary">

--- a/docs/src/pages/components/cards/OutlinedCard.tsx
+++ b/docs/src/pages/components/cards/OutlinedCard.tsx
@@ -33,7 +33,7 @@ export default function OutlinedCard() {
         <Typography className={classes.title} color="textSecondary" gutterBottom>
           Word of the Day
         </Typography>
-        <Typography variant="h5" component="h2">
+        <Typography variant="h5" component="div">
           be{bull}nev{bull}o{bull}lent
         </Typography>
         <Typography className={classes.pos} color="textSecondary">

--- a/docs/src/pages/components/cards/SimpleCard.js
+++ b/docs/src/pages/components/cards/SimpleCard.js
@@ -33,7 +33,7 @@ export default function SimpleCard() {
         <Typography className={classes.title} color="textSecondary" gutterBottom>
           Word of the Day
         </Typography>
-        <Typography variant="h5" component="h2">
+        <Typography variant="h5" component="div">
           be{bull}nev{bull}o{bull}lent
         </Typography>
         <Typography className={classes.pos} color="textSecondary">

--- a/docs/src/pages/components/cards/SimpleCard.tsx
+++ b/docs/src/pages/components/cards/SimpleCard.tsx
@@ -33,7 +33,7 @@ export default function SimpleCard() {
         <Typography className={classes.title} color="textSecondary" gutterBottom>
           Word of the Day
         </Typography>
-        <Typography variant="h5" component="h2">
+        <Typography variant="h5" component="div">
           be{bull}nev{bull}o{bull}lent
         </Typography>
         <Typography className={classes.pos} color="textSecondary">

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.js
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.js
@@ -26,7 +26,9 @@ const DialogTitle = withStyles(styles)((props) => {
   const { children, classes, onClose, ...other } = props;
   return (
     <MuiDialogTitle disableTypography className={classes.root} {...other}>
-      <Typography variant="h6">{children}</Typography>
+      <Typography variant="h6" component="div">
+        {children}
+      </Typography>
       {onClose ? (
         <IconButton
           aria-label="close"

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
@@ -38,7 +38,9 @@ const DialogTitle = withStyles(styles)((props: DialogTitleProps) => {
   const { children, classes, onClose, ...other } = props;
   return (
     <MuiDialogTitle disableTypography className={classes.root} {...other}>
-      <Typography variant="h6">{children}</Typography>
+      <Typography variant="h6" component="div">
+        {children}
+      </Typography>
       {onClose ? (
         <IconButton
           aria-label="close"

--- a/docs/src/pages/components/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/components/dialogs/FullScreenDialog.js
@@ -60,7 +60,7 @@ export default function FullScreenDialog() {
             >
               <CloseIcon />
             </IconButton>
-            <Typography variant="h6" className={classes.title}>
+            <Typography variant="h6" className={classes.title} component="div">
               Sound
             </Typography>
             <Button autoFocus color="inherit" onClick={handleClose}>

--- a/docs/src/pages/components/dialogs/FullScreenDialog.tsx
+++ b/docs/src/pages/components/dialogs/FullScreenDialog.tsx
@@ -68,7 +68,7 @@ export default function FullScreenDialog() {
             >
               <CloseIcon />
             </IconButton>
-            <Typography variant="h6" className={classes.title}>
+            <Typography variant="h6" className={classes.title} component="div">
               Sound
             </Typography>
             <Button autoFocus color="inherit" onClick={handleClose}>

--- a/docs/src/pages/components/dialogs/SimpleDialog.js
+++ b/docs/src/pages/components/dialogs/SimpleDialog.js
@@ -83,7 +83,9 @@ export default function SimpleDialogDemo() {
 
   return (
     <div>
-      <Typography variant="subtitle1">Selected: {selectedValue}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Selected: {selectedValue}
+      </Typography>
       <br />
       <Button variant="outlined" onClick={handleClickOpen}>
         Open simple dialog

--- a/docs/src/pages/components/dialogs/SimpleDialog.tsx
+++ b/docs/src/pages/components/dialogs/SimpleDialog.tsx
@@ -81,7 +81,9 @@ export default function SimpleDialogDemo() {
 
   return (
     <div>
-      <Typography variant="subtitle1">Selected: {selectedValue}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Selected: {selectedValue}
+      </Typography>
       <br />
       <Button variant="outlined" onClick={handleClickOpen}>
         Open simple dialog

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -34,12 +34,12 @@ export default function MiddleDividers() {
       <div className={classes.section1}>
         <Grid container alignItems="center">
           <Grid item xs>
-            <Typography gutterBottom variant="h4">
+            <Typography gutterBottom variant="h4" component="div">
               Toothbrush
             </Typography>
           </Grid>
           <Grid item>
-            <Typography gutterBottom variant="h6">
+            <Typography gutterBottom variant="h6" component="div">
               $4.50
             </Typography>
           </Grid>

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -36,12 +36,12 @@ export default function MiddleDividers() {
       <div className={classes.section1}>
         <Grid container alignItems="center">
           <Grid item xs>
-            <Typography gutterBottom variant="h4">
+            <Typography gutterBottom variant="h4" component="div">
               Toothbrush
             </Typography>
           </Grid>
           <Grid item>
-            <Typography gutterBottom variant="h6">
+            <Typography gutterBottom variant="h6" component="div">
               $4.50
             </Typography>
           </Grid>

--- a/docs/src/pages/components/drawers/ClippedDrawer.js
+++ b/docs/src/pages/components/drawers/ClippedDrawer.js
@@ -46,7 +46,7 @@ export default function ClippedDrawer() {
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Clipped drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/ClippedDrawer.tsx
+++ b/docs/src/pages/components/drawers/ClippedDrawer.tsx
@@ -48,7 +48,7 @@ export default function ClippedDrawer() {
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Clipped drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/MiniDrawer.js
+++ b/docs/src/pages/components/drawers/MiniDrawer.js
@@ -116,7 +116,7 @@ export default function MiniDrawer() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Mini variant drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/MiniDrawer.tsx
+++ b/docs/src/pages/components/drawers/MiniDrawer.tsx
@@ -118,7 +118,7 @@ export default function MiniDrawer() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Mini variant drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PermanentDrawerLeft.js
+++ b/docs/src/pages/components/drawers/PermanentDrawerLeft.js
@@ -47,7 +47,7 @@ export default function PermanentDrawerLeft() {
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Permanent drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PermanentDrawerLeft.tsx
+++ b/docs/src/pages/components/drawers/PermanentDrawerLeft.tsx
@@ -49,7 +49,7 @@ export default function PermanentDrawerLeft() {
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Permanent drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PermanentDrawerRight.js
+++ b/docs/src/pages/components/drawers/PermanentDrawerRight.js
@@ -47,7 +47,7 @@ export default function PermanentDrawerRight() {
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Permanent drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PermanentDrawerRight.tsx
+++ b/docs/src/pages/components/drawers/PermanentDrawerRight.tsx
@@ -49,7 +49,7 @@ export default function PermanentDrawerRight() {
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Permanent drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PersistentDrawerLeft.js
+++ b/docs/src/pages/components/drawers/PersistentDrawerLeft.js
@@ -109,7 +109,7 @@ export default function PersistentDrawerLeft() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Persistent drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PersistentDrawerLeft.tsx
+++ b/docs/src/pages/components/drawers/PersistentDrawerLeft.tsx
@@ -111,7 +111,7 @@ export default function PersistentDrawerLeft() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Persistent drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/PersistentDrawerRight.js
+++ b/docs/src/pages/components/drawers/PersistentDrawerRight.js
@@ -100,7 +100,7 @@ export default function PersistentDrawerRight() {
         })}
       >
         <Toolbar>
-          <Typography variant="h6" noWrap className={classes.title}>
+          <Typography variant="h6" noWrap className={classes.title} component="div">
             Persistent drawer
           </Typography>
           <IconButton

--- a/docs/src/pages/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/src/pages/components/drawers/PersistentDrawerRight.tsx
@@ -102,7 +102,7 @@ export default function PersistentDrawerRight() {
         })}
       >
         <Toolbar>
-          <Typography variant="h6" noWrap className={classes.title}>
+          <Typography variant="h6" noWrap className={classes.title} component="div">
             Persistent drawer
           </Typography>
           <IconButton

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -106,7 +106,7 @@ function ResponsiveDrawer(props) {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Responsive drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
@@ -115,7 +115,7 @@ export default function ResponsiveDrawer(props: Props) {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" noWrap component="div">
             Responsive drawer
           </Typography>
         </Toolbar>

--- a/docs/src/pages/components/grid/CSSGrid.js
+++ b/docs/src/pages/components/grid/CSSGrid.js
@@ -28,7 +28,7 @@ export default function CSSGrid() {
 
   return (
     <div>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         Material-UI Grid:
       </Typography>
       <Grid container spacing={3}>
@@ -52,7 +52,7 @@ export default function CSSGrid() {
         </Grid>
       </Grid>
       <Divider className={classes.divider} />
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         CSS Grid Layout:
       </Typography>
       <div className={classes.container}>

--- a/docs/src/pages/components/grid/CSSGrid.tsx
+++ b/docs/src/pages/components/grid/CSSGrid.tsx
@@ -30,7 +30,7 @@ export default function CSSGrid() {
 
   return (
     <div>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         Material-UI Grid:
       </Typography>
       <Grid container spacing={3}>
@@ -54,7 +54,7 @@ export default function CSSGrid() {
         </Grid>
       </Grid>
       <Divider className={classes.divider} />
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         CSS Grid Layout:
       </Typography>
       <div className={classes.container}>

--- a/docs/src/pages/components/grid/ComplexGrid.js
+++ b/docs/src/pages/components/grid/ComplexGrid.js
@@ -45,7 +45,7 @@ export default function ComplexGrid() {
           <Grid item xs={12} sm container>
             <Grid item xs container direction="column" spacing={2}>
               <Grid item xs>
-                <Typography gutterBottom variant="subtitle1">
+                <Typography gutterBottom variant="subtitle1" component="div">
                   Standard license
                 </Typography>
                 <Typography variant="body2" gutterBottom>
@@ -62,7 +62,9 @@ export default function ComplexGrid() {
               </Grid>
             </Grid>
             <Grid item>
-              <Typography variant="subtitle1">$19.00</Typography>
+              <Typography variant="subtitle1" component="div">
+                $19.00
+              </Typography>
             </Grid>
           </Grid>
         </Grid>

--- a/docs/src/pages/components/grid/ComplexGrid.tsx
+++ b/docs/src/pages/components/grid/ComplexGrid.tsx
@@ -47,7 +47,7 @@ export default function ComplexGrid() {
           <Grid item xs={12} sm container>
             <Grid item xs container direction="column" spacing={2}>
               <Grid item xs>
-                <Typography gutterBottom variant="subtitle1">
+                <Typography gutterBottom variant="subtitle1" component="div">
                   Standard license
                 </Typography>
                 <Typography variant="body2" gutterBottom>
@@ -64,7 +64,9 @@ export default function ComplexGrid() {
               </Grid>
             </Grid>
             <Grid item>
-              <Typography variant="subtitle1">$19.00</Typography>
+              <Typography variant="subtitle1" component="div">
+                $19.00
+              </Typography>
             </Grid>
           </Grid>
         </Grid>

--- a/docs/src/pages/components/hidden/BreakpointDown.js
+++ b/docs/src/pages/components/hidden/BreakpointDown.js
@@ -29,7 +29,9 @@ function BreakpointDown(props) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">Current width: {width}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Current width: {width}
+      </Typography>
       <div className={classes.container}>
         <Hidden xsDown>
           <Paper className={classes.paper}>xsDown</Paper>

--- a/docs/src/pages/components/hidden/BreakpointDown.tsx
+++ b/docs/src/pages/components/hidden/BreakpointDown.tsx
@@ -30,7 +30,9 @@ function BreakpointDown(props: WithWidth) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">Current width: {width}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Current width: {width}
+      </Typography>
       <div className={classes.container}>
         <Hidden xsDown>
           <Paper className={classes.paper}>xsDown</Paper>

--- a/docs/src/pages/components/hidden/BreakpointOnly.js
+++ b/docs/src/pages/components/hidden/BreakpointOnly.js
@@ -29,7 +29,9 @@ function BreakpointOnly(props) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">Current width: {width}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Current width: {width}
+      </Typography>
       <div className={classes.container}>
         <Hidden only="lg">
           <Paper className={classes.paper}>Hidden on lg</Paper>

--- a/docs/src/pages/components/hidden/BreakpointOnly.tsx
+++ b/docs/src/pages/components/hidden/BreakpointOnly.tsx
@@ -30,7 +30,9 @@ function BreakpointOnly(props: WithWidth) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">Current width: {width}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Current width: {width}
+      </Typography>
       <div className={classes.container}>
         <Hidden only="lg">
           <Paper className={classes.paper}>Hidden on lg</Paper>

--- a/docs/src/pages/components/hidden/BreakpointUp.js
+++ b/docs/src/pages/components/hidden/BreakpointUp.js
@@ -29,7 +29,9 @@ function BreakpointUp(props) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">Current width: {width}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Current width: {width}
+      </Typography>
       <div className={classes.container}>
         <Hidden xsUp>
           <Paper className={classes.paper}>xsUp</Paper>

--- a/docs/src/pages/components/hidden/BreakpointUp.tsx
+++ b/docs/src/pages/components/hidden/BreakpointUp.tsx
@@ -30,7 +30,9 @@ function BreakpointUp(props: WithWidth) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">Current width: {width}</Typography>
+      <Typography variant="subtitle1" component="div">
+        Current width: {width}
+      </Typography>
       <div className={classes.container}>
         <Hidden xsUp>
           <Paper className={classes.paper}>xsUp</Paper>

--- a/docs/src/pages/components/hidden/GridIntegration.js
+++ b/docs/src/pages/components/hidden/GridIntegration.js
@@ -24,7 +24,7 @@ function GridIntegration(props) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         Current width: {width}
       </Typography>
       <Grid container spacing={3}>

--- a/docs/src/pages/components/hidden/GridIntegration.tsx
+++ b/docs/src/pages/components/hidden/GridIntegration.tsx
@@ -25,7 +25,7 @@ function GridIntegration(props: WithWidth) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         Current width: {width}
       </Typography>
       <Grid container spacing={3}>

--- a/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.js
+++ b/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.js
@@ -52,10 +52,10 @@ export default function FontAwesomeSvgIconDemo() {
 
   return (
     <div className={classes.root}>
-      <IconButton>
+      <IconButton aria-label="Example">
         <FontAwesomeIcon icon={faEllipsisV} />
       </IconButton>
-      <IconButton>
+      <IconButton aria-label="Example">
         <FontAwesomeSvgIcon icon={faEllipsisV} />
       </IconButton>
       <Button variant="contained" startIcon={<FontAwesomeIcon icon={faInfo} />}>

--- a/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.tsx
@@ -55,10 +55,10 @@ export default function FontAwesomeSvgIconDemo() {
 
   return (
     <div className={classes.root}>
-      <IconButton>
+      <IconButton aria-label="Example">
         <FontAwesomeIcon icon={faEllipsisV} />
       </IconButton>
-      <IconButton>
+      <IconButton aria-label="Example">
         <FontAwesomeSvgIcon icon={faEllipsisV} />
       </IconButton>
       <Button variant="contained" startIcon={<FontAwesomeIcon icon={faInfo} />}>

--- a/docs/src/pages/components/lists/InteractiveList.js
+++ b/docs/src/pages/components/lists/InteractiveList.js
@@ -66,7 +66,7 @@ export default function InteractiveList() {
       </FormGroup>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Text only
           </Typography>
           <div className={classes.demo}>
@@ -83,7 +83,7 @@ export default function InteractiveList() {
           </div>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Icon with text
           </Typography>
           <div className={classes.demo}>
@@ -105,7 +105,7 @@ export default function InteractiveList() {
       </Grid>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Avatar with text
           </Typography>
           <div className={classes.demo}>
@@ -127,7 +127,7 @@ export default function InteractiveList() {
           </div>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Avatar with text and icon
           </Typography>
           <div className={classes.demo}>

--- a/docs/src/pages/components/lists/InteractiveList.tsx
+++ b/docs/src/pages/components/lists/InteractiveList.tsx
@@ -68,7 +68,7 @@ export default function InteractiveList() {
       </FormGroup>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Text only
           </Typography>
           <div className={classes.demo}>
@@ -85,7 +85,7 @@ export default function InteractiveList() {
           </div>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Icon with text
           </Typography>
           <div className={classes.demo}>
@@ -107,7 +107,7 @@ export default function InteractiveList() {
       </Grid>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Avatar with text
           </Typography>
           <div className={classes.demo}>
@@ -129,7 +129,7 @@ export default function InteractiveList() {
           </div>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Typography variant="h6" className={classes.title}>
+          <Typography variant="h6" className={classes.title} component="div">
             Avatar with text and icon
           </Typography>
           <div className={classes.demo}>

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -54,7 +54,7 @@ export default function CustomizedMenus() {
   return (
     <div>
       <Button
-        aria-controls="customized-menu"
+        aria-controls="demo-customized-menu"
         aria-haspopup="true"
         variant="contained"
         onClick={handleClick}
@@ -62,7 +62,7 @@ export default function CustomizedMenus() {
         Open Menu
       </Button>
       <StyledMenu
-        id="customized-menu"
+        id="demo-customized-menu"
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -54,7 +54,7 @@ export default function CustomizedMenus() {
   return (
     <div>
       <Button
-        aria-controls="customized-menu"
+        aria-controls="demo-customized-menu"
         aria-haspopup="true"
         variant="contained"
         onClick={handleClick}
@@ -62,7 +62,7 @@ export default function CustomizedMenus() {
         Open Menu
       </Button>
       <StyledMenu
-        id="customized-menu"
+        id="demo-customized-menu"
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}

--- a/docs/src/pages/components/menus/PositionedMenu.js
+++ b/docs/src/pages/components/menus/PositionedMenu.js
@@ -17,14 +17,14 @@ export default function PositionedMenu() {
   return (
     <div>
       <Button
-        aria-controls="positioned-menu"
+        aria-controls="demo-positioned-menu"
         aria-haspopup="true"
         onClick={handleClick}
       >
         Open Menu
       </Button>
       <Menu
-        id="positioned-menu"
+        id="demo-positioned-menu"
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}

--- a/docs/src/pages/components/menus/PositionedMenu.tsx
+++ b/docs/src/pages/components/menus/PositionedMenu.tsx
@@ -17,14 +17,14 @@ export default function PositionedMenu() {
   return (
     <div>
       <Button
-        aria-controls="positioned-menu"
+        aria-controls="demo-positioned-menu"
         aria-haspopup="true"
         onClick={handleClick}
       >
         Open Menu
       </Button>
       <Menu
-        id="positioned-menu"
+        id="demo-positioned-menu"
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}

--- a/docs/src/pages/components/popper/ScrollPlayground.js
+++ b/docs/src/pages/components/popper/ScrollPlayground.js
@@ -258,7 +258,9 @@ export default function ScrollPlayground() {
       <Grid container spacing={2}>
         <Grid container item xs={12}>
           <Grid item xs={12}>
-            <Typography variant="h6">Appearance</Typography>
+            <Typography variant="h6" component="div">
+              Appearance
+            </Typography>
           </Grid>
           <Grid item xs={6}>
             <TextField
@@ -314,7 +316,9 @@ export default function ScrollPlayground() {
           </Grid>
         </Grid>
         <Grid item xs={12}>
-          <Typography variant="h6">Modifiers (options from Popper.js)</Typography>
+          <Typography variant="h6" component="div">
+            Modifiers (options from Popper.js)
+          </Typography>
         </Grid>
         <Grid container item xs={12} spacing={1}>
           <Grid item xs={6}>

--- a/docs/src/pages/components/snackbars/FabIntegrationSnackbar.js
+++ b/docs/src/pages/components/snackbars/FabIntegrationSnackbar.js
@@ -49,7 +49,7 @@ export default function FabIntegrationSnackbar() {
             >
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit">
+            <Typography variant="h6" color="inherit" component="div">
               App Bar
             </Typography>
           </Toolbar>

--- a/docs/src/pages/components/snackbars/FabIntegrationSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/FabIntegrationSnackbar.tsx
@@ -51,7 +51,7 @@ export default function FabIntegrationSnackbar() {
             >
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit">
+            <Typography variant="h6" color="inherit" component="div">
               App Bar
             </Typography>
           </Toolbar>

--- a/docs/src/pages/components/text-fields/HelperTextAligned.js
+++ b/docs/src/pages/components/text-fields/HelperTextAligned.js
@@ -15,10 +15,16 @@ export default function HelperTextAligned() {
     <div className={classes.root}>
       <TextField
         helperText="Please enter your name"
+        id="demo-helper-text-aligned"
         label="Name"
         variant="standard"
       />
-      <TextField helperText=" " label="Name" variant="standard" />
+      <TextField
+        helperText=" "
+        id="demo-helper-text-aligned-no-helper"
+        label="Name"
+        variant="standard"
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextAligned.tsx
+++ b/docs/src/pages/components/text-fields/HelperTextAligned.tsx
@@ -15,10 +15,16 @@ export default function HelperTextAligned() {
     <div className={classes.root}>
       <TextField
         helperText="Please enter your name"
+        id="demo-helper-text-aligned"
         label="Name"
         variant="standard"
       />
-      <TextField helperText=" " label="Name" variant="standard" />
+      <TextField
+        helperText=" "
+        id="demo-helper-text-aligned-no-helper"
+        label="Name"
+        variant="standard"
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextMisaligned.js
+++ b/docs/src/pages/components/text-fields/HelperTextMisaligned.js
@@ -15,10 +15,15 @@ export default function HelperTextMisaligned() {
     <div className={classes.root}>
       <TextField
         helperText="Please enter your name"
+        id="demo-helper-text-misaligned"
         label="Name"
         variant="standard"
       />
-      <TextField label="Name" variant="standard" />
+      <TextField
+        id="demo-helper-text-misaligned-no-helper"
+        label="Name"
+        variant="standard"
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/text-fields/HelperTextMisaligned.tsx
+++ b/docs/src/pages/components/text-fields/HelperTextMisaligned.tsx
@@ -15,10 +15,15 @@ export default function HelperTextMisaligned() {
     <div className={classes.root}>
       <TextField
         helperText="Please enter your name"
+        id="demo-helper-text-misaligned"
         label="Name"
         variant="standard"
       />
-      <TextField label="Name" variant="standard" />
+      <TextField
+        id="demo-helper-text-misaligned-no-helper"
+        label="Name"
+        variant="standard"
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/typography/Types.js
+++ b/docs/src/pages/components/typography/Types.js
@@ -14,22 +14,22 @@ export default function Types() {
 
   return (
     <div className={classes.root}>
-      <Typography variant="h1" component="h2" gutterBottom>
+      <Typography variant="h1" component="div" gutterBottom>
         h1. Heading
       </Typography>
-      <Typography variant="h2" gutterBottom>
+      <Typography variant="h2" gutterBottom component="div">
         h2. Heading
       </Typography>
-      <Typography variant="h3" gutterBottom>
+      <Typography variant="h3" gutterBottom component="div">
         h3. Heading
       </Typography>
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="h4" gutterBottom component="div">
         h4. Heading
       </Typography>
-      <Typography variant="h5" gutterBottom>
+      <Typography variant="h5" gutterBottom component="div">
         h5. Heading
       </Typography>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="h6" gutterBottom component="div">
         h6. Heading
       </Typography>
       <Typography variant="subtitle1" gutterBottom>

--- a/docs/src/pages/components/typography/Types.js
+++ b/docs/src/pages/components/typography/Types.js
@@ -32,11 +32,11 @@ export default function Types() {
       <Typography variant="h6" gutterBottom component="div">
         h6. Heading
       </Typography>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
         blanditiis tenetur
       </Typography>
-      <Typography variant="subtitle2" gutterBottom>
+      <Typography variant="subtitle2" gutterBottom component="div">
         subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
         blanditiis tenetur
       </Typography>

--- a/docs/src/pages/components/typography/Types.tsx
+++ b/docs/src/pages/components/typography/Types.tsx
@@ -14,22 +14,22 @@ export default function Types() {
 
   return (
     <div className={classes.root}>
-      <Typography variant="h1" component="h2" gutterBottom>
+      <Typography variant="h1" component="div" gutterBottom>
         h1. Heading
       </Typography>
-      <Typography variant="h2" gutterBottom>
+      <Typography variant="h2" gutterBottom component="div">
         h2. Heading
       </Typography>
-      <Typography variant="h3" gutterBottom>
+      <Typography variant="h3" gutterBottom component="div">
         h3. Heading
       </Typography>
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="h4" gutterBottom component="div">
         h4. Heading
       </Typography>
-      <Typography variant="h5" gutterBottom>
+      <Typography variant="h5" gutterBottom component="div">
         h5. Heading
       </Typography>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="h6" gutterBottom component="div">
         h6. Heading
       </Typography>
       <Typography variant="subtitle1" gutterBottom>

--- a/docs/src/pages/components/typography/Types.tsx
+++ b/docs/src/pages/components/typography/Types.tsx
@@ -32,11 +32,11 @@ export default function Types() {
       <Typography variant="h6" gutterBottom component="div">
         h6. Heading
       </Typography>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subtitle1" gutterBottom component="div">
         subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
         blanditiis tenetur
       </Typography>
-      <Typography variant="subtitle2" gutterBottom>
+      <Typography variant="subtitle2" gutterBottom component="div">
         subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
         blanditiis tenetur
       </Typography>


### PR DESCRIPTION
Used `lighthouse` 6.4.

Most noticeable all `Typography` uses with `variant="h*"` or `variant="subtitle*"` now use `div` instead of a heading. Until we have context-sensitive headings these are just unsafe in the docs. Used https://astexplorer.net/#/gist/b413a45e6d2def5d59e0f244aa2886fa/bace95b9aaba43ead4d4a2d6b86e3afc9ba7654d to codemod all uses of `Typography` in `docs/src/pages/**/*.{js,tsx}`.

The rest is described in each commit.