### PR TITLE
[docs] Fix rtl not working

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -114,7 +114,7 @@
     "rimraf": "^3.0.0",
     "styled-components": "^5.0.0",
     "stylis": "^4.0.3",
-    "stylis-plugin-rtl": "^1.0.0",
+    "stylis-plugin-rtl": "^2.0.0",
     "webfontloader": "^1.6.28",
     "webpack": "^4.41.0",
     "webpack-bundle-analyzer": "^4.1.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -114,7 +114,7 @@
     "rimraf": "^3.0.0",
     "styled-components": "^5.0.0",
     "stylis": "^4.0.3",
-    "stylis-plugin-rtl": "^2.0.0",
+    "stylis-plugin-rtl": "^2.0.1",
     "webfontloader": "^1.6.28",
     "webpack": "^4.41.0",
     "webpack-bundle-analyzer": "^4.1.0"

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -287,9 +287,6 @@ function AppWrapper(props) {
     initRedux({ options: { userLanguage: pageProps.userLanguage } }),
   );
 
-  const [rtl, setRtl] = React.useState(false);
-  const rtlContextValue = { rtl, setRtl };
-
   React.useEffect(() => {
     loadDependencies();
     registerServiceWorker();

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -9,10 +9,6 @@ import PropTypes from 'prop-types';
 import acceptLanguage from 'accept-language';
 import { create } from 'jss';
 import jssRtl from 'jss-rtl';
-import { StyleSheetManager } from 'styled-components';
-import { CacheProvider } from '@emotion/react';
-import createCache from '@emotion/cache';
-import rtlPlugin from 'stylis-plugin-rtl';
 import { useRouter } from 'next/router';
 import { StylesProvider, jssPreset } from '@material-ui/styles';
 import pages from 'docs/src/pages';
@@ -20,11 +16,13 @@ import initRedux from 'docs/src/modules/redux/initRedux';
 import PageContext from 'docs/src/modules/components/PageContext';
 import GoogleAnalytics from 'docs/src/modules/components/GoogleAnalytics';
 import loadScript from 'docs/src/modules/utils/loadScript';
-import RtlContext from 'docs/src/modules/utils/RtlContext';
 import { ThemeProvider } from 'docs/src/modules/components/ThemeContext';
 import { pathnameToLanguage, getCookie } from 'docs/src/modules/utils/helpers';
 import { ACTION_TYPES, CODE_VARIANTS, LANGUAGES } from 'docs/src/modules/constants';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
+import StyledEngineProvider, { cacheLtr } from 'docs/src/modules/utils/StyledEngineProvider';
+
+export { cacheLtr };
 
 // Configure JSS
 const jss = create({
@@ -281,17 +279,6 @@ function findActivePage(currentPages, pathname) {
   return activePage;
 }
 
-// Cache for the ltr version of the styles
-export const cacheLtr = createCache({ key: 'css' });
-cacheLtr.compat = true;
-
-// Cache for the rtl version of the styles
-const cacheRtl = createCache({
-  key: 'rtl',
-  stylisPlugins: [rtlPlugin],
-});
-cacheRtl.compat = true;
-
 function AppWrapper(props) {
   const { children, pageProps } = props;
 
@@ -333,17 +320,13 @@ function AppWrapper(props) {
         ))}
       </NextHead>
       <ReduxProvider store={redux}>
-        <RtlContext.Provider value={rtlContextValue}>
-          <PageContext.Provider value={{ activePage, pages, versions: pageProps.versions }}>
-            <StyleSheetManager stylisPlugins={rtl ? [rtlPlugin] : []}>
-              <CacheProvider value={rtl ? cacheRtl : cacheLtr}>
-                <StylesProvider jss={jss}>
-                  <ThemeProvider>{children}</ThemeProvider>
-                </StylesProvider>
-              </CacheProvider>
-            </StyleSheetManager>
-          </PageContext.Provider>
-        </RtlContext.Provider>
+        <PageContext.Provider value={{ activePage, pages, versions: pageProps.versions }}>
+          <StylesProvider jss={jss}>
+            <ThemeProvider>
+              <StyledEngineProvider>{children}</StyledEngineProvider>
+            </ThemeProvider>
+          </StylesProvider>
+        </PageContext.Provider>
         <LanguageNegotiation />
         <Analytics />
       </ReduxProvider>

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -15,7 +15,6 @@ import Brightness7Icon from '@material-ui/icons/Brightness7';
 import SettingsBrightnessIcon from '@material-ui/icons/SettingsBrightness';
 import FormatTextdirectionLToRIcon from '@material-ui/icons/FormatTextdirectionLToR';
 import FormatTextdirectionRToLIcon from '@material-ui/icons/FormatTextdirectionRToL';
-import RtlContext from 'docs/src/modules/utils/RtlContext';
 import Link from 'docs/src/modules/components/Link';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import { useChangeTheme } from 'docs/src/modules/components/ThemeContext';
@@ -57,7 +56,6 @@ function AppSettingsDrawer(props) {
   const [mode, setMode] = React.useState(getCookie('paletteMode') || 'system');
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
-  const { rtl, setRtl } = React.useContext(RtlContext);
 
   const handleChangeThemeMode = (event, paletteMode) => {
     if (paletteMode === null) {
@@ -80,8 +78,6 @@ function AppSettingsDrawer(props) {
       direction = theme.direction;
     }
 
-    setRtl(!rtl);
-    // TODO: remove in v5 after the style engine is moved to emotion
     changeTheme({ direction });
   };
 

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -15,6 +15,7 @@ import Brightness7Icon from '@material-ui/icons/Brightness7';
 import SettingsBrightnessIcon from '@material-ui/icons/SettingsBrightness';
 import FormatTextdirectionLToRIcon from '@material-ui/icons/FormatTextdirectionLToR';
 import FormatTextdirectionRToLIcon from '@material-ui/icons/FormatTextdirectionRToL';
+import RtlContext from 'docs/src/modules/utils/RtlContext';
 import Link from 'docs/src/modules/components/Link';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import { useChangeTheme } from 'docs/src/modules/components/ThemeContext';
@@ -56,6 +57,7 @@ function AppSettingsDrawer(props) {
   const [mode, setMode] = React.useState(getCookie('paletteMode') || 'system');
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
+  const { rtl, setRtl } = React.useContext(RtlContext);
 
   const handleChangeThemeMode = (event, paletteMode) => {
     if (paletteMode === null) {
@@ -78,6 +80,8 @@ function AppSettingsDrawer(props) {
       direction = theme.direction;
     }
 
+    setRtl(!rtl);
+    // TODO: remove in v5 after the style engine is moved to emotion
     changeTheme({ direction });
   };
 

--- a/docs/src/modules/utils/RtlContext.js
+++ b/docs/src/modules/utils/RtlContext.js
@@ -1,8 +1,0 @@
-import React from 'react';
-
-const RltContext = React.createContext({
-  rtl: false,
-  setRtl: () => {},
-});
-
-export default RltContext;

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { StyleSheetManager } from 'styled-components';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import rtlPlugin from 'stylis-plugin-rtl';
+import { useTheme } from '@material-ui/core/styles';
+
+// Cache for the ltr version of the styles
+export const cacheLtr = createCache({ key: 'css' });
+cacheLtr.compat = true;
+
+// Cache for the rtl version of the styles
+const cacheRtl = createCache({
+  key: 'rtl',
+  stylisPlugins: [rtlPlugin],
+});
+cacheRtl.compat = true;
+
+const StyledEngineProvider = (props) => {
+  const theme = useTheme();
+
+  const rtl = theme.direction === 'rtl';
+
+  return (
+    <StyleSheetManager stylisPlugins={rtl ? [rtlPlugin] : []}>
+      <CacheProvider value={rtl ? cacheRtl : cacheLtr}>{props.children}</CacheProvider>
+    </StyleSheetManager>
+  );
+};
+
+export default StyledEngineProvider;

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheetManager } from 'styled-components';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
@@ -26,6 +27,10 @@ const StyledEngineProvider = (props) => {
       <CacheProvider value={rtl ? cacheRtl : cacheLtr}>{props.children}</CacheProvider>
     </StyleSheetManager>
   );
+};
+
+StyledEngineProvider.proptypes = {
+  children: PropTypes.node,
 };
 
 export default StyledEngineProvider;

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -29,7 +29,7 @@ const StyledEngineProvider = (props) => {
   );
 };
 
-StyledEngineProvider.proptypes = {
+StyledEngineProvider.propTypes = {
   children: PropTypes.node,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6276,10 +6276,10 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-cssjanus@^1.3.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/cssjanus/-/cssjanus-1.3.2.tgz#7c23d39be92f63e1557a75c015f61d95009bd6b3"
-  integrity sha512-5pM/C1MIfoqhXa7k9PqSnrjj1SSZDakfyB1DZhdYyJoDUH+evGbsUg6/bpQapTJeSnYaj0rdzPUMeM33CvB0vw==
+cssjanus@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cssjanus/-/cssjanus-2.0.1.tgz#e0fe6e805b3ad960245a5ab81295609480d040dd"
+  integrity sha512-jYvhjWiID0AVlHHcmk1cOycfAjVCbx4oIsjgvw4VdpqBfxy2IaqIRm66cA4xqqKzQWmdTdzevUusdL8TO+FR9g==
 
 cssnano-preset-simple@1.2.0:
   version "1.2.0"
@@ -15979,12 +15979,12 @@ stylelint@^13.7.2:
     v8-compile-cache "^2.2.0"
     write-file-atomic "^3.0.3"
 
-stylis-plugin-rtl@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stylis-plugin-rtl/-/stylis-plugin-rtl-1.1.0.tgz#028d72419ccc47eeaaec684f3e192534f2c57ece"
-  integrity sha512-FPoSxP+gbBLJRUXDRDFNBhqy/eToquDLn7ZrjIVBRfXaZ9bunwNnDtDm2qW1EoU0c93krm1Dy+8iVmJpjRGsKw==
+stylis-plugin-rtl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stylis-plugin-rtl/-/stylis-plugin-rtl-2.0.0.tgz#5f43fb2fd6220577210b89b339b49f15aedc6b7b"
+  integrity sha512-8Hz94K25hLhZHIYzLYwXU/Qh4Xio1M+CXd4A40G1fzXwxw1kNyAVNcLPPwkL6ywMQry87WoS2XisR1ZqQZfqoQ==
   dependencies:
-    cssjanus "^1.3.0"
+    cssjanus "^2.0.1"
 
 stylis-rule-sheet@0.0.10:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15979,10 +15979,10 @@ stylelint@^13.7.2:
     v8-compile-cache "^2.2.0"
     write-file-atomic "^3.0.3"
 
-stylis-plugin-rtl@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stylis-plugin-rtl/-/stylis-plugin-rtl-2.0.0.tgz#5f43fb2fd6220577210b89b339b49f15aedc6b7b"
-  integrity sha512-8Hz94K25hLhZHIYzLYwXU/Qh4Xio1M+CXd4A40G1fzXwxw1kNyAVNcLPPwkL6ywMQry87WoS2XisR1ZqQZfqoQ==
+stylis-plugin-rtl@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/stylis-plugin-rtl/-/stylis-plugin-rtl-2.0.1.tgz#f6cd2d445f41c06565b2ace2b5fdc5cd8b527ca3"
+  integrity sha512-yHinsc2vQCkIKWW+PrlfcRZi0wt6y8C5eVEkc4FWkc+kX4vQgztO0Ah7Yj8UCVJUNnS2U2++6pepwd7wDuDVLg==
   dependencies:
     cssjanus "^2.0.1"
 


### PR DESCRIPTION
This PR fixes two issues with RTL:
1. since 11 emotion is compatible with v2 of the stylist plugin rtl, so it has been updated in the dependencies of the docs
2. Refactored the docs to depend on the `theme.direction` prop, rather than a new rtl context.
