### PR TITLE
[useMediaQuery] Fix a false return at the first call

### DIFF
--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -89,7 +89,28 @@ describe('MyTests', () => {
   });
 });
 ```
+## Client-side only rendering
 
+In order to perform the server-side reconciliation, the hook needs to render twice.
+A first time with `false` and a second time with the resolved value.
+This double pass rendering cycle comes with a drawback. It's slower.
+You can set the `noSsr` option to `true` if you are doing **client-side only** rendering.
+
+```jsx
+const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
+```
+
+or it can turn it on globally with the theme:
+
+```jsx
+const theme = createMuiTheme({
+  props: {
+    MuiUseMediaQuery: {
+      noSsr: true,
+    },
+  },
+});
+```
 ## Server-side rendering
 
 > ⚠️ Server-side rendering and client-side media queries are fundamentally at odds.
@@ -174,10 +195,10 @@ You can reproduce the same behavior with a `useWidth` hook:
   we return a default matches during the first mount. The default value is `false`.
 - `options.matchMedia` (_Function_ [optional]): You can provide your own implementation of _matchMedia_. This can be used for handling an iframe content window.
 - `options.noSsr` (_Boolean_ [optional]): Defaults to `false`.
-  In order to perform the server-side rendering reconciliation, it needs to render twice.
-  A first time with nothing and a second time with the children.
+  In order to perform the server-side reconciliation, the hook needs to render twice.
+  A first time with `false` and a second time with the resolved value.
   This double pass rendering cycle comes with a drawback. It's slower.
-  You can set this flag to `true` if you are **not doing server-side rendering**.
+  You can set this option to `true` if you are doing **client-side only** rendering.
 - `options.ssrMatchMedia` (_Function_ [optional]): You can provide your own implementation of _matchMedia_ in a [server-side rendering context](#server-side-rendering).
 
 Note: You can change the default options using the [`default props`](/customization/globals/#default-props) feature of the theme with the `MuiUseMediaQuery` key.

--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -92,22 +92,24 @@ describe('MyTests', () => {
 
 ## Client-side only rendering
 
-In order to perform the server-side reconciliation, the hook needs to render twice.
-A first time with `false` and a second time with the resolved value.
+To perform the server-side hydration, the hook needs to render twice.
+A first time with `false`, the value of the server, and a second time with the resolved value.
 This double pass rendering cycle comes with a drawback. It's slower.
 You can set the `noSsr` option to `true` if you are doing **client-side only** rendering.
 
-```jsx
+```js
 const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 ```
 
 or it can turn it on globally with the theme:
 
-```jsx
+```js
 const theme = createMuiTheme({
-  props: {
+  components: {
     MuiUseMediaQuery: {
-      noSsr: true,
+      defaultProps: {
+        noSsr: true,
+      },
     },
   },
 });
@@ -197,8 +199,8 @@ You can reproduce the same behavior with a `useWidth` hook:
   we return a default matches during the first mount. The default value is `false`.
 - `options.matchMedia` (_Function_ [optional]): You can provide your own implementation of _matchMedia_. This can be used for handling an iframe content window.
 - `options.noSsr` (_Boolean_ [optional]): Defaults to `false`.
-  In order to perform the server-side reconciliation, the hook needs to render twice.
-  A first time with `false` and a second time with the resolved value.
+  To perform the server-side hydration, the hook needs to render twice.
+  A first time with `false`, the value of the server, and a second time with the resolved value.
   This double pass rendering cycle comes with a drawback. It's slower.
   You can set this option to `true` if you are doing **client-side only** rendering.
 - `options.ssrMatchMedia` (_Function_ [optional]): You can provide your own implementation of _matchMedia_ in a [server-side rendering context](#server-side-rendering).

--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -89,6 +89,7 @@ describe('MyTests', () => {
   });
 });
 ```
+
 ## Client-side only rendering
 
 In order to perform the server-side reconciliation, the hook needs to render twice.
@@ -111,6 +112,7 @@ const theme = createMuiTheme({
   },
 });
 ```
+
 ## Server-side rendering
 
 > ⚠️ Server-side rendering and client-side media queries are fundamentally at odds.

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
-// useEnhacedEffect does nothing on server side, so when the unit test
-// is executed it appears a warning
-// To pass the test we add a validation where useEnhacedEffect is used
-// in any environment but 'test'
+// useEnhacedEffect does nothing on server side, so when
+// the unit test is executed it appears a warning
+// To pass the test we add a validation where
+// useEnhacedEffect is used in any environment but 'test'
 const useEnhancedEffectNoTests =
   process.env.NODE_ENV !== 'test' ? useEnhancedEffect : React.useEffect;
 

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
+// useEnhacedEffect does nothing on server side, so when the unit test
+// is executed it appears a warning
+// To pass the test we add a validation where useEnhacedEffect is used
+// in any environment but 'test'
 const useEnhancedEffectNoTests =
   process.env.NODE_ENV !== 'test' ? useEnhancedEffect : React.useEffect;
 

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
+const useEnhancedEffectNoTests =
+  process.env.NODE_ENV !== 'test' ? useEnhancedEffect : React.useEffect;
+
 export default function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();
   const props = getThemeProps({
@@ -55,7 +58,7 @@ export default function useMediaQuery(queryInput, options = {}) {
     return defaultMatches;
   });
 
-  useEnhancedEffect(() => {
+  useEnhancedEffectNoTests(() => {
     let active = true;
 
     if (!supportMatchMedia) {

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -2,13 +2,6 @@ import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
-// useEnhacedEffect does nothing on server side, so when
-// the unit test is executed it appears a warning
-// To pass the test we add a validation where
-// useEnhacedEffect is used in any environment but 'test'
-const useEnhancedEffectNoTests =
-  process.env.NODE_ENV !== 'test' ? useEnhancedEffect : React.useEffect;
-
 export default function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();
   const props = getThemeProps({
@@ -62,7 +55,7 @@ export default function useMediaQuery(queryInput, options = {}) {
     return defaultMatches;
   });
 
-  useEnhancedEffectNoTests(() => {
+  useEnhancedEffect(() => {
     let active = true;
 
     if (!supportMatchMedia) {

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 
+const useEnhancedEffect =
+  typeof window !== 'undefined' && process.env.NODE_ENV != 'test'
+    ? React.useLayoutEffect
+    : React.useEffect
+
 export default function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();
   const props = getThemeProps({
@@ -54,7 +59,7 @@ export default function useMediaQuery(queryInput, options = {}) {
     return defaultMatches;
   });
 
-  React.useEffect(() => {
+  useEnhancedEffect(() => {
     let active = true;
 
     if (!supportMatchMedia) {

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
-
-const useEnhancedEffect =
-  typeof window !== 'undefined' && process.env.NODE_ENV !== 'test'
-    ? React.useLayoutEffect
-    : React.useEffect;
+import useEnhancedEffect from '../utils/useEnhancedEffect';
 
 export default function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 
 const useEnhancedEffect =
-  typeof window !== 'undefined' && process.env.NODE_ENV != 'test'
+  typeof window !== 'undefined' && process.env.NODE_ENV !== 'test'
     ? React.useLayoutEffect
     : React.useEffect
 

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -4,7 +4,7 @@ import { getThemeProps, useTheme } from '@material-ui/styles';
 const useEnhancedEffect =
   typeof window !== 'undefined' && process.env.NODE_ENV !== 'test'
     ? React.useLayoutEffect
-    : React.useEffect
+    : React.useEffect;
 
 export default function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -241,30 +241,34 @@ describe('useMediaQuery', () => {
     const serverRender = createServerRender();
 
     it('should use the ssr match media ponyfill', () => {
-      const ref = React.createRef();
-      function MyComponent() {
-        const matches = useMediaQuery('(min-width:2000px)');
-        values(matches);
-        return <span ref={ref}>{`${matches}`}</span>;
-      }
+      let markup;
+      expect(() => {
+        const ref = React.createRef();
+        function MyComponent() {
+          const matches = useMediaQuery('(min-width:2000px)');
+          values(matches);
+          return <span ref={ref}>{`${matches}`}</span>;
+        }
 
-      const Test = () => {
-        const ssrMatchMedia = (query) => ({
-          matches: mediaQuery.match(query, {
-            width: 3000,
-          }),
-        });
+        const Test = () => {
+          const ssrMatchMedia = (query) => ({
+            matches: mediaQuery.match(query, {
+              width: 3000,
+            }),
+          });
 
-        return (
-          <ThemeProvider
-            theme={{ components: { MuiUseMediaQuery: { defaultProps: { ssrMatchMedia } } } }}
-          >
-            <MyComponent />
-          </ThemeProvider>
-        );
-      };
+          return (
+            <ThemeProvider
+              theme={{ components: { MuiUseMediaQuery: { defaultProps: { ssrMatchMedia } } } }}
+            >
+              <MyComponent />
+            </ThemeProvider>
+          );
+        };
 
-      const markup = serverRender(<Test />);
+        markup = serverRender(<Test />);
+      }).toErrorDev(['Warning: useLayoutEffect does nothing on the server']);
+
       expect(markup.text()).to.equal('true');
       expect(values.callCount).to.equal(1);
     });


### PR DESCRIPTION
Closes #21142 

I added the `useEnhancedEffect` function as recommended to solve the problem we see in this [demo](https://codesandbox.io/s/material-demo-w3xyj?file=/demo.tsx)
Also, I added the documentation suggested to the demo page to make it more clear.

I modified these files: 
`/material-ui/packages/material-ui/src/useMediaQuery/useMediaQuery.js`
`/docs/src/pages/components/use-media-query/use-media-query.md b/docs/src/pages/components/use-media-query/use-media-query.md`


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
