### PR TITLE
[docs] Fix duplicated styles generated from emotion

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -312,6 +312,11 @@ function AppWrapper(props) {
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
+
+    const emotionStyles = document.querySelector('#emotion-server-side');
+    if (emotionStyles) {
+      emotionStyles.parentElement.removeChild(emotionStyles);
+    }
   }, []);
 
   const activePage = findActivePage(pages, router.pathname);

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -312,11 +312,6 @@ function AppWrapper(props) {
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
-
-    const emotionStyles = document.querySelector('#emotion-server-side');
-    if (emotionStyles) {
-      emotionStyles.parentElement.removeChild(emotionStyles);
-    }
   }, []);
 
   const activePage = findActivePage(pages, router.pathname);

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -168,7 +168,7 @@ MyDocument.getInitialProps = async (ctx) => {
         <style
           id="emotion-server-side"
           key="emotion-server-side"
-          data-emotion-css={emotionStyles.ids.join(' ')}
+          data-emotion={`css ${emotionStyles.ids.join(' ')}`}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: emotionStyles.css }}
         />,


### PR DESCRIPTION
This PR fixes duplicated classes generated for the components that use emotion as styled engine.

![image](https://user-images.githubusercontent.com/4512430/100867373-67710480-349a-11eb-9f32-fa776d22ee64.png)

The styles are identical. I couldn't find any other solution, this is the only relevant discussion I stable apon https://github.com/emotion-js/emotion/issues/1061, but we already use the `CacheProvider` for the ltr/rtl styles generated.