### PR TITLE
[docs] Fix icon alignment in /components/breadcrumbs

### DIFF
--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
@@ -10,9 +10,9 @@ import GrainIcon from '@material-ui/icons/Grain';
 const useStyles = makeStyles((theme) => ({
   link: {
     display: 'flex',
+    alignItems: 'center',
   },
   icon: {
-    alignItems: 'center',
     marginRight: theme.spacing(0.5),
     width: 20,
     height: 20,

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
@@ -14,8 +14,6 @@ const useStyles = makeStyles((theme) => ({
   },
   icon: {
     marginRight: theme.spacing(0.5),
-    width: 20,
-    height: 20,
   },
 }));
 
@@ -30,7 +28,7 @@ export default function IconBreadcrumbs() {
   return (
     <Breadcrumbs aria-label="breadcrumb">
       <Link color="inherit" href="/" onClick={handleClick} className={classes.link}>
-        <HomeIcon className={classes.icon} />
+        <HomeIcon fontSize="inherit" className={classes.icon} />
         Material-UI
       </Link>
       <Link
@@ -39,11 +37,11 @@ export default function IconBreadcrumbs() {
         onClick={handleClick}
         className={classes.link}
       >
-        <WhatshotIcon className={classes.icon} />
+        <WhatshotIcon fontSize="inherit" className={classes.icon} />
         Core
       </Link>
       <Typography color="textPrimary" className={classes.link}>
-        <GrainIcon className={classes.icon} />
+        <GrainIcon fontSize="inherit" className={classes.icon} />
         Breadcrumb
       </Typography>
     </Breadcrumbs>

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
@@ -12,6 +12,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
   },
   icon: {
+    alignItems: 'center',
     marginRight: theme.spacing(0.5),
     width: 20,
     height: 20,

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
@@ -11,9 +11,9 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     link: {
       display: 'flex',
+      alignItems: 'center',
     },
     icon: {
-      alignItems: 'center',
       marginRight: theme.spacing(0.5),
       width: 20,
       height: 20,

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
@@ -15,8 +15,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     icon: {
       marginRight: theme.spacing(0.5),
-      width: 20,
-      height: 20,
     },
   }),
 );
@@ -32,7 +30,7 @@ export default function IconBreadcrumbs() {
   return (
     <Breadcrumbs aria-label="breadcrumb">
       <Link color="inherit" href="/" onClick={handleClick} className={classes.link}>
-        <HomeIcon className={classes.icon} />
+        <HomeIcon fontSize="inherit" className={classes.icon} />
         Material-UI
       </Link>
       <Link
@@ -41,11 +39,11 @@ export default function IconBreadcrumbs() {
         onClick={handleClick}
         className={classes.link}
       >
-        <WhatshotIcon className={classes.icon} />
+        <WhatshotIcon fontSize="inherit" className={classes.icon} />
         Core
       </Link>
       <Typography color="textPrimary" className={classes.link}>
-        <GrainIcon className={classes.icon} />
+        <GrainIcon fontSize="inherit" className={classes.icon} />
         Breadcrumb
       </Typography>
     </Breadcrumbs>

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
     },
     icon: {
+      alignItems: 'center',
       marginRight: theme.spacing(0.5),
       width: 20,
       height: 20,


### PR DESCRIPTION
Put icons and text on the same baseline when increasing the default font size.

To see the difference you have to increase the default font size in your browser (Chrome: Settings > Appearance > Font Size). On "Large" it's already misaligned.

Preview: https://deploy-preview-23818--material-ui.netlify.app//components/breadcrumbs/#breadcrumbs-with-icons
Current: https://next--material-ui.netlify.app/components/breadcrumbs/#breadcrumbs-with-icons