### PR TITLE
[docs] Fix color contrast of code within links

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -169,7 +169,7 @@ const styles = (theme) => ({
     },
     '& a, & a code': {
       // Style taken from the Link component
-      color: theme.palette.secondary.main,
+      color: theme.palette.primary.main,
       textDecoration: 'none',
       '&:hover': {
         textDecoration: 'underline',


### PR DESCRIPTION
Preview: https://deploy-preview-23819--material-ui.netlify.app/components/breadcrumbs/#api
Current: Preview: https://next--material-ui.netlify.app/components/breadcrumbs/#api


Current color of links within markdown became outdated at some point (see existing comment). Also restores visual consistency of links in the docs.