### PR TITLE
[docs] Fix source on Github links

### DIFF
--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -8,7 +8,7 @@ import Head from 'docs/src/modules/components/Head';
 import AppFrame from 'docs/src/modules/components/AppFrame';
 import EditPage from 'docs/src/modules/components/EditPage';
 import AppContainer from 'docs/src/modules/components/AppContainer';
-import { SOURCE_CODE_ROOT_URL } from 'docs/src/modules/constants';
+import { SOURCE_CODE_REPO } from 'docs/src/modules/constants';
 import Demo from 'docs/src/modules/components/Demo';
 import AppTableOfContents from 'docs/src/modules/components/AppTableOfContents';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
@@ -134,7 +134,7 @@ function MarkdownDocs(props) {
                   }}
                   disableAd={disableAd}
                   demoOptions={renderedMarkdownOrDemo}
-                  githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
+                  githubLocation={`${SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}/docs/src/${name}`}
                 />
               );
             })}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?

Fixed source github links to open url based on lib version.

### Why is it needed?

When a github link from any pages in docs is clicked, it is showing 404 message.

### Related issue(s)/PR(s)

Closes #23406 
