### PR TITLE
[test] Skip tests with cascading network requests

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -64,6 +64,7 @@ const blacklist = [
   'docs-components-grid/InteractiveGrid.png', // Redux isolation
   'docs-components-grid/SpacingGrid.png', // Needs interaction
   'docs-components-hidden', // Need to dynamically resize to test
+  'docs-components-icons/FontAwesomeIconSize.png', // Relies on cascading network requests
   'docs-components-image-list', // Image don't load
   'docs-components-material-icons/synonyms.png', // No component
   'docs-components-menus', // Need interaction


### PR DESCRIPTION
The skipped tests breaks the visual regression tests frequently. It uses fontawesome which kicks of cascading network requests. These are hard to await since we have to know ahead of time which request kicks of other ones we have to await.

Skipping the test since it's mainly concerned with fontawesome anyway. If this test becomes more important we can try out some retry logic if the test kicked of some requests during execution which we didn't await before taking the screenshot.