### PR TITLE
[utils] Fix minified errors throwing with _formatMuiErrorMessage

### DIFF
--- a/packages/material-ui-utils/macros/MuiError.macro.js
+++ b/packages/material-ui-utils/macros/MuiError.macro.js
@@ -161,10 +161,10 @@ function muiError({ references, babel, config, source }) {
 
     // Outputs:
     // formatMuiErrorMessage(ERROR_CODE, adj, noun)
-    const prodMessage = babel.types.callExpression(formatMuiErrorMessageIdentifier, [
-      babel.types.numericLiteral(errorCode),
-      ...errorMessageExpressions,
-    ]);
+    const prodMessage = babel.types.callExpression(
+      babel.types.cloneDeep(formatMuiErrorMessageIdentifier),
+      [babel.types.numericLiteral(errorCode), ...errorMessageExpressions],
+    );
 
     // Outputs:
     // new Error(

--- a/packages/material-ui-utils/src/capitalize.test.js
+++ b/packages/material-ui-utils/src/capitalize.test.js
@@ -9,6 +9,6 @@ describe('capitalize', () => {
   it('should throw when not used correctly', () => {
     expect(() => {
       capitalize();
-    }).to.throw(/expects a string argument/);
+    }).toThrowMinified(/expects a string argument/);
   });
 });

--- a/packages/material-ui/src/styles/colorManipulator.test.js
+++ b/packages/material-ui/src/styles/colorManipulator.test.js
@@ -220,7 +220,7 @@ describe('utils/colorManipulator', () => {
     it('throw on invalid colors', () => {
       expect(() => {
         getLuminance('black');
-      }).to.throw('Material-UI: Unsupported `black` color');
+      }).toThrowMinified('Material-UI: Unsupported `black` color');
     });
   });
 
@@ -278,7 +278,7 @@ describe('utils/colorManipulator', () => {
     it('throw on invalid colors', () => {
       expect(() => {
         alpha('white', 0.4);
-      }).to.throw('Material-UI: Unsupported `white` color');
+      }).toThrowMinified('Material-UI: Unsupported `white` color');
     });
   });
 

--- a/packages/material-ui/src/styles/createPalette.test.js
+++ b/packages/material-ui/src/styles/createPalette.test.js
@@ -149,19 +149,19 @@ describe('createPalette()', () => {
     });
 
     it('throws an exception when a wrong color is provided', () => {
-      expect(() => createPalette({ primary: '#fff' })).to.throw(
+      expect(() => createPalette({ primary: '#fff' })).toThrowMinified(
         [
           'Material-UI: The color (primary) provided to augmentColor(color) is invalid.',
           'The color object needs to have a `main` property or a `500` property.',
         ].join('\n'),
       );
-      expect(() => createPalette({ primary: { main: { foo: 'bar' } } })).to.throw(
+      expect(() => createPalette({ primary: { main: { foo: 'bar' } } })).toThrowMinified(
         [
           'Material-UI: The color (primary) provided to augmentColor(color) is invalid.',
           '`color.main` should be a string, but `{"foo":"bar"}` was provided instead.',
         ].join('\n'),
       );
-      expect(() => createPalette({ primary: { main: undefined } })).to.throw(
+      expect(() => createPalette({ primary: { main: undefined } })).toThrowMinified(
         [
           'Material-UI: The color (primary) provided to augmentColor(color) is invalid.',
           '`color.main` should be a string, but `undefined` was provided instead.',

--- a/packages/material-ui/src/styles/responsiveFontSizes.test.js
+++ b/packages/material-ui/src/styles/responsiveFontSizes.test.js
@@ -65,7 +65,10 @@ describe('responsiveFontSizes', () => {
       });
       expect(() => {
         responsiveFontSizes(theme);
-      }).to.throw();
+      }).toThrowMinified(
+        'Material-UI: Unsupported non-unitless line height with grid alignment.\n' +
+          'Use unitless line heights instead.',
+      );
     });
   });
 });

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -415,9 +415,14 @@ chai.use((chaiAPI, utils) => {
     // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
     if (process.env.NODE_ENV !== 'production') {
       (this as any).to.throw(expectedDevMessage);
-      // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
     } else {
-      (this as any).to.throw('Minified Material-UI error');
+      utils.flag(
+        this,
+        'message',
+        "Looks like the error was not minified. This can happen if the error code hasn't been generated yet. Run `yarn extract-error-codes` and try again.",
+      );
+      // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
+      (this as any).to.throw('Minified Material-UI error', 'helper');
     }
   });
 });

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -107,6 +107,11 @@ declare global {
        * @example expect(() => render()).toErrorDev(['first warning', 'then the second'])
        */
       toErrorDev(messages?: string | string[]): void;
+      /**
+       * Asserts that the given callback throws an error matching the given message in development (process.env.NODE_ENV !== 'production').
+       * In production it expects a minified error.
+       */
+      toThrowMinified(message: string): void;
     }
   }
 }
@@ -404,6 +409,16 @@ chai.use((chaiAPI, utils) => {
     // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
     utils.transferFlags(this as any, assertion, false);
     assertion.to.equal(expectedDate.toISOString());
+  });
+
+  chai.Assertion.addMethod('toThrowMinified', function toThrowMinified(expectedDevMessage) {
+    // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
+    if (process.env.NODE_ENV !== 'production') {
+      (this as any).to.throw(expectedDevMessage);
+      // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
+    } else {
+      (this as any).to.throw('Minified Material-UI error');
+    }
   });
 });
 


### PR DESCRIPTION
some errors thrown from `createPalette` where throwing with `_formatMuiErrorMessage is undefined` in node (or rather when transpiling to commonJS).

Fixed by following https://babeljs.io/docs/en/babel-helper-module-imports.html#examples.

Discovered when running tests in production. I also added a custom matcher for thrown `MuiError` which should be preferred. We're not enforcing this right now since I don't know where this prod-testing experiment is going. So far it uncovered at least one bug.