### PR TITLE
[TextField] Add size prop for outlined and filled input

### DIFF
--- a/docs/pages/api-docs/filled-input.md
+++ b/docs/pages/api-docs/filled-input.md
@@ -72,11 +72,11 @@ Any other props supplied will be provided to the root element ([InputBase](/api/
 | <span class="prop-name">adornedStart</span> | <span class="prop-name">.MuiFilledInput-adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
 | <span class="prop-name">adornedEnd</span> | <span class="prop-name">.MuiFilledInput-adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
 | <span class="prop-name">error</span> | <span class="prop-name">.Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiFilledInput-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiFilledInput-sizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">multiline</span> | <span class="prop-name">.MuiFilledInput-multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">hiddenLabel</span> | <span class="prop-name">.MuiFilledInput-hiddenLabel</span> | Styles applied to the root element if `hiddenLabel={true}`.
 | <span class="prop-name">input</span> | <span class="prop-name">.MuiFilledInput-input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">.MuiFilledInput-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputSizeSmall</span> | <span class="prop-name">.MuiFilledInput-inputSizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">inputHiddenLabel</span> | <span class="prop-name">.MuiFilledInput-inputHiddenLabel</span> | Styles applied to the `input` if in `<FormControl hiddenLabel />`.
 | <span class="prop-name">inputMultiline</span> | <span class="prop-name">.MuiFilledInput-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputAdornedStart</span> | <span class="prop-name">.MuiFilledInput-inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.

--- a/docs/pages/api-docs/form-control.md
+++ b/docs/pages/api-docs/form-control.md
@@ -60,7 +60,7 @@ The `MuiFormControl` name can be used for providing [default props](/customizati
 | <span class="prop-name">hiddenLabel</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the label is hidden. This is used to increase density for a `FilledInput`. Be sure to add `aria-label` to the `input` element. |
 | <span class="prop-name">margin</span> | <span class="prop-type">'dense'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'</span> | <span class="prop-default">'none'</span> | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the label will indicate that the `input` is required. |
-| <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | The size of the text field. |
+| <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> | <span class="prop-default">'medium'</span> | The size of the text field. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/form-helper-text.md
+++ b/docs/pages/api-docs/form-helper-text.md
@@ -50,7 +50,7 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">root</span> | <span class="prop-name">.MuiFormHelperText-root</span> | Styles applied to the root element.
 | <span class="prop-name">error</span> | <span class="prop-name">.Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
 | <span class="prop-name">disabled</span> | <span class="prop-name">.Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiFormHelperText-marginDense</span> | Styles applied to the root element if `margin="dense"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiFormHelperText-sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">contained</span> | <span class="prop-name">.MuiFormHelperText-contained</span> | Styles applied to the root element if `variant="filled"` or `variant="outlined"`.
 | <span class="prop-name">focused</span> | <span class="prop-name">.Mui-focused</span> | Pseudo-class applied to the root element if `focused={true}`.
 | <span class="prop-name">filled</span> | <span class="prop-name">.MuiFormHelperText-filled</span> | Pseudo-class applied to the root element if `filled={true}`.

--- a/docs/pages/api-docs/input-adornment.md
+++ b/docs/pages/api-docs/input-adornment.md
@@ -50,7 +50,7 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">positionEnd</span> | <span class="prop-name">.MuiInputAdornment-positionEnd</span> | Styles applied to the root element if `position="end"`.
 | <span class="prop-name">disablePointerEvents</span> | <span class="prop-name">.MuiInputAdornment-disablePointerEvents</span> | Styles applied to the root element if `disablePointerEvents=true`.
 | <span class="prop-name">hiddenLabel</span> | <span class="prop-name">.MuiInputAdornment-hiddenLabel</span> | Styles applied if the adornment is used inside &lt;FormControl hiddenLabel />.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiInputAdornment-marginDense</span> | Styles applied if the adornment is used inside &lt;FormControl margin="dense" />.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiInputAdornment-sizeSmall</span> | Styles applied if the adornment is used inside &lt;FormControl size="small" />.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/pages/api-docs/input-base.md
+++ b/docs/pages/api-docs/input-base.md
@@ -74,13 +74,13 @@ Any other props supplied will be provided to the root element (native element).
 | <span class="prop-name">adornedStart</span> | <span class="prop-name">.MuiInputBase-adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
 | <span class="prop-name">adornedEnd</span> | <span class="prop-name">.MuiInputBase-adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
 | <span class="prop-name">error</span> | <span class="prop-name">.Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiInputBase-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiInputBase-sizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">multiline</span> | <span class="prop-name">.MuiInputBase-multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">colorSecondary</span> | <span class="prop-name">.MuiInputBase-colorSecondary</span> | Styles applied to the root element if the color is secondary.
 | <span class="prop-name">fullWidth</span> | <span class="prop-name">.MuiInputBase-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 | <span class="prop-name">hiddenLabel</span> | <span class="prop-name">.MuiInputBase-hiddenLabel</span> | Styles applied to the root element if `hiddenLabel={true}`.
 | <span class="prop-name">input</span> | <span class="prop-name">.MuiInputBase-input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">.MuiInputBase-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputSizeSmall</span> | <span class="prop-name">.MuiInputBase-inputSizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">inputMultiline</span> | <span class="prop-name">.MuiInputBase-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputTypeSearch</span> | <span class="prop-name">.MuiInputBase-inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
 | <span class="prop-name">inputAdornedStart</span> | <span class="prop-name">.MuiInputBase-inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.

--- a/docs/pages/api-docs/input-base.md
+++ b/docs/pages/api-docs/input-base.md
@@ -54,6 +54,7 @@ The `MuiInputBase` name can be used for providing [default props](/customization
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> |  | It prevents the user from changing the value of the field (not from interacting with the field). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element is required. The prop defaults to the value (`false`) inherited from the parent FormControl component. |
 | <span class="prop-name">rows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Number of rows to display when multiline option is set to true. |
+| <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | The size of the text field. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> | <span class="prop-default">'text'</span> | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |

--- a/docs/pages/api-docs/input-label.md
+++ b/docs/pages/api-docs/input-label.md
@@ -55,7 +55,7 @@ Any other props supplied will be provided to the root element ([FormLabel](/api/
 | <span class="prop-name">required</span> | <span class="prop-name">.Mui-required</span> | Pseudo-class applied to the root element if `required={true}`.
 | <span class="prop-name">asterisk</span> | <span class="prop-name">.MuiInputLabel-asterisk</span> | Pseudo-class applied to the asterisk element.
 | <span class="prop-name">formControl</span> | <span class="prop-name">.MuiInputLabel-formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiInputLabel-marginDense</span> | Styles applied to the root element if `margin="dense"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiInputLabel-sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">shrink</span> | <span class="prop-name">.MuiInputLabel-shrink</span> | Styles applied to the `input` element if `shrink={true}`.
 | <span class="prop-name">animated</span> | <span class="prop-name">.MuiInputLabel-animated</span> | Styles applied to the `input` element unless `disableAnimation={true}`.
 | <span class="prop-name">filled</span> | <span class="prop-name">.MuiInputLabel-filled</span> | Styles applied to the root element if `variant="filled"`.

--- a/docs/pages/api-docs/input.md
+++ b/docs/pages/api-docs/input.md
@@ -71,11 +71,11 @@ Any other props supplied will be provided to the root element ([InputBase](/api/
 | <span class="prop-name">colorSecondary</span> | <span class="prop-name">.MuiInput-colorSecondary</span> | Styles applied to the root element if color secondary.
 | <span class="prop-name">underline</span> | <span class="prop-name">.MuiInput-underline</span> | Styles applied to the root element unless `disableUnderline={true}`.
 | <span class="prop-name">error</span> | <span class="prop-name">.Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiInput-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiInput-sizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">multiline</span> | <span class="prop-name">.MuiInput-multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">fullWidth</span> | <span class="prop-name">.MuiInput-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 | <span class="prop-name">input</span> | <span class="prop-name">.MuiInput-input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">.MuiInput-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputSizeSmall</span> | <span class="prop-name">.MuiInput-inputSizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">inputMultiline</span> | <span class="prop-name">.MuiInput-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputTypeSearch</span> | <span class="prop-name">.MuiInput-inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
 

--- a/docs/pages/api-docs/outlined-input.md
+++ b/docs/pages/api-docs/outlined-input.md
@@ -54,6 +54,7 @@ The `MuiOutlinedInput` name can be used for providing [default props](/customiza
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> |  | It prevents the user from changing the value of the field (not from interacting with the field). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element is required. The prop defaults to the value (`false`) inherited from the parent FormControl component. |
 | <span class="prop-name">rows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Number of rows to display when multiline option is set to true. |
+| <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | The size of the outlined input field. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> | <span class="prop-default">'text'</span> | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |

--- a/docs/pages/api-docs/outlined-input.md
+++ b/docs/pages/api-docs/outlined-input.md
@@ -54,7 +54,6 @@ The `MuiOutlinedInput` name can be used for providing [default props](/customiza
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> |  | It prevents the user from changing the value of the field (not from interacting with the field). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element is required. The prop defaults to the value (`false`) inherited from the parent FormControl component. |
 | <span class="prop-name">rows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Number of rows to display when multiline option is set to true. |
-| <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | The size of the outlined input field. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> | <span class="prop-default">'text'</span> | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
@@ -74,11 +73,11 @@ Any other props supplied will be provided to the root element ([InputBase](/api/
 | <span class="prop-name">adornedStart</span> | <span class="prop-name">.MuiOutlinedInput-adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
 | <span class="prop-name">adornedEnd</span> | <span class="prop-name">.MuiOutlinedInput-adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
 | <span class="prop-name">error</span> | <span class="prop-name">.Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | <span class="prop-name">.MuiOutlinedInput-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiOutlinedInput-sizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">multiline</span> | <span class="prop-name">.MuiOutlinedInput-multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">notchedOutline</span> | <span class="prop-name">.MuiOutlinedInput-notchedOutline</span> | Styles applied to the `NotchedOutline` element.
 | <span class="prop-name">input</span> | <span class="prop-name">.MuiOutlinedInput-input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">.MuiOutlinedInput-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputSizeSmall</span> | <span class="prop-name">.MuiOutlinedInput-inputSizeSmall</span> | Styles applied to the `input` element if `size="small"`.
 | <span class="prop-name">inputMultiline</span> | <span class="prop-name">.MuiOutlinedInput-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputAdornedStart</span> | <span class="prop-name">.MuiOutlinedInput-inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
 | <span class="prop-name">inputAdornedEnd</span> | <span class="prop-name">.MuiOutlinedInput-inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.

--- a/docs/src/pages/components/slider/InputSlider.js
+++ b/docs/src/pages/components/slider/InputSlider.js
@@ -49,7 +49,7 @@ export default function InputSlider() {
         <Grid item>
           <Input
             value={value}
-            margin="dense"
+            size="small"
             onChange={handleInputChange}
             onBlur={handleBlur}
             inputProps={{

--- a/docs/src/pages/components/slider/InputSlider.tsx
+++ b/docs/src/pages/components/slider/InputSlider.tsx
@@ -54,7 +54,7 @@ export default function InputSlider() {
         <Grid item>
           <Input
             value={value}
-            margin="dense"
+            size="small"
             onChange={handleInputChange}
             onBlur={handleBlur}
             inputProps={{

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -999,6 +999,7 @@ const classes = makeStyles(theme => ({
   ```
 
 - Rename `marginDense` and `inputMarginDense` classes to `sizeSmall` and `inputSizeSmall` to match the prop.
+
 ```diff
 -<Input margin="dense" />
 +<Input size="small" />

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -979,7 +979,7 @@ const classes = makeStyles(theme => ({
   +<TextField minRows={2} maxRows={5} />
   ```
 
-- Change ref forwarding expections on custom `inputComponent`.
+- Change ref forwarding expectations on custom `inputComponent`.
   The component should forward the `ref` prop instead of the `inputRef` prop.
 
   ```diff
@@ -997,6 +997,8 @@ const classes = makeStyles(theme => ({
   -     getInputRef={inputRef}
   +     getInputRef={ref}
   ```
+
+- Rename `marginDense` and `inputMarginDense` classes to `sizeSmall` and `inputSizeSmall` to match the prop.
 
 ### TextareaAutosize
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -999,6 +999,10 @@ const classes = makeStyles(theme => ({
   ```
 
 - Rename `marginDense` and `inputMarginDense` classes to `sizeSmall` and `inputSizeSmall` to match the prop.
+```diff
+-<Input margin="dense" />
++<Input size="small" />
+```
 
 ### TextareaAutosize
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1000,10 +1000,10 @@ const classes = makeStyles(theme => ({
 
 - Rename `marginDense` and `inputMarginDense` classes to `sizeSmall` and `inputSizeSmall` to match the prop.
 
-```diff
--<Input margin="dense" />
-+<Input size="small" />
-```
+  ```diff
+  -<Input margin="dense" />
+  +<Input size="small" />
+  ```
 
 ### TextareaAutosize
 

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -69,7 +69,7 @@ export const styles = (theme) => ({
         padding: '6px 0',
       },
     },
-    '&[class*="MuiInput-root"][class*="MuiInput-marginDense"]': {
+    '&[class*="MuiInput-root"][class*="MuiInput-sizeSmall"]': {
       '& $input': {
         padding: '2px 4px 3px',
       },
@@ -95,7 +95,7 @@ export const styles = (theme) => ({
         right: 9,
       },
     },
-    '&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-marginDense"]': {
+    '&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-sizeSmall"]': {
       padding: 6,
       '& $input': {
         padding: '2.5px 4px',
@@ -117,7 +117,7 @@ export const styles = (theme) => ({
         right: 9,
       },
     },
-    '&[class*="MuiFilledInput-root"][class*="MuiFilledInput-marginDense"]': {
+    '&[class*="MuiFilledInput-root"][class*="MuiFilledInput-sizeSmall"]': {
       paddingBottom: 1,
       '& $input': {
         padding: '2.5px 4px',

--- a/packages/material-ui/src/FilledInput/FilledInput.d.ts
+++ b/packages/material-ui/src/FilledInput/FilledInput.d.ts
@@ -22,16 +22,16 @@ export interface FilledInputProps extends StandardProps<InputBaseProps> {
     adornedEnd?: string;
     /** Pseudo-class applied to the root element if `error={true}`. */
     error?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    marginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    sizeSmall?: string;
     /** Styles applied to the root element if `multiline={true}`. */
     multiline?: string;
     /** Styles applied to the root element if `hiddenLabel={true}`. */
     hiddenLabel?: string;
     /** Styles applied to the `input` element. */
     input?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall?: string;
     /** Styles applied to the `input` if in `<FormControl hiddenLabel />`. */
     inputHiddenLabel?: string;
     /** Styles applied to the `input` element if `multiline={true}`. */

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -99,12 +99,12 @@ export const styles = (theme) => {
     },
     /* Pseudo-class applied to the root element if `error={true}`. */
     error: {},
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    marginDense: {},
+    /* Styles applied to the `input` element if `size="small"`. */
+    sizeSmall: {},
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '25px 12px 8px',
-      '&$marginDense': {
+      '&$sizeSmall': {
         paddingTop: 21,
         paddingBottom: 4,
       },
@@ -126,8 +126,8 @@ export const styles = (theme) => {
         borderTopRightRadius: 'inherit',
       },
     },
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense: {
+    /* Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall: {
       paddingTop: 21,
       paddingBottom: 4,
     },
@@ -135,7 +135,7 @@ export const styles = (theme) => {
     inputHiddenLabel: {
       paddingTop: 16,
       paddingBottom: 17,
-      '&$inputMarginDense': {
+      '&$inputSizeSmall': {
         paddingTop: 8,
         paddingBottom: 9,
       },

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { PropTypes } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'> {
@@ -56,7 +55,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
      * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
      * @default 'none'
      */
-    margin?: PropTypes.Margin;
+    margin?: 'dense' | 'normal' | 'none';
     /**
      * If `true`, the label will indicate that the `input` is required.
      * @default false
@@ -64,6 +63,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
     required?: boolean;
     /**
      * The size of the text field.
+     * @default 'medium'
      */
     size?: 'small' | 'medium';
     /**

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -69,12 +69,12 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
     component: Component = 'div',
     disabled = false,
     error = false,
-    fullWidth = false,
     focused: visuallyFocused,
+    fullWidth = false,
     hiddenLabel = false,
     margin = 'none',
     required = false,
-    size,
+    size = 'medium',
     variant = 'standard',
     ...other
   } = props;
@@ -166,7 +166,7 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
     focused,
     fullWidth,
     hiddenLabel,
-    margin: (size === 'small' ? 'dense' : undefined) || margin,
+    size,
     onBlur: () => {
       setFocused(false);
     },
@@ -265,6 +265,7 @@ FormControl.propTypes = {
   required: PropTypes.bool,
   /**
    * The size of the text field.
+   * @default 'medium'
    */
   size: PropTypes.oneOf(['medium', 'small']),
   /**

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -38,7 +38,7 @@ describe('<FormControl />', () => {
       const root = container.firstChild;
 
       expect(root).not.to.have.class(classes.marginNormal);
-      expect(root).not.to.have.class(classes.marginDense);
+      expect(root).not.to.have.class(classes.sizeSmall);
     });
 
     it('can have the margin normal class', () => {
@@ -46,7 +46,7 @@ describe('<FormControl />', () => {
       const root = container.firstChild;
 
       expect(root).to.have.class(classes.marginNormal);
-      expect(root).not.to.have.class(classes.marginDense);
+      expect(root).not.to.have.class(classes.sizeSmall);
     });
 
     it('can have the margin dense class', () => {
@@ -232,10 +232,10 @@ describe('<FormControl />', () => {
         const formControlRef = React.createRef();
         const { setProps } = render(<FormControlled ref={formControlRef} />);
 
-        expect(formControlRef.current).to.have.property('margin', 'none');
+        expect(formControlRef.current).to.have.property('size', 'medium');
 
-        setProps({ margin: 'dense' });
-        expect(formControlRef.current).to.have.property('margin', 'dense');
+        setProps({ size: 'small' });
+        expect(formControlRef.current).to.have.property('size', 'small');
       });
 
       it('should have the fullWidth prop from the instance', () => {

--- a/packages/material-ui/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.d.ts
@@ -19,8 +19,8 @@ export interface FormHelperTextTypeMap<P = {}, D extends React.ElementType = 'p'
       error?: string;
       /** Pseudo-class applied to the root element if `disabled={true}`. */
       disabled?: string;
-      /** Styles applied to the root element if `margin="dense"`. */
-      marginDense?: string;
+      /** Styles applied to the root element if `size="small"`. */
+      sizeSmall?: string;
       /** Styles applied to the root element if `variant="filled"` or `variant="outlined"`. */
       contained?: string;
       /** Pseudo-class applied to the root element if `focused={true}`. */

--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -24,8 +24,8 @@ export const styles = (theme) => ({
   error: {},
   /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
-  /* Styles applied to the root element if `margin="dense"`. */
-  marginDense: {
+  /* Styles applied to the root element if `size="small"`. */
+  sizeSmall: {
     marginTop: 4,
   },
   /* Styles applied to the root element if `variant="filled"` or `variant="outlined"`. */
@@ -61,7 +61,7 @@ const FormHelperText = React.forwardRef(function FormHelperText(props, ref) {
   const fcs = formControlState({
     props,
     muiFormControl,
-    states: ['variant', 'margin', 'disabled', 'error', 'filled', 'focused', 'required'],
+    states: ['variant', 'size', 'disabled', 'error', 'filled', 'focused', 'required'],
   });
 
   return (
@@ -70,7 +70,7 @@ const FormHelperText = React.forwardRef(function FormHelperText(props, ref) {
         classes.root,
         {
           [classes.contained]: fcs.variant === 'filled' || fcs.variant === 'outlined',
-          [classes.marginDense]: fcs.margin === 'dense',
+          [classes.sizeSmall]: fcs.size === 'small',
           [classes.disabled]: fcs.disabled,
           [classes.error]: fcs.error,
           [classes.filled]: fcs.filled,

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -62,23 +62,23 @@ describe('<FormHelperText />', () => {
       });
     });
 
-    describe('margin', () => {
-      describe('dense margin FormControl', () => {
-        it('should have the dense class', () => {
+    describe('size', () => {
+      describe('small margin FormControl', () => {
+        it('should have the small class', () => {
           const { getByText } = render(
-            <FormControl margin="dense">
+            <FormControl size="small">
               <FormHelperText>Foo</FormHelperText>
             </FormControl>,
           );
 
-          expect(getByText(/Foo/)).to.have.class(classes.marginDense);
+          expect(getByText(/Foo/)).to.have.class(classes.sizeSmall);
         });
       });
 
       it('should be overridden by props', () => {
         function FormHelperTextInFormControl(props) {
           return (
-            <FormControl dense="none">
+            <FormControl size="medium">
               <FormHelperText {...props}>Foo</FormHelperText>
             </FormControl>
           );
@@ -88,9 +88,9 @@ describe('<FormHelperText />', () => {
           <FormHelperTextInFormControl>Foo</FormHelperTextInFormControl>,
         );
 
-        expect(getByText(/Foo/)).not.to.have.class(classes.marginDense);
-        setProps({ margin: 'dense' });
-        expect(getByText(/Foo/)).to.have.class(classes.marginDense);
+        expect(getByText(/Foo/)).not.to.have.class(classes.sizeSmall);
+        setProps({ size: 'small' });
+        expect(getByText(/Foo/)).to.have.class(classes.sizeSmall);
       });
     });
   });

--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -20,16 +20,16 @@ export interface InputProps extends StandardProps<InputBaseProps> {
     underline?: string;
     /** Pseudo-class applied to the root element if `error={true}`. */
     error?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    marginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    sizeSmall?: string;
     /** Styles applied to the root element if `multiline={true}`. */
     multiline?: string;
     /** Styles applied to the root element if `fullWidth={true}`. */
     fullWidth?: string;
     /** Styles applied to the `input` element. */
     input?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall?: string;
     /** Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline?: string;
     /** Styles applied to the `input` element if `type="search"`. */

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -80,16 +80,16 @@ export const styles = (theme) => {
     },
     /* Pseudo-class applied to the root element if `error={true}`. */
     error: {},
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    marginDense: {},
+    /* Styles applied to the `input` element if `size="small"`. */
+    sizeSmall: {},
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {},
     /* Styles applied to the root element if `fullWidth={true}`. */
     fullWidth: {},
     /* Styles applied to the `input` element. */
     input: {},
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense: {},
+    /* Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall: {},
     /* Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline: {},
     /* Styles applied to the `input` element if `type="search"`. */

--- a/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
@@ -19,8 +19,8 @@ export interface InputAdornmentTypeMap<P = {}, D extends React.ElementType = 'di
       disablePointerEvents?: string;
       /** Styles applied if the adornment is used inside <FormControl hiddenLabel />. */
       hiddenLabel?: string;
-      /** Styles applied if the adornment is used inside <FormControl margin="dense" />. */
-      marginDense?: string;
+      /** Styles applied if the adornment is used inside <FormControl size="small" />. */
+      sizeSmall?: string;
     };
     /**
      * The content of the component, normally an `IconButton` or string.

--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -34,8 +34,8 @@ export const styles = {
   },
   /* Styles applied if the adornment is used inside <FormControl hiddenLabel />. */
   hiddenLabel: {},
-  /* Styles applied if the adornment is used inside <FormControl margin="dense" />. */
-  marginDense: {},
+  /* Styles applied if the adornment is used inside <FormControl size="small" />. */
+  sizeSmall: {},
 };
 
 const InputAdornment = React.forwardRef(function InputAdornment(props, ref) {
@@ -79,7 +79,7 @@ const InputAdornment = React.forwardRef(function InputAdornment(props, ref) {
             [classes.positionStart]: position === 'start',
             [classes.positionEnd]: position === 'end',
             [classes.disablePointerEvents]: disablePointerEvents,
-            [classes.marginDense]: muiFormControl.margin === 'dense',
+            [classes.sizeSmall]: muiFormControl.size === 'small',
             [classes.hiddenLabel]: muiFormControl.hiddenLabel,
           },
           className,

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -177,14 +177,14 @@ describe('<InputAdornment />', () => {
     expect(adornment.firstChild).to.have.property('nodeName', 'DIV');
   });
 
-  it('applies a marginDense class inside <FormControl margin="dense" />', () => {
+  it('applies a size small class inside <FormControl size="small" />', () => {
     const { getByTestId } = render(
-      <FormControl margin="dense">
+      <FormControl size="small">
         <InputAdornment data-testid="root">$</InputAdornment>
       </FormControl>,
     );
 
-    expect(getByTestId('root')).to.have.class(classes.marginDense);
+    expect(getByTestId('root')).to.have.class(classes.sizeSmall);
   });
 
   it('applies a hiddenLabel class inside <FormControl hiddenLabel />', () => {

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -40,8 +40,8 @@ export interface InputBaseProps
     adornedEnd?: string;
     /** Pseudo-class applied to the root element if `error={true}`. */
     error?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    marginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    sizeSmall?: string;
     /** Styles applied to the root element if `multiline={true}`. */
     multiline?: string;
     /** Styles applied to the root element if the color is secondary. */
@@ -52,8 +52,8 @@ export interface InputBaseProps
     hiddenLabel?: string;
     /** Styles applied to the `input` element. */
     input?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall?: string;
     /** Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline?: string;
     /** Styles applied to the `input` element if `type="search"`. */

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -179,6 +179,10 @@ export interface InputBaseProps
    */
   minRows?: string | number;
   /**
+   * The size of the text field.
+   */
+  size?: 'small' | 'medium';
+  /**
    * Start `InputAdornment` for this component.
    */
   startAdornment?: React.ReactNode;
@@ -191,10 +195,6 @@ export interface InputBaseProps
    * The value of the `input` element, required for a controlled component.
    */
   value?: unknown;
-  /**
-   * The size of the text field.
-   */
-  size?: 'small' | 'medium';
 }
 
 export interface InputBaseComponentProps

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -191,6 +191,10 @@ export interface InputBaseProps
    * The value of the `input` element, required for a controlled component.
    */
   value?: unknown;
+  /**
+   * The size of the text field.
+   */
+  size?: 'small' | 'medium';
 }
 
 export interface InputBaseComponentProps

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -203,6 +203,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     ...other
   } = props;
 
+
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);
 

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -203,7 +203,6 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     ...other
   } = props;
 
-
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);
 

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -165,6 +165,8 @@ export const styles = (theme) => {
  * It contains a load of style reset and some state logic.
  */
 const InputBase = React.forwardRef(function InputBase(props, ref) {
+  console.log("input base props", props) 
+  console.log("size input base propd", props.size)
   const {
     'aria-describedby': ariaDescribedby,
     autoComplete,
@@ -199,9 +201,10 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     startAdornment,
     type = 'text',
     value: valueProp,
+    size,
     ...other
   } = props;
-
+  console.log("props input base", props)
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);
 
@@ -397,7 +400,8 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
       muiFormControl.setAdornedStart(Boolean(startAdornment));
     }
   }, [muiFormControl, startAdornment]);
-
+  console.log( "size inputbase", size)
+  console.log( size === 'small')
   return (
     <div
       className={clsx(
@@ -409,7 +413,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
           [classes.fullWidth]: fullWidth,
           [classes.focused]: fcs.focused,
           [classes.formControl]: muiFormControl,
-          [classes.marginDense]: fcs.margin === 'dense',
+          [classes.marginDense]: (fcs.margin === 'dense' || size === 'small'),
           [classes.multiline]: multiline,
           [classes.adornedStart]: startAdornment,
           [classes.adornedEnd]: endAdornment,
@@ -449,7 +453,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
               [classes.disabled]: fcs.disabled,
               [classes.inputTypeSearch]: type === 'search',
               [classes.inputMultiline]: multiline,
-              [classes.inputMarginDense]: fcs.margin === 'dense',
+              [classes.inputMarginDense]: (fcs.margin === 'dense' || size === 'small'),
               [classes.inputHiddenLabel]: fcs.hiddenLabel,
               [classes.inputAdornedStart]: startAdornment,
               [classes.inputAdornedEnd]: endAdornment,
@@ -620,6 +624,10 @@ InputBase.propTypes = {
    * Number of rows to display when multiline option is set to true.
    */
   rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * The size of the text field.
+   */
+  size: PropTypes.oneOf(['medium', 'small']),
   /**
    * Start `InputAdornment` for this component.
    */

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -65,12 +65,12 @@ export const styles = (theme) => {
     adornedEnd: {},
     /* Pseudo-class applied to the root element if `error={true}`. */
     error: {},
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    marginDense: {},
+    /* Styles applied to the `input` element if `size="small"`. */
+    sizeSmall: {},
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '4px 0 5px',
-      '&$marginDense': {
+      '&$sizeSmall': {
         paddingTop: 1,
       },
     },
@@ -134,8 +134,8 @@ export const styles = (theme) => {
         animationName: 'mui-auto-fill',
       },
     },
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense: {
+    /* Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall: {
       paddingTop: 1,
     },
     /* Styles applied to the `input` element if `multiline={true}`. */
@@ -241,7 +241,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
   const fcs = formControlState({
     props,
     muiFormControl,
-    states: ['color', 'disabled', 'error', 'hiddenLabel', 'margin', 'required', 'filled'],
+    states: ['color', 'disabled', 'error', 'hiddenLabel', 'size', 'required', 'filled'],
   });
 
   fcs.focused = muiFormControl ? muiFormControl.focused : focused;
@@ -410,7 +410,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
           [classes.fullWidth]: fullWidth,
           [classes.focused]: fcs.focused,
           [classes.formControl]: muiFormControl,
-          [classes.marginDense]: fcs.margin === 'dense' || size === 'small',
+          [classes.sizeSmall]: fcs.size === 'small',
           [classes.multiline]: multiline,
           [classes.adornedStart]: startAdornment,
           [classes.adornedEnd]: endAdornment,
@@ -450,7 +450,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
               [classes.disabled]: fcs.disabled,
               [classes.inputTypeSearch]: type === 'search',
               [classes.inputMultiline]: multiline,
-              [classes.inputMarginDense]: fcs.margin === 'dense' || size === 'small',
+              [classes.inputSizeSmall]: fcs.size === 'small',
               [classes.inputHiddenLabel]: fcs.hiddenLabel,
               [classes.inputAdornedStart]: startAdornment,
               [classes.inputAdornedEnd]: endAdornment,

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -202,6 +202,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     size,
     ...other
   } = props;
+
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);
 
@@ -397,6 +398,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
       muiFormControl.setAdornedStart(Boolean(startAdornment));
     }
   }, [muiFormControl, startAdornment]);
+
   return (
     <div
       className={clsx(

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -165,8 +165,6 @@ export const styles = (theme) => {
  * It contains a load of style reset and some state logic.
  */
 const InputBase = React.forwardRef(function InputBase(props, ref) {
-  console.log("input base props", props) 
-  console.log("size input base propd", props.size)
   const {
     'aria-describedby': ariaDescribedby,
     autoComplete,
@@ -204,7 +202,6 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     size,
     ...other
   } = props;
-  console.log("props input base", props)
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);
 
@@ -400,8 +397,6 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
       muiFormControl.setAdornedStart(Boolean(startAdornment));
     }
   }, [muiFormControl, startAdornment]);
-  console.log( "size inputbase", size)
-  console.log( size === 'small')
   return (
     <div
       className={clsx(
@@ -413,7 +408,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
           [classes.fullWidth]: fullWidth,
           [classes.focused]: fcs.focused,
           [classes.formControl]: muiFormControl,
-          [classes.marginDense]: (fcs.margin === 'dense' || size === 'small'),
+          [classes.marginDense]: fcs.margin === 'dense' || size === 'small',
           [classes.multiline]: multiline,
           [classes.adornedStart]: startAdornment,
           [classes.adornedEnd]: endAdornment,
@@ -453,7 +448,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
               [classes.disabled]: fcs.disabled,
               [classes.inputTypeSearch]: type === 'search',
               [classes.inputMultiline]: multiline,
-              [classes.inputMarginDense]: (fcs.margin === 'dense' || size === 'small'),
+              [classes.inputMarginDense]: fcs.margin === 'dense' || size === 'small',
               [classes.inputHiddenLabel]: fcs.hiddenLabel,
               [classes.inputAdornedStart]: startAdornment,
               [classes.inputAdornedEnd]: endAdornment,

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -196,10 +196,10 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     readOnly,
     renderSuffix,
     rows,
+    size,
     startAdornment,
     type = 'text',
     value: valueProp,
-    size,
     ...other
   } = props;
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -41,6 +41,11 @@ describe('<InputBase />', () => {
     expect(input).not.to.have.attribute('required');
   });
 
+  it('should add the right class when size is small', () => {
+    const { container } = render(<InputBase size="small" />);
+    expect(container.firstChild).to.have.class(classes.sizeSmall);
+  });
+
   describe('multiline', () => {
     it('should render an <TextareaAutosize /> when passed the multiline prop', () => {
       const { container } = render(<InputBase multiline />);
@@ -315,29 +320,29 @@ describe('<InputBase />', () => {
       });
     });
 
-    describe('margin', () => {
-      it('should have the inputMarginDense class in a dense context', () => {
+    describe('size', () => {
+      it('should have the inputSizeSmall class in a dense context', () => {
         const { container } = render(
-          <FormControl margin="dense">
+          <FormControl size="small">
             <InputBase />
           </FormControl>,
         );
-        expect(container.querySelector('input')).to.have.class(classes.inputMarginDense);
+        expect(container.querySelector('input')).to.have.class(classes.inputSizeSmall);
       });
 
       it('should be overridden by props', () => {
         function InputBaseInFormWithMargin(props) {
           return (
-            <FormControl margin="none">
+            <FormControl size="medium">
               <InputBase {...props} />
             </FormControl>
           );
         }
         const { container, setProps } = render(<InputBaseInFormWithMargin />);
-        expect(container.querySelector('input')).not.to.have.class(classes.inputMarginDense);
+        expect(container.querySelector('input')).not.to.have.class(classes.inputSizeSmall);
 
-        setProps({ margin: 'dense' });
-        expect(container.querySelector('input')).to.have.class(classes.inputMarginDense);
+        setProps({ size: 'small' });
+        expect(container.querySelector('input')).to.have.class(classes.inputSizeSmall);
       });
 
       it('has an inputHiddenLabel class to further reduce margin', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -25,8 +25,8 @@ export interface InputLabelProps extends StandardProps<FormLabelProps> {
     asterisk?: string;
     /** Styles applied to the root element if the component is a descendant of `FormControl`. */
     formControl?: string;
-    /** Styles applied to the root element if `margin="dense"`. */
-    marginDense?: string;
+    /** Styles applied to the root element if `size="small"`. */
+    sizeSmall?: string;
     /** Styles applied to the `input` element if `shrink={true}`. */
     shrink?: string;
     /** Styles applied to the `input` element unless `disableAnimation={true}`. */

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -30,9 +30,9 @@ export const styles = (theme) => ({
     // slight alteration to spec spacing to match visual spec result
     transform: 'translate(0, 24px) scale(1)',
   },
-  /* Styles applied to the root element if `margin="dense"`. */
-  marginDense: {
-    // Compensation for the `Input.inputDense` style.
+  /* Styles applied to the root element if `size="small"`. */
+  sizeSmall: {
+    // Compensation for the `Input.inputSizeSmall` style.
     transform: 'translate(0, 21px) scale(1)',
   },
   /* Styles applied to the `input` element if `shrink={true}`. */
@@ -56,12 +56,12 @@ export const styles = (theme) => ({
     zIndex: 1,
     pointerEvents: 'none',
     transform: 'translate(12px, 20px) scale(1)',
-    '&$marginDense': {
+    '&$sizeSmall': {
       transform: 'translate(12px, 17px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(12px, 10px) scale(0.75)',
-      '&$marginDense': {
+      '&$sizeSmall': {
         transform: 'translate(12px, 7px) scale(0.75)',
       },
     },
@@ -72,7 +72,7 @@ export const styles = (theme) => ({
     zIndex: 1,
     pointerEvents: 'none',
     transform: 'translate(14px, 20px) scale(1)',
-    '&$marginDense': {
+    '&$sizeSmall': {
       transform: 'translate(14px, 12px) scale(1)',
     },
     '&$shrink': {
@@ -102,7 +102,7 @@ const InputLabel = React.forwardRef(function InputLabel(props, ref) {
   const fcs = formControlState({
     props,
     muiFormControl,
-    states: ['margin', 'variant'],
+    states: ['size', 'variant'],
   });
 
   return (
@@ -114,7 +114,7 @@ const InputLabel = React.forwardRef(function InputLabel(props, ref) {
           [classes.formControl]: muiFormControl,
           [classes.animated]: !disableAnimation,
           [classes.shrink]: shrink,
-          [classes.marginDense]: fcs.margin === 'dense',
+          [classes.sizeSmall]: fcs.size === 'small',
           [classes.filled]: fcs.variant === 'filled',
           [classes.outlined]: fcs.variant === 'outlined',
         },

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -49,14 +49,14 @@ describe('<InputLabel />', () => {
       expect(getByTestId('root')).to.have.class(classes.formControl);
     });
 
-    it('should have the labelDense class when margin is dense', () => {
+    it('should have the small class', () => {
       const { getByTestId } = render(
-        <FormControl margin="dense">
+        <FormControl size="small">
           <InputLabel data-testid="root" />
         </FormControl>,
       );
 
-      expect(getByTestId('root')).to.have.class(classes.marginDense);
+      expect(getByTestId('root')).to.have.class(classes.sizeSmall);
     });
 
     describe('filled', () => {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
@@ -53,6 +53,10 @@ export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
    * If `true`, the outline is notched to accommodate the label.
    */
   notched?: boolean;
+  /**
+   * The size of the outlined input field.
+   */
+  size?: 'small' | 'medium';
 }
 
 export type OutlinedInputClassKey = keyof NonNullable<OutlinedInputProps['classes']>;

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
@@ -21,16 +21,16 @@ export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
     adornedEnd?: string;
     /** Pseudo-class applied to the root element if `error={true}`. */
     error?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    marginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    sizeSmall?: string;
     /** Styles applied to the root element if `multiline={true}`. */
     multiline?: string;
     /** Styles applied to the `NotchedOutline` element. */
     notchedOutline?: string;
     /** Styles applied to the `input` element. */
     input?: string;
-    /** Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense?: string;
+    /** Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall?: string;
     /** Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline?: string;
     /** Styles applied to the `input` element if `startAdornment` is provided. */
@@ -53,10 +53,6 @@ export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
    * If `true`, the outline is notched to accommodate the label.
    */
   notched?: boolean;
-  /**
-   * The size of the outlined input field.
-   */
-  size?: 'small' | 'medium';
 }
 
 export type OutlinedInputClassKey = keyof NonNullable<OutlinedInputProps['classes']>;

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -110,7 +110,6 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
     notched,
     type = 'text',
     size,
-    // margin = (size === 'small' ? 'dense' : undefined),
     ...other
   } = props;
 

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -55,12 +55,12 @@ export const styles = (theme) => {
     },
     /* Pseudo-class applied to the root element if `error={true}`. */
     error: {},
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    marginDense: {},
+    /* Styles applied to the `input` element if `size="small"`. */
+    sizeSmall: {},
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '16.5px 14px',
-      '&$marginDense': {
+      '&$sizeSmall': {
         paddingTop: 10.5,
         paddingBottom: 10.5,
       },
@@ -79,8 +79,8 @@ export const styles = (theme) => {
         borderRadius: 'inherit',
       },
     },
-    /* Styles applied to the `input` element if `margin="dense"`. */
-    inputMarginDense: {
+    /* Styles applied to the `input` element if `size="small"`. */
+    inputSizeSmall: {
       paddingTop: 8.5,
       paddingBottom: 8.5,
     },
@@ -108,7 +108,6 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
     labelWidth = 0,
     multiline = false,
     notched,
-    size,
     type = 'text',
     ...other
   } = props;
@@ -137,7 +136,6 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
       multiline={multiline}
       ref={ref}
       type={type}
-      size={size}
       {...other}
     />
   );
@@ -272,10 +270,6 @@ OutlinedInput.propTypes = {
    * Number of rows to display when multiline option is set to true.
    */
   rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  /**
-   * The size of the outlined input field.
-   */
-  size: PropTypes.oneOf(['medium', 'small']),
   /**
    * Start `InputAdornment` for this component.
    */

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -100,7 +100,6 @@ export const styles = (theme) => {
 };
 
 const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
-  console.log('props outline input',props, props.classes, 'size', props.size)
   const {
     classes,
     fullWidth = false,
@@ -114,7 +113,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
     // margin = (size === 'small' ? 'dense' : undefined),
     ...other
   } = props;
-  
+
   return (
     <InputBase
       renderSuffix={(state) => (

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -100,6 +100,7 @@ export const styles = (theme) => {
 };
 
 const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
+  console.log('props outline input',props, props.classes, 'size', props.size)
   const {
     classes,
     fullWidth = false,
@@ -109,9 +110,11 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
     multiline = false,
     notched,
     type = 'text',
+    size,
+    // margin = (size === 'small' ? 'dense' : undefined),
     ...other
   } = props;
-
+  
   return (
     <InputBase
       renderSuffix={(state) => (
@@ -136,6 +139,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
       multiline={multiline}
       ref={ref}
       type={type}
+      size={size}
       {...other}
     />
   );
@@ -270,6 +274,10 @@ OutlinedInput.propTypes = {
    * Number of rows to display when multiline option is set to true.
    */
   rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * The size of the outlined input field.
+   */
+  size: PropTypes.oneOf(['medium', 'small']),
   /**
    * Start `InputAdornment` for this component.
    */

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -108,8 +108,8 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
     labelWidth = 0,
     multiline = false,
     notched,
-    type = 'text',
     size,
+    type = 'text',
     ...other
   } = props;
 

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -29,9 +29,9 @@ describe('<OutlinedInput />', () => {
     expect(container.querySelector('.notched-outlined')).not.to.equal(null);
   });
 
-  it('should add the classes when size is small', () => {
-    const { container } = render(<OutlinedInput size="small" id="smInput" />);
+  it('should add the inputMarginDense class when size is small', () => {
+    const { container } = render(<OutlinedInput size="small" />);
 
-    expect(container.querySelector('input')).to.have.class(classes.inputMarginDense);
+    expect(container.firstChild).to.have.class(classes.inputMarginDense);
   });
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -28,10 +28,4 @@ describe('<OutlinedInput />', () => {
 
     expect(container.querySelector('.notched-outlined')).not.to.equal(null);
   });
-
-  it('should add the inputMarginDense class when size is small', () => {
-    const { container } = render(<OutlinedInput size="small" />);
-
-    expect(container.firstChild).to.have.class(classes.marginDense);
-  });
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -32,6 +32,6 @@ describe('<OutlinedInput />', () => {
   it('should add the inputMarginDense class when size is small', () => {
     const { container } = render(<OutlinedInput size="small" />);
 
-    expect(container.firstChild).to.have.class(classes.inputMarginDense);
+    expect(container.firstChild).to.have.class(classes.marginDense);
   });
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -28,4 +28,10 @@ describe('<OutlinedInput />', () => {
 
     expect(container.querySelector('.notched-outlined')).not.to.equal(null);
   });
+
+  it('should add the classes when size is small', () => {
+    const { container } = render(<OutlinedInput size="small" id="smInput" />);
+
+    expect(container.querySelector('input')).to.have.class(classes.inputMarginDense);
+  });
 });

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps, PropTypes } from '..';
+import { InternalStandardProps as StandardProps } from '..';
 import { FormControlProps } from '../FormControl';
 import { FormHelperTextProps } from '../FormHelperText';
 import { InputBaseProps } from '../InputBase';
@@ -93,7 +93,7 @@ export interface BaseTextFieldProps
   /**
    * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
    */
-  margin?: PropTypes.Margin;
+  margin?: 'none' | 'dense' | 'normal';
   /**
    * If `true`, a `textarea` element is rendered.instead of an input.
    * @default false

--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { OverridableStringUnion } from '@material-ui/types';
-import { PropTypes } from '..';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Variant } from '../styles/createTypography';
 
@@ -13,7 +12,7 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
      * Set the text-align on the component.
      * @default 'inherit'
      */
-    align?: PropTypes.Alignment;
+    align?: 'inherit' | 'left' | 'center' | 'right' | 'justify';
     /**
      * The content of the component.
      */

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -66,9 +66,7 @@ export interface Color {
 }
 
 export namespace PropTypes {
-  type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';
   type Color = 'inherit' | 'primary' | 'secondary' | 'default';
-  type Margin = 'none' | 'dense' | 'normal';
 }
 
 // From index.js


### PR DESCRIPTION
### Breaking changes

- [TextField] Rename `marginDense` and `inputMarginDense` classes to `sizeSmall` and `inputSizeSmall` to match the prop.

---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #19796 

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Changed outlinedInput and Base input for exposed size property similarly to the TextField. 


