### PR TITLE
[core] Replace fs-extra deprecated function (exists)

### DIFF
--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -187,9 +187,9 @@ async function worker({ svgPath, options, renameFilter, template }) {
   const destPath = renameFilter(svgPathObj, innerPath, options);
 
   const outputFileDir = path.dirname(path.join(options.outputDir, destPath));
-  const exists2 = await fse.exists(outputFileDir);
+  const pathExists = await fse.pathExists(outputFileDir);
 
-  if (!exists2) {
+  if (!pathExists) {
     console.log(`Making dir: ${outputFileDir}`);
     fse.mkdirpSync(outputFileDir);
   }
@@ -237,8 +237,8 @@ export async function main(options) {
     if (typeof renameFilter !== 'function') {
       throw Error('renameFilter must be a function');
     }
-    const exists1 = await fse.exists(options.outputDir);
-    if (!exists1) {
+    const pathExists = await fse.pathExists(options.outputDir);
+    if (!pathExists) {
       await fse.mkdir(options.outputDir);
     }
 

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -45,9 +45,7 @@ async function createModulePackages({ from, to }) {
       ]);
 
       if (!typingsExist) {
-        throw new Error(
-          `index.d.ts for ${directoryPackage} is missing. Path: '${typingsPath}'`,
-        );
+        throw new Error(`index.d.ts for ${directoryPackage} is missing. Path: '${typingsPath}'`);
       }
 
       return packageJsonPath;

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -34,15 +34,20 @@ async function createModulePackages({ from, to }) {
         main: path.join('../node', directoryPackage, 'index.js'),
         types: './index.d.ts',
       };
+
       const packageJsonPath = path.join(to, directoryPackage, 'package.json');
 
+      const typingsPath = path.join(to, directoryPackage, 'index.d.ts');
+
       const [typingsExist] = await Promise.all([
-        fse.exists(path.join(to, directoryPackage, 'index.d.ts')),
+        fse.pathExists(typingsPath),
         fse.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2)),
       ]);
 
       if (!typingsExist) {
-        throw new Error(`index.d.ts for ${directoryPackage} is missing`);
+        throw new Error(
+          `index.d.ts for ${directoryPackage} is missing. Path: '${typingsPath}'`,
+        );
       }
 
       return packageJsonPath;
@@ -51,7 +56,7 @@ async function createModulePackages({ from, to }) {
 }
 
 async function typescriptCopy({ from, to }) {
-  if (!(await fse.exists(to))) {
+  if (!(await fse.pathExists(to))) {
     console.warn(`path ${to} does not exists`);
     return [];
   }
@@ -66,6 +71,7 @@ async function createPackageFile() {
   const { nyc, scripts, devDependencies, workspaces, ...packageDataOther } = JSON.parse(
     packageData,
   );
+
   const newPackageData = {
     ...packageDataOther,
     private: false,
@@ -81,6 +87,7 @@ async function createPackageFile() {
       : {}),
     types: './index.d.ts',
   };
+
   const targetPath = path.resolve(buildPath, './package.json');
 
   await fse.writeFile(targetPath, JSON.stringify(newPackageData, null, 2), 'utf8');


### PR DESCRIPTION
`Fs-extra` package deprecated the `exists` function.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #23847

Thanks!
