### PR TITLE
[Autocomplete] Fix useAutocomplete groupedOptions type

### DIFF
--- a/docs/src/pages/components/autocomplete/CustomizedHook.tsx
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.tsx
@@ -176,7 +176,7 @@ export default function CustomizedHook() {
           </div>
           {groupedOptions.length > 0 ? (
             <Listbox {...getListboxProps()}>
-              {groupedOptions.map((option, index) => (
+              {(groupedOptions as typeof top100Films).map((option, index) => (
                 <li {...getOptionProps({ option, index })}>
                   <span>{option.title}</span>
                   <CheckIcon fontSize="small" />

--- a/docs/src/pages/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/src/pages/components/autocomplete/UseAutocomplete.tsx
@@ -63,7 +63,7 @@ export default function UseAutocomplete() {
       </div>
       {groupedOptions.length > 0 ? (
         <ul className={classes.listbox} {...getListboxProps()}>
-          {groupedOptions.map((option, index) => (
+          {(groupedOptions as typeof top100Films).map((option, index) => (
             <li {...getOptionProps({ option, index })}>{option.title}</li>
           ))}
         </ul>

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -321,5 +321,5 @@ export default function useAutocomplete<
   /**
    * The options to render. It's either `T[]` or `AutocompleteGroupedOption<T>[]` if the grouping feature is enabled.
    */
-  groupedOptions: T[] | AutocompleteGroupedOption<T>[];
+  groupedOptions: T[] | Array<AutocompleteGroupedOption<T>>;
 };

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -319,7 +319,7 @@ export default function useAutocomplete<
   setAnchorEl: () => void;
   focusedTag: number;
   /**
-   * The options to render. It's either `T[]` or `AutocompleteGroupedOption<T>[]` if the grouping feature is enabled.
+   * The options to render. It's either `T[]` or `AutocompleteGroupedOption<T>[]` if the groupBy prop is provided.
    */
   groupedOptions: T[] | Array<AutocompleteGroupedOption<T>>;
 };

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -318,5 +318,8 @@ export default function useAutocomplete<
   anchorEl: null | HTMLElement;
   setAnchorEl: () => void;
   focusedTag: number;
-  groupedOptions: Array<T | AutocompleteGroupedOption<T>>;
+  /**
+   * The options to render. It's either `T[]` or `AutocompleteGroupedOption<T>[]` if the grouping feature is enabled.
+   */
+  groupedOptions: T[] | AutocompleteGroupedOption<T>[];
 };

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -14,6 +14,13 @@ export interface FilterOptionsState<T> {
   getOptionLabel: (option: T) => string;
 }
 
+export interface AutocompleteGroupedOption<T = string> {
+  key: number;
+  index: number;
+  group: string;
+  options: T[];
+}
+
 export function createFilterOptions<T>(
   config?: CreateFilterOptionsConfig<T>
 ): (options: T[], state: FilterOptionsState<T>) => T[];
@@ -311,5 +318,5 @@ export default function useAutocomplete<
   anchorEl: null | HTMLElement;
   setAnchorEl: () => void;
   focusedTag: number;
-  groupedOptions: T[];
+  groupedOptions: Array<T | AutocompleteGroupedOption<T>>;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Question about this:

I had to update the demos to fix type errors caused by the type definition change.  The current demos aren't explicit about the fact that `groupedOptions` changes shape when `groupBy` is provided; And their behavior will actually break without explanation if you do provide `groupBy` to `useAutocomplete` ([Demo](https://codesandbox.io/s/material-ui-issue-forked-6bidf?file=/src/Demo.tsx)).  With the type definition change, you do get type errors now if you don't handle the union type on `groupedOptions`, which is good, but I think it would be of benefit to add a bit more explanation of that behavior to the demos, as it seems a bit unexpected to me.  I'm happy to do that, I'm just wondering what form you think would be appropriate.  Would just a comment do? Would you want an example of how to actually handle the different types?  Or something else?  What do you think?

Fixes #23846 