### PR TITLE
[DatePicker] StaticDatePicker scrolls the page after selecting a year

### DIFF
--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -193,7 +193,6 @@ const DayPicker = React.forwardRef(function DayPicker<
       <FadeTransitionGroup
         reduceAnimations={reduceAnimations}
         className={classes.viewTransitionContainer}
-        transKey={openView}
       >
         <div>
           {openView === 'year' && (

--- a/packages/material-ui-lab/src/DayPicker/PickersFadeTransitionGroup.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersFadeTransitionGroup.tsx
@@ -4,7 +4,6 @@ import { createStyles, WithStyles, withStyles, Theme } from '@material-ui/core/s
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 interface FadeTransitionProps {
-  transKey: React.Key;
   className?: string;
   reduceAnimations: boolean;
   children: React.ReactElement;
@@ -48,7 +47,6 @@ const FadeTransitionGroup: React.FC<FadeTransitionProps & WithStyles<typeof styl
   children,
   className,
   reduceAnimations,
-  transKey,
 }) => {
   if (reduceAnimations) {
     return children;
@@ -73,7 +71,6 @@ const FadeTransitionGroup: React.FC<FadeTransitionProps & WithStyles<typeof styl
       <CSSTransition
         mountOnEnter
         unmountOnExit
-        key={transKey}
         timeout={{ appear: animationDuration, enter: animationDuration / 2, exit: 0 }}
         classNames={transitionClasses}
       >


### PR DESCRIPTION
- If you use the `StaticDatePicker` and you select a year, the scroll position jumps down the page a bit.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #23650 

Deleted `transKey` on `FadeTransitionGroup`
