### PR TITLE
[Select] Fixing typescript not recognizing the 'component' property on the 'MenuListProps'

### DIFF
--- a/packages/material-ui/src/List/List.d.ts
+++ b/packages/material-ui/src/List/List.d.ts
@@ -51,9 +51,20 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
  *
  * - [List API](https://material-ui.com/api/list/)
  */
-declare const List: OverridableComponent<ListTypeMap>;
+declare const List: OverridableList;
+
+export interface OverridableList extends OverridableComponent<ListTypeMap> {
+  <D extends React.ElementType = ListTypeMap['defaultComponent'], P = {}>(
+    props: ListPropsWithComponent<D, P>
+  ): JSX.Element;
+}
 
 export type ListClassKey = keyof NonNullable<ListTypeMap['props']['classes']>;
+
+export type ListPropsWithComponent<
+  D extends React.ElementType = ListTypeMap['defaultComponent'],
+  P = {}
+> = { component?: D } & ListProps<D, P>;
 
 export type ListProps<
   D extends React.ElementType = ListTypeMap['defaultComponent'],

--- a/packages/material-ui/src/List/List.js
+++ b/packages/material-ui/src/List/List.js
@@ -82,7 +82,7 @@ List.propTypes = {
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
    */
-  component: PropTypes.elementType,
+  component: PropTypes /* @typescript-to-proptypes-ignore */.elementType,
   /**
    * If `true`, compact vertical padding designed for keyboard and mouse input is used for
    * the list and list items.

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { ListProps } from '../List';
+import { ListPropsWithComponent } from '../List';
 
-export interface MenuListProps extends ListProps {
+export interface MenuListProps extends ListPropsWithComponent<React.ElementType> {
   /**
    * If `true`, will focus the `[role="menu"]` container and move into tab order.
    * @default false

--- a/packages/material-ui/src/Select/Select.spec.tsx
+++ b/packages/material-ui/src/Select/Select.spec.tsx
@@ -40,4 +40,12 @@ function genericValueTest() {
     {/* Whoops. The value in onChange won't be a string */}
     <MenuItem value={2} />
   </Select>;
+
+  <Select
+    MenuProps={{
+      MenuListProps: {
+        component: 'div',
+      },
+    }}
+  />;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

(This builds off of discussion in #17646)

Fixes #17579.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

These changes try and follow a similar pattern for the `CardHeader` in #20179. Guidance on how I should write more robust tests for this would be appreciated as well as if this is even going in the right direction in the first place :-)
