### PR TITLE
[envinfo] Ask for output from envinfo in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -54,14 +54,10 @@ Steps:
 ## Your Environment 🌎
 
 <!--
-  Include as many relevant details about the environment with which you experienced the bug.
-  If you encounter issues with TypeScript please include version and tsconfig.
+  Run `npx @material-ui/envinfo` and post the results.
+  If you encounter issues with TypeScript please include the used tsconfig.
 -->
 
-| Tech        | Version |
-| ----------- | ------- |
-| Material-UI | v5.?.?  |
-| React       |         |
-| Browser     |         |
-| TypeScript  |         |
-| etc.        |         |
+```
+  Output from `npx @material-ui/envinfo` goes here.
+```

--- a/packages/material-ui-envinfo/README.md
+++ b/packages/material-ui-envinfo/README.md
@@ -1,0 +1,41 @@
+# @material-ui/envinfo
+
+Prints information about the current environment relevant to Material-UI packages to the console.
+Please use this package if you report [issues to Material-UI](https://github.com/mui-org/material-ui/issues).
+
+## Usage
+
+```bash
+$ npx @material-ui/envinfo
+
+  System:
+    OS: Linux 5.4 Ubuntu 20.04.1 LTS (Focal Fossa)
+  Binaries:
+    Node: 12.20.0 - ~/.nvm/versions/node/v12.20.0/bin/node
+    Yarn: 1.22.4 - /usr/bin/yarn
+    npm: 6.14.8 - ~/.nvm/versions/node/v12.20.0/bin/npm
+  Browsers:
+    Chrome: 87.0.4280.66
+    Firefox: 83.0
+  npmPackages:
+    @emotion/react: ^11.0.0 => 11.1.1
+    @emotion/styled: ^11.0.0 => 11.0.0
+    @material-ui/codemod:  5.0.0-alpha.17
+    @material-ui/core:  5.0.0-alpha.18
+    @material-ui/docs:  5.0.0-alpha.1
+    @material-ui/envinfo:  1.0.0
+    @material-ui/icons:  5.0.0-alpha.15
+    @material-ui/lab:  5.0.0-alpha.18
+    @material-ui/styled-engine:  5.0.0-alpha.18
+    @material-ui/styled-engine-sc:  5.0.0-alpha.18
+    @material-ui/styles:  5.0.0-alpha.18
+    @material-ui/system:  5.0.0-alpha.18
+    @material-ui/types:  5.1.0
+    @material-ui/unstyled:  5.0.0-alpha.18
+    @material-ui/utils:  5.0.0-alpha.18
+    @types/react: ^17.0.0 => 17.0.0
+    react: ^16.14.0 => 16.14.0
+    react-dom: ^16.14.0 => 16.14.0
+    styled-components:  5.2.1
+    typescript: ^4.0.2 => 4.0.5
+```

--- a/packages/material-ui-envinfo/index.js
+++ b/packages/material-ui-envinfo/index.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const envinfo = require('envinfo');
+
+envinfo.run(
+  {
+    npmPackages: `{${[
+      '@material-ui/*',
+      // Peer dependencies
+      'react',
+      'react-dom',
+      // optional peer deps
+      '@emotion/react',
+      '@emotion/styled',
+      'styled-components',
+      '@types/react',
+      // auxiliary libraries
+      'typescript',
+    ]}}`,
+    Binaries: ['Node', 'Yarn', 'npm'],
+    System: ['OS'],
+    Browsers: ['Chrome', 'Firefox', 'Safari', 'Edge'],
+  },
+  {
+    // `markdown: true` uses level 2 headings. It doesn't necessarily fit our issue template
+    console: true,
+    duplicates: true,
+    // include transitive dependencies and important packages that are transitive dependencies (e.g. `jsdom` is usually a transitive dependency inside jest)
+    fullTree: true,
+    showNotFound: true,
+  },
+);

--- a/packages/material-ui-envinfo/package.json
+++ b/packages/material-ui-envinfo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@material-ui/envinfo",
+  "license": "MIT",
+  "description": "Logs infos about the environment relevant to @material-ui/*",
+  "version": "1.0.0",
+  "bin": "./index.js",
+  "dependencies": {
+    "envinfo": "^7.7.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui",
+    "directory": "packages/material-ui-envinfo"
+  }
+}

--- a/packages/material-ui-envinfo/package.json
+++ b/packages/material-ui-envinfo/package.json
@@ -7,6 +7,10 @@
   "dependencies": {
     "envinfo": "^7.7.3"
   },
+  "author": "Material-UI Team",
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mui-org/material-ui",


### PR DESCRIPTION
Reduces work required when opening an issue and provides better environment information by leveraging [`envinfo`](https://www.npmjs.com/package/envinfo):

(Currently only works if you've checked out this branch and ran `yarn`. Once this is merged and published it works as advertised.)
```bash
$ npx @material-ui/envinfo

  System:
    OS: Linux 5.4 Ubuntu 20.04.1 LTS (Focal Fossa)
  Binaries:
    Node: 12.20.0 - ~/.nvm/versions/node/v12.20.0/bin/node
    Yarn: 1.22.4 - /usr/bin/yarn
    npm: 6.14.8 - ~/.nvm/versions/node/v12.20.0/bin/npm
  Browsers:
    Chrome: 87.0.4280.66
    Firefox: 83.0
  npmPackages:
    @emotion/react: ^11.0.0 => 11.1.1
    @emotion/styled: ^11.0.0 => 11.0.0
    @material-ui/codemod:  5.0.0-alpha.17
    @material-ui/core:  5.0.0-alpha.18
    @material-ui/docs:  5.0.0-alpha.1
    @material-ui/envinfo:  1.0.0
    @material-ui/icons:  5.0.0-alpha.15
    @material-ui/lab:  5.0.0-alpha.18
    @material-ui/styled-engine:  5.0.0-alpha.18
    @material-ui/styled-engine-sc:  5.0.0-alpha.18
    @material-ui/styles:  5.0.0-alpha.18
    @material-ui/system:  5.0.0-alpha.18
    @material-ui/types:  5.1.0
    @material-ui/unstyled:  5.0.0-alpha.18
    @material-ui/utils:  5.0.0-alpha.18
    @types/react: ^17.0.0 => 17.0.0
    react: ^16.14.0 => 16.14.0
    react-dom: ^16.14.0 => 16.14.0
    styled-components:  5.2.1
    typescript: ^4.0.2 => 4.0.5
```