### PR TITLE
[Autocomplete] Improve DX/UX when getOptionLabel is not configured correctly

### DIFF
--- a/docs/src/pages/components/autocomplete/UseAutocomplete.js
+++ b/docs/src/pages/components/autocomplete/UseAutocomplete.js
@@ -50,6 +50,8 @@ export default function UseAutocomplete() {
     getOptionLabel: (option) => option.title,
   });
 
+  // HOLA DESDE CODE
+
   return (
     <div>
       <div {...getRootProps()}>

--- a/docs/src/pages/components/autocomplete/UseAutocomplete.js
+++ b/docs/src/pages/components/autocomplete/UseAutocomplete.js
@@ -50,8 +50,6 @@ export default function UseAutocomplete() {
     getOptionLabel: (option) => option.title,
   });
 
-  // HOLA DESDE CODE
-
   return (
     <div>
       <div {...getRootProps()}>

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -1170,7 +1170,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           freeSolo
           onChange={handleChange}
-          options={[{ name: 'one' }, { name: 'two ' }]}
+          options={[{ name: 'one' }, {}]}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
@@ -1183,6 +1183,9 @@ describe('<Autocomplete />', () => {
       }).toErrorDev([
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         // strict mode renders twice
+        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
+        // strict mode renders twice
+        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -103,10 +103,11 @@ export default function useAutocomplete(props) {
 
   let getOptionLabel = getOptionLabelProp;
 
-  if (process.env.NODE_ENV !== 'production') {
-    getOptionLabel = (option) => {
-      const optionLabel = getOptionLabelProp(option);
-      if (typeof optionLabel !== 'string') {
+
+  getOptionLabel = (option) => {
+    const optionLabel = getOptionLabelProp(option);
+    if (typeof optionLabel !== 'string') {
+      if (process.env.NODE_ENV !== 'production') {
         const erroneousReturn =
           optionLabel === undefined ? 'undefined' : `${typeof optionLabel} (${optionLabel})`;
         console.error(
@@ -115,9 +116,10 @@ export default function useAutocomplete(props) {
           )}.`,
         );
       }
-      return optionLabel;
-    };
-  }
+      return String (optionLabel);
+    }
+    return optionLabel;
+  };
 
   const ignoreFocus = React.useRef(false);
   const firstFocus = React.useRef(true);

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -103,7 +103,6 @@ export default function useAutocomplete(props) {
 
   let getOptionLabel = getOptionLabelProp;
 
-
   getOptionLabel = (option) => {
     const optionLabel = getOptionLabelProp(option);
     if (typeof optionLabel !== 'string') {
@@ -116,7 +115,7 @@ export default function useAutocomplete(props) {
           )}.`,
         );
       }
-      return String (optionLabel);
+      return String(optionLabel);
     }
     return optionLabel;
   };

--- a/scripts/react-next.diff
+++ b/scripts/react-next.diff
@@ -71,9 +71,12 @@ index 92a2ce6ebf..742df9b951 100644
          fireEvent.change(textbox, { target: { value: 'a' } });
          fireEvent.keyDown(textbox, { key: 'Enter' });
        }).toErrorDev([
--        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
--        // strict mode renders twice
          'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
+-        // strict mode renders twice
+-        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
+         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
+-        // strict mode renders twice
+-        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
          'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
          'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
 @@ -1223,9 +1221,6 @@ describe('<Autocomplete />', () => {


### PR DESCRIPTION
Closses #23572

Fixes the console error following Oliver's suggestion.

I modified:
/Users/nsl-intern/material-ui/packages/material-ui/src/useAutocomplete/useAutocomplete.js

Made some tests to make sure it worked in:
/Users/nsl-intern/material-ui/docs/src/pages/components/autocomplete/UseAutocomplete.js

- [x]  I have followed (at least) the PR section of the contributing guide.