### PR TITLE
[docs] Add prepend option on emotion caches to allow JSS style overrides

### DIFF
--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -7,12 +7,13 @@ import rtlPlugin from 'stylis-plugin-rtl';
 import { useTheme } from '@material-ui/core/styles';
 
 // Cache for the ltr version of the styles
-export const cacheLtr = createCache({ key: 'css' });
+export const cacheLtr = createCache({ key: 'css', prepend: true });
 cacheLtr.compat = true;
 
 // Cache for the rtl version of the styles
 const cacheRtl = createCache({
   key: 'rtl',
+  prepend: true,
   stylisPlugins: [rtlPlugin],
 });
 cacheRtl.compat = true;


### PR DESCRIPTION
This PR adds the `prepend` option to the emotion caches that we use in the docs, to allow emotion's styles to be injected first, which will allow JSS overrides. The need of this has been discovered, by the argos differences in https://github.com/mui-org/material-ui/pull/23841 - once we converted the `Typography` component, which is widely used, we need to allow JSS (`makeStyles`) to override the styles for it.