### PR TITLE
[test] Run benchmarks in Azure Pipelines when approved

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,17 @@ jobs:
       - run:
           name: Upload screenshots to Argos CI
           command: yarn test:argos
+  benchmark:
+    <<: *defaults
+    steps:
+      - checkout
+      - install_js
+      - prepare_chrome_headless
+      - run:
+          name: yarn benchmark:browser
+          command: yarn benchmark:browser
+      - store_artifacts:
+          path: ./tmp/benchmarks
 workflows:
   version: 2
   pipeline:
@@ -262,6 +273,8 @@ workflows:
             - test_static
             - test_types
             - test_browser
+      - benchmark:
+          type: approval
   react-next:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,17 +239,6 @@ jobs:
       - run:
           name: Upload screenshots to Argos CI
           command: yarn test:argos
-  benchmark:
-    <<: *defaults
-    steps:
-      - checkout
-      - install_js
-      - prepare_chrome_headless
-      - run:
-          name: yarn benchmark:browser
-          command: yarn benchmark:browser
-      - store_artifacts:
-          path: ./tmp/benchmarks
 workflows:
   version: 2
   pipeline:
@@ -273,8 +262,6 @@ workflows:
             - test_static
             - test_types
             - test_browser
-      - benchmark:
-          type: approval
   react-next:
     triggers:
       - schedule:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ variables:
     REACT_DIST_TAG: 'stable'
     # Preserve this path structure since it is locked in various tooling
     S3_ARTIFACTS_PATH_PERMA: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)/'
-  - name: command
+  command: 'none'
 
 jobs:
   - job: size-snapshot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,12 +35,11 @@ variables:
     REACT_DIST_TAG: 'stable'
     # Preserve this path structure since it is locked in various tooling
     S3_ARTIFACTS_PATH_PERMA: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)/'
-  command: 'sizeSnapshot'
 
 jobs:
   - job: sizeSnapshot
     displayName: 'Bundle size monitoring'
-    condition: eq(variables.command, 'sizeSnapshot')
+    condition: eq($[variables.command], 'sizeSnapshot')
     steps:
       - task: NodeTool@0
         inputs:
@@ -161,7 +160,7 @@ jobs:
 
   - job: benchmark
     displayName: 'Performance monitoring'
-    condition: eq(variables.command, 'benchmark')
+    condition: eq($[variables.command], 'benchmark')
     steps:
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ variables:
   command: 'none'
 
 jobs:
-  - job: size-snapshot
+  - job: sizeSnapshot
     displayName: 'Bundle size monitoring'
     steps:
       - task: NodeTool@0
@@ -167,9 +167,9 @@ jobs:
           versionSpec: '10.x'
         displayName: 'Install Node.js'
 
+      # From https://github.com/GoogleChrome/puppeteer/blob/811415bc8c47f7882375629b57b3fe186ad61ed4/docs/troubleshooting.md#chrome-headless-doesnt-launch
       - script: |
           sudo apt-get update
-        # From https://github.com/GoogleChrome/puppeteer/blob/811415bc8c47f7882375629b57b3fe186ad61ed4/docs/troubleshooting.md#chrome-headless-doesnt-launch
           sudo apt-get install -y --force-yes gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
         displayName: 'Install dependencies for Chrome Headless'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,121 +35,152 @@ variables:
     REACT_DIST_TAG: 'stable'
     # Preserve this path structure since it is locked in various tooling
     S3_ARTIFACTS_PATH_PERMA: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)/'
+  - name: command
 
-steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '10.x'
-    displayName: 'Install Node.js'
+jobs:
+  - job: size-snapshot
+    displayName: 'Bundle size monitoring'
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '10.x'
+        displayName: 'Install Node.js'
 
-  - script: |
-      node scripts/use-react-dist-tag.js $(REACT_DIST_TAG)
-      yarn install
-    displayName: 'install dependencies'
+      - script: |
+          node scripts/use-react-dist-tag.js $(REACT_DIST_TAG)
+          yarn install
+        displayName: 'install dependencies'
 
-  - task: Cache@2
-    inputs:
-      key: 'node-modules-cache | yarn.lock'
-      path: node_modules/.cache
-    displayName: Cache node_modules/.cache
+      - task: Cache@2
+        inputs:
+          key: 'node-modules-cache | yarn.lock'
+          path: node_modules/.cache
+        displayName: Cache node_modules/.cache
 
-  - script: |
-      yarn danger ci
-    displayName: 'prepare danger on PRs'
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-    env:
-      AZURE_BUILD_ID: $(Build.BuildId)
-      DANGER_COMMAND: 'prepareBundleSizeReport'
-      DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
+      - script: |
+          yarn danger ci
+        displayName: 'prepare danger on PRs'
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+        env:
+          AZURE_BUILD_ID: $(Build.BuildId)
+          DANGER_COMMAND: 'prepareBundleSizeReport'
+          DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
 
-  - script: |
-      yarn lerna run --ignore @material-ui/icons --parallel --scope "@material-ui/*" build
-    displayName: 'build @material-ui packages'
+      - script: |
+          yarn lerna run --ignore @material-ui/icons --parallel --scope "@material-ui/*" build
+        displayName: 'build @material-ui packages'
 
-  - script: |
-      cd packages/material-ui/build
-      npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
-      npm pack
-      mv material-ui-core-0.0.0-canary.$(Build.SourceVersion).tgz ../../../material-ui-core.tgz
-    displayName: 'create @material-ui/core canary distributable'
+      - script: |
+          cd packages/material-ui/build
+          npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
+          npm pack
+          mv material-ui-core-0.0.0-canary.$(Build.SourceVersion).tgz ../../../material-ui-core.tgz
+        displayName: 'create @material-ui/core canary distributable'
 
-  - task: S3Upload@1
-    inputs:
-      regionName: 'eu-central-1'
-      bucketName: 'eps1lon-material-ui'
-      globExpressions: '*.tgz'
-      targetFolder: $(S3_ARTIFACTS_PATH_PERMA)
-      filesAcl: 'public-read'
-    displayName: 'Upload distributables to S3'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    env:
-      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+      - task: S3Upload@1
+        inputs:
+          regionName: 'eu-central-1'
+          bucketName: 'eps1lon-material-ui'
+          globExpressions: '*.tgz'
+          targetFolder: $(S3_ARTIFACTS_PATH_PERMA)
+          filesAcl: 'public-read'
+        displayName: 'Upload distributables to S3'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        env:
+          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: 'canaries'
-      targetPath: 'material-ui-core.tgz'
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: 'canaries'
+          targetPath: 'material-ui-core.tgz'
 
-  - task: Cache@2
-    inputs:
-      key: 'nextjs-build | yarn.lock'
-      path: $(DOCS_NEXT_CACHE_FOLDER)
-    displayName: Cache nextjs build
+      - task: Cache@2
+        inputs:
+          key: 'nextjs-build | yarn.lock'
+          path: $(DOCS_NEXT_CACHE_FOLDER)
+        displayName: Cache nextjs build
 
-  - script: |
-      set -o pipefail
-      mkdir -p scripts/sizeSnapshot/build	
-      yarn docs:build | tee scripts/sizeSnapshot/build/docs.next
-    displayName: 'build docs for size snapshot'
-    env:
-      NODE_OPTIONS: '--max_old_space_size=4096'
+      - script: |
+          set -o pipefail
+          mkdir -p scripts/sizeSnapshot/build	
+          yarn docs:build | tee scripts/sizeSnapshot/build/docs.next
+        displayName: 'build docs for size snapshot'
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
 
-  - script: |
-      yarn size:snapshot
-    displayName: 'create a size snapshot'
+      - script: |
+          yarn size:snapshot
+        displayName: 'create a size snapshot'
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'persist size snapshot as pipeline artifact'
-    inputs:
-      artifactName: 'size-snapshot'
-      targetPath: 'size-snapshot.json'
+      - task: PublishPipelineArtifact@1
+        displayName: 'persist size snapshot as pipeline artifact'
+        inputs:
+          artifactName: 'size-snapshot'
+          targetPath: 'size-snapshot.json'
 
-  - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
-    displayName: 'persist size snapshot on S3'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      awsCredentials: 's3 artifacts'
-      regionName: 'eu-central-1'
-      bucketName: 'eps1lon-material-ui'
-      sourceFolder: '$(System.DefaultWorkingDirectory)'
-      globExpressions: 'size-snapshot.json'
-      targetFolder: $(S3_ARTIFACTS_PATH_PERMA)
-      filesAcl: 'public-read'
-      contentType: application/json
-      logRequest: true
-      logResponse: true
+      - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
+        displayName: 'persist size snapshot on S3'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        inputs:
+          awsCredentials: 's3 artifacts'
+          regionName: 'eu-central-1'
+          bucketName: 'eps1lon-material-ui'
+          sourceFolder: '$(System.DefaultWorkingDirectory)'
+          globExpressions: 'size-snapshot.json'
+          targetFolder: $(S3_ARTIFACTS_PATH_PERMA)
+          filesAcl: 'public-read'
+          contentType: application/json
+          logRequest: true
+          logResponse: true
 
-  - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
-    displayName: 'symlink size-snapshot to latest'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Reason'], 'Schedule'))
-    inputs:
-      awsCredentials: 's3 artifacts'
-      regionName: 'eu-central-1'
-      bucketName: 'eps1lon-material-ui'
-      sourceFolder: '$(System.DefaultWorkingDirectory)'
-      globExpressions: 'size-snapshot.json'
-      targetFolder: 'artifacts/$(Build.SourceBranchName)/latest/'
-      filesAcl: 'public-read'
-      contentType: application/json
-      logRequest: true
-      logResponse: true
+      - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
+        displayName: 'symlink size-snapshot to latest'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Reason'], 'Schedule'))
+        inputs:
+          awsCredentials: 's3 artifacts'
+          regionName: 'eu-central-1'
+          bucketName: 'eps1lon-material-ui'
+          sourceFolder: '$(System.DefaultWorkingDirectory)'
+          globExpressions: 'size-snapshot.json'
+          targetFolder: 'artifacts/$(Build.SourceBranchName)/latest/'
+          filesAcl: 'public-read'
+          contentType: application/json
+          logRequest: true
+          logResponse: true
 
-  - script: |
-      yarn danger ci
-    displayName: 'run danger on PRs'
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-    env:
-      AZURE_BUILD_ID: $(Build.BuildId)
-      DANGER_COMMAND: 'reportBundleSize'
-      DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
+      - script: |
+          yarn danger ci
+        displayName: 'run danger on PRs'
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+        env:
+          AZURE_BUILD_ID: $(Build.BuildId)
+          DANGER_COMMAND: 'reportBundleSize'
+          DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
+
+  - job: benchmark
+    displayName: 'Performance monitoring'
+    condition: eq(variables.command, 'benchmark')
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '10.x'
+        displayName: 'Install Node.js'
+
+      - script: |
+          sudo apt-get update
+        # From https://github.com/GoogleChrome/puppeteer/blob/811415bc8c47f7882375629b57b3fe186ad61ed4/docs/troubleshooting.md#chrome-headless-doesnt-launch
+          sudo apt-get install -y --force-yes gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+        displayName: 'Install dependencies for Chrome Headless'
+
+      - script: yarn install
+        displayName: 'install dependencies'
+
+      - script: yarn benchmark:browser
+        displayName: 'yarn benchmark:browser'
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish benchmark results as a pipeline artifact.'
+        inputs:
+          artifactName: 'benchmarks'
+          targetPath: 'tmp/benchmarks'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ variables:
 jobs:
   - job: sizeSnapshot
     displayName: 'Bundle size monitoring'
-    condition: eq($[variables.command], 'sizeSnapshot')
+    condition: eq(variables['command'], 'sizeSnapshot')
     steps:
       - task: NodeTool@0
         inputs:
@@ -160,7 +160,7 @@ jobs:
 
   - job: benchmark
     displayName: 'Performance monitoring'
-    condition: eq($[variables.command], 'benchmark')
+    condition: eq(variables['command'], 'benchmark')
     steps:
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,11 +35,12 @@ variables:
     REACT_DIST_TAG: 'stable'
     # Preserve this path structure since it is locked in various tooling
     S3_ARTIFACTS_PATH_PERMA: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)/'
-  command: 'none'
+  command: 'sizeSnapshot'
 
 jobs:
   - job: sizeSnapshot
     displayName: 'Bundle size monitoring'
+    condition: eq(variables.command, 'sizeSnapshot')
     steps:
       - task: NodeTool@0
         inputs:

--- a/benchmark/browser/README.md
+++ b/benchmark/browser/README.md
@@ -12,6 +12,8 @@ You should use these numbers exclusively for comparing performance between diffe
 
 ## Output
 
+For compareable results ask a maintainer to approve the CircleCI job `benchmark`.
+
 ```
 noop (baseline):
   04.77 ±00.96ms

--- a/benchmark/browser/README.md
+++ b/benchmark/browser/README.md
@@ -16,29 +16,29 @@ For compareable results ask a maintainer to approve the CircleCI job `benchmark`
 
 ```
 noop (baseline):
-  04.77 ±00.96ms
+  05.82 ±00.29ms
 React primitives:
-  69.49 ±10.60ms
+  42.62 ±03.55ms
 React components:
-  88 ±4%
+  128 ±4%
 Styled Material-UI:
-  119 ±6%
+  192 ±8%
 Styled emotion:
-  108 ±5%
+  179 ±8%
 Styled SC:
-  127 ±6%
+  224 ±13%
 makeStyles:
-  112 ±6%
+  184 ±9%
 Box Baseline:
-  125 ±5%
+  213 ±11%
 Box Material-UI:
-  255 ±7%
+  501 ±23%
 Box Theme-UI:
-  236 ±8%
+  447 ±20%
 Box Chakra-UI:
-  193 ±5%
+  364 ±17%
 styled-components Box + @material-ui/system:
-  271 ±6%
+  506 ±22%
 styled-components Box + styled-system:
-  222 ±5%
+  388 ±12%
 ```


### PR DESCRIPTION
So that every member can update/inspect the results.

Example run: https://dev.azure.com/mui-org/Material-UI/_build/results?buildId=19952&view=results
How to run:
1. Click on the "Details" link of the azure pipelines check of a GitHub PR
1. Continue to the build on dev.azure.com
1. "Run new"
1. Variables
1. Use `benchmark` for `command`
1. Run
1. The result will be available as a pipeline artifact

![benchmark run](https://user-images.githubusercontent.com/12292047/101530962-e54d7800-3992-11eb-89e0-74ec9bb92ecc.gif)


<details>
<summary>why CircleCI is not viable</summary>

Might prevent dependabot from automatically merging. If that happens I'll try a different approach (e.g. webhooks, uncommenting lines in the CI config etc.)
Update: Yep, CircleCI approvals are not viable for github: https://ideas.circleci.com/cloud-feature-requests/p/show-overall-all-checks-have-passed-status-in-github-even-on-builds-with-incompl
Update2: I have no idea how to even look at the approved job. It immediately went green and the link for the job (from github) just points to the full pipeline: https://circleci.com/workflow-run/ab4615e9-b491-49d8-aaf5-5ea082c5a3ec?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-workflow-link
</details>

