### PR TITLE
[test] Add conformance tests for testing the `theme.components` options for the v5 components

### DIFF
--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -36,6 +36,10 @@ describe('<Slider />', () => {
     inheritComponent: SliderUnstyled,
     mount,
     refInstanceof: window.HTMLSpanElement,
+    muiName: 'MuiSlider',
+    ThemeProvider,
+    createMuiTheme,
+    testVariantProps: { color: 'primary', orientation: 'vertical' },
   }));
 
   it('should call handlers', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -37,8 +37,6 @@ describe('<Slider />', () => {
     mount,
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSlider',
-    ThemeProvider,
-    createMuiTheme,
     testVariantProps: { color: 'primary', orientation: 'vertical' },
   }));
 

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -41,7 +41,7 @@ function testThemeComponents(element, getOptions) {
 
   describe('theme: components', () => {
     it("respect theme's defaultProps", () => {
-      const { muiName, testThemeComponentsDefaultPropWith: testProp = 'id' } = getOptions();
+      const { muiName, testThemeComponentsDefaultPropName: testProp = 'id' } = getOptions();
       const theme = createMuiTheme({
         components: {
           [muiName]: {

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -99,13 +99,15 @@ function testThemeComponents(element, getOptions) {
         },
       });
 
-      const { container } = render(
+      const { getByTestId } = render(
         <ThemeProvider theme={theme}>
-          {React.cloneElement(element, testVariantProps)}
+          {React.cloneElement(element, { ...testVariantProps, 'data-testid': 'with-props' })}
+          {React.cloneElement(element, { 'data-testid': 'without-props' })}
         </ThemeProvider>,
       );
 
-      expect(container.firstChild).to.toHaveComputedStyle(testStyle);
+      expect(getByTestId('with-props')).to.toHaveComputedStyle(testStyle);
+      expect(getByTestId('without-props')).not.to.toHaveComputedStyle(testStyle);
     });
   });
 }

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
 import * as React from 'react';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { createClientRender } from './createClientRender';
 import {
   testClassName,
@@ -43,8 +44,6 @@ function testThemeComponents(element, getOptions) {
       const {
         muiName,
         testThemeComponentsDefaultPropWith: testProp = 'id',
-        createMuiTheme,
-        ThemeProvider,
       } = getOptions();
       const theme = createMuiTheme({
         components: {
@@ -62,7 +61,7 @@ function testThemeComponents(element, getOptions) {
     });
 
     it("respect theme's styleOverrides", () => {
-      const { muiName, createMuiTheme, ThemeProvider } = getOptions();
+      const { muiName } = getOptions();
 
       const testStyle = {
         marginTop: '13px',
@@ -84,7 +83,7 @@ function testThemeComponents(element, getOptions) {
     });
 
     it("respect theme's variants", () => {
-      const { muiName, testVariantProps = {}, createMuiTheme, ThemeProvider } = getOptions();
+      const { muiName, testVariantProps = {} } = getOptions();
 
       const testStyle = {
         marginTop: '13px',

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -54,7 +54,7 @@ function testThemeComponents(element, getOptions) {
 
       const { container } = render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
 
-      expect(container.firstChild[testProp]).to.equal('testProp');
+      expect(container.firstChild).to.have.attribute(testProp, 'testProp');
     });
 
     it("respect theme's styleOverrides", () => {

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -41,10 +41,7 @@ function testThemeComponents(element, getOptions) {
 
   describe('theme: components', () => {
     it("respect theme's defaultProps", () => {
-      const {
-        muiName,
-        testThemeComponentsDefaultPropWith: testProp = 'id',
-      } = getOptions();
+      const { muiName, testThemeComponentsDefaultPropWith: testProp = 'id' } = getOptions();
       const theme = createMuiTheme({
         components: {
           [muiName]: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
