### PR TITLE
[Grid] Remove side effects when direction="column" and xs={} is used 

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -120,10 +120,16 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `direction="column"`. */
   'direction-xs-column': {
     flexDirection: 'column',
+    '& $item': {
+      maxWidth: 'none',
+    },
   },
   /* Styles applied to the root element if `direction="column-reverse"`. */
   'direction-xs-column-reverse': {
     flexDirection: 'column-reverse',
+    '& $item': {
+      maxWidth: 'none',
+    },
   },
   /* Styles applied to the root element if `direction="row-reverse"`. */
   'direction-xs-row-reverse': {

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -120,14 +120,14 @@ export const styles = (theme) => ({
   /* Styles applied to the root element if `direction="column"`. */
   'direction-xs-column': {
     flexDirection: 'column',
-    '& $item': {
+    '& > $item': {
       maxWidth: 'none',
     },
   },
   /* Styles applied to the root element if `direction="column-reverse"`. */
   'direction-xs-column-reverse': {
     flexDirection: 'column-reverse',
-    '& $item': {
+    '& > $item': {
       maxWidth: 'none',
     },
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #23891