### PR TITLE
[docs] Use link colors for nav

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -28,7 +28,6 @@ const useStyles = makeStyles((theme) => ({
       duration: theme.transitions.duration.shortest,
     }),
     '&:hover': {
-      color: theme.palette.text.primary,
       backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.hoverOpacity),
     },
     '&.Mui-focusVisible': {
@@ -55,9 +54,7 @@ const useStyles = makeStyles((theme) => ({
   },
   open: {},
   link: {
-    color: theme.palette.text.secondary,
     '&.app-drawer-active': {
-      color: theme.palette.primary.main,
       backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
       '&:hover': {
         backgroundColor: alpha(


### PR DESCRIPTION
Alternative to https://github.com/mui-org/material-ui/pull/23457 which was inspired by https://github.com/mui-org/material-ui/pull/23457#issuecomment-740908080.

I probably had some custom CSS enabled but the analysis in https://github.com/mui-org/material-ui/pull/23457#issuecomment-740908080 is incorrect. This PR implements the observed behavior.

The current state of the docs is not ok so this is another attempt at reconciling it.