### PR TITLE
[test] Add support for firefox in visual regressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
       - install_js
       - run:
           name: Run visual regression tests
-          command: xvfb-run yarn test:regressions
+          command: xvfb-run yarn test:regressions --browser firefox
       - run:
           name: Upload screenshots to Argos CI
           command: yarn test:argos

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -2,11 +2,25 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as playwright from 'playwright';
 
-async function main() {
+/**
+ * @param {object} options
+ * @param {'chromium' | 'firefox'} options.browser
+ */
+async function main(options) {
+  const { browser: browserName } = options;
+  const supportedBrowsers = ['chromium', 'firefox'];
+  if (supportedBrowsers.indexOf(browserName) === -1) {
+    throw new TypeError(
+      `Unable to find a browser name '${browserName}'. Only the following browsers are supported: ${supportedBrowsers.join(
+        ',',
+      )}`,
+    );
+  }
+
   const baseUrl = 'http://localhost:5000';
   const screenshotDir = path.resolve(__dirname, './screenshots/chrome');
 
-  const browser = await playwright.chromium.launch({
+  const browser = await playwright[browserName].launch({
     args: ['--font-render-hinting=none'],
     // otherwise the loaded google Roboto font isn't applied
     headless: false,
@@ -84,7 +98,10 @@ async function main() {
   run();
 }
 
-main().catch((error) => {
+const browserArgOffset = process.argv.indexOf('--browser');
+main({
+  browser: browserArgOffset === -1 ? 'chromium' : process.argv[browserArgOffset + 1],
+}).catch((error) => {
   // error during setup.
   // Throwing lets mocha hang.
   console.error(error);

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -11,7 +11,7 @@ async function main(options) {
   const supportedBrowsers = ['chromium', 'firefox'];
   if (supportedBrowsers.indexOf(browserName) === -1) {
     throw new TypeError(
-      `Unable to find a browser name '${browserName}'. Only the following browsers are supported: ${supportedBrowsers.join(
+      `Unable to find a browser named '${browserName}'. Only the following browsers are supported: ${supportedBrowsers.join(
         ',',
       )}`,
     );


### PR DESCRIPTION
Might come in handy if we run into visual inconsistencies. Mainly motivated by testing playwright capabilities.

Update: Output is actually equal :tada:. If we need this we can always revisit. In the meantime it's a member expression that needs changing so let's leave it at that.