### PR TITLE
[core] Improve envinfo instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -57,7 +57,11 @@ Steps:
   Run `npx @material-ui/envinfo` and post the results.
   If you encounter issues with TypeScript please include the used tsconfig.
 -->
-
+<details>
+  <summary>`npx @material-ui/envinfo`</summary>
+  
 ```
+  Don't forget to mention which browser you used.
   Output from `npx @material-ui/envinfo` goes here.
 ```
+</details>

--- a/packages/material-ui-envinfo/envinfo.test.js
+++ b/packages/material-ui-envinfo/envinfo.test.js
@@ -10,6 +10,8 @@ describe('@material-ui/envinfo', () => {
       this.skip();
     }
 
+    // Building might take some time
+    this.timeout(10000);
     execFileSync('yarn', ['build'], { cwd: packagePath, stdio: 'pipe' });
   });
 


### PR DESCRIPTION
Full info takes up quite a bit of screen real estate which is mostly too much considering it's rarely the cause of the issue. Wrapping it in `<details />` might help. Let's see if it's clear where to paste the info.

Also emphasizes that we sometimes need to know which particular browser is used.
