### PR TITLE
[core] Force LF for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf
 # Undo the GitHub's default
 # https://github.com/github/linguist/blob/96ad1185828f44bb9b774328a584551ee57ed264/lib/linguist/vendor.yml#L177
 packages/**/*.d.ts -linguist-vendored


### PR DESCRIPTION
Right now we allow checking out files with CR/LF. This means that every script dealing with newlines has to consider both cases. This oftentimes leads to blocking windows developers if changes are made by unix devs because they don't have to consider CR/LF. Windows devs do because CI runs on unix.

Additionally, prettier already defaults to LF so if you check out a file, change it, run prettier, you already re-format the whole file creating large, potentially confusing diffs.

**for windows devs**:

After this PR is merged and you've updated your branch with the changes you probably need to update your newlines. **COMMIT OR STASH CHANGES BEFORE YOU DO OR THE PROGRESS IN YOUR WORKING TREE IS LOST**
```bash
$ git rm --cached -r .
$ git reset --hard
```

I'm not updating scripts dealing with CR/LF. The code does no harm, change does. It can be factored out when we need to change the code.
