### PR TITLE
[docs] Fix production deploy

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -23,6 +23,7 @@ const reactMode = 'legacy';
 // eslint-disable-next-line no-console
 console.log(`Using React '${reactMode}' mode.`);
 const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
+const vercelDeploy = Boolean(process.env.VERCEL);
 
 module.exports = {
   typescript: {
@@ -176,7 +177,7 @@ module.exports = {
 
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
-    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify) {
+    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify && !vercelDeploy) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');


### PR DESCRIPTION
Didn't need any code changes to fix it. I'm leaving the change to vercel in regardless to get a feel of how much slower exporting every locale is. Actual analysis of the issue below.

production deploys are currently failing for `next` (e.g. https://app.netlify.com/sites/material-ui/deploys/5fd31f0b071ca50007de7b01). Opening to notify that we're aware of the issue.

## post-mortem

Broken when merging https://github.com/mui-org/material-ui/pull/23745. Shortly after it another PR was merged skipping the netlify deploy so https://app.netlify.com/sites/material-ui/deploys/5fd2552ee192c200082e8622 is the first one failing even though it's unrelated.

Figuring out:
1. [x] why is it not failing on PRs even though it fails with the english locale
1. [x] Netlify only issue? 

Looks like a caching issue. Notice how on https://app.netlify.com/sites/material-ui/deploys/5fd31f0b071ca50007de7b01 we fail with a cache hit. However, https://app.netlify.com/sites/material-ui/deploys/5fd39c682427ad0c51e57510 is passing with a cache miss (I re-deployed with a cleared cache). The failing pages got introduced on a skipped build. This comes down to nextjs caching things like the page and routes manifest. However, the cache key for those is the yarn.lock file so we could have a cache hit even though pages changed. 

I'm not sure whether netlify should never skip on `next` or if nextjs should re-generate those files all the time. If nextjs actually caches these manifests that aggressively then we should get build failures everytime we change pages. That should be a frequent problem but considering `next export` is an "advanced use case" it might be a rare bug for them.