### PR TITLE
[experimentalStyled] Add name and slot options 

### DIFF
--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -56,7 +56,7 @@ const overridesResolver = (props, styles) => {
 const BadgeRoot = styled(
   'span',
   {},
-  { muiName: 'MuiBadge', overridesResolver },
+  { displayName: 'BadgeRoot', className: 'MuiBadge-root', muiName: 'MuiBadge', overridesResolver },
 )({
   position: 'relative',
   display: 'inline-flex',
@@ -68,7 +68,7 @@ const BadgeRoot = styled(
 const BadgeBadge = styled(
   'span',
   {},
-  { muiName: 'MuiBadge-badge', overridesResolver },
+  { displayName: 'BadgeBadge', className: 'MuiBadge-badge', overridesResolver },
 )((props) => ({
   display: 'flex',
   flexDirection: 'row',

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -56,7 +56,7 @@ const overridesResolver = (props, styles) => {
 const BadgeRoot = styled(
   'span',
   {},
-  { displayName: 'BadgeRoot', className: 'MuiBadge-root', muiName: 'MuiBadge', overridesResolver },
+  { name: 'Badge', slot: 'Root', overridesResolver },
 )({
   position: 'relative',
   display: 'inline-flex',
@@ -68,7 +68,7 @@ const BadgeRoot = styled(
 const BadgeBadge = styled(
   'span',
   {},
-  { displayName: 'BadgeBadge', className: 'MuiBadge-badge', overridesResolver },
+  { name: 'Badge', slot: 'Badge', overridesResolver },
 )((props) => ({
   display: 'flex',
   flexDirection: 'row',

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -68,7 +68,7 @@ const overridesResolver = (props, styles) => {
 export const SliderRoot = experimentalStyled(
   'span',
   {},
-  { muiName: 'MuiSlider', overridesResolver },
+  { displayName: 'SliderRoot', muiName: 'MuiSlider', className: 'MuiSlider-root', overridesResolver },
 )((props) => ({
   height: 2,
   width: '100%',
@@ -131,7 +131,7 @@ export const SliderRoot = experimentalStyled(
 export const SliderRail = experimentalStyled(
   'span',
   {},
-  { muiName: 'MuiSlider-rail' },
+  { displayName: 'SliderRail', className: 'MuiSlider-rail' },
 )((props) => ({
   display: 'block',
   position: 'absolute',
@@ -152,7 +152,7 @@ export const SliderRail = experimentalStyled(
 export const SliderTrack = experimentalStyled(
   'span',
   {},
-  { muiName: 'MuiSlider-track' },
+  { displayName: 'SliderTrack', className: 'MuiSlider-track' },
 )((props) => ({
   display: 'block',
   position: 'absolute',
@@ -177,7 +177,7 @@ export const SliderTrack = experimentalStyled(
 export const SliderThumb = experimentalStyled(
   'span',
   {},
-  { muiName: 'MuiSlider-thumb' },
+  { displayName: 'SliderThumb', className: 'MuiSlider-thumb' },
 )((props) => ({
   position: 'absolute',
   width: 12,
@@ -240,7 +240,7 @@ export const SliderThumb = experimentalStyled(
   }),
 }));
 
-export const SliderValueLabel = experimentalStyled(SliderValueLabelUnstyled)((props) => ({
+export const SliderValueLabel = experimentalStyled(SliderValueLabelUnstyled, {}, { displayName: 'SliderValueLabel', className: 'MuiSlider-valueLabel' })((props) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
   [`&.${sliderClasses.valueLabelOpen}`]: {
@@ -262,7 +262,7 @@ export const SliderValueLabel = experimentalStyled(SliderValueLabelUnstyled)((pr
 export const SliderMark = experimentalStyled(
   'span',
   {},
-  { muiName: 'MuiSlider-mark' },
+  { displayName: 'SliderMark', className: 'MuiSlider-mark' },
 )((props) => ({
   position: 'absolute',
   width: 2,
@@ -278,7 +278,7 @@ export const SliderMark = experimentalStyled(
 export const SliderMarkLabel = experimentalStyled(
   'span',
   {},
-  { muiName: 'MuiSlider-markLabel' },
+  { displayName: 'SliderMarkLabel', className: 'MuiSlider-markLabel' },
 )((props) => ({
   ...props.theme.typography.body2,
   color: props.theme.palette.text.secondary,

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -69,9 +69,8 @@ export const SliderRoot = experimentalStyled(
   'span',
   {},
   {
-    displayName: 'SliderRoot',
-    muiName: 'MuiSlider',
-    className: 'MuiSlider-root',
+    name: 'Slider',
+    slot: 'Root',
     overridesResolver,
   },
 )((props) => ({
@@ -136,7 +135,7 @@ export const SliderRoot = experimentalStyled(
 export const SliderRail = experimentalStyled(
   'span',
   {},
-  { displayName: 'SliderRail', className: 'MuiSlider-rail' },
+  { name: 'Slider', slot: 'Rail' },
 )((props) => ({
   display: 'block',
   position: 'absolute',
@@ -157,7 +156,7 @@ export const SliderRail = experimentalStyled(
 export const SliderTrack = experimentalStyled(
   'span',
   {},
-  { displayName: 'SliderTrack', className: 'MuiSlider-track' },
+  { name: 'Slider', slot: 'Track' },
 )((props) => ({
   display: 'block',
   position: 'absolute',
@@ -182,7 +181,7 @@ export const SliderTrack = experimentalStyled(
 export const SliderThumb = experimentalStyled(
   'span',
   {},
-  { displayName: 'SliderThumb', className: 'MuiSlider-thumb' },
+  { name: 'Slider', slot: 'Thumb' },
 )((props) => ({
   position: 'absolute',
   width: 12,
@@ -248,7 +247,7 @@ export const SliderThumb = experimentalStyled(
 export const SliderValueLabel = experimentalStyled(
   SliderValueLabelUnstyled,
   {},
-  { displayName: 'SliderValueLabel', className: 'MuiSlider-valueLabel' },
+  { name: 'Slider', slot: 'ValueLabel' },
 )((props) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
@@ -271,7 +270,7 @@ export const SliderValueLabel = experimentalStyled(
 export const SliderMark = experimentalStyled(
   'span',
   {},
-  { displayName: 'SliderMark', className: 'MuiSlider-mark' },
+  { name: 'Slider', slot: 'Mark' },
 )((props) => ({
   position: 'absolute',
   width: 2,
@@ -287,7 +286,7 @@ export const SliderMark = experimentalStyled(
 export const SliderMarkLabel = experimentalStyled(
   'span',
   {},
-  { displayName: 'SliderMarkLabel', className: 'MuiSlider-markLabel' },
+  { name: 'Slider', slot: 'MarkLabel' },
 )((props) => ({
   ...props.theme.typography.body2,
   color: props.theme.palette.text.secondary,

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -68,7 +68,12 @@ const overridesResolver = (props, styles) => {
 export const SliderRoot = experimentalStyled(
   'span',
   {},
-  { displayName: 'SliderRoot', muiName: 'MuiSlider', className: 'MuiSlider-root', overridesResolver },
+  {
+    displayName: 'SliderRoot',
+    muiName: 'MuiSlider',
+    className: 'MuiSlider-root',
+    overridesResolver,
+  },
 )((props) => ({
   height: 2,
   width: '100%',
@@ -240,7 +245,11 @@ export const SliderThumb = experimentalStyled(
   }),
 }));
 
-export const SliderValueLabel = experimentalStyled(SliderValueLabelUnstyled, {}, { displayName: 'SliderValueLabel', className: 'MuiSlider-valueLabel' })((props) => ({
+export const SliderValueLabel = experimentalStyled(
+  SliderValueLabelUnstyled,
+  {},
+  { displayName: 'SliderValueLabel', className: 'MuiSlider-valueLabel' },
+)((props) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
   [`&.${sliderClasses.valueLabelOpen}`]: {

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -180,9 +180,8 @@ export interface StyledOptions {
 }
 
 interface MuiStyledOptions<Theme extends object = any> {
-  displayName?: string;
-  className?: string;
-  muiName?: string;
+  name: string;
+  slot: string;
   overridesResolver?: (props: any, styles: string | object, name: string) => string | object;
   skipSx?: boolean;
 }

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -180,8 +180,8 @@ export interface StyledOptions {
 }
 
 interface MuiStyledOptions<Theme extends object = any> {
-  name: string;
-  slot: string;
+  name?: string;
+  slot?: string;
   overridesResolver?: (props: any, styles: string | object, name: string) => string | object;
   skipSx?: boolean;
 }

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -180,7 +180,9 @@ export interface StyledOptions {
 }
 
 interface MuiStyledOptions<Theme extends object = any> {
-  muiName: string;
+  displayName?: string;
+  className?: string;
+  muiName?: string;
   overridesResolver?: (props: any, styles: string | object, name: string) => string | object;
   skipSx?: boolean;
 }

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -76,7 +76,7 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   let className;
 
   if (componentName && componentSlot) {
-    displayName = `${componentName}${componentSlot}`;
+    displayName = `${componentName}${componentSlot || ''}`;
     name = !componentSlot || componentSlot === 'Root' ? `Mui${componentName}` : null;
     className = `Mui${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
   }

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -63,9 +63,11 @@ const shouldForwardProp = (prop) =>
   prop !== 'styleProps' && prop !== 'theme' && prop !== 'isRtl' && prop !== 'sx' && prop !== 'as';
 
 const experimentalStyled = (tag, options, muiOptions = {}) => {
+  const displayName = muiOptions.displayName;
   const name = muiOptions.muiName;
+  const className = muiOptions.className;
   const skipSx = muiOptions.skipSx || false;
-  const defaultStyledResolver = styled(tag, { shouldForwardProp, label: name, ...options });
+  const defaultStyledResolver = styled(tag, { shouldForwardProp, label: className || name, ...options });
   const muiStyledResolver = (styleArg, ...expressions) => {
     const expressionsWithDefaultTheme = expressions
       ? expressions.map((stylesArg) => {
@@ -116,7 +118,10 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
         styleArg({ theme: isEmpty(themeInput) ? defaultTheme : themeInput, ...other });
     }
 
-    return defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
+    const Component = defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
+    Component.displayName = displayName || name;
+
+    return Component;
   };
   return muiStyledResolver;
 };

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -77,7 +77,7 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
 
   if (componentName && componentSlot) {
     displayName = `${componentName}${componentSlot}`;
-    name = componentSlot === 'Root' ? `Mui${componentName}` : null;
+    name = !componentSlot || componentSlot === 'Root' ? `Mui${componentName}` : null;
     className = `Mui${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
   }
 

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -62,14 +62,26 @@ const variantsResolver = (props, styles, theme, name) => {
 const shouldForwardProp = (prop) =>
   prop !== 'styleProps' && prop !== 'theme' && prop !== 'isRtl' && prop !== 'sx' && prop !== 'as';
 
+const lowercaseFirstLetter = (string) => {
+  return string.charAt(0).toLowerCase() + string.slice(1);
+};
+
 const experimentalStyled = (tag, options, muiOptions = {}) => {
-  const displayName = muiOptions.displayName;
-  const name = muiOptions.muiName;
-  const className = muiOptions.className;
+  const componentName = muiOptions.name;
+  const componentSlot = muiOptions.slot;
   const skipSx = muiOptions.skipSx || false;
+
+  let displayName, name, className;
+
+  if (componentName && componentSlot) {
+    displayName = `${componentName}${componentSlot}`;
+    name = componentSlot === 'Root' ? `Mui${componentName}` : null;
+    className = `Mui${componentName}-${lowercaseFirstLetter(componentSlot)}`;
+  }
+
   const defaultStyledResolver = styled(tag, {
     shouldForwardProp,
-    label: className || name || displayName,
+    label: className || componentName || '',
     ...options,
   });
   const muiStyledResolver = (styleArg, ...expressions) => {
@@ -123,7 +135,10 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
     }
 
     const Component = defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
-    Component.displayName = displayName || name;
+
+    if (displayName || name) {
+      Component.displayName = displayName || name;
+    }
 
     return Component;
   };

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -75,7 +75,7 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   let name;
   let className;
 
-  if (componentName && componentSlot) {
+  if (componentName) {
     displayName = `${componentName}${componentSlot || ''}`;
     name = !componentSlot || componentSlot === 'Root' ? `Mui${componentName}` : null;
     className = `Mui${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -78,7 +78,7 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   if (componentName && componentSlot) {
     displayName = `${componentName}${componentSlot}`;
     name = componentSlot === 'Root' ? `Mui${componentName}` : null;
-    className = `Mui${componentName}-${lowercaseFirstLetter(componentSlot)}`;
+    className = `Mui${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
   }
 
   const defaultStyledResolver = styled(tag, {

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -71,7 +71,9 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   const componentSlot = muiOptions.slot;
   const skipSx = muiOptions.skipSx || false;
 
-  let displayName, name, className;
+  let displayName;
+  let name;
+  let className;
 
   if (componentName && componentSlot) {
     displayName = `${componentName}${componentSlot}`;

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -67,7 +67,11 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   const name = muiOptions.muiName;
   const className = muiOptions.className;
   const skipSx = muiOptions.skipSx || false;
-  const defaultStyledResolver = styled(tag, { shouldForwardProp, label: className || name, ...options });
+  const defaultStyledResolver = styled(tag, {
+    shouldForwardProp,
+    label: className || name || displayName,
+    ...options,
+  });
   const muiStyledResolver = (styleArg, ...expressions) => {
     const expressionsWithDefaultTheme = expressions
       ? expressions.map((stylesArg) => {

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -363,7 +363,7 @@ describe('experimentalStyled', () => {
       const TestNoSx = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver, skipSx: true },
+        { overridesResolver: testOverridesResolver, skipSx: true },
       )(({ sx = {} }) => ({
         ...(sx.mt && {
           marginTop: `${sx.mt * -1}px`,
@@ -384,7 +384,7 @@ describe('experimentalStyled', () => {
       const TestWithSx = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver },
+        { overridesResolver: testOverridesResolver },
       )(({ sx = {} }) => ({
         ...(sx.mt && {
           marginTop: `${sx.m * -1}px`,

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -402,5 +402,82 @@ describe('experimentalStyled', () => {
         marginTop: '8px',
       });
     });
+
+    it('should set displayName properly', () => {
+      const Component = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { displayName: 'Component', muiName: 'MuiComponent' },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      expect(Component.displayName).to.equal("Component");
+    });
+
+    it('should set displayName as muiName if displayName is not specified', () => {
+      const Component = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { muiName: 'MuiComponent' },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      expect(Component.displayName).to.equal("MuiComponent");
+    });
+
+    it('should use className when generating the classes', () => {
+      const Component = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { displayName: 'Component', muiName: 'MuiComponent', className: 'MuiComponent-root' },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <Component>Test</Component>,
+      );
+
+      expect(container.firstChild.getAttribute('class').includes('MuiComponent-root')).to.equal(true);
+    });
+
+    it('should use muiName as className when generating the classes if className is not defined', () => {
+      const Component = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { displayName: 'Component', muiName: 'MuiComponent' },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <Component>Test</Component>,
+      );
+
+      expect(container.firstChild.getAttribute('class').includes('MuiComponent')).to.equal(true);
+    });
+
+    it('should use displayName as className when generating the classes if className and muiName are not defined', () => {
+      const Component = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { displayName: 'Component' },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <Component>Test</Component>,
+      );
+
+      expect(container.firstChild.getAttribute('class').includes('Component')).to.equal(true);
+    });
   });
 });

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -185,7 +185,7 @@ describe('experimentalStyled', () => {
       TestObj = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver },
+        { name: 'Test', overridesResolver: testOverridesResolver },
       )({
         width: '200px',
         height: '300px',

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -176,7 +176,7 @@ describe('experimentalStyled', () => {
       Test = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver },
       )`
         width: 200px;
         height: 300px;
@@ -185,7 +185,7 @@ describe('experimentalStyled', () => {
       TestObj = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver },
       )({
         width: '200px',
         height: '300px',
@@ -363,7 +363,7 @@ describe('experimentalStyled', () => {
       const TestNoSx = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { muiName: 'MuiTest', overridesResolver: testOverridesResolver, skipSx: true },
+        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver, skipSx: true },
       )(({ sx = {} }) => ({
         ...(sx.mt && {
           marginTop: `${sx.mt * -1}px`,
@@ -384,7 +384,7 @@ describe('experimentalStyled', () => {
       const TestWithSx = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { muiName: 'MuiTest', overridesResolver: testOverridesResolver },
+        { name: 'Test', slot: 'Root', overridesResolver: testOverridesResolver },
       )(({ sx = {} }) => ({
         ...(sx.mt && {
           marginTop: `${sx.m * -1}px`,
@@ -407,75 +407,56 @@ describe('experimentalStyled', () => {
       const Component = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { displayName: 'Component', muiName: 'MuiComponent' },
+        { name: 'Component' },
       )`
         width: 200px;
         height: 300px;
       `;
 
-      expect(Component.displayName).to.equal("Component");
+      expect(Component.displayName).to.equal('Component');
     });
 
-    it('should set displayName as muiName if displayName is not specified', () => {
+    it('should set displayName as name + slot if both are specified', () => {
       const Component = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { muiName: 'MuiComponent' },
+        { name: 'Component', slot: 'Root' },
       )`
         width: 200px;
         height: 300px;
       `;
 
-      expect(Component.displayName).to.equal("MuiComponent");
+      expect(Component.displayName).to.equal('ComponentRoot');
     });
 
-    it('should use className when generating the classes', () => {
+    it('should set the className when generating the classes', () => {
       const Component = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { displayName: 'Component', muiName: 'MuiComponent', className: 'MuiComponent-root' },
+        { name: 'Component', slot: 'Slot' },
       )`
         width: 200px;
         height: 300px;
       `;
 
-      const { container } = render(
-        <Component>Test</Component>,
+      const { container } = render(<Component>Test</Component>);
+
+      expect(container.firstChild.getAttribute('class').includes('MuiComponent-slot')).to.equal(
+        true,
       );
-
-      expect(container.firstChild.getAttribute('class').includes('MuiComponent-root')).to.equal(true);
     });
 
-    it('should use muiName as className when generating the classes if className is not defined', () => {
+    it('should use name as className when slot is not specified', () => {
       const Component = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { displayName: 'Component', muiName: 'MuiComponent' },
+        { name: 'Component' },
       )`
         width: 200px;
         height: 300px;
       `;
 
-      const { container } = render(
-        <Component>Test</Component>,
-      );
-
-      expect(container.firstChild.getAttribute('class').includes('MuiComponent')).to.equal(true);
-    });
-
-    it('should use displayName as className when generating the classes if className and muiName are not defined', () => {
-      const Component = styled(
-        'div',
-        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
-        { displayName: 'Component' },
-      )`
-        width: 200px;
-        height: 300px;
-      `;
-
-      const { container } = render(
-        <Component>Test</Component>,
-      );
+      const { container } = render(<Component>Test</Component>);
 
       expect(container.firstChild.getAttribute('class').includes('Component')).to.equal(true);
     });

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -441,12 +441,20 @@ describe('experimentalStyled', () => {
 
       const { container } = render(<Component>Test</Component>);
 
-      expect(container.firstChild.getAttribute('class').includes('MuiComponent-slot')).to.equal(
-        true,
-      );
+      const classList = Array.from(container.firstChild.classList);
+      const regExp = new RegExp(`.*-MuiComponent-slot$`);
+      let containsValidClass = false;
+
+      classList.forEach((className) => {
+        if (regExp.test(className)) {
+          containsValidClass = true;
+        }
+      });
+
+      expect(containsValidClass).to.equal(true);
     });
 
-    it('should use name as className when slot is not specified', () => {
+    it('should set the className as root if no slot is specified', () => {
       const Component = styled(
         'div',
         { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
@@ -458,7 +466,17 @@ describe('experimentalStyled', () => {
 
       const { container } = render(<Component>Test</Component>);
 
-      expect(container.firstChild.getAttribute('class').includes('Component')).to.equal(true);
+      const classList = Array.from(container.firstChild.classList);
+      const regExp = new RegExp(`.*-MuiComponent-root$`);
+      let containsValidClass = false;
+
+      classList.forEach((className) => {
+        if (regExp.test(className)) {
+          containsValidClass = true;
+        }
+      });
+
+      expect(containsValidClass).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
This PR aims to resolve https://github.com/mui-org/material-ui/pull/23745#discussion_r537590851 by providing `name` and `slot` as options in the `experimentalStyled` utility.

Here is the output of both the generated HTML and the React tree.

## HTML 
Previously:
![classes old](https://user-images.githubusercontent.com/4512430/101926557-9e9a9080-3bd3-11eb-92a7-bf3ca175c8f6.png)

Now:
![Classes new](https://user-images.githubusercontent.com/4512430/101926580-a5c19e80-3bd3-11eb-9087-9765c2f13037.png)

## React tree
Previously:
![component names old dev](https://user-images.githubusercontent.com/4512430/101926918-21235000-3bd4-11eb-9e11-397d4fded09a.png)


Now:
![components new name](https://user-images.githubusercontent.com/4512430/101926622-b70aab00-3bd3-11eb-8afd-28e108e1339c.png)

