### PR TITLE
[docs] Add link to the sx docs page in the API description

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -1018,6 +1018,11 @@ async function buildDocs(options: {
         description += ' See <a href="#css">CSS API</a> below for more details.';
       }
 
+      if (propName === 'sx') {
+        // TODO: Dedupe this for l10n
+        description += ' See the <a href="/system/basics/#the-sx-prop">`sx` page</a> for more details.';
+      }
+
       componentApi.propDescriptions = {
         ...componentApi.propDescriptions,
         [propName]: description && description.replace(/\n@default.*$/, ''),

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -1020,7 +1020,8 @@ async function buildDocs(options: {
 
       if (propName === 'sx') {
         // TODO: Dedupe this for l10n
-        description += ' See the <a href="/system/basics/#the-sx-prop">`sx` page</a> for more details.';
+        description +=
+          ' See the <a href="/system/basics/#the-sx-prop">`sx` page</a> for more details.';
       }
 
       componentApi.propDescriptions = {

--- a/docs/translations/api-docs/badge/badge.json
+++ b/docs/translations/api-docs/badge/badge.json
@@ -12,7 +12,7 @@
     "max": "Max count to show.",
     "overlap": "Wrapped shape the badge should overlap.",
     "showZero": "Controls whether the badge is hidden when <code>badgeContent</code> is zero.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "variant": "The variant to use.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component."
   },

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -22,7 +22,7 @@
     "orientation": "The slider orientation.",
     "scale": "A transformation function, to change the scale of the slider.",
     "step": "The granularity with which the slider can step through values. (A &quot;discrete&quot; slider.) The <code>min</code> prop serves as the origin for the valid values. We recommend (max - min) to be evenly divisible by the step.<br>When step is <code>null</code>, the thumb can only be slid onto marks provided with the <code>marks</code> prop.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "track": "The track presentation:<br>- <code>normal</code> the track will render a bar representing the slider value. - <code>inverted</code> the track will render a bar representing the remaining slider value. - <code>false</code> the track will render without a bar.",
     "value": "The value of the slider. For ranged sliders, provide an array with two values.",
     "valueLabelDisplay": "Controls when the value label is displayed:<br>- <code>auto</code> the value label will display when the thumb is hovered or focused. - <code>on</code> will display persistently. - <code>off</code> will never display.",


### PR DESCRIPTION
This PR improves the API description for the `sx` prop by linking it's docs page.