### PR TITLE
[system] Remove visuallyHidden and move to /utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2247,7 +2247,7 @@ Big thanks to the 33 contributors who made this release possible. Here are some 
 
   ```diff
   -import Typography from '@material-ui/core/Typography';
-  +import { visuallyHidden } from '@material-ui/system';
+  +import { visuallyHidden } from '@material-ui/utils';
   +import styled from 'styled-component';
 
   +const Span = styled('span')(visuallyHidden);

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -331,7 +331,7 @@ You need to provide a text alternative that is only visible to assistive technol
 
 ```jsx
 import Icon from '@material-ui/core/Icon';
-import { visuallyHidden } from '@material-ui/system';
+import { visuallyHidden } from '@material-ui/utils';
 import { makeStyles } from '@material-ui/core/styles';
 
 const classes = makeStyles({ visuallyHidden })();

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -20,7 +20,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import DeleteIcon from '@material-ui/icons/Delete';
 import FilterListIcon from '@material-ui/icons/FilterList';
-import { visuallyHidden } from '@material-ui/system';
+import { visuallyHidden } from '@material-ui/utils';
 
 function createData(name, calories, fat, carbs, protein) {
   return {

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -19,7 +19,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import DeleteIcon from '@material-ui/icons/Delete';
 import FilterListIcon from '@material-ui/icons/FilterList';
-import { visuallyHidden } from '@material-ui/system';
+import { visuallyHidden } from '@material-ui/utils';
 import { CSSProperties } from '@material-ui/styles';
 
 interface Data {

--- a/docs/src/pages/system/screen-readers/VisuallyHiddenUsage.js
+++ b/docs/src/pages/system/screen-readers/VisuallyHiddenUsage.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Link from '@material-ui/core/Link';
-import { visuallyHidden } from '@material-ui/system';
+import { visuallyHidden } from '@material-ui/utils';
 import Box from '@material-ui/core/Box';
 
 export default function VisuallyHiddenUsage() {

--- a/docs/src/pages/system/screen-readers/VisuallyHiddenUsage.tsx
+++ b/docs/src/pages/system/screen-readers/VisuallyHiddenUsage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Link from '@material-ui/core/Link';
-import { visuallyHidden } from '@material-ui/system';
+import { visuallyHidden } from '@material-ui/utils';
 import Box from '@material-ui/core/Box';
 
 export default function VisuallyHiddenUsage() {

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -259,8 +259,6 @@ export const typography: SimpleStyleFunction<
 >;
 export type TypographyProps = PropsFor<typeof typography>;
 
-export const visuallyHidden: React.CSSProperties;
-
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function unstable_getThemeValue(prop: string, value: any, theme: object): any;
 

--- a/packages/material-ui-system/src/index.js
+++ b/packages/material-ui-system/src/index.js
@@ -20,6 +20,5 @@ export * from './spacing';
 export { default as style } from './style';
 export { default as typography } from './typography';
 export * from './typography';
-export { default as visuallyHidden } from './visuallyHidden';
 export { default as unstable_styleFunctionSx } from './styleFunctionSx';
 export { default as unstable_getThemeValue } from './getThemeValue';

--- a/packages/material-ui-utils/src/index.ts
+++ b/packages/material-ui-utils/src/index.ts
@@ -30,3 +30,4 @@ export {
   getNormalizedScrollLeft as unstable_getNormalizedScrollLeft,
 } from './scrollLeft';
 export { default as usePreviousProps } from './usePreviousProps';
+export { default as visuallyHidden } from './visuallyHidden';

--- a/packages/material-ui-utils/src/visuallyHidden.ts
+++ b/packages/material-ui-utils/src/visuallyHidden.ts
@@ -1,4 +1,6 @@
-const visuallyHidden = {
+import type { CSSProperties } from 'react';
+
+const visuallyHidden: CSSProperties = {
   border: 0,
   clip: 'rect(0 0 0 0)',
   height: 1,

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { visuallyHidden } from '@material-ui/system';
-import { chainPropTypes } from '@material-ui/utils';
+import { chainPropTypes, visuallyHidden } from '@material-ui/utils';
 import { useTheme, withStyles } from '../styles';
 import {
   capitalize,


### PR DESCRIPTION
**BREAKING CHANGE**
Only applies if you've installed `@material-ui/system@5.0.0-alpha.1`
```diff
-import { visuallyHidden } from '@material-ui/system';
+import { visuallyHidden } from '@material-ui/utils';
```


Cherry-picked from https://github.com/mui-org/material-ui/pull/23902 so that we know what's going on.

I went ahead an removed it directly from the system. It was only added during this alpha which is the whole point of an alpha: iterate on the API.

Not adding this to the v5 milestone or else it'll be considered a breaking change from v4 to v5. It's only a breaking change between alphas.