### PR TITLE
[DateRangePicker] Option to choose months in DateRangePicker

### DIFF
--- a/docs/src/pages/components/date-range-picker/BasicDateRangePicker.tsx
+++ b/docs/src/pages/components/date-range-picker/BasicDateRangePicker.tsx
@@ -14,6 +14,8 @@ export default function BasicDateRangePicker() {
         startText="Check-in"
         endText="Check-out"
         value={value}
+        monthRangeBegin={3}
+        monthRangeEnd={11}
         onChange={(newValue) => {
           setValue(newValue);
         }}

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -184,6 +184,14 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   minDate: PropTypes.any,
   /**
+   * @ignore
+   */
+  monthRangeBegin: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
+   * @ignore
+   */
+  monthRangeEnd: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
    * "OK" button text.
    * @default "OK"
    */

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerView.tsx
@@ -61,6 +61,8 @@ export function DateRangePickerView<TDate>(props: DateRangePickerViewProps<TDate
     isMobileKeyboardViewOpen,
     maxDate,
     minDate,
+    monthRangeBegin,
+    monthRangeEnd,
     onDateChange,
     onMonthChange,
     open,
@@ -99,6 +101,7 @@ export function DateRangePickerView<TDate>(props: DateRangePickerViewProps<TDate
   });
 
   const toShowToolbar = showToolbar ?? wrapperVariant !== 'desktop';
+  console.log(monthRangeBegin, monthRangeEnd);
 
   const scrollToDayIfNeeded = (day: TDate | null) => {
     if (!day || !utils.isValid(day) || isDateDisabled(day)) {
@@ -183,6 +186,8 @@ export function DateRangePickerView<TDate>(props: DateRangePickerViewProps<TDate
       disablePast,
       minDate,
       maxDate,
+      monthRangeBegin,
+      monthRangeEnd,
       ...calendarState,
       ...other,
     };

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -27,6 +27,9 @@ export interface ExportedDesktopDateRangeCalendarProps<TDate> {
    * @default 2
    */
   calendars?: 1 | 2 | 3;
+  monthRangeBegin?:  0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11; 
+  monthRangeEnd?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 ; 
+  
   /**
    * Custom renderer for `<DateRangePicker />` days. @DateIOType
    * @example (date, DateRangeDayProps) => <DateRangePickerDay {...DateRangeDayProps} />
@@ -107,6 +110,8 @@ function DateRangePickerViewDesktop<TDate>(
     maxDate: __maxDate,
     currentlySelectingRangeEnd,
     currentMonth,
+    monthRangeBegin,
+    monthRangeEnd,
     renderDay = (_, dateRangeProps) => <DateRangeDay {...dateRangeProps} />,
     ...other
   } = props;
@@ -150,12 +155,32 @@ function DateRangePickerViewDesktop<TDate>(
     [],
   );
 
+  const getNextMonthInRange = (): void => {
+    console.log(monthRangeEnd);
+    if (monthRangeBegin && utils.getMonth(currentMonth) === monthRangeEnd) {
+      const diff = 11 - Math.abs(monthRangeEnd - monthRangeBegin); 
+      changeMonth(utils.addMonths(currentMonth, -diff));
+    } else {
+      changeMonth(utils.getNextMonth(currentMonth));
+    }
+    console.log(utils.getMonth(currentMonth));
+  }
+
+  const getPrevMonthInRange = (): void => {
+    if (monthRangeEnd && utils.getMonth(currentMonth) === monthRangeBegin) {
+      const diff = 11 - Math.abs(monthRangeEnd - monthRangeBegin); 
+      changeMonth(utils.addMonths(currentMonth, diff));
+    } else {
+      changeMonth(utils.getPreviousMonth(currentMonth));
+    }
+  }
+
   const selectNextMonth = React.useCallback(() => {
-    changeMonth(utils.getNextMonth(currentMonth));
+    getNextMonthInRange();
   }, [changeMonth, currentMonth, utils]);
 
   const selectPreviousMonth = React.useCallback(() => {
-    changeMonth(utils.getPreviousMonth(currentMonth));
+    getPrevMonthInRange();
   }, [changeMonth, currentMonth, utils]);
 
   return (

--- a/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
@@ -69,6 +69,8 @@ export function makeDateRangePicker<TWrapper extends SomeWrapper>(
     calendars,
     value,
     onChange,
+    monthRangeBegin,
+    monthRangeEnd,
     mask = '__/__/____',
     startText = 'Start',
     endText = 'End',
@@ -90,8 +92,12 @@ export function makeDateRangePicker<TWrapper extends SomeWrapper>(
       ...other,
       value,
       onChange,
+      monthRangeBegin,
+      monthRangeEnd,
       inputFormat: passedInputFormat || utils.formats.keyboardDate,
     };
+
+    console.log(monthRangeBegin, monthRangeEnd);
 
     const restProps = {
       ...other,

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -162,6 +162,14 @@ const DesktopDateRangePicker = makeDateRangePicker(
    */
   minDate: PropTypes.any,
   /**
+   * @ignore
+   */
+  monthRangeBegin: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
+   * @ignore
+   */
+  monthRangeEnd: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
    * Callback fired when date is accepted @DateIOType.
    */
   onAccept: PropTypes.func,

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -178,6 +178,14 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   minDate: PropTypes.any,
   /**
+   * @ignore
+   */
+  monthRangeBegin: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
+   * @ignore
+   */
+  monthRangeEnd: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
    * "OK" button text.
    * @default "OK"
    */

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -164,6 +164,14 @@ const StaticDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', S
    */
   minDate: PropTypes.any,
   /**
+   * @ignore
+   */
+  monthRangeBegin: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
+   * @ignore
+   */
+  monthRangeEnd: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+  /**
    * Callback fired when date is accepted @DateIOType.
    */
   onAccept: PropTypes.func,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Not sure if this is was was the enhancement requested in #23957 but I added some framework to be able to select which months a user would want to display in `DateRangePicker`. If I misunderstood the request I can come back to this later or someone else can pick it up. 