### PR TITLE
[CssBaseline] Change body font size to body1 (1rem)

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -418,6 +418,23 @@ const classes = makeStyles(theme => ({
   +<Collapse classes={{ root: 'collapse' }}>
   ```
 
+### CssBaseline
+
+- The `body` font size has changed from `theme.typography.body2` (`0.875rem`) to `theme.typography.body1` (`1rem`).
+  To return to the previous size, you can override it in the theme:
+
+  ```js
+  const theme = createMuiTheme({
+    typography: {
+      body1: {
+        fontSize: '0.875rem',
+      },
+    },
+  });
+  ```
+
+(Note that this will also affect use of the Typography component with the default `body1` variant).
+
 ### Dialog
 
 - The onE\* transition props were removed. Use TransitionProps instead.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -433,7 +433,7 @@ const classes = makeStyles(theme => ({
   });
   ```
 
-(Note that this will also affect use of the Typography component with the default `body1` variant).
+  (Note that this will also affect use of the Typography component with the default `body1` variant).
 
 ### Dialog
 

--- a/packages/material-ui/src/CssBaseline/CssBaseline.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.js
@@ -22,7 +22,7 @@ const scrollBar = {
 
 export const body = (theme) => ({
   color: theme.palette.text.primary,
-  ...theme.typography.body2,
+  ...theme.typography.body1,
   backgroundColor: theme.palette.background.default,
   '@media print': {
     // Save printer ink.


### PR DESCRIPTION
### Breaking changes

- [CssBaseline] The `body` font size has changed from `theme.typography.body2` (`0.875rem`) to `theme.typography.body1` (`1rem`).
  To return to the previous size, you can override it in the theme:

  ```js
  const theme = createMuiTheme({
    typography: {
      body1: {
        fontSize: '0.875rem',
      },
    },
  });
  ```

  (Note that this will also affect use of the Typography component with the default `body1` variant).

---

Closes #17100
Part of #20012
