### PR TITLE
[core] Track size of /unstyled

### DIFF
--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -81,7 +81,7 @@ async function getWebpackEntries() {
     },
     {
       name: '@material-ui/unstyled',
-      path: 'packages/material-ui-unstyled/build/esm/index.js',
+      path: 'packages/material-ui-unstyled/build/index.js',
     },
     {
       name: '@material-ui/utils',

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -80,6 +80,10 @@ async function getWebpackEntries() {
       path: 'packages/material-ui/build/useScrollTrigger/index.js',
     },
     {
+      name: '@material-ui/unstyled',
+      path: 'packages/material-ui-unstyled/build/esm/index.js',
+    },
+    {
       name: '@material-ui/utils',
       path: 'packages/material-ui-utils/build/esm/index.js',
     },


### PR DESCRIPTION
Ideally we would track individual component. Though we should look at the time this adds to CI if we've got a bit more components. 

For now tracking the package size is more of a smoke test to verify that the package is built properly and we're not pulling in something big.

Update: 6.14 kB seems fine.