### PR TITLE
[core] Batch small changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.0.0-alpha.19
 
+###### _Dec 13, 2020_
+
 Big thanks to the 24 contributors who made this release possible. Here are some highlights ✨:
 
 - 👩‍🎤 Migrate the Badge to emotion (#23745) @mnajdova.
@@ -128,6 +130,8 @@ Big thanks to the 24 contributors who made this release possible. Here are some 
 
 ## 5.0.0-alpha.18
 
+###### _Dec 3, 2020_
+
 Big thanks to the 17 contributors who made this release possible. Here are some highlights ✨:
 
 - Fix most of the issues with the system (#23716, #23635, #23737, #23733, #23700, #23688) @mnajdova.
@@ -218,7 +222,7 @@ Big thanks to the 17 contributors who made this release possible. Here are some 
 
 ## 5.0.0-alpha.17
 
-###### _Nov 23 2020_
+###### _Nov 23, 2020_
 
 Big thanks to the 18 contributors who made this release possible. Here are some highlights ✨:
 
@@ -366,7 +370,7 @@ Big thanks to the 18 contributors who made this release possible. Here are some 
 
 ## 5.0.0-alpha.16
 
-###### _Nov 14 2020_
+###### _Nov 14, 2020_
 
 Big thanks to the 34 contributors who made this release possible. Here are some highlights ✨:
 
@@ -470,7 +474,7 @@ Big thanks to the 34 contributors who made this release possible. Here are some 
 
 ## 5.0.0-alpha.15
 
-###### _Nov 4 2020_
+###### _Nov 4, 2020_
 
 Big thanks to the 20 contributors who made this release possible. Here are some highlights ✨:
 
@@ -582,7 +586,7 @@ Big thanks to the 20 contributors who made this release possible. Here are some 
 
 ## 5.0.0-alpha.14
 
-###### _Oct 23 2020_
+###### _Oct 23, 2020_
 
 Big thanks to the 23 contributors who made this release possible.
 Here are some highlights ✨:
@@ -753,7 +757,7 @@ Here are some highlights ✨:
 
 ## 5.0.0-alpha.13
 
-###### _Oct 17 2020_
+###### _Oct 17, 2020_
 
 Big thanks to the 25 contributors who made this release possible.
 Here are some highlights ✨:

--- a/docs/package.json
+++ b/docs/package.json
@@ -125,7 +125,6 @@
     "@types/marked": "^1.2.1",
     "@types/recharts": "^1.8.14",
     "babel-plugin-unwrap-createstyles": "5.0.0-alpha.0",
-    "cpy-cli": "^3.0.0",
     "cross-fetch": "^3.0.5",
     "gm": "^1.23.0"
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production next build --profile",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "rimraf ./node_modules/.cache/babel-loader && next dev",
+    "dev": "rimraf ./node_modules/.cache/babel-loader && rimraf ./.next/cache/ && next dev",
     "deploy": "git push material-ui-docs next:next",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production next build --profile",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "rimraf ./node_modules/.cache/babel-loader && rimraf ./.next/cache/ && next dev",
+    "dev": "rimraf ./node_modules/.cache/babel-loader && next dev",
     "deploy": "git push material-ui-docs next:next",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",

--- a/docs/pages/api-docs/badge-unstyled.json
+++ b/docs/pages/api-docs/badge-unstyled.json
@@ -69,6 +69,6 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js",
   "inheritance": null,
-  "demos": "",
+  "demos": "<ul><li><a href=\"/components/badges/\">Badges</a></li></ul>",
   "styledComponent": true
 }

--- a/docs/src/pages/components/badges/UnstyledBadge.js
+++ b/docs/src/pages/components/badges/UnstyledBadge.js
@@ -53,7 +53,7 @@ const StyledBadge = styled(BadgeUnstyled)`
   }
 `;
 
-const BadgeContent = () => {
+function BadgeContent() {
   return (
     <Box
       sx={{
@@ -66,7 +66,7 @@ const BadgeContent = () => {
       }}
     />
   );
-};
+}
 
 export default function UnstyledBadge() {
   return (

--- a/docs/src/pages/components/badges/UnstyledBadge.tsx
+++ b/docs/src/pages/components/badges/UnstyledBadge.tsx
@@ -59,7 +59,7 @@ const StyledBadge: React.FC<StyledBadgeProps> = styled(BadgeUnstyled)`
   }
 `;
 
-const BadgeContent = () => {
+function BadgeContent() {
   return (
     <Box
       sx={{
@@ -72,7 +72,7 @@ const BadgeContent = () => {
       }}
     />
   );
-};
+}
 
 export default function UnstyledBadge() {
   return (

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -1,6 +1,6 @@
 ---
 title: React Badge component
-components: Badge
+components: Badge, BadgeUnstyled
 githubLabel: 'component: Badge'
 ---
 

--- a/docs/src/pages/customization/palette/Intentions.js
+++ b/docs/src/pages/customization/palette/Intentions.js
@@ -18,6 +18,7 @@ const useStyles = makeStyles((theme) => ({
       height: theme.spacing(6),
       marginRight: theme.spacing(1),
       borderRadius: theme.shape.borderRadius,
+      boxShadow: 'inset 0 2px 4px 0 rgba(0, 0, 0, .06)',
     },
   },
 }));

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -15,7 +15,7 @@ A set of reusable components for design tools is available, designed to match th
 
 - [Figma](https://material-ui.com/store/items/figma-react/?utm_source=docs&utm_medium=referral&utm_campaign=related-projects-figma): A large UI kit with over 600 handcrafted Material-UI components.
 - [Sketch](https://material-ui.com/store/items/sketch-react/?utm_source=docs&utm_medium=referral&utm_campaign=related-projects-sketch): A large UI kit with over 600 handcrafted Material-UI symbols.
-- [Adobe XD](https://material-ui.com/store/items/adobe-xd-react/?utm_source=docs&utm_medium=referral&utm_campaign=related-projects-adobe-xd): A large UI kit with over 600 handcrafted Material-UI symbols.
+- [Adobe XD](https://material-ui.com/store/items/adobe-xd-react/?utm_source=docs&utm_medium=referral&utm_campaign=related-projects-adobe-xd): A large UI kit with over 600 handcrafted Material-UI components.
 - [Framer](https://packages.framer.com/package/material-ui/material-ui): A small free UI kit of Material-UI components.
 
 ## Images and illustrations

--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -88,5 +88,5 @@ A set of reusable components for design tools is available, designed to match th
 
 - [Figma](https://material-ui.com/store/items/figma-react/?utm_source=docs&utm_medium=referral&utm_campaign=installation-figma): A large UI kit with over 600 handcrafted Material-UI components.
 - [Sketch](https://material-ui.com/store/items/sketch-react/?utm_source=docs&utm_medium=referral&utm_campaign=installation-sketch): A large UI kit with over 600 handcrafted Material-UI symbols.
-- [Adobe XD](https://material-ui.com/store/items/adobe-xd-react/?utm_source=docs&utm_medium=referral&utm_campaign=installation-adobe-xd): A large UI kit with over 600 handcrafted Material-UI symbols.
+- [Adobe XD](https://material-ui.com/store/items/adobe-xd-react/?utm_source=docs&utm_medium=referral&utm_campaign=installation-adobe-xd): A large UI kit with over 600 handcrafted Material-UI components.
 - [Framer](https://packages.framer.com/package/material-ui/material-ui): A small free UI kit of Material-UI components.

--- a/docs/src/pages/getting-started/templates/checkout/Checkout.js
+++ b/docs/src/pages/getting-started/templates/checkout/Checkout.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
+import Container from '@material-ui/core/Container';
 import Toolbar from '@material-ui/core/Toolbar';
 import Paper from '@material-ui/core/Paper';
 import Stepper from '@material-ui/core/Stepper';
@@ -30,16 +31,10 @@ function Copyright() {
 const useStyles = makeStyles((theme) => ({
   appBar: {
     position: 'relative',
+    borderBottom: `1px solid ${theme.palette.divider}`,
   },
-  layout: {
-    width: 'auto',
-    marginLeft: theme.spacing(2),
-    marginRight: theme.spacing(2),
-    [theme.breakpoints.up('md')]: {
-      width: 600,
-      marginLeft: 'auto',
-      marginRight: 'auto',
-    },
+  main: {
+    marginBottom: theme.spacing(4),
   },
   paper: {
     marginTop: theme.spacing(3),
@@ -94,15 +89,20 @@ export default function Checkout() {
   return (
     <React.Fragment>
       <CssBaseline />
-      <AppBar position="absolute" color="default" className={classes.appBar}>
+      <AppBar
+        position="absolute"
+        color="default"
+        elevation={0}
+        className={classes.appBar}
+      >
         <Toolbar>
           <Typography variant="h6" color="inherit" noWrap>
             Company name
           </Typography>
         </Toolbar>
       </AppBar>
-      <main className={classes.layout}>
-        <Paper className={classes.paper}>
+      <Container component="main" className={classes.main} maxWidth="sm">
+        <Paper className={classes.paper} variant="outlined">
           <Typography component="h1" variant="h4" align="center">
             Checkout
           </Typography>
@@ -148,7 +148,7 @@ export default function Checkout() {
           </React.Fragment>
         </Paper>
         <Copyright />
-      </main>
+      </Container>
     </React.Fragment>
   );
 }

--- a/docs/src/pages/getting-started/templates/checkout/Checkout.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/Checkout.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
+import Container from '@material-ui/core/Container';
 import Toolbar from '@material-ui/core/Toolbar';
 import Paper from '@material-ui/core/Paper';
 import Stepper from '@material-ui/core/Stepper';
@@ -30,16 +31,10 @@ function Copyright() {
 const useStyles = makeStyles((theme) => ({
   appBar: {
     position: 'relative',
+    borderBottom: `1px solid ${theme.palette.divider}`,
   },
-  layout: {
-    width: 'auto',
-    marginLeft: theme.spacing(2),
-    marginRight: theme.spacing(2),
-    [theme.breakpoints.up('md')]: {
-      width: 600,
-      marginLeft: 'auto',
-      marginRight: 'auto',
-    },
+  main: {
+    marginBottom: theme.spacing(4),
   },
   paper: {
     marginTop: theme.spacing(3),
@@ -94,15 +89,15 @@ export default function Checkout() {
   return (
     <React.Fragment>
       <CssBaseline />
-      <AppBar position="absolute" color="default" className={classes.appBar}>
+      <AppBar position="absolute" color="default" elevation={0} className={classes.appBar}>
         <Toolbar>
           <Typography variant="h6" color="inherit" noWrap>
             Company name
           </Typography>
         </Toolbar>
       </AppBar>
-      <main className={classes.layout}>
-        <Paper className={classes.paper}>
+      <Container component="main" className={classes.main} maxWidth="sm">
+        <Paper className={classes.paper} variant="outlined">
           <Typography component="h1" variant="h4" align="center">
             Checkout
           </Typography>
@@ -147,7 +142,7 @@ export default function Checkout() {
           </React.Fragment>
         </Paper>
         <Copyright />
-      </main>
+      </Container>
     </React.Fragment>
   );
 }

--- a/docs/src/pages/getting-started/templates/checkout/Checkout.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/Checkout.tsx
@@ -89,7 +89,12 @@ export default function Checkout() {
   return (
     <React.Fragment>
       <CssBaseline />
-      <AppBar position="absolute" color="default" elevation={0} className={classes.appBar}>
+      <AppBar
+        position="absolute"
+        color="default"
+        elevation={0}
+        className={classes.appBar}
+      >
         <Toolbar>
           <Typography variant="h6" color="inherit" noWrap>
             Company name

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.js
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.js
@@ -106,7 +106,7 @@ export default function SignIn() {
           </Grid>
         </form>
       </div>
-      <Box sx={{ mt: 8 }}>
+      <Box sx={{ mt: 8, mb: 4 }}>
         <Copyright />
       </Box>
     </Container>

--- a/docs/src/pages/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/src/pages/getting-started/templates/sign-in/SignIn.tsx
@@ -106,7 +106,7 @@ export default function SignIn() {
           </Grid>
         </form>
       </div>
-      <Box sx={{ mt: 8 }}>
+      <Box sx={{ mt: 8, mb: 4 }}>
         <Copyright />
       </Box>
     </Container>

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -393,7 +393,7 @@ const classes = makeStyles(theme => ({
   +<Box sx={{ border: "1px dashed grey", p: [2, 3, 4], m: 2 }}>
   ```
 
-[This codemod](https://github.com/mui-org/material-ui/tree/HEAD/packages/material-ui-codemod#box-sx-prop) will automatically update your code to the new syntax.
+  [This codemod](https://github.com/mui-org/material-ui/tree/HEAD/packages/material-ui-codemod#box-sx-prop) will automatically update your code to the new syntax.
 
 - The `borderRadius` system prop value transformation has been changed. If it receives a number, it multiplies this value with the `theme.shape.borderRadius` value. Use a string to provide an explicit value, in `px`.
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -394,6 +394,7 @@ const classes = makeStyles(theme => ({
   ```
 
   [This codemod](https://github.com/mui-org/material-ui/tree/HEAD/packages/material-ui-codemod#box-sx-prop) will automatically update your code to the new syntax.
+  You can [read this section](/system/basics/#api-tradeoff) for the why behind the change of API.
 
 - The `borderRadius` system prop value transformation has been changed. If it receives a number, it multiplies this value with the `theme.shape.borderRadius` value. Use a string to provide an explicit value, in `px`.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,11 +4092,6 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-arrify@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
-  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
-
 asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -5968,37 +5963,6 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
-
-cp-file@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-7.0.0.tgz#b9454cfd07fe3b974ab9ea0e5f29655791a9b8cd"
-  integrity sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    make-dir "^3.0.0"
-    nested-error-stacks "^2.0.0"
-    p-event "^4.1.0"
-
-cpy-cli@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/cpy-cli/-/cpy-cli-3.1.1.tgz#2adb06544102c948ce098e522d5b8ddcf4f7c0b4"
-  integrity sha512-HCpNdBkQy3rw+uARLuIf0YurqsMXYzBa9ihhSAuxYJcNIrqrSq3BstPfr0cQN38AdMrQiO9Dp4hYy7GtGJsLPg==
-  dependencies:
-    cpy "^8.0.0"
-    meow "^6.1.1"
-
-cpy@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cpy/-/cpy-8.0.0.tgz#8195db0db19a9ea6aa4f229784cbf3e3f53c3158"
-  integrity sha512-iTjLUqtVr45e17GFAyxA0lqFinbGMblMCTtAqrPzT/IETNtDuyyhDDk8weEZ08MiCc6EcuyNq2KtGH5J2BIAoQ==
-  dependencies:
-    arrify "^2.0.1"
-    cp-file "^7.0.0"
-    globby "^9.2.0"
-    is-glob "^4.0.1"
-    junk "^3.1.0"
-    nested-error-stacks "^2.1.0"
-    p-all "^2.1.0"
 
 crc32-stream@^3.0.1:
   version "3.0.1"
@@ -10343,11 +10307,6 @@ jss@10.5.0, jss@^10.0.3:
     array-includes "^3.1.1"
     object.assign "^4.1.1"
 
-junk@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
-  integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
-
 just-extend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
@@ -11192,23 +11151,6 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
-meow@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
-  integrity sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==
-  dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "^4.0.2"
-    normalize-package-data "^2.5.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.13.1"
-    yargs-parser "^18.1.3"
-
 meow@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.0.0.tgz#1aa10ee61046719e334ffdc038bb5069250ec99a"
@@ -11395,7 +11337,7 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@4.1.0, minimist-options@^4.0.2:
+minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
   integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
@@ -11719,11 +11661,6 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
-  integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
 next-tick@~1.0.0:
   version "1.0.0"
@@ -12405,24 +12342,10 @@ override-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/override-require/-/override-require-1.1.1.tgz#6ae22fadeb1f850ffb0cf4c20ff7b87e5eb650df"
   integrity sha1-auIvresfhQ/7DPTCD/e4fl62UN8=
 
-p-all@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-all/-/p-all-2.1.0.tgz#91419be56b7dee8fe4c5db875d55e0da084244a0"
-  integrity sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==
-  dependencies:
-    p-map "^2.0.0"
-
 p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
-
-p-event@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
-  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
-  dependencies:
-    p-timeout "^3.1.0"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -12485,7 +12408,7 @@ p-map-series@^1.0.0:
   dependencies:
     p-reduce "^1.0.0"
 
-p-map@^2.0.0, p-map@^2.1.0:
+p-map@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
@@ -12520,13 +12443,6 @@ p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
-
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -16434,11 +16350,6 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type-fest@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
-  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
 type-fest@^0.18.0:
   version "0.18.1"


### PR DESCRIPTION
- [docs] Apply documentation convention 99e194c: prefer function in the docs
- [docs] Add missing link for badge API 638a4e4: for consistency with slider
- [docs] Adobe XD has components not symbols 733f561: a fact
- [core] cpy-cli is no longer used 684eebc: self explanatory
- [CHANGELOG] Fix small mistake e9a8bfc: oops, my bad
- [docs] Fix indentation ffe8b65: to better render
- [docs] Link rational, in case we don't rollback 2a473d1: We have talked about taking a step back and introduce. the props back. The discussion starts at https://github.com/mui-org/material-ui/issues/22342#issuecomment-745604270.
- ~[docs] Clear .next cache f96b45f: I have faced an issue with Marija unstyled components where I needed to clear the cache. We probably want to do it anytime anyway.~
- [docs] Update a bit the templates to the latest API and design prefer abba8db: I'm excited about the opportunity we have to improve the templates in v5. We can remove almost all the withStyles with the system. We can update the design to be more aligned with how Material Design is used by Google on desktop products. We can use the DataGrid component in the dashboard demo.
- [docs] Add a light box-shadow touch 59eac37: a nice touch that helps when the color is light, to create contrast with its white surrounding.
