### PR TITLE
[docs] Improve displayed versions

### DIFF
--- a/docs/pages/versions.js
+++ b/docs/pages/versions.js
@@ -32,10 +32,10 @@ async function getBranches() {
 }
 
 Page.getInitialProps = async () => {
-  const FILTERED_BRANCHES = ['latest', 'staging', 'l10n', 'next'];
+  const FILTERED_BRANCHES = ['latest', 'l10n', 'next'];
 
   const branches = await getBranches();
-  let versions = branches.map((n) => n.name);
+  let versions = branches.map((branch) => branch.name);
   versions = versions.filter((value) => FILTERED_BRANCHES.indexOf(value) === -1);
   versions = versions.map((version) => ({
     version,
@@ -55,6 +55,17 @@ Page.getInitialProps = async () => {
   versions = versions.sort((a, b) =>
     formatVersion(b.version).localeCompare(formatVersion(a.version)),
   );
+
+  if (
+    branches.find((branch) => branch.name === 'next') &&
+    !versions.find((version) => /beta|alpha/.test(version.version))
+  ) {
+    versions.unshift({
+      version: `v${Number(versions[0].version[1]) + 1} pre-release`,
+      url: 'https://next.material-ui.com',
+    });
+  }
+
   versions = sortedUniqBy(versions, 'version');
 
   const { demos, docs } = prepareMarkdown({ pageFilename, requireRaw });

--- a/docs/src/pages/versions/ReleasedVersions.js
+++ b/docs/src/pages/versions/ReleasedVersions.js
@@ -20,7 +20,7 @@ const styles = {
   },
 };
 
-function StableVersions(props) {
+function ReleasedVersions(props) {
   const { classes } = props;
   const { versions } = React.useContext(PageContext);
 
@@ -47,7 +47,8 @@ function StableVersions(props) {
                 </Link>
               </TableCell>
               <TableCell>
-                {doc.version.length >= 6 ? (
+                {doc.version.length >= 6 &&
+                doc.version.indexOf('pre-release') === -1 ? (
                   <Link
                     variant="body2"
                     color="secondary"
@@ -66,8 +67,8 @@ function StableVersions(props) {
   );
 }
 
-StableVersions.propTypes = {
+ReleasedVersions.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(StableVersions);
+export default withStyles(styles)(ReleasedVersions);

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -2,11 +2,11 @@
 
 <p class="description">You can come back to this page and switch the version of the docs you're reading at any time.</p>
 
-## Stable versions
+## Released versions
 
-The most recent version is recommended in production.
+The most recent stable version is recommended in production.
 
-{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
+{{"demo": "pages/versions/ReleasedVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Latest versions
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -4,7 +4,7 @@
 
 ## Released versions
 
-The most recent stable version is recommended in production.
+The most recent stable version (✓) is recommended for use in production.
 
 {{"demo": "pages/versions/ReleasedVersions.js", "hideToolbar": true, "bg": "inline"}}
 


### PR DESCRIPTION
Problems with v5:

- Release note link is broken
- Documentation link is broken
- v5 is not a stable release

<img width="850" alt="Capture d’écran 2020-12-20 à 00 08 45" src="https://user-images.githubusercontent.com/3165635/102701463-8bcd2f00-4257-11eb-958e-e828c55be169.png">

https://material-ui.com/versions/

The solution:

<img width="866" alt="Capture d’écran 2020-12-20 à 00 05 43" src="https://user-images.githubusercontent.com/3165635/102701458-7ce67c80-4257-11eb-8a91-16d4fd6cd77d.png">
