### PR TITLE
[docs] Show a better file on codesandbox

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -279,6 +279,7 @@ export default function DemoToolbar(props) {
     form.target = '_blank';
     form.action = 'https://codeSandbox.io/api/v1/sandboxes/define';
     addHiddenInput(form, 'parameters', parameters);
+    addHiddenInput(form, 'query', 'file=/demo.tsx');
     document.body.appendChild(form);
     form.submit();
     document.body.removeChild(form);


### PR DESCRIPTION
I got the idea for this change during a user-interview this week. The user was frustrating about having to click each time to display the correct file. In hindsight, it does seem obvious. Here is the change after opening a demo in Codesandbox:

**Before** 

<img width="857" alt="Capture d’écran 2020-12-20 à 00 19 27" src="https://user-images.githubusercontent.com/3165635/102701617-0cd8f600-4259-11eb-9b6f-3dea32c466ed.png">

**After**

<img width="889" alt="Capture d’écran 2020-12-20 à 00 19 19" src="https://user-images.githubusercontent.com/3165635/102701623-195d4e80-4259-11eb-99bc-0fa697685b60.png">
