### PR TITLE
[system] Replace grid gap properties

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -273,6 +273,7 @@ const classes = makeStyles(theme => ({
 ### System
 
 - The following system functions (and properties) were renamed, because they are considered deprecated CSS:
+
 1. `gridGap` to `gap`
 2. `gridColumnGap` to `columnGap`
 3. `gridRowGap` to `rowGap`
@@ -422,19 +423,20 @@ As the core components use emotion as a styled engine, the props used by emotion
   ```
 
 - The following properties were renamed, because they are considered deprecated CSS proeprties:
+
 1. `gridGap` to `gap`
 2. `gridColumnGap` to `columnGap`
 3. `gridRowGap` to `rowGap`
 
-  ```diff
-  -<Box gridGap='10px'>
-  +<Box sx={{ gap: '10px' }}>
-  ```
+```diff
+-<Box gridGap='10px'>
++<Box sx={{ gap: '10px' }}>
+```
 
-  ```diff
-  -<Box gridColumnGap='10px' gridRowGap='20px'>
-  +<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
-  ```
+```diff
+-<Box gridColumnGap='10px' gridRowGap='20px'>
++<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
+```
 
 ### Button
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -270,6 +270,13 @@ const classes = makeStyles(theme => ({
 }));
 ```
 
+### System
+
+The following system functions (and properties) were renamed, because they are considered deprecated CSS:
+- `gridGap` to `gap`
+- `gridColumnGap` to `columnGap`
+- `gridRowGap` to `rowGap`
+
 ### Core components
 
 As the core components use emotion as a styled engine, the props used by emotion are not intercepted. The prop `as` in the following codesnippet will not be propagated to the `SomeOtherComponent`.
@@ -412,6 +419,23 @@ As the core components use emotion as a styled engine, the props used by emotion
   ```diff
   -<Box sx={{ borderRadius: 16 }}>
   +<Box sx={{ borderRadius: '16px' }}>
+  ```
+
+#### Box
+
+The following properties were renamed, because they are considered deprecated CSS proeprties:
+- `gridGap` to `gap`
+- `gridColumnGap` to `columnGap`
+- `gridRowGap` to `rowGap`
+
+  ```diff
+  -<Box gridGap='10px'>
+  +<Box sx={{ gap: '10px' }}>
+  ```
+
+  ```diff
+  -<Box gridColumnGap='10px' gridRowGap='20px'>
+  +<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
   ```
 
 ### Button

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -272,10 +272,10 @@ const classes = makeStyles(theme => ({
 
 ### System
 
-The following system functions (and properties) were renamed, because they are considered deprecated CSS:
-- `gridGap` to `gap`
-- `gridColumnGap` to `columnGap`
-- `gridRowGap` to `rowGap`
+- The following system functions (and properties) were renamed, because they are considered deprecated CSS:
+1. `gridGap` to `gap`
+2. `gridColumnGap` to `columnGap`
+3. `gridRowGap` to `rowGap`
 
 ### Core components
 
@@ -421,12 +421,10 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Box sx={{ borderRadius: '16px' }}>
   ```
 
-#### Box
-
-The following properties were renamed, because they are considered deprecated CSS proeprties:
-- `gridGap` to `gap`
-- `gridColumnGap` to `columnGap`
-- `gridRowGap` to `rowGap`
+- The following properties were renamed, because they are considered deprecated CSS proeprties:
+1. `gridGap` to `gap`
+2. `gridColumnGap` to `columnGap`
+3. `gridRowGap` to `rowGap`
 
   ```diff
   -<Box gridGap='10px'>

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -428,15 +428,15 @@ As the core components use emotion as a styled engine, the props used by emotion
 2. `gridColumnGap` to `columnGap`
 3. `gridRowGap` to `rowGap`
 
-  ```diff
-  -<Box gridGap="10px">
-  +<Box sx={{ gap: '10px' }}>
-  ```
+```diff
+-<Box gridGap="10px">
++<Box sx={{ gap: '10px' }}>
+```
 
-  ```diff
-  -<Box gridColumnGap="10px" gridRowGap="20px">
-  +<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
-  ```
+```diff
+-<Box gridColumnGap="10px" gridRowGap="20px">
++<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
+```
 
 ### Button
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -428,15 +428,15 @@ As the core components use emotion as a styled engine, the props used by emotion
 2. `gridColumnGap` to `columnGap`
 3. `gridRowGap` to `rowGap`
 
-```diff
--<Box gridGap='10px'>
-+<Box sx={{ gap: '10px' }}>
-```
+  ```diff
+  -<Box gridGap="10px">
+  +<Box sx={{ gap: '10px' }}>
+  ```
 
-```diff
--<Box gridColumnGap='10px' gridRowGap='20px'>
-+<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
-```
+  ```diff
+  -<Box gridColumnGap="10px" gridRowGap="20px">
+  +<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
+  ```
 
 ### Button
 

--- a/packages/material-ui-system/src/grid.js
+++ b/packages/material-ui-system/src/grid.js
@@ -1,16 +1,16 @@
 import style from './style';
 import compose from './compose';
 
-export const gridGap = style({
-  prop: 'gridGap',
+export const gap = style({
+  prop: 'gap',
 });
 
-export const gridColumnGap = style({
-  prop: 'gridColumnGap',
+export const columnGap = style({
+  prop: 'columnGap',
 });
 
-export const gridRowGap = style({
-  prop: 'gridRowGap',
+export const rowGap = style({
+  prop: 'rowGap',
 });
 
 export const gridColumn = style({
@@ -50,9 +50,9 @@ export const gridArea = style({
 });
 
 const grid = compose(
-  gridGap,
-  gridColumnGap,
-  gridRowGap,
+  gap,
+  columnGap,
+  rowGap,
   gridColumn,
   gridRow,
   gridAutoFlow,

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -91,9 +91,9 @@ export type FlexboxProps = PropsFor<typeof flexbox>;
 
 // grid.js
 export const grid: SimpleStyleFunction<
-  | 'gridGap'
-  | 'gridColumnGap'
-  | 'gridRowGap'
+  | 'gap'
+  | 'columnGap'
+  | 'rowGap'
   | 'gridColumn'
   | 'gridRow'
   | 'gridAutoFlow'


### PR DESCRIPTION
## BREAKING CHANGES 

The following properties were renamed because they are considered deprecated CSS properties:
1. `gridGap` to `gap`
2. `gridColumnGap` to `columnGap`
3. `gridRowGap` to `rowGap`

  ```diff
  -<Box gridGap="10px">
  +<Box sx={{ gap: '10px' }}>
  ```

  ```diff
  -<Box gridColumnGap="10px" gridRowGap="20px">
  +<Box sx={{ columnGap: '10px', rowGap: '20px' }}>
  ```