### PR TITLE
[TreeView] Add preventScroll for tree focus

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -223,7 +223,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   function handleFocus(event) {
     // DOM focus stays on the tree which manages focus with aria-activedescendant
     if (event.target === event.currentTarget) {
-      ownerDocument(event.target).getElementById(treeId).focus();
+      ownerDocument(event.target).getElementById(treeId).focus({ preventScroll: true });
     }
 
     const unfocusable = !disabledItemsFocusable && disabled;

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -414,6 +414,22 @@ describe('<TreeItem />', () => {
 
         expect(getByTestId('parent')).toHaveVirtualFocus();
       });
+
+      it('should focus on tree with scroll prevented', () => {
+        const { getByRole, getByTestId } = render(
+          <TreeView>
+            <TreeItem nodeId="1" label="one" data-testid="one" />
+            <TreeItem nodeId="2" label="two" data-testid="two" />
+          </TreeView>,
+        );
+        const focus = spy(getByRole('tree'), 'focus');
+
+        act(() => {
+          getByTestId('one').focus();
+        });
+
+        expect(focus.calledOnceWithExactly({ preventScroll: true })).to.equals(true);
+      });
     });
 
     describe('Navigation', () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Add prevent scroll when DOM tree is focused, which disables scroll to view of the focused element.

### Why is it needed?
`preventScroll` should restrict scroll, hence preventing scroll jump

### Related issue(s)/PR(s)
Closes #24096 