### PR TITLE
[DatePicker] Hide outline on container

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -86,7 +86,7 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -100,7 +100,7 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -112,7 +112,7 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
    */
   dateAdapter: PropTypes.object,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -186,7 +186,7 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
     PropTypes.string,
   ]),
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -251,7 +251,7 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
    */
   rifmFormatter: PropTypes.func,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -260,7 +260,7 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
    */
   showToolbar: PropTypes.bool,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -34,7 +34,7 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -48,7 +48,7 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -71,7 +71,7 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   desktopModeMediaQuery: PropTypes.string,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -184,7 +184,7 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   minDate: PropTypes.any,
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -312,7 +312,7 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   showDaysOutsideCurrentMonth: PropTypes.bool,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -326,7 +326,7 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   startText: PropTypes.node,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -172,7 +172,7 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   ampmInClock: PropTypes.bool,
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -186,7 +186,7 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -213,7 +213,7 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   desktopModeMediaQuery: PropTypes.string,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -379,7 +379,7 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   minutesStep: PropTypes.number,
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -509,7 +509,7 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   showDaysOutsideCurrentMonth: PropTypes.bool,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -522,7 +522,7 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   timeIcon: PropTypes.node,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -30,7 +30,7 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -44,7 +44,7 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -56,7 +56,7 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   dateAdapter: PropTypes.object,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -130,7 +130,7 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
     PropTypes.string,
   ]),
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -195,7 +195,7 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   rifmFormatter: PropTypes.func,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -204,7 +204,7 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   showToolbar: PropTypes.bool,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -34,7 +34,7 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -48,7 +48,7 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -65,7 +65,7 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   defaultCalendarMonth: PropTypes.any,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -178,7 +178,7 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   minDate: PropTypes.any,
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -302,7 +302,7 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   showDaysOutsideCurrentMonth: PropTypes.bool,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -316,7 +316,7 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   startText: PropTypes.node,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -50,7 +50,7 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   ampmInClock: PropTypes.bool,
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -64,7 +64,7 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -85,7 +85,7 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   defaultCalendarMonth: PropTypes.any,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -251,7 +251,7 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   minutesStep: PropTypes.number,
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -377,7 +377,7 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   showDaysOutsideCurrentMonth: PropTypes.bool,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -390,7 +390,7 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   timeIcon: PropTypes.node,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -42,7 +42,7 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   ampmInClock: PropTypes.bool,
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -56,7 +56,7 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -68,7 +68,7 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   dateAdapter: PropTypes.object,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -157,7 +157,7 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   minutesStep: PropTypes.number,
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -231,7 +231,7 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   shouldDisableTime: PropTypes.func,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -240,7 +240,7 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   showToolbar: PropTypes.bool,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/MonthPicker/PickersMonth.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/PickersMonth.tsx
@@ -20,7 +20,7 @@ export const styles = (theme: Theme) =>
       alignItems: 'center',
       justifyContent: 'center',
       cursor: 'pointer',
-      outline: 'none',
+      outline: 0,
       height: 64,
       transition: theme.transitions.create('font-size', { duration: '100ms' }),
       '&:focus': {

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -113,7 +113,7 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   ampmInClock: PropTypes.bool,
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText: PropTypes.node,
@@ -127,7 +127,7 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   clearable: PropTypes.bool,
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText: PropTypes.node,
@@ -145,7 +145,7 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   desktopModeMediaQuery: PropTypes.string,
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps: PropTypes.object,
   /**
@@ -234,7 +234,7 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   minutesStep: PropTypes.number,
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText: PropTypes.node,
@@ -312,7 +312,7 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   shouldDisableTime: PropTypes.func,
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton: PropTypes.bool,
@@ -321,7 +321,7 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   showToolbar: PropTypes.bool,
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText: PropTypes.node,

--- a/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
@@ -132,16 +132,8 @@ const PickersModalDialog: React.FC<PickerModalDialogProps & WithStyles<typeof st
             {todayText}
           </Button>
         )}
-        {cancelText && (
-          <Button onClick={onDismiss}>
-            {cancelText}
-          </Button>
-        )}
-        {okText && (
-          <Button onClick={onAccept}>
-            {okText}
-          </Button>
-        )}
+        {cancelText && <Button onClick={onDismiss}>{cancelText}</Button>}
+        {okText && <Button onClick={onAccept}>{okText}</Button>}
       </DialogActions>
     </Dialog>
   );

--- a/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
@@ -9,22 +9,22 @@ import { DIALOG_WIDTH, DIALOG_WIDTH_WIDER } from './constants/dimensions';
 
 export interface ExportedPickerModalProps {
   /**
-   * "OK" button text.
+   * Ok button text.
    * @default "OK"
    */
   okText?: React.ReactNode;
   /**
-   * "CANCEL" Text message
+   * Cancel text message
    * @default "CANCEL"
    */
   cancelText?: React.ReactNode;
   /**
-   * "CLEAR" Text message
+   * Clear text message
    * @default "CLEAR"
    */
   clearText?: React.ReactNode;
   /**
-   * "TODAY" Text message
+   * Today text message
    * @default "TODAY"
    */
   todayText?: React.ReactNode;
@@ -34,12 +34,12 @@ export interface ExportedPickerModalProps {
    */
   clearable?: boolean;
   /**
-   * If `true`, the today button will be displayed. **Note** that `showClearButton` has a higher priority.
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
    * @default false
    */
   showTodayButton?: boolean;
   /**
-   * Props to be passed directly to material-ui [Dialog](https://material-ui.com/components/dialogs)
+   * Props applied to the [`Dialog`](/api/dialog/) element.
    */
   DialogProps?: Partial<MuiDialogProps>;
 }
@@ -54,33 +54,26 @@ export interface PickerModalDialogProps extends ExportedPickerModalProps {
 }
 
 export const styles = createStyles({
-  dialogRoot: {
+  container: {
+    outline: 0,
+  },
+  paper: {
+    outline: 0,
     minWidth: DIALOG_WIDTH,
   },
-  dialogRootWider: {
+  paperWider: {
     minWidth: DIALOG_WIDTH_WIDER,
   },
-  dialogContainer: {
-    '&:focus > $dialogRoot': {
-      outline: 'auto',
-      '@media (pointer:coarse)': {
-        outline: 0,
-      },
-    },
-  },
-  dialog: {
+  content: {
     '&:first-child': {
       padding: 0,
     },
   },
-  dialogAction: {
-    // requested for overrides
-  },
+  action: {},
   withAdditionalAction: {
     // set justifyContent to default value to fix IE11 layout bug
     // see https://github.com/mui-org/material-ui-pickers/pull/267
     justifyContent: 'flex-start',
-
     '& > *:first-child': {
       marginRight: 'auto',
     },
@@ -93,60 +86,59 @@ const PickersModalDialog: React.FC<PickerModalDialogProps & WithStyles<typeof st
   props,
 ) => {
   const {
-    open,
-    classes,
     cancelText = 'Cancel',
     children,
+    classes,
     clearable = false,
     clearText = 'Clear',
+    DialogProps = {},
     okText = 'OK',
     onAccept,
     onClear,
     onDismiss,
     onSetToday,
+    open,
     showTodayButton = false,
     todayText = 'Today',
     wider,
-    DialogProps,
   } = props;
 
-  const MuiDialogClasses = DialogProps?.classes;
   return (
     <Dialog
       open={open}
       onClose={onDismiss}
-      classes={{
-        container: classes.dialogContainer,
-        paper: clsx(classes.dialogRoot, {
-          [classes.dialogRootWider]: wider,
-        }),
-        ...MuiDialogClasses,
-      }}
       {...DialogProps}
+      classes={{
+        ...DialogProps.classes,
+        container: classes.container,
+        paper: clsx(classes.paper, {
+          [classes.paperWider]: wider,
+        }),
+      }}
     >
-      <DialogContent className={classes.dialog}>{children}</DialogContent>
+      <DialogContent className={classes.content}>{children}</DialogContent>
       <DialogActions
-        className={clsx(classes.dialogAction, {
+        className={clsx(classes.action, {
           [classes.withAdditionalAction]: clearable || showTodayButton,
         })}
       >
         {clearable && (
-          <Button data-mui-test="clear-action-button" color="primary" onClick={onClear}>
+          <Button data-mui-test="clear-action-button" onClick={onClear}>
             {clearText}
           </Button>
         )}
         {showTodayButton && (
-          <Button data-mui-test="today-action-button" color="primary" onClick={onSetToday}>
+          <Button data-mui-test="today-action-button" onClick={onSetToday}>
             {todayText}
           </Button>
         )}
         {cancelText && (
-          <Button color="primary" onClick={onDismiss}>
+          <Button onClick={onDismiss}>
             {cancelText}
           </Button>
         )}
         {okText && (
-          <Button color="primary" onClick={onAccept}>
+          <Button onClick={onAccept}>
             {okText}
           </Button>
         )}

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -10,7 +10,6 @@ import { useForkRef, setRef, useEventCallback } from '@material-ui/core/utils';
 import { createStyles, WithStyles, withStyles, Theme } from '@material-ui/core/styles';
 import { TransitionProps as MuiTransitionProps } from '@material-ui/core/transitions';
 import { useGlobalKeyDown, keycode } from './hooks/useKeyDown';
-import { IS_TOUCH_DEVICE_MEDIA } from './constants/dimensions';
 import { executeInTheNextEventLoopTick } from './utils';
 
 export interface ExportedPickerPopperProps {
@@ -41,11 +40,7 @@ export const styles = (theme: Theme) =>
     },
     paper: {
       transformOrigin: 'top center',
-      '&:focus': {
-        [IS_TOUCH_DEVICE_MEDIA]: {
-          outline: 0,
-        },
-      },
+      outline: 0,
     },
     topTransition: {
       transformOrigin: 'bottom center',


### PR DESCRIPTION
Apply the same tradeoff as the Dialog and Drawer components, hide the outline. Also, take the opportunity to "clean" the component.

Closes #23532.