### PR TITLE
[docs] Fix warning about wrong prop type

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -302,7 +302,7 @@ function AppFrame(props) {
 AppFrame.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
-  disableDrawer: PropTypes.boolean,
+  disableDrawer: PropTypes.bool,
 };
 
 export default withStyles(styles)(AppFrame);

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -302,7 +302,7 @@ function AppFrame(props) {
 AppFrame.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
-  disableDrawer: PropTypes.node,
+  disableDrawer: PropTypes.boolean,
 };
 
 export default withStyles(styles)(AppFrame);


### PR DESCRIPTION
Fixes the warning:

```
Warning: Failed prop type: Invalid prop `disableDrawer` supplied to `AppFrame`, expected a ReactNode.
    in AppFrame (at withStyles.js:72)
    in WithStyles(AppFrame) (at TopLayoutCompany.js:30)
    in TopLayoutCompany (at withStyles.js:72)
    in WithStyles(TopLayoutCompany) (at jobs.js:14)
    in Page (at _app.js:348)
    in Context.Provider (at StyledEngineProvider.js:28)
    in Context.Provider
    in Context.Provider
    in ae (at StyledEngineProvider.js:27)
    in StyledEngineProvider (at _app.js:325)
    in Context.Provider (at ThemeContext.js:249)
    in Context.Provider (at ThemeProvider.js:11)
    in InnerThemeProvider (at ThemeProvider.js:33)
    in Context.Provider (at ThemeProvider.js:64)
    in ThemeProvider (at ThemeProvider.js:32)
    in ThemeProvider (at ThemeContext.js:248)
    in ThemeProvider (at _app.js:324)
    in Context.Provider (at StylesProvider.js:75)
    in StylesProvider (at _app.js:323)
    in Context.Provider (at StylesProvider.js:11)
    in StylesProvider (at _app.js:322)
    in Context.Provider (at _app.js:321)
    in Context.Provider
    in Provider (at _app.js:320)
    in Fragment (at _app.js:314)
    in AppWrapper (at _app.js:347)
    in MyApp (at _document.js:129)
    in Context.Provider (at StylesProvider.js:75)
    in StylesProvider (at ServerStyleSheets.js:20)
    in Context.Provider
    in Context.Provider
    in ae
    in Unknown
    in Context.Provider
    in Context.Provider
    in Context.Provider
    in Context.Provider
    in AppContainer
```