### PR TITLE
[Link] Improve integration with Next.js

### DIFF
--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -28,9 +28,9 @@ The project uses [Next.js](https://github.com/zeit/next.js), which is a framewor
 
 If you want to use URL objects within MUI components you can import `NextComposedLink` and use it as follows:
 
-```
-import MuiButton from "@material-ui/core/Button";
-import { NextLinkComposed } from "../src/Link";
+```js
+import MuiButton from '@material-ui/core/Button';
+import { NextLinkComposed } from '../src/Link';
 
 export default function Index() {
   return (
@@ -38,8 +38,8 @@ export default function Index() {
       <MuiButton
         component={NextLinkComposed}
         to={{
-          pathname: "/about",
-          query: { name: "test" }
+          pathname: '/about',
+          query: { name: 'test' },
         }}
       >
         MuiButton link

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -26,7 +26,7 @@ The project uses [Next.js](https://github.com/zeit/next.js), which is a framewor
 
 ## Object URL support
 
-If you want to use URL objects within MUI components you can import `NextComposedLink` and use it as follows:
+If you want to use [URL objects](https://nextjs.org/docs/api-reference/next/link#with-url-object) within MUI components you can import `NextComposedLink` and use it as follows:
 
 ```js
 import MuiButton from '@material-ui/core/Button';

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -24,27 +24,50 @@ or:
 
 The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
 
-## Object URL support
+## The link component
 
-If you want to use [URL objects](https://nextjs.org/docs/api-reference/next/link#with-url-object) within MUI components you can import `NextComposedLink` and use it as follows:
+Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
+The example provides adapters for usage with Material-UI.
 
-```js
-import MuiButton from '@material-ui/core/Button';
-import { NextLinkComposed } from '../src/Link';
+- The first version of the adapter is the `NextLinkComposed` component.
+  This component is unstyled and only responsible for handling the navigation.
+  The prop `href` was renamed `to`.
 
-export default function Index() {
-  return (
-    <div>
-      <MuiButton
+  ```tsx
+  import Button from '@material-ui/core/Button';
+  import { NextLinkComposed } from '../src/Link';
+
+  export default function Index() {
+    return (
+      <Button
         component={NextLinkComposed}
         to={{
           pathname: '/about',
           query: { name: 'test' },
         }}
       >
-        MuiButton link
-      </MuiButton>
-    </div>
-  );
-}
-```
+        Button link
+      </Button>
+    );
+  }
+  ```
+
+- The second version of the adapter is the `Link` component.
+  This component is styled, it leverages the [link component of Material-UI](https://material-ui.com/components/links/) with `NextLinkComposed`.
+
+  ```tsx
+  import Link from '../src/Link';
+
+  export default function Index() {
+    return (
+      <Link
+        to={{
+          pathname: '/about',
+          query: { name: 'test' },
+        }}
+      >
+        Link
+      </Link>
+    );
+  }
+  ```

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -61,7 +61,7 @@ The example provides adapters for usage with Material-UI.
   export default function Index() {
     return (
       <Link
-        to={{
+        href={{
           pathname: '/about',
           query: { name: 'test' },
         }}

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -26,7 +26,7 @@ The project uses [Next.js](https://github.com/zeit/next.js), which is a framewor
 
 ## Object URL support
 
-If you want to use URL objects within MUI components you can import NextComposedLink and use it as follows:
+If you want to use URL objects within MUI components you can import `NextComposedLink` and use it as follows:
 
 ```
 import MuiButton from "@material-ui/core/Button";

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -23,3 +23,28 @@ or:
 ## The idea behind the example
 
 The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+
+## Object URL support
+
+If you want to use URL objects within MUI components you can import NextComposedLink and use it as follows:
+
+```
+import MuiButton from "@material-ui/core/Button";
+import { NextLinkComposed } from "../src/Link";
+
+export default function Index() {
+  return (
+    <div>
+      <MuiButton
+        component={NextLinkComposed}
+        to={{
+          pathname: "/about",
+          query: { name: "test" }
+        }}
+      >
+        MuiButton link
+      </MuiButton>
+    </div>
+  );
+}
+```

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -5,46 +5,39 @@ import { useRouter } from 'next/router';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
 import MuiLink, { LinkProps as MuiLinkProps } from '@material-ui/core/Link';
 
-type NextComposedProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> &
-  Omit<NextLinkProps, 'as'> & { linkAs?: NextLinkProps['as'] };
+type NextLinkComposedProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> &
+  Omit<NextLinkProps, 'href'> & { to: NextLinkProps['href']; href?: any };
 
-const NextComposed = React.forwardRef<HTMLAnchorElement, NextComposedProps>((props, ref) => {
-  const { href, linkAs, replace, scroll, passHref, shallow, prefetch, ...other } = props;
+export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
+  (props, ref) => {
+    const { to, as, href, replace, scroll, passHref, shallow, prefetch, ...other } = props;
 
-  return (
-    <NextLink
-      href={href}
-      prefetch={prefetch}
-      as={linkAs}
-      replace={replace}
-      scroll={scroll}
-      shallow={shallow}
-      passHref={passHref}
-    >
-      <a ref={ref} {...other} />
-    </NextLink>
-  );
-});
+    return (
+      <NextLink
+        href={to}
+        prefetch={prefetch}
+        as={as}
+        replace={replace}
+        scroll={scroll}
+        shallow={shallow}
+        passHref={passHref}
+      >
+        <a ref={ref} {...other} />
+      </NextLink>
+    );
+  },
+);
 
-interface LinkPropsBase {
+export type LinkProps = {
   activeClassName?: string;
-  innerRef?: React.Ref<HTMLAnchorElement>;
   naked?: boolean;
-}
-
-export type LinkProps = LinkPropsBase & NextComposedProps & Omit<MuiLinkProps, 'href'>;
+} & Omit<NextLinkComposedProps, 'to'> &
+  Omit<MuiLinkProps, 'href'>;
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/#with-link
-function Link(props: LinkProps) {
-  const {
-    href,
-    activeClassName = 'active',
-    className: classNameProps,
-    innerRef,
-    naked,
-    ...other
-  } = props;
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
+  const { href, activeClassName = 'active', className: classNameProps, naked, ...other } = props;
 
   const router = useRouter();
   const pathname = typeof href === 'string' ? href : href.pathname;
@@ -53,20 +46,12 @@ function Link(props: LinkProps) {
   });
 
   if (naked) {
-    return <NextComposed className={className} ref={innerRef} href={href} {...other} />;
+    return <NextLinkComposed className={className} ref={ref as any} to={href} {...other} />;
   }
 
   return (
-    <MuiLink
-      component={NextComposed}
-      className={className}
-      ref={innerRef}
-      href={href as string}
-      {...other}
-    />
+    <MuiLink component={NextLinkComposed} className={className} ref={ref} to={href} {...other} />
   );
-}
+});
 
-export default React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
-  <Link {...props} innerRef={ref} />
-));
+export default Link;

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -28,9 +28,9 @@ The project uses [Next.js](https://github.com/zeit/next.js), which is a framewor
 
 If you want to use URL objects within MUI components you can import `NextComposedLink` and use it as follows:
 
-```
-import MuiButton from "@material-ui/core/Button";
-import { NextLinkComposed } from "../src/Link";
+```js
+import MuiButton from '@material-ui/core/Button';
+import { NextLinkComposed } from '../src/Link';
 
 export default function Index() {
   return (
@@ -38,8 +38,8 @@ export default function Index() {
       <MuiButton
         component={NextLinkComposed}
         to={{
-          pathname: "/about",
-          query: { name: "test" }
+          pathname: '/about',
+          query: { name: 'test' },
         }}
       >
         MuiButton link

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -26,7 +26,7 @@ The project uses [Next.js](https://github.com/zeit/next.js), which is a framewor
 
 ## Object URL support
 
-If you want to use URL objects within MUI components you can import `NextComposedLink` and use it as follows:
+If you want to use [URL objects](https://nextjs.org/docs/api-reference/next/link#with-url-object) within MUI components you can import `NextComposedLink` and use it as follows:
 
 ```js
 import MuiButton from '@material-ui/core/Button';

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -24,27 +24,50 @@ or:
 
 The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
 
-## Object URL support
+## The link component
 
-If you want to use [URL objects](https://nextjs.org/docs/api-reference/next/link#with-url-object) within MUI components you can import `NextComposedLink` and use it as follows:
+Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
+The example provides adapters for usage with Material-UI.
 
-```js
-import MuiButton from '@material-ui/core/Button';
-import { NextLinkComposed } from '../src/Link';
+- The first version of the adapter is the `NextLinkComposed` component.
+  This component is unstyled and only responsible for handling the navigation.
+  The prop `href` was renamed `to`.
 
-export default function Index() {
-  return (
-    <div>
-      <MuiButton
+  ```tsx
+  import Button from '@material-ui/core/Button';
+  import { NextLinkComposed } from '../src/Link';
+
+  export default function Index() {
+    return (
+      <Button
         component={NextLinkComposed}
         to={{
           pathname: '/about',
           query: { name: 'test' },
         }}
       >
-        MuiButton link
-      </MuiButton>
-    </div>
-  );
-}
-```
+        Button link
+      </Button>
+    );
+  }
+  ```
+
+- The second version of the adapter is the `Link` component.
+  This component is styled, it leverages the [link component of Material-UI](https://material-ui.com/components/links/) with `NextLinkComposed`.
+
+  ```tsx
+  import Link from '../src/Link';
+
+  export default function Index() {
+    return (
+      <Link
+        to={{
+          pathname: '/about',
+          query: { name: 'test' },
+        }}
+      >
+        Link
+      </Link>
+    );
+  }
+  ```

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -61,7 +61,7 @@ The example provides adapters for usage with Material-UI.
   export default function Index() {
     return (
       <Link
-        to={{
+        href={{
           pathname: '/about',
           query: { name: 'test' },
         }}

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -26,7 +26,7 @@ The project uses [Next.js](https://github.com/zeit/next.js), which is a framewor
 
 ## Object URL support
 
-If you want to use URL objects within MUI components you can import NextComposedLink and use it as follows:
+If you want to use URL objects within MUI components you can import `NextComposedLink` and use it as follows:
 
 ```
 import MuiButton from "@material-ui/core/Button";

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -23,3 +23,28 @@ or:
 ## The idea behind the example
 
 The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+
+## Object URL support
+
+If you want to use URL objects within MUI components you can import NextComposedLink and use it as follows:
+
+```
+import MuiButton from "@material-ui/core/Button";
+import { NextLinkComposed } from "../src/Link";
+
+export default function Index() {
+  return (
+    <div>
+      <MuiButton
+        component={NextLinkComposed}
+        to={{
+          pathname: "/about",
+          query: { name: "test" }
+        }}
+      >
+        MuiButton link
+      </MuiButton>
+    </div>
+  );
+}
+```

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -6,24 +6,21 @@ import { useRouter } from 'next/router';
 import NextLink from 'next/link';
 import MuiLink from '@material-ui/core/Link';
 
-const NextComposed = React.forwardRef(function NextComposed(props, ref) {
+export const NextLinkComposed = React.forwardRef(function NextComposed(props, ref) {
   // eslint-disable-next-line react/prop-types
-  const { href, linkAs, replace, scroll, passHref, shallow, prefetch, ...other } = props;
+  const { href, to, as, replace, scroll, passHref, shallow, prefetch, ...other } = props;
 
   return (
-    <NextLink
-      href={href}
-      prefetch={prefetch}
-      as={linkAs}
-      replace={replace}
-      scroll={scroll}
-      shallow={shallow}
-      passHref={passHref}
-    >
+    <NextLink href={to} as={as}>
       <a ref={ref} {...other} />
     </NextLink>
   );
 });
+
+NextLinkComposed.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  prefetch: PropTypes.bool,
+};
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/#with-link
@@ -44,20 +41,26 @@ function Link(props) {
   });
 
   if (naked) {
-    return <NextComposed className={className} ref={innerRef} href={href} {...other} />;
+    return <NextLinkComposed className={className} ref={innerRef} to={href} {...other} />;
   }
 
   return (
-    <MuiLink component={NextComposed} className={className} ref={innerRef} href={href} {...other} />
+    <MuiLink
+      component={NextLinkComposed}
+      className={className}
+      ref={innerRef}
+      to={href}
+      {...other}
+    />
   );
 }
 
 Link.propTypes = {
   activeClassName: PropTypes.string,
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   className: PropTypes.string,
   href: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-  linkAs: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   naked: PropTypes.bool,
   onClick: PropTypes.func,
   prefetch: PropTypes.bool,

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -455,7 +455,7 @@ ButtonBase.propTypes = {
   /**
    * @ignore
    */
-  href: PropTypes.string,
+  href: PropTypes /* @typescript-to-proptypes-ignore */.any,
   /**
    * @ignore
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR attempts to improve the integration with Next.JS, improving the Link component, updating the examples and removing unwanted type errors logged in the console or linted by TypeScript.

- Update Next.js examples
- Update prop-types for consistency between `MuiButtonBase` and `MuiLink`
- Add note on both readme about Object URL support and how to use `NextLinkComposed`

Closes #24106