### PR TITLE
[core] Refactor styled() components to ease out the migration process 

### DIFF
--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
@@ -5,8 +5,8 @@ import { unstable_capitalize as capitalize, usePreviousProps } from '@material-u
 import isHostComponent from '../utils/isHostComponent';
 import badgeUnstyledClasses, { getBadgeUtilityClass } from './badgeUnstyledClasses';
 
-const useUtilityClasses = (props) => {
-  const { variant, anchorOrigin, overlap, invisible, classes = {} } = props;
+const useUtilityClasses = (styleProps) => {
+  const { variant, anchorOrigin, overlap, invisible, classes = {} } = styleProps;
 
   const utilityClasses = {
     root: clsx(badgeUnstyledClasses['root'], classes['root']),
@@ -82,7 +82,7 @@ const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {
     variant = variantProp,
   } = invisible ? prevProps : props;
 
-  const stateAndProps = {
+  const styleProps = {
     ...props,
     anchorOrigin,
     badgeContent,
@@ -98,7 +98,7 @@ const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {
     displayValue = badgeContent > max ? `${max}+` : badgeContent;
   }
 
-  const classes = useUtilityClasses({ ...stateAndProps, classes: classesProp });
+  const classes = useUtilityClasses({ ...styleProps, classes: classesProp });
 
   const Root = components.Root || Component;
   const rootProps = componentsProps.root || {};
@@ -111,7 +111,7 @@ const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {
       {...rootProps}
       {...(!isHostComponent(Root) && {
         as: Component,
-        styleProps: { ...stateAndProps, ...rootProps.styleProps },
+        styleProps: { ...styleProps, ...rootProps.styleProps },
         theme,
       })}
       ref={ref}
@@ -122,7 +122,7 @@ const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {
       <Badge
         {...badgeProps}
         {...(!isHostComponent(Badge) && {
-          styleProps: { ...stateAndProps, ...badgeProps.styleProps },
+          styleProps: { ...styleProps, ...badgeProps.styleProps },
           theme,
         })}
         className={clsx(classes.badge, badgeProps.className)}

--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
@@ -8,7 +8,7 @@ import badgeUnstyledClasses, { getBadgeUtilityClass } from './badgeUnstyledClass
 const useUtilityClasses = (styleProps) => {
   const { variant, anchorOrigin, overlap, invisible, classes = {} } = styleProps;
 
-  const utilityClasses = {
+  return {
     root: clsx(badgeUnstyledClasses['root'], classes['root']),
     badge: clsx(
       badgeUnstyledClasses['badge'],
@@ -30,8 +30,6 @@ const useUtilityClasses = (styleProps) => {
       },
     ),
   };
-
-  return utilityClasses;
 };
 
 const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {

--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
@@ -5,7 +5,7 @@ import { unstable_capitalize as capitalize, usePreviousProps } from '@material-u
 import isHostComponent from '../utils/isHostComponent';
 import badgeUnstyledClasses, { getBadgeUtilityClass } from './badgeUnstyledClasses';
 
-const useBadgeClasses = (props) => {
+const useUtilityClasses = (props) => {
   const { variant, anchorOrigin, overlap, invisible, classes = {} } = props;
 
   const utilityClasses = {
@@ -98,7 +98,7 @@ const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {
     displayValue = badgeContent > max ? `${max}+` : badgeContent;
   }
 
-  const classes = useBadgeClasses({ ...stateAndProps, classes: classesProp });
+  const classes = useUtilityClasses({ ...stateAndProps, classes: classesProp });
 
   const Root = components.Root || Component;
   const rootProps = componentsProps.root || {};

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -145,8 +145,8 @@ function doesSupportTouchActionNone() {
   return cachedSupportsTouchActionNone;
 }
 
-const useUtilityClasses = (props) => {
-  const { disabled, marked, orientation, track, classes = {} } = props;
+const useUtilityClasses = (styleProps) => {
+  const { disabled, marked, orientation, track, classes = {} } = styleProps;
 
   const utilityClasses = {
     root: clsx(sliderUnstyledClasses['root'], classes['root'], {
@@ -604,7 +604,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
 
   // all props with defaults
   // consider extracting to hook an reusing the lint rule for the varints
-  const stateAndProps = {
+  const styleProps = {
     ...props,
     classes: {},
     disabled,
@@ -620,7 +620,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
     marked: marks.length > 0 && marks.some((mark) => mark.label),
   };
 
-  const utilityClasses = useUtilityClasses({ ...stateAndProps, classes: classesProp });
+  const utilityClasses = useUtilityClasses({ ...styleProps, classes: classesProp });
 
   return (
     <Root
@@ -629,7 +629,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
       {...rootProps}
       {...(!isHostComponent(Root) && {
         as: Component,
-        styleProps: { ...stateAndProps, ...rootProps.styleProps },
+        styleProps: { ...styleProps, ...rootProps.styleProps },
         theme,
       })}
       {...other}
@@ -638,7 +638,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
       <Rail
         {...railProps}
         {...(!isHostComponent(Rail) && {
-          styleProps: { ...stateAndProps, ...railProps.styleProps },
+          styleProps: { ...styleProps, ...railProps.styleProps },
           theme,
         })}
         className={clsx(utilityClasses.rail, railProps.className)}
@@ -646,7 +646,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
       <Track
         {...trackProps}
         {...(!isHostComponent(Track) && {
-          styleProps: { ...stateAndProps, ...trackProps.styleProps },
+          styleProps: { ...styleProps, ...trackProps.styleProps },
           theme,
         })}
         className={clsx(utilityClasses.track, trackProps.className)}
@@ -678,7 +678,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
               data-index={index}
               {...markProps}
               {...(!isHostComponent(Mark) && {
-                styleProps: { ...stateAndProps, ...markProps.styleProps, markActive },
+                styleProps: { ...styleProps, ...markProps.styleProps, markActive },
                 theme,
               })}
               style={{ ...style, ...markProps.style }}
@@ -693,7 +693,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                 {...markLabelProps}
                 {...(!isHostComponent(MarkLabel) && {
                   styleProps: {
-                    ...stateAndProps,
+                    ...styleProps,
                     ...markLabelProps.styleProps,
                     markLabelActive: markActive,
                   },
@@ -732,7 +732,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
             {...valueLabelProps}
             className={clsx(utilityClasses.valueLabel, valueLabelProps.className)}
             {...(!isHostComponent(ValueLabel) && {
-              styleProps: { ...stateAndProps, ...valueLabelProps.styleProps },
+              styleProps: { ...styleProps, ...valueLabelProps.styleProps },
               theme,
             })}
           >
@@ -760,7 +760,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                 [utilityClasses['focusVisible']]: focusVisible === index,
               })}
               {...(!isHostComponent(Thumb) && {
-                styleProps: { ...stateAndProps, ...thumbProps.styleProps },
+                styleProps: { ...styleProps, ...thumbProps.styleProps },
                 theme,
               })}
               style={{ ...style, ...thumbProps.style }}

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -145,7 +145,7 @@ function doesSupportTouchActionNone() {
   return cachedSupportsTouchActionNone;
 }
 
-const useSliderClasses = (props) => {
+const useUtilityClasses = (props) => {
   const { disabled, marked, orientation, track, classes = {} } = props;
 
   const utilityClasses = {
@@ -620,7 +620,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
     marked: marks.length > 0 && marks.some((mark) => mark.label),
   };
 
-  const utilityClasses = useSliderClasses({ ...stateAndProps, classes: classesProp });
+  const utilityClasses = useUtilityClasses({ ...stateAndProps, classes: classesProp });
 
   return (
     <Root

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -148,7 +148,7 @@ function doesSupportTouchActionNone() {
 const useUtilityClasses = (styleProps) => {
   const { disabled, marked, orientation, track, classes = {} } = styleProps;
 
-  const utilityClasses = {
+  return {
     root: clsx(sliderUnstyledClasses['root'], classes['root'], {
       [sliderUnstyledClasses['disabled']]: disabled,
       [classes['disabled']]: disabled,
@@ -176,8 +176,6 @@ const useUtilityClasses = (styleProps) => {
     disabled: clsx(sliderUnstyledClasses['disabled'], classes['disabled']),
     focusVisible: clsx(sliderUnstyledClasses['focusVisible'], classes['focusVisible']),
   };
-
-  return utilityClasses;
 };
 
 const Forward = ({ children }) => children;

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -42,7 +42,7 @@ const AvatarRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   position: 'relative',
   display: 'flex',
   alignItems: 'center',
@@ -50,24 +50,24 @@ const AvatarRoot = experimentalStyled(
   flexShrink: 0,
   width: 40,
   height: 40,
-  fontFamily: props.theme.typography.fontFamily,
-  fontSize: props.theme.typography.pxToRem(20),
+  fontFamily: theme.typography.fontFamily,
+  fontSize: theme.typography.pxToRem(20),
   lineHeight: 1,
   borderRadius: '50%',
   overflow: 'hidden',
   userSelect: 'none',
-  ...(props.styleProps.variant === 'rounded' && {
-    borderRadius: props.theme.shape.borderRadius,
+  ...(styleProps.variant === 'rounded' && {
+    borderRadius: theme.shape.borderRadius,
   }),
-  ...(props.styleProps.variant === 'square' && {
+  ...(styleProps.variant === 'square' && {
     borderRadius: 0,
   }),
-  ...(props.styleProps.colorDefault && {
-    color: props.theme.palette.background.default,
+  ...(styleProps.colorDefault && {
+    color: theme.palette.background.default,
     backgroundColor:
-      props.theme.palette.mode === 'light'
-        ? props.theme.palette.grey[400]
-        : props.theme.palette.grey[600],
+      theme.palette.mode === 'light'
+        ? theme.palette.grey[400]
+        : theme.palette.grey[600],
   }),
 }));
 

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -9,29 +9,25 @@ import avatarClasses, { getAvatarUtilityClass } from './avatarClasses';
 const overridesResolver = (props, styles) => {
   const { variant = 'circular' } = props;
 
-  const styleOverrides = {
+  return {
     ...styles.root,
     ...styles[variant],
     [`&.${avatarClasses.colorDefault}`]: styles.colorDefault,
     [`&.${avatarClasses.img}`]: styles.img,
     [`&.${avatarClasses.fallback}`]: styles.fallback,
   };
-
-  return styleOverrides;
 };
 
 const useUtilityClasses = (styleProps) => {
   const { classes = {}, variant, colorDefault } = styleProps;
 
-  const utilityClasses = {
+  return {
     root: clsx(avatarClasses.root, classes.root, getAvatarUtilityClass(variant), {
       [avatarClasses.colorDefault]: colorDefault,
     }),
     img: clsx(avatarClasses.img, classes.img),
     fallback: clsx(avatarClasses.fallback, classes.fallback),
   };
-
-  return utilityClasses;
 };
 
 const AvatarRoot = experimentalStyled(

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -65,9 +65,7 @@ const AvatarRoot = experimentalStyled(
   ...(styleProps.colorDefault && {
     color: theme.palette.background.default,
     backgroundColor:
-      theme.palette.mode === 'light'
-        ? theme.palette.grey[400]
-        : theme.palette.grey[600],
+      theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
   }),
 }));
 

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -20,8 +20,8 @@ const overridesResolver = (props, styles) => {
   return styleOverrides;
 };
 
-const useUtilityClasses = (props) => {
-  const { classes = {}, variant, colorDefault } = props;
+const useUtilityClasses = (styleProps) => {
+  const { classes = {}, variant, colorDefault } = styleProps;
 
   const utilityClasses = {
     root: clsx(avatarClasses.root, classes.root, getAvatarUtilityClass(variant), {
@@ -160,13 +160,13 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
   const hasImg = src || srcSet;
   const hasImgNotFailing = hasImg && loaded !== 'error';
 
-  const stateAndProps = {
+  const styleProps = {
     ...props,
     variant,
     colorDefault: !hasImgNotFailing,
   };
 
-  const classes = useUtilityClasses(stateAndProps);
+  const classes = useUtilityClasses(styleProps);
 
   if (hasImgNotFailing) {
     children = (
@@ -190,7 +190,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
   return (
     <AvatarRoot
       as={Component}
-      styleProps={stateAndProps}
+      styleProps={styleProps}
       className={clsx(classes.root, className)}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -20,7 +20,7 @@ const overridesResolver = (props, styles) => {
   return styleOverrides;
 };
 
-const useAvatarClasses = (props) => {
+const useUtilityClasses = (props) => {
   const { classes = {}, variant, colorDefault } = props;
 
   const utilityClasses = {
@@ -166,7 +166,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     colorDefault: !hasImgNotFailing,
   };
 
-  const classes = useAvatarClasses(stateAndProps);
+  const classes = useUtilityClasses(stateAndProps);
 
   if (hasImgNotFailing) {
     children = (

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -197,8 +197,8 @@ const BadgeBadge = styled(
   }),
 }));
 
-const extendBadgeClasses = (props) => {
-  const { color, classes = {} } = props;
+const extendUtilityClasses = (styleProps) => {
+  const { color, classes = {} } = styleProps;
 
   return {
     ...classes,
@@ -237,7 +237,8 @@ const Badge = React.forwardRef(function Badge(inputProps, ref) {
 
   const { color = colorProp } = invisible ? prevProps : props;
 
-  const classes = extendBadgeClasses({ ...props, invisible, color });
+  const styleProps = { ...props, invisible, color };
+  const classes = extendUtilityClasses(styleProps);
 
   return (
     <BadgeUnstyled

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -36,7 +36,7 @@ const overridesResolver = (props, styles) => {
     overlap = 'rectangular',
   } = props;
 
-  const styleOverrides = deepmerge(styles.root, {
+  return deepmerge(styles.root, {
     [`& .${badgeClasses.badge}`]: {
       ...styles.badge,
       ...styles[variant],
@@ -49,8 +49,6 @@ const overridesResolver = (props, styles) => {
       ...(invisible && styles.invisible),
     },
   });
-
-  return styleOverrides;
 };
 
 const BadgeRoot = styled(

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -69,7 +69,7 @@ const BadgeBadge = styled(
   'span',
   {},
   { name: 'Badge', slot: 'Badge', overridesResolver },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   display: 'flex',
   flexDirection: 'row',
   flexWrap: 'wrap',
@@ -78,32 +78,32 @@ const BadgeBadge = styled(
   alignItems: 'center',
   position: 'absolute',
   boxSizing: 'border-box',
-  fontFamily: props.theme.typography.fontFamily,
-  fontWeight: props.theme.typography.fontWeightMedium,
-  fontSize: props.theme.typography.pxToRem(12),
+  fontFamily: theme.typography.fontFamily,
+  fontWeight: theme.typography.fontWeightMedium,
+  fontSize: theme.typography.pxToRem(12),
   minWidth: RADIUS_STANDARD * 2,
   lineHeight: 1,
   padding: '0 6px',
   height: RADIUS_STANDARD * 2,
   borderRadius: RADIUS_STANDARD,
   zIndex: 1, // Render the badge on top of potential ripples.
-  transition: props.theme.transitions.create('transform', {
-    easing: props.theme.transitions.easing.easeInOut,
-    duration: props.theme.transitions.duration.enteringScreen,
+  transition: theme.transitions.create('transform', {
+    easing: theme.transitions.easing.easeInOut,
+    duration: theme.transitions.duration.enteringScreen,
   }),
-  ...(props.styleProps.color !== 'default' && {
-    backgroundColor: props.theme.palette[props.styleProps.color].main,
-    color: props.theme.palette[props.styleProps.color].contrastText,
+  ...(styleProps.color !== 'default' && {
+    backgroundColor: theme.palette[styleProps.color].main,
+    color: theme.palette[styleProps.color].contrastText,
   }),
-  ...(props.styleProps.variant === 'dot' && {
+  ...(styleProps.variant === 'dot' && {
     borderRadius: RADIUS_DOT,
     height: RADIUS_DOT * 2,
     minWidth: RADIUS_DOT * 2,
     padding: 0,
   }),
-  ...(props.styleProps.anchorOrigin.vertical === 'top' &&
-    props.styleProps.anchorOrigin.horizontal === 'right' &&
-    props.styleProps.overlap === 'rectangular' && {
+  ...(styleProps.anchorOrigin.vertical === 'top' &&
+    styleProps.anchorOrigin.horizontal === 'right' &&
+    styleProps.overlap === 'rectangular' && {
       top: 0,
       right: 0,
       transform: 'scale(1) translate(50%, -50%)',
@@ -112,9 +112,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(50%, -50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'bottom' &&
-    props.styleProps.anchorOrigin.horizontal === 'right' &&
-    props.styleProps.overlap === 'rectangular' && {
+  ...(styleProps.anchorOrigin.vertical === 'bottom' &&
+    styleProps.anchorOrigin.horizontal === 'right' &&
+    styleProps.overlap === 'rectangular' && {
       bottom: 0,
       right: 0,
       transform: 'scale(1) translate(50%, 50%)',
@@ -123,9 +123,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(50%, 50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'top' &&
-    props.styleProps.anchorOrigin.horizontal === 'left' &&
-    props.styleProps.overlap === 'rectangular' && {
+  ...(styleProps.anchorOrigin.vertical === 'top' &&
+    styleProps.anchorOrigin.horizontal === 'left' &&
+    styleProps.overlap === 'rectangular' && {
       top: 0,
       left: 0,
       transform: 'scale(1) translate(-50%, -50%)',
@@ -134,9 +134,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(-50%, -50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'bottom' &&
-    props.styleProps.anchorOrigin.horizontal === 'left' &&
-    props.styleProps.overlap === 'rectangular' && {
+  ...(styleProps.anchorOrigin.vertical === 'bottom' &&
+    styleProps.anchorOrigin.horizontal === 'left' &&
+    styleProps.overlap === 'rectangular' && {
       bottom: 0,
       left: 0,
       transform: 'scale(1) translate(-50%, 50%)',
@@ -145,9 +145,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(-50%, 50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'top' &&
-    props.styleProps.anchorOrigin.horizontal === 'right' &&
-    props.styleProps.overlap === 'circular' && {
+  ...(styleProps.anchorOrigin.vertical === 'top' &&
+    styleProps.anchorOrigin.horizontal === 'right' &&
+    styleProps.overlap === 'circular' && {
       top: '14%',
       right: '14%',
       transform: 'scale(1) translate(50%, -50%)',
@@ -156,9 +156,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(50%, -50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'bottom' &&
-    props.styleProps.anchorOrigin.horizontal === 'right' &&
-    props.styleProps.overlap === 'circular' && {
+  ...(styleProps.anchorOrigin.vertical === 'bottom' &&
+    styleProps.anchorOrigin.horizontal === 'right' &&
+    styleProps.overlap === 'circular' && {
       bottom: '14%',
       right: '14%',
       transform: 'scale(1) translate(50%, 50%)',
@@ -167,9 +167,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(50%, 50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'top' &&
-    props.styleProps.anchorOrigin.horizontal === 'left' &&
-    props.styleProps.overlap === 'circular' && {
+  ...(styleProps.anchorOrigin.vertical === 'top' &&
+    styleProps.anchorOrigin.horizontal === 'left' &&
+    styleProps.overlap === 'circular' && {
       top: '14%',
       left: '14%',
       transform: 'scale(1) translate(-50%, -50%)',
@@ -178,9 +178,9 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(-50%, -50%)',
       },
     }),
-  ...(props.styleProps.anchorOrigin.vertical === 'bottom' &&
-    props.styleProps.anchorOrigin.horizontal === 'left' &&
-    props.styleProps.overlap === 'circular' && {
+  ...(styleProps.anchorOrigin.vertical === 'bottom' &&
+    styleProps.anchorOrigin.horizontal === 'left' &&
+    styleProps.overlap === 'circular' && {
       bottom: '14%',
       left: '14%',
       transform: 'scale(1) translate(-50%, 50%)',
@@ -189,10 +189,10 @@ const BadgeBadge = styled(
         transform: 'scale(0) translate(-50%, 50%)',
       },
     }),
-  ...(props.styleProps.invisible && {
-    transition: props.theme.transitions.create('transform', {
-      easing: props.theme.transitions.easing.easeInOut,
-      duration: props.theme.transitions.duration.leavingScreen,
+  ...(styleProps.invisible && {
+    transition: theme.transitions.create('transform', {
+      easing: theme.transitions.easing.easeInOut,
+      duration: theme.transitions.duration.leavingScreen,
     }),
   }),
 }));

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -80,18 +80,18 @@ const useButtonClasses = (props) => {
   return utilityClasses;
 };
 
-const commonIconStyles = (props) => ({
-  ...(props.styleProps.size === 'small' && {
+const commonIconStyles = (styleProps) => ({
+  ...(styleProps.size === 'small' && {
     '& > *:nth-of-type(1)': {
       fontSize: 18,
     },
   }),
-  ...(props.styleProps.size === 'medium' && {
+  ...(styleProps.size === 'medium' && {
     '& > *:nth-of-type(1)': {
       fontSize: 20,
     },
   }),
-  ...(props.styleProps.size === 'large' && {
+  ...(styleProps.size === 'large' && {
     '& > *:nth-of-type(1)': {
       fontSize: 22,
     },
@@ -105,14 +105,14 @@ const ButtonStartIcon = experimentalStyled(
     name: 'Button',
     slot: 'StartIcon',
   },
-)((props) => ({
+)(({ styleProps }) => ({
   display: 'inherit',
   marginRight: 8,
   marginLeft: -4,
-  ...(props.styleProps.size === 'small' && {
+  ...(styleProps.size === 'small' && {
     marginLeft: -2,
   }),
-  ...commonIconStyles(props),
+  ...commonIconStyles(styleProps),
 }));
 
 const ButtonEndIcon = experimentalStyled(
@@ -122,14 +122,14 @@ const ButtonEndIcon = experimentalStyled(
     name: 'Button',
     slot: 'EndIcon',
   },
-)((props) => ({
+)(({ styleProps }) => ({
   display: 'inherit',
   marginRight: -4,
   marginLeft: 8,
-  ...(props.styleProps.size === 'small' && {
+  ...(styleProps.size === 'small' && {
     marginRight: -2,
   }),
-  ...commonIconStyles(props),
+  ...commonIconStyles(styleProps),
 }));
 
 const ButtonLabel = experimentalStyled(
@@ -154,171 +154,171 @@ const ButtonRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)((props) => ({
-  ...props.theme.typography.button,
+)(({ theme, styleProps }) => ({
+  ...theme.typography.button,
   minWidth: 64,
   padding: '6px 16px',
-  borderRadius: props.theme.shape.borderRadius,
-  transition: props.theme.transitions.create(
+  borderRadius: theme.shape.borderRadius,
+  transition: theme.transitions.create(
     ['background-color', 'box-shadow', 'border-color', 'color'],
     {
-      duration: props.theme.transitions.duration.short,
+      duration: theme.transitions.duration.short,
     },
   ),
   '&:hover': {
     textDecoration: 'none',
     backgroundColor: alpha(
-      props.theme.palette.text.primary,
-      props.theme.palette.action.hoverOpacity,
+      theme.palette.text.primary,
+      theme.palette.action.hoverOpacity,
     ),
     // Reset on touch devices, it doesn't add specificity
     '@media (hover: none)': {
       backgroundColor: 'transparent',
     },
-    ...(props.styleProps.variant === 'text' &&
-      props.styleProps.color !== 'inherit' && {
+    ...(styleProps.variant === 'text' &&
+      styleProps.color !== 'inherit' && {
         backgroundColor: alpha(
-          props.theme.palette[props.styleProps.color].main,
-          props.theme.palette.action.hoverOpacity,
+          theme.palette[styleProps.color].main,
+          theme.palette.action.hoverOpacity,
         ),
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
           backgroundColor: 'transparent',
         },
       }),
-    ...(props.styleProps.variant === 'outlined' &&
-      props.styleProps.color !== 'inherit' && {
-        border: `1px solid ${props.theme.palette[props.styleProps.color].main}`,
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color !== 'inherit' && {
+        border: `1px solid ${theme.palette[styleProps.color].main}`,
         backgroundColor: alpha(
-          props.theme.palette[props.styleProps.color].main,
-          props.theme.palette.action.hoverOpacity,
+          theme.palette[styleProps.color].main,
+          theme.palette.action.hoverOpacity,
         ),
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
           backgroundColor: 'transparent',
         },
       }),
-    ...(props.styleProps.variant === 'contained' && {
-      backgroundColor: props.theme.palette.grey.A100,
-      boxShadow: props.theme.shadows[4],
+    ...(styleProps.variant === 'contained' && {
+      backgroundColor: theme.palette.grey.A100,
+      boxShadow: theme.shadows[4],
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
-        boxShadow: props.theme.shadows[2],
-        backgroundColor: props.theme.palette.grey[300],
+        boxShadow: theme.shadows[2],
+        backgroundColor: theme.palette.grey[300],
       },
     }),
-    ...(props.styleProps.variant === 'contained' &&
-      props.styleProps.color !== 'inherit' && {
-        backgroundColor: props.theme.palette[props.styleProps.color].dark,
+    ...(styleProps.variant === 'contained' &&
+      styleProps.color !== 'inherit' && {
+        backgroundColor: theme.palette[styleProps.color].dark,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
-          backgroundColor: props.theme.palette[props.styleProps.color].main,
+          backgroundColor: theme.palette[styleProps.color].main,
         },
       }),
-    ...(props.styleProps.disableElevation && {
+    ...(styleProps.disableElevation && {
       boxShadow: 'none',
     }),
   },
   '&:active': {
-    ...(props.styleProps.variant === 'contained' && {
-      boxShadow: props.theme.shadows[8],
+    ...(styleProps.variant === 'contained' && {
+      boxShadow: theme.shadows[8],
     }),
-    ...(props.styleProps.disableElevation && {
+    ...(styleProps.disableElevation && {
       boxShadow: 'none',
     }),
   },
   '&.Mui-focusVisible': {
-    ...(props.styleProps.variant === 'contained' && {
-      boxShadow: props.theme.shadows[6],
+    ...(styleProps.variant === 'contained' && {
+      boxShadow: theme.shadows[6],
     }),
-    ...(props.styleProps.disableElevation && {
+    ...(styleProps.disableElevation && {
       boxShadow: 'none',
     }),
   },
   '&.Mui-disabled': {
-    color: props.theme.palette.action.disabled,
-    ...(props.styleProps.variant === 'outlined' && {
-      border: `1px solid ${props.theme.palette.action.disabledBackground}`,
+    color: theme.palette.action.disabled,
+    ...(styleProps.variant === 'outlined' && {
+      border: `1px solid ${theme.palette.action.disabledBackground}`,
     }),
-    ...(props.styleProps.variant === 'outlined' &&
-      props.styleProps.color === 'secondary' && {
-        border: `1px solid ${props.theme.palette.action.disabled}`,
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color === 'secondary' && {
+        border: `1px solid ${theme.palette.action.disabled}`,
       }),
-    ...(props.styleProps.variant === 'contained' && {
-      color: props.theme.palette.action.disabled,
-      boxShadow: props.theme.shadows[0],
-      backgroundColor: props.theme.palette.action.disabledBackground,
+    ...(styleProps.variant === 'contained' && {
+      color: theme.palette.action.disabled,
+      boxShadow: theme.shadows[0],
+      backgroundColor: theme.palette.action.disabledBackground,
     }),
-    ...(props.styleProps.disableElevation && {
+    ...(styleProps.disableElevation && {
       boxShadow: 'none',
     }),
   },
-  ...(props.styleProps.variant === 'text' && {
+  ...(styleProps.variant === 'text' && {
     padding: '6px 8px',
   }),
-  ...(props.styleProps.variant === 'text' &&
-    props.styleProps.color !== 'inherit' && {
-      color: props.theme.palette[props.styleProps.color].main,
+  ...(styleProps.variant === 'text' &&
+    styleProps.color !== 'inherit' && {
+      color: theme.palette[styleProps.color].main,
     }),
-  ...(props.styleProps.variant === 'outlined' && {
+  ...(styleProps.variant === 'outlined' && {
     padding: '5px 15px',
     border: `1px solid ${
-      props.theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+      theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
     }`,
   }),
-  ...(props.styleProps.variant === 'outlined' &&
-    props.styleProps.color !== 'inherit' && {
-      color: props.theme.palette[props.styleProps.color].main,
-      border: `1px solid ${alpha(props.theme.palette[props.styleProps.color].main, 0.5)}`,
+  ...(styleProps.variant === 'outlined' &&
+    styleProps.color !== 'inherit' && {
+      color: theme.palette[styleProps.color].main,
+      border: `1px solid ${alpha(theme.palette[styleProps.color].main, 0.5)}`,
     }),
-  ...(props.styleProps.variant === 'contained' && {
-    color: props.theme.palette.getContrastText(props.theme.palette.grey[300]),
-    backgroundColor: props.theme.palette.grey[300],
-    boxShadow: props.theme.shadows[2],
+  ...(styleProps.variant === 'contained' && {
+    color: theme.palette.getContrastText(theme.palette.grey[300]),
+    backgroundColor: theme.palette.grey[300],
+    boxShadow: theme.shadows[2],
   }),
-  ...(props.styleProps.variant === 'contained' &&
-    props.styleProps.color !== 'inherit' && {
-      color: props.theme.palette[props.styleProps.color].contrastText,
-      backgroundColor: props.theme.palette[props.styleProps.color].main,
+  ...(styleProps.variant === 'contained' &&
+    styleProps.color !== 'inherit' && {
+      color: theme.palette[styleProps.color].contrastText,
+      backgroundColor: theme.palette[styleProps.color].main,
     }),
-  ...(props.styleProps.disableElevation && {
+  ...(styleProps.disableElevation && {
     boxShadow: 'none',
   }),
-  ...(props.styleProps.color === 'inherit' && {
+  ...(styleProps.color === 'inherit' && {
     color: 'inherit',
     borderColor: 'currentColor',
   }),
-  ...(props.styleProps.size === 'small' &&
-    props.styleProps.variant === 'text' && {
+  ...(styleProps.size === 'small' &&
+    styleProps.variant === 'text' && {
       padding: '4px 5px',
-      fontSize: props.theme.typography.pxToRem(13),
+      fontSize: theme.typography.pxToRem(13),
     }),
-  ...(props.styleProps.size === 'large' &&
-    props.styleProps.variant === 'text' && {
+  ...(styleProps.size === 'large' &&
+    styleProps.variant === 'text' && {
       padding: '8px 11px',
-      fontSize: props.theme.typography.pxToRem(15),
+      fontSize: theme.typography.pxToRem(15),
     }),
-  ...(props.styleProps.size === 'small' &&
-    props.styleProps.variant === 'outlined' && {
+  ...(styleProps.size === 'small' &&
+    styleProps.variant === 'outlined' && {
       padding: '3px 9px',
-      fontSize: props.theme.typography.pxToRem(13),
+      fontSize: theme.typography.pxToRem(13),
     }),
-  ...(props.styleProps.size === 'large' &&
-    props.styleProps.variant === 'outlined' && {
+  ...(styleProps.size === 'large' &&
+    styleProps.variant === 'outlined' && {
       padding: '7px 21px',
-      fontSize: props.theme.typography.pxToRem(15),
+      fontSize: theme.typography.pxToRem(15),
     }),
-  ...(props.styleProps.size === 'small' &&
-    props.styleProps.variant === 'contained' && {
+  ...(styleProps.size === 'small' &&
+    styleProps.variant === 'contained' && {
       padding: '4px 10px',
-      fontSize: props.theme.typography.pxToRem(13),
+      fontSize: theme.typography.pxToRem(13),
     }),
-  ...(props.styleProps.size === 'large' &&
-    props.styleProps.variant === 'contained' && {
+  ...(styleProps.size === 'large' &&
+    styleProps.variant === 'contained' && {
       padding: '8px 22px',
-      fontSize: props.theme.typography.pxToRem(15),
+      fontSize: theme.typography.pxToRem(15),
     }),
-  ...(props.styleProps.fullWidth && {
+  ...(styleProps.fullWidth && {
     width: '100%',
   }),
 }));

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -40,7 +40,7 @@ const overridesResolver = (props, styles) => {
   return styleOverrides;
 };
 
-const useButtonClasses = (props) => {
+const useUtilityClasses = (props) => {
   const { color, disableElevation, fullWidth, size, variant, classes = {} } = props;
 
   const utilityClasses = {
@@ -354,7 +354,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     variant,
   };
 
-  const classes = useButtonClasses(stateAndProps);
+  const classes = useUtilityClasses(stateAndProps);
 
   const startIcon = startIconProp && (
     <ButtonStartIcon className={classes.startIcon} styleProps={stateAndProps}>

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -17,7 +17,7 @@ const overridesResolver = (props, styles) => {
     variant = 'text',
   } = props;
 
-  const styleOverrides = {
+  return {
     ...styles.root,
     ...styles[variant],
     ...styles[`${variant}${capitalize(color)}`],
@@ -36,14 +36,12 @@ const overridesResolver = (props, styles) => {
       ...styles[`iconSize${capitalize(size)}`],
     },
   };
-
-  return styleOverrides;
 };
 
 const useUtilityClasses = (styleProps) => {
   const { color, disableElevation, fullWidth, size, variant, classes = {} } = styleProps;
 
-  const utilityClasses = {
+  return {
     root: clsx(
       buttonClasses.root,
       classes.root,
@@ -76,8 +74,6 @@ const useUtilityClasses = (styleProps) => {
       getButtonUtilityClass(`iconSize${capitalize(size)}`),
     ),
   };
-
-  return utilityClasses;
 };
 
 const commonIconStyles = (styleProps) => ({

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -167,10 +167,7 @@ const ButtonRoot = experimentalStyled(
   ),
   '&:hover': {
     textDecoration: 'none',
-    backgroundColor: alpha(
-      theme.palette.text.primary,
-      theme.palette.action.hoverOpacity,
-    ),
+    backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.hoverOpacity),
     // Reset on touch devices, it doesn't add specificity
     '@media (hover: none)': {
       backgroundColor: 'transparent',

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -40,8 +40,8 @@ const overridesResolver = (props, styles) => {
   return styleOverrides;
 };
 
-const useUtilityClasses = (props) => {
-  const { color, disableElevation, fullWidth, size, variant, classes = {} } = props;
+const useUtilityClasses = (styleProps) => {
+  const { color, disableElevation, fullWidth, size, variant, classes = {} } = styleProps;
 
   const utilityClasses = {
     root: clsx(
@@ -341,7 +341,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     ...other
   } = props;
 
-  const stateAndProps = {
+  const styleProps = {
     ...props,
     color,
     component,
@@ -354,16 +354,16 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     variant,
   };
 
-  const classes = useUtilityClasses(stateAndProps);
+  const classes = useUtilityClasses(styleProps);
 
   const startIcon = startIconProp && (
-    <ButtonStartIcon className={classes.startIcon} styleProps={stateAndProps}>
+    <ButtonStartIcon className={classes.startIcon} styleProps={styleProps}>
       {startIconProp}
     </ButtonStartIcon>
   );
 
   const endIcon = endIconProp && (
-    <ButtonEndIcon className={classes.endIcon} styleProps={stateAndProps}>
+    <ButtonEndIcon className={classes.endIcon} styleProps={styleProps}>
       {endIconProp}
     </ButtonEndIcon>
   );
@@ -371,7 +371,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   return (
     <ButtonRoot
       className={clsx(classes.root, className)}
-      styleProps={stateAndProps}
+      styleProps={styleProps}
       component={component}
       disabled={disabled}
       focusRipple={!disableFocusRipple}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -60,8 +60,8 @@ export const ButtonBaseRoot = experimentalStyled(
   },
 });
 
-const useUtilityClasses = (props) => {
-  const { disabled, focusVisible, focusVisibleClassName, classes = {} } = props;
+const useUtilityClasses = (styleProps) => {
+  const { disabled, focusVisible, focusVisibleClassName, classes = {} } = styleProps;
 
   const utilityClasses = {
     root: clsx(buttonBaseClasses['root'], classes['root'], {
@@ -335,7 +335,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     }, [enableTouchRipple]);
   }
 
-  const stateAndProps = {
+  const styleProps = {
     ...props,
     centerRipple,
     component,
@@ -347,13 +347,13 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     focusVisible,
   };
 
-  const classes = useUtilityClasses(stateAndProps);
+  const classes = useUtilityClasses(styleProps);
 
   return (
     <ButtonBaseRoot
       as={ComponentProp}
       className={clsx(classes.root, className)}
-      styleProps={stateAndProps}
+      styleProps={styleProps}
       onBlur={handleBlur}
       onClick={onClick}
       onFocus={handleFocus}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -13,13 +13,11 @@ import buttonBaseClasses from './buttonBaseClasses';
 const overridesResolver = (props, styles) => {
   const { disabled, focusVisible } = props;
 
-  const styleOverrides = {
+  return {
     ...styles.root,
     ...(disabled && styles.disabled),
     ...(focusVisible && styles.focusVisible),
   };
-
-  return styleOverrides;
 };
 
 export const ButtonBaseRoot = experimentalStyled(
@@ -63,7 +61,7 @@ export const ButtonBaseRoot = experimentalStyled(
 const useUtilityClasses = (styleProps) => {
   const { disabled, focusVisible, focusVisibleClassName, classes = {} } = styleProps;
 
-  const utilityClasses = {
+  return {
     root: clsx(buttonBaseClasses['root'], classes['root'], {
       [buttonBaseClasses['disabled']]: disabled,
       [classes['disabled']]: disabled,
@@ -72,8 +70,6 @@ const useUtilityClasses = (styleProps) => {
       [focusVisibleClassName]: focusVisible,
     }),
   };
-
-  return utilityClasses;
 };
 
 /**

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -60,7 +60,7 @@ export const ButtonBaseRoot = experimentalStyled(
   },
 });
 
-const useButtonBaseClasses = (props) => {
+const useUtilityClasses = (props) => {
   const { disabled, focusVisible, focusVisibleClassName, classes = {} } = props;
 
   const utilityClasses = {
@@ -347,7 +347,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     focusVisible,
   };
 
-  const classes = useButtonBaseClasses(stateAndProps);
+  const classes = useUtilityClasses(stateAndProps);
 
   return (
     <ButtonBaseRoot

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -357,8 +357,8 @@ SliderRoot.propTypes = {
   }),
 };
 
-const extendUtilityClasses = (props) => {
-  const { color, classes = {} } = props;
+const extendUtilityClasses = (styleProps) => {
+  const { color, classes = {} } = styleProps;
 
   return {
     ...classes,
@@ -383,7 +383,9 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
   const props = useThemeProps({ props: inputProps, name: 'MuiSlider' });
   const { components = {}, componentsProps = {}, color = 'primary', ...other } = props;
 
-  const classes = extendUtilityClasses({ ...props, color });
+  const styleProps = { ...props, color };
+
+  const classes = extendUtilityClasses(styleProps);
 
   return (
     <SliderUnstyled

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -357,7 +357,7 @@ SliderRoot.propTypes = {
   }),
 };
 
-const extendSliderClasses = (props) => {
+const extendUtilityClasses = (props) => {
   const { color, classes = {} } = props;
 
   return {
@@ -383,7 +383,7 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
   const props = useThemeProps({ props: inputProps, name: 'MuiSlider' });
   const { components = {}, componentsProps = {}, color = 'primary', ...other } = props;
 
-  const classes = extendSliderClasses({ ...props, color });
+  const classes = extendUtilityClasses({ ...props, color });
 
   return (
     <SliderUnstyled

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -73,7 +73,7 @@ export const SliderRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   height: 2,
   width: '100%',
   boxSizing: 'content-box',
@@ -82,17 +82,17 @@ export const SliderRoot = experimentalStyled(
   position: 'relative',
   cursor: 'pointer',
   touchAction: 'none',
-  color: props.theme.palette.primary.main,
+  color: theme.palette.primary.main,
   WebkitTapHighlightColor: 'transparent',
-  ...(props.styleProps.color === 'secondary' && {
-    color: props.theme.palette.secondary.main,
+  ...(styleProps.color === 'secondary' && {
+    color: theme.palette.secondary.main,
   }),
   [`&.${sliderClasses.disabled}`]: {
     pointerEvents: 'none',
     cursor: 'default',
-    color: props.theme.palette.grey[400],
+    color: theme.palette.grey[400],
   },
-  ...(props.styleProps.orientation === 'vertical' && {
+  ...(styleProps.orientation === 'vertical' && {
     width: 2,
     height: '100%',
     padding: '0 13px',
@@ -101,16 +101,16 @@ export const SliderRoot = experimentalStyled(
   '@media (pointer: coarse)': {
     // Reach 42px touch target, about ~8mm on screen.
     padding: '20px 0',
-    ...(props.styleProps.orientation === 'vertical' && {
+    ...(styleProps.orientation === 'vertical' && {
       padding: '0 20px',
     }),
   },
   '@media print': {
     colorAdjust: 'exact',
   },
-  ...(props.styleProps.marked && {
+  ...(styleProps.marked && {
     marginBottom: 20,
-    ...(props.styleProps.orientation === 'vertical' && {
+    ...(styleProps.orientation === 'vertical' && {
       marginBottom: 'auto',
       marginRight: 20,
     }),
@@ -126,7 +126,7 @@ export const SliderRoot = experimentalStyled(
     transform: 'rotate(-45deg)',
   },
   [`& .${sliderClasses.valueLabelLabel}`]: {
-    color: props.theme.palette.primary.contrastText,
+    color: theme.palette.primary.contrastText,
     transform: 'rotate(45deg)',
     textAlign: 'center',
   },
@@ -136,7 +136,7 @@ export const SliderRail = experimentalStyled(
   'span',
   {},
   { name: 'Slider', slot: 'Rail' },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   display: 'block',
   position: 'absolute',
   width: '100%',
@@ -144,11 +144,11 @@ export const SliderRail = experimentalStyled(
   borderRadius: 1,
   backgroundColor: 'currentColor',
   opacity: 0.38,
-  ...(props.styleProps.orientation === 'vertical' && {
+  ...(styleProps.orientation === 'vertical' && {
     height: '100%',
     width: 2,
   }),
-  ...(props.styleProps.track === 'inverted' && {
+  ...(styleProps.track === 'inverted' && {
     opacity: 1,
   }),
 }));
@@ -157,24 +157,24 @@ export const SliderTrack = experimentalStyled(
   'span',
   {},
   { name: 'Slider', slot: 'Track' },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   display: 'block',
   position: 'absolute',
   height: 2,
   borderRadius: 1,
   backgroundColor: 'currentColor',
-  ...(props.styleProps.orientation === 'vertical' && {
+  ...(styleProps.orientation === 'vertical' && {
     width: 2,
   }),
-  ...(props.styleProps.track === false && {
+  ...(styleProps.track === false && {
     display: 'none',
   }),
-  ...(props.styleProps.track === 'inverted' && {
+  ...(styleProps.track === 'inverted' && {
     backgroundColor:
       // Same logic as the LinearProgress track color
-      props.theme.palette.mode === 'light'
-        ? lighten(props.theme.palette.primary.main, 0.62)
-        : darken(props.theme.palette.primary.main, 0.5),
+      theme.palette.mode === 'light'
+        ? lighten(theme.palette.primary.main, 0.62)
+        : darken(theme.palette.primary.main, 0.5),
   }),
 }));
 
@@ -182,7 +182,7 @@ export const SliderThumb = experimentalStyled(
   'span',
   {},
   { name: 'Slider', slot: 'Thumb' },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 12,
   height: 12,
@@ -195,8 +195,8 @@ export const SliderThumb = experimentalStyled(
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  transition: props.theme.transitions.create(['box-shadow'], {
-    duration: props.theme.transitions.duration.shortest,
+  transition: theme.transitions.create(['box-shadow'], {
+    duration: theme.transitions.duration.shortest,
   }),
   '&::after': {
     position: 'absolute',
@@ -209,20 +209,20 @@ export const SliderThumb = experimentalStyled(
     bottom: -15,
   },
   [`&:hover, &.${sliderClasses.focusVisible}`]: {
-    boxShadow: `0px 0px 0px 8px ${alpha(props.theme.palette.primary.main, 0.16)}`,
+    boxShadow: `0px 0px 0px 8px ${alpha(theme.palette.primary.main, 0.16)}`,
     '@media (hover: none)': {
       boxShadow: 'none',
     },
   },
   [`&.${sliderClasses.active}`]: {
-    boxShadow: `0px 0px 0px 14px ${alpha(props.theme.palette.primary.main, 0.16)}`,
+    boxShadow: `0px 0px 0px 14px ${alpha(theme.palette.primary.main, 0.16)}`,
   },
   [`&.${sliderClasses.disabled}`]: {
     width: 8,
     height: 8,
     marginLeft: -4,
     marginTop: -3,
-    ...(props.styleProps.orientation === 'vertical' && {
+    ...(styleProps.orientation === 'vertical' && {
       marginLeft: -3,
       marginBottom: -4,
     }),
@@ -230,16 +230,16 @@ export const SliderThumb = experimentalStyled(
       boxShadow: 'none',
     },
   },
-  ...(props.styleProps.orientation === 'vertical' && {
+  ...(styleProps.orientation === 'vertical' && {
     marginLeft: -5,
     marginBottom: -6,
   }),
-  ...(props.styleProps.color === 'secondary' && {
+  ...(styleProps.color === 'secondary' && {
     [`&:hover, &.${sliderClasses.focusVisible}`]: {
-      boxShadow: `0px 0px 0px 8px ${alpha(props.theme.palette.secondary.main, 0.16)}`,
+      boxShadow: `0px 0px 0px 8px ${alpha(theme.palette.secondary.main, 0.16)}`,
     },
     [`&.${sliderClasses.active}`]: {
-      boxShadow: `0px 0px 0px 14px ${alpha(props.theme.palette.secondary.main, 0.16)}`,
+      boxShadow: `0px 0px 0px 14px ${alpha(theme.palette.secondary.main, 0.16)}`,
     },
   }),
 }));
@@ -248,18 +248,18 @@ export const SliderValueLabel = experimentalStyled(
   SliderValueLabelUnstyled,
   {},
   { name: 'Slider', slot: 'ValueLabel' },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
   [`&.${sliderClasses.valueLabelOpen}`]: {
     transform: 'scale(1) translateY(-10px)',
   },
   zIndex: 1,
-  ...props.theme.typography.body2,
-  fontSize: props.theme.typography.pxToRem(12),
+  ...theme.typography.body2,
+  fontSize: theme.typography.pxToRem(12),
   lineHeight: 1.2,
-  transition: props.theme.transitions.create(['transform'], {
-    duration: props.theme.transitions.duration.shortest,
+  transition: theme.transitions.create(['transform'], {
+    duration: theme.transitions.duration.shortest,
   }),
   top: -34,
   transformOrigin: 'bottom center',
@@ -271,14 +271,14 @@ export const SliderMark = experimentalStyled(
   'span',
   {},
   { name: 'Slider', slot: 'Mark' },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 2,
   height: 2,
   borderRadius: 1,
   backgroundColor: 'currentColor',
-  ...(props.styleProps.markActive && {
-    backgroundColor: props.theme.palette.background.paper,
+  ...(styleProps.markActive && {
+    backgroundColor: theme.palette.background.paper,
     opacity: 0.8,
   }),
 }));
@@ -287,26 +287,26 @@ export const SliderMarkLabel = experimentalStyled(
   'span',
   {},
   { name: 'Slider', slot: 'MarkLabel' },
-)((props) => ({
-  ...props.theme.typography.body2,
-  color: props.theme.palette.text.secondary,
+)(({ theme, styleProps }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
   position: 'absolute',
   top: 26,
   transform: 'translateX(-50%)',
   whiteSpace: 'nowrap',
-  ...(props.styleProps.orientation === 'vertical' && {
+  ...(styleProps.orientation === 'vertical' && {
     top: 'auto',
     left: 26,
     transform: 'translateY(50%)',
   }),
   '@media (pointer: coarse)': {
     top: 40,
-    ...(props.styleProps.orientation === 'vertical' && {
+    ...(styleProps.orientation === 'vertical' && {
       left: 31,
     }),
   },
-  ...(props.styleProps.markLabelActive && {
-    color: props.theme.palette.text.primary,
+  ...(styleProps.markLabelActive && {
+    color: theme.palette.text.primary,
   }),
 }));
 

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -136,7 +136,7 @@ export const SliderRail = experimentalStyled(
   'span',
   {},
   { name: 'Slider', slot: 'Rail' },
-)(({ theme, styleProps }) => ({
+)(({ styleProps }) => ({
   display: 'block',
   position: 'absolute',
   width: '100%',
@@ -248,7 +248,7 @@ export const SliderValueLabel = experimentalStyled(
   SliderValueLabelUnstyled,
   {},
   { name: 'Slider', slot: 'ValueLabel' },
-)(({ theme, styleProps }) => ({
+)(({ theme }) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
   [`&.${sliderClasses.valueLabelOpen}`]: {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -42,7 +42,7 @@ const overridesResolver = (props, styles) => {
 
   const marked = marks.length > 0 && marks.some((mark) => mark.label);
 
-  const styleOverrides = {
+  return {
     ...styles.root,
     ...styles[`color${capitalize(color)}`],
     [`&.${sliderClasses.disabled}`]: styles.disabled,
@@ -61,8 +61,6 @@ const overridesResolver = (props, styles) => {
       [`&.${sliderClasses.disabled}`]: styles.disabled,
     },
   };
-
-  return styleOverrides;
 };
 
 export const SliderRoot = experimentalStyled(

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -79,8 +79,8 @@ const defaultVariantMapping = {
   inherit: 'p',
 };
 
-const useUtilityClasses = (props) => {
-  const { align, color, display, gutterBottom, noWrap, paragraph, variant, classes = {} } = props;
+const useUtilityClasses = (styleProps) => {
+  const { align, color, display, gutterBottom, noWrap, paragraph, variant, classes = {} } = styleProps;
 
   const utilityClasses = {
     root: clsx(
@@ -125,7 +125,7 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
     ...other
   } = props;
 
-  const stateAndProps = {
+  const styleProps = {
     ...props,
     align,
     className,
@@ -144,13 +144,13 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
     (paragraph ? 'p' : variantMapping[variant] || defaultVariantMapping[variant]) ||
     'span';
 
-  const classes = useUtilityClasses(stateAndProps);
+  const classes = useUtilityClasses(styleProps);
 
   return (
     <TypographyRoot
       as={Component}
       ref={ref}
-      styleProps={stateAndProps}
+      styleProps={styleProps}
       className={clsx(classes.root, className)}
       {...other}
     />

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -21,7 +21,7 @@ const getTextColor = (color, palette) => {
 const overridesResolver = (props, styles) => {
   const { styleProps = {} } = props;
 
-  const styleOverrides = {
+  return {
     ...styles.root,
     ...(styleProps.variant && styles[styleProps.variant]),
     ...(styleProps.color && styles[`color${capitalize(styleProps.color)}`]),
@@ -31,8 +31,6 @@ const overridesResolver = (props, styles) => {
     ...(styleProps.gutterBottom && styles.gutterBottom),
     ...(styleProps.paragraph && styles.paragraph),
   };
-
-  return styleOverrides;
 };
 
 export const TypographyRoot = experimentalStyled(
@@ -82,7 +80,7 @@ const defaultVariantMapping = {
 const useUtilityClasses = (styleProps) => {
   const { align, color, display, gutterBottom, noWrap, paragraph, variant, classes = {} } = styleProps;
 
-  const utilityClasses = {
+  return {
     root: clsx(
       typographyClasses['root'],
       classes['root'],
@@ -104,8 +102,6 @@ const useUtilityClasses = (styleProps) => {
       },
     ),
   };
-
-  return utilityClasses;
 };
 
 const Typography = React.forwardRef(function Typography(inProps, ref) {

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -78,7 +78,16 @@ const defaultVariantMapping = {
 };
 
 const useUtilityClasses = (styleProps) => {
-  const { align, color, display, gutterBottom, noWrap, paragraph, variant, classes = {} } = styleProps;
+  const {
+    align,
+    color,
+    display,
+    gutterBottom,
+    noWrap,
+    paragraph,
+    variant,
+    classes = {},
+  } = styleProps;
 
   return {
     root: clsx(

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -39,29 +39,29 @@ export const TypographyRoot = experimentalStyled(
   'span',
   {},
   { name: 'Typography', slot: 'Root', overridesResolver },
-)((props) => ({
+)(({ theme, styleProps }) => ({
   margin: 0,
-  ...(props.styleProps.variant && props.theme.typography[props.styleProps.variant]),
-  ...(props.styleProps.align !== 'inherit' && {
-    textAlign: props.styleProps.align,
+  ...(styleProps.variant && theme.typography[styleProps.variant]),
+  ...(styleProps.align !== 'inherit' && {
+    textAlign: styleProps.align,
   }),
-  ...(props.styleProps.noWrap && {
+  ...(styleProps.noWrap && {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   }),
-  ...(props.styleProps.gutterBottom && {
+  ...(styleProps.gutterBottom && {
     marginBottom: '0.35em',
   }),
-  ...(props.styleProps.paragraph && {
+  ...(styleProps.paragraph && {
     marginBottom: 16,
   }),
-  ...(props.styleProps.color &&
-    props.styleProps.color !== 'initial' && {
-      color: getTextColor(props.styleProps.color, props.theme.palette),
+  ...(styleProps.color &&
+    styleProps.color !== 'initial' && {
+      color: getTextColor(styleProps.color, theme.palette),
     }),
-  ...(props.styleProps.display !== 'initial' && {
-    display: props.styleProps.display,
+  ...(styleProps.display !== 'initial' && {
+    display: styleProps.display,
   }),
 }));
 

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -79,7 +79,7 @@ const defaultVariantMapping = {
   inherit: 'p',
 };
 
-const useTypographyClasses = (props) => {
+const useUtilityClasses = (props) => {
   const { align, color, display, gutterBottom, noWrap, paragraph, variant, classes = {} } = props;
 
   const utilityClasses = {
@@ -144,7 +144,7 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
     (paragraph ? 'p' : variantMapping[variant] || defaultVariantMapping[variant]) ||
     'span';
 
-  const classes = useTypographyClasses(stateAndProps);
+  const classes = useUtilityClasses(stateAndProps);
 
   return (
     <TypographyRoot


### PR DESCRIPTION
This PR applies some refactorings on the  styled()` components proposed in https://github.com/mui-org/material-ui/pull/24114

1. Reduce the need to change theme import paths when migrating the components from `withStyles` to `styled`. This should allow a faster migration. 

```diff
const AvatarRoot = experimentalStyled(
  'div',
  {},
  {
    name: 'Avatar',
    slot: 'Root',
    overridesResolver,
  },
-)((props) => ({
+)(({ theme, styleProps }) => ({
```

2. Reduce prop name renaming, make it easier to navigate the code:

```diff
    <AvatarRoot
      as={Component}
-     styleProps={stateAndProps}
+     styleProps={styleProps}
      className={clsx(classes.root, className)}
      ref={ref}
```

```diff
-const useAvatarClasses = (props) => {
- const { classes = {}, variant, colorDefault } = props;
+const useAvatarClasses = (styleProps) => {
+ const { classes = {}, variant, colorDefault } = styleProps;

  const utilityClasses = {
```

I got confused about what was what. 

4. Do we need to name the returned value of `overridesResolver`? What about:

```diff
const overridesResolver = (props, styles) => {
  const { variant = 'circular' } = props;

- const styleOverrides = {
+ return {
    ...styles.root,
    ...styles[variant],
    [`&.${avatarClasses.img}`]: styles.img,
    [`&.${avatarClasses.fallback}`]: styles.fallback,
  };
-
- return styleOverrides;
};
```

Same question for no intermediate variable in `useAvatarClasses`.

5. Do we need to give `useAvatarClasses` a specific name? What about a generic one to make it easier to copy & paste?

```diff
-const useAvatarClasses = (props) => {
+const useUtilityClasses = (props) => {
  const { classes = {}, variant, colorDefault } = props;

  const utilityClasses = {
    root: clsx(avatarClasses.root, classes.root, getAvatarUtilityClass(variant), {
      [avatarClasses.colorDefault]: colorDefault,
    }),
```