### PR TITLE
[DatePicker] Nested imports for better DX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -284,7 +284,7 @@ module.exports = {
       },
     },
     {
-      files: ['packages/material-ui-*/src/**/*{.ts,.tsx,.js}'],
+      files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
       excludedFiles: ['*.d.ts', '*.spec.tsx'],
       rules: {
         'no-restricted-imports': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -285,7 +285,7 @@ module.exports = {
     },
     {
       files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
-      excludedFiles: ['*.d.ts', '*.spec.tsx'],
+      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -283,5 +283,18 @@ module.exports = {
         'no-bitwise': 'off',
       },
     },
+    {
+      files: ['packages/material-ui-*/src/**/*{.ts,.tsx,.js}'],
+      excludedFiles: '*.d.ts',
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            // Prefer one level nested imports to avoid bundling everything in dev mode.
+            paths: ['@material-ui/core', '@material-ui/lab'],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -285,7 +285,7 @@ module.exports = {
     },
     {
       files: ['packages/material-ui-*/src/**/*{.ts,.tsx,.js}'],
-      excludedFiles: '*.d.ts',
+      excludedFiles: ['*.d.ts', '*.spec.tsx'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,10 @@
 const path = require('path');
 
+const forbitTopLevelMessage = [
+  'Prefer one level nested imports to avoid bundling everything in dev mode',
+  'See https://github.com/mui-org/material-ui/pull/24147 for the kind of win it can unlock.',
+].join('\n');
+
 module.exports = {
   root: true, // So parent files don't get applied
   globals: {
@@ -290,11 +295,16 @@ module.exports = {
         'no-restricted-imports': [
           'error',
           {
-            paths: ['@material-ui/core', '@material-ui/lab'],
-            message: [
-              'Prefer one level nested imports to avoid bundling everything in dev mode',
-              'See https://github.com/mui-org/material-ui/pull/24147 for the kind of win it can unlock.',
-            ].join('\n'),
+            paths: [
+              {
+                name: '@material-ui/core',
+                message: forbitTopLevelMessage,
+              },
+              {
+                name: '@material-ui/lab',
+                message: forbitTopLevelMessage,
+              },
+            ],
           },
         ],
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -290,8 +290,11 @@ module.exports = {
         'no-restricted-imports': [
           'error',
           {
-            // Prefer one level nested imports to avoid bundling everything in dev mode.
             paths: ['@material-ui/core', '@material-ui/lab'],
+            message: [
+              'Prefer one level nested imports to avoid bundling everything in dev mode',
+              'See https://github.com/mui-org/material-ui/pull/24147 for the kind of win it can unlock.',
+            ].join('\n'),
           },
         ],
       },

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import ButtonBase, { ButtonBaseProps } from '@material-ui/core/ButtonBase';
 import { createStyles, WithStyles, withStyles, Theme, alpha } from '@material-ui/core/styles';
-import { useForkRef } from '@material-ui/core';
+import { useForkRef } from '@material-ui/core/utils';
 import { ExtendMui } from '../internal/pickers/typings/helpers';
 import { onSpaceOrEnter } from '../internal/pickers/utils';
 import { useUtils } from '../internal/pickers/hooks/useUtils';

--- a/packages/material-ui-lab/src/Timeline/Timeline.tsx
+++ b/packages/material-ui-lab/src/Timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+// eslint-disable-next-line no-restricted-imports -- importing types
 import { InternalStandardProps as StandardProps } from '@material-ui/core';
 import { capitalize } from '@material-ui/core/utils';
 import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useViews.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useViews.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useControlled } from '@material-ui/core';
+import { useControlled } from '@material-ui/core/utils';
 import { arrayIncludes } from '../utils';
 import { PickerSelectionState } from './usePickerState';
 import { AllAvailableViews } from '../typings/Views';

--- a/packages/material-ui-lab/src/internal/pickers/typings/helpers.ts
+++ b/packages/material-ui-lab/src/internal/pickers/typings/helpers.ts
@@ -1,4 +1,4 @@
-import { WithStyles } from '@material-ui/core';
+import { WithStyles } from '@material-ui/core/styles';
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { stub } from 'sinon';
 import { SheetsRegistry } from 'jss';
-import { Input } from '@material-ui/core';
+import Input from '@material-ui/core/Input';
 import { createClientRender, screen } from 'test/utils';
 import { isMuiElement } from '@material-ui/core/utils';
 import { createMuiTheme } from '@material-ui/core/styles';

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils';
-import { Input } from '@material-ui/core';
+import Input from '@material-ui/core/Input';
 import { isMuiElement } from '@material-ui/core/utils';
 import PropTypes from 'prop-types';
 import withTheme from './withTheme';


### PR DESCRIPTION
Closes #24146

Import one level deep to reduce the amount of JavaScript sent to the client in development.

In modern tooling, tree-shaking is only enabled in production. Not all developers have a fast computer. The change aims to reduce the amount of JavaScript loaded. The pain is growing as we add more modules to `@material-ui/core`.

I couldn't find any other cases like this in the codebase. Here is the impact when including [this demo](https://next.material-ui.com/components/date-picker/#basic-usage) (and only) with a high-end computer:

**Before**

<img width="807" alt="master network" src="https://user-images.githubusercontent.com/3165635/103212430-09093b80-490b-11eb-9876-01ecd1316bd1.png">
<img width="311" alt="master js" src="https://user-images.githubusercontent.com/3165635/103212432-09a1d200-490b-11eb-95f1-e15d2189d257.png">

**After**

<img width="808" alt="pr network" src="https://user-images.githubusercontent.com/3165635/103212434-0c042c00-490b-11eb-844c-e66cc40bbfc3.png">
<img width="319" alt="pr js" src="https://user-images.githubusercontent.com/3165635/103212435-0c042c00-490b-11eb-9948-e85cdb83a378.png">

I would call this a quick-win, a low effort: -200ms improvement in DX. It's not making a fundamental difference but doesn't cost much to accept it 🤷‍♂️. My biggest fear is about making it possible to grow `@material-ui/core` in size (feature set) without being in a disadvantage compared to projects that ship one component, e.g. [react-dates](https://github.com/airbnb/react-dates).