### PR TITLE
[core] Reduce number of files included in language server

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,5 +38,5 @@
     // Otherwise we get react-native typings which conflict with dom.lib.
     "types": ["node", "react"]
   },
-  "exclude": ["**/build", "**/node_modules", "docs/.next", "docs/export"]
+  "exclude": ["**/.*/", "**/build", "**/node_modules", "docs/export"]
 }


### PR DESCRIPTION
Hopefully this removes the "To enable project-wide JavaScript/TypeScript language features, exclude large folders with source files that you do not work on." warning in VSCode.

Seems to be a common misconfiguration: https://github.com/microsoft/TypeScript/wiki/Performance#misconfigured-include-and-exclude