### PR TITLE
[core] Reduce response time of initial PR bot comment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,12 +51,6 @@ jobs:
           yarn install
         displayName: 'install dependencies'
 
-      - task: Cache@2
-        inputs:
-          key: 'node-modules-cache | yarn.lock'
-          path: node_modules/.cache
-        displayName: Cache node_modules/.cache
-
       - script: |
           yarn danger ci
         displayName: 'prepare danger on PRs'
@@ -65,6 +59,12 @@ jobs:
           AZURE_BUILD_ID: $(Build.BuildId)
           DANGER_COMMAND: 'prepareBundleSizeReport'
           DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)
+
+      - task: Cache@2
+        inputs:
+          key: 'node-modules-cache | yarn.lock'
+          path: node_modules/.cache
+        displayName: Cache node_modules/.cache
 
       - script: |
           yarn lerna run --ignore @material-ui/icons --parallel --scope "@material-ui/*" build


### PR DESCRIPTION
We don't need `node_modules/.cache` when submitting the initial comment so we can defer the download saving 10-15s.

I planned some additional cloning speed-ups by switching to [treeless clones](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/). This isn't possible in any of our CI providers (Azure, CircleCI) without forking their checkout command. This isn't worth it IMO for a couple of seconds. Shallow clones are not viable since various tasks rely on the commit history.