### PR TITLE
[Select] Improve description on how it extends the Input components

### DIFF
--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -25,7 +25,8 @@ It's meant to be an improved version of the "react-select" and "downshift" packa
 
 ## Props
 
-The Select component is implemented as a custom `<input>` element on top of the [text field components](/components/text-fields).
+The Select component is implemented as a custom `<input>` element of the [InputBase](/api/input-base/).
+It extends the [text field components](/components/text-fields) sub-components, either the [Input](/api/input/), [FilledInput](/api/filled-input/), or [OutlinedInput](/api/outlined-input/), depending on the variant selected.
 It shares the same styles and many of the same props. Refer to the respective component's API page for details.
 
 ### Filled and outlined variants

--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -25,6 +25,9 @@ It's meant to be an improved version of the "react-select" and "downshift" packa
 
 ## Props
 
+The Select component is implemented as a custom `<input>` element on top of the [text field components](/components/text-fields).
+It allows sharing the same style and many of the same props.
+
 ### Filled and outlined variants
 
 {{"demo": "pages/components/selects/SelectVariants.js"}}
@@ -140,6 +143,3 @@ For a [native select](#native-select), you should mention a label by giving the 
   <option value="20">Twenty</option>
 </NativeSelect>
 ```
-## Reduce Height of Select Fields
-
-If you are using the `TextField` wrapper component as mentioned above you can take advantage of the size prop to reduce the height of your select field, see the details [in this section](/components/text-fields/#sizes).

--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -26,7 +26,7 @@ It's meant to be an improved version of the "react-select" and "downshift" packa
 ## Props
 
 The Select component is implemented as a custom `<input>` element on top of the [text field components](/components/text-fields).
-It allows sharing the same style and many of the same props.
+It shares the same styles and many of the same props. Refer to the respective component's API page for details.
 
 ### Filled and outlined variants
 

--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -140,3 +140,6 @@ For a [native select](#native-select), you should mention a label by giving the 
   <option value="20">Twenty</option>
 </NativeSelect>
 ```
+## Reduce Height of Select Fields
+
+If you are using the `TextField` wrapper component as mentioned above you can take advantage of the size prop to reduce the height of your select field, see the details [in this section](/components/text-fields/#sizes).


### PR DESCRIPTION
Add in some information on how to resize the select component.  I couldn't find this information and was going to start adding in custom styles until I foud the size prop, so I hope this can also help others.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
