### PR TITLE
[DatePicker] Fix accessibility issue with heading

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
@@ -34,6 +34,7 @@ const PickersToolbarText: React.FC<PickersToolbarTextProps & WithStyles<typeof s
       className={clsx(classes.root, className, {
         [classes.selected]: selected,
       })}
+      component="span"
       {...other}
     >
       {value}

--- a/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
@@ -7,7 +7,6 @@ import { ExtendMui } from './typings/helpers';
 export interface PickersToolbarTextProps extends ExtendMui<TypographyProps> {
   selected?: boolean;
   value: React.ReactNode;
-  component?: React.ElementType;
 }
 
 export const styles = (theme: Theme) => {

--- a/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
@@ -7,7 +7,7 @@ import { ExtendMui } from './typings/helpers';
 export interface PickersToolbarTextProps extends ExtendMui<TypographyProps> {
   selected?: boolean;
   value: React.ReactNode;
-  component?: React.ElementType
+  component?: React.ElementType;
 }
 
 export const styles = (theme: Theme) => {

--- a/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersToolbarText.tsx
@@ -7,6 +7,7 @@ import { ExtendMui } from './typings/helpers';
 export interface PickersToolbarTextProps extends ExtendMui<TypographyProps> {
   selected?: boolean;
   value: React.ReactNode;
+  component?: React.ElementType
 }
 
 export const styles = (theme: Theme) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #24174

This fixes the immediate issue regarding ToolbarText taking in a variant, such as h3, and creating an h3 element. This causes issues with accessibility. This automatically sets component as span, but can be overridden by props being passed over. I added an optional component prop type, I am not sure if this is necessary due to it already having the TypographyProps, but the documentation had mentioned adding prop types when new props (like component) are added.

One question posed, but not addressed, is allowing headings to be injected. The link mentioned at https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html holds a heading within the modal of their date picker because it is a heading for their modal. I believe this is a secondary issue, one that would be an improvement not necessarily handled by ToolbarText. If this were to take in the heading prop, 06:30 AM would be ```<h6>06</h6><h6>:</h6><h6>30</h6>```.  This does not make sense necessarily. It would be more appropriate to single out a single label that identifies the heading of a modal, and have that wrapped with a singular element with a customizable heading.