### PR TITLE
[core] Create issue mark duplicate

### DIFF
--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -14,5 +14,5 @@ jobs:
           actions: 'mark-duplicate'
           token: ${{ secrets.GITHUB_TOKEN }}
           duplicate-command: '/d'
-          labels: 'duplicate'
+          duplicate-labels: 'duplicate'
           close-issue: true

--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -13,6 +13,5 @@ jobs:
         with:
           actions: 'mark-duplicate'
           token: ${{ secrets.GITHUB_TOKEN }}
-          duplicate-command: '/d'
           duplicate-labels: 'duplicate'
           close-issue: true

--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -1,0 +1,18 @@
+name: Issue Mark Duplicate
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  mark-duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mark-duplicate
+        uses: actions-cool/issues-helper@v1.6
+        with:
+          actions: 'mark-duplicate'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          duplicate-command: '/d'
+          labels: 'duplicate'
+          close-issue: true


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

HI, @oliviertassinari I saw that when you deal with duplicate issue, like https://github.com/mui-org/material-ui/issues/24153 has some operations.

I think this GitHub Actions will help you.

### 😀 It achieved

The function implemented by the current configuration is: when you enter `Duplicate of #24153` or `/d #24153`, the system will ~automatically remove all labels,~ add `duplicate`, and close the issue at the same time.

This Actions also supports more parameters:

| Param | Desc  | Type | Required |
| -- | -- | -- | -- |
| actions | Action type | string | ✔ |
| token | - | string | ✔ |
| duplicate-command | Simple commands can be set, such as: `/d` | string | ✖ |
| duplicate-labels | Add additional labels to this issue | string | ✖ |
| labels | Replace the labels of the issue | string | ✖ |
| contents | Add emoji for this comment | string | ✖ |
| close-issue | Whether to close the issue at the same time | string | ✖ |

- `duplicate-command`: When setting concise commands, while still supporting the original `Duplicate of`
- `close-issue`: Both `true` or `'true'` can take effect

### 🤖 About Actions

This Actions also contains many other functions, which can be viewed [here](https://github.com/actions-cool/issues-helper)

