### PR TITLE
[core] Monitor progress of fixing type imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,9 @@ jobs:
       - run:
           name: Diff declaration files
           command: |
-            git add -f packages/material-ui/build
-            git add -f packages/material-ui-lab/build
-            git add -f packages/material-ui-utils/build
+            git add -f packages/material-ui/build || echo '/core declarations do not exist'
+            git add -f packages/material-ui-lab/build || echo '/lab declarations do not exist'
+            git add -f packages/material-ui-utils/build || echo '/utils declarations do not exist'
             yarn lerna run --parallel build:types
             git --no-pager diff
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,9 @@ jobs:
               exit 1
             fi
       - run:
+          name: Check builds
+          command: yarn test:build
+      - run:
           name: material-ui-icons
           command: |
             # latest commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,11 +178,6 @@ jobs:
           keys:
             # We assume that the target branch is `next`
             - typescript-declaration-files-next
-          paths:
-            # packages with generated declaration files
-            - packages/material-ui/build
-            - packages/material-ui-lab/build
-            - packages/material-ui-utils/build
 
       - run:
           name: Diff declaration files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,9 @@ jobs:
           name: Tests TypeScript definitions
           command: yarn typescript
 
-      # We assume that the target branch is `next`
       - restore_cache:
           keys:
+            # We assume that the target branch is `next`
             - typescript-declaration-files-next
           paths:
             # packages with generated declaration files
@@ -202,19 +202,13 @@ jobs:
             set +e
             node scripts/testBuiltTypes.js
             exit 0
-
-      # Persist accepted commits i.e. those on the target branch
-      - when:
-          condition:
-            - equal: [next, << pipeline.git.branch >>]
-          steps:
-            - save_cache:
-                key: typescript-declaration-files-next
-                paths:
-                  # packages with generated declaration files
-                  - packages/material-ui/build
-                  - packages/material-ui-lab/build
-                  - packages/material-ui-utils/build
+      - save_cache:
+          key: typescript-declaration-files-{{ .Branch }}
+          paths:
+            # packages with generated declaration files
+            - packages/material-ui/build
+            - packages/material-ui-lab/build
+            - packages/material-ui-utils/build
   test_types_next:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
           command: yarn typescript
 
       - restore_cache:
+          name: Restore generated declaration files
           keys:
             # We assume that the target branch is `next`
             - typescript-declaration-files-next
@@ -198,6 +199,7 @@ jobs:
             node scripts/testBuiltTypes.js
             exit 0
       - save_cache:
+          name: Save generated declaration files
           key: typescript-declaration-files-{{ .Branch }}
           paths:
             # packages with generated declaration files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,6 @@ jobs:
               exit 1
             fi
       - run:
-          name: Check builds
-          command: yarn test:build
-      - run:
           name: material-ui-icons
           command: |
             # latest commit
@@ -176,6 +173,48 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: yarn typescript
+
+      # We assume that the target branch is `next`
+      - restore_cache:
+          keys:
+            - typescript-declaration-files-next
+          paths:
+            # packages with generated declaration files
+            - packages/material-ui/build
+            - packages/material-ui-lab/build
+            - packages/material-ui-utils/build
+
+      - run:
+          name: Diff declaration files
+          command: |
+            git add -f packages/material-ui/build
+            git add -f packages/material-ui-lab/build
+            git add -f packages/material-ui-utils/build
+            yarn lerna run --parallel build:types
+            git --no-pager diff
+
+      - run:
+          name: Log defect declaration files
+          command: |
+            # ignore build failures
+            # Fixing these takes some effort that isn't viable to merge in a single PR.
+            # We'll simply monitor them for now.
+            set +e
+            node scripts/testBuiltTypes.js
+            exit 0
+
+      # Persist accepted commits i.e. those on the target branch
+      - when:
+          condition:
+            - equal: [next, << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: typescript-declaration-files-next
+                paths:
+                  # packages with generated declaration files
+                  - packages/material-ui/build
+                  - packages/material-ui-lab/build
+                  - packages/material-ui-utils/build
   test_types_next:
     <<: *defaults
     steps:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "start": "yarn && yarn docs:dev",
     "t": "node test/cli.js",
     "test": "yarn lint && yarn typescript && yarn test:coverage",
+    "test:build": "node scripts/testBuiltTypes",
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=text mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:coverage:ci": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=lcov mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=html mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "start": "yarn && yarn docs:dev",
     "t": "node test/cli.js",
     "test": "yarn lint && yarn typescript && yarn test:coverage",
-    "test:build": "node scripts/testBuiltTypes",
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=text mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:coverage:ci": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=lcov mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=html mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",

--- a/scripts/testBuiltTypes.js
+++ b/scripts/testBuiltTypes.js
@@ -1,15 +1,9 @@
-const childProcess = require('child_process');
 const glob = require('fast-glob');
 const fse = require('fs-extra');
 const path = require('path');
-const { promisify } = require('util');
-
-const execFile = promisify(childProcess.execFile);
 
 async function main() {
   const workspaceRoot = path.resolve(__dirname, '..');
-
-  await execFile('yarn', ['lerna', 'run', '--parallel', 'build:types'], { cwd: workspaceRoot });
 
   const declarationFiles = await glob('**/build/**/*.d.ts', {
     absolute: true,

--- a/scripts/testBuiltTypes.js
+++ b/scripts/testBuiltTypes.js
@@ -27,7 +27,11 @@ async function main() {
 
       if (importsTypesRelativeToWorkspace) {
         console.error(
-          `${declarationFilePath} possibly imports types that are unreachable once published.`,
+          // readable path for CI while making it clickable locally
+          `${path.relative(
+            process.cwd(),
+            declarationFilePath,
+          )} possibly imports types that are unreachable once published.`,
         );
         process.exitCode = 1;
       }


### PR DESCRIPTION
Monitors progress in fixing https://github.com/mui-org/material-ui/issues/24112 by:
- diffing generated declaration files against the ones on `next`
- logging files that still have faulty imports

The fixes for https://github.com/mui-org/material-ui/issues/24112 are useful regardless of https://github.com/mui-org/material-ui/issues/24112. Since they have different rationales (have two more fixes locally that are different than https://github.com/mui-org/material-ui/pull/24158) I'll file them as separate PRs.  Should also help debug potential breakage.