### PR TITLE
[slider] Fix circular type reference in SliderValueLabel

### DIFF
--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -47,7 +47,7 @@ type SliderMarkLabelProps = NonNullable<SliderTypeMap['props']['componentsProps'
 type SliderRailProps = NonNullable<SliderTypeMap['props']['componentsProps']>['rail'];
 type SliderTrackProps = NonNullable<SliderTypeMap['props']['componentsProps']>['track'];
 type SliderThumbProps = NonNullable<SliderTypeMap['props']['componentsProps']>['thumb'];
-type SliderValueLabel = NonNullable<SliderTypeMap['props']['componentsProps']>['valueLabel'];
+type SliderValueLabelProps = NonNullable<SliderTypeMap['props']['componentsProps']>['valueLabel'];
 
 export const SliderRoot: React.FC<SliderRootProps>;
 export const SliderMark: React.FC<SliderMarkProps>;
@@ -55,7 +55,7 @@ export const SliderMarkLabel: React.FC<SliderMarkLabelProps>;
 export const SliderRail: React.FC<SliderRailProps>;
 export const SliderTrack: React.FC<SliderTrackProps>;
 export const SliderThumb: React.FC<SliderThumbProps>;
-export const SliderValueLabel: React.FC<SliderValueLabel>;
+export const SliderValueLabel: React.FC<SliderValueLabelProps>;
 
 /**
  *


### PR DESCRIPTION
I'll have to do a thorough review of these types anyway. I'm not sure if they're accurate, too strict or too loose.

This particular issue was detected by `@typescript-eslint/*` 4.11.1. It uncovered a series of other issues that we'll fix in separate PRs. I want these type changes focused for changelog and in case they break something. 