### PR TITLE
[Skeleton] Fix default TypeScript component type

### DIFF
--- a/packages/material-ui/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui/src/Skeleton/Skeleton.d.ts
@@ -56,7 +56,7 @@ export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
      */
     width?: number | string;
   };
-  defaultComponent: 'div';
+  defaultComponent: D;
 }
 
 /**


### PR DESCRIPTION
Skeleton used to declare `div` but it's actually `span` at runtime. The issue was that the generic parameter `D` was unused.

This particular issue was detected by @typescript-eslint/* 4.11.1. It uncovered a series of other issues that we'll fix in separate PRs. I want these type changes focused for changelog and in case they break something.