### PR TITLE
[core] Remove unused generics from experimentalStyled

### DIFF
--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -179,7 +179,7 @@ export interface StyledOptions {
   target?: string;
 }
 
-interface MuiStyledOptions<Theme extends object = any> {
+interface MuiStyledOptions {
   name?: string;
   slot?: string;
   overridesResolver?: (props: any, styles: string | object) => string | object;
@@ -191,13 +191,13 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <Tag extends React.ComponentType<any>, ExtraProps = {}>(
     tag: Tag,
     options?: StyledOptions,
-    muiOptions?: MuiStyledOptions<Theme>
+    muiOptions?: MuiStyledOptions
   ): CreateStyledComponentExtrinsic<Tag, ExtraProps, Theme>;
 
   <Tag extends keyof JSXInEl, ExtraProps = {}>(
     tag: Tag,
     options?: StyledOptions,
-    muiOptions?: MuiStyledOptions<Theme>
+    muiOptions?: MuiStyledOptions
   ): CreateStyledComponentIntrinsic<Tag, ExtraProps, Theme>;
 }
 


### PR DESCRIPTION
The generic parameter of `MuiStyledOptions` was unused.

This particular issue was detected by `@typescript-eslint/*` 4.11.1. It uncovered a series of other issues that we'll fix in separate PRs. I want these type changes focused for changelog and in case they break something. 