### PR TITLE
[TimePicker] Prevent conflicting type parameter in `ClockProps#getClockLabelText`

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -27,7 +27,7 @@ export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
   minutesStep?: number;
   ampmInClock?: boolean;
   allowKeyboardControl?: boolean;
-  getClockLabelText: <TDate>(
+  getClockLabelText: (
     view: 'hours' | 'minutes' | 'seconds',
     time: TDate,
     adapter: MuiPickersAdapter<TDate>,
@@ -118,7 +118,7 @@ function Clock<TDate>(props: ClockProps<TDate> & WithStyles<typeof styles>) {
     value,
   } = props;
 
-  const utils = useUtils();
+  const utils = useUtils<TDate>();
   const isStatic = React.useContext(IsStaticVariantContext);
   const wrapperVariant = React.useContext(WrapperVariantContext);
   const isMoving = React.useRef(false);

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -294,7 +294,6 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
         ampmInClock={ampmInClock}
         type={view}
         ampm={ampm}
-        // @ts-expect-error TODO figure out this weird error
         getClockLabelText={getClockLabelText}
         minutesStep={minutesStep}
         allowKeyboardControl={allowKeyboardControl}


### PR DESCRIPTION
The given time and getClockLabelText could be passed assuming different date types since they didn't use the same type parameter. The name was identical but the type could be different because on shadowed the other.

This particular issue was detected by `@typescript-eslint/*` 4.11.1. It uncovered a series of other issues that we'll fix in separate PRs. I want these type changes focused for changelog and in case they break something. 