### PR TITLE
[core] Platform agnostic build script for envinfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  # Tests dev-only scripts across all supported dev environments
+  test-dev:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: yarn install
+      - run: yarn release:build

--- a/packages/material-ui-envinfo/scripts/build.js
+++ b/packages/material-ui-envinfo/scripts/build.js
@@ -6,7 +6,6 @@ const { promisify } = require('util');
 const packageRoot = path.resolve(__dirname, '../');
 const buildDirectory = path.join(packageRoot, 'build');
 
-const execFile = promisify(childProcess.execFile);
 const exec = promisify(childProcess.exec);
 
 /**
@@ -28,14 +27,14 @@ async function main() {
   // hardcoded by npm
   const untarDestination = path.join(packageRoot, 'package');
   try {
-    await execFile(
-      'tar',
+    await exec(
       [
+        'tar',
         '-xzf',
         // absolute paths are not interpreted as local files
         // `--force-local` is not available in BSD tar (macOS)
         path.relative(packageRoot, packageTgzPath),
-      ],
+      ].join(' '),
       {
         cwd: packageRoot,
       },

--- a/packages/material-ui-envinfo/scripts/build.js
+++ b/packages/material-ui-envinfo/scripts/build.js
@@ -7,7 +7,6 @@ const packageRoot = path.resolve(__dirname, '../');
 const buildDirectory = path.join(packageRoot, 'build');
 
 const exec = promisify(childProcess.exec);
-const execFile = promisify(childProcess.execFile);
 
 /**
  * Moves published files to `/build`.
@@ -17,7 +16,7 @@ async function main() {
   // clean
   await fse.remove(buildDirectory);
 
-  const { stdout: filenames } = await execFile('npm', ['pack'], { cwd: packageRoot });
+  const { stdout: filenames } = await exec('npm pack', { cwd: packageRoot });
   const packageTgzPath = path.join(
     packageRoot,
     // https://docs.npmjs.com/cli/v6/commands/npm-pack
@@ -28,9 +27,18 @@ async function main() {
   // hardcoded by npm
   const untarDestination = path.join(packageRoot, 'package');
   try {
-    await exec(['tar', '--force-local', '-xzf', packageTgzPath].join(' '), {
-      cwd: packageRoot,
-    });
+    await exec(
+      [
+        'tar',
+        '-xzf',
+        // absolute paths are not interpreted as local files
+        // `--force-local` is not available in BSD tar (macOS)
+        path.relative(packageRoot, packageTgzPath),
+      ].join(' '),
+      {
+        cwd: packageRoot,
+      },
+    );
     await fse.move(untarDestination, buildDirectory);
   } finally {
     await fse.remove(untarDestination);

--- a/packages/material-ui-envinfo/scripts/build.js
+++ b/packages/material-ui-envinfo/scripts/build.js
@@ -7,6 +7,7 @@ const packageRoot = path.resolve(__dirname, '../');
 const buildDirectory = path.join(packageRoot, 'build');
 
 const execFile = promisify(childProcess.execFile);
+const exec = promisify(childProcess.exec);
 
 /**
  * Moves published files to `/build`.
@@ -16,11 +17,7 @@ async function main() {
   // clean
   await fse.remove(buildDirectory);
 
-  const { stdout: filenames } = await execFile(
-    /^win/.test(process.platform) ? 'npm.cmd' : 'npm',
-    ['pack'],
-    { cwd: packageRoot },
-  );
+  const { stdout: filenames } = await exec('npm pack', { cwd: packageRoot });
   const packageTgzPath = path.join(
     packageRoot,
     // https://docs.npmjs.com/cli/v6/commands/npm-pack
@@ -31,7 +28,18 @@ async function main() {
   // hardcoded by npm
   const untarDestination = path.join(packageRoot, 'package');
   try {
-    await execFile('tar', ['-xzf', packageTgzPath], { cwd: packageRoot });
+    await execFile(
+      'tar',
+      [
+        '-xzf',
+        // absolute paths are not interpreted as local files
+        // `--force-local` is not available in BSD tar (macOS)
+        path.relative(packageRoot, packageTgzPath),
+      ],
+      {
+        cwd: packageRoot,
+      },
+    );
     await fse.move(untarDestination, buildDirectory);
   } finally {
     await fse.remove(untarDestination);


### PR DESCRIPTION
Also sets up a specialized workflow for testing that dev-only scripts run across all platforms.

Proof of concept:
- [macOS failure](https://github.com/mui-org/material-ui/runs/1627655738?check_suite_focus=true)
- [windows failure](https://github.com/mui-org/material-ui/runs/1627655738?check_suite_focus=true)