### PR TITLE
[DatePicker] Fix year only view, hide the current month 

### DIFF
--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewMobile.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewMobile.tsx
@@ -55,15 +55,15 @@ export function DateRangePickerViewMobile<TDate>(props: DesktopDateRangeCalendar
   return (
     <React.Fragment>
       <PickersCalendarHeader
-        openView="date"
-        views={onlyDateView}
-        onMonthChange={changeMonth as any}
-        leftArrowButtonText={leftArrowButtonText}
         components={components}
         componentsProps={componentsProps}
-        rightArrowButtonText={rightArrowButtonText}
-        minDate={minDate}
+        leftArrowButtonText={leftArrowButtonText}
         maxDate={maxDate}
+        minDate={minDate}
+        onMonthChange={changeMonth as any}
+        openView="date"
+        rightArrowButtonText={rightArrowButtonText}
+        views={onlyDateView}
         {...other}
       />
       <PickersCalendar<TDate>

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.test.tsx
@@ -58,4 +58,15 @@ describe('<DayPicker />', () => {
     expect(screen.queryByLabelText(/switch to year view/i)).to.equal(null);
     expect(screen.getByLabelText('year view is open, switch to calendar view')).toBeVisible();
   });
+
+  it('should skip the header', () => {
+    render(
+      <DayPicker
+        views={['year']}
+        date={adapterToUse.date('2019-01-01T00:00:00.000')}
+        onChange={() => {}}
+      />,
+    );
+    expect(document.querySelector('.MuiPickersCalendarHeader-root')).to.equal(null);
+  });
 });

--- a/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
@@ -157,6 +157,11 @@ function PickersCalendarHeader<TDate>(
     }
   };
 
+  // No need to display more information
+  if (views.length === 1 && views[0] === 'year') {
+    return null;
+  }
+
   return (
     <div className={classes.root}>
       <div role="presentation" className={classes.label} onClick={handleToggleView}>


### PR DESCRIPTION
When you use the DatePicker and you select the year to be displayed only, the current month is shown with the year.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #24195

Updated `PickersCalendarHeader` to show nothing in the case of displaying the year only.