### PR TITLE
[core] Add missing sx typings on the components migrated to emotion

### DIFF
--- a/docs/pages/api-docs/avatar.json
+++ b/docs/pages/api-docs/avatar.json
@@ -8,6 +8,7 @@
     "sizes": { "type": { "name": "string" } },
     "src": { "type": { "name": "string" } },
     "srcSet": { "type": { "name": "string" } },
+    "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {
         "name": "union",

--- a/docs/pages/api-docs/button-base.json
+++ b/docs/pages/api-docs/button-base.json
@@ -11,6 +11,7 @@
     "focusRipple": { "type": { "name": "bool" } },
     "focusVisibleClassName": { "type": { "name": "string" } },
     "onFocusVisible": { "type": { "name": "func" } },
+    "sx": { "type": { "name": "object" } },
     "TouchRippleProps": { "type": { "name": "object" } }
   },
   "name": "ButtonBase",

--- a/docs/pages/api-docs/button.json
+++ b/docs/pages/api-docs/button.json
@@ -25,6 +25,7 @@
       "default": "'medium'"
     },
     "startIcon": { "type": { "name": "node" } },
+    "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {
         "name": "union",

--- a/docs/pages/api-docs/typography.json
+++ b/docs/pages/api-docs/typography.json
@@ -27,6 +27,7 @@
     "gutterBottom": { "type": { "name": "bool" } },
     "noWrap": { "type": { "name": "bool" } },
     "paragraph": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {
         "name": "union",

--- a/docs/translations/api-docs/avatar/avatar.json
+++ b/docs/translations/api-docs/avatar/avatar.json
@@ -9,6 +9,7 @@
     "sizes": "The <code>sizes</code> attribute for the <code>img</code> element.",
     "src": "The <code>src</code> attribute for the <code>img</code> element.",
     "srcSet": "The <code>srcSet</code> attribute for the <code>img</code> element. Use this attribute for responsive image display.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "variant": "The shape of the avatar."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/button-base/button-base.json
+++ b/docs/translations/api-docs/button-base/button-base.json
@@ -12,6 +12,7 @@
     "focusRipple": "If <code>true</code>, the base button will have a keyboard focus ripple.",
     "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/master/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed.",
     "onFocusVisible": "Callback fired when the component is focused with a keyboard. We trigger a <code>onFocus</code> callback too.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "TouchRippleProps": "Props applied to the <code>TouchRipple</code> element."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/button/button.json
+++ b/docs/translations/api-docs/button/button.json
@@ -14,6 +14,7 @@
     "href": "The URL to link to when the button is clicked. If defined, an <code>a</code> element will be used as the root node.",
     "size": "The size of the button. <code>small</code> is equivalent to the dense button styling.",
     "startIcon": "Element placed before the children.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/typography/typography.json
+++ b/docs/translations/api-docs/typography/typography.json
@@ -10,6 +10,7 @@
     "gutterBottom": "If <code>true</code>, the text will have a bottom margin.",
     "noWrap": "If <code>true</code>, the text will not wrap, but instead will truncate with a text overflow ellipsis.<br>Note that text overflow can only happen with block or inline-block level elements (the element needs to have a width in order to overflow).",
     "paragraph": "If <code>true</code>, the text will have a bottom margin.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "variant": "Applies the theme typography styles.",
     "variantMapping": "The component maps the variant prop to a range of different HTML element types. For instance, subtitle1 to <code>&lt;h6&gt;</code>. If you wish to change that mapping, you can provide your own. Alternatively, you can use the <code>component</code> prop."
   },

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -23,6 +23,7 @@ export const componentSettings = {
       'sizes',
       'src',
       'srcSet',
+      'sx',
       // FIXME: `Union`
       'variant',
     ],
@@ -82,6 +83,7 @@ export const componentSettings = {
     ignoredProps: [
       'children',
       'disableFocusRipple',
+      'sx',
       // union not supported by framer ControlType
       // interface, control types and default value need to be hardcoded
       'variant',
@@ -345,6 +347,7 @@ export const componentSettings = {
       'gutterBottom',
       'internalDeprecatedVariant',
       'paragraph',
+      'sx',
       // FIXME: `Union`
       'variant',
       'variantMapping',

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -59,7 +59,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */
-    sx?: SxProps<Theme>;    
+    sx?: SxProps<Theme>;
     /**
      * The shape of the avatar.
      * @default 'circular'

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '@material-ui/core/styles';
 import { OverridableStringUnion } from '@material-ui/types';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
@@ -54,6 +56,10 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * Use this attribute for responsive image display.
      */
     srcSet?: string;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;    
     /**
      * The shape of the avatar.
      * @default 'circular'

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -243,6 +243,10 @@ Avatar.propTypes = {
    */
   srcSet: PropTypes.string,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The shape of the avatar.
    * @default 'circular'
    */

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -1,4 +1,6 @@
 import { OverridableStringUnion } from '@material-ui/types';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '@material-ui/core/styles';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 
@@ -135,6 +137,10 @@ export type ButtonTypeMap<
      * Element placed before the children.
      */
     startIcon?: React.ReactNode;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
     /**
      * The variant to use.
      * @default 'text'

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -470,6 +470,10 @@ Button.propTypes = {
    */
   startIcon: PropTypes.node,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * @ignore
    */
   type: PropTypes.oneOfType([PropTypes.oneOf(['button', 'reset', 'submit']), PropTypes.string]),

--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '@material-ui/core/styles';
 import { TouchRippleProps } from './TouchRipple';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 
@@ -74,6 +76,10 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
      * We trigger a `onFocus` callback too.
      */
     onFocusVisible?: React.FocusEventHandler<any>;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
     // @types/react is stricter
     /**
      * @default 0

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -505,6 +505,10 @@ ButtonBase.propTypes = {
    */
   onTouchStart: PropTypes.func,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * @default 0
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { OverridableStringUnion } from '@material-ui/types';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '@material-ui/core/styles';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Variant } from '../styles/createTypography';
 
@@ -117,6 +119,10 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
      * @default false
      */
     paragraph?: boolean;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
     /**
      * Applies the theme typography styles.
      * @default 'body1'

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -226,6 +226,10 @@ Typography.propTypes = {
    */
   paragraph: PropTypes.bool,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * Applies the theme typography styles.
    * @default 'body1'
    */


### PR DESCRIPTION
The PR adds the missing types for the `sx` prop on the components migrated to emotion