### PR TITLE
[docs] Fix broken benchmark link

### DIFF
--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -18,7 +18,7 @@ Material-UI's styling solution is inspired by many other styling libraries such 
 
 <!-- #default-branch-switch -->
 
-- 🚀 It's [blazing fast](https://github.com/mui-org/material-ui/blob/next/packages/material-ui-benchmark/README.md#material-uistyles).
+- 🚀 It's [blazing fast](https://github.com/mui-org/material-ui/blob/HEAD/benchmark/server#material-uistyles).
 - 🧩 It's extensible via a [plugin](https://github.com/cssinjs/jss/blob/master/docs/plugins.md) API.
 - ⚡️ It uses [JSS](https://github.com/cssinjs/jss) at its core – a [high performance](https://github.com/cssinjs/jss/blob/master/docs/performance.md) JavaScript to CSS compiler which works at runtime and server-side.
 - 📦 Less than [15 KB gzipped](https://bundlephobia.com/result?p=@material-ui/styles); and no bundle size increase if used alongside Material-UI.


### PR DESCRIPTION
One of the links in the file is broken as mentioned in issue #24209.
This has been fixed here, in accordance with this comment: https://github.com/mui-org/material-ui/issues/24209#issuecomment-752951876

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #24209.