### PR TITLE
[styled] Fix missing types for sx prop

### DIFF
--- a/docs/src/pages/components/badges/UnstyledBadge.js
+++ b/docs/src/pages/components/badges/UnstyledBadge.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
-
 import BadgeUnstyled from '@material-ui/unstyled/BadgeUnstyled';
 import Box from '@material-ui/core/Box';
 

--- a/docs/src/pages/components/badges/UnstyledBadge.tsx
+++ b/docs/src/pages/components/badges/UnstyledBadge.tsx
@@ -1,16 +1,9 @@
 import * as React from 'react';
-import { experimentalStyled as styled, Theme } from '@material-ui/core/styles';
-import { SxProps } from '@material-ui/system';
-import BadgeUnstyled, {
-  BadgeUnstyledProps,
-} from '@material-ui/unstyled/BadgeUnstyled';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import BadgeUnstyled from '@material-ui/unstyled/BadgeUnstyled';
 import Box from '@material-ui/core/Box';
 
-interface StyledBadgeProps extends BadgeUnstyledProps {
-  sx?: SxProps<Theme>;
-}
-
-const StyledBadge: React.FC<StyledBadgeProps> = styled(BadgeUnstyled)`
+const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as CSS from 'csstype';
+import { SxProps } from '@material-ui/system';
 import { Theme as DefaultTheme } from './createMuiTheme';
 
 export interface SerializedStyles {
@@ -188,13 +189,13 @@ interface MuiStyledOptions {
 }
 
 export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
-  <Tag extends React.ComponentType<any>, ExtraProps = {}>(
+  <Tag extends React.ComponentType<any>, ExtraProps = { sx?: SxProps<Theme> }>(
     tag: Tag,
     options?: StyledOptions,
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponentExtrinsic<Tag, ExtraProps, Theme>;
 
-  <Tag extends keyof JSXInEl, ExtraProps = {}>(
+  <Tag extends keyof JSXInEl, ExtraProps = { sx?: SxProps<Theme> }>(
     tag: Tag,
     options?: StyledOptions,
     muiOptions?: MuiStyledOptions

--- a/packages/material-ui/src/styles/experimentalStyled.spec.tsx
+++ b/packages/material-ui/src/styles/experimentalStyled.spec.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+
+const Box = styled('div')``;
+
+function SxTest() {
+  <Box sx={{ p: [2, 3, 4] }} />;
+}


### PR DESCRIPTION
With this PR the `experimentalStyled()` adds automatically the sx prop in the component's props interface