### PR TITLE
[Autocomplete] Fix VoiceOver not reading the correct activedescendant

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -190,6 +190,7 @@ module.exports = {
         'jsx-a11y/click-events-have-key-events': 'off',
         'jsx-a11y/control-has-associated-label': 'off',
         'jsx-a11y/iframe-has-title': 'off',
+        'jsx-a11y/label-has-associated-control': 'off',
         'jsx-a11y/mouse-events-have-key-events': 'off',
         'jsx-a11y/no-noninteractive-tabindex': 'off',
         'jsx-a11y/no-static-element-interactions': 'off',

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -12,8 +12,7 @@ import {
 import { spy } from 'sinon';
 import TextField from '@material-ui/core/TextField';
 import Chip from '@material-ui/core/Chip';
-import { createFilterOptions } from '../useAutocomplete/useAutocomplete';
-import Autocomplete from './Autocomplete';
+import Autocomplete, { createFilterOptions } from '@material-ui/core/Autocomplete';
 
 function checkHighlightIs(listbox, expected) {
   if (expected) {

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -186,24 +186,24 @@ export default function useAutocomplete(props) {
 
   const filteredOptions = popupOpen
     ? filterOptions(
-        options.filter((option) => {
-          if (
-            filterSelectedOptions &&
-            (multiple ? value : [value]).some(
-              (value2) => value2 !== null && getOptionSelected(option, value2),
-            )
-          ) {
-            return false;
-          }
-          return true;
-        }),
-        // we use the empty string to manipulate `filterOptions` to not filter any options
-        // i.e. the filter predicate always returns true
-        {
-          inputValue: inputValueIsSelectedValue && inputPristine ? '' : inputValue,
-          getOptionLabel,
-        },
-      )
+      options.filter((option) => {
+        if (
+          filterSelectedOptions &&
+          (multiple ? value : [value]).some(
+            (value2) => value2 !== null && getOptionSelected(option, value2),
+          )
+        ) {
+          return false;
+        }
+        return true;
+      }),
+      // we use the empty string to manipulate `filterOptions` to not filter any options
+      // i.e. the filter predicate always returns true
+      {
+        inputValue: inputValueIsSelectedValue && inputPristine ? '' : inputValue,
+        getOptionLabel,
+      },
+    )
     : [];
 
   const listboxAvailable = open && filteredOptions.length > 0;
@@ -218,10 +218,9 @@ export default function useAutocomplete(props) {
         console.warn(
           [
             `Material-UI: The value provided to ${componentName} is invalid.`,
-            `None of the options match with \`${
-              missingValue.length > 1
-                ? JSON.stringify(missingValue)
-                : JSON.stringify(missingValue[0])
+            `None of the options match with \`${missingValue.length > 1
+              ? JSON.stringify(missingValue)
+              : JSON.stringify(missingValue[0])
             }\`.`,
             'You can use the `getOptionSelected` prop to customize the equality test.',
           ].join('\n'),
@@ -1005,7 +1004,7 @@ export default function useAutocomplete(props) {
       const disabled = getOptionDisabled ? getOptionDisabled(option) : false;
 
       return {
-        key: index,
+        key: getOptionLabel(option),
         tabIndex: -1,
         role: 'option',
         id: `${id}-option-${index}`,

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -186,24 +186,24 @@ export default function useAutocomplete(props) {
 
   const filteredOptions = popupOpen
     ? filterOptions(
-      options.filter((option) => {
-        if (
-          filterSelectedOptions &&
-          (multiple ? value : [value]).some(
-            (value2) => value2 !== null && getOptionSelected(option, value2),
-          )
-        ) {
-          return false;
-        }
-        return true;
-      }),
-      // we use the empty string to manipulate `filterOptions` to not filter any options
-      // i.e. the filter predicate always returns true
-      {
-        inputValue: inputValueIsSelectedValue && inputPristine ? '' : inputValue,
-        getOptionLabel,
-      },
-    )
+        options.filter((option) => {
+          if (
+            filterSelectedOptions &&
+            (multiple ? value : [value]).some(
+              (value2) => value2 !== null && getOptionSelected(option, value2),
+            )
+          ) {
+            return false;
+          }
+          return true;
+        }),
+        // we use the empty string to manipulate `filterOptions` to not filter any options
+        // i.e. the filter predicate always returns true
+        {
+          inputValue: inputValueIsSelectedValue && inputPristine ? '' : inputValue,
+          getOptionLabel,
+        },
+      )
     : [];
 
   const listboxAvailable = open && filteredOptions.length > 0;
@@ -218,9 +218,10 @@ export default function useAutocomplete(props) {
         console.warn(
           [
             `Material-UI: The value provided to ${componentName} is invalid.`,
-            `None of the options match with \`${missingValue.length > 1
-              ? JSON.stringify(missingValue)
-              : JSON.stringify(missingValue[0])
+            `None of the options match with \`${
+              missingValue.length > 1
+                ? JSON.stringify(missingValue)
+                : JSON.stringify(missingValue[0])
             }\`.`,
             'You can use the `getOptionSelected` prop to customize the equality test.',
           ].join('\n'),

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-associated-control */
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils';

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
@@ -1,164 +1,215 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import * as React from 'react';
 import { expect } from 'chai';
-import { createFilterOptions } from './useAutocomplete';
+import { createClientRender } from 'test/utils';
+import useAutocomplete, { createFilterOptions } from '@material-ui/core/useAutocomplete';
 
-describe('createFilterOptions', () => {
-  it('defaults to getOptionLabel for text filtering', () => {
-    const filterOptions = createFilterOptions();
+describe('useAutocomplete', () => {
+  const render = createClientRender();
 
-    const getOptionLabel = (option) => option.name;
-    const options = [
-      {
-        id: '1234',
-        name: 'cat',
-      },
-      {
-        id: '5678',
-        name: 'dog',
-      },
-      {
-        id: '9abc',
-        name: 'emu',
-      },
-    ];
+  it('should use unique keys for the option', () => {
+    let keys;
+    const Test = () => {
+      const {
+        groupedOptions,
+        getRootProps,
+        getInputLabelProps,
+        getInputProps,
+        getListboxProps,
+        getOptionProps,
+      } = useAutocomplete({
+        options: [{ label: 'foo' }, { label: 'bar' }],
+        open: true,
+      });
 
-    expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([options[0]]);
+      keys = groupedOptions.map((option, index) => getOptionProps({ option, index }).key);
+
+      return (
+        <div>
+          <div {...getRootProps()}>
+            <label {...getInputLabelProps()}>useAutocomplete</label>
+            <input {...getInputProps()} />
+          </div>
+          {groupedOptions.length > 0 ? (
+            <ul {...getListboxProps()}>
+              {groupedOptions.map((option, index) => (
+                <li {...getOptionProps({ option, index })}>{option.title}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      );
+    };
+
+    render(<Test />);
+    expect(keys).to.deep.equal(['foo', 'bar']);
   });
 
-  it('filters without error with empty option set', () => {
-    const filterOptions = createFilterOptions();
-
-    const getOptionLabel = (option) => option.name;
-    const options = [];
-
-    expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([]);
-  });
-
-  describe('option: limit', () => {
-    it('limits the number of suggested options to be shown', () => {
-      const filterOptions = createFilterOptions({ limit: 2 });
+  describe('createFilterOptions', () => {
+    it('defaults to getOptionLabel for text filtering', () => {
+      const filterOptions = createFilterOptions();
 
       const getOptionLabel = (option) => option.name;
       const options = [
         {
           id: '1234',
-          name: 'a1',
+          name: 'cat',
         },
         {
           id: '5678',
-          name: 'a2',
+          name: 'dog',
         },
         {
           id: '9abc',
-          name: 'a3',
-        },
-        {
-          id: '9abc',
-          name: 'a4',
+          name: 'emu',
         },
       ];
 
       expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([
         options[0],
-        options[1],
       ]);
     });
-  });
 
-  describe('option: matchFrom', () => {
-    let filterOptions;
-    let getOptionLabel;
-    let options;
-    beforeEach(() => {
-      filterOptions = createFilterOptions({ matchFrom: 'any' });
-      getOptionLabel = (option) => option.name;
-      options = [
-        {
-          id: '1234',
-          name: 'ab',
-        },
-        {
-          id: '5678',
-          name: 'ba',
-        },
-        {
-          id: '9abc',
-          name: 'ca',
-        },
-      ];
+    it('filters without error with empty option set', () => {
+      const filterOptions = createFilterOptions();
+
+      const getOptionLabel = (option) => option.name;
+      const options = [];
+
+      expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([]);
     });
 
-    describe('any', () => {
-      it('show all results that match', () => {
-        expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal(options);
+    describe('option: limit', () => {
+      it('limits the number of suggested options to be shown', () => {
+        const filterOptions = createFilterOptions({ limit: 2 });
+
+        const getOptionLabel = (option) => option.name;
+        const options = [
+          {
+            id: '1234',
+            name: 'a1',
+          },
+          {
+            id: '5678',
+            name: 'a2',
+          },
+          {
+            id: '9abc',
+            name: 'a3',
+          },
+          {
+            id: '9abc',
+            name: 'a4',
+          },
+        ];
+
+        expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal([
+          options[0],
+          options[1],
+        ]);
       });
     });
 
-    describe('start', () => {
-      it('show only results that start with search', () => {
-        expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal(options);
+    describe('option: matchFrom', () => {
+      let filterOptions;
+      let getOptionLabel;
+      let options;
+      beforeEach(() => {
+        filterOptions = createFilterOptions({ matchFrom: 'any' });
+        getOptionLabel = (option) => option.name;
+        options = [
+          {
+            id: '1234',
+            name: 'ab',
+          },
+          {
+            id: '5678',
+            name: 'ba',
+          },
+          {
+            id: '9abc',
+            name: 'ca',
+          },
+        ];
+      });
+
+      describe('any', () => {
+        it('show all results that match', () => {
+          expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal(
+            options,
+          );
+        });
+      });
+
+      describe('start', () => {
+        it('show only results that start with search', () => {
+          expect(filterOptions(options, { inputValue: 'a', getOptionLabel })).to.deep.equal(
+            options,
+          );
+        });
       });
     });
-  });
 
-  describe('option: ignoreAccents', () => {
-    it('does not ignore accents', () => {
-      const filterOptions = createFilterOptions({ ignoreAccents: false });
+    describe('option: ignoreAccents', () => {
+      it('does not ignore accents', () => {
+        const filterOptions = createFilterOptions({ ignoreAccents: false });
 
-      const getOptionLabel = (option) => option.name;
-      const options = [
-        {
-          id: '1234',
-          name: 'áb',
-        },
-        {
-          id: '5678',
-          name: 'ab',
-        },
-        {
-          id: '9abc',
-          name: 'áe',
-        },
-        {
-          id: '9abc',
-          name: 'ae',
-        },
-      ];
+        const getOptionLabel = (option) => option.name;
+        const options = [
+          {
+            id: '1234',
+            name: 'áb',
+          },
+          {
+            id: '5678',
+            name: 'ab',
+          },
+          {
+            id: '9abc',
+            name: 'áe',
+          },
+          {
+            id: '9abc',
+            name: 'ae',
+          },
+        ];
 
-      expect(filterOptions(options, { inputValue: 'á', getOptionLabel })).to.deep.equal([
-        options[0],
-        options[2],
-      ]);
+        expect(filterOptions(options, { inputValue: 'á', getOptionLabel })).to.deep.equal([
+          options[0],
+          options[2],
+        ]);
+      });
     });
-  });
 
-  describe('option: ignoreCase', () => {
-    it('matches results with case insensitive', () => {
-      const filterOptions = createFilterOptions({ ignoreCase: false });
+    describe('option: ignoreCase', () => {
+      it('matches results with case insensitive', () => {
+        const filterOptions = createFilterOptions({ ignoreCase: false });
 
-      const getOptionLabel = (option) => option.name;
-      const options = [
-        {
-          id: '1234',
-          name: 'Ab',
-        },
-        {
-          id: '5678',
-          name: 'ab',
-        },
-        {
-          id: '9abc',
-          name: 'Ae',
-        },
-        {
-          id: '9abc',
-          name: 'ae',
-        },
-      ];
+        const getOptionLabel = (option) => option.name;
+        const options = [
+          {
+            id: '1234',
+            name: 'Ab',
+          },
+          {
+            id: '5678',
+            name: 'ab',
+          },
+          {
+            id: '9abc',
+            name: 'Ae',
+          },
+          {
+            id: '9abc',
+            name: 'ae',
+          },
+        ];
 
-      expect(filterOptions(options, { inputValue: 'A', getOptionLabel })).to.deep.equal([
-        options[0],
-        options[2],
-      ]);
+        expect(filterOptions(options, { inputValue: 'A', getOptionLabel })).to.deep.equal([
+          options[0],
+          options[2],
+        ]);
+      });
     });
   });
 });


### PR DESCRIPTION
I switched the key from index to the getOptionLabel function in order for a11y to appropriately read dropdown labels

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #24198 
