### PR TITLE
[styled] Support components without theme

### DIFF
--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as CSS from 'csstype';
+import { SxProps } from '@material-ui/system';
 import { Theme as DefaultTheme } from './createMuiTheme';
 
 export interface SerializedStyles {
@@ -11,40 +12,27 @@ export interface SerializedStyles {
 
 export type CSSProperties = CSS.PropertiesFallback<number | string>;
 export type CSSPropertiesWithMultiValues = {
-  [K in keyof CSSProperties]: CSSProperties[K] | Array<Extract<CSSProperties[K], string>>;
-};
-/**
- * @desc Following type exists for autocompletion of key.
- */
-export type CSSPseudos<MP> = { [K in CSS.Pseudos]?: ObjectInterpolation<MP> };
-export interface CSSOthersObject<MP> {
-  [propertiesName: string]: Interpolation<MP>;
+  [K in keyof CSSProperties]:
+    | CSSProperties[K]
+    | Array<Extract<CSSProperties[K], string>>
 }
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
 
+export interface CSSOthersObject {
+  [propertiesName: string]: CSSInterpolation
+}
 export type CSSPseudosForCSSObject = { [K in CSS.Pseudos]?: CSSObject };
 
 export interface ArrayCSSInterpolation extends Array<CSSInterpolation> {}
-
-export type CSSInterpolation =
-  | null
-  | undefined
-  | boolean
-  | number
-  | string
-  | ComponentSelector
-  | Keyframes
-  | SerializedStyles
-  | CSSObject
-  | ArrayCSSInterpolation;
 
 export interface CSSOthersObjectForCSSObject {
   [propertiesName: string]: CSSInterpolation;
 }
 
 export interface CSSObject
-  extends CSSPropertiesWithMultiValues,
-    CSSPseudosForCSSObject,
-    CSSOthersObjectForCSSObject {}
+    extends CSSPropertiesWithMultiValues,
+      CSSPseudos,
+      CSSOthersObject {}    
 
 export interface ComponentSelector {
   __emotion_styles: any;
@@ -57,44 +45,45 @@ export type Keyframes = {
   toString: () => string;
 } & string;
 
-export interface ArrayInterpolation<MP> extends Array<Interpolation<MP>> {}
-export interface ObjectInterpolation<MP>
-  extends CSSPropertiesWithMultiValues,
-    CSSPseudos<MP>,
-    CSSOthersObject<MP> {}
-export type FunctionInterpolation<MP> = (mergedProps: MP) => Interpolation<MP>;
-
 export type Equal<A, B, T, F> = A extends B ? (B extends A ? T : F) : F;
 
-export type Interpolation<MP = undefined> =
-  | null
-  | undefined
-  | boolean
-  | number
-  | string
-  | ComponentSelector
-  | Keyframes
-  | SerializedStyles
-  | ArrayInterpolation<MP>
-  | ObjectInterpolation<MP>
-  | Equal<MP, undefined, never, FunctionInterpolation<MP>>;
+export type InterpolationPrimitive =
+| null
+| undefined
+| boolean
+| number
+| string
+| ComponentSelector
+| Keyframes
+| SerializedStyles
+| CSSObject
+
+export type CSSInterpolation = InterpolationPrimitive | ArrayCSSInterpolation
+
+export interface FunctionInterpolation<Props> {
+  (props: Props): Interpolation<Props>
+}  
+
+export interface ArrayInterpolation<Props>
+  extends Array<Interpolation<Props>> {}
+
+export type Interpolation<Props> =
+  | InterpolationPrimitive
+  | ArrayInterpolation<Props>
+  | FunctionInterpolation<Props>  
 
 /**
  * @desc Utility type for getting props type of React component.
+ * It takes `defaultProps` into an account - making props with defaults optional.
  */
 export type PropsOf<
   C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithRef<C>>;
+> = JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>
 
 export type Omit<T, U> = T extends any ? Pick<T, Exclude<keyof T, U>> : never;
 export type Overwrapped<T, U> = Pick<T, Extract<keyof T, keyof U>>;
 
 type JSXInEl = JSX.IntrinsicElements;
-type ReactClassPropKeys = keyof React.ClassAttributes<any>;
-
-export type WithTheme<P, T> = P extends { theme: infer Theme }
-  ? P & { theme: Exclude<Theme, undefined> }
-  : P & { theme: T };
 
 export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
   extends React.FunctionComponent<InnerProps & StyleProps & { theme?: Theme }>,
@@ -110,73 +99,10 @@ export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
   ): StyledComponent<PropsOf<Tag>, StyleProps, Theme>;
 }
 
-interface CreateStyledComponentBaseThemed<
-  InnerProps,
-  ExtraProps,
-  StyledInstanceTheme extends object
-> {
-  <
-    StyleProps extends Omit<Overwrapped<InnerProps, StyleProps>, ReactClassPropKeys> = Omit<
-      InnerProps & ExtraProps,
-      ReactClassPropKeys
-    >
-  >(
-    ...styles: Array<Interpolation<WithTheme<StyleProps, StyledInstanceTheme>>>
-  ): StyledComponent<InnerProps, StyleProps, StyledInstanceTheme>;
-  <
-    StyleProps extends Omit<Overwrapped<InnerProps, StyleProps>, ReactClassPropKeys> = Omit<
-      InnerProps & ExtraProps,
-      ReactClassPropKeys
-    >
-  >(
-    template: TemplateStringsArray,
-    ...styles: Array<Interpolation<WithTheme<StyleProps, StyledInstanceTheme>>>
-  ): StyledComponent<InnerProps, StyleProps, StyledInstanceTheme>;
-}
-
-interface CreateStyledComponentBaseThemeless<InnerProps, ExtraProps> {
-  <
-    StyleProps extends Omit<Overwrapped<InnerProps, StyleProps>, ReactClassPropKeys> = Omit<
-      InnerProps & ExtraProps,
-      ReactClassPropKeys
-    >,
-    Theme extends object = object
-  >(
-    ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>
-  ): StyledComponent<InnerProps, StyleProps, Theme>;
-  <
-    StyleProps extends Omit<Overwrapped<InnerProps, StyleProps>, ReactClassPropKeys> = Omit<
-      InnerProps & ExtraProps,
-      ReactClassPropKeys
-    >,
-    Theme extends object = object
-  >(
-    template: TemplateStringsArray,
-    ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>
-  ): StyledComponent<InnerProps, StyleProps, Theme>;
-}
-
-export type CreateStyledComponentBase<InnerProps, ExtraProps, StyledInstanceTheme extends object> =
-  // this "reversed" condition checks if StyledInstanceTheme was already parametrized when using CreateStyled
-  object extends StyledInstanceTheme
-    ? CreateStyledComponentBaseThemeless<InnerProps, ExtraProps>
-    : CreateStyledComponentBaseThemed<InnerProps, ExtraProps, StyledInstanceTheme>;
-
-export type CreateStyledComponentIntrinsic<
-  Tag extends keyof JSXInEl,
-  ExtraProps,
-  Theme extends object
-> = CreateStyledComponentBase<JSXInEl[Tag], ExtraProps, Theme>;
-export type CreateStyledComponentExtrinsic<
-  Tag extends React.ComponentType<any>,
-  ExtraProps,
-  Theme extends object
-> = CreateStyledComponentBase<PropsOf<Tag>, ExtraProps, Theme>;
-
-export interface StyledOptions {
-  label?: string;
-  shouldForwardProp?(propName: string): boolean;
-  target?: string;
+export interface StyledOptions<Props> {
+  label?: string
+  shouldForwardProp?(propName: PropertyKey): boolean
+  target?: string
 }
 
 interface MuiStyledOptions {
@@ -187,18 +113,155 @@ interface MuiStyledOptions {
   skipSx?: boolean;
 }
 
-export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
-  <Tag extends React.ComponentType<any>, ExtraProps = {}>(
-    tag: Tag,
-    options?: StyledOptions,
-    muiOptions?: MuiStyledOptions
-  ): CreateStyledComponentExtrinsic<Tag, ExtraProps, Theme>;
+/** Same as StyledOptions but shouldForwardProp must be a type guard */
+export interface FilteringStyledOptions<
+  Props,
+  ForwardedProps extends keyof Props = keyof Props
+> {
+  label?: string
+  shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps
+  target?: string
+}
 
-  <Tag extends keyof JSXInEl, ExtraProps = {}>(
-    tag: Tag,
-    options?: StyledOptions,
+/**
+ * @typeparam ComponentProps  Props which will be included when withComponent is called
+ * @typeparam SpecificComponentProps  Props which will *not* be included when withComponent is called
+ */
+export interface CreateStyledComponent<
+  ComponentProps extends {},
+  SpecificComponentProps extends {} = {},
+  JSXProps extends {} = {}
+> {
+  /**
+   * @typeparam AdditionalProps  Additional props to add to your styled component
+   */
+  <AdditionalProps extends {} = {}>(
+    ...styles: Array<
+      Interpolation<
+        ComponentProps &
+          SpecificComponentProps &
+          AdditionalProps & { theme: DefaultTheme }
+      >
+    >
+  ): StyledComponent<
+    ComponentProps & AdditionalProps,
+    SpecificComponentProps,
+    JSXProps
+  >
+
+  (
+    template: TemplateStringsArray,
+    ...styles: Array<
+      Interpolation<ComponentProps & SpecificComponentProps & { theme: DefaultTheme }>
+    >
+  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>
+
+  /**
+   * @typeparam AdditionalProps  Additional props to add to your styled component
+   */
+  <AdditionalProps extends {}>(
+    template: TemplateStringsArray,
+    ...styles: Array<
+      Interpolation<
+        ComponentProps &
+          SpecificComponentProps &
+          AdditionalProps & { theme: DefaultTheme }
+      >
+    >
+  ): StyledComponent<
+    ComponentProps & AdditionalProps,
+    SpecificComponentProps,
+    JSXProps
+  >
+}
+
+export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
+  <
+    C extends React.ComponentClass<React.ComponentProps<C>>,
+    ForwardedProps extends keyof React.ComponentProps<
+      C
+    > = keyof React.ComponentProps<C>
+  >(
+    component: C,
+    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>,
     muiOptions?: MuiStyledOptions
-  ): CreateStyledComponentIntrinsic<Tag, ExtraProps, Theme>;
+  ): CreateStyledComponent<
+    Pick<PropsOf<C>, ForwardedProps> & {
+      theme?: Theme
+      as?: React.ElementType
+      sx?: SxProps<Theme>
+    },
+    {},
+    {
+      ref?: React.Ref<InstanceType<C>>
+    }
+  >
+
+  <C extends React.ComponentClass<React.ComponentProps<C>>>(
+    component: C,
+    options?: StyledOptions<React.ComponentProps<C>>,
+    muiOptions?: MuiStyledOptions
+  ): CreateStyledComponent<
+    PropsOf<C> & {
+      theme?: Theme
+      as?: React.ElementType
+      sx?: SxProps<Theme> 
+    },
+    {},
+    {
+      ref?: React.Ref<InstanceType<C>>
+    }
+  >
+
+  <
+    C extends React.ComponentType<React.ComponentProps<C>>,
+    ForwardedProps extends keyof React.ComponentProps<
+      C
+    > = keyof React.ComponentProps<C>
+  >(
+    component: C,
+    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>,
+    muiOptions?: MuiStyledOptions
+  ): CreateStyledComponent<
+    Pick<PropsOf<C>, ForwardedProps> & {
+      theme?: Theme
+      as?: React.ElementType
+      sx?: SxProps<Theme> 
+    }
+  >
+
+  <C extends React.ComponentType<React.ComponentProps<C>>>(
+    component: C,
+    options?: StyledOptions<React.ComponentProps<C>>,
+    muiOptions?: MuiStyledOptions
+  ): CreateStyledComponent<
+    PropsOf<C> & {
+      theme?: Theme
+      as?: React.ElementType
+      sx?: SxProps<Theme> 
+    }
+  >
+
+  <
+    Tag extends keyof JSX.IntrinsicElements,
+    ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag]
+  >(
+    tag: Tag,
+    options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps>,
+    muiOptions?: MuiStyledOptions
+  ): CreateStyledComponent<
+    { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme>; },
+    Pick<JSX.IntrinsicElements[Tag], ForwardedProps>
+  >
+
+  <Tag extends keyof JSX.IntrinsicElements>(
+    tag: Tag,
+    options?: StyledOptions<JSX.IntrinsicElements[Tag]>,
+    muiOptions?: MuiStyledOptions
+  ): CreateStyledComponent<
+    { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme>; },
+    JSX.IntrinsicElements[Tag]
+  >
 }
 
 /**

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -12,14 +12,12 @@ export interface SerializedStyles {
 
 export type CSSProperties = CSS.PropertiesFallback<number | string>;
 export type CSSPropertiesWithMultiValues = {
-  [K in keyof CSSProperties]:
-    | CSSProperties[K]
-    | Array<Extract<CSSProperties[K], string>>
-}
-export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
+  [K in keyof CSSProperties]: CSSProperties[K] | Array<Extract<CSSProperties[K], string>>;
+};
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
 
 export interface CSSOthersObject {
-  [propertiesName: string]: CSSInterpolation
+  [propertiesName: string]: CSSInterpolation;
 }
 export type CSSPseudosForCSSObject = { [K in CSS.Pseudos]?: CSSObject };
 
@@ -29,10 +27,7 @@ export interface CSSOthersObjectForCSSObject {
   [propertiesName: string]: CSSInterpolation;
 }
 
-export interface CSSObject
-    extends CSSPropertiesWithMultiValues,
-      CSSPseudos,
-      CSSOthersObject {}    
+export interface CSSObject extends CSSPropertiesWithMultiValues, CSSPseudos, CSSOthersObject {}
 
 export interface ComponentSelector {
   __emotion_styles: any;
@@ -48,29 +43,28 @@ export type Keyframes = {
 export type Equal<A, B, T, F> = A extends B ? (B extends A ? T : F) : F;
 
 export type InterpolationPrimitive =
-| null
-| undefined
-| boolean
-| number
-| string
-| ComponentSelector
-| Keyframes
-| SerializedStyles
-| CSSObject
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | ComponentSelector
+  | Keyframes
+  | SerializedStyles
+  | CSSObject;
 
-export type CSSInterpolation = InterpolationPrimitive | ArrayCSSInterpolation
+export type CSSInterpolation = InterpolationPrimitive | ArrayCSSInterpolation;
 
 export interface FunctionInterpolation<Props> {
-  (props: Props): Interpolation<Props>
-}  
+  (props: Props): Interpolation<Props>;
+}
 
-export interface ArrayInterpolation<Props>
-  extends Array<Interpolation<Props>> {}
+export interface ArrayInterpolation<Props> extends Array<Interpolation<Props>> {}
 
 export type Interpolation<Props> =
   | InterpolationPrimitive
   | ArrayInterpolation<Props>
-  | FunctionInterpolation<Props>  
+  | FunctionInterpolation<Props>;
 
 /**
  * @desc Utility type for getting props type of React component.
@@ -78,7 +72,7 @@ export type Interpolation<Props> =
  */
 export type PropsOf<
   C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>
+> = JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>;
 
 export type Omit<T, U> = T extends any ? Pick<T, Exclude<keyof T, U>> : never;
 export type Overwrapped<T, U> = Pick<T, Extract<keyof T, keyof U>>;
@@ -100,9 +94,9 @@ export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
 }
 
 export interface StyledOptions<Props> {
-  label?: string
-  shouldForwardProp?(propName: PropertyKey): boolean
-  target?: string
+  label?: string;
+  shouldForwardProp?(propName: PropertyKey): boolean;
+  target?: string;
 }
 
 interface MuiStyledOptions {
@@ -114,13 +108,10 @@ interface MuiStyledOptions {
 }
 
 /** Same as StyledOptions but shouldForwardProp must be a type guard */
-export interface FilteringStyledOptions<
-  Props,
-  ForwardedProps extends keyof Props = keyof Props
-> {
-  label?: string
-  shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps
-  target?: string
+export interface FilteringStyledOptions<Props, ForwardedProps extends keyof Props = keyof Props> {
+  label?: string;
+  shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps;
+  target?: string;
 }
 
 /**
@@ -138,23 +129,17 @@ export interface CreateStyledComponent<
   <AdditionalProps extends {} = {}>(
     ...styles: Array<
       Interpolation<
-        ComponentProps &
-          SpecificComponentProps &
-          AdditionalProps & { theme: DefaultTheme }
+        ComponentProps & SpecificComponentProps & AdditionalProps & { theme: DefaultTheme }
       >
     >
-  ): StyledComponent<
-    ComponentProps & AdditionalProps,
-    SpecificComponentProps,
-    JSXProps
-  >
+  ): StyledComponent<ComponentProps & AdditionalProps, SpecificComponentProps, JSXProps>;
 
   (
     template: TemplateStringsArray,
     ...styles: Array<
       Interpolation<ComponentProps & SpecificComponentProps & { theme: DefaultTheme }>
     >
-  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>
+  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
 
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
@@ -163,39 +148,31 @@ export interface CreateStyledComponent<
     template: TemplateStringsArray,
     ...styles: Array<
       Interpolation<
-        ComponentProps &
-          SpecificComponentProps &
-          AdditionalProps & { theme: DefaultTheme }
+        ComponentProps & SpecificComponentProps & AdditionalProps & { theme: DefaultTheme }
       >
     >
-  ): StyledComponent<
-    ComponentProps & AdditionalProps,
-    SpecificComponentProps,
-    JSXProps
-  >
+  ): StyledComponent<ComponentProps & AdditionalProps, SpecificComponentProps, JSXProps>;
 }
 
 export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<
-      C
-    > = keyof React.ComponentProps<C>
+    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>,
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
-      theme?: Theme
-      as?: React.ElementType
-      sx?: SxProps<Theme>
+      theme?: Theme;
+      as?: React.ElementType;
+      sx?: SxProps<Theme>;
     },
     {},
     {
-      ref?: React.Ref<InstanceType<C>>
+      ref?: React.Ref<InstanceType<C>>;
     }
-  >
+  >;
 
   <C extends React.ComponentClass<React.ComponentProps<C>>>(
     component: C,
@@ -203,32 +180,30 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponent<
     PropsOf<C> & {
-      theme?: Theme
-      as?: React.ElementType
-      sx?: SxProps<Theme> 
+      theme?: Theme;
+      as?: React.ElementType;
+      sx?: SxProps<Theme>;
     },
     {},
     {
-      ref?: React.Ref<InstanceType<C>>
+      ref?: React.Ref<InstanceType<C>>;
     }
-  >
+  >;
 
   <
     C extends React.ComponentType<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<
-      C
-    > = keyof React.ComponentProps<C>
+    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>,
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
-      theme?: Theme
-      as?: React.ElementType
-      sx?: SxProps<Theme> 
+      theme?: Theme;
+      as?: React.ElementType;
+      sx?: SxProps<Theme>;
     }
-  >
+  >;
 
   <C extends React.ComponentType<React.ComponentProps<C>>>(
     component: C,
@@ -236,11 +211,11 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponent<
     PropsOf<C> & {
-      theme?: Theme
-      as?: React.ElementType
-      sx?: SxProps<Theme> 
+      theme?: Theme;
+      as?: React.ElementType;
+      sx?: SxProps<Theme>;
     }
-  >
+  >;
 
   <
     Tag extends keyof JSX.IntrinsicElements,
@@ -250,18 +225,18 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps>,
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponent<
-    { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme>; },
+    { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme> },
     Pick<JSX.IntrinsicElements[Tag], ForwardedProps>
-  >
+  >;
 
   <Tag extends keyof JSX.IntrinsicElements>(
     tag: Tag,
     options?: StyledOptions<JSX.IntrinsicElements[Tag]>,
     muiOptions?: MuiStyledOptions
   ): CreateStyledComponent<
-    { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme>; },
+    { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme> },
     JSX.IntrinsicElements[Tag]
-  >
+  >;
 }
 
 /**

--- a/packages/material-ui/src/styles/experimentalStyled.spec.tsx
+++ b/packages/material-ui/src/styles/experimentalStyled.spec.tsx
@@ -5,7 +5,6 @@ const Box = styled('div')(({ theme }) => ({
   color: theme.palette.primary.main,
 }));
 
-
 const SimpleBox = styled('div')``;
 
 function SxTestSimpleBox() {

--- a/packages/material-ui/src/styles/experimentalStyled.spec.tsx
+++ b/packages/material-ui/src/styles/experimentalStyled.spec.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+
+const Box = styled('div')(({ theme }) => ({
+  color: theme.palette.primary.main,
+}));
+
+
+const SimpleBox = styled('div')``;
+
+function SxTestSimpleBox() {
+  <SimpleBox sx={{ p: [2, 3, 4] }} />;
+}
+
+function SxTest() {
+  <Box sx={{ p: [2, 3, 4] }} />;
+}
+
+function WorksWithNoTheme() {
+  <Box />;
+}


### PR DESCRIPTION
This fixed the TS issue when component cannot be used without providing `theme` props, or adding empty props object in the generic.

I also update the typings based on the types in emotion@11