### PR TITLE
[Button] Remove inner span wrapper

### DIFF
--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -22,8 +22,6 @@ export type ButtonTypeMap<
     classes?: {
       /** Styles applied to the root element. */
       root?: string;
-      /** Styles applied to the span element that wraps the children. */
-      label?: string;
       /** Styles applied to the root element if `variant="text"`. */
       text?: string;
       /** Styles applied to the root element if `variant="text"` and `color="inherit"`. */

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -26,7 +26,6 @@ const overridesResolver = (props, styles) => {
     ...(color === 'inherit' && styles.colorInherit),
     ...(disableElevation && styles.disableElevation),
     ...(fullWidth && styles.fullWidth),
-    [`& .${buttonClasses.label}`]: styles.label,
     [`& .${buttonClasses.startIcon}`]: {
       ...styles.startIcon,
       ...styles[`iconSize${capitalize(size)}`],
@@ -62,7 +61,6 @@ const useUtilityClasses = (styleProps) => {
         [classes.fullWidth]: fullWidth,
       },
     ),
-    label: clsx(buttonClasses.label, classes.label),
     startIcon: clsx(
       buttonClasses.startIcon,
       classes.startIcon,
@@ -127,20 +125,6 @@ const ButtonEndIcon = experimentalStyled(
   }),
   ...commonIconStyles(styleProps),
 }));
-
-const ButtonLabel = experimentalStyled(
-  'span',
-  {},
-  {
-    name: 'MuiButton',
-    slot: 'Label',
-  },
-)({
-  width: '100%', // Ensure the correct width for iOS Safari
-  display: 'inherit',
-  alignItems: 'inherit',
-  justifyContent: 'inherit',
-});
 
 const ButtonRoot = experimentalStyled(
   ButtonBase,
@@ -376,17 +360,9 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       type={type}
       {...other}
     >
-      {/*
-       * The inner <span> is required to vertically align the children.
-       * Browsers don't support `display: flex` on a <button> element.
-       * https://github.com/philipwalton/flexbugs/blob/master/README.md#flexbug-9
-       * TODO v5: evaluate if still required for the supported browsers.
-       */}
-      <ButtonLabel className={classes.label}>
-        {startIcon}
-        {children}
-        {endIcon}
-      </ButtonLabel>
+      {startIcon}
+      {children}
+      {endIcon}
     </ButtonRoot>
   );
 });

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -22,7 +22,7 @@ describe('<Button />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     muiName: 'MuiButton',
-    testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
+    testDeepOverrides: null,
     testVariantProps: { variant: 'contained', fullWidth: true },
     skip: ['componentsProp'],
   }));
@@ -271,23 +271,21 @@ describe('<Button />', () => {
   it('should render a button with startIcon', () => {
     const { getByRole } = render(<Button startIcon={<span>icon</span>}>Hello World</Button>);
     const button = getByRole('button');
-    const label = button.querySelector(`.${classes.label}`);
 
     expect(button).to.have.class(classes.root);
     expect(button).to.have.class(classes.text);
-    expect(label.firstChild).not.to.have.class(classes.endIcon);
-    expect(label.firstChild).to.have.class(classes.startIcon);
+    expect(button.querySelector(`.${classes.startIcon}`)).not.to.equal(null);
+    expect(button.querySelector(`.${classes.endIcon}`)).to.equal(null);
   });
 
   it('should render a button with endIcon', () => {
     const { getByRole } = render(<Button endIcon={<span>icon</span>}>Hello World</Button>);
     const button = getByRole('button');
-    const label = button.querySelector(`.${classes.label}`);
 
     expect(button).to.have.class(classes.root);
     expect(button).to.have.class(classes.text);
-    expect(label.lastChild).not.to.have.class(classes.startIcon);
-    expect(label.lastChild).to.have.class(classes.endIcon);
+    expect(button.querySelector(`.${classes.startIcon}`)).to.equal(null);
+    expect(button.querySelector(`.${classes.endIcon}`)).not.to.equal(null);
   });
 
   it('should have a ripple by default', () => {


### PR DESCRIPTION
Exploratory removal since the flexbox bug is now fixed in WebKit.

Right now it's not apparent if we even need this workaround with default styling. It seems to me this is only added in case people add `display: flex` and are not aware of the flexbox bug. So even if we still support browsers with this bug it might be interesting to revisit if it's worth fixing this bug if it only happens in some browsers with certain styles.


TODO:
- [ ] check status of fix in opera and decide what to do if not fixed
- [ ] Safari iOS vs Safari macOS (we support 10.? on iOS but 12.x on macOS)