### PR TITLE
[docs] Fix iframe demos with emotion

### DIFF
--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -2,6 +2,8 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { create } from 'jss';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
 import { makeStyles, useTheme, jssPreset, StylesProvider } from '@material-ui/core/styles';
 import rtl from 'jss-rtl';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
@@ -25,13 +27,25 @@ function FramedDemo(props) {
     };
   }, [document]);
 
+  const cache = React.useMemo(
+    () =>
+      createCache({
+        key: 'iframe-demo',
+        prepend: true,
+        container: document.body,
+      }),
+    [document],
+  );
+
   const getWindow = React.useCallback(() => document.defaultView, [document]);
 
   return (
     <StylesProvider jss={jss} sheetsManager={sheetsManager}>
-      {React.cloneElement(children, {
-        window: getWindow,
-      })}
+      <CacheProvider value={cache}>
+        {React.cloneElement(children, {
+          window: getWindow,
+        })}
+      </CacheProvider>
     </StylesProvider>
   );
 }

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -32,7 +32,7 @@ function FramedDemo(props) {
       createCache({
         key: 'iframe-demo',
         prepend: true,
-        container: document.body,
+        container: document.head,
       }),
     [document],
   );
@@ -68,7 +68,8 @@ const useStyles = makeStyles(
 );
 
 function DemoFrame(props) {
-  const { children, title, ...other } = props;
+  const { children, name, ...other } = props;
+  const title = `${name} demo`;
   const classes = useStyles();
   /**
    * @type {import('react').Ref<HTMLIFrameElement>}
@@ -109,7 +110,7 @@ function DemoFrame(props) {
 
 DemoFrame.propTypes = {
   children: PropTypes.node.isRequired,
-  title: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
 };
 
 /**
@@ -119,7 +120,7 @@ DemoFrame.propTypes = {
 function DemoSandboxed(props) {
   const { component: Component, iframe, name, onResetDemoClick, ...other } = props;
   const Sandbox = iframe ? DemoFrame : React.Fragment;
-  const sandboxProps = iframe ? { title: `${name} demo`, ...other } : {};
+  const sandboxProps = iframe ? { name, ...other } : {};
 
   const t = useTranslate();
 


### PR DESCRIPTION
The problem was raised in https://github.com/mui-org/material-ui/issues/24097#issuecomment-750911353 and can be seen on:

<img width="373" alt="Capture d’écran 2021-01-03 à 10 57 51" src="https://user-images.githubusercontent.com/3165635/103476024-8a9d1580-4db2-11eb-8cfc-704ddadd3687.png">

https://next--material-ui.netlify.app/components/drawers/#persistent-drawer

It's a blocker to merge #24227 as the container only makes sense for a top-level layout, all the demos use an iframe.

Preview: https://deploy-preview-24232--material-ui.netlify.app/components/drawers/#persistent-drawer