### PR TITLE
[core] Fix relative import of types

### DIFF
--- a/packages/material-ui/src/Badge/Badge.d.ts
+++ b/packages/material-ui/src/Badge/Badge.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
-import { Theme } from '@material-ui/core/styles';
 import { OverridableStringUnion } from '@material-ui/types';
 import {
   ExtendBadgeUnstyledTypeMap,
   BadgeUnstyledTypeMap,
   BadgeUnstyledClasses,
 } from '@material-ui/unstyled';
+import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface BadgePropsVariantOverrides {}

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -1,6 +1,6 @@
 import { OverridableStringUnion } from '@material-ui/types';
 import { SxProps } from '@material-ui/system';
-import { Theme } from '@material-ui/core/styles';
+import { Theme } from '../styles';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
-import { Theme } from '@material-ui/core/styles';
+import { Theme } from '../styles';
 import { TouchRippleProps } from './TouchRipple';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 

--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { SxProps } from '@material-ui/system';
 import {
   ExtendSliderUnstyledTypeMap,
   ExtendSliderUnstyled,
   SliderUnstyledTypeMap,
   SliderUnstyledClasses,
 } from '@material-ui/unstyled';
-import { Theme } from '@material-ui/core/styles';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '../styles';
 import { OverrideProps } from '../OverridableComponent';
 
 export type SliderTypeMap<

--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OverridableStringUnion } from '@material-ui/types';
 import { SxProps } from '@material-ui/system';
-import { Theme } from '@material-ui/core/styles';
+import { Theme } from '../styles';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Variant } from '../styles/createTypography';
 


### PR DESCRIPTION
Types that are in the same package should be imported with a relative path. Found and extracted from #24227.