### PR TITLE
[DatePicker] Remove unused type parameters

### DIFF
--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerView.tsx
@@ -4,18 +4,19 @@ import { isRangeValid } from '../internal/pickers/date-utils';
 import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 import { calculateRangeChange } from './date-range-manager';
 import { useUtils } from '../internal/pickers/hooks/useUtils';
-import { SharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import DateRangePickerToolbar from './DateRangePickerToolbar';
 import { useCalendarState } from '../DayPicker/useCalendarState';
 import { DateRangePickerViewMobile } from './DateRangePickerViewMobile';
 import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { MobileKeyboardInputView } from '../internal/pickers/Picker/Picker';
 import DateRangePickerInput, { DateRangeInputProps } from './DateRangePickerInput';
-import { RangeInput, DateRange, CurrentlySelectingRangeEndProps } from './RangeTypes';
+import { DateRange, CurrentlySelectingRangeEndProps } from './RangeTypes';
 import { ExportedDayPickerProps, defaultReduceAnimations } from '../DayPicker/DayPicker';
 import DateRangePickerViewDesktop, {
   ExportedDesktopDateRangeCalendarProps,
 } from './DateRangePickerViewDesktop';
+import { PickerSelectionState } from '../internal/pickers/hooks/usePickerState';
+import { WrapperVariant } from '../internal/pickers/wrappers/Wrapper';
 
 type BaseCalendarPropsToReuse<TDate> = Omit<
   ExportedDayPickerProps<TDate>,
@@ -35,11 +36,19 @@ export interface ExportedDateRangePickerViewProps<TDate>
 
 interface DateRangePickerViewProps<TDate>
   extends CurrentlySelectingRangeEndProps,
-    ExportedDateRangePickerViewProps<TDate>,
-    SharedPickerProps<RangeInput<TDate>, DateRange<TDate>, DateRangeInputProps> {
+    ExportedDateRangePickerViewProps<TDate> {
   open: boolean;
   startText: React.ReactNode;
   endText: React.ReactNode;
+  isMobileKeyboardViewOpen: boolean;
+  toggleMobileKeyboardView: () => void;
+  DateInputProps: DateRangeInputProps;
+  date: DateRange<TDate>;
+  onDateChange: (
+    date: DateRange<TDate>,
+    currentWrapperVariant: WrapperVariant,
+    isFinish?: PickerSelectionState,
+  ) => void;
 }
 
 /**

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -8,9 +8,11 @@ import { KeyboardDateInput } from '../KeyboardDateInput';
 import { useIsLandscape } from '../hooks/useIsLandscape';
 import { DIALOG_WIDTH, VIEW_HEIGHT } from '../constants/dimensions';
 import { WrapperVariantContext } from '../wrappers/WrapperVariantContext';
+import { WrapperVariant } from '../wrappers/Wrapper';
+import { DateInputPropsLike } from '../wrappers/WrapperProps';
 import { PickerSelectionState } from '../hooks/usePickerState';
 import { BasePickerProps, CalendarAndClockProps } from '../typings/BasePicker';
-import { WithViewsProps, SharedPickerProps } from './SharedPickerProps';
+import { WithViewsProps } from './SharedPickerProps';
 import { AllAvailableViews, TimePickerView, DatePickerView } from '../typings/Views';
 import PickerView from './PickerView';
 
@@ -22,11 +24,18 @@ export interface ExportedPickerProps<TView extends AllAvailableViews>
   timeIcon?: React.ReactNode;
 }
 
-export type PickerProps<
-  TView extends AllAvailableViews,
-  TInputValue = any,
-  TDateValue = any
-> = ExportedPickerProps<TView> & SharedPickerProps<TInputValue, TDateValue>;
+export interface PickerProps<TView extends AllAvailableViews, TDateValue = any>
+  extends ExportedPickerProps<TView> {
+  isMobileKeyboardViewOpen: boolean;
+  toggleMobileKeyboardView: () => void;
+  DateInputProps: DateInputPropsLike;
+  date: TDateValue;
+  onDateChange: (
+    date: TDateValue,
+    currentWrapperVariant: WrapperVariant,
+    isFinish?: PickerSelectionState,
+  ) => void;
+}
 
 export const MobileKeyboardInputView = styled('div')(
   {

--- a/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
@@ -1,10 +1,7 @@
 import { BasePickerProps } from '../typings/BasePicker';
 import { ExportedDateInputProps } from '../PureDateInput';
 import { WithDateAdapterProps } from '../withDateAdapterProp';
-import { PickerSelectionState } from '../hooks/usePickerState';
-import { DateInputPropsLike } from '../wrappers/WrapperProps';
 import { AllAvailableViews } from '../typings/Views';
-import { WrapperVariant } from '../wrappers/Wrapper';
 
 export type AllSharedPickerProps<TInputValue = any, TDateValue = any> = BasePickerProps<
   TInputValue,
@@ -12,18 +9,6 @@ export type AllSharedPickerProps<TInputValue = any, TDateValue = any> = BasePick
 > &
   ExportedDateInputProps<TInputValue, TDateValue> &
   WithDateAdapterProps<TDateValue>;
-
-export interface SharedPickerProps<TInputValue, TDateValue, TInputProps = DateInputPropsLike> {
-  isMobileKeyboardViewOpen: boolean;
-  toggleMobileKeyboardView: () => void;
-  DateInputProps: TInputProps;
-  date: TDateValue;
-  onDateChange: (
-    date: TDateValue,
-    currentWrapperVariant: WrapperVariant,
-    isFinish?: PickerSelectionState,
-  ) => void;
-}
 
 export interface WithViewsProps<T extends AllAvailableViews> {
   /**


### PR DESCRIPTION
**TypeScript BREAKING CHANGE**
```diff
-PickerProps<View, InputValue, DateValue>
+PickerProps<View, DateValue>
```

The second type parameter was unused.

The linter detected unused type parameters in `SharedPickerProps`. I then discovered that we have two types with the same name in the codebase so I just removed one and inlined its properties where it was used. When we re-discover the purpose of the removed type we can document it.

I suspect `Picker/SharedPickerProps.tsx` should be named `Picker/utils.tsx` but we'll see once I dig more into the types. Next step will be figuring out what the difference is between `SharedPickerProps` and `AllSharedPickerProps` and why `|SharedPickerProps| > |AllSharedPickerProps|`<sup>1</sup>. In my mind you usually find `|AllSomeInterface| > |SomeInterface|` but it's probably best to avoid these `All*` qualifiers altogether if they're not explained.

<sup>1</sup> `|Interface|` is the number of properties `Interface` has.