### PR TITLE
[core] Support public paths in module augmentation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,9 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: yarn typescript
+      - run:
+          name: Test module augmenation
+          command: yarn workspace @material-ui/core typescript:module-augmentation
 
       - restore_cache:
           name: Restore generated declaration files

--- a/docs/pages/blog/2020-q3-update.md
+++ b/docs/pages/blog/2020-q3-update.md
@@ -45,7 +45,7 @@ Here are the most significant improvements since June 2020. This was a dense qua
   });
 
   // Optionally retain type safety:
-  declare module '@material-ui/core/Button/Button' {
+  declare module '@material-ui/core/Button' {
     interface ButtonPropsVariantOverrides {
       dashed: true;
     }

--- a/docs/src/pages/components/tables/ReactVirtualizedTable.tsx
+++ b/docs/src/pages/components/tables/ReactVirtualizedTable.tsx
@@ -16,7 +16,7 @@ import {
   TableHeaderProps,
 } from 'react-virtualized';
 
-declare module '@material-ui/core/styles/withStyles' {
+declare module '@material-ui/core/styles' {
   // Augment the BaseCSSProperties so that we can control jss-rtl
   interface BaseCSSProperties {
     /*

--- a/docs/src/pages/components/use-media-query/UseWidth.tsx
+++ b/docs/src/pages/components/use-media-query/UseWidth.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
+  Breakpoint,
   Theme,
   ThemeProvider,
   useTheme,
   createMuiTheme,
 } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
 type BreakpointOrNull = Breakpoint | null;
 

--- a/docs/src/pages/customization/breakpoints/WithWidth.tsx
+++ b/docs/src/pages/customization/breakpoints/WithWidth.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import withWidth from '@material-ui/core/withWidth';
 import Typography from '@material-ui/core/Typography';
-import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
+import { Breakpoint } from '@material-ui/core/styles';
 
 type TagName = 'em' | 'u' | 'del';
 

--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -120,8 +120,10 @@ const theme = createMuiTheme({
 
 If you are using TypeScript, you would also need to use [module augmentation](/guides/typescript/#customization-of-theme) for the theme to accept the above values.
 
+<!-- Tested with packages/material-ui/test/typescript/breakpointsOverrides.augmentation.tsconfig.json -->
+
 ```ts
-declare module '@material-ui/core/styles/createBreakpoints' {
+declare module '@material-ui/core/styles' {
   interface BreakpointOverrides {
     xs: false; // removes the `xs` breakpoint
     sm: false;

--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -153,13 +153,23 @@ const theme = createMuiTheme({
 
 If you are using TypeScript, you would also need to use [module augmentation](/guides/typescript/#customization-of-theme) for the theme to accept the above values.
 
+<!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
+
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'];
     };
   }
+
+  interface Palette {
+    neutral: Palette['primary'];
+  }
+  interface PaletteOptions {
+    neutral: PaletteOptions['primary'];
+  }
+
   interface PaletteColor {
     darker?: string;
   }
@@ -170,15 +180,6 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     status: {
       danger: React.CSSProperties['color'];
     };
-  }
-}
-
-declare module '@material-ui/core/styles/createPalette' {
-  interface Palette {
-    neutral: Palette['primary'];
-  }
-  interface PaletteOptions {
-    neutral: PaletteOptions['primary'];
   }
 }
 ```

--- a/docs/src/pages/customization/theme-components/GlobalThemeVariants.tsx
+++ b/docs/src/pages/customization/theme-components/GlobalThemeVariants.tsx
@@ -7,7 +7,7 @@ import {
 } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-declare module '@material-ui/core/Button/Button' {
+declare module '@material-ui/core/Button' {
   interface ButtonPropsVariantOverrides {
     dashed: true;
   }

--- a/docs/src/pages/customization/theme-components/theme-components.md
+++ b/docs/src/pages/customization/theme-components/theme-components.md
@@ -84,8 +84,10 @@ const theme = createMuiTheme({
 
 If you're using TypeScript, you'll need to specify your new variants/colors, using [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
+<!-- Tested with packages/material-ui/test/typescript/augmentation/themeComponents.spec.ts -->
+
 ```tsx
-declare module '@material-ui/core/Button/Button' {
+declare module '@material-ui/core/Button' {
   interface ButtonPropsVariantOverrides {
     dashed: true;
   }

--- a/docs/src/pages/customization/theming/CustomStyles.tsx
+++ b/docs/src/pages/customization/theming/CustomStyles.tsx
@@ -9,7 +9,7 @@ import {
 } from '@material-ui/core/styles';
 import { orange } from '@material-ui/core/colors';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles' {
   interface Theme {
     status: {
       danger: string;

--- a/docs/src/pages/customization/typography/typography.md
+++ b/docs/src/pages/customization/typography/typography.md
@@ -239,20 +239,22 @@ const theme = createMuiTheme({
 
 You need to make sure that the typings for the theme's `typography` variants and the `Typogrpahy`'s `variant` prop reflects the new set of variants.
 
+<!-- Tested with packages/material-ui/test/typescript/augmentation/typographyVariants.spec.ts -->
+
 ```ts
-declare module '@material-ui/core/styles/createTypography' {
-  interface Typography {
+declare module '@material-ui/core/styles' {
+  interface TypographyVariants {
     poster: React.CSSProperties;
   }
 
   // allow configuration using `createMuiTheme`
-  interface TypographyOptions {
+  interface TypographyVariantsOptions {
     poster?: React.CSSProperties;
   }
 }
 
 // Update the Typography's variant prop options
-declare module '@material-ui/core/Typography/Typography' {
+declare module '@material-ui/core/Typography' {
   interface TypographyPropsVariantOverrides {
     poster: true;
     h3: false;

--- a/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
+++ b/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
-declare module '@material-ui/core/styles/withStyles' {
+declare module '@material-ui/core/styles' {
   // Augment the BaseCSSProperties so that we can control jss-rtl
   interface BaseCSSProperties {
     /**

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -235,10 +235,9 @@ When adding custom properties to the `Theme`, you may continue to use it in a st
 The following example adds an `appDrawer` prop that is merged into the one exported by `material-ui`:
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
-import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
+import { Breakpoint, Theme } from '@material-ui/core/styles';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width'];

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -330,7 +330,7 @@ export default function CustomBreakpoints() {
 If you are using TypeScript, you will also need to use [module augmentation](/guides/typescript/#customization-of-theme) for the theme to accept the above values.
 
 ```ts
-declare module '@material-ui/core/styles/createBreakpoints' {
+declare module '@material-ui/core/styles' {
   interface BreakpointOverrides {
     xs: false; // removes the `xs` breakpoint
     sm: false;

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -38,7 +38,8 @@
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.{js,ts,tsx}'",
-    "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json && tsc -p tsconfig.build.json"
+    "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json && tsc -p tsconfig.build.json",
+    "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",

--- a/packages/material-ui/scripts/testModuleAugmentation.js
+++ b/packages/material-ui/scripts/testModuleAugmentation.js
@@ -1,0 +1,58 @@
+const childProcess = require('child_process');
+const glob = require('fast-glob');
+const path = require('path');
+const { promisify } = require('util');
+
+const exec = promisify(childProcess.exec);
+const packageRoot = path.resolve(__dirname, '../');
+
+async function test(tsconfigPath) {
+  try {
+    await exec(['yarn', 'tsc', '--project', tsconfigPath].join(' '), { cwd: packageRoot });
+  } catch (error) {
+    if (error.stdout !== undefined) {
+      // `exec` error
+      throw new Error(error.stdout);
+    }
+    // Unknown error
+    throw error;
+  }
+}
+
+/**
+ * Tests various module augmentation scenarios.
+ * We can't run them with a single `tsc` run since these apply globally.
+ * Running them all would mean they're not isolated.
+ * Each test case represents a section in our docs.
+ *
+ * We're not using mocha since mocha is used for runtime tests.
+ * This script also allows us to test in parallel which we can't do with our mocha tests.
+ */
+async function main() {
+  const tsconfigPaths = await glob('test/typescript/moduleAugmentation/*.tsconfig.json', {
+    absolute: true,
+    cwd: packageRoot,
+  });
+
+  await Promise.all(
+    tsconfigPaths.map(async (tsconfigPath) => {
+      await test(tsconfigPath).then(
+        () => {
+          // eslint-disable-next-line no-console -- test runner feedback
+          console.log(`PASS ${path.relative(process.cwd(), tsconfigPath)}`);
+        },
+        (error) => {
+          // don't bail but log the error
+          console.error(`FAIL ${path.relative(process.cwd(), tsconfigPath)}\n ${error.message}`);
+          // and mark the test as failed
+          process.exitCode = 1;
+        },
+      );
+    }),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/material-ui/src/styles/createMuiTheme.d.ts
+++ b/packages/material-ui/src/styles/createMuiTheme.d.ts
@@ -9,6 +9,8 @@ import { Transitions, TransitionsOptions } from './transitions';
 import { ZIndex, ZIndexOptions } from './zIndex';
 import { Components } from './components';
 
+export { Breakpoint, BreakpointOverrides } from './createBreakpoints';
+
 export type Direction = 'ltr' | 'rtl';
 
 export interface ThemeOptions {

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -2,14 +2,27 @@ export * from './colorManipulator';
 export {
   default as createMuiTheme,
   default as unstable_createMuiStrictModeTheme,
+  Breakpoint,
+  BreakpointOverrides,
   ThemeOptions,
   Theme,
   Direction,
 } from './createMuiTheme';
 export { default as adaptV4Theme, DeprecatedThemeOptions } from './adaptV4Theme';
-export { PaletteColorOptions, SimplePaletteColorOptions } from './createPalette';
+export {
+  Palette,
+  PaletteColor,
+  PaletteColorOptions,
+  PaletteOptions,
+  SimplePaletteColorOptions,
+} from './createPalette';
 export { default as createStyles } from './createStyles';
-export { TypographyStyle, Variant as TypographyVariant } from './createTypography';
+export {
+  Typography as TypographyVariants,
+  TypographyOptions as TypographyVariantsOptions,
+  TypographyStyle,
+  Variant as TypographyVariant,
+} from './createTypography';
 export { default as makeStyles } from './makeStyles';
 export { default as responsiveFontSizes } from './responsiveFontSizes';
 export { ComponentsPropsList } from './props';

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.ts
@@ -1,0 +1,26 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+// testing docs/src/pages/customization/breakpoints/breakpoints.md
+
+declare module '@material-ui/core/styles' {
+  interface BreakpointOverrides {
+    xs: false; // removes the `xs` breakpoint
+    sm: false;
+    md: false;
+    lg: false;
+    xl: false;
+    tablet: true; // adds the `tablet` breakpoint
+    laptop: true;
+    desktop: true;
+  }
+}
+
+createMuiTheme({
+  breakpoints: {
+    values: {
+      tablet: 640,
+      laptop: 1024,
+      desktop: 1280,
+    },
+  },
+});

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.tsconfig.json
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig",
+  "files": ["breakpointsOverrides.spec.ts"]
+}

--- a/packages/material-ui/test/typescript/moduleAugmentation/paletteColors.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/paletteColors.spec.ts
@@ -1,0 +1,44 @@
+// testing docs/src/pages/customization/palette/palette.md
+import { createMuiTheme } from '@material-ui/core/styles';
+
+declare module '@material-ui/core/styles' {
+  interface Theme {
+    status: {
+      danger: React.CSSProperties['color'];
+    };
+  }
+
+  interface Palette {
+    neutral: Palette['primary'];
+  }
+  interface PaletteOptions {
+    neutral: PaletteOptions['primary'];
+  }
+
+  interface PaletteColor {
+    darker?: string;
+  }
+  interface SimplePaletteColorOptions {
+    darker?: string;
+  }
+  interface ThemeOptions {
+    status: {
+      danger: React.CSSProperties['color'];
+    };
+  }
+}
+
+const theme = createMuiTheme({
+  status: {
+    danger: '#e53e3e',
+  },
+  palette: {
+    primary: {
+      main: '#0971f1',
+      darker: '#053e85',
+    },
+    neutral: {
+      main: '#5c6ac4',
+    },
+  },
+});

--- a/packages/material-ui/test/typescript/moduleAugmentation/paletteColors.tsconfig.json
+++ b/packages/material-ui/test/typescript/moduleAugmentation/paletteColors.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig",
+  "files": ["paletteColors.spec.ts"]
+}

--- a/packages/material-ui/test/typescript/moduleAugmentation/themeComponents.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/themeComponents.spec.ts
@@ -1,0 +1,31 @@
+// testing docs/src/pages/customization/theme-components/theme-components.md
+import { blue, red } from '@material-ui/core/colors';
+import { createMuiTheme } from '@material-ui/core/styles';
+
+declare module '@material-ui/core/Button' {
+  interface ButtonPropsVariantOverrides {
+    dashed: true;
+  }
+}
+
+const theme = createMuiTheme({
+  components: {
+    MuiButton: {
+      variants: [
+        {
+          props: { variant: 'dashed' },
+          style: {
+            textTransform: 'none',
+            border: `2px dashed grey${blue[500]}`,
+          },
+        },
+        {
+          props: { variant: 'dashed', color: 'secondary' },
+          style: {
+            border: `4px dashed ${red[500]}`,
+          },
+        },
+      ],
+    },
+  },
+});

--- a/packages/material-ui/test/typescript/moduleAugmentation/themeComponents.tsconfig.json
+++ b/packages/material-ui/test/typescript/moduleAugmentation/themeComponents.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig",
+  "files": ["themeComponents.spec.ts"]
+}

--- a/packages/material-ui/test/typescript/moduleAugmentation/typographyVariants.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/typographyVariants.spec.tsx
@@ -1,0 +1,39 @@
+// testing docs/src/pages/customization/typography/typography.md
+import { createMuiTheme } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import * as React from 'react';
+
+declare module '@material-ui/core/styles' {
+  interface TypographyVariants {
+    poster: React.CSSProperties;
+  }
+
+  // allow configuration using `createMuiTheme`
+  interface TypographyVariantsOptions {
+    poster?: React.CSSProperties;
+  }
+}
+
+// Update the Typography's variant prop options
+declare module '@material-ui/core/Typography' {
+  interface TypographyPropsVariantOverrides {
+    poster: true;
+    h3: false;
+  }
+}
+
+const theme = createMuiTheme({
+  typography: {
+    poster: {
+      color: 'red',
+    },
+    // Disable h3 variant
+    h3: undefined,
+  },
+});
+
+<Typography variant="poster">poster</Typography>;
+
+/* This variant is no longer supported */
+// @ts-expect-error
+<Typography variant="h3">h3</Typography>;

--- a/packages/material-ui/test/typescript/moduleAugmentation/typographyVariants.tsconfig.json
+++ b/packages/material-ui/test/typescript/moduleAugmentation/typographyVariants.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig",
+  "files": ["typographyVariants.spec.tsx"]
+}

--- a/packages/material-ui/tsconfig.json
+++ b/packages/material-ui/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["test/typescript/moduleAugmentation"]
 }


### PR DESCRIPTION
1. Use public paths in module augmentation
2. Test documented module augmentation /cc @mnajdova 

We have a notion of what we consider "public paths". However, this does not apply to type imports which makes it harder to teach ("ok here, but not ok there"). Since we already make types public by documenting that the paths are public we might as well export them directly which means we can simplify how we teach public paths.

The existing patterns continue to work but are more likely to break during refactoring. The patterns we now document are tested in CI and therefore a lot more robust.

## Implementation choices
### separate script 

1. does not slow down `test:unit`
1. Allows parallel testing (which we haven't set up for `mocha`)
1. can be included in test suite that runs with TypeScript nightlies
