### PR TITLE
Update .eslintrc.js to allow chai chainable getters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -175,6 +175,8 @@ module.exports = {
             patterns: ['test/utils/*'],
           },
         ],
+        // allows chainable getters when using the chai expected assertion
+        "@typescript-eslint/no-unused-expressions": "off",
 
         'material-ui/disallow-active-element-as-key-event-target': 'error',
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

While adding some chai `expect` assertions using their [chainable getters](https://www.chaijs.com/api/bdd/) (like `expect(foo).to.be.true`) I ran into `@typescrpt-eslint/no-unused-expressions` warnings. This small change to the `.eslintrc.js` config allows those assertions in test files. I assume this is something everyone will want to use with `expect`, since that's a good deal of this assertion syntax's value, in my opinion.
