### PR TITLE
[DatePicker] Simplify ExtendWrapper type

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -91,6 +91,10 @@ const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(R
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -39,6 +39,10 @@ const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', Respons
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
@@ -5,7 +5,7 @@ import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { withDateAdapterProp } from '../internal/pickers/withDateAdapterProp';
 import { makeWrapperComponent } from '../internal/pickers/wrappers/makeWrapperComponent';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
-import { SomeWrapper, ExtendWrapper } from '../internal/pickers/wrappers/Wrapper';
+import { SomeWrapper, PublicWrapperProps } from '../internal/pickers/wrappers/Wrapper';
 import { RangeInput, AllSharedDateRangePickerProps, DateRange } from './RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
@@ -36,7 +36,7 @@ export interface BaseDateRangePickerProps<TDate>
 
 export type DateRangePickerComponent<TWrapper extends SomeWrapper> = <TDate>(
   props: BaseDateRangePickerProps<TDate> &
-    ExtendWrapper<TWrapper> &
+    PublicWrapperProps<TWrapper> &
     AllSharedDateRangePickerProps<TDate> &
     React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element;
@@ -78,7 +78,7 @@ export function makeDateRangePicker<TWrapper extends SomeWrapper>(
     ...other
   }: BaseDateRangePickerProps<TDate> &
     AllSharedDateRangePickerProps<TDate> &
-    ExtendWrapper<TWrapper>) {
+    PublicWrapperProps<TWrapper>) {
     const utils = useUtils();
     const minDate = useParsedDate(__minDate);
     const maxDate = useParsedDate(__maxDate);

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -177,6 +177,10 @@ const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unk
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -30,6 +30,10 @@ const DesktopDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkn
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -37,6 +37,10 @@ const DesktopDateRangePicker = makeDateRangePicker(
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -50,6 +50,10 @@ const DesktopDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPr
    */
   ampmInClock: PropTypes.bool,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -42,6 +42,10 @@ const DesktopTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Des
    */
   ampmInClock: PropTypes.bool,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -35,6 +35,10 @@ const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -39,6 +39,10 @@ const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', M
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -55,6 +55,10 @@ const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -47,6 +47,10 @@ const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Mobi
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -30,6 +30,10 @@ const StaticDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unkno
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -34,6 +34,10 @@ const StaticDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', S
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -50,6 +50,10 @@ const StaticDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerPro
    */
   ampmInClock: PropTypes.bool,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -42,6 +42,10 @@ const StaticTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Stat
    */
   ampmInClock: PropTypes.bool,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -118,6 +118,10 @@ const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(Responsive
    */
   cancelText: PropTypes.node,
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * className applied to the root component.
    */
   className: PropTypes.string,

--- a/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
@@ -5,7 +5,7 @@ import { MuiPickersAdapter } from '../hooks/useUtils';
 import { parsePickerInputValue } from '../date-utils';
 import { withDefaultProps } from '../withDefaultProps';
 import { KeyboardDateInput } from '../KeyboardDateInput';
-import { SomeWrapper, ExtendWrapper } from '../wrappers/Wrapper';
+import { SomeWrapper, PublicWrapperProps } from '../wrappers/Wrapper';
 import { ResponsiveWrapper } from '../wrappers/ResponsiveWrapper';
 import { withDateAdapterProp } from '../withDateAdapterProp';
 import { makeWrapperComponent } from '../wrappers/makeWrapperComponent';
@@ -19,7 +19,7 @@ type AllAvailableForOverrideProps = ExportedPickerProps<AllAvailableViews>;
 
 export type AllPickerProps<T, TWrapper extends SomeWrapper = SomeWrapper> = T &
   AllSharedPickerProps &
-  ExtendWrapper<TWrapper>;
+  PublicWrapperProps<TWrapper>;
 
 export interface MakePickerOptions<T extends unknown> {
   name: string;
@@ -40,7 +40,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
 
-export type SharedPickerProps<TDate, TWrapper extends SomeWrapper> = ExtendWrapper<TWrapper> &
+export type SharedPickerProps<TDate, TWrapper extends SomeWrapper> = PublicWrapperProps<TWrapper> &
   AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
   React.RefAttributes<HTMLInputElement>;
 
@@ -62,7 +62,7 @@ export function makePickerWithStateAndWrapper<
   });
 
   function PickerWithState<TDate>(
-    __props: T & AllSharedPickerProps<ParsableDate<TDate>, TDate> & ExtendWrapper<TWrapper>,
+    __props: T & AllSharedPickerProps<ParsableDate<TDate>, TDate> & PublicWrapperProps<TWrapper>,
   ) {
     const allProps = useInterceptProps(__props) as AllPickerProps<T, TWrapper>;
 

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/Wrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/Wrapper.tsx
@@ -1,19 +1,9 @@
 import StaticWrapper from './StaticWrapper';
 import MobileWrapper from './MobileWrapper';
 import DesktopWrapper from './DesktopWrapper';
-import { ResponsiveWrapper, ResponsiveWrapperProps } from './ResponsiveWrapper';
+import { ResponsiveWrapper } from './ResponsiveWrapper';
 import DesktopTooltipWrapper from './DesktopTooltipWrapper';
-import {
-  StaticWrapperProps,
-  MobileWrapperProps,
-  DesktopWrapperProps,
-  PrivateWrapperProps,
-} from './WrapperProps';
-
-type UniqueWrapperComponentProps<T extends React.FC<any>> = Omit<
-  React.ComponentProps<T>,
-  keyof PrivateWrapperProps
->;
+import { PrivateWrapperProps } from './WrapperProps';
 
 export type SomeWrapper =
   | typeof ResponsiveWrapper
@@ -22,18 +12,10 @@ export type SomeWrapper =
   | typeof DesktopWrapper
   | typeof DesktopTooltipWrapper;
 
-// prettier-ignore
-export type ExtendWrapper<TWrapper extends SomeWrapper> =
-  UniqueWrapperComponentProps<TWrapper> extends StaticWrapperProps
-  ? StaticWrapperProps
-  // make sure that ResponsiveWrapper extends props for mobile and desktop so we must check it before them and only for unique prop
-  : UniqueWrapperComponentProps<TWrapper> extends Pick<ResponsiveWrapperProps, 'desktopModeMediaQuery'>
-  ? ResponsiveWrapperProps
-  : UniqueWrapperComponentProps<TWrapper> extends DesktopWrapperProps
-  ? DesktopWrapperProps
-  : UniqueWrapperComponentProps<TWrapper> extends MobileWrapperProps
-  ? MobileWrapperProps
-  : {};
+export type PublicWrapperProps<TWrapper extends SomeWrapper> = Omit<
+  React.ComponentProps<TWrapper>,
+  keyof PrivateWrapperProps
+>;
 
 // Required for babel https://github.com/vercel/next.js/issues/7882. Replace with `export type` in future
 export type WrapperVariant = import('./WrapperVariantContext').WrapperVariant;


### PR DESCRIPTION
All the wrapper components currently implement `SomeWrapperProps & PrivateWrapperProps` props. In some places we need to extract the `SomeWrapperProps` from these component types.

Currently we're doing this by comparing their props interface (- `PrivateWrapperProps` to a known list of interfaces and return the first known interface that extends it.

However, this approach is flawed if multiple interfaces implement the same property. In that case the first compared interface wins ([minimal illustration of the issue](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQdwAdjFlAXlnAApTABuyVrwhh0Abzpw4orEwBccAEYQIAGxxM6AXwbNW7TnABiqkWLiTpuABbA1AE0pMA-Iux4YAOg-4AchAOWFJwBKpucKgwfEwA5vS6jCxsHLhcAELIUOYSIbb2TnIRvt4lAUH00kpZikwAriBKbAkMMACeYFwAqkzAAI51WDkAPDkAfHAAvHAA8iDAMKPEYgA0cADWWG0QBDx8gsLLqGN07Z1wAOJYMACSyYZpS6LHU3A9-YMj43BYAB6sTAc6FMEBycBcJjMRzgineAyGRyeYgmfwBQLgmWy0IhmLBinEiQA9ISMQBBAAiikoMDqUCY6AABiCcgy1qgbBA6o44NTaUw4AzcUcGacOhksncDKkuNMrrd7tLhkLnnAAGR7ARCBHPE7Ey4zGaUnnXPmM5nC0XnEGSlJGWXXG0PLDDc0q9W8TWHHVAA)).

I see no reason to just stick with a simple "public props = all props - private props".

This doesn't fix any actual issue because incidentally these known interfaces don't share props (yet). However, the underlying components share props implicitly: `children` via `React.FunctionComponent`. 

We want to avoid implicit interfaces. At some point we decided that every component supports `children` but that just doesn't reflect reality so in the future implicit children will be gone. So I'm in the process of making the types future-proof when I spot problems. I'm currently reasoning about pickers interface and implementation. Most of the types aren't documented and their names oftentimes do not explain their purpose because TypeScript jargon isn't standardized. For example, we had the `ExtendWrapper` type but that one works completely different compared to `ExtendButtonBase`. Both mention a component but one returns the public props while the other one returns a component type. We (and I mean mostly myself here) need to take more care when creating types and be extra verbose. In a structural type system the name of the type is irrelevant. Only its structure counts.