### PR TITLE
[TimePicker] Add pointer cursor for clock in desktop

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -68,6 +68,10 @@ export const styles: MuiStyles<ClockClassKey> = (theme): StyleRules<ClockClassKe
     // Disable scroll capabilities.
     touchAction: 'none',
     userSelect: 'none',
+    '@media (pointer: fine)': {
+      cursor: 'pointer',
+      borderRadius: '50%',
+    },
     '&:active': {
       cursor: 'move',
     },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Add pointer for cursor when mouse over event happens on the clock element.

### Why is it needed?
The cursor should indicate clickable on the clock.

### Related issue(s)/PR(s)
Closes #24170 