### PR TITLE
[core] Create issue labeled

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,0 +1,18 @@
+name: Issue Labeled
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  label-duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: remove labels
+        if: github.event.label.name == 'duplicate'
+        uses: actions-cool/issues-helper@v1.7
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: 'status: incomplete,status: needs triage'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

HI, @oliviertassinari 

Last time, when you type `Duplicate of #xx`, it will add the `duplicate` label automatically.

And I found that you often need to manually remove these 2 labels, so I added this. It will only remove these 2 labels if the issue has these 2 labels or one of them and has no effect on others. If there are any omissions labels, you can tell me.


