### PR TITLE
[Textfield] Add error color for form input with secondary color

### DIFF
--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -28,6 +28,10 @@ export const styles = (theme) => ({
     '&$focused': {
       color: theme.palette.secondary.main,
     },
+    '&$error': {
+      // To remove once we migrate to emotion
+      color: theme.palette.error.main,
+    },
   },
   /* Pseudo-class applied to the root element if `focused={true}`. */
   focused: {},

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -154,4 +154,42 @@ describe('<FormLabel />', () => {
       });
     });
   });
+
+  describe('prop: color', () => {
+    describe('secondary', () => {
+      it('should have color secondary class', () => {
+        const { container } = render(<FormLabel color="secondary" />);
+
+        expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
+        expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.colorSecondary);
+      });
+
+      it('should have the focused class and style', () => {
+        const { container, getByTestId } = render(
+          <FormLabel data-testid="FormLabel" color="secondary" focused />,
+        );
+
+        expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
+        expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(
+          classes.focused,
+        );
+
+        expect(getByTestId('FormLabel')).toHaveComputedStyle({ color: 'rgb(245, 0, 87)' });
+      });
+
+      it('should have the error class and style, even when focused', () => {
+        const { container, getByTestId } = render(
+          <FormLabel data-testid="FormLabel" color="secondary" focused error />,
+        );
+
+        expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
+        expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(
+          classes.focused,
+        );
+        expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.error);
+
+        expect(getByTestId('FormLabel')).toHaveComputedStyle({ color: 'rgb(244, 67, 54)' });
+      });
+    });
+  });
 });

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -156,40 +156,26 @@ describe('<FormLabel />', () => {
   });
 
   describe('prop: color', () => {
-    describe('secondary', () => {
-      it('should have color secondary class', () => {
-        const { container } = render(<FormLabel color="secondary" />);
+    it('should have color secondary class', () => {
+      const { container } = render(<FormLabel color="secondary" />);
+      expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
+      expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.colorSecondary);
+    });
 
-        expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
-        expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.colorSecondary);
-      });
+    it('should have the focused class and style', () => {
+      const { container, getByTestId } = render(
+        <FormLabel data-testid="FormLabel" color="secondary" focused />,
+      );
+      expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.focused);
+      expect(getByTestId('FormLabel')).toHaveComputedStyle({ color: 'rgb(245, 0, 87)' });
+    });
 
-      it('should have the focused class and style', () => {
-        const { container, getByTestId } = render(
-          <FormLabel data-testid="FormLabel" color="secondary" focused />,
-        );
-
-        expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
-        expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(
-          classes.focused,
-        );
-
-        expect(getByTestId('FormLabel')).toHaveComputedStyle({ color: 'rgb(245, 0, 87)' });
-      });
-
-      it('should have the error class and style, even when focused', () => {
-        const { container, getByTestId } = render(
-          <FormLabel data-testid="FormLabel" color="secondary" focused error />,
-        );
-
-        expect(container.querySelectorAll(`.${classes.colorSecondary}`)).to.have.lengthOf(1);
-        expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(
-          classes.focused,
-        );
-        expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.error);
-
-        expect(getByTestId('FormLabel')).toHaveComputedStyle({ color: 'rgb(244, 67, 54)' });
-      });
+    it('should have the error class and style, even when focused', () => {
+      const { container, getByTestId } = render(
+        <FormLabel data-testid="FormLabel" color="secondary" focused error />,
+      );
+      expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.error);
+      expect(getByTestId('FormLabel')).toHaveComputedStyle({ color: 'rgb(244, 67, 54)' });
     });
   });
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -40,6 +40,10 @@ export const styles = (theme) => {
       '&$focused $notchedOutline': {
         borderColor: theme.palette.secondary.main,
       },
+      '&$error $notchedOutline': {
+        // To remove once we migrate to emotion
+        borderColor: theme.palette.error.main,
+      },
     },
     /* Styles applied to the root element if the component is focused. */
     focused: {},


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Add error color for form input with secondary color when focused.

### Why is it needed?
It will add error color and override focused color with error color for focused form input.

### Related issue(s)/PR(s)
Closes #24261 
