### PR TITLE
[docs] Focus docs search input when the shortcut is clicked

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -269,7 +269,7 @@ export default function AppSearch() {
       />
       <div className={clsx(classes.shortcut, { 'Mui-focused': focused })}>
         {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-        {macOS ? '⌘' : 'Ctrl'}K
+        {macOS ? '⌘' : 'Ctrl+'}K
       </div>
     </div>
   );

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -120,6 +120,9 @@ const useStyles = makeStyles(
       transition: theme.transitions.create('opacity', {
         duration: theme.transitions.duration.shortest,
       }),
+      // So that clicks target the input.
+      // Makes the text non selectable but neither is the placeholder or adornment.
+      pointerEvents: 'none',
       '&.Mui-focused': {
         opacity: 0,
       },


### PR DESCRIPTION
Before:
![Recording that shows when you click the shortcut in the app search input the input isn't focused](https://i.ibb.co/bBNv00V/doc-searchshort-pointer.gif)
After:
![Recording that shows when you click the shortcut in the app search input the input is focused](https://i.ibb.co/hKh0MYd/doc-searchshort-pointer-after.gif)

Update: 
```diff
-CtrlK
+Ctrl+K
```
Rationale: https://github.com/mui-org/material-ui/pull/24296#issuecomment-755992971