### PR TITLE
[test] Skip expensive GitHub actions on l10nbot commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   # Tests dev-only scripts across all supported dev environments
   test-dev:
+    if: ${{ github.actor != 'l10nbot' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   # Tests dev-only scripts across all supported dev environments
   test-dev:
+    # l10nbot does not affect dev scripts.
     if: ${{ github.actor != 'l10nbot' }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   main:
+    # l10nbot creates a lot of commits at once which starves CI.
+    # We rely on other pushes to mark these branches as outdated.
+    if: ${{ github.actor != 'l10nbot' }}
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are dirty


### PR DESCRIPTION
Ported behavior of azure pipelines and CircleCI to GitHub actions. Now I just need to cancel ~1300 jobs in the queue :grimacing: 

Update:
Cancelling queued runs of l10nbot with https://gist.github.com/eps1lon/9c822429bffb5db5a3f221dd00fea842#file-cancel-gh-actions-js