### PR TITLE
[test] Persist new declaration files in CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,8 @@ jobs:
       - restore_cache:
           name: Restore generated declaration files
           keys:
-            # We assume that the target branch is `next`
+            # We assume that the target branch is `next` and that declaration files are persisted in commit order.
+            # "If there are multiple matches, the most recently generated cache will be used."
             - typescript-declaration-files-next
 
       - run:
@@ -203,7 +204,7 @@ jobs:
             exit 0
       - save_cache:
           name: Save generated declaration files
-          key: typescript-declaration-files-{{ .Branch }}
+          key: typescript-declaration-files-{{ .Branch }}-{{ .Revision }}
           paths:
             # packages with generated declaration files
             - packages/material-ui/build


### PR DESCRIPTION
Noticed in https://github.com/mui-org/material-ui/pull/24298 that we compared against older declaration files: https://app.circleci.com/pipelines/github/mui-org/material-ui/32797/workflows/0d6cea67-a1a7-4282-a56b-405a6560eb38/jobs/211262/parallel-runs/0/steps/0-111

CircleCI isn't saving the cache if it already exists so we need to force it by using the `.Revision` placeholder as an approximation for "declaration files changed".

The diff is still not accurate for outdated branches since we compare against the latest commit on `next`. But this task has a very narrow use case so this limitation should be fine. 