### PR TITLE
[lab] Prevent possible null pointer in useValidation

### DIFF
--- a/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
@@ -46,8 +46,7 @@ export const useDateRangeValidation = makeValidationHook<
   RangeInput<unknown>,
   BaseDateRangePickerProps<any>
 >(validateDateRange, {
-  defaultValidationError: [null, null],
-  isSameError: (a, b) => a[1] === b[1] && a[0] === b[0],
+  isSameError: (a, b) => b !== null && a[1] === b[1] && a[0] === b[0],
 });
 
 export function makeDateRangePicker<TWrapper extends SomeWrapper>(

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useValidation.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useValidation.ts
@@ -14,8 +14,7 @@ export interface ValidationProps<TError, TDateValue> {
 }
 
 export interface ValidationHookOptions<TError> {
-  defaultValidationError?: TError;
-  isSameError?: (a: TError, b: TError) => boolean;
+  isSameError?: (a: TError, b: TError | null) => boolean;
 }
 
 const defaultIsSameError = (a: unknown, b: unknown) => a === b;
@@ -26,13 +25,11 @@ export function makeValidationHook<
   TProps extends ValidationProps<TError, TDateValue>
 >(
   validateFn: (utils: MuiPickersAdapter, value: TDateValue, props: TProps) => TError,
-  { defaultValidationError, isSameError = defaultIsSameError }: ValidationHookOptions<TError> = {},
+  { isSameError = defaultIsSameError }: ValidationHookOptions<TError> = {},
 ) {
   return (value: TDateValue, props: TProps) => {
     const utils = useUtils();
-    const previousValidationErrorRef = React.useRef<TError>(
-      defaultValidationError || null,
-    ) as React.MutableRefObject<TError>;
+    const previousValidationErrorRef = React.useRef<TError | null>(null);
 
     const validationError = validateFn(utils, value, props);
 


### PR DESCRIPTION
The very first `isSameError` can be `null` unless `defaultValidationError` is supplied. This was unsound at a type level but worked since the only unsafe comparison of `TError` actually supplied `defaultValidationError`.

We could make this sound at a type level without changing runtime but this is excessive considering it is a one-off use case.