### PR TITLE
[lab] Reduce coupling of parsing picker input value and props

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/date-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.ts
@@ -106,10 +106,7 @@ export const getFormatAndMaskByViews = (
   };
 };
 
-export function parsePickerInputValue(
-  utils: MuiPickersAdapter,
-  { value }: BasePickerProps,
-): unknown | null {
+export function parsePickerInputValue(utils: MuiPickersAdapter, value: unknown): unknown {
   const parsedValue = utils.date(value);
 
   return utils.isValid(parsedValue) ? parsedValue : null;
@@ -117,7 +114,7 @@ export function parsePickerInputValue(
 
 export function parseRangeInputValue<TDate>(
   utils: MuiPickersAdapter,
-  { value = [null, null] }: BasePickerProps<RangeInput<TDate>, DateRange<TDate>>,
+  value: RangeInput<TDate> = [null, null],
 ) {
   return value.map((date) =>
     !utils.isValid(date) || date === null ? null : utils.startOfDay(utils.date(date)),

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.ts
@@ -1,7 +1,6 @@
 import { RangeInput, NonEmptyDateRange, DateRange } from '../../DateRangePicker/RangeTypes';
 import { arrayIncludes } from './utils';
 import { ParsableDate } from './constants/prop-types';
-import { BasePickerProps } from './typings/BasePicker';
 import { DatePickerView } from './typings/Views';
 import { MuiPickersAdapter } from './hooks/useUtils';
 

--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -4,8 +4,8 @@ import { WrapperVariant } from '../wrappers/Wrapper';
 import { BasePickerProps } from '../typings/BasePicker';
 import { useUtils, useNow, MuiPickersAdapter } from './useUtils';
 
-export interface PickerStateValueManager<TInput, TDateValue> {
-  parseInput: (utils: MuiPickersAdapter, props: BasePickerProps<TInput, TDateValue>) => TDateValue;
+export interface PickerStateValueManager<TInputValue, TDateValue> {
+  parseInput: (utils: MuiPickersAdapter, value: TInputValue) => TDateValue;
   emptyValue: TDateValue;
   areValuesEqual: (
     utils: MuiPickersAdapter,
@@ -37,14 +37,14 @@ export function usePickerState<TInput, TDateValue>(
   const now = useNow();
   const utils = useUtils();
   const { isOpen, setIsOpen } = useOpenState(props);
-  const [pickerDate, setPickerDate] = React.useState(valueManager.parseInput(utils, props));
+  const [pickerDate, setPickerDate] = React.useState(valueManager.parseInput(utils, value));
 
   // Mobile keyboard view is a special case.
   // When it's open picker should work like closed, cause we are just showing text field
   const [isMobileKeyboardViewOpen, setMobileKeyboardViewOpen] = React.useState(false);
 
   React.useEffect(() => {
-    const parsedDateValue = valueManager.parseInput(utils, props);
+    const parsedDateValue = valueManager.parseInput(utils, value);
     setPickerDate((currentPickerDate) => {
       if (!valueManager.areValuesEqual(utils, currentPickerDate, parsedDateValue)) {
         return parsedDateValue;
@@ -52,8 +52,7 @@ export function usePickerState<TInput, TDateValue>(
 
       return currentPickerDate;
     });
-    // We need to react only on value change, because `date` could potentially return new Date() on each render
-  }, [value, utils]); // eslint-disable-line
+  }, [value, utils, valueManager]);
 
   const acceptDate = React.useCallback(
     (acceptedDate: TDateValue, needClosePicker: boolean) => {


### PR DESCRIPTION
We were passing the full props object to `parsePickerInputValue` when we only ever needed the value. Removed this unnecessary coupling so that it's more apparent when we actually need to run the effect that re-computes this. 

This revealed that the reason for disabling `react/exhaustive-dependencies` was outdated. It only served micro-optimization because, right now, every call site of `usePickerState` passed a stable `valueManager` so using it as a dependency was extraneous. However, this might break in the future so we need to be aware of it.

In the end we probably don't need the effect anyway (https://github.com/mui-org/material-ui/pull/24315) but in order to reason about the code I need to trim all the unnecessary parts.