### PR TITLE
[docs] Widen example datetime-local picker so it's not clipped

### DIFF
--- a/docs/src/pages/components/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.js
@@ -1,34 +1,18 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const useStyles = makeStyles((theme) => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
-  textField: {
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    width: 240,
-  },
-}));
-
 export default function DateAndTimePickers() {
-  const classes = useStyles();
-
   return (
-    <form className={classes.container} noValidate>
+    <form noValidate>
       <TextField
         id="datetime-local"
         label="Next appointment"
         type="datetime-local"
         defaultValue="2017-05-24T10:30"
-        className={classes.textField}
+        style={{ width: 250 }}
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard"
       />
     </form>
   );

--- a/docs/src/pages/components/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme) => ({
   textField: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
-    width: 200,
+    width: 240,
   },
 }));
 

--- a/docs/src/pages/components/pickers/DateAndTimePickers.tsx
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.tsx
@@ -1,36 +1,18 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      flexWrap: 'wrap',
-    },
-    textField: {
-      marginLeft: theme.spacing(1),
-      marginRight: theme.spacing(1),
-      width: 200,
-    },
-  }),
-);
-
 export default function DateAndTimePickers() {
-  const classes = useStyles();
-
   return (
-    <form className={classes.container} noValidate>
+    <form noValidate>
       <TextField
         id="datetime-local"
         label="Next appointment"
         type="datetime-local"
         defaultValue="2017-05-24T10:30"
-        className={classes.textField}
+        style={{ width: 250 }}
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard"
       />
     </form>
   );

--- a/docs/src/pages/components/pickers/DatePickers.js
+++ b/docs/src/pages/components/pickers/DatePickers.js
@@ -1,34 +1,18 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const useStyles = makeStyles((theme) => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
-  textField: {
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    width: 200,
-  },
-}));
-
 export default function DatePickers() {
-  const classes = useStyles();
-
   return (
-    <form className={classes.container} noValidate>
+    <form noValidate>
       <TextField
         id="date"
         label="Birthday"
         type="date"
         defaultValue="2017-05-24"
-        className={classes.textField}
+        style={{ width: 220 }}
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard"
       />
     </form>
   );

--- a/docs/src/pages/components/pickers/DatePickers.tsx
+++ b/docs/src/pages/components/pickers/DatePickers.tsx
@@ -1,36 +1,18 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      flexWrap: 'wrap',
-    },
-    textField: {
-      marginLeft: theme.spacing(1),
-      marginRight: theme.spacing(1),
-      width: 200,
-    },
-  }),
-);
-
 export default function DatePickers() {
-  const classes = useStyles();
-
   return (
-    <form className={classes.container} noValidate>
+    <form noValidate>
       <TextField
         id="date"
         label="Birthday"
         type="date"
         defaultValue="2017-05-24"
-        className={classes.textField}
+        style={{ width: 220 }}
         InputLabelProps={{
           shrink: true,
         }}
-        variant="standard"
       />
     </form>
   );

--- a/docs/src/pages/components/pickers/TimePickers.js
+++ b/docs/src/pages/components/pickers/TimePickers.js
@@ -1,37 +1,21 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const useStyles = makeStyles((theme) => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
-  textField: {
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    width: 200,
-  },
-}));
-
 export default function TimePickers() {
-  const classes = useStyles();
-
   return (
-    <form className={classes.container} noValidate>
+    <form noValidate>
       <TextField
         id="time"
         label="Alarm clock"
         type="time"
         defaultValue="07:30"
-        className={classes.textField}
         InputLabelProps={{
           shrink: true,
         }}
         inputProps={{
           step: 300, // 5 min
         }}
-        variant="standard"
+        style={{ width: 150 }}
       />
     </form>
   );

--- a/docs/src/pages/components/pickers/TimePickers.tsx
+++ b/docs/src/pages/components/pickers/TimePickers.tsx
@@ -1,39 +1,21 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      flexWrap: 'wrap',
-    },
-    textField: {
-      marginLeft: theme.spacing(1),
-      marginRight: theme.spacing(1),
-      width: 200,
-    },
-  }),
-);
-
 export default function TimePickers() {
-  const classes = useStyles();
-
   return (
-    <form className={classes.container} noValidate>
+    <form noValidate>
       <TextField
         id="time"
         label="Alarm clock"
         type="time"
         defaultValue="07:30"
-        className={classes.textField}
         InputLabelProps={{
           shrink: true,
         }}
         inputProps={{
           step: 300, // 5 min
         }}
-        variant="standard"
+        style={{ width: 150 }}
       />
     </form>
   );

--- a/docs/src/pages/components/pickers/pickers.md
+++ b/docs/src/pages/components/pickers/pickers.md
@@ -24,19 +24,19 @@ packageName: '@material-ui/lab'
 
 ⚠️ Native input controls support by browsers [isn't perfect](https://caniuse.com/#feat=input-datetime).
 
-### Datepickers
+### Date picker
 
 A native datepicker example with `type="date"`.
 
 {{"demo": "pages/components/pickers/DatePickers.js"}}
 
-### Date & Time pickers
+### Date & Time picker
 
 A native date & time picker example with `type="datetime-local"`.
 
 {{"demo": "pages/components/pickers/DateAndTimePickers.js"}}
 
-### Time pickers
+### Time picker
 
 A native time picker example with `type="time"`.
 


### PR DESCRIPTION
I noticed the AM/PM bit of this datetime-local date picker is clipped with the current width (see [here](https://material-ui.com/components/pickers/#date-time-pickers) in the documentation site).  This one was easy enough to reproduce and model a fix for using the linked CodeSandbox so that's how I checked this fix.

### Before
![image](https://user-images.githubusercontent.com/5456178/104083763-20430580-51f6-11eb-96a8-6771188f80e7.png)

### After
![image](https://user-images.githubusercontent.com/5456178/104083765-276a1380-51f6-11eb-98a4-4f8a08cc1e05.png)

