### PR TITLE
Add @types/react-transition-group to lab devDependencies

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@material-ui/types": "5.1.4",
     "@types/luxon": "^1.25.0",
+    "@types/react-transition-group": "^4.4.0",
     "date-fns": "^2.0.0",
     "dayjs": "^1.8.17",
     "luxon": "^1.21.3",


### PR DESCRIPTION
Without it, tsc complains about the react-transition-group imports being untyped.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
