### PR TITLE
[website] Add Discover more

### DIFF
--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import BrandingRoot from 'docs/src/modules/branding/BrandingRoot';
 import BrandingBeginToday from 'docs/src/modules/branding/BrandingBeginToday';
+import BrandingDiscoverMore from 'docs/src/modules/branding/BrandingDiscoverMore';
 
 export default function Page() {
   return (
     <BrandingRoot>
+      <BrandingDiscoverMore />
       <BrandingBeginToday />
     </BrandingRoot>
   );
@@ -235,74 +237,6 @@ export default function Page() {
 //     background: color === 'info' ? theme.palette.vividBlue : theme.palette.primary.main,
 //     width: 80,
 //     height: 80,
-//   },
-// }));
-
-// const DiscoverMoreCard = styled((props: any) => {
-//   const { imagePosition, src, alt, title, children, href, ...other } = props;
-//   return (
-//     <Card elevation={0} {...other}>
-//       <CardContent>
-//         <Grid
-//           className="DiscoverMoreCard-header"
-//           component="a"
-//           href={href}
-//           container
-//           direction="row"
-//           spacing={1}
-//         >
-//           <Grid item>
-//             <Typography variant="h4">{title}</Typography>
-//           </Grid>
-//           <Grid item>
-//             <ArrowCirleIcon />
-//           </Grid>
-//         </Grid>
-//         <Typography className="DiscoverMoreCard-content">{children}</Typography>
-//         <Box
-//           component="img"
-//           alt={alt}
-//           src={src}
-//           sx={{
-//             height: 243,
-//             width: imagePosition === 'center' ? 290 : 330,
-//             display: 'block',
-//             marginTop: 'auto',
-//           }}
-//         />
-//       </CardContent>
-//     </Card>
-//   );
-// })(({ theme, ...props }) => ({
-//   '&[class*="MuiCard-root"]': {
-//     background: theme.palette.secondary.main,
-//     color: 'white',
-//   },
-//   '& img': {
-//     marginLeft: props.imagePosition === 'center' || props.imagePosition === 'end' ? 'auto' : 0,
-//     marginRight: props.imagePosition === 'center' ? 'auto' : 0,
-//   },
-//   '& svg': {
-//     marginTop: 4,
-//   },
-//   height: theme.spacing(50),
-//   padding: 0,
-//   '& .DiscoverMoreCard-header': {
-//     textDecoration: 'none',
-//     color: 'white',
-//     padding: theme.spacing(2),
-//   },
-//   '& .DiscoverMoreCard-content': {
-//     padding: theme.spacing(2),
-//   },
-//   '& [class*="MuiCardContent-root"]': {
-//     display: 'flex',
-//     flexDirection: 'column',
-//     height: '100%',
-//     padding: 0,
-//     '&:last-child': {
-//       paddingBottom: 0,
-//     },
 //   },
 // }));
 
@@ -994,51 +928,6 @@ export default function Page() {
 //                 </Link>
 //                 .
 //               </SupportCard>
-//             </Grid>
-//           </Grid>
-//         </Grid>
-
-//         <Grid container spacing={1} className="MuiGrid-panel MuiGrid-discoverMore">
-//           <Grid item xs={12}>
-//             <Typography variant="h2" align="center">
-//               Discover more
-//             </Typography>
-//           </Grid>
-//           <Grid item xs={12}>
-//             <Grid container spacing={2} alignItems="center" justifyContent="center">
-//               <Grid item lg={4} md={8} xs={12}>
-//                 <DiscoverMoreCard
-//                   title="Road map"
-//                   src="/static/branding/about/roadmap.png"
-//                   alt="Roadmap"
-//                   href="/discover-more/roadmap/"
-//                   imagePosition="end"
-//                 >
-//                   Living document, layout out future plans and updates.
-//                 </DiscoverMoreCard>
-//               </Grid>
-//               <Grid item lg={4} md={8} xs={12}>
-//                 <DiscoverMoreCard
-//                   title="Sponsors and Backers"
-//                   src="/static/branding/about/sponsors.png"
-//                   alt="Sponsors"
-//                   href="/discover-more/backers/"
-//                   imagePosition="center"
-//                 >
-//                   Support Material-UI core development through crowdfunding.
-//                 </DiscoverMoreCard>
-//               </Grid>
-//               <Grid item lg={4} md={8} xs={12}>
-//                 <DiscoverMoreCard
-//                   title="Contact Us"
-//                   alt="Open chat"
-//                   src="/static/branding/about/contact.png"
-//                   href="/company/contact/"
-//                   imagePosition="start"
-//                 >
-//                   Send us a message, we’re all ears!
-//                 </DiscoverMoreCard>
-//               </Grid>
 //             </Grid>
 //           </Grid>
 //         </Grid>

--- a/docs/src/modules/branding/BrandingDiscoverMore.tsx
+++ b/docs/src/modules/branding/BrandingDiscoverMore.tsx
@@ -71,7 +71,7 @@ export default function BrandingDiscoverMore() {
             href="/discover-more/roadmap/"
             imagePosition="flex-end"
           >
-            Living document, layout out future plans and updates.
+            Living document, laying out future plans and updates.
           </DiscoverMoreCard>
         </Grid>
         <Grid item xs={12} md={6} lg={4}>

--- a/docs/src/modules/branding/BrandingDiscoverMore.tsx
+++ b/docs/src/modules/branding/BrandingDiscoverMore.tsx
@@ -66,7 +66,7 @@ export default function BrandingDiscoverMore() {
       <Grid container spacing={2}>
         <Grid item xs={12} md={4}>
           <DiscoverMoreCard
-            title="Road map"
+            title="Roadmap"
             src="/static/branding/about/roadmap.png"
             href="/discover-more/roadmap/"
             imagePosition="flex-end"

--- a/docs/src/modules/branding/BrandingDiscoverMore.tsx
+++ b/docs/src/modules/branding/BrandingDiscoverMore.tsx
@@ -6,7 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import ArrowCirleIcon from 'docs/src/modules/branding/icons/ArrowCircle';
 import Link from 'docs/src/modules/components/Link';
 
-interface DiscoverMoreCardProp {
+interface DiscoverMoreCardProps {
   children: string;
   href: string;
   imagePosition: 'flex-start' | 'center' | 'flex-end';
@@ -14,7 +14,7 @@ interface DiscoverMoreCardProp {
   title: string;
 }
 
-function DiscoverMoreCard(props: DiscoverMoreCardProp) {
+function DiscoverMoreCard(props: DiscoverMoreCardProps) {
   const { imagePosition, src, title, href, children } = props;
   return (
     <Box

--- a/docs/src/modules/branding/BrandingDiscoverMore.tsx
+++ b/docs/src/modules/branding/BrandingDiscoverMore.tsx
@@ -51,16 +51,7 @@ function DiscoverMoreCard(props: DiscoverMoreCardProp) {
         <Typography sx={{ mt: 1, color: 'greyAA' }}>{children}</Typography>
       </Box>
       <Box sx={{ display: 'flex', justifyContent: imagePosition }}>
-        <Box
-          component="img"
-          alt=""
-          src={src}
-          sx={{
-            height: 243,
-            width: imagePosition === 'center' ? 290 : 330,
-            display: 'block',
-          }}
-        />
+        <img alt="" src={src} height={243} width={imagePosition === 'center' ? 290 : 330} />
       </Box>
     </Box>
   );

--- a/docs/src/modules/branding/BrandingDiscoverMore.tsx
+++ b/docs/src/modules/branding/BrandingDiscoverMore.tsx
@@ -23,14 +23,14 @@ function DiscoverMoreCard(props: DiscoverMoreCardProps) {
         color: 'white',
         borderRadius: 1,
         overflow: 'hidden',
-        minHeight: 420,
+        minHeight: { xs: 420, md: 460, lg: 420 },
         padding: 0,
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',
       }}
     >
-      <Box sx={{ p: 5, pt: 6 }}>
+      <Box sx={{ p: 5, pt: 6, pb: 3 }}>
         <Box
           component={Link}
           sx={{
@@ -64,7 +64,7 @@ export default function BrandingDiscoverMore() {
         Discover more
       </Typography>
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6} lg={4}>
+        <Grid item xs={12} md={4}>
           <DiscoverMoreCard
             title="Road map"
             src="/static/branding/about/roadmap.png"
@@ -74,7 +74,7 @@ export default function BrandingDiscoverMore() {
             Living document, laying out future plans and updates.
           </DiscoverMoreCard>
         </Grid>
-        <Grid item xs={12} md={6} lg={4}>
+        <Grid item xs={12} md={4}>
           <DiscoverMoreCard
             title="Sponsors and Backers"
             src="/static/branding/about/sponsors.png"
@@ -84,7 +84,7 @@ export default function BrandingDiscoverMore() {
             Support Material-UI core development through crowdfunding.
           </DiscoverMoreCard>
         </Grid>
-        <Grid item xs={12} md={6} lg={4}>
+        <Grid item xs={12} md={4}>
           <DiscoverMoreCard
             title="Contact Us"
             src="/static/branding/about/contact.png"

--- a/docs/src/modules/branding/BrandingDiscoverMore.tsx
+++ b/docs/src/modules/branding/BrandingDiscoverMore.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import Container from '@material-ui/core/Container';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import ArrowCirleIcon from 'docs/src/modules/branding/icons/ArrowCircle';
+import Link from 'docs/src/modules/components/Link';
+
+interface DiscoverMoreCardProp {
+  children: string;
+  href: string;
+  imagePosition: 'flex-start' | 'center' | 'flex-end';
+  src: string;
+  title: string;
+}
+
+function DiscoverMoreCard(props: DiscoverMoreCardProp) {
+  const { imagePosition, src, title, href, children } = props;
+  return (
+    <Box
+      sx={{
+        bgcolor: 'secondary.main',
+        color: 'white',
+        borderRadius: 1,
+        overflow: 'hidden',
+        minHeight: 420,
+        padding: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+      }}
+    >
+      <Box sx={{ p: 5, pt: 6 }}>
+        <Box
+          component={Link}
+          sx={{
+            textDecoration: 'none',
+            color: 'white',
+            display: 'flex',
+            '& svg': {
+              mt: '2px',
+            },
+          }}
+          href={href}
+        >
+          <Typography variant="h4" component="h3" sx={{ mr: 1 }}>
+            {title}
+          </Typography>
+          <ArrowCirleIcon />
+        </Box>
+        <Typography sx={{ mt: 1, color: 'greyAA' }}>{children}</Typography>
+      </Box>
+      <Box sx={{ display: 'flex', justifyContent: imagePosition }}>
+        <Box
+          component="img"
+          alt=""
+          src={src}
+          sx={{
+            height: 243,
+            width: imagePosition === 'center' ? 290 : 330,
+            display: 'block',
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export default function BrandingDiscoverMore() {
+  return (
+    <Container sx={{ mt: [10, 18], mb: [12, 20] }}>
+      <Typography variant="h2" sx={{ mb: 4 }}>
+        Discover more
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6} lg={4}>
+          <DiscoverMoreCard
+            title="Road map"
+            src="/static/branding/about/roadmap.png"
+            href="/discover-more/roadmap/"
+            imagePosition="flex-end"
+          >
+            Living document, layout out future plans and updates.
+          </DiscoverMoreCard>
+        </Grid>
+        <Grid item xs={12} md={6} lg={4}>
+          <DiscoverMoreCard
+            title="Sponsors and Backers"
+            src="/static/branding/about/sponsors.png"
+            href="/discover-more/backers/"
+            imagePosition="center"
+          >
+            Support Material-UI core development through crowdfunding.
+          </DiscoverMoreCard>
+        </Grid>
+        <Grid item xs={12} md={6} lg={4}>
+          <DiscoverMoreCard
+            title="Contact Us"
+            src="/static/branding/about/contact.png"
+            href="/company/contact/"
+            imagePosition="flex-start"
+          >
+            Send us a message, we’re all ears!
+          </DiscoverMoreCard>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}


### PR DESCRIPTION
https://deploy-preview-24327--material-ui.netlify.app/branding/about/

A new block

<img width="1047" alt="Capture d’écran 2021-01-11 à 23 56 09" src="https://user-images.githubusercontent.com/3165635/104247722-9a7ac080-5468-11eb-96e1-add19ee05a13.png">
