### PR TITLE
[DatePicker] Expose useUtils() hook

### DIFF
--- a/packages/material-ui-lab/src/index.d.ts
+++ b/packages/material-ui-lab/src/index.d.ts
@@ -150,3 +150,5 @@ export * from './YearPicker';
 
 export { default as useAutocomplete } from './useAutocomplete';
 export * from './useAutocomplete';
+
+export { useUtils } from './internal/pickers/hooks/useUtils';

--- a/packages/material-ui-lab/src/index.js
+++ b/packages/material-ui-lab/src/index.js
@@ -151,3 +151,5 @@ export * from './YearPicker';
 
 // createFilterOptions is exported from Autocomplete
 export { default as useAutocomplete } from './useAutocomplete';
+
+export { useUtils } from './internal/pickers/hooks/useUtils';


### PR DESCRIPTION
`MuiPickersAdapterContext` is already [exposed](https://github.com/mui-org/material-ui/blob/df073cde0961d5f27818a2e783b3958b2e114268/packages/material-ui-lab/src/index.d.ts#L47), so application code can already do:

```
import {MuiPickersAdapter, MuiPickersAdapterContext} from '@material-ui/lab';
const utils = React.useContext(MuiPickersAdapterContext) as MuiPickersAdapter<...>;
```

Exposing `useUtils()` makes the application code cleaner and gives it the benefit of the built-in null check.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
