### PR TITLE
[docs] Do not show 'Add' if user input matches existing option

### DIFF
--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
@@ -28,11 +28,13 @@ export default function FreeSoloCreateOption() {
       filterOptions={(options, params) => {
         const filtered = filter(options, params);
 
+        const { inputValue } = params;
         // Suggest the creation of a new value
-        if (params.inputValue !== '') {
+        const isExisting = options.some((option) => inputValue === option.title);
+        if (inputValue !== '' && !isExisting) {
           filtered.push({
-            inputValue: params.inputValue,
-            title: `Add "${params.inputValue}"`,
+            inputValue: inputValue,
+            title: `Add "${inputValue}"`,
           });
         }
 

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
@@ -33,7 +33,7 @@ export default function FreeSoloCreateOption() {
         const isExisting = options.some((option) => inputValue === option.title);
         if (inputValue !== '' && !isExisting) {
           filtered.push({
-            inputValue: inputValue,
+            inputValue,
             title: `Add "${inputValue}"`,
           });
         }

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.tsx
@@ -28,11 +28,13 @@ export default function FreeSoloCreateOption() {
       filterOptions={(options, params) => {
         const filtered = filter(options, params);
 
+        const { inputValue } = params;
         // Suggest the creation of a new value
-        if (params.inputValue !== '') {
+        const isExisting = options.some((option) => inputValue === option.title);
+        if (inputValue !== '' && !isExisting) {
           filtered.push({
-            inputValue: params.inputValue,
-            title: `Add "${params.inputValue}"`,
+            inputValue,
+            title: `Add "${inputValue}"`,
           });
         }
 


### PR DESCRIPTION
I noticed some unideal UX when copying the example from the docs for my Autocomplete component.  For the free solo with user input, I think if the user enters something that matches one of the existing options, it makes sense to hide the `Add "thing"` option.

### Before
![before](https://user-images.githubusercontent.com/5456178/104115367-aaa56b00-52c3-11eb-8265-1ad8b9aba2ea.png)

### After
![after](https://user-images.githubusercontent.com/5456178/104115370-b133e280-52c3-11eb-90ac-355f84df432a.png)
