### PR TITLE
[test] Compensate for Circle CI's low performance

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,6 +8,7 @@ module.exports = {
     'docs/.next/**',
   ],
   recursive: true,
+  timeout: (process.env.CIRCLECI === 'true' ? 3 : 1) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
   require: [require.resolve('./test/utils/setupBabel'), require.resolve('./test/utils/setupJSDOM')],
   'watch-ignore': [

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,7 +8,7 @@ module.exports = {
     'docs/.next/**',
   ],
   recursive: true,
-  timeout: (process.env.CIRCLECI === 'true' ? 3 : 1) * 1000, // Circle CI has low-performance CPUs.
+  timeout: (process.env.CIRCLECI === 'true' ? 3 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
   require: [require.resolve('./test/utils/setupBabel'), require.resolve('./test/utils/setupJSDOM')],
   'watch-ignore': [

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
@@ -541,21 +541,31 @@ describe('<MenuList> integration', () => {
       expect(screen.getByText('Worm')).toHaveFocus();
     });
 
-    it('should reset the character buffer after 500ms', (done) => {
-      render(
-        <MenuList autoFocus>
-          <MenuItem>Worm</MenuItem>
-          <MenuItem>Ordinary</MenuItem>
-        </MenuList>,
-      );
+    describe('time', () => {
+      let clock;
+      beforeEach(() => {
+        clock = useFakeTimers();
+      });
 
-      fireEvent.keyDown(screen.getByRole('menu'), { key: 'W' });
-      setTimeout(() => {
+      afterEach(() => {
+        act(() => {
+          clock.restore();
+        });
+      });
+
+      it('should reset the character buffer after 500ms', () => {
+        render(
+          <MenuList autoFocus>
+            <MenuItem>Worm</MenuItem>
+            <MenuItem>Ordinary</MenuItem>
+          </MenuList>,
+        );
+
+        fireEvent.keyDown(screen.getByRole('menu'), { key: 'W' });
+        clock.tick(501);
         fireEvent.keyDown(screen.getByText('Worm'), { key: 'o' });
-
         expect(screen.getByText('Ordinary')).toHaveFocus();
-        done();
-      }, 500);
+      });
     });
 
     it('should match ignoring hidden text', function testHiddenText() {


### PR DESCRIPTION
The changes are motivated by the performance issue Circle CI has had since Friday, *test_unit-1* takes 6-7 minutes to run. It's x2 slower than usual. This leads to our slower tests to timeout 50% of the time.

Under normal conditions, the test in my env runs in 1min and in the CI, in about 2-3 minutes, hence the factor of x3. From what I recall, I don't have the faster machine in the team, I hope the 1s as the max timeout is enough for everybody. We might need to adjust it.

I have used this opportunity to remove the usage of a `setTimeout(500ms)` in a test case.

