### PR TITLE
[docs] Sync AppSearch.tsx with AppSearch.js

### DIFF
--- a/docs/src/modules/branding/AppSearch.tsx
+++ b/docs/src/modules/branding/AppSearch.tsx
@@ -113,6 +113,9 @@ const useStyles = makeStyles(
       transition: theme.transitions.create('opacity', {
         duration: theme.transitions.duration.shortest,
       }),
+      // So that clicks target the input.
+      // Makes the text non selectable but neither is the placeholder or adornment.
+      pointerEvents: 'none',
       '&.Mui-focused': {
         opacity: 0,
       },
@@ -163,7 +166,7 @@ export default function AppSearch() {
         }}
       />
       <div className={clsx(classes.shortcut, { 'Mui-focused': focused })}>
-        {macOS ? '⌘' : 'Ctrl'}+K
+        {macOS ? '⌘' : 'Ctrl+'}K
       </div>
     </div>
   );

--- a/docs/src/modules/branding/AppSearch.tsx
+++ b/docs/src/modules/branding/AppSearch.tsx
@@ -163,7 +163,7 @@ export default function AppSearch() {
         }}
       />
       <div className={clsx(classes.shortcut, { 'Mui-focused': focused })}>
-        {macOS ? '⌘' : 'Ctrl'}K
+        {macOS ? '⌘' : 'Ctrl'}+K
       </div>
     </div>
   );

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -269,7 +269,7 @@ export default function AppSearch() {
       />
       <div className={clsx(classes.shortcut, { 'Mui-focused': focused })}>
         {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-        {macOS ? '⌘' : 'Ctrl+'}K
+        {macOS ? '⌘' : 'Ctrl'}+K
       </div>
     </div>
   );

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -269,7 +269,7 @@ export default function AppSearch() {
       />
       <div className={clsx(classes.shortcut, { 'Mui-focused': focused })}>
         {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-        {macOS ? '⌘' : 'Ctrl'}+K
+        {macOS ? '⌘' : 'Ctrl+'}K
       </div>
     </div>
   );


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This change was made to help more clearly show the keybind required to trigger the search functionality in the next version of the Documentation.
