### PR TITLE
[test] Reduce download times of playwright binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,11 @@ commands:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}
             - v2-yarn-sha-
+      - restore_cache:
+          keys:
+            - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v1-playwright-{{ arch }}-
+            - v1-playwright-
       - run:
           name: Install js dependencies
           command: yarn
@@ -66,6 +71,10 @@ jobs:
       - run:
           name: Check for duplicated packages
           command: yarn deduplicate
+      - save_cache:
+          key: v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/ms-playwright
       - save_cache:
           key: v2-yarn-sha-{{ checksum "yarn.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
       - restore_cache:
           when:
             condition:
-              equals: [true, << parameters.withBrowsers >> ]
+              equals: [true, << parameters.withBrowsers >>]
           keys:
             - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
             - v1-playwright-{{ arch }}-
@@ -69,6 +69,7 @@ commands:
             echo "skip browsers: $PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD";
             yarn
           environment:
+            # `<<^ parameter.foo >>` syntax: https://discuss.circleci.com/t/conditional-string-feature-but-with-inverse-logic/28708/4
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<^ parameters.withBrowsers >>1<</ parameters.withBrowsers >>
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,6 @@ defaults: &defaults
 
 commands:
   install_js:
-    parameters:
-      withBrowsers:
-        description: Whether we need to install browser binaries as well.
-        type: boolean
-        default: true
     steps:
       - run:
           name: View install environment
@@ -56,28 +51,20 @@ commands:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}
             - v2-yarn-sha-
       - restore_cache:
-          when:
-            condition:
-              equals: [true, << parameters.withBrowsers >>]
           keys:
             - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
             - v1-playwright-{{ arch }}-
             - v1-playwright-
       - run:
           name: Install js dependencies
-          command: |
-            echo "skip browsers: $PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD";
-            yarn
-          environment:
-            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<^ parameters.withBrowsers >>1<</ parameters.withBrowsers >>
+          command: yarn
 
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
-      - install_js:
-          withBrowsers: true
+      - install_js
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
@@ -270,8 +257,7 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js:
-          withBrowsers: true
+      - install_js
       - run:
           name: Tests real browsers
           command: yarn test:karma
@@ -294,8 +280,7 @@ jobs:
 
     steps:
       - checkout
-      - install_js:
-          withBrowsers: true
+      - install_js
       - run:
           name: Tests real browsers
           # Run a couple of times for a better sample.
@@ -321,8 +306,7 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js:
-          withBrowsers: true
+      - install_js
       - run:
           name: Run visual regression tests
           command: xvfb-run yarn test:regressions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ commands:
             echo "skip browsers: $PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD";
             yarn
           environment:
-            # `<<^ parameter.foo >>` syntax: https://discuss.circleci.com/t/conditional-string-feature-but-with-inverse-logic/28708/4
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<^ parameters.withBrowsers >>1<</ parameters.withBrowsers >>
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,11 @@ defaults: &defaults
 
 commands:
   install_js:
+    parameters:
+      withBrowsers:
+        description: Whether we need to install browser binaries as well.
+        type: boolean
+        default: true
     steps:
       - run:
           name: View install environment
@@ -51,20 +56,28 @@ commands:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}
             - v2-yarn-sha-
       - restore_cache:
+          when:
+            condition:
+              equals: [true, << parameters.withBrowsers >> ]
           keys:
             - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
             - v1-playwright-{{ arch }}-
             - v1-playwright-
       - run:
           name: Install js dependencies
-          command: yarn
+          command: |
+            echo "skip browsers: $PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD";
+            yarn
+          environment:
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<^ parameters.withBrowsers >>1<</ parameters.withBrowsers >>
 
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
-      - install_js
+      - install_js:
+          withBrowsers: true
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
@@ -257,7 +270,8 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js
+      - install_js:
+          withBrowsers: true
       - run:
           name: Tests real browsers
           command: yarn test:karma
@@ -280,7 +294,8 @@ jobs:
 
     steps:
       - checkout
-      - install_js
+      - install_js:
+          withBrowsers: true
       - run:
           name: Tests real browsers
           # Run a couple of times for a better sample.
@@ -306,7 +321,8 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js
+      - install_js:
+          withBrowsers: true
       - run:
           name: Run visual regression tests
           command: xvfb-run yarn test:regressions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 14
       - run: yarn install
-        environment:
+        env:
           # Don't need playwright in this job
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
       - run: yarn release:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,7 @@ jobs:
         with:
           node-version: 14
       - run: yarn install
+        environment:
+          # Don't need playwright in this job
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
       - run: yarn release:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
       - run: yarn install
         env:
           # Don't need playwright in this job
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - run: yarn release:build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
         displayName: 'install dependencies'
         env:
           # Don't use playwright in this job
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
       - script: |
           yarn danger ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,9 @@ jobs:
           node scripts/use-react-dist-tag.js $(REACT_DIST_TAG)
           yarn install
         displayName: 'install dependencies'
+        env:
+          # Don't use playwright in this job
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
 
       - script: |
           yarn danger ci


### PR DESCRIPTION
Either cache the binaries or simply skip their download entirely if we know they're not needed (GH actions, Azure pipelines).

The downloads might contribute to a high variance in the install command ([4min 30s](https://app.circleci.com/pipelines/github/mui-org/material-ui/32926/workflows/0455010b-4d02-4a22-a4f3-4c17fd56b019/jobs/211628/parallel-runs/0/steps/0-105) vs. [1min 30s](https://app.circleci.com/pipelines/github/mui-org/material-ui/33144/workflows/257ad232-24c7-4e30-8e16-4f30814c867a/jobs/212292/parallel-runs/0/steps/0-105)) 

[Can't have a conditional `restore_cache`](https://app.circleci.com/pipelines/github/mui-org/material-ui/33150/workflows/9050d966-db67-492b-8255-ce59f5c94249/jobs/212321/parallel-runs/0/steps/0-105)