### PR TITLE
[test] Move callback args to right side of assertion

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePicker.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.test.tsx
@@ -121,7 +121,8 @@ describe('<DatePicker />', () => {
     expect(getByMuiTest('calendar-month-text')).to.have.text('January');
 
     // onChange must be dispatched with newly selected date
-    expect(onChangeMock.calledWith(adapterToUse.date('2018-01-01T00:00:00.000'))).to.be.equal(true);
+    expect(onChangeMock.callCount).to.equal(1);
+    expect(onChangeMock.args[0][0]).toEqualDateTime(adapterToUse.date('2018-01-01T00:00:00.000'));
   });
 
   it('allows to change only year', () => {
@@ -208,7 +209,8 @@ describe('<DatePicker />', () => {
     openMobilePicker();
     fireEvent.click(screen.getByText('Clear'));
 
-    expect(onChangeMock.calledWith(null)).to.be.equal(true);
+    expect(onChangeMock.callCount).to.equal(1);
+    expect(onChangeMock.args[0][0]).to.equal(null);
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 

--- a/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerKeyboard.test.tsx
@@ -266,7 +266,8 @@ describe('<DatePicker /> keyboard interactions', () => {
           },
         });
 
-        expect(onErrorMock.calledWith(expectedError)).to.be.equal(true);
+        expect(onErrorMock.callCount).to.equal(1);
+        expect(onErrorMock.args[0][0]).to.equal(expectedError);
       });
     });
   });

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
@@ -209,12 +209,9 @@ describe('<DateRangePicker />', () => {
       },
     });
 
-    expect(
-      onChangeMock.calledWith([
-        adapterToUse.date('2019-06-06T00:00:00.000'),
-        adapterToUse.date('2019-06-06T00:00:00.000'),
-      ]),
-    ).to.equal(true);
+    expect(onChangeMock.callCount).to.equal(1);
+    expect(onChangeMock.args[0][0]).toEqualDateTime(adapterToUse.date('2019-06-06T00:00:00.000'));
+    expect(onChangeMock.args[0][1]).toEqualDateTime(adapterToUse.date('2019-06-06T00:00:00.000'));
   });
 
   it('scrolls current month to the active selection on focusing appropriate field', () => {

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.test.tsx
@@ -55,7 +55,7 @@ describe('<DateTimePicker />', () => {
       this.skip();
     }
 
-    let onChangeMock: SinonSpy<any> = spy();
+    const onChangeMock: SinonSpy<any> = spy();
     const clockTouchEvent = {
       changedTouches: [
         {
@@ -67,13 +67,15 @@ describe('<DateTimePicker />', () => {
 
     function DateTimePickerWithState() {
       const [date, setDate] = React.useState<Date | null>(null);
-      onChangeMock = spy(setDate);
 
       return (
         <MobileDateTimePicker
           value={date}
           toolbarPlaceholder="Enter Date"
-          onChange={(newDate) => onChangeMock(newDate)}
+          onChange={(newDate) => {
+            setDate(newDate);
+            onChangeMock(newDate);
+          }}
           renderInput={(params) => <TextField autoFocus {...params} />}
         />
       );
@@ -108,9 +110,12 @@ describe('<DateTimePicker />', () => {
     fireTouchChangedEvent(getByMuiTest('clock'), 'touchend', clockTouchEvent);
 
     expect(getByMuiTest('minutes')).to.have.text('53');
+    expect(onChangeMock.callCount).to.equal(4);
 
     fireEvent.click(screen.getByText(/ok/i));
-    expect(onChangeMock.calledWith(adapterToUse.date('2010-01-15T11:53:00.000'))).to.be.equal(true);
+
+    expect(onChangeMock.callCount).to.equal(5);
+    expect(onChangeMock.args[4][0]).toEqualDateTime(adapterToUse.date('2010-01-15T11:53:00.000'));
   });
 
   it('prop: open – overrides open state', () => {

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.test.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.test.tsx
@@ -287,7 +287,8 @@ describe('<TimePicker />', () => {
           },
         });
 
-        expect(onErrorMock.calledWith(expectedError)).to.be.equal(true);
+        expect(onErrorMock.callCount).to.equal(1);
+        expect(onErrorMock.args[0][0]).to.equal(expectedError);
       });
     });
   });

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
@@ -59,6 +59,7 @@ describe('<YearPicker />', () => {
     );
 
     fireEvent.click(screen.getByText('2025', { selector: 'button' }));
-    expect(onChangeMock.calledWith(adapterToUse.date('2025-02-02T00:00:00.000'))).to.equal(true);
+    expect(onChangeMock.callCount).to.equal(1);
+    expect(onChangeMock.args[0][0]).toEqualDateTime(adapterToUse.date('2025-02-02T00:00:00.000'));
   });
 });

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -129,12 +129,11 @@ describe('withStyles', () => {
       const StyledComponent = withStyles(styles)(MyComp);
       render(<StyledComponent mySuppliedProp={222} />);
 
-      expect(
-        jssCallbackStub.calledWith({
-          myDefaultProp: 111,
-          mySuppliedProp: 222,
-        }),
-      ).to.equal(true);
+      expect(jssCallbackStub.callCount).to.equal(1);
+      expect(jssCallbackStub.args[0][0]).to.deep.equal({
+        myDefaultProp: 111,
+        mySuppliedProp: 222,
+      });
     });
 
     it('should support theme.props', () => {

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -173,7 +173,7 @@ describe('<Menu />', () => {
 
     popover.props().TransitionProps.onEntering(elementForHandleEnter);
     expect(onEnteringSpy.callCount).to.equal(1);
-    expect(onEnteringSpy.calledWith(elementForHandleEnter)).to.equal(true);
+    expect(onEnteringSpy.args[0][0]).to.equal(elementForHandleEnter);
   });
 
   it('should call TransitionProps.onEntering, disableAutoFocusItem', () => {
@@ -191,7 +191,7 @@ describe('<Menu />', () => {
 
     popover.props().TransitionProps.onEntering(elementForHandleEnter);
     expect(onEnteringSpy.callCount).to.equal(1);
-    expect(onEnteringSpy.calledWith(elementForHandleEnter)).to.equal(true);
+    expect(onEnteringSpy.args[0][0]).to.equal(elementForHandleEnter);
   });
 
   it('should call onClose on tab', () => {

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -106,7 +106,7 @@ describe('<SpeedDial />', () => {
       });
       fireEvent.keyDown(buttonWrapper, { key: ' ' });
       expect(handleKeyDown.callCount).to.equal(1);
-      expect(handleKeyDown.calledWithMatch({ key: ' ' })).to.equal(true);
+      expect(handleKeyDown.args[0][0]).to.have.property('key', ' ');
     });
   });
 


### PR DESCRIPTION
Generally, `expect(*)` should always receive the "bare" object i.e. not include any property access. The reason being that in case of a mismatch you want to see actionable debug information from the matcher. Otherwise you almost always end up logging the actual value anyway once it fails. The exception to this rule is if you don't have useful matchers to use.

`expect(sinonSpy.calledWith(value)).to.equal(true)` is problematic for two reasons:
- you don't see the actual value once it fails
- you don't know which call it is or how often the spy was called at all


Specifically, `DateTimePicker.test` `allows to select full date end-to-end` was failing after internal refactoring (https://github.com/mui-org/material-ui/pull/24367). It didn't provide actionable information that revealed that the behavior was still correct, but the testing approach problematic. I used this opportunity to refactor the other usages of `.calledWith`.

I don't see how we can safely flag these uses statically `no-restricted-properties` has no information about the context so it might flag appropriate uses. I think the "no access on the left side of the assertion" is a better heuristic.