### PR TITLE
[lab] Reflect draft pattern of picker value in implementation

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -107,9 +107,9 @@ export function usePickerState<TInput, TDateValue>(
     [
       acceptDate,
       disableCloseOnSelect,
-      draftState.draft,
       isOpen,
       now,
+      draftState.draft,
       setIsOpen,
       valueManager.emptyValue,
     ],
@@ -138,7 +138,7 @@ export function usePickerState<TInput, TDateValue>(
         // if selectionState === "shallow" do nothing (we already update picker state)
       },
     }),
-    [acceptDate, disableCloseOnSelect, draftState.draft, isMobileKeyboardViewOpen],
+    [acceptDate, disableCloseOnSelect, isMobileKeyboardViewOpen, draftState.draft],
   );
 
   const inputProps = React.useMemo(

--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -135,7 +135,7 @@ export function usePickerState<TInput, TDateValue>(
           acceptDate(newDate, shouldCloseOnSelect);
         }
 
-        // if selectionState === "shallow" do nothing (we already update picker state)
+        // if selectionState === "shallow" do nothing (we already update the draft state)
       },
     }),
     [acceptDate, disableCloseOnSelect, isMobileKeyboardViewOpen, draftState.draft],

--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -16,6 +16,16 @@ export interface PickerStateValueManager<TInputValue, TDateValue> {
 
 export type PickerSelectionState = 'partial' | 'shallow' | 'finish';
 
+interface Draftable<T> {
+  committed: T;
+  draft: T;
+}
+
+interface DraftAction<DraftValue> {
+  type: 'update' | 'reset';
+  payload: DraftValue;
+}
+
 export function usePickerState<TInput, TDateValue>(
   props: BasePickerProps<TInput, TDateValue>,
   valueManager: PickerStateValueManager<TInput, TDateValue>,
@@ -34,25 +44,39 @@ export function usePickerState<TInput, TDateValue>(
     throw new Error('inputFormat prop is required');
   }
 
-  const now = useNow();
+  const now = useNow<TDateValue>();
   const utils = useUtils();
   const { isOpen, setIsOpen } = useOpenState(props);
-  const [pickerDate, setPickerDate] = React.useState(valueManager.parseInput(utils, value));
+
+  function initDraftableDate(date: TDateValue): Draftable<TDateValue> {
+    return { committed: date, draft: date };
+  }
+
+  const parsedDateValue = valueManager.parseInput(utils, value);
+  const [draftState, dispatch] = React.useReducer(
+    (state: Draftable<TDateValue>, action: DraftAction<TDateValue>): Draftable<TDateValue> => {
+      switch (action.type) {
+        case 'reset':
+          return initDraftableDate(action.payload);
+        case 'update':
+          return {
+            ...state,
+            draft: action.payload,
+          };
+        default:
+          return state;
+      }
+    },
+    parsedDateValue,
+    initDraftableDate,
+  );
+  if (!valueManager.areValuesEqual(utils, draftState.committed, parsedDateValue)) {
+    dispatch({ type: 'reset', payload: parsedDateValue });
+  }
 
   // Mobile keyboard view is a special case.
   // When it's open picker should work like closed, cause we are just showing text field
   const [isMobileKeyboardViewOpen, setMobileKeyboardViewOpen] = React.useState(false);
-
-  React.useEffect(() => {
-    const parsedDateValue = valueManager.parseInput(utils, value);
-    setPickerDate((currentPickerDate) => {
-      if (!valueManager.areValuesEqual(utils, currentPickerDate, parsedDateValue)) {
-        return parsedDateValue;
-      }
-
-      return currentPickerDate;
-    });
-  }, [value, utils, valueManager]);
 
   const acceptDate = React.useCallback(
     (acceptedDate: TDateValue, needClosePicker: boolean) => {
@@ -73,20 +97,27 @@ export function usePickerState<TInput, TDateValue>(
     () => ({
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
-      onAccept: () => acceptDate(pickerDate, true),
+      onAccept: () => acceptDate(draftState.draft, true),
       onDismiss: () => setIsOpen(false),
       onSetToday: () => {
-        // TODO FIX ME
-        setPickerDate(now as any);
-        acceptDate(now as any, !disableCloseOnSelect);
+        dispatch({ type: 'update', payload: now });
+        acceptDate(now, !disableCloseOnSelect);
       },
     }),
-    [acceptDate, disableCloseOnSelect, isOpen, now, pickerDate, setIsOpen, valueManager.emptyValue],
+    [
+      acceptDate,
+      disableCloseOnSelect,
+      draftState.draft,
+      isOpen,
+      now,
+      setIsOpen,
+      valueManager.emptyValue,
+    ],
   );
 
   const pickerProps = React.useMemo(
     () => ({
-      date: pickerDate,
+      date: draftState.draft,
       isMobileKeyboardViewOpen,
       toggleMobileKeyboardView: () => setMobileKeyboardViewOpen(!isMobileKeyboardViewOpen),
       onDateChange: (
@@ -94,7 +125,7 @@ export function usePickerState<TInput, TDateValue>(
         wrapperVariant: WrapperVariant,
         selectionState: PickerSelectionState = 'partial',
       ) => {
-        setPickerDate(newDate);
+        dispatch({ type: 'update', payload: newDate });
         if (selectionState === 'partial') {
           acceptDate(newDate, false);
         }
@@ -107,7 +138,7 @@ export function usePickerState<TInput, TDateValue>(
         // if selectionState === "shallow" do nothing (we already update picker state)
       },
     }),
-    [acceptDate, disableCloseOnSelect, isMobileKeyboardViewOpen, pickerDate],
+    [acceptDate, disableCloseOnSelect, draftState.draft, isMobileKeyboardViewOpen],
   );
 
   const inputProps = React.useMemo(
@@ -124,7 +155,7 @@ export function usePickerState<TInput, TDateValue>(
   const pickerState = { pickerProps, inputProps, wrapperProps };
   React.useDebugValue(pickerState, () => ({
     MuiPickerState: {
-      pickerDate,
+      pickerDraft: draftState,
       other: pickerState,
     },
   }));

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
@@ -22,7 +22,7 @@ export function useUtils<T = unknown>() {
   return utils as MuiPickersAdapter<T>;
 }
 
-export function useNow<TDate = unknown>() {
+export function useNow<TDate = unknown>(): TDate {
   const utils = useUtils<TDate>();
   const now = React.useRef(utils.date());
 


### PR DESCRIPTION
Based on https://github.com/mui-org/material-ui/pull/24366 ([diff](https://github.com/eps1lon/material-ui/compare/test/drop-calledWith...eps1lon:fix/lab-pickers-on-change))

I [originally misidentified that `usePickerState` needs `getDerivedStateFromProps`](https://github.com/mui-org/material-ui/pull/24315/commits/9dd7afc8ccbf40ea1f8865aa02d58be395ba92b8?file-filters%5B%5D=.ts#diff-e02e96ce7f2b6008184ad7ab79b7e9edd19601b3f28a5f11e6d43c26854a2dc1). I believe now that `usePickerState` implements the draft pattern but the previous implementation used `useEffect`. However, that pattern can be implemented without needing to commit twice. The React docs go over this in more detail: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recap (look for usage of "draft").

We still have cascading updates (https://mui-dashboard.netlify.app/test-profile/212342/details/%3CDatePicker%20%2F%3E%20render%20proper%20month).

Latest `test_profile` on `next`: https://mui-dashboard.netlify.app/test-profile/212357
Latest `test_profile` on this PR: https://mui-dashboard.netlify.app/test-profile/212342