### PR TITLE
[lab] Fix import paths in generated declaration files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,14 +209,8 @@ jobs:
             git --no-pager diff
 
       - run:
-          name: Log defect declaration files
-          command: |
-            # ignore build failures
-            # Fixing these takes some effort that isn't viable to merge in a single PR.
-            # We'll simply monitor them for now.
-            set +e
-            node scripts/testBuiltTypes.js
-            exit 0
+          name: Any defect declaration files?
+          command: node scripts/testBuiltTypes.js
       - save_cache:
           name: Save generated declaration files
           key: typescript-declaration-files-{{ .Branch }}-{{ .Revision }}

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -29,7 +29,7 @@
     "build:node": "node ../../scripts/build node",
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag next",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-lab/**/*.test.{js,ts,tsx}'",

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -28,7 +28,7 @@
     "build:node": "node ../../scripts/build node",
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag next",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-utils/**/*.test.{js,ts,tsx}'",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -33,7 +33,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:umd": "cross-env BABEL_ENV=stable rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "node ../../scripts/buildTypes",
     "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true yarn build:modern",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",

--- a/scripts/buildTypes.js
+++ b/scripts/buildTypes.js
@@ -1,0 +1,133 @@
+const chalk = require('chalk');
+const childProcess = require('child_process');
+const glob = require('fast-glob');
+const fse = require('fs-extra');
+const path = require('path');
+const { promisify } = require('util');
+const yargs = require('yargs');
+
+const exec = promisify(childProcess.exec);
+
+/**
+ * Fixes a wrong import path caused by https://github.com/microsoft/TypeScript/issues/39117
+ *
+ * @remarks Paths are hardcoded since it is unclear if all these broken import paths target "public paths".
+ *
+ * @param {string} importPath
+ */
+function rewriteImportPath(importPath) {
+  if (importPath.startsWith('../material-ui/src')) {
+    return importPath.replace('../material-ui/src', '@material-ui/core');
+  }
+  if (importPath.startsWith('../material-ui-styles/src')) {
+    return importPath.replace('../material-ui-styles/src', '@material-ui/styles');
+  }
+
+  throw new Error(`Don't know where to rewrite '${importPath}' to`);
+}
+
+async function main() {
+  const packageRoot = process.cwd();
+
+  const tsconfigPath = path.join(packageRoot, 'tsconfig.build.json');
+  if (!fse.existsSync(tsconfigPath)) {
+    throw new Error(
+      'Unable to find a tsconfig to build this project. ' +
+        `The package root needs to contain a 'tsconfig.build.json'. ` +
+        `The package root is '${packageRoot}'`,
+    );
+  }
+
+  await exec(['yarn', 'tsc', '-p', tsconfigPath].join(' '));
+
+  const publishDir = path.join(packageRoot, 'build');
+  const declarationFiles = await glob('**/*.d.ts', { absolute: true, cwd: publishDir });
+  if (declarationFiles.length === 0) {
+    throw new Error(`Unable to find declaration files in '${publishDir}'`);
+  }
+
+  async function rewriteImportPaths(declarationFile) {
+    const code = await fse.readFile(declarationFile, { encoding: 'utf8' });
+    let fixedCode = code;
+    const changes = [];
+
+    // find all type `import()`
+    // not to be confused with `import type`
+    const importTypeRegExp = /import\(([^)]+)\)/g;
+
+    let importTypeMatch;
+    // eslint-disable-next-line no-cond-assign -- Waiting for RegExp.prototype.matchAll
+    while ((importTypeMatch = importTypeRegExp.exec(code)) !== null) {
+      // First and last character are quotes.
+      // TypeScript mixes single and double quotes.
+      const importPath = importTypeMatch[1].slice(1, -1);
+      // In filesystem semantics `@material-ui/core` is a relative path.
+      // But when resolving imports these specifiers are considered "bare specifiers" and work differently.
+      // We're only interested in imports that are considered "relative path imports".
+      const isBareImportSpecifier = !importPath.startsWith('.');
+      if (!isBareImportSpecifier) {
+        const resolvedImport = path.resolve(declarationFile, importPath);
+        const importPathFromPublishDir = path.relative(publishDir, resolvedImport);
+        const isImportReachableWhenPublished = !importPathFromPublishDir.startsWith('.');
+
+        if (!isImportReachableWhenPublished) {
+          try {
+            const fixedImportPath = rewriteImportPath(importPathFromPublishDir);
+            const originalImportType = importTypeMatch[0];
+            const fixedImportType = importTypeMatch[0].replace(importPath, fixedImportPath);
+
+            // Make it easy to visually scan for the created lines.
+            changes.push(`-${chalk.bgRed(originalImportType)}\n+${chalk.bgGreen(fixedImportType)}`);
+            fixedCode = fixedCode.replace(originalImportType, fixedImportType);
+          } catch (error) {
+            throw new Error(`${declarationFile}: ${error}`);
+          }
+        }
+      }
+    }
+
+    const changed = changes.length > 0;
+    if (changed) {
+      await fse.writeFile(declarationFile, fixedCode);
+    }
+
+    return changes;
+  }
+
+  let rewrittenTally = 0;
+  let errorTally = 0;
+  await Promise.all(
+    declarationFiles.map(async (declarationFile) => {
+      try {
+        const rewrites = await rewriteImportPaths(declarationFile, publishDir);
+        if (rewrites.length > 0) {
+          // eslint-disable-next-line no-console -- Verbose logging
+          console.log(`${chalk.bgYellow`FIXED`} '${declarationFile}':\n${rewrites.join('\n')}`);
+          rewrittenTally += 1;
+        } else {
+          // eslint-disable-next-line no-console -- Verbose logging
+          console.log(`${chalk.bgGreen`OK`} '${declarationFile}'`);
+        }
+      } catch (error) {
+        console.error(error);
+        errorTally += 1;
+        process.exitCode = 1;
+      }
+    }),
+  );
+
+  // eslint-disable-next-line no-console -- Verbose logging
+  console.log(`Fixed: ${rewrittenTally}\nFailed: ${errorTally}\nTotal: ${declarationFiles.length}`);
+}
+
+yargs
+  .command({
+    command: '$0',
+    description:
+      'Builds a project with a fix for https://github.com/microsoft/TypeScript/issues/39117',
+    handler: main,
+  })
+  .help()
+  .strict(true)
+  .version(false)
+  .parse();

--- a/scripts/buildTypes.js
+++ b/scripts/buildTypes.js
@@ -16,11 +16,14 @@ const exec = promisify(childProcess.exec);
  * @param {string} importPath
  */
 function rewriteImportPath(importPath) {
-  if (importPath.startsWith('../material-ui/src')) {
-    return importPath.replace('../material-ui/src', '@material-ui/core');
+  const coreSrcPath = path.join('..', 'material-ui', 'src');
+  if (importPath.startsWith(coreSrcPath)) {
+    return importPath.replace(coreSrcPath, '@material-ui/core');
   }
-  if (importPath.startsWith('../material-ui-styles/src')) {
-    return importPath.replace('../material-ui-styles/src', '@material-ui/styles');
+
+  const stylesSrcPath = path.join('..', 'material-ui-styles', 'src');
+  if (importPath.startsWith(stylesSrcPath)) {
+    return importPath.replace(stylesSrcPath, '@material-ui/styles');
   }
 
   throw new Error(`Don't know where to rewrite '${importPath}' to`);

--- a/scripts/buildTypes.js
+++ b/scripts/buildTypes.js
@@ -13,15 +13,15 @@ const exec = promisify(childProcess.exec);
  *
  * @remarks Paths are hardcoded since it is unclear if all these broken import paths target "public paths".
  *
- * @param {string} importPath
+ * @param {string} importPath - POSIX path
  */
 function rewriteImportPath(importPath) {
-  const coreSrcPath = path.join('..', 'material-ui', 'src');
+  const coreSrcPath = path.posix.join('..', 'material-ui', 'src');
   if (importPath.startsWith(coreSrcPath)) {
     return importPath.replace(coreSrcPath, '@material-ui/core');
   }
 
-  const stylesSrcPath = path.join('..', 'material-ui-styles', 'src');
+  const stylesSrcPath = path.posix.join('..', 'material-ui-styles', 'src');
   if (importPath.startsWith(stylesSrcPath)) {
     return importPath.replace(stylesSrcPath, '@material-ui/styles');
   }
@@ -75,7 +75,10 @@ async function main() {
 
         if (!isImportReachableWhenPublished) {
           try {
-            const fixedImportPath = rewriteImportPath(importPathFromPublishDir);
+            const fixedImportPath = rewriteImportPath(
+              // ensure relative POSIX path
+              importPathFromPublishDir.replace(/\\/g, '/'),
+            );
             const originalImportType = importTypeMatch[0];
             const fixedImportType = importTypeMatch[0].replace(importPath, fixedImportPath);
 


### PR DESCRIPTION
Rewrites `import()` types from `material-ui/src` and `material-ui-styles/src` to their corresponding bare imports specifiers (`@material-ui/core` and `@material-ui/styles`). 

These are hardcoded at the moment to be careful with what we rewrite. I hope that this isn't something we have to maintain long-term.

This PR doesn't confirm that the created paths are correct but we now prevent publishing importing from source by switching https://github.com/mui-org/material-ui/pull/24188 from log to failure.

Changes: https://app.circleci.com/pipelines/github/mui-org/material-ui/33261/workflows/1bdc104f-9827-43bc-b987-2dbeb3e46fbf/jobs/212685/parallel-runs/0/steps/0-112

Closes #24112