### PR TITLE
[core] Skip downloading browser binaries when building docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,8 @@
 [build.environment]
   NODE_VERSION = "10"
   NODE_OPTIONS = "--max_old_space_size=4096"
+  # Not using `playwright` when building docs.
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 
 [[plugins]]
   package = "./packages/netlify-plugin-cache-docs"


### PR DESCRIPTION
I'm guessing that downloading browser binaries caused https://app.netlify.com/sites/material-ui/deploys/5ffe3b6482a4970007159301

Seems to have an effect considering the install time went down.
Install time on this PR: 63s (https://app.netlify.com/sites/material-ui/deploys/5ffe84e42fdb7b0008a94c07)
Install time on next: 80-87s (sampled from the last 3 runs on next: https://app.netlify.com/sites/material-ui/deploys/5ffe878e255f010007a5696e, https://app.netlify.com/sites/material-ui/deploys/5ffe864f12c7d70007a378c3, https://app.netlify.com/sites/material-ui/deploys/5ffe3634a3ae5700077c2f96)