### PR TITLE
[core] Normalize generating declaration files

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -38,7 +38,7 @@
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.{js,ts,tsx}'",
-    "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json && tsc -p tsconfig.build.json",
+    "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
   },
   "peerDependencies": {

--- a/scripts/buildTypes.js
+++ b/scripts/buildTypes.js
@@ -41,7 +41,7 @@ async function main() {
     );
   }
 
-  await exec(['yarn', 'tsc', '-p', tsconfigPath].join(' '));
+  await exec(['yarn', 'tsc', '-b', tsconfigPath].join(' '));
 
   const publishDir = path.join(packageRoot, 'build');
   const declarationFiles = await glob('**/*.d.ts', { absolute: true, cwd: publishDir });


### PR DESCRIPTION
- don't generate declaration files in `test_types` (were previously only built for `/core`)
  We already generate them in our GitHub `CI` workflow and `codesandbox/ci` task.
  When they fail, they fail because of an incorrect build setup. If they fail because of the type-checker, the prior type-checking already failed. So they don't add anything to `test_types` with regards to type-checking.
- Use `-b` flag when generating declaration files
  This is required to build referenced projects. It's working with `-p` right now (probably due to the order in which we build) but broke https://github.com/mui-org/material-ui/pull/24396.