### PR TITLE
[docs] Document default values of external props

### DIFF
--- a/docs/pages/api-docs/filled-input.json
+++ b/docs/pages/api-docs/filled-input.json
@@ -12,7 +12,7 @@
     "fullWidth": { "type": { "name": "bool" } },
     "id": { "type": { "name": "string" } },
     "inputComponent": { "type": { "name": "elementType" }, "default": "'input'" },
-    "inputProps": { "type": { "name": "object" } },
+    "inputProps": { "type": { "name": "object" }, "default": "{}" },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "margin": { "type": { "name": "enum", "description": "'dense'<br>&#124;&nbsp;'none'" } },
     "maxRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },

--- a/docs/pages/api-docs/input.json
+++ b/docs/pages/api-docs/input.json
@@ -12,7 +12,7 @@
     "fullWidth": { "type": { "name": "bool" } },
     "id": { "type": { "name": "string" } },
     "inputComponent": { "type": { "name": "elementType" }, "default": "'input'" },
-    "inputProps": { "type": { "name": "object" } },
+    "inputProps": { "type": { "name": "object" }, "default": "{}" },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "margin": { "type": { "name": "enum", "description": "'dense'<br>&#124;&nbsp;'none'" } },
     "maxRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },

--- a/docs/pages/api-docs/outlined-input.json
+++ b/docs/pages/api-docs/outlined-input.json
@@ -11,7 +11,7 @@
     "fullWidth": { "type": { "name": "bool" } },
     "id": { "type": { "name": "string" } },
     "inputComponent": { "type": { "name": "elementType" }, "default": "'input'" },
-    "inputProps": { "type": { "name": "object" } },
+    "inputProps": { "type": { "name": "object" }, "default": "{}" },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
     "labelWidth": { "type": { "name": "number" }, "default": "0" },

--- a/docs/pages/api-docs/text-field.json
+++ b/docs/pages/api-docs/text-field.json
@@ -23,7 +23,8 @@
       "type": {
         "name": "enum",
         "description": "'dense'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'"
-      }
+      },
+      "default": "'none'"
     },
     "maxRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
     "minRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -207,7 +207,7 @@ function createDescribeableProp(
   prop: PropDescriptor,
   propName: string,
 ): DescribeablePropDescriptor | null {
-  const { defaultValue, jsdocDefaultValue, description, required, type } = prop;
+  const { defaultValue, jsdocDefaultValue, description, external, required, type } = prop;
 
   const renderedDefaultValue = defaultValue?.value.replace(/\r?\n/g, '');
   const renderDefaultValue = Boolean(
@@ -232,9 +232,11 @@ function createDescribeableProp(
   }
 
   if (jsdocDefaultValue !== undefined && defaultValue === undefined) {
-    throw new Error(
-      `Declared a @default annotation in JSDOC for prop '${propName}' but could not find a default value in the implementation.`,
-    );
+    if (!external) {
+      throw new Error(
+        `Declared a @default annotation in JSDOC for prop '${propName}' but could not find a default value in the implementation.`,
+      );
+    }
   } else if (jsdocDefaultValue === undefined && defaultValue !== undefined && renderDefaultValue) {
     const shouldHaveDefaultAnnotation =
       // Discriminator for polymorphism which is not documented at the component level.

--- a/docs/src/modules/utils/defaultPropsHandler.js
+++ b/docs/src/modules/utils/defaultPropsHandler.js
@@ -86,14 +86,13 @@ function getDefaultValuesFromProps(properties, documentation) {
     }
 
     const propertyPath = implementedProps[propName];
-    if (propertyPath === undefined) {
-      // Make sure we don't confuse it later with a prop where the implemented default value does not match the documented one.
-      propDescriptor.defaultValue = jsdocDefaultValue;
-    } else {
+    if (propertyPath !== undefined) {
       const defaultValue = getDefaultValue(propertyPath);
       if (defaultValue) {
         propDescriptor.defaultValue = defaultValue;
       }
+    } else {
+      propDescriptor.external = true;
     }
   });
 }

--- a/docs/src/modules/utils/defaultPropsHandler.js
+++ b/docs/src/modules/utils/defaultPropsHandler.js
@@ -53,36 +53,54 @@ function getJsdocDefaultValue(jsdoc) {
   return { value: defaultTag.description };
 }
 
+/**
+ *
+ * @param {import('@babel/core').NodePath} properties
+ * @param {*} documentation
+ */
 function getDefaultValuesFromProps(properties, documentation) {
+  const { props: documentedProps } = documentation.toObject();
+  const implementedProps = {};
   properties
     .filter((propertyPath) => types.Property.check(propertyPath.node))
     .forEach((propertyPath) => {
       const propName = getPropertyName(propertyPath);
-      if (!propName) return;
-
-      const propDescriptor = documentation.getPropDescriptor(propName);
-      if (propDescriptor.description === undefined) {
-        // private props have no propsType validator and therefore
-        // not description.
-        // They are either not subject to eslint react/prop-types
-        // or are and then we catch these issues during linting.
-        return;
+      if (propName) {
+        implementedProps[propName] = propertyPath;
       }
+    });
 
-      const jsdocDefaultValue = getJsdocDefaultValue(
-        parseDoctrine(propDescriptor.description, {
-          sloppy: true,
-        }),
-      );
-      if (jsdocDefaultValue) {
-        propDescriptor.jsdocDefaultValue = jsdocDefaultValue;
-      }
+  // Sometimes we list props in .propTypes even though they're implemented by another component
+  // These props are spread so they won't appear in the component implementation.
+  Object.entries(documentedProps).forEach(([propName, propDescriptor]) => {
+    if (propDescriptor.description === undefined) {
+      // private props have no propsType validator and therefore
+      // not description.
+      // They are either not subject to eslint react/prop-types
+      // or are and then we catch these issues during linting.
+      return;
+    }
 
+    const jsdocDefaultValue = getJsdocDefaultValue(
+      parseDoctrine(propDescriptor.description, {
+        sloppy: true,
+      }),
+    );
+    if (jsdocDefaultValue) {
+      propDescriptor.jsdocDefaultValue = jsdocDefaultValue;
+    }
+
+    const propertyPath = implementedProps[propName];
+    if (propertyPath === undefined) {
+      // Make sure we don't confuse it later with a prop where the implemented default value does not match the documented one.
+      propDescriptor.defaultValue = jsdocDefaultValue;
+    } else {
       const defaultValue = getDefaultValue(propertyPath);
       if (defaultValue) {
         propDescriptor.defaultValue = defaultValue;
       }
-    });
+    }
+  });
 }
 
 function getRenderBody(componentDefinition) {

--- a/docs/src/modules/utils/defaultPropsHandler.js
+++ b/docs/src/modules/utils/defaultPropsHandler.js
@@ -53,11 +53,6 @@ function getJsdocDefaultValue(jsdoc) {
   return { value: defaultTag.description };
 }
 
-/**
- *
- * @param {import('@babel/core').NodePath} properties
- * @param {*} documentation
- */
 function getDefaultValuesFromProps(properties, documentation) {
   const { props: documentedProps } = documentation.toObject();
   const implementedProps = {};

--- a/docs/types/react-docgen.d.ts
+++ b/docs/types/react-docgen.d.ts
@@ -11,11 +11,6 @@ declare module 'react-docgen' {
   export interface BasePropTypeDescriptor {
     computed?: boolean;
     description?: string;
-    /**
-     * External props are props that are documented on the component but implemented somewhere else.
-     * For example, TextField documents `margin` but `margin` is spread to `FormControl` which actually implements `margin`.
-     */
-    external?: boolean;
     raw: string;
     required?: boolean;
     type?: PropType;
@@ -112,6 +107,12 @@ declare module 'react-docgen' {
     // augmented by docs/src/modules/utils/defaultPropsHandler.js
     jsdocDefaultValue?: { computed: boolean; value: string };
     description?: string;
+    // augmented by docs/src/modules/utils/defaultPropsHandler.js
+    /**
+     * External props are props that are documented on the component but implemented somewhere else.
+     * For example, TextField documents `margin` but `margin` is spread to `FormControl` which actually implements `margin`.
+     */
+    external?: boolean;
     required?: boolean;
     /**
      * react-docgen has this as nullable but it was never treated as such

--- a/docs/types/react-docgen.d.ts
+++ b/docs/types/react-docgen.d.ts
@@ -11,6 +11,11 @@ declare module 'react-docgen' {
   export interface BasePropTypeDescriptor {
     computed?: boolean;
     description?: string;
+    /**
+     * External props are props that are documented on the component but implemented somewhere else.
+     * For example, TextField documents `margin` but `margin` is spread to `FormControl` which actually implements `margin`.
+     */
+    external?: boolean;
     raw: string;
     required?: boolean;
     type?: PropType;

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -91,10 +91,6 @@ export interface BaseTextFieldProps
    */
   label?: React.ReactNode;
   /**
-   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
-   */
-  margin?: 'none' | 'dense' | 'normal';
-  /**
    * If `true`, a `textarea` element is rendered instead of an input.
    * @default false
    */

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -285,6 +285,7 @@ TextField.propTypes = {
   label: PropTypes.node,
   /**
    * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
+   * @default 'none'
    */
   margin: PropTypes.oneOf(['dense', 'none', 'normal']),
   /**

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -134,6 +134,7 @@ const useExternalDocumentation: Record<string, '*' | string[]> = {
     'variant',
   ],
   Tab: ['disableRipple'],
+  TextField: ['margin'],
   ToggleButton: ['disableRipple'],
 };
 const transitionCallbacks = [


### PR DESCRIPTION
Adds default value to API docs for:

- `TextField#margin`
- `Input#inputProps`
- `FilledInput#inputProps`
- `OutlinedInput#inputProps`

These were previously ignored because the props was not implemented in the documented component but in the extended component. We do force the documentation sometimes in `yarn proptypes` with `useExternalDocumentation` so we need to account for that in our default props handler.