### PR TITLE
[styled-engine] Rename StylesProvider to StyledEngineProvider

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -11,7 +11,7 @@ import { create } from 'jss';
 import jssRtl from 'jss-rtl';
 import { useRouter } from 'next/router';
 import { StylesProvider, jssPreset } from '@material-ui/styles';
-import { StylesProvider as CoreStylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 import pages from 'docs/src/pages';
 import initRedux from 'docs/src/modules/redux/initRedux';
 import PageContext from 'docs/src/modules/components/PageContext';
@@ -21,7 +21,7 @@ import { ThemeProvider } from 'docs/src/modules/components/ThemeContext';
 import { pathnameToLanguage, getCookie } from 'docs/src/modules/utils/helpers';
 import { ACTION_TYPES, CODE_VARIANTS, LANGUAGES } from 'docs/src/modules/constants';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
-import StyledEngineProvider, { cacheLtr } from 'docs/src/modules/utils/StyledEngineProvider';
+import DocsStyledEngineProvider, { cacheLtr } from 'docs/src/modules/utils/StyledEngineProvider';
 
 export { cacheLtr };
 
@@ -320,13 +320,13 @@ function AppWrapper(props) {
       </NextHead>
       <ReduxProvider store={redux}>
         <PageContext.Provider value={{ activePage, pages, versions: pageProps.versions }}>
-          <CoreStylesProvider injectFirst>
+          <StyledEngineProvider injectFirst>
             <StylesProvider jss={jss}>
               <ThemeProvider>
-                <StyledEngineProvider>{children}</StyledEngineProvider>
+                <DocsStyledEngineProvider>{children}</DocsStyledEngineProvider>
               </ThemeProvider>
             </StylesProvider>
-          </CoreStylesProvider>
+          </StyledEngineProvider>
         </PageContext.Provider>
         <LanguageNegotiation />
         <Analytics />

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -11,13 +11,13 @@ function jsDemo(demoData) {
       'index.js': `
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 import Demo from './demo';
 
 ReactDOM.render(
-  <StylesProvider injectFirst>
+  <StyledEngineProvider injectFirst>
     <Demo />
-  </StylesProvider>,
+  </StyledEngineProvider>,
   document.querySelector("#root")
 );
     `.trim(),
@@ -36,13 +36,13 @@ function tsDemo(demoData) {
       'index.tsx': `
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 import Demo from './demo';
 
 ReactDOM.render(
-  <StylesProvider injectFirst>
+  <StyledEngineProvider injectFirst>
     <Demo />
-  </StylesProvider>,
+  </StyledEngineProvider>,
   document.querySelector("#root")
 );
     `.trim(),

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -55,13 +55,13 @@ export default function PlainCssSlider() {
 
 ```jsx
 import * as React from 'react';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 
 export default function GlobalCssPriority() {
   return (
-    <StylesProvider injectFirst>
+    <StyledEngineProvider injectFirst>
       {/* Your component tree. Now you can override Material-UI's styles. */}
-    </StylesProvider>
+    </StyledEngineProvider>
   );
 }
 ```
@@ -208,13 +208,13 @@ export default function GlobalCssSlider() {
 
 ```jsx
 import * as React from 'react';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 
 export default function GlobalCssPriority() {
   return (
-    <StylesProvider injectFirst>
+    <StyledEngineProvider injectFirst>
       {/* Your component tree. Now you can override Material-UI's styles. */}
-    </StylesProvider>
+    </StyledEngineProvider>
   );
 }
 ```
@@ -462,13 +462,13 @@ export default function CssModulesSlider() {
 
 ```jsx
 import * as React from 'react';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 
 export default function GlobalCssPriority() {
   return (
-    <StylesProvider injectFirst>
+    <StyledEngineProvider injectFirst>
       {/* Your component tree. Now you can override Material-UI's styles. */}
-    </StylesProvider>
+    </StyledEngineProvider>
   );
 }
 ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -78,13 +78,13 @@ The styled engine used in v5 by default is [`emotion`](https://github.com/emotio
 
 ```jsx
 import * as React from 'react';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 
 export default function GlobalCssPriority() {
   return (
-    <StylesProvider injectFirst>
+    <StyledEngineProvider injectFirst>
       {/* Your component tree. Now you can override Material-UI's styles. */}
-    </StylesProvider>
+    </StyledEngineProvider>
   );
 }
 ```

--- a/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.d.ts
+++ b/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.d.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+export interface StyledEngineProviderProps {
+  children?: React.ReactNode;
+  injectFirst?: boolean;
+}
+
+export default function StyledEngineProvider(props: StyledEngineProviderProps): JSX.Element;

--- a/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-export default function StylesProvider(props) {
+export default function StyledEngineProvider(props) {
   const { injectFirst, children } = props;
 
   if (injectFirst && typeof window !== 'undefined') {
@@ -15,7 +15,7 @@ export default function StylesProvider(props) {
   return children;
 }
 
-StylesProvider.propTypes = {
+StyledEngineProvider.propTypes = {
   /**
    * Your component tree.
    */

--- a/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/index.d.ts
+++ b/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './StyledEngineProvider';
+export * from './StyledEngineProvider';

--- a/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/index.js
+++ b/packages/material-ui-styled-engine-sc/src/StyledEngineProvider/index.js
@@ -1,0 +1,1 @@
+export { default } from './StyledEngineProvider';

--- a/packages/material-ui-styled-engine-sc/src/StylesProvider/StylesProvider.d.ts
+++ b/packages/material-ui-styled-engine-sc/src/StylesProvider/StylesProvider.d.ts
@@ -1,8 +1,0 @@
-import * as React from 'react';
-
-export interface StylesProviderProps {
-  children?: React.ReactNode;
-  injectFirst?: boolean;
-}
-
-export default function StylesProvider(props: StylesProviderProps): JSX.Element;

--- a/packages/material-ui-styled-engine-sc/src/StylesProvider/index.d.ts
+++ b/packages/material-ui-styled-engine-sc/src/StylesProvider/index.d.ts
@@ -1,2 +1,0 @@
-export { default } from './StylesProvider';
-export * from './StylesProvider';

--- a/packages/material-ui-styled-engine-sc/src/StylesProvider/index.js
+++ b/packages/material-ui-styled-engine-sc/src/StylesProvider/index.js
@@ -1,1 +1,0 @@
-export { default } from './StylesProvider';

--- a/packages/material-ui-styled-engine-sc/src/index.d.ts
+++ b/packages/material-ui-styled-engine-sc/src/index.d.ts
@@ -1,6 +1,6 @@
 export * from 'styled-components';
 export { default } from 'styled-components';
-export { default as StylesProvider } from './StylesProvider';
+export { default as StyledEngineProvider } from './StyledEngineProvider';
 
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';

--- a/packages/material-ui-styled-engine-sc/src/index.js
+++ b/packages/material-ui-styled-engine-sc/src/index.js
@@ -12,5 +12,5 @@ export default function styled(tag, options) {
 }
 
 export { ThemeContext, keyframes } from 'styled-components';
-export { default as StylesProvider } from './StylesProvider';
+export { default as StyledEngineProvider } from './StyledEngineProvider';
 export { default as GlobalStyles } from './GlobalStyles';

--- a/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.d.ts
+++ b/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.d.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+export interface StyledEngineProviderProps {
+  children?: React.ReactNode;
+  injectFirst?: boolean;
+}
+
+export default function StyledEngineProvider(props: StyledEngineProviderProps): JSX.Element;

--- a/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -6,12 +6,12 @@ import createCache from '@emotion/cache';
 // Cache with option to prepend emotion's style tag
 export const cache = createCache({ key: 'css', prepend: true });
 
-export default function StylesProvider(props) {
+export default function StyledEngineProvider(props) {
   const { injectFirst, children } = props;
   return injectFirst ? <CacheProvider value={cache}>{children}</CacheProvider> : children;
 }
 
-StylesProvider.propTypes = {
+StyledEngineProvider.propTypes = {
   /**
    * Your component tree.
    */

--- a/packages/material-ui-styled-engine/src/StyledEngineProvider/index.d.ts
+++ b/packages/material-ui-styled-engine/src/StyledEngineProvider/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './StyledEngineProvider';
+export * from './StyledEngineProvider';

--- a/packages/material-ui-styled-engine/src/StyledEngineProvider/index.js
+++ b/packages/material-ui-styled-engine/src/StyledEngineProvider/index.js
@@ -1,0 +1,1 @@
+export { default } from './StyledEngineProvider';

--- a/packages/material-ui-styled-engine/src/StylesProvider/StylesProvider.d.ts
+++ b/packages/material-ui-styled-engine/src/StylesProvider/StylesProvider.d.ts
@@ -1,8 +1,0 @@
-import * as React from 'react';
-
-export interface StylesProviderProps {
-  children?: React.ReactNode;
-  injectFirst?: boolean;
-}
-
-export default function StylesProvider(props: StylesProviderProps): JSX.Element;

--- a/packages/material-ui-styled-engine/src/StylesProvider/index.d.ts
+++ b/packages/material-ui-styled-engine/src/StylesProvider/index.d.ts
@@ -1,2 +1,0 @@
-export { default } from './StylesProvider';
-export * from './StylesProvider';

--- a/packages/material-ui-styled-engine/src/StylesProvider/index.js
+++ b/packages/material-ui-styled-engine/src/StylesProvider/index.js
@@ -1,1 +1,0 @@
-export { default } from './StylesProvider';

--- a/packages/material-ui-styled-engine/src/index.d.ts
+++ b/packages/material-ui-styled-engine/src/index.d.ts
@@ -2,7 +2,7 @@ export * from '@emotion/styled';
 export { default } from '@emotion/styled';
 export { ThemeContext, keyframes } from '@emotion/react';
 
-export { default as StylesProvider } from './StylesProvider';
+export { default as StyledEngineProvider } from './StyledEngineProvider';
 
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';

--- a/packages/material-ui-styled-engine/src/index.js
+++ b/packages/material-ui-styled-engine/src/index.js
@@ -1,4 +1,4 @@
 export { default } from '@emotion/styled';
 export { ThemeContext, keyframes } from '@emotion/react';
-export { default as StylesProvider } from './StylesProvider';
+export { default as StyledEngineProvider } from './StyledEngineProvider';
 export { default as GlobalStyles } from './GlobalStyles';

--- a/packages/material-ui/src/StyledEngineProvider/index.d.ts
+++ b/packages/material-ui/src/StyledEngineProvider/index.d.ts
@@ -1,0 +1,1 @@
+export { StyledEngineProvider as default } from '@material-ui/styled-engine';

--- a/packages/material-ui/src/StyledEngineProvider/index.js
+++ b/packages/material-ui/src/StyledEngineProvider/index.js
@@ -1,0 +1,1 @@
+export { StyledEngineProvider as default } from '@material-ui/styled-engine';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -473,7 +473,6 @@ export * from './useAutocomplete';
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
 
-
 /**
  * @deprecated will be removed in v5.beta, please use StyledEngineProvider instead
  */

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -473,4 +473,9 @@ export * from './useAutocomplete';
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
 
-export { StylesProvider } from '@material-ui/styled-engine';
+
+/**
+ * @deprecated will be removed in v5.beta, please use StyledEngineProvider instead
+ */
+export { StyledEngineProvider as StylesProvider } from '@material-ui/styled-engine';
+export { StyledEngineProvider } from '@material-ui/styled-engine';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -476,5 +476,5 @@ export * from './GlobalStyles';
 /**
  * @deprecated will be removed in v5.beta, please use StyledEngineProvider instead
  */
-export { StyledEngineProvider as StylesProvider } from '@material-ui/styled-engine';
-export { StyledEngineProvider } from '@material-ui/styled-engine';
+export { default as StylesProvider } from './StyledEngineProvider';
+export { default as StyledEngineProvider } from './StyledEngineProvider';

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -405,7 +405,7 @@ export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
 
 /**
- * @deprecated will be removed in v5.beta, please use StyledEngineProvider instead
+ * @deprecated will be removed in v5 beta, please use StyledEngineProvider instead
  */
-export { StyledEngineProvider as StylesProvider } from '@material-ui/styled-engine';
-export { StyledEngineProvider } from '@material-ui/styled-engine';
+export { default as StylesProvider } from './StyledEngineProvider';
+export { default as StyledEngineProvider } from './StyledEngineProvider';

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -404,4 +404,8 @@ export { default as useAutocomplete } from './useAutocomplete';
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
 
-export { StylesProvider } from '@material-ui/styled-engine';
+/**
+ * @deprecated will be removed in v5.beta, please use StyledEngineProvider instead
+ */
+export { StyledEngineProvider as StylesProvider } from '@material-ui/styled-engine';
+export { StyledEngineProvider } from '@material-ui/styled-engine';

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useFakeTimers } from 'sinon';
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = (theme) => ({
@@ -72,11 +72,11 @@ function TestViewer(props) {
   }, []);
 
   return (
-    <StylesProvider injectFirst>
+    <StyledEngineProvider injectFirst>
       <div aria-busy={!ready} data-testid="testcase" className={classes.root}>
         {children}
       </div>
-    </StylesProvider>
+    </StyledEngineProvider>
   );
 }
 


### PR DESCRIPTION
### Breaking change

- [styled-engine] Clear the confusion between the JSS and emotion/sc API

```diff
-import { StylesProvider } from '@material-ui/core';
+import StyledEngineProvider from '@material-ui/core/StyledEngineProvider';
```

or 

```diff
-import { StylesProvider } from '@material-ui/core';
+import { StyledEngineProvider } from '@material-ui/core';
```


---

With https://github.com/mui-org/material-ui/pull/23934 we have introduced `StylesProvider` component that has the `injectFirst` option to allow emotion styles to be injected first. We re-exported this component from `@mateiral-ui/core`. However, as we already have component `StylesProvider` which is exported from `@material-ui/core/styles`, there was lots of confusion around what's the difference and which one is the correct one. There was discussion around this on this issue https://github.com/mui-org/material-ui/issues/24109

The proposal in this PR is to rename the new provider as `StyledEngineProvider`, with the hope that the name will indicate that it is part of the new `@material-ui/styled-engine` package.