### PR TITLE
[DateRangePicker] Remove variant prop override for Textfield

### DIFF
--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerInput.tsx
@@ -151,7 +151,6 @@ const DateRangePickerInput: React.FC<DateRangeInputProps & WithStyles<typeof sty
     TextFieldProps: {
       ...TextFieldProps,
       ref: startRef,
-      variant: 'outlined',
       focused: open && currentlySelectingRangeEnd === 'start',
     },
     inputProps: {
@@ -170,7 +169,6 @@ const DateRangePickerInput: React.FC<DateRangeInputProps & WithStyles<typeof sty
     TextFieldProps: {
       ...TextFieldProps,
       ref: endRef,
-      variant: 'outlined',
       focused: open && currentlySelectingRangeEnd === 'end',
     },
     inputProps: {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Remove leaky variant for Textfield input prop in DateRangePickerInput component.

### Why is it needed?
It will prevent overriding variant prop for Textfield input.

### Related issue(s)/PR(s)
Closes #24166 