### PR TITLE
[alert] Migrate to emotion

### DIFF
--- a/docs/pages/api-docs/alert.json
+++ b/docs/pages/api-docs/alert.json
@@ -26,14 +26,14 @@
       },
       "default": "'success'"
     },
+    "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {
         "name": "union",
         "description": "'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
-    },
-    "sx": { "type": { "name": "object" } }
+    }
   },
   "name": "Alert",
   "styles": {

--- a/docs/pages/api-docs/alert.json
+++ b/docs/pages/api-docs/alert.json
@@ -32,7 +32,8 @@
         "description": "'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
-    }
+    },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "Alert",
   "styles": {
@@ -65,5 +66,5 @@
   "filename": "/packages/material-ui/src/Alert/Alert.js",
   "inheritance": { "component": "Paper", "pathname": "/api/paper/" },
   "demos": "<ul><li><a href=\"/components/alert/\">Alert</a></li></ul>",
-  "styledComponent": false
+  "styledComponent": true
 }

--- a/docs/translations/api-docs/alert/alert.json
+++ b/docs/translations/api-docs/alert/alert.json
@@ -11,8 +11,8 @@
     "onClose": "Callback fired when the component requests to be closed. When provided and no <code>action</code> prop is set, a close icon button is displayed that triggers the callback when clicked.<br><br><strong>Signature:</strong><br><code>function(event: object) =&gt; void</code><br><em>event:</em> The event source of the callback.",
     "role": "The ARIA role attribute of the element.",
     "severity": "The severity of the alert. This defines the color and icon used.",
-    "variant": "The variant to use.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/alert/alert.json
+++ b/docs/translations/api-docs/alert/alert.json
@@ -11,7 +11,8 @@
     "onClose": "Callback fired when the component requests to be closed. When provided and no <code>action</code> prop is set, a close icon button is displayed that triggers the callback when clicked.<br><br><strong>Signature:</strong><br><code>function(event: object) =&gt; void</code><br><em>event:</em> The event source of the callback.",
     "role": "The ARIA role attribute of the element.",
     "severity": "The severity of the alert. This defines the color and icon used.",
-    "variant": "The variant to use."
+    "variant": "The variant to use.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/packages/material-ui/src/Alert/Alert.d.ts
+++ b/packages/material-ui/src/Alert/Alert.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { OverridableStringUnion } from '@material-ui/types';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 import { PaperProps } from '../Paper';
 
 export type Color = 'success' | 'info' | 'warning' | 'error';
@@ -101,6 +102,10 @@ export interface AlertProps extends StandardProps<PaperProps, 'variant'> {
    * @default 'standard'
    */
   variant?: OverridableStringUnion<AlertVariantDefaults, AlertPropsVariantOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type AlertClassKey = keyof NonNullable<AlertProps['classes']>;

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { useThemeVariants } from '@material-ui/styles';
-import withStyles from '../styles/withStyles';
+import experimentalStyled from '../styles/experimentalStyled';
 import { darken, lighten } from '../styles/colorManipulator';
 import capitalize from '../utils/capitalize';
 import Paper from '../Paper';
+import { getAppBarUtilityClass } from './alertClasses';
 import IconButton from '../IconButton';
 import SuccessOutlinedIcon from '../internal/svg-icons/SuccessOutlined';
 import ReportProblemOutlinedIcon from '../internal/svg-icons/ReportProblemOutlined';
@@ -13,19 +16,46 @@ import ErrorOutlineIcon from '../internal/svg-icons/ErrorOutline';
 import InfoOutlinedIcon from '../internal/svg-icons/InfoOutlined';
 import CloseIcon from '../internal/svg-icons/Close';
 
-export const styles = (theme) => {
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(styles.root || {}, {
+    ...styles[`${styleProps.variant}${capitalize(styleProps.color || styleProps.severity)}`],
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { variant, color, severity, classes } = styleProps;
+
+  const slots = {
+    root: ['root', `${variant}${capitalize(color || severity)}`],
+    icon: ['icon'],
+    message: ['message'],
+    action: ['action'],
+  };
+
+  return composeClasses(slots, getAppBarUtilityClass, classes);
+};
+
+const AlertRoot = experimentalStyled(
+  Paper,
+  {},
+  {
+    name: 'MuiAlert',
+    slot: 'Root',
+    overridesResolver,
+  },
+)(({ theme, styleProps }) => {
   const getColor = theme.palette.mode === 'light' ? darken : lighten;
   const getBackgroundColor = theme.palette.mode === 'light' ? lighten : darken;
 
   return {
     /* Styles applied to the root element. */
-    root: {
-      ...theme.typography.body2,
-      borderRadius: theme.shape.borderRadius,
-      backgroundColor: 'transparent',
-      display: 'flex',
-      padding: '6px 16px',
-    },
+    ...theme.typography.body2,
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: 'transparent',
+    display: 'flex',
+    padding: '6px 16px',
     /* Styles applied to the root element if `variant="filled"`. */
     filled: {},
     /* Styles applied to the root element if `variant="outlined"`. */
@@ -33,115 +63,151 @@ export const styles = (theme) => {
     /* Styles applied to the root element if `variant="standard"`. */
     standard: {},
     /* Styles applied to the root element if `variant="standard"` and `color="success"`. */
-    standardSuccess: {
-      color: getColor(theme.palette.success.main, 0.6),
-      backgroundColor: getBackgroundColor(theme.palette.success.main, 0.9),
-      '& $icon': {
-        color: theme.palette.success.main,
-      },
-    },
+    ...(styleProps.variant === 'standard' &&
+      styleProps.color === 'success' && {
+        color: getColor(theme.palette.success.main, 0.6),
+        backgroundColor: getBackgroundColor(theme.palette.success.main, 0.9),
+        '& $icon': {
+          color: theme.palette.success.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="standard"` and `color="info"`. */
-    standardInfo: {
-      color: getColor(theme.palette.info.main, 0.6),
-      backgroundColor: getBackgroundColor(theme.palette.info.main, 0.9),
-      '& $icon': {
-        color: theme.palette.info.main,
-      },
-    },
+    ...(styleProps.variant === 'standard' &&
+      styleProps.color === 'info' && {
+        color: getColor(theme.palette.info.main, 0.6),
+        backgroundColor: getBackgroundColor(theme.palette.info.main, 0.9),
+        '& $icon': {
+          color: theme.palette.info.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="standard"` and `color="warning"`. */
-    standardWarning: {
-      color: getColor(theme.palette.warning.main, 0.6),
-      backgroundColor: getBackgroundColor(theme.palette.warning.main, 0.9),
-      '& $icon': {
-        color: theme.palette.warning.main,
-      },
-    },
+    ...(styleProps.variant === 'standard' &&
+      styleProps.color === 'warning' && {
+        color: getColor(theme.palette.warning.main, 0.6),
+        backgroundColor: getBackgroundColor(theme.palette.warning.main, 0.9),
+        '& $icon': {
+          color: theme.palette.warning.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="standard"` and `color="error"`. */
-    standardError: {
-      color: getColor(theme.palette.error.main, 0.6),
-      backgroundColor: getBackgroundColor(theme.palette.error.main, 0.9),
-      '& $icon': {
-        color: theme.palette.error.main,
-      },
-    },
+    ...(styleProps.variant === 'standard' &&
+      styleProps.color === 'error' && {
+        color: getColor(theme.palette.error.main, 0.6),
+        backgroundColor: getBackgroundColor(theme.palette.error.main, 0.9),
+        '& $icon': {
+          color: theme.palette.error.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="outlined"` and `color="success"`. */
-    outlinedSuccess: {
-      color: getColor(theme.palette.success.main, 0.6),
-      border: `1px solid ${theme.palette.success.main}`,
-      '& $icon': {
-        color: theme.palette.success.main,
-      },
-    },
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color === 'success' && {
+        color: getColor(theme.palette.success.main, 0.6),
+        border: `1px solid ${theme.palette.success.main}`,
+        '& $icon': {
+          color: theme.palette.success.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="outlined"` and `color="info"`. */
-    outlinedInfo: {
-      color: getColor(theme.palette.info.main, 0.6),
-      border: `1px solid ${theme.palette.info.main}`,
-      '& $icon': {
-        color: theme.palette.info.main,
-      },
-    },
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color === 'info' && {
+        color: getColor(theme.palette.info.main, 0.6),
+        border: `1px solid ${theme.palette.info.main}`,
+        '& $icon': {
+          color: theme.palette.info.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="outlined"` and `color="warning"`. */
-    outlinedWarning: {
-      color: getColor(theme.palette.warning.main, 0.6),
-      border: `1px solid ${theme.palette.warning.main}`,
-      '& $icon': {
-        color: theme.palette.warning.main,
-      },
-    },
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color === 'warning' && {
+        color: getColor(theme.palette.warning.main, 0.6),
+        border: `1px solid ${theme.palette.warning.main}`,
+        '& $icon': {
+          color: theme.palette.warning.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="outlined"` and `color="error"`. */
-    outlinedError: {
-      color: getColor(theme.palette.error.main, 0.6),
-      border: `1px solid ${theme.palette.error.main}`,
-      '& $icon': {
-        color: theme.palette.error.main,
-      },
-    },
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color === 'error' && {
+        color: getColor(theme.palette.error.main, 0.6),
+        border: `1px solid ${theme.palette.error.main}`,
+        '& $icon': {
+          color: theme.palette.error.main,
+        },
+      }),
     /* Styles applied to the root element if `variant="filled"` and `color="success"`. */
-    filledSuccess: {
-      color: '#fff',
-      fontWeight: theme.typography.fontWeightMedium,
-      backgroundColor: theme.palette.success.main,
-    },
+    ...(styleProps.variant === 'filled' &&
+      styleProps.color === 'success' && {
+        color: '#fff',
+        fontWeight: theme.typography.fontWeightMedium,
+        backgroundColor: theme.palette.success.main,
+      }),
     /* Styles applied to the root element if `variant="filled"` and `color="info"`. */
-    filledInfo: {
-      color: '#fff',
-      fontWeight: theme.typography.fontWeightMedium,
-      backgroundColor: theme.palette.info.main,
-    },
+    ...(styleProps.variant === 'filled' &&
+      styleProps.color === 'info' && {
+        color: '#fff',
+        fontWeight: theme.typography.fontWeightMedium,
+        backgroundColor: theme.palette.info.main,
+      }),
     /* Styles applied to the root element if `variant="filled"` and `color="warning"`. */
-    filledWarning: {
-      color: '#fff',
-      fontWeight: theme.typography.fontWeightMedium,
-      backgroundColor: theme.palette.warning.main,
-    },
+    ...(styleProps.variant === 'filled' &&
+      styleProps.color === 'warning' && {
+        color: '#fff',
+        fontWeight: theme.typography.fontWeightMedium,
+        backgroundColor: theme.palette.warning.main,
+      }),
     /* Styles applied to the root element if `variant="filled"` and `color="error"`. */
-    filledError: {
-      color: '#fff',
-      fontWeight: theme.typography.fontWeightMedium,
-      backgroundColor: theme.palette.error.main,
-    },
-    /* Styles applied to the icon wrapper element. */
-    icon: {
-      marginRight: 12,
-      padding: '7px 0',
-      display: 'flex',
-      fontSize: 22,
-      opacity: 0.9,
-    },
-    /* Styles applied to the message wrapper element. */
-    message: {
-      padding: '8px 0',
-    },
-    /* Styles applied to the action wrapper element if `action` is provided. */
-    action: {
-      display: 'flex',
-      alignItems: 'center',
-      marginLeft: 'auto',
-      paddingLeft: 16,
-      marginRight: -8,
-    },
+    ...(styleProps.variant === 'filled' &&
+      styleProps.color === 'error' && {
+        color: '#fff',
+        fontWeight: theme.typography.fontWeightMedium,
+        backgroundColor: theme.palette.error.main,
+      }),
   };
-};
+});
+
+/* Styles applied to the icon wrapper element. */
+const AlertIcon = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiAlert',
+    slot: 'Icon',
+  },
+)({
+  marginRight: 12,
+  padding: '7px 0',
+  display: 'flex',
+  fontSize: 22,
+  opacity: 0.9,
+});
+
+/* Styles applied to the message wrapper element. */
+const AlertMessage = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiAlert',
+    slot: 'Message',
+  },
+)({
+  padding: '8px 0',
+});
+
+/* Styles applied to the action wrapper element if `action` is provided. */
+const AlertAction = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiAlert',
+    slot: 'Message',
+  },
+)({
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: 'auto',
+  paddingLeft: 16,
+  marginRight: -8,
+});
 
 const defaultIconMapping = {
   success: <SuccessOutlinedIcon fontSize="inherit" />,
@@ -154,7 +220,6 @@ const Alert = React.forwardRef(function Alert(props, ref) {
   const {
     action,
     children,
-    classes,
     className,
     closeText = 'Close',
     color,
@@ -166,6 +231,15 @@ const Alert = React.forwardRef(function Alert(props, ref) {
     variant = 'standard',
     ...other
   } = props;
+
+  const styleProps = {
+    ...other,
+    variant,
+    color,
+    severity,
+  };
+
+  const classes = useUtilityClasses(styleProps);
 
   const themeVariantsClasses = useThemeVariants(
     {
@@ -180,29 +254,23 @@ const Alert = React.forwardRef(function Alert(props, ref) {
   );
 
   return (
-    <Paper
+    <AlertRoot
       role={role}
       square
       elevation={0}
-      className={clsx(
-        classes.root,
-        classes[variant],
-        classes[`${variant}${capitalize(color || severity)}`],
-        themeVariantsClasses,
-        className,
-      )}
+      className={clsx(classes.root, classes[variant], themeVariantsClasses, className)}
       ref={ref}
       {...other}
     >
       {icon !== false ? (
-        <div className={classes.icon}>
+        <AlertIcon className={classes.icon}>
           {icon || iconMapping[severity] || defaultIconMapping[severity]}
-        </div>
+        </AlertIcon>
       ) : null}
-      <div className={classes.message}>{children}</div>
-      {action != null ? <div className={classes.action}>{action}</div> : null}
+      <AlertMessage className={classes.message}>{children}</AlertMessage>
+      {action != null ? <AlertAction className={classes.action}>{action}</AlertAction> : null}
       {action == null && onClose ? (
-        <div className={classes.action}>
+        <AlertAction className={classes.action}>
           <IconButton
             size="small"
             aria-label={closeText}
@@ -212,9 +280,9 @@ const Alert = React.forwardRef(function Alert(props, ref) {
           >
             <CloseIcon fontSize="small" />
           </IconButton>
-        </div>
+        </AlertAction>
       ) : null}
-    </Paper>
+    </AlertRoot>
   );
 });
 
@@ -285,6 +353,10 @@ Alert.propTypes = {
    */
   severity: PropTypes.oneOf(['error', 'info', 'success', 'warning']),
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The variant to use.
    * @default 'standard'
    */
@@ -294,4 +366,4 @@ Alert.propTypes = {
   ]),
 };
 
-export default withStyles(styles, { name: 'MuiAlert' })(Alert);
+export default Alert;

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -61,7 +61,8 @@ const AlertRoot = experimentalStyled(
     display: 'flex',
     padding: '6px 16px',
     /* Styles applied to the root element if variant="standard". */
-    ...(color && styleProps.variant === 'standard' && {
+    ...(color &&
+      styleProps.variant === 'standard' && {
         color: getColor(theme.palette[color].main, 0.6),
         backgroundColor: getBackgroundColor(theme.palette[color].main, 0.9),
         [`& .${alertClasses.icon}`]: {
@@ -69,7 +70,8 @@ const AlertRoot = experimentalStyled(
         },
       }),
     /* Styles applied to the root element if variant="outlined". */
-    ...(color && styleProps.variant === 'outlined' && {
+    ...(color &&
+      styleProps.variant === 'outlined' && {
         color: getColor(theme.palette[color].main, 0.6),
         border: `1px solid ${theme.palette[color].main}`,
         [`& .${alertClasses.icon}`]: {
@@ -77,7 +79,8 @@ const AlertRoot = experimentalStyled(
         },
       }),
     /* Styles applied to the root element if variant="filled". */
-    ...(color && styleProps.variant === 'filled' && {
+    ...(color &&
+      styleProps.variant === 'filled' && {
         color: '#fff',
         fontWeight: theme.typography.fontWeightMedium,
         backgroundColor: theme.palette[color].main,

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -51,6 +51,7 @@ const AlertRoot = experimentalStyled(
 )(({ theme, styleProps }) => {
   const getColor = theme.palette.mode === 'light' ? darken : lighten;
   const getBackgroundColor = theme.palette.mode === 'light' ? lighten : darken;
+  const color = styleProps.color || styleProps.severity;
 
   return {
     /* Styles applied to the root element. */
@@ -60,29 +61,26 @@ const AlertRoot = experimentalStyled(
     display: 'flex',
     padding: '6px 16px',
     /* Styles applied to the root element if variant="standard". */
-    ...(styleProps.variant === 'standard' &&
-      styleProps.color && {
-        color: getColor(theme.palette[styleProps.color].main, 0.6),
-        backgroundColor: getBackgroundColor(theme.palette[styleProps.color].main, 0.9),
+    ...(color && styleProps.variant === 'standard' && {
+        color: getColor(theme.palette[color].main, 0.6),
+        backgroundColor: getBackgroundColor(theme.palette[color].main, 0.9),
         [`& .${alertClasses.icon}`]: {
-          color: theme.palette[styleProps.color].main,
+          color: theme.palette[color].main,
         },
       }),
     /* Styles applied to the root element if variant="outlined". */
-    ...(styleProps.variant === 'outlined' &&
-      styleProps.color && {
-        color: getColor(theme.palette[styleProps.color].main, 0.6),
-        border: `1px solid ${theme.palette[styleProps.color].main}`,
+    ...(color && styleProps.variant === 'outlined' && {
+        color: getColor(theme.palette[color].main, 0.6),
+        border: `1px solid ${theme.palette[color].main}`,
         [`& .${alertClasses.icon}`]: {
-          color: theme.palette[styleProps.color].main,
+          color: theme.palette[color].main,
         },
       }),
     /* Styles applied to the root element if variant="filled". */
-    ...(styleProps.variant === 'filled' &&
-      styleProps.color && {
+    ...(color && styleProps.variant === 'filled' && {
         color: '#fff',
         fontWeight: theme.typography.fontWeightMedium,
-        backgroundColor: theme.palette[styleProps.color].main,
+        backgroundColor: theme.palette[color].main,
       }),
   };
 });

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -258,6 +258,7 @@ const Alert = React.forwardRef(function Alert(props, ref) {
       role={role}
       square
       elevation={0}
+      styleProps={styleProps}
       className={clsx(classes.root, classes[variant], themeVariantsClasses, className)}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -60,7 +60,8 @@ const AlertRoot = experimentalStyled(
     display: 'flex',
     padding: '6px 16px',
     /* Styles applied to the root element if variant="standard". */
-    ...(styleProps.variant === 'standard' && styleProps.color && {
+    ...(styleProps.variant === 'standard' &&
+      styleProps.color && {
         color: getColor(theme.palette[styleProps.color].main, 0.6),
         backgroundColor: getBackgroundColor(theme.palette[styleProps.color].main, 0.9),
         [`& .${alertClasses.icon}`]: {
@@ -68,7 +69,8 @@ const AlertRoot = experimentalStyled(
         },
       }),
     /* Styles applied to the root element if variant="outlined". */
-    ...(styleProps.variant === 'outlined' && styleProps.color && {
+    ...(styleProps.variant === 'outlined' &&
+      styleProps.color && {
         color: getColor(theme.palette[styleProps.color].main, 0.6),
         border: `1px solid ${theme.palette[styleProps.color].main}`,
         [`& .${alertClasses.icon}`]: {
@@ -76,7 +78,8 @@ const AlertRoot = experimentalStyled(
         },
       }),
     /* Styles applied to the root element if variant="filled". */
-    ...(styleProps.variant === 'filled' && styleProps.color && {
+    ...(styleProps.variant === 'filled' &&
+      styleProps.color && {
         color: '#fff',
         fontWeight: theme.typography.fontWeightMedium,
         backgroundColor: theme.palette[styleProps.color].main,

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -60,7 +60,7 @@ const AlertRoot = experimentalStyled(
     display: 'flex',
     padding: '6px 16px',
     /* Styles applied to the root element if variant="standard". */
-    ...(styleProps.variant === 'standard' && {
+    ...(styleProps.variant === 'standard' && styleProps.color && {
         color: getColor(theme.palette[styleProps.color].main, 0.6),
         backgroundColor: getBackgroundColor(theme.palette[styleProps.color].main, 0.9),
         [`& .${alertClasses.icon}`]: {
@@ -68,7 +68,7 @@ const AlertRoot = experimentalStyled(
         },
       }),
     /* Styles applied to the root element if variant="outlined". */
-    ...(styleProps.variant === 'outlined' && {
+    ...(styleProps.variant === 'outlined' && styleProps.color && {
         color: getColor(theme.palette[styleProps.color].main, 0.6),
         border: `1px solid ${theme.palette[styleProps.color].main}`,
         [`& .${alertClasses.icon}`]: {
@@ -76,7 +76,7 @@ const AlertRoot = experimentalStyled(
         },
       }),
     /* Styles applied to the root element if variant="filled". */
-    ...(styleProps.variant === 'filled' && {
+    ...(styleProps.variant === 'filled' && styleProps.color && {
         color: '#fff',
         fontWeight: theme.typography.fontWeightMedium,
         backgroundColor: theme.palette[styleProps.color].main,

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -8,7 +8,7 @@ import experimentalStyled from '../styles/experimentalStyled';
 import { darken, lighten } from '../styles/colorManipulator';
 import capitalize from '../utils/capitalize';
 import Paper from '../Paper';
-import { getAppBarUtilityClass } from './alertClasses';
+import { getAlertUtilityClass } from './alertClasses';
 import IconButton from '../IconButton';
 import SuccessOutlinedIcon from '../internal/svg-icons/SuccessOutlined';
 import ReportProblemOutlinedIcon from '../internal/svg-icons/ReportProblemOutlined';
@@ -34,7 +34,7 @@ const useUtilityClasses = (styleProps) => {
     action: ['action'],
   };
 
-  return composeClasses(slots, getAppBarUtilityClass, classes);
+  return composeClasses(slots, getAlertUtilityClass, classes);
 };
 
 const AlertRoot = experimentalStyled(

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -20,7 +20,11 @@ const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
   return deepmerge(styles.root || {}, {
+    ...styles[styleProps.variant],
     ...styles[`${styleProps.variant}${capitalize(styleProps.color || styleProps.severity)}`],
+    [`& .${avatarClasses.icon}`]: styles.icon,
+    [`& .${avatarClasses.message}`]: styles.message,
+    [`& .${avatarClasses.action}`]: styles.action,
   });
 };
 

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
 import { darken, lighten } from '../styles/colorManipulator';
 import capitalize from '../utils/capitalize';
 import Paper from '../Paper';
@@ -139,7 +140,8 @@ const defaultIconMapping = {
   info: <InfoOutlinedIcon fontSize="inherit" />,
 };
 
-const Alert = React.forwardRef(function Alert(props, ref) {
+const Alert = React.forwardRef(function Alert(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiAlert' });
   const {
     action,
     children,
@@ -175,14 +177,16 @@ const Alert = React.forwardRef(function Alert(props, ref) {
       {...other}
     >
       {icon !== false ? (
-        <AlertIcon className={classes.icon}>
+        <AlertIcon styleProps={styleProps} className={classes.icon}>
           {icon || iconMapping[severity] || defaultIconMapping[severity]}
         </AlertIcon>
       ) : null}
-      <AlertMessage className={classes.message}>{children}</AlertMessage>
+      <AlertMessage styleProps={styleProps} className={classes.message}>
+        {children}
+      </AlertMessage>
       {action != null ? <AlertAction className={classes.action}>{action}</AlertAction> : null}
       {action == null && onClose ? (
-        <AlertAction className={classes.action}>
+        <AlertAction styleProps={styleProps} className={classes.action}>
           <IconButton
             size="small"
             aria-label={closeText}

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -123,7 +123,7 @@ const AlertAction = experimentalStyled(
   {},
   {
     name: 'MuiAlert',
-    slot: 'Message',
+    slot: 'Action',
   },
 )({
   display: 'flex',

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { useThemeVariants } from '@material-ui/styles';
 import experimentalStyled from '../styles/experimentalStyled';
 import { darken, lighten } from '../styles/colorManipulator';
 import capitalize from '../utils/capitalize';
 import Paper from '../Paper';
-import { getAlertUtilityClass } from './alertClasses';
+import alertClasses, { getAlertUtilityClass } from './alertClasses';
 import IconButton from '../IconButton';
 import SuccessOutlinedIcon from '../internal/svg-icons/SuccessOutlined';
 import ReportProblemOutlinedIcon from '../internal/svg-icons/ReportProblemOutlined';
@@ -22,9 +21,9 @@ const overridesResolver = (props, styles) => {
   return deepmerge(styles.root || {}, {
     ...styles[styleProps.variant],
     ...styles[`${styleProps.variant}${capitalize(styleProps.color || styleProps.severity)}`],
-    [`& .${avatarClasses.icon}`]: styles.icon,
-    [`& .${avatarClasses.message}`]: styles.message,
-    [`& .${avatarClasses.action}`]: styles.action,
+    [`& .${alertClasses.icon}`]: styles.icon,
+    [`& .${alertClasses.message}`]: styles.message,
+    [`& .${alertClasses.action}`]: styles.action,
   });
 };
 
@@ -32,7 +31,7 @@ const useUtilityClasses = (styleProps) => {
   const { variant, color, severity, classes } = styleProps;
 
   const slots = {
-    root: ['root', `${variant}${capitalize(color || severity)}`],
+    root: ['root', `${variant}${capitalize(color || severity)}`, `${variant}`],
     icon: ['icon'],
     message: ['message'],
     action: ['action'],
@@ -60,111 +59,27 @@ const AlertRoot = experimentalStyled(
     backgroundColor: 'transparent',
     display: 'flex',
     padding: '6px 16px',
-    /* Styles applied to the root element if `variant="filled"`. */
-    filled: {},
-    /* Styles applied to the root element if `variant="outlined"`. */
-    outlined: {},
-    /* Styles applied to the root element if `variant="standard"`. */
-    standard: {},
-    /* Styles applied to the root element if `variant="standard"` and `color="success"`. */
-    ...(styleProps.variant === 'standard' &&
-      styleProps.color === 'success' && {
-        color: getColor(theme.palette.success.main, 0.6),
-        backgroundColor: getBackgroundColor(theme.palette.success.main, 0.9),
-        '& $icon': {
-          color: theme.palette.success.main,
+    /* Styles applied to the root element if variant="standard". */
+    ...(styleProps.variant === 'standard' && {
+        color: getColor(theme.palette[styleProps.color].main, 0.6),
+        backgroundColor: getBackgroundColor(theme.palette[styleProps.color].main, 0.9),
+        [`& .${alertClasses.icon}`]: {
+          color: theme.palette[styleProps.color].main,
         },
       }),
-    /* Styles applied to the root element if `variant="standard"` and `color="info"`. */
-    ...(styleProps.variant === 'standard' &&
-      styleProps.color === 'info' && {
-        color: getColor(theme.palette.info.main, 0.6),
-        backgroundColor: getBackgroundColor(theme.palette.info.main, 0.9),
-        '& $icon': {
-          color: theme.palette.info.main,
+    /* Styles applied to the root element if variant="outlined". */
+    ...(styleProps.variant === 'outlined' && {
+        color: getColor(theme.palette[styleProps.color].main, 0.6),
+        border: `1px solid ${theme.palette[styleProps.color].main}`,
+        [`& .${alertClasses.icon}`]: {
+          color: theme.palette[styleProps.color].main,
         },
       }),
-    /* Styles applied to the root element if `variant="standard"` and `color="warning"`. */
-    ...(styleProps.variant === 'standard' &&
-      styleProps.color === 'warning' && {
-        color: getColor(theme.palette.warning.main, 0.6),
-        backgroundColor: getBackgroundColor(theme.palette.warning.main, 0.9),
-        '& $icon': {
-          color: theme.palette.warning.main,
-        },
-      }),
-    /* Styles applied to the root element if `variant="standard"` and `color="error"`. */
-    ...(styleProps.variant === 'standard' &&
-      styleProps.color === 'error' && {
-        color: getColor(theme.palette.error.main, 0.6),
-        backgroundColor: getBackgroundColor(theme.palette.error.main, 0.9),
-        '& $icon': {
-          color: theme.palette.error.main,
-        },
-      }),
-    /* Styles applied to the root element if `variant="outlined"` and `color="success"`. */
-    ...(styleProps.variant === 'outlined' &&
-      styleProps.color === 'success' && {
-        color: getColor(theme.palette.success.main, 0.6),
-        border: `1px solid ${theme.palette.success.main}`,
-        '& $icon': {
-          color: theme.palette.success.main,
-        },
-      }),
-    /* Styles applied to the root element if `variant="outlined"` and `color="info"`. */
-    ...(styleProps.variant === 'outlined' &&
-      styleProps.color === 'info' && {
-        color: getColor(theme.palette.info.main, 0.6),
-        border: `1px solid ${theme.palette.info.main}`,
-        '& $icon': {
-          color: theme.palette.info.main,
-        },
-      }),
-    /* Styles applied to the root element if `variant="outlined"` and `color="warning"`. */
-    ...(styleProps.variant === 'outlined' &&
-      styleProps.color === 'warning' && {
-        color: getColor(theme.palette.warning.main, 0.6),
-        border: `1px solid ${theme.palette.warning.main}`,
-        '& $icon': {
-          color: theme.palette.warning.main,
-        },
-      }),
-    /* Styles applied to the root element if `variant="outlined"` and `color="error"`. */
-    ...(styleProps.variant === 'outlined' &&
-      styleProps.color === 'error' && {
-        color: getColor(theme.palette.error.main, 0.6),
-        border: `1px solid ${theme.palette.error.main}`,
-        '& $icon': {
-          color: theme.palette.error.main,
-        },
-      }),
-    /* Styles applied to the root element if `variant="filled"` and `color="success"`. */
-    ...(styleProps.variant === 'filled' &&
-      styleProps.color === 'success' && {
+    /* Styles applied to the root element if variant="filled". */
+    ...(styleProps.variant === 'filled' && {
         color: '#fff',
         fontWeight: theme.typography.fontWeightMedium,
-        backgroundColor: theme.palette.success.main,
-      }),
-    /* Styles applied to the root element if `variant="filled"` and `color="info"`. */
-    ...(styleProps.variant === 'filled' &&
-      styleProps.color === 'info' && {
-        color: '#fff',
-        fontWeight: theme.typography.fontWeightMedium,
-        backgroundColor: theme.palette.info.main,
-      }),
-    /* Styles applied to the root element if `variant="filled"` and `color="warning"`. */
-    ...(styleProps.variant === 'filled' &&
-      styleProps.color === 'warning' && {
-        color: '#fff',
-        fontWeight: theme.typography.fontWeightMedium,
-        backgroundColor: theme.palette.warning.main,
-      }),
-    /* Styles applied to the root element if `variant="filled"` and `color="error"`. */
-    ...(styleProps.variant === 'filled' &&
-      styleProps.color === 'error' && {
-        color: '#fff',
-        fontWeight: theme.typography.fontWeightMedium,
-        backgroundColor: theme.palette.error.main,
+        backgroundColor: theme.palette[styleProps.color].main,
       }),
   };
 });
@@ -245,25 +160,13 @@ const Alert = React.forwardRef(function Alert(props, ref) {
 
   const classes = useUtilityClasses(styleProps);
 
-  const themeVariantsClasses = useThemeVariants(
-    {
-      ...props,
-      closeText,
-      iconMapping,
-      role,
-      severity,
-      variant,
-    },
-    'MuiAlert',
-  );
-
   return (
     <AlertRoot
       role={role}
       square
       elevation={0}
       styleProps={styleProps}
-      className={clsx(classes.root, classes[variant], themeVariantsClasses, className)}
+      className={clsx(classes.root, className)}
       ref={ref}
       {...other}
     >

--- a/packages/material-ui/src/Alert/Alert.test.js
+++ b/packages/material-ui/src/Alert/Alert.test.js
@@ -1,15 +1,11 @@
 import * as React from 'react';
-import { getClasses, createMount, describeConformance } from 'test/utils';
+import { createMount, describeConformance } from 'test/utils';
+import classes from './alertClasses';
 import Paper from '../Paper';
 import Alert from './Alert';
 
 describe('<Alert />', () => {
   const mount = createMount();
-  let classes;
-
-  before(() => {
-    classes = getClasses(<Alert />);
-  });
 
   describeConformance(<Alert />, () => ({
     classes,

--- a/packages/material-ui/src/Alert/Alert.test.js
+++ b/packages/material-ui/src/Alert/Alert.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMount, describeConformance } from 'test/utils';
+import { createMount, describeConformanceV5 } from 'test/utils';
 import classes from './alertClasses';
 import Paper from '../Paper';
 import Alert from './Alert';
@@ -7,11 +7,13 @@ import Alert from './Alert';
 describe('<Alert />', () => {
   const mount = createMount();
 
-  describeConformance(<Alert />, () => ({
+  describeConformanceV5(<Alert />, () => ({
     classes,
     inheritComponent: Paper,
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiAlert',
+    skip: ['componentsProp'],
+    testVariantProps: { variant: 'standard', color: 'success' },
   }));
 });

--- a/packages/material-ui/src/Alert/Alert.test.js
+++ b/packages/material-ui/src/Alert/Alert.test.js
@@ -13,7 +13,8 @@ describe('<Alert />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAlert',
-    skip: ['componentsProp'],
     testVariantProps: { variant: 'standard', color: 'success' },
+    testDeepOverrides: { slotName: 'message', slotClassName: classes.message },
+    skip: ['componentsProp'],
   }));
 });

--- a/packages/material-ui/src/Alert/alertClasses.d.ts
+++ b/packages/material-ui/src/Alert/alertClasses.d.ts
@@ -1,0 +1,21 @@
+export interface AlertClasses {
+  root: string;
+  filledSuccess: string,
+  filledInfo: string,
+  filledWarning: string,
+  filledError: string,
+  outlinedSuccess: string,
+  outlinedInfo: string,
+  outlinedWarning: string,
+  outlinedError: string,
+  standardSuccess: string,
+  standardInfo: string,
+  standardWarning: string,
+  standardError: string,
+}
+
+declare const alertClasses: AlertClasses;
+
+export function getAlertUtilityClass(slot: string): string;
+
+export default alertClasses;

--- a/packages/material-ui/src/Alert/alertClasses.d.ts
+++ b/packages/material-ui/src/Alert/alertClasses.d.ts
@@ -1,17 +1,20 @@
 export interface AlertClasses {
   root: string;
-  filledSuccess: string,
-  filledInfo: string,
-  filledWarning: string,
-  filledError: string,
-  outlinedSuccess: string,
-  outlinedInfo: string,
-  outlinedWarning: string,
-  outlinedError: string,
-  standardSuccess: string,
-  standardInfo: string,
-  standardWarning: string,
-  standardError: string,
+  action: string;  
+  icon: string;
+  message: string;
+  filledSuccess: string;
+  filledInfo: string;
+  filledWarning: string;
+  filledError: string;
+  outlinedSuccess: string;
+  outlinedInfo: string;
+  outlinedWarning: string;
+  outlinedError: string;
+  standardSuccess: string;
+  standardInfo: string;
+  standardWarning: string;
+  standardError: string;
 }
 
 declare const alertClasses: AlertClasses;

--- a/packages/material-ui/src/Alert/alertClasses.d.ts
+++ b/packages/material-ui/src/Alert/alertClasses.d.ts
@@ -1,6 +1,6 @@
 export interface AlertClasses {
   root: string;
-  action: string;  
+  action: string;
   icon: string;
   message: string;
   filledSuccess: string;

--- a/packages/material-ui/src/Alert/alertClasses.js
+++ b/packages/material-ui/src/Alert/alertClasses.js
@@ -6,7 +6,7 @@ export function getAlertUtilityClass(slot) {
 
 const alertClasses = generateUtilityClasses('MuiAlert', [
   'root',
-  'action',  
+  'action',
   'icon',
   'message',
   'filledSuccess',

--- a/packages/material-ui/src/Alert/alertClasses.js
+++ b/packages/material-ui/src/Alert/alertClasses.js
@@ -6,6 +6,9 @@ export function getAlertUtilityClass(slot) {
 
 const alertClasses = generateUtilityClasses('MuiAlert', [
   'root',
+  'action',  
+  'icon',
+  'message',
   'filledSuccess',
   'filledInfo',
   'filledWarning',

--- a/packages/material-ui/src/Alert/alertClasses.js
+++ b/packages/material-ui/src/Alert/alertClasses.js
@@ -1,0 +1,23 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getAlertUtilityClass(slot) {
+  return generateUtilityClass('MuiAlert', slot);
+}
+
+const alertClasses = generateUtilityClasses('MuiAlert', [
+  'root',
+  'filledSuccess',
+  'filledInfo',
+  'filledWarning',
+  'filledError',
+  'outlinedSuccess',
+  'outlinedInfo',
+  'outlinedWarning',
+  'outlinedError',
+  'standardSuccess',
+  'standardInfo',
+  'standardWarning',
+  'standardError',
+]);
+
+export default alertClasses;

--- a/packages/material-ui/src/Alert/index.d.ts
+++ b/packages/material-ui/src/Alert/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './Alert';
 export * from './Alert';
+
+export { default as alertClasses } from './alertClasses';
+export * from './alertClasses';

--- a/packages/material-ui/src/Alert/index.js
+++ b/packages/material-ui/src/Alert/index.js
@@ -1,1 +1,4 @@
 export { default } from './Alert';
+
+export { default as alertClasses } from './alertClasses';
+export * from './alertClasses';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I took a first stab at the Alert component for the emotion migration. One of #24405.

I have not yet figured out how to test and I would say generally a bit confused exactly how `overridesResolver` and `useUtilityClasses` works but I'll be figuring that out the next few days.  I'm opening this now 1) in case anyone wants to add some pointers 😅  and 2) so no one duplicates the work.  

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
