### PR TITLE
[Checkbox][Switch] Document defaultChecked

### DIFF
--- a/docs/pages/api-docs/checkbox.json
+++ b/docs/pages/api-docs/checkbox.json
@@ -10,6 +10,7 @@
       },
       "default": "'secondary'"
     },
+    "defaultChecked": { "type": { "name": "bool" } },
     "disabled": { "type": { "name": "bool" } },
     "disableRipple": { "type": { "name": "bool" } },
     "icon": { "type": { "name": "node" }, "default": "<CheckBoxOutlineBlankIcon />" },

--- a/docs/pages/api-docs/switch.json
+++ b/docs/pages/api-docs/switch.json
@@ -10,6 +10,7 @@
       },
       "default": "'secondary'"
     },
+    "defaultChecked": { "type": { "name": "bool" } },
     "disabled": { "type": { "name": "bool" } },
     "disableRipple": { "type": { "name": "bool" } },
     "edge": {

--- a/docs/translations/api-docs/checkbox/checkbox.json
+++ b/docs/translations/api-docs/checkbox/checkbox.json
@@ -5,6 +5,7 @@
     "checkedIcon": "The icon to display when the component is checked.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultChecked": "The default checked state. Use when the component is not controlled.",
     "disabled": "If <code>true</code>, the component is disabled.",
     "disableRipple": "If <code>true</code>, the ripple effect is disabled.",
     "icon": "The icon to display when the component is unchecked.",

--- a/docs/translations/api-docs/switch/switch.json
+++ b/docs/translations/api-docs/switch/switch.json
@@ -5,6 +5,7 @@
     "checkedIcon": "The icon to display when the component is checked.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultChecked": "The default checked state. Use when the component is not controlled.",
     "disabled": "If <code>true</code>, the component is disabled.",
     "disableRipple": "If <code>true</code>, the ripple effect is disabled.",
     "edge": "If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape).",

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -6,6 +6,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 interface Props {
   checked: boolean;
   color: 'default' | 'primary' | 'secondary';
+  defaultChecked?: boolean;
   disabled: boolean;
   size: 'medium' | 'small';
   label: string;
@@ -53,6 +54,10 @@ addPropertyControls(Checkbox, {
     type: ControlType.Enum,
     title: 'Color',
     options: ['default', 'primary', 'secondary'],
+  },
+  defaultChecked: {
+    type: ControlType.Boolean,
+    title: 'Default checked',
   },
   disabled: {
     type: ControlType.Boolean,

--- a/framer/Material-UI.framerfx/code/Switch.tsx
+++ b/framer/Material-UI.framerfx/code/Switch.tsx
@@ -6,6 +6,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 interface Props {
   checked: boolean;
   color: 'default' | 'primary' | 'secondary';
+  defaultChecked?: boolean;
   disabled: boolean;
   size: 'medium' | 'small';
   label: string;
@@ -59,6 +60,10 @@ addPropertyControls(Switch, {
     type: ControlType.Enum,
     title: 'Color',
     options: ['default', 'primary', 'secondary'],
+  },
+  defaultChecked: {
+    type: ControlType.Boolean,
+    title: 'Default checked',
   },
   disabled: {
     type: ControlType.Boolean,

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -130,6 +130,10 @@ Checkbox.propTypes = {
    */
   color: PropTypes.oneOf(['default', 'primary', 'secondary']),
   /**
+   * The default checked state. Use when the component is not controlled.
+   */
+  defaultChecked: PropTypes.bool,
+  /**
    * If `true`, the component is disabled.
    */
   disabled: PropTypes.bool,

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -218,7 +218,7 @@ Switch.propTypes = {
    */
   color: PropTypes.oneOf(['default', 'primary', 'secondary']),
   /**
-   * @ignore
+   * The default checked state. Use when the component is not controlled.
    */
   defaultChecked: PropTypes.bool,
   /**

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -19,6 +19,9 @@ export interface SwitchBaseProps
     disabled?: string;
     inpit?: string;
   };
+  /**
+   * The default checked state. Use when the component is not controlled.
+   */
   defaultChecked?: boolean;
   disabled?: boolean;
   /**

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -112,6 +112,7 @@ const useExternalDocumentation: Record<string, '*' | string[]> = {
   MenuItem: ['dense'],
   OutlinedInput: useExternalPropsFromInputBase,
   Radio: ['disableRipple', 'id', 'inputProps', 'inputRef', 'required'],
+  Checkbox: ['defaultChecked'],
   Switch: [
     'checked',
     'defaultChecked',


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Adds proptype for native checkbox prop defaultChecked. Generates docs for defaultChecked prop for Switch and Checkbox components.

### Why is it needed?
Does prop validation for defaultChecked prop in Checkbox component.

### Related issue(s)/PR(s)
Closes #24426 
