### PR TITLE
[core] Pass styleProps on all slots in the styled() components

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -171,6 +171,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
         src={src}
         srcSet={srcSet}
         sizes={sizes}
+        styleProps={styleProps}
         className={classes.img}
         {...imgProps}
       />

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -363,7 +363,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
        * https://github.com/philipwalton/flexbugs/blob/master/README.md#flexbug-9
        * TODO v5: evaluate if still required for the supported browsers.
        */}
-      <ButtonLabel className={classes.label}>
+      <ButtonLabel className={classes.label} styleProps={styleProps}>
         {startIcon}
         {children}
         {endIcon}


### PR DESCRIPTION
So far we've been passing styleProps on the slots that actually use these props in the styled functions. However, I belive it's better for consistency to send them to all slots, as future changes to the styled function won't require changes like this.