### PR TITLE
[test] Split tests in describeConformanceV5 to isolate them

### DIFF
--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -48,7 +48,13 @@ describe('<TouchRipple />', () => {
     inheritComponent: 'span',
     mount,
     refInstanceof: Object,
-    skip: ['componentsProp', 'refForwarding', 'themeComponents'],
+    skip: [
+      'componentsProp',
+      'refForwarding',
+      'themeDefaultProps',
+      'themeStyleOverrides',
+      'themeVariants',
+    ],
   }));
 
   describe('prop: center', () => {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -51,7 +51,6 @@ describe('<TouchRipple />', () => {
     skip: [
       'componentsProp',
       'refForwarding',
-      'themeDefaultProps',
       'themeStyleOverrides',
       'themeVariants',
     ],

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -49,12 +49,7 @@ describe('<TouchRipple />', () => {
     mount,
     refInstanceof: Object,
     muiName: 'MuiTouchRipple',
-    skip: [
-      'componentsProp',
-      'refForwarding',
-      'themeStyleOverrides',
-      'themeVariants',
-    ],
+    skip: ['componentsProp', 'refForwarding', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   describe('prop: center', () => {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -48,6 +48,7 @@ describe('<TouchRipple />', () => {
     inheritComponent: 'span',
     mount,
     refInstanceof: Object,
+    muiName: 'MuiTouchRipple',
     skip: [
       'componentsProp',
       'refForwarding',

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -31,15 +31,15 @@ function testComponentsProp(element, getOptions) {
 }
 
 /**
- * Material-UI theme has a components section that allows specifying default props, overrides and variants
+ * Material-UI theme has a components section that allows specifying default props.
  * Components from @inheritComponent
  * @param {React.ReactElement} element
  * @param {() => ConformanceOptions} getOptions
  */
-function testThemeComponents(element, getOptions) {
+function testThemeDefaultProps(element, getOptions) {
   const render = createClientRender();
 
-  describe('theme: components', () => {
+  describe('theme: default components', () => {
     it("respect theme's defaultProps", () => {
       const { muiName, testThemeComponentsDefaultPropName: testProp = 'id' } = getOptions();
       const theme = createMuiTheme({
@@ -56,7 +56,19 @@ function testThemeComponents(element, getOptions) {
 
       expect(container.firstChild).to.have.attribute(testProp, 'testProp');
     });
+  });
+}
 
+/**
+ * Material-UI theme has a components section that allows specifying style overrides.
+ * Components from @inheritComponent
+ * @param {React.ReactElement} element
+ * @param {() => ConformanceOptions} getOptions
+ */
+function testThemeStyleOverrides(element, getOptions) {
+  const render = createClientRender();
+
+  describe('theme: style overrides', () => {
     it("respect theme's styleOverrides custom state", () => {
       const { muiName, testStateOverrides } = getOptions();
 
@@ -158,7 +170,19 @@ function testThemeComponents(element, getOptions) {
         });
       }
     });
+  });
+}
 
+/**
+ * Material-UI theme has a components section that allows specifying custom variants.
+ * Components from @inheritComponent
+ * @param {React.ReactElement} element
+ * @param {() => ConformanceOptions} getOptions
+ */
+function testThemeVariants(element, getOptions) {
+  const render = createClientRender();
+
+  describe('theme: variants', () => {
     it("respect theme's variants", () => {
       const { muiName, testVariantProps = {} } = getOptions();
 
@@ -199,7 +223,9 @@ const fullSuite = {
   refForwarding: describeRef,
   rootClass: testRootClass,
   reactTestRenderer: testReactTestRenderer,
-  themeComponents: testThemeComponents,
+  themeDefaultProps: testThemeDefaultProps,
+  themeStyleOverrides: testThemeStyleOverrides,
+  themeVariants: testThemeVariants,
 };
 
 /**


### PR DESCRIPTION
Inspired by https://github.com/mui-org/material-ui/pull/24448#discussion_r559097653

Some components does not support any styling props, so testing if the variants work does not make sense. However, so far we had the option to only disable all `theme.components` related test, not just one of them. This PR splits this tests to allow that scenario.