### PR TITLE
[docs] Compute spreadable from tests

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -39,7 +39,7 @@ interface ReactApi extends ReactDocgenApi {
   inheritance: { component: string; pathname: string } | null;
   name: string;
   pagesMarkdown: Array<{ components: string[]; filename: string; pathname: string }>;
-  spread: boolean;
+  spread: boolean | undefined;
   src: string;
   styles: {
     classes: string[];
@@ -1020,7 +1020,6 @@ async function buildDocs(options: {
   reactApi.name = name;
   reactApi.styles = styles;
   reactApi.pagesMarkdown = pagesMarkdown;
-  reactApi.spread = spread;
   reactApi.EOL = getLineFeed(src);
 
   // styled components does not have the options static
@@ -1035,6 +1034,7 @@ async function buildDocs(options: {
   const testInfo = await parseTest(componentObject.filename);
   // no Object.assign to visually check for collisions
   reactApi.forwardsRefTo = testInfo.forwardsRefTo;
+  reactApi.spread = testInfo.spread ?? spread;
 
   // Relative location in the file system.
   reactApi.filename = componentObject.filename.replace(workspaceRoot, '');

--- a/docs/src/modules/utils/parseTest.ts
+++ b/docs/src/modules/utils/parseTest.ts
@@ -95,9 +95,27 @@ function getInheritComponentName(valueNode: babel.types.Node): string | undefine
   return (valueNode as any).name;
 }
 
+function getSkippedTests(valueNode: babel.types.Node): string[] {
+  if (!babel.types.isArrayExpression(valueNode)) {
+    throw new TypeError(
+      `Unabled to determine skipped tests from '${valueNode.type}'. Expected an 'ArrayExpression' i.e. \`skippedTests: ["a", "b"]\`.`,
+    );
+  }
+
+  return valueNode.elements.map((element) => {
+    if (!babel.types.isStringLiteral(element)) {
+      throw new TypeError(
+        `Unable to determine skipped test from '${element?.type}'. Expected a 'StringLiter' i.e. \`"a"\`.`,
+      );
+    }
+    return element.value;
+  });
+}
+
 export interface ParseResult {
   forwardsRefTo: string | undefined;
   inheritComponent: string | undefined;
+  spread: boolean | undefined;
 }
 
 export default async function parseTest(componentFilename: string): Promise<ParseResult> {
@@ -123,12 +141,14 @@ export default async function parseTest(componentFilename: string): Promise<Pars
   const result: ParseResult = {
     forwardsRefTo: undefined,
     inheritComponent: undefined,
+    spread: undefined,
   };
 
   if (descriptor === null) {
     return result;
   }
 
+  let skippedTests: string[] = [];
   descriptor.properties.forEach((property) => {
     if (!babel.types.isObjectProperty(property)) {
       return;
@@ -143,10 +163,15 @@ export default async function parseTest(componentFilename: string): Promise<Pars
       case 'inheritComponent':
         result.inheritComponent = getInheritComponentName(property.value);
         break;
+      case 'skip':
+        skippedTests = getSkippedTests(property.value);
+        break;
       default:
         break;
     }
   });
+
+  result.spread = !skippedTests.includes('propsSpread');
 
   return result;
 }


### PR DESCRIPTION
We used `exactPropType = ` as an indicator for non spreadable props. From now on we will use this only as fallback and use parsing of `describeConformance` as the source of truth. 

This is less brittle (current "marker" relies on formatting and isn't tested when `describeConformance` isn't used) and will be required for API documentation of `*Picker` components.