### PR TITLE
[Grid] Add system props

### DIFF
--- a/docs/pages/api-docs/grid.json
+++ b/docs/pages/api-docs/grid.json
@@ -1,19 +1,5 @@
 {
   "props": {
-    "alignContent": {
-      "type": {
-        "name": "enum",
-        "description": "'center'<br>&#124;&nbsp;'flex-end'<br>&#124;&nbsp;'flex-start'<br>&#124;&nbsp;'space-around'<br>&#124;&nbsp;'space-between'<br>&#124;&nbsp;'stretch'"
-      },
-      "default": "'stretch'"
-    },
-    "alignItems": {
-      "type": {
-        "name": "enum",
-        "description": "'baseline'<br>&#124;&nbsp;'center'<br>&#124;&nbsp;'flex-end'<br>&#124;&nbsp;'flex-start'<br>&#124;&nbsp;'stretch'"
-      },
-      "default": "'stretch'"
-    },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
@@ -26,13 +12,6 @@
       "default": "'row'"
     },
     "item": { "type": { "name": "bool" } },
-    "justifyContent": {
-      "type": {
-        "name": "enum",
-        "description": "'center'<br>&#124;&nbsp;'flex-end'<br>&#124;&nbsp;'flex-start'<br>&#124;&nbsp;'space-around'<br>&#124;&nbsp;'space-between'<br>&#124;&nbsp;'space-evenly'"
-      },
-      "default": "'flex-start'"
-    },
     "lg": {
       "type": {
         "name": "union",
@@ -97,20 +76,6 @@
       "direction-xs-row-reverse",
       "wrap-xs-nowrap",
       "wrap-xs-wrap-reverse",
-      "align-items-xs-center",
-      "align-items-xs-flex-start",
-      "align-items-xs-flex-end",
-      "align-items-xs-baseline",
-      "align-content-xs-center",
-      "align-content-xs-flex-start",
-      "align-content-xs-flex-end",
-      "align-content-xs-space-between",
-      "align-content-xs-space-around",
-      "justify-content-xs-center",
-      "justify-content-xs-flex-end",
-      "justify-content-xs-space-between",
-      "justify-content-xs-space-around",
-      "justify-content-xs-space-evenly",
       "spacing-xs-1",
       "spacing-xs-2",
       "spacing-xs-3",

--- a/docs/src/pages/components/grid/InteractiveGrid.tsx
+++ b/docs/src/pages/components/grid/InteractiveGrid.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import Grid, {
-  GridItemsAlignment,
-  GridJustification,
-  GridDirection,
-} from '@material-ui/core/Grid';
+import Grid, { GridDirection } from '@material-ui/core/Grid';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -12,6 +8,21 @@ import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+
+type GridItemsAlignment =
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'stretch'
+  | 'baseline';
+
+type GridJustification =
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -136,3 +136,7 @@ If used, these props may have undesirable effects on the height of the `Grid` it
 Material-UI doesn't provide any CSS Grid functionality itself, but as seen below you can easily use CSS Grid to layout your pages.
 
 {{"demo": "pages/components/grid/CSSGrid.js", "bg": true}}
+
+## System props
+
+As a CSS utility component, the `Grid` supports all [`system`](/system/properties/) properties. You can use them as prop directly on the component.

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -139,4 +139,4 @@ Material-UI doesn't provide any CSS Grid functionality itself, but as seen below
 
 ## System props
 
-As a CSS utility component, the `Grid` supports all [`system`](/system/properties/) properties. You can use them as prop directly on the component.
+As a CSS utility component, the `Grid` supports all [`system`](/system/properties/) properties. You can use them as props directly on the component.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -672,6 +672,28 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Grid justifyContent="center">
   ```
 
+- The props: `alignItems` `alignContent` and `justifyContent` and their `classes` and style overrides keys were removed: "align-items-xs-center", "align-items-xs-flex-start", "align-items-xs-flex-end", "align-items-xs-baseline", "align-content-xs-center", "align-content-xs-flex-start", "align-content-xs-flex-end", "align-content-xs-space-between", "align-content-xs-space-around", "justify-content-xs-center", "justify-content-xs-flex-end", "justify-content-xs-space-between", "justify-content-xs-space-around" and "justify-content-xs-space-evenly". These props are now considered part of the system, not on the `Grid` component itself. If you still wish to add overrides for them, you can use the `theme.components.MuiGrid.variants` options. For example
+
+  ```diff
+  const theme = createMuiTheme({
+    components: {
+      MuiGrid: {
+  -     styleOverrides: {
+  -       "align-items-xs-flex-end": {
+  -         marginTop: '20px',
+  -       },
+  -     },
+  +     variants: {
+  +       props: { alignItems: "flex-end" },
+  +       style: {
+  +         marginTop: '20px',
+  +       },
+  +     }],
+      },
+    },
+  });
+  ```
+
 ### GridList
 
 - Rename the `GridList` components to `ImageList` to align with the current Material Design naming.

--- a/docs/translations/api-docs/grid/grid.json
+++ b/docs/translations/api-docs/grid/grid.json
@@ -1,15 +1,12 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "alignContent": "Defines the <code>align-content</code> style property. It&#39;s applied for all screen sizes.",
-    "alignItems": "Defines the <code>align-items</code> style property. It&#39;s applied for all screen sizes.",
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "container": "If <code>true</code>, the component will have the flex <em>container</em> behavior. You should be wrapping <em>items</em> with a <em>container</em>.",
     "direction": "Defines the <code>flex-direction</code> style property. It is applied for all screen sizes.",
     "item": "If <code>true</code>, the component will have the flex <em>item</em> behavior. You should be wrapping <em>items</em> with a <em>container</em>.",
-    "justifyContent": "Defines the <code>justify-content</code> style property. It is applied for all screen sizes.",
     "lg": "Defines the number of grids the component is going to use. It&#39;s applied for the <code>lg</code> breakpoint and wider screens if not overridden.",
     "md": "Defines the number of grids the component is going to use. It&#39;s applied for the <code>md</code> breakpoint and wider screens if not overridden.",
     "sm": "Defines the number of grids the component is going to use. It&#39;s applied for the <code>sm</code> breakpoint and wider screens if not overridden.",
@@ -61,76 +58,6 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>wrap=\"reverse\"</code>"
-    },
-    "align-items-xs-center": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignItems=\"center\"</code>"
-    },
-    "align-items-xs-flex-start": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignItems=\"flex-start\"</code>"
-    },
-    "align-items-xs-flex-end": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignItems=\"flex-end\"</code>"
-    },
-    "align-items-xs-baseline": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignItems=\"baseline\"</code>"
-    },
-    "align-content-xs-center": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignContent=\"center\"</code>"
-    },
-    "align-content-xs-flex-start": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignContent=\"flex-start\"</code>"
-    },
-    "align-content-xs-flex-end": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignContent=\"flex-end\"</code>"
-    },
-    "align-content-xs-space-between": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignContent=\"space-between\"</code>"
-    },
-    "align-content-xs-space-around": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>alignContent=\"space-around\"</code>"
-    },
-    "justify-content-xs-center": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>justifyContent=\"center\"</code>"
-    },
-    "justify-content-xs-flex-end": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>justifyContent=\"flex-end\"</code>"
-    },
-    "justify-content-xs-space-between": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>justifyContent=\"space-between\"</code>"
-    },
-    "justify-content-xs-space-around": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>justifyContent=\"space-around\"</code>"
-    },
-    "justify-content-xs-space-evenly": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>justifyContent=\"space-evenly\"</code>"
     }
   }
 }

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -288,6 +288,23 @@ export interface CSSOthersObjectForCSSObject {
   [propertiesName: string]: CSSInterpolation;
 }
 
+export type SystemProps = PropsFor<
+  ComposedStyleFunction<
+    [
+      typeof borders,
+      typeof display,
+      typeof flexbox,
+      typeof grid,
+      typeof palette,
+      typeof positions,
+      typeof shadows,
+      typeof sizing,
+      typeof spacing,
+      typeof typography
+    ]
+  >
+>;
+
 export {
   default as unstable_styleFunctionSx,
   extendSxProp as unstable_extendSxProp,

--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -1,38 +1,7 @@
 import * as React from 'react';
-import {
-  borders,
-  ComposedStyleFunction,
-  display,
-  flexbox,
-  grid,
-  palette,
-  positions,
-  shadows,
-  sizing,
-  spacing,
-  typography,
-  PropsFor,
-  SxProps,
-} from '@material-ui/system';
+import { SystemProps, SxProps } from '@material-ui/system';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Theme } from '../styles/createMuiTheme';
-
-type SystemProps = PropsFor<
-  ComposedStyleFunction<
-    [
-      typeof borders,
-      typeof display,
-      typeof flexbox,
-      typeof grid,
-      typeof palette,
-      typeof positions,
-      typeof shadows,
-      typeof sizing,
-      typeof spacing,
-      typeof typography
-    ]
-  >
->;
 
 export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -1,29 +1,11 @@
 import * as React from 'react';
-import { SxProps } from '@material-ui/system';
+import { SxProps, SystemProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
-
-export type GridItemsAlignment = 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';
-
-export type GridContentAlignment =
-  | 'stretch'
-  | 'center'
-  | 'flex-start'
-  | 'flex-end'
-  | 'space-between'
-  | 'space-around';
 
 export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
 export type GridSpacing = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
-
-export type GridJustification =
-  | 'flex-start'
-  | 'center'
-  | 'flex-end'
-  | 'space-between'
-  | 'space-around'
-  | 'space-evenly';
 
 export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
@@ -32,175 +14,130 @@ export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 export type GridClassKey = keyof NonNullable<GridTypeMap['props']['classes']>;
 
 export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
-    /**
-     * Defines the `align-content` style property.
-     * It's applied for all screen sizes.
-     * @default 'stretch'
-     */
-    alignContent?: GridContentAlignment;
-    /**
-     * Defines the `align-items` style property.
-     * It's applied for all screen sizes.
-     * @default 'stretch'
-     */
-    alignItems?: GridItemsAlignment;
-    /**
-     * The content of the component.
-     */
-    children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: {
-      /** Styles applied to the root element. */
-      root?: string;
-      /** Styles applied to the root element if `container={true}`. */
-      container?: string;
-      /** Styles applied to the root element if `item={true}`. */
-      item?: string;
-      /** Styles applied to the root element if `zeroMinWidth={true}`. */
-      zeroMinWidth?: string;
-      /** Styles applied to the root element if `direction="column"`. */
-      'direction-xs-column'?: string;
-      /** Styles applied to the root element if `direction="column-reverse"`. */
-      'direction-xs-column-reverse'?: string;
-      /** Styles applied to the root element if `direction="row-reverse"`. */
-      'direction-xs-row-reverse'?: string;
-      /** Styles applied to the root element if `wrap="nowrap"`. */
-      'wrap-xs-nowrap'?: string;
-      /** Styles applied to the root element if `wrap="reverse"`. */
-      'wrap-xs-wrap-reverse'?: string;
-      /** Styles applied to the root element if `alignItems="center"`. */
-      'align-items-xs-center'?: string;
-      /** Styles applied to the root element if `alignItems="flex-start"`. */
-      'align-items-xs-flex-start'?: string;
-      /** Styles applied to the root element if `alignItems="flex-end"`. */
-      'align-items-xs-flex-end'?: string;
-      /** Styles applied to the root element if `alignItems="baseline"`. */
-      'align-items-xs-baseline'?: string;
-      /** Styles applied to the root element if `alignContent="center"`. */
-      'align-content-xs-center'?: string;
-      /** Styles applied to the root element if `alignContent="flex-start"`. */
-      'align-content-xs-flex-start'?: string;
-      /** Styles applied to the root element if `alignContent="flex-end"`. */
-      'align-content-xs-flex-end'?: string;
-      /** Styles applied to the root element if `alignContent="space-between"`. */
-      'align-content-xs-space-between'?: string;
-      /** Styles applied to the root element if `alignContent="space-around"`. */
-      'align-content-xs-space-around'?: string;
-      /** Styles applied to the root element if `justifyContent="center"`. */
-      'justify-content-xs-center'?: string;
-      /** Styles applied to the root element if `justifyContent="flex-end"`. */
-      'justify-content-xs-flex-end'?: string;
-      /** Styles applied to the root element if `justifyContent="space-between"`. */
-      'justify-content-xs-space-between'?: string;
-      /** Styles applied to the root element if `justifyContent="space-around"`. */
-      'justify-content-xs-space-around'?: string;
-      /** Styles applied to the root element if `justifyContent="space-evenly"`. */
-      'justify-content-xs-space-evenly'?: string;
-      'spacing-xs-1'?: string;
-      'spacing-xs-2'?: string;
-      'spacing-xs-3'?: string;
-      'spacing-xs-4'?: string;
-      'spacing-xs-5'?: string;
-      'spacing-xs-6'?: string;
-      'spacing-xs-7'?: string;
-      'spacing-xs-8'?: string;
-      'spacing-xs-9'?: string;
-      'spacing-xs-10'?: string;
-      'grid-xs-auto'?: string;
-      'grid-xs-true'?: string;
-      'grid-xs-1'?: string;
-      'grid-xs-2'?: string;
-      'grid-xs-3'?: string;
-      'grid-xs-4'?: string;
-      'grid-xs-5'?: string;
-      'grid-xs-6'?: string;
-      'grid-xs-7'?: string;
-      'grid-xs-8'?: string;
-      'grid-xs-9'?: string;
-      'grid-xs-10'?: string;
-      'grid-xs-11'?: string;
-      'grid-xs-12'?: string;
+  props: P &
+    SystemProps & {
+      /**
+       * The content of the component.
+       */
+      children?: React.ReactNode;
+      /**
+       * Override or extend the styles applied to the component.
+       */
+      classes?: {
+        /** Styles applied to the root element. */
+        root?: string;
+        /** Styles applied to the root element if `container={true}`. */
+        container?: string;
+        /** Styles applied to the root element if `item={true}`. */
+        item?: string;
+        /** Styles applied to the root element if `zeroMinWidth={true}`. */
+        zeroMinWidth?: string;
+        /** Styles applied to the root element if `direction="column"`. */
+        'direction-xs-column'?: string;
+        /** Styles applied to the root element if `direction="column-reverse"`. */
+        'direction-xs-column-reverse'?: string;
+        /** Styles applied to the root element if `direction="row-reverse"`. */
+        'direction-xs-row-reverse'?: string;
+        /** Styles applied to the root element if `wrap="nowrap"`. */
+        'wrap-xs-nowrap'?: string;
+        /** Styles applied to the root element if `wrap="reverse"`. */
+        'wrap-xs-wrap-reverse'?: string;
+        'spacing-xs-1'?: string;
+        'spacing-xs-2'?: string;
+        'spacing-xs-3'?: string;
+        'spacing-xs-4'?: string;
+        'spacing-xs-5'?: string;
+        'spacing-xs-6'?: string;
+        'spacing-xs-7'?: string;
+        'spacing-xs-8'?: string;
+        'spacing-xs-9'?: string;
+        'spacing-xs-10'?: string;
+        'grid-xs-auto'?: string;
+        'grid-xs-true'?: string;
+        'grid-xs-1'?: string;
+        'grid-xs-2'?: string;
+        'grid-xs-3'?: string;
+        'grid-xs-4'?: string;
+        'grid-xs-5'?: string;
+        'grid-xs-6'?: string;
+        'grid-xs-7'?: string;
+        'grid-xs-8'?: string;
+        'grid-xs-9'?: string;
+        'grid-xs-10'?: string;
+        'grid-xs-11'?: string;
+        'grid-xs-12'?: string;
+      };
+      /**
+       * If `true`, the component will have the flex *container* behavior.
+       * You should be wrapping *items* with a *container*.
+       * @default false
+       */
+      container?: boolean;
+      /**
+       * Defines the `flex-direction` style property.
+       * It is applied for all screen sizes.
+       * @default 'row'
+       */
+      direction?: GridDirection;
+      /**
+       * If `true`, the component will have the flex *item* behavior.
+       * You should be wrapping *items* with a *container*.
+       * @default false
+       */
+      item?: boolean;
+      /**
+       * Defines the number of grids the component is going to use.
+       * It's applied for the `lg` breakpoint and wider screens if not overridden.
+       * @default false
+       */
+      lg?: boolean | GridSize;
+      /**
+       * Defines the number of grids the component is going to use.
+       * It's applied for the `md` breakpoint and wider screens if not overridden.
+       * @default false
+       */
+      md?: boolean | GridSize;
+      /**
+       * Defines the number of grids the component is going to use.
+       * It's applied for the `sm` breakpoint and wider screens if not overridden.
+       * @default false
+       */
+      sm?: boolean | GridSize;
+      /**
+       * Defines the space between the type `item` component.
+       * It can only be used on a type `container` component.
+       * @default 0
+       */
+      spacing?: GridSpacing;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps<Theme>;
+      /**
+       * Defines the `flex-wrap` style property.
+       * It's applied for all screen sizes.
+       * @default 'wrap'
+       */
+      wrap?: GridWrap;
+      /**
+       * Defines the number of grids the component is going to use.
+       * It's applied for the `xl` breakpoint and wider screens.
+       * @default false
+       */
+      xl?: boolean | GridSize;
+      /**
+       * Defines the number of grids the component is going to use.
+       * It's applied for all the screen sizes with the lowest priority.
+       * @default false
+       */
+      xs?: boolean | GridSize;
+      /**
+       * If `true`, it sets `min-width: 0` on the item.
+       * Refer to the limitations section of the documentation to better understand the use case.
+       * @default false
+       */
+      zeroMinWidth?: boolean;
     };
-    /**
-     * If `true`, the component will have the flex *container* behavior.
-     * You should be wrapping *items* with a *container*.
-     * @default false
-     */
-    container?: boolean;
-    /**
-     * Defines the `flex-direction` style property.
-     * It is applied for all screen sizes.
-     * @default 'row'
-     */
-    direction?: GridDirection;
-    /**
-     * If `true`, the component will have the flex *item* behavior.
-     * You should be wrapping *items* with a *container*.
-     * @default false
-     */
-    item?: boolean;
-    /**
-     * Defines the `justify-content` style property.
-     * It is applied for all screen sizes.
-     * @default 'flex-start'
-     */
-    justifyContent?: GridJustification;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `lg` breakpoint and wider screens if not overridden.
-     * @default false
-     */
-    lg?: boolean | GridSize;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `md` breakpoint and wider screens if not overridden.
-     * @default false
-     */
-    md?: boolean | GridSize;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `sm` breakpoint and wider screens if not overridden.
-     * @default false
-     */
-    sm?: boolean | GridSize;
-    /**
-     * Defines the space between the type `item` component.
-     * It can only be used on a type `container` component.
-     * @default 0
-     */
-    spacing?: GridSpacing;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
-    /**
-     * Defines the `flex-wrap` style property.
-     * It's applied for all screen sizes.
-     * @default 'wrap'
-     */
-    wrap?: GridWrap;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `xl` breakpoint and wider screens.
-     * @default false
-     */
-    xl?: boolean | GridSize;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for all the screen sizes with the lowest priority.
-     * @default false
-     */
-    xs?: boolean | GridSize;
-    /**
-     * If `true`, it sets `min-width: 0` on the item.
-     * Refer to the limitations section of the documentation to better understand the use case.
-     * @default false
-     */
-    zeroMinWidth?: boolean;
-  };
   defaultComponent: D;
 }
 

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { deepmerge } from '@material-ui/utils';
+import { unstable_extendSxProp as extendSxProp } from '@material-ui/system';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import requirePropFactory from '../utils/requirePropFactory';
 import experimentalStyled from '../styles/experimentalStyled';
@@ -103,12 +104,9 @@ function generateGap({ theme, styleProps }) {
 
 const overridesResolver = (props, styles) => {
   const {
-    alignContent,
-    alignItems,
     container,
     direction,
     item,
-    justifyContent,
     lg,
     md,
     sm,
@@ -126,9 +124,6 @@ const overridesResolver = (props, styles) => {
     ...(container && spacing !== 0 && styles[`spacing-xs-${String(spacing)}`]),
     ...(direction !== 'row' && styles[`direction-xs-${String(direction)}`]),
     ...(wrap !== 'wrap' && styles[`wrap-xs-${String(wrap)}`]),
-    ...(alignItems !== 'stretch' && styles[`align-items-xs-${String(alignItems)}`]),
-    ...(alignContent !== 'stretch' && styles[`align-content-xs-${String(alignContent)}`]),
-    ...(justifyContent !== 'flex-start' && styles[`justify-content-xs-${String(justifyContent)}`]),
     ...(xs !== false && styles[`grid-xs-${String(xs)}`]),
     ...(sm !== false && styles[`grid-sm-${String(sm)}`]),
     ...(md !== false && styles[`grid-md-${String(md)}`]),
@@ -182,15 +177,6 @@ const GridRoot = experimentalStyled(
     ...(styleProps.wrap === 'reverse' && {
       flexWrap: 'wrap-reverse',
     }),
-    ...(styleProps.alignItems && {
-      alignItems: styleProps.alignItems,
-    }),
-    ...(styleProps.alignContent && {
-      alignContent: styleProps.alignContent,
-    }),
-    ...(styleProps.justifyContent && {
-      justifyContent: styleProps.justifyContent,
-    }),
   }),
   generateGap,
   ({ theme, styleProps }) =>
@@ -203,13 +189,10 @@ const GridRoot = experimentalStyled(
 
 const useUtilityClasses = (styleProps) => {
   const {
-    alignContent,
-    alignItems,
     classes,
     container,
     direction,
     item,
-    justifyContent,
     lg,
     md,
     sm,
@@ -229,9 +212,6 @@ const useUtilityClasses = (styleProps) => {
       container && spacing !== 0 && `spacing-xs-${String(spacing)}`,
       direction !== 'row' && `direction-xs-${String(direction)}`,
       wrap !== 'wrap' && `wrap-xs-${String(wrap)}`,
-      alignItems !== 'stretch' && `align-items-xs-${String(alignItems)}`,
-      alignContent !== 'stretch' && `align-content-xs-${String(alignContent)}`,
-      justifyContent !== 'flex-start' && `justify-content-xs-${String(justifyContent)}`,
       xs !== false && `grid-xs-${String(xs)}`,
       sm !== false && `grid-sm-${String(sm)}`,
       md !== false && `grid-md-${String(md)}`,
@@ -244,17 +224,14 @@ const useUtilityClasses = (styleProps) => {
 };
 
 const Grid = React.forwardRef(function Grid(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiGrid' });
-
+  const themeProps = useThemeProps({ props: inProps, name: 'MuiGrid' });
+  const props = extendSxProp(themeProps);
   const {
-    alignContent = 'stretch',
-    alignItems = 'stretch',
     className,
     component = 'div',
     container = false,
     direction = 'row',
     item = false,
-    justifyContent = 'flex-start',
     lg = false,
     md = false,
     sm = false,
@@ -268,12 +245,9 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
 
   const styleProps = {
     ...props,
-    alignContent,
-    alignItems,
     container,
     direction,
     item,
-    justifyContent,
     lg,
     md,
     sm,
@@ -302,25 +276,6 @@ Grid.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
-  /**
-   * Defines the `align-content` style property.
-   * It's applied for all screen sizes.
-   * @default 'stretch'
-   */
-  alignContent: PropTypes.oneOf([
-    'center',
-    'flex-end',
-    'flex-start',
-    'space-around',
-    'space-between',
-    'stretch',
-  ]),
-  /**
-   * Defines the `align-items` style property.
-   * It's applied for all screen sizes.
-   * @default 'stretch'
-   */
-  alignItems: PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
   /**
    * The content of the component.
    */
@@ -356,19 +311,6 @@ Grid.propTypes = {
    * @default false
    */
   item: PropTypes.bool,
-  /**
-   * Defines the `justify-content` style property.
-   * It is applied for all screen sizes.
-   * @default 'flex-start'
-   */
-  justifyContent: PropTypes.oneOf([
-    'center',
-    'flex-end',
-    'flex-start',
-    'space-around',
-    'space-between',
-    'space-evenly',
-  ]),
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `lg` breakpoint and wider screens if not overridden.
@@ -444,10 +386,7 @@ if (process.env.NODE_ENV !== 'production') {
   Grid['propTypes' + ''] = {
     // eslint-disable-next-line react/forbid-foreign-prop-types
     ...Grid.propTypes,
-    alignContent: requireProp('container'),
-    alignItems: requireProp('container'),
     direction: requireProp('container'),
-    justifyContent: requireProp('container'),
     lg: requireProp('item'),
     md: requireProp('item'),
     sm: requireProp('item'),

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -64,30 +64,6 @@ describe('<Grid />', () => {
     });
   });
 
-  describe('prop: alignItems', () => {
-    it('should apply the align-item class', () => {
-      const { container } = render(<Grid alignItems="center" container />);
-
-      expect(container.firstChild).to.have.class(classes['align-items-xs-center']);
-    });
-  });
-
-  describe('prop: alignContent', () => {
-    it('should apply the align-content class', () => {
-      const { container } = render(<Grid alignContent="center" container />);
-
-      expect(container.firstChild).to.have.class(classes['align-content-xs-center']);
-    });
-  });
-
-  describe('prop: justifyContent', () => {
-    it('should apply the justify-content class', () => {
-      const { container } = render(<Grid justifyContent="space-evenly" container />);
-
-      expect(container.firstChild).to.have.class(classes['justify-content-xs-space-evenly']);
-    });
-  });
-
   describe('gutter', () => {
     it('should generate the right values', function test() {
       if (/jsdom/.test(window.navigator.userAgent)) this.skip();
@@ -139,6 +115,20 @@ describe('<Grid />', () => {
         paddingTop: '16px',
         paddingLeft: '16px',
       });
+    });
+  });
+
+  it('combines system properties with the sx prop', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const { container } = render(<Grid mt={2} mr={1} sx={{ marginRight: 5, mb: 2 }} />);
+
+    expect(container.firstChild).toHaveComputedStyle({
+      marginTop: '16px',
+      marginRight: '40px',
+      marginBottom: '16px',
     });
   });
 });

--- a/packages/material-ui/src/Grid/gridClasses.d.ts
+++ b/packages/material-ui/src/Grid/gridClasses.d.ts
@@ -24,29 +24,9 @@ export interface GridClasses {
   'direction-xs-row-reverse': string;
   'direction-xs-row': string;
 
-  'align-content-xs-center': string;
-  'align-content-xs-flex-end': string;
-  'align-content-xs-flex-start': string;
-  'align-content-xs-space-around': string;
-  'align-content-xs-space-between': string;
-  'align-content-xs-stretch': string;
-
-  'align-items-xs-baseline': string;
-  'align-items-xs-center': string;
-  'align-items-xs-flex-end': string;
-  'align-items-xs-flex-start': string;
-  'align-items-xs-stretch': string;
-
   'wrap-xs-nowrap': string;
   'wrap-xs-wrap-reverse': string;
   'wrap-xs-wrap': string;
-
-  'justify-content-xs-center': string;
-  'justify-content-xs-flex-end': string;
-  'justify-content-xs-flex-start': string;
-  'justify-content-xs-space-around': string;
-  'justify-content-xs-space-between': string;
-  'justify-content-xs-space-evenly': string;
 
   'grid-xs-auto': string;
   'grid-xs-true': string;

--- a/packages/material-ui/src/Grid/gridClasses.js
+++ b/packages/material-ui/src/Grid/gridClasses.js
@@ -6,23 +6,6 @@ export function getGridUtilityClass(slot) {
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 const DIRECTIONS = ['column-reverse', 'column', 'row-reverse', 'row'];
-const ALIGN_CONTENTS = [
-  'center',
-  'flex-end',
-  'flex-start',
-  'space-around',
-  'space-between',
-  'stretch',
-];
-const ALIGN_ITEMS = ['baseline', 'center', 'flex-end', 'flex-start', 'stretch'];
-const JUSTIFY_CONTENTS = [
-  'center',
-  'flex-end',
-  'flex-start',
-  'space-around',
-  'space-between',
-  'space-evenly',
-];
 const WRAPS = ['nowrap', 'wrap-reverse', 'wrap'];
 const GRID_SIZES = ['auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
@@ -36,14 +19,8 @@ const gridClasses = generateUtilityClasses('MuiGrid', [
   ...SPACINGS.map((spacing) => `spacing-xs-${spacing}`),
   // direction values
   ...DIRECTIONS.map((direction) => `direction-xs-${direction}`),
-  // align content values
-  ...ALIGN_CONTENTS.map((alignContent) => `align-content-xs-${alignContent}`),
-  // align items values
-  ...ALIGN_ITEMS.map((alignItems) => `align-items-xs-${alignItems}`),
   // wrap values
   ...WRAPS.map((wrap) => `wrap-xs-${wrap}`),
-  // justify content values
-  ...JUSTIFY_CONTENTS.map((justifyContent) => `justify-content-xs-${justifyContent}`),
 
   // grid sizes for all breakpoints
   ...GRID_SIZES.map((size) => `grid-xs-${String(size)}`),


### PR DESCRIPTION
# BREAKING CHANGE

The props: `alignItems` `alignContent` and `justifyContent` and their `classes` and style overrides keys were removed: "align-items-xs-center", "align-items-xs-flex-start", "align-items-xs-flex-end", "align-items-xs-baseline", "align-content-xs-center", "align-content-xs-flex-start", "align-content-xs-flex-end", "align-content-xs-space-between", "align-content-xs-space-around", "justify-content-xs-center", "justify-content-xs-flex-end", "justify-content-xs-space-between", "justify-content-xs-space-around" and "justify-content-xs-space-evenly". These props are now considered part of the system, not on the `Grid` component itself. If you still wish to add overrides for them, you can use the `theme.components.MuiGrid.variants` options. For example

  ```diff
  const theme = createMuiTheme({
    components: {
      MuiGrid: {
  -     styleOverrides: {
  -       "align-items-xs-flex-end": {
  -         marginTop: '20px',
  -       },
  -     },
  +     variants: {
  +       props: { alignItems: "flex-end" },
  +       style: {
  +         marginTop: '20px',
  +       },
  +     }],
      },
    },
  });
  ```
---

This PR adds the system props on the `Grid` component.

Another iteration on #24485