### PR TITLE
[Dialog] Convert role `none presentation` to `presentation`

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -206,7 +206,7 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
         appear
         in={open}
         timeout={transitionDuration}
-        role="none presentation"
+        role="presentation"
         {...TransitionProps}
       >
         {/* roles are applied via cloneElement from TransitionComponent */}

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -153,10 +153,10 @@ describe('<Dialog />', () => {
   });
 
   describe('backdrop', () => {
-    it('does have `role` `none presentation`', () => {
+    it('does have `role` `presentation`', () => {
       render(<Dialog open>foo</Dialog>);
 
-      expect(findBackdrop(screen)).to.have.attribute('role', 'none presentation');
+      expect(findBackdrop(screen)).to.have.attribute('role', 'presentation');
     });
 
     it('calls onBackdropClick and onClose when clicked', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Role attribute does not support multiple values. The values `none` and `presentation` have the exact same meaning. `presentation` is more widely supported currently.

This was surfaces while running `jest-axe` against a private repo that is using `material-ui`. The rule that failed is
https://dequeuniversity.com/rules/axe/4.1/aria-roles?application=RuleDescription

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
