### PR TITLE
[Collapse] Migrate to emotion

### DIFF
--- a/docs/pages/api-docs/collapse.json
+++ b/docs/pages/api-docs/collapse.json
@@ -20,6 +20,7 @@
       "default": "duration.standard"
     }
   },
+  "sx": { "type": { "name": "object" } },
   "name": "Collapse",
   "styles": {
     "classes": ["root", "horizontal", "entered", "hidden", "wrapper", "wrapperInner"],

--- a/docs/pages/api-docs/collapse.json
+++ b/docs/pages/api-docs/collapse.json
@@ -18,9 +18,9 @@
         "description": "'auto'<br>&#124;&nbsp;number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
       "default": "duration.standard"
-    }
+    },
+    "sx": { "type": { "name": "object" } }
   },
-  "sx": { "type": { "name": "object" } },
   "name": "Collapse",
   "styles": {
     "classes": ["root", "horizontal", "entered", "hidden", "wrapper", "wrapperInner"],
@@ -35,5 +35,5 @@
     "pathname": "https://reactcommunity.org/react-transition-group/transition#Transition-props"
   },
   "demos": "<ul><li><a href=\"/components/cards/\">Cards</a></li>\n<li><a href=\"/components/lists/\">Lists</a></li>\n<li><a href=\"/components/transitions/\">Transitions</a></li></ul>",
-  "styledComponent": false
+  "styledComponent": true
 }

--- a/docs/pages/api-docs/collapse.json
+++ b/docs/pages/api-docs/collapse.json
@@ -12,14 +12,14 @@
       "type": { "name": "enum", "description": "'horizontal'<br>&#124;&nbsp;'vertical'" },
       "default": "'vertical'"
     },
+    "sx": { "type": { "name": "object" } },
     "timeout": {
       "type": {
         "name": "union",
         "description": "'auto'<br>&#124;&nbsp;number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
       "default": "duration.standard"
-    },
-    "sx": { "type": { "name": "object" } }
+    }
   },
   "name": "Collapse",
   "styles": {

--- a/docs/translations/api-docs/collapse/collapse.json
+++ b/docs/translations/api-docs/collapse/collapse.json
@@ -7,7 +7,8 @@
     "component": "The component used for the root node. Either a string to use a HTML element or a component.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "in": "If <code>true</code>, the component will transition in.",
     "orientation": "The transition orientation.",
-    "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to &#39;auto&#39; to automatically calculate transition time based on height."
+    "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to &#39;auto&#39; to automatically calculate transition time based on height.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/collapse/collapse.json
+++ b/docs/translations/api-docs/collapse/collapse.json
@@ -7,8 +7,8 @@
     "component": "The component used for the root node. Either a string to use a HTML element or a component.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "in": "If <code>true</code>, the component will transition in.",
     "orientation": "The transition orientation.",
-    "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to &#39;auto&#39; to automatically calculate transition time based on height.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to &#39;auto&#39; to automatically calculate transition time based on height."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -25,10 +25,6 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
     wrapper?: string;
     /** Styles applied to the inner wrapper element. */
     wrapperInner?: string;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   /**
    * The width (horizontal) or height (vertical) of the container when collapsed.
@@ -57,6 +53,10 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
    * @default duration.standard
    */
   timeout?: TransitionProps['timeout'] | 'auto';
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type CollapseClassKey = keyof NonNullable<CollapseProps['classes']>;

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 import { TransitionProps } from '../transitions/transition';
 
 export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'> {
@@ -24,6 +25,10 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
     wrapper?: string;
     /** Styles applied to the inner wrapper element. */
     wrapperInner?: string;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
   };
   /**
    * The width (horizontal) or height (vertical) of the container when collapsed.

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -18,7 +18,10 @@ const overridesResolver = (props, styles) => {
   return deepmerge(styles.root || {}, {
     ...styles[styleProps.orientation],
     ...(styleProps.state === 'entered' && styles.entered),
-    ...(styleProps.state === 'exited' && !styleProps.in && styleProps.collapsedSize === '0px' && styles.hidden),
+    ...(styleProps.state === 'exited' &&
+      !styleProps.in &&
+      styleProps.collapsedSize === '0px' &&
+      styles.hidden),
     [`& .${collapseClasses.wrapper}`]: styles.wrapper,
     [`& .${collapseClasses.wrapperInner}`]: styles.wrapperInner,
   });
@@ -51,23 +54,25 @@ const CollapseRoot = experimentalStyled(
   height: 0,
   overflow: 'hidden',
   transition: theme.transitions.create('height'),
-  '&$horizontal': {
+  ...(styleProps.orientation === 'horizontal' && {
     height: 'auto',
     width: 0,
     transition: theme.transitions.create('width'),
-  },
+  }),
   /* Styles applied to the root element when the transition has entered. */
   ...(styleProps.state === 'entered' && {
     height: 'auto',
     overflow: 'visible',
-    '&$horizontal': {
+    ...(styleProps.orientation === 'horizontal' && {
       width: 'auto',
-    },
+    }),
   }),
   /* Styles applied to the root element when the transition has exited and `collapsedSize` = 0px. */
-  ...(styleProps.state === 'exited' && !styleProps.in && styleProps.collapsedSize === '0px' && {
-    visibility: 'hidden',
-  }),
+  ...(styleProps.state === 'exited' &&
+    !styleProps.in &&
+    styleProps.collapsedSize === '0px' && {
+      visibility: 'hidden',
+    }),
 }));
 
 /* Styles applied to the outer wrapper element. */
@@ -82,10 +87,10 @@ const CollapseWrapper = experimentalStyled(
   // Hack to get children with a negative margin to not falsify the height computation.
   display: 'flex',
   width: '100%',
-  '&$horizontal': {
+  ...(styleProps.orientation === 'horizontal' && {
     width: 'auto',
     height: '100%',
-  },
+  }),
 }));
 
 /* Styles applied to the inner wrapper element. */
@@ -98,10 +103,10 @@ const CollapseWrapperInner = experimentalStyled(
   },
 )(({ styleProps }) => ({
   width: '100%',
-  '&$horizontal': {
+  ...(styleProps.orientation === 'horizontal' && {
     width: 'auto',
     height: '100%',
-  },
+  }),
 }));
 
 /**

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -140,7 +140,6 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     ...props,
     orientation,
     collapsedSize: collapsedSizeProp,
-    in: inProp,
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -382,6 +382,10 @@ Collapse.propTypes = {
    */
   style: PropTypes.object,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    *
@@ -397,10 +401,6 @@ Collapse.propTypes = {
       exit: PropTypes.number,
     }),
   ]),
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.object,
 };
 
 Collapse.muiSupportAuto = true;

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -293,7 +293,6 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
           className={clsx(
             classes.root,
             {
-              [classes.horizontal]: isHorizontal,
               [classes.entered]: state === 'entered',
               [classes.hidden]: state === 'exited' && !inProp && collapsedSize === '0px',
             },
@@ -309,16 +308,12 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
         >
           <CollapseWrapper
             styleProps={{ ...styleProps, state }}
-            className={clsx(classes.wrapper, {
-              [classes.horizontal]: isHorizontal,
-            })}
+            className={classes.wrapper}
             ref={wrapperRef}
           >
             <CollapseWrapperInner
               styleProps={{ ...styleProps, state }}
-              className={clsx(classes.wrapperInner, {
-                [classes.horizontal]: isHorizontal,
-              })}
+              className={classes.wrapperInner}
             >
               {children}
             </CollapseWrapperInner>

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -397,6 +397,10 @@ Collapse.propTypes = {
       exit: PropTypes.number,
     }),
   ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
 };
 
 Collapse.muiSupportAuto = true;

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -112,6 +112,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     children,
     className,
     collapsedSize: collapsedSizeProp = '0px',
+    component,
     in: inProp,
     onEnter,
     onEntered,
@@ -278,6 +279,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     >
       {(state, childProps) => (
         <CollapseRoot
+          as={component}
           className={clsx(
             classes.root,
             {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -20,9 +20,9 @@ describe('<Collapse />', () => {
     inheritComponent: Transition,
     mount,
     refInstanceof: window.HTMLDivElement,
-    testComponentPropWith: 'span',
     muiName: 'MuiCollapse',
     testVariantProps: { orientation: 'horizontal' },
+    skip: ['componentsProp'],
   }));
 
   it('should render a container around the wrapper', () => {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -1,30 +1,28 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Collapse from './Collapse';
+import classes from './collapseClasses';
 
 describe('<Collapse />', () => {
   const mount = createMount({ strict: true });
-  let classes;
   const defaultProps = {
     in: true,
     children: <div />,
   };
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<Collapse {...defaultProps} />);
-  });
-
-  describeConformance(<Collapse {...defaultProps} />, () => ({
+  describeConformanceV5(<Collapse {...defaultProps} />, () => ({
     classes,
     inheritComponent: Transition,
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
+    muiName: 'MuiCollapse',
+    testVariantProps: { orientation: 'horizontal' },
   }));
 
   it('should render a container around the wrapper', () => {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -22,6 +22,7 @@ describe('<Collapse />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiCollapse',
     testVariantProps: { orientation: 'horizontal' },
+    testDeepOverrides: { slotName: 'wrapper', slotClassName: classes.wrapper },
     skip: ['componentsProp'],
   }));
 

--- a/packages/material-ui/src/Collapse/collapseClasses.d.ts
+++ b/packages/material-ui/src/Collapse/collapseClasses.d.ts
@@ -1,0 +1,12 @@
+export interface CollapseClasses {
+  root: string;
+  horizontal: string;
+  wrapper: string;
+  wrapperInner: string;
+}
+
+declare const collapseClasses: CollapseClasses;
+
+export function getCollapseUtilityClass(slot: string): string;
+
+export default collapseClasses;

--- a/packages/material-ui/src/Collapse/collapseClasses.d.ts
+++ b/packages/material-ui/src/Collapse/collapseClasses.d.ts
@@ -1,6 +1,9 @@
 export interface CollapseClasses {
   root: string;
   horizontal: string;
+  vertical: string;
+  entered: string;
+  hidden: string;
   wrapper: string;
   wrapperInner: string;
 }

--- a/packages/material-ui/src/Collapse/collapseClasses.js
+++ b/packages/material-ui/src/Collapse/collapseClasses.js
@@ -7,6 +7,9 @@ export function getCollapseUtilityClass(slot) {
 const collapseClasses = generateUtilityClasses('MuiCollapse', [
   'root',
   'horizontal',
+  'vertical',
+  'entered',
+  'hidden',
   'wrapper',
   'wrapperInner',
 ]);

--- a/packages/material-ui/src/Collapse/collapseClasses.js
+++ b/packages/material-ui/src/Collapse/collapseClasses.js
@@ -1,0 +1,14 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getCollapseUtilityClass(slot) {
+  return generateUtilityClass('MuiCollapse', slot);
+}
+
+const collapseClasses = generateUtilityClasses('MuiCollapse', [
+  'root',
+  'horizontal',
+  'wrapper',
+  'wrapperInner',
+]);
+
+export default collapseClasses;

--- a/packages/material-ui/src/Collapse/index.d.ts
+++ b/packages/material-ui/src/Collapse/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './Collapse';
 export * from './Collapse';
+
+export { default as collapseClasses } from './collapseClasses';
+export * from './collapseClasses';

--- a/packages/material-ui/src/Collapse/index.js
+++ b/packages/material-ui/src/Collapse/index.js
@@ -1,1 +1,4 @@
 export { default } from './Collapse';
+
+export { default as collapseClasses } from './collapseClasses';
+export * from './collapseClasses';

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
-import Collapse, { collapseClasses } from '../Collapse';
+import { collapseClasses } from '../Collapse';
 import Stepper from '../Stepper';
 import Step from '../Step';
 import StepContent from './StepContent';

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,20 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createClientRender, createMount, describeConformance } from 'test/utils';
-import Collapse from '../Collapse';
+import Collapse, { collapseClasses } from '../Collapse';
 import Stepper from '../Stepper';
 import Step from '../Step';
 import StepContent from './StepContent';
 
 describe('<StepContent />', () => {
   let classes;
-  let collapseClasses;
   const mount = createMount({ strict: true });
   const render = createClientRender();
 
   before(() => {
     classes = getClasses(<StepContent />);
-    collapseClasses = getClasses(<Collapse />);
   });
 
   describeConformance(<StepContent />, () => ({


### PR DESCRIPTION
This PR migrates the `Collapse` component for v5 as a part of #24405.

**Notice:** this is my very first pull request to this repository.  If I have made any mistakes, please do not hesitate to let me know and I will fix it right away!  Feel free to give any and all critique -- I'm a big girl, I can handle it.  😛 

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

_This contribution, and all other contributions I make to Material UI, are performed under [Gooborg Studios, LLC](https://www.gooborg.com) on behalf of [Fox and Geese, LLC](https://github.com/foxandgeese).  Both companies agree to surrender all contributions under MUI's MIT license._