### PR TITLE
[core] Fix styleProps to always contain all props

### DIFF
--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -158,7 +158,7 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
   } = props;
 
   const styleProps = {
-    ...other,
+    ...props,
     variant,
     color,
     severity,

--- a/packages/material-ui/src/AlertTitle/AlertTitle.js
+++ b/packages/material-ui/src/AlertTitle/AlertTitle.js
@@ -43,6 +43,7 @@ const AlertTitle = React.forwardRef(function AlertTitle(inProps, ref) {
 
   const { className, ...other } = props;
 
+  // TODO: convert to simple assignment after the type error in defaultPropsHandler.js:60:6 is fixed
   const styleProps = { ...props };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui/src/AlertTitle/AlertTitle.js
+++ b/packages/material-ui/src/AlertTitle/AlertTitle.js
@@ -43,7 +43,7 @@ const AlertTitle = React.forwardRef(function AlertTitle(inProps, ref) {
 
   const { className, ...other } = props;
 
-  const styleProps = props;
+  const styleProps = { ...props };
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/AlertTitle/AlertTitle.js
+++ b/packages/material-ui/src/AlertTitle/AlertTitle.js
@@ -43,7 +43,7 @@ const AlertTitle = React.forwardRef(function AlertTitle(inProps, ref) {
 
   const { className, ...other } = props;
 
-  const styleProps = other;
+  const styleProps = props;
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -118,7 +118,7 @@ const AppBar = React.forwardRef(function AppBar(inProps, ref) {
   const { className, color = 'primary', position = 'fixed', ...other } = props;
 
   const styleProps = {
-    ...other,
+    ...props,
     color,
     position,
   };

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.js
@@ -86,7 +86,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
   const clampedMax = max < 2 ? 2 : max;
 
   const styleProps = {
-    ...other,
+    ...props,
     max,
     spacing,
     variant,


### PR DESCRIPTION
I overlooked in the reviews, that people were spreading `other`, not `props` on the `styleProps`. `styleProps` should contain all props with defaults, not just a subset of it, so that we can avoid int he future issues for some props not being passed to the styled funciton.