### PR TITLE
[docs] Fix ToC on /api pages linking to api-docs

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -177,8 +177,7 @@ module.exports = {
 
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
-    // REVERT LATER deploy all locales for testing
-    if (process.env.PULL_REQUEST !== 'true' && !l10nPRInNetlify && !vercelDeploy) {
+    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify && !vercelDeploy) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -177,7 +177,8 @@ module.exports = {
 
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
-    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify && !vercelDeploy) {
+    // REVERT LATER deploy all locales for testing
+    if (process.env.PULL_REQUEST !== 'true' && !l10nPRInNetlify && !vercelDeploy) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -117,7 +117,7 @@ ClassesTable.propTypes = {
   componentStyles: PropTypes.object.isRequired,
 };
 
-function getTransaltedHeader(t, header) {
+function getTranslatedHeader(t, header) {
   const translations = {
     import: t('api-docs.import'),
     componentName: t('api-docs.componentName'),
@@ -139,7 +139,7 @@ function Heading(props) {
     <Level>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content */}
       <a className="anchor-link" id={kebabCaseHash} />
-      {getTransaltedHeader(t, hash)}
+      {getTranslatedHeader(t, hash)}
       <a
         className="anchor-link-style"
         aria-hidden="true"
@@ -199,7 +199,7 @@ function ApiDocs(props) {
   sections.forEach((sectionName) => {
     if (sectionName) {
       toc.push({
-        text: getTransaltedHeader(t, sectionName),
+        text: getTranslatedHeader(t, sectionName),
         hash: sectionName,
         children: [
           ...(sectionName === 'props' && inheritance

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -186,7 +186,7 @@ export default function AppTableOfContents(props) {
     <Link
       display="block"
       color={activeState === item.hash ? 'textPrimary' : 'textSecondary'}
-      href={`${activePage.pathname}#${item.hash}`}
+      href={`${activePage.linkProps?.as ?? activePage.pathname}#${item.hash}`}
       underline="none"
       onClick={handleClick(item.hash)}
       className={clsx(

--- a/docs/src/modules/components/PageContext.js
+++ b/docs/src/modules/components/PageContext.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 /**
- * @type {React.Context<{ activePage: { pathname: string }, pages: Array<import('docs/src/pages').MuiPage>, versions: unknown[] }>}
+ * @type {React.Context<{ activePage: import('docs/src/pages').MuiPage>, pages: Array<import('docs/src/pages').MuiPage>, versions: unknown[] }>}
  */
 const PageContext = React.createContext();
 


### PR DESCRIPTION
current `next`: https://60083a7d297f240007fb4a7f--material-ui.netlify.app/api/accordion/
PR (with all locales): https://60084e9dc1b516000793d8ec--material-ui.netlify.app/api/accordion/