### PR TITLE
[docs] Fix ToC "Component name" fragment link on /api/*

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -120,12 +120,21 @@ ClassesTable.propTypes = {
 function getTransaltedHeader(t, header) {
   const translations = {
     import: t('api-docs.import'),
-    componentName: t('api-docs.componentName'),
+    'component-name': t('api-docs.componentName'),
     props: t('api-docs.props'),
     inheritance: t('api-docs.inheritance'),
     demos: t('api-docs.demos'),
     css: 'CSS',
   };
+
+  // TODO Drop runtime type-checking once we type-check this file
+  if (!translations.hasOwnProperty(header)) {
+    throw new TypeError(
+      `Unable to translate header '${header}'. Did you mean one of '${Object.keys(
+        translations,
+      ).join("', '")}'`,
+    );
+  }
 
   return translations[header] || header;
 }
@@ -265,7 +274,7 @@ import { ${componentName} } from '${source}';`}
         ) : null}
         {componentStyles.name && (
           <React.Fragment>
-            <Heading hash="componentName" />
+            <Heading hash="component-name" />
             <span
               dangerouslySetInnerHTML={{
                 __html: t('api-docs.styleOverrides').replace(

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -142,19 +142,13 @@ function getTransaltedHeader(t, header) {
 function Heading(props) {
   const { hash, level: Level = 'h2' } = props;
   const t = useTranslate();
-  const kebabCaseHash = hash === 'componentName' ? 'component-name' : `${hash}`;
 
   return (
     <Level>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content */}
-      <a className="anchor-link" id={kebabCaseHash} />
+      <a className="anchor-link" id={hash} />
       {getTransaltedHeader(t, hash)}
-      <a
-        className="anchor-link-style"
-        aria-hidden="true"
-        aria-label="anchor"
-        href={`#${kebabCaseHash}`}
-      >
+      <a className="anchor-link-style" aria-hidden="true" aria-label="anchor" href={`#${hash}`}>
         <svg>
           <use xlinkHref="#anchor-link-icon" />
         </svg>


### PR DESCRIPTION
The table of contents entry for `Component name` on `/api/*` pages is currently not translated.

The issue was that we didn't decide on whether to name the hash `component-name` or `componentName` and ended up passing around different formats (and sometimes converting it back again)

Note that the link is still wrong since it links to `/api-docs` which is fixed in https://github.com/mui-org/material-ui/pull/24515

current `next`: https://60083a7d297f240007fb4a7f--material-ui.netlify.app/ru/api/accordion/
PR: https://deploy-preview-24517--material-ui.netlify.app/api/accordion/

