### PR TITLE
[docs] Make <main> responsive to font size

### DIFF
--- a/docs/src/modules/components/AppContainer.js
+++ b/docs/src/modules/components/AppContainer.js
@@ -7,6 +7,12 @@ import Container from '@material-ui/core/Container';
 const useStyles = makeStyles((theme) => ({
   root: {
     paddingTop: 80 + 16,
+    [theme.breakpoints.up('md')]: {
+      // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
+      // 120ch ≈ 960px (theme.breakpoints.values.md) using 16px Roboto
+      // TODO Does it make sense to create breakpoints based on `ch`?
+      maxWidth: '120ch',
+    },
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(6),
       paddingRight: theme.spacing(6),
@@ -22,7 +28,7 @@ export default function AppContainer(props) {
     <Container
       component="main"
       id="main-content"
-      maxWidth="md"
+      maxWidth={false}
       tabIndex={-1}
       className={clsx(classes.root, className)}
       {...other}


### PR DESCRIPTION
This is a bit of an experiment how we can reconcile grids in Material design with system-adjustable font settings.

Right now we're restricting `<main>` to a pixel based max-width. This works fine with the default font settings. However, browsers can change the default font settings. Increasing the font size to "Large" in chrome (20px) leads to a cramped props tables in /api:

![Screenshot from 2021-01-21 15-32-17](https://user-images.githubusercontent.com/12292047/105364878-f4644e80-5bfd-11eb-9a9e-274b0e2509a5.png)

By making the max-width based on `ch` we give every font setting the same amount of characters per line (up until the screen is no longer big  enough).
Preview: https://deploy-preview-24531--material-ui.netlify.app/api/text-field/

In the end, it might be interesting if we could make breakpoints based on `ch` entirely. This is just an incomplete fix for our specific problem in props tables.