### PR TITLE
[DatePicker] Remove unnecessary wrapping dom node

### DIFF
--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -17,7 +17,6 @@ export type PickersDayClassKey =
   | 'dayOutsideMonth'
   | 'hiddenDaySpacingFiller'
   | 'today'
-  | 'dayLabel'
   | 'selected'
   | 'disabled';
 
@@ -70,9 +69,6 @@ export const styles: MuiStyles<PickersDayClassKey> = (theme): StyleRules<Pickers
     '&:not($selected)': {
       border: `1px solid ${theme.palette.text.secondary}`,
     },
-  },
-  dayLabel: {
-    // need for overrides
   },
   selected: {},
   disabled: {},
@@ -243,7 +239,7 @@ const PickersDay = React.forwardRef(function PickersDay<TDate>(
       onClick={handleClick}
       {...other}
     >
-      <span className={classes.dayLabel}>{utils.format(day, 'dayOfMonth')}</span>
+      {utils.format(day, 'dayOfMonth')}
     </ButtonBase>
   );
 });


### PR DESCRIPTION
### Breaking changes

- [DatePicker] Remove the `.MuiPickersDay-dayLabel` node, customizations can be applied on `.MuiPickersDay-root` directly.

---

resolves #24162. For context, the div was added in https://github.com/mui-org/material-ui-pickers/pull/1416.