### PR TITLE
[Accordion] Migrate AccordionActions to emotion

### DIFF
--- a/docs/pages/api-docs/accordion-actions.json
+++ b/docs/pages/api-docs/accordion-actions.json
@@ -2,7 +2,8 @@
   "props": {
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "disableSpacing": { "type": { "name": "bool" } }
+    "disableSpacing": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "AccordionActions",
   "styles": { "classes": ["root", "spacing"], "globalClasses": {}, "name": "MuiAccordionActions" },
@@ -11,6 +12,6 @@
   "filename": "/packages/material-ui/src/AccordionActions/AccordionActions.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/accordion/\">Accordion</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/accordion-actions/accordion-actions.json
+++ b/docs/translations/api-docs/accordion-actions/accordion-actions.json
@@ -3,7 +3,8 @@
   "propDescriptions": {
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
-    "disableSpacing": "If <code>true</code>, the actions do not have additional margin."
+    "disableSpacing": "If <code>true</code>, the actions do not have additional margin.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/packages/material-ui/src/AccordionActions/AccordionActions.d.ts
+++ b/packages/material-ui/src/AccordionActions/AccordionActions.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 
 export interface AccordionActionsProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**
@@ -20,6 +21,10 @@ export interface AccordionActionsProps extends StandardProps<React.HTMLAttribute
    * @default false
    */
   disableSpacing?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type AccordionActionsClassKey = keyof NonNullable<AccordionActionsProps['classes']>;

--- a/packages/material-ui/src/AccordionActions/AccordionActions.test.js
+++ b/packages/material-ui/src/AccordionActions/AccordionActions.test.js
@@ -1,20 +1,18 @@
 import * as React from 'react';
-import { getClasses, createMount, describeConformance } from 'test/utils';
+import { createMount, describeConformanceV5 } from 'test/utils';
 import AccordionActions from './AccordionActions';
+import classes from './accordionActionsClasses';
 
 describe('<AccordionActions />', () => {
   const mount = createMount();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<AccordionActions>foo</AccordionActions>);
-  });
-
-  describeConformance(<AccordionActions>Conformance</AccordionActions>, () => ({
+  describeConformanceV5(<AccordionActions>Conformance</AccordionActions>, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiAccordionActions',
+    testVariantProps: { disableSpacing: true },
+    skip: ['componentProp', 'componentsProp'],
   }));
 });

--- a/packages/material-ui/src/AccordionActions/accordionActionsClasses.d.ts
+++ b/packages/material-ui/src/AccordionActions/accordionActionsClasses.d.ts
@@ -1,0 +1,10 @@
+export interface AccordionActionsClasses {
+  root: string;
+  spacing: string;
+}
+
+declare const accordionActionsClasses: AccordionActionsClasses;
+
+export function getAccordionActionsUtilityClass(slot: string): string;
+
+export default accordionActionsClasses;

--- a/packages/material-ui/src/AccordionActions/accordionActionsClasses.js
+++ b/packages/material-ui/src/AccordionActions/accordionActionsClasses.js
@@ -1,0 +1,9 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getAccordionActionsUtilityClass(slot) {
+  return generateUtilityClass('MuiAccordionActions', slot);
+}
+
+const accordionActionsClasses = generateUtilityClasses('MuiAccordionActions', ['root', 'spacing']);
+
+export default accordionActionsClasses;

--- a/packages/material-ui/src/AccordionActions/index.d.ts
+++ b/packages/material-ui/src/AccordionActions/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './AccordionActions';
 export * from './AccordionActions';
+
+export { default as accordionActionsClasses } from './accordionActionsClasses';
+export * from './accordionActionsClasses';

--- a/packages/material-ui/src/AccordionActions/index.js
+++ b/packages/material-ui/src/AccordionActions/index.js
@@ -1,1 +1,4 @@
 export { default } from './AccordionActions';
+
+export { default as accordionActionsClasses } from './accordionActionsClasses';
+export * from './accordionActionsClasses';


### PR DESCRIPTION
This PR migrates the `AccordionActions` component to the new emotion format as a part of #24405.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
