### PR TITLE
[Accordion] Migrate AccordionDetails to emotion

### DIFF
--- a/docs/pages/api-docs/accordion-details.json
+++ b/docs/pages/api-docs/accordion-details.json
@@ -1,7 +1,8 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } }
+    "classes": { "type": { "name": "object" } },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "AccordionDetails",
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiAccordionDetails" },
@@ -10,6 +11,6 @@
   "filename": "/packages/material-ui/src/AccordionDetails/AccordionDetails.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/accordion/\">Accordion</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/accordion-details/accordion-details.json
+++ b/docs/translations/api-docs/accordion-details/accordion-details.json
@@ -2,7 +2,8 @@
   "componentDescription": "",
   "propDescriptions": {
     "children": "The content of the component.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details."
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
 }

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.d.ts
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 
 export interface AccordionDetailsProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**
@@ -13,6 +14,10 @@ export interface AccordionDetailsProps extends StandardProps<React.HTMLAttribute
     /** Styles applied to the root element. */
     root?: string;
   };
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type AccordionDetailsClassKey = keyof NonNullable<AccordionDetailsProps['classes']>;

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.js
@@ -1,19 +1,54 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
+import { getAccordionDetailsUtilityClass } from './accordionDetailsClasses';
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    padding: theme.spacing(1, 2, 2),
+const overridesResolver = (props, styles) => {
+  return deepmerge(styles.root || {}, {});
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes } = styleProps;
+
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getAccordionDetailsUtilityClass, classes);
+};
+
+const AccordionDetailsRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiAccordionDetails',
+    slot: 'Root',
+    overridesResolver,
   },
-});
+)(({ theme }) => ({
+  /* Styles applied to the root element. */
+  padding: theme.spacing(1, 2, 2),
+}));
 
-const AccordionDetails = React.forwardRef(function AccordionDetails(props, ref) {
-  const { classes, className, ...other } = props;
+const AccordionDetails = React.forwardRef(function AccordionDetails(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiAccordionDetails' });
+  const { className, ...other } = props;
+  const styleProps = { ...props };
 
-  return <div className={clsx(classes.root, className)} ref={ref} {...other} />;
+  const classes = useUtilityClasses(styleProps);
+
+  return (
+    <AccordionDetailsRoot
+      className={clsx(classes.root, className)}
+      ref={ref}
+      styleProps={styleProps}
+      {...other}
+    />
+  );
 });
 
 AccordionDetails.propTypes = {
@@ -33,6 +68,10 @@ AccordionDetails.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiAccordionDetails' })(AccordionDetails);
+export default AccordionDetails;

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getAccordionDetailsUtilityClass } from './accordionDetailsClasses';
 
 const overridesResolver = (props, styles) => {
-  return deepmerge(styles.root || {}, {});
+  return styles.root || {};
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
@@ -1,23 +1,20 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import AccordionDetails from './AccordionDetails';
+import classes from './accordionDetailsClasses';
 
 describe('<AccordionDetails />', () => {
   const mount = createMount();
   const render = createClientRender();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<AccordionDetails>foo</AccordionDetails>);
-  });
-
-  describeConformance(<AccordionDetails>Conformance</AccordionDetails>, () => ({
+  describeConformanceV5(<AccordionDetails>Conformance</AccordionDetails>, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiAccordionDetails',
+    skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
   it('should render a children element', () => {

--- a/packages/material-ui/src/AccordionDetails/accordionDetailsClasses.d.ts
+++ b/packages/material-ui/src/AccordionDetails/accordionDetailsClasses.d.ts
@@ -1,0 +1,9 @@
+export interface AccordionDetailsClasses {
+  root: string;
+}
+
+declare const accordionDetailsClasses: AccordionDetailsClasses;
+
+export function getAccordionDetailsUtilityClass(slot: string): string;
+
+export default accordionDetailsClasses;

--- a/packages/material-ui/src/AccordionDetails/accordionDetailsClasses.js
+++ b/packages/material-ui/src/AccordionDetails/accordionDetailsClasses.js
@@ -1,0 +1,9 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getAccordionDetailsUtilityClass(slot) {
+  return generateUtilityClass('MuiAccordionDetails', slot);
+}
+
+const accordionDetailsClasses = generateUtilityClasses('MuiAccordionDetails', ['root']);
+
+export default accordionDetailsClasses;

--- a/packages/material-ui/src/AccordionDetails/index.d.ts
+++ b/packages/material-ui/src/AccordionDetails/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './AccordionDetails';
 export * from './AccordionDetails';
+
+export { default as accordionDetailsClasses } from './accordionDetailsClasses';
+export * from './accordionDetailsClasses';

--- a/packages/material-ui/src/AccordionDetails/index.js
+++ b/packages/material-ui/src/AccordionDetails/index.js
@@ -1,1 +1,4 @@
 export { default } from './AccordionDetails';
+
+export { default as accordionDetailsClasses } from './accordionDetailsClasses';
+export * from './accordionDetailsClasses';


### PR DESCRIPTION
This PR migrates the `AccordionDetails` component to the new emotion format as a part of #24405.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
