### PR TITLE
[Switch] Migrate SwitchBase to emotion

### DIFF
--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SxProps } from '@material-ui/system';
-import { InternalStandardProps as StandardProps, Theme } from '..';
+import { InternalStandardProps as StandardProps } from '..';
 import { IconButtonProps } from '../IconButton';
 
 export interface SwitchBaseProps

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -18,7 +18,7 @@ export interface SwitchBaseProps
     root?: string;
     checked?: string;
     disabled?: string;
-    inpit?: string;
+    input?: string;
   };
   /**
    * The default checked state. Use when the component is not controlled.

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -59,10 +59,6 @@ export interface SwitchBaseProps
    * If `true`, the `input` element is required.
    */
   required?: boolean;
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: SxProps<Theme>;
   tabIndex?: number;
   type?: React.InputHTMLAttributes<HTMLInputElement>['type'];
   /**

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 import { IconButtonProps } from '../IconButton';
 
 export interface SwitchBaseProps
@@ -58,6 +59,10 @@ export interface SwitchBaseProps
    * If `true`, the `input` element is required.
    */
   required?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: SxProps<Theme>;
   tabIndex?: number;
   type?: React.InputHTMLAttributes<HTMLInputElement>['type'];
   /**

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -1,41 +1,77 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType } from '@material-ui/utils';
+import { refType, deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
 import useControlled from '../utils/useControlled';
 import useFormControl from '../FormControl/useFormControl';
-import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
+import switchBaseClasses, { getSwitchBaseUtilityClass } from './switchBaseClasses';
 
-export const styles = {
-  root: {
-    padding: 9,
-  },
-  checked: {},
-  disabled: {},
-  input: {
-    cursor: 'inherit',
-    position: 'absolute',
-    opacity: 0,
-    width: '100%',
-    height: '100%',
-    top: 0,
-    left: 0,
-    margin: 0,
-    padding: 0,
-    zIndex: 1,
-  },
+const overridesResolver = (props, styles) => {
+  return deepmerge(styles.root || {}, {
+    [`&.${switchBaseClasses.checked}`]: styles.checked,
+    [`&.${switchBaseClasses.disabled}`]: styles.disabled,
+    [`& .${switchBaseClasses.input}`]: styles.input,
+  });
 };
+
+const useUtilityClasses = (styleProps) => {
+  const { classes, checked, disabled } = styleProps;
+
+  const slots = {
+    root: ['root', checked && 'checked', disabled && 'disabled'],
+    input: ['input'],
+  };
+
+  return composeClasses(slots, getSwitchBaseUtilityClass, classes);
+};
+
+const SwitchBaseRoot = experimentalStyled(
+  IconButton,
+  {},
+  {
+    name: 'PrivateSwitchBase',
+    slot: 'Root',
+    overridesResolver,
+  },
+)({
+  /* Styles applied to the root element. */
+  padding: 9,
+});
+
+const SwitchBaseInput = experimentalStyled(
+  'input',
+  {},
+  {
+    name: 'PrivateSwitchBase',
+    slot: 'Input',
+  },
+)({
+  /* Styles applied to the internal input element. */
+  cursor: 'inherit',
+  position: 'absolute',
+  opacity: 0,
+  width: '100%',
+  height: '100%',
+  top: 0,
+  left: 0,
+  margin: 0,
+  padding: 0,
+  zIndex: 1,
+});
 
 /**
  * @ignore - internal component.
  */
-const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
+const SwitchBase = React.forwardRef(function SwitchBase(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'PrivateSwitchBase' });
   const {
     autoFocus,
     checked: checkedProp,
     checkedIcon,
-    classes,
     className,
     defaultChecked,
     disabled: disabledProp,
@@ -109,26 +145,28 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
 
   const hasLabelFor = type === 'checkbox' || type === 'radio';
 
+  const styleProps = {
+    ...props,
+    checked,
+    disabled,
+  };
+
+  const classes = useUtilityClasses(styleProps);
+
   return (
-    <IconButton
+    <SwitchBaseRoot
       component="span"
-      className={clsx(
-        classes.root,
-        {
-          [classes.checked]: checked,
-          [classes.disabled]: disabled,
-        },
-        className,
-      )}
+      className={clsx(classes.root, className)}
       disabled={disabled}
       tabIndex={null}
       role={undefined}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      styleProps={styleProps}
       ref={ref}
       {...other}
     >
-      <input
+      <SwitchBaseInput
         autoFocus={autoFocus}
         checked={checkedProp}
         defaultChecked={defaultChecked}
@@ -140,13 +178,14 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
         readOnly={readOnly}
         ref={inputRef}
         required={required}
+        styleProps={styleProps}
         tabIndex={tabIndex}
         type={type}
         value={value}
         {...inputProps}
       />
       {checked ? checkedIcon : icon}
-    </IconButton>
+    </SwitchBaseRoot>
   );
 });
 
@@ -165,11 +204,6 @@ SwitchBase.propTypes = {
    * The icon to display when the component is checked.
    */
   checkedIcon: PropTypes.node.isRequired,
-  /**
-   * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
-   */
-  classes: PropTypes.object.isRequired,
   /**
    * @ignore
    */
@@ -227,6 +261,10 @@ SwitchBase.propTypes = {
    */
   required: PropTypes.bool,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -240,4 +278,4 @@ SwitchBase.propTypes = {
   value: PropTypes.any,
 };
 
-export default withStyles(styles, { name: 'PrivateSwitchBase' })(SwitchBase);
+export default SwitchBase;

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -205,6 +205,11 @@ SwitchBase.propTypes = {
    */
   checkedIcon: PropTypes.node.isRequired,
   /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css) below for more details.
+   */
+  classes: PropTypes.object.isRequired,
+  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -208,7 +208,7 @@ SwitchBase.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -12,8 +12,6 @@ import switchBaseClasses, { getSwitchBaseUtilityClass } from './switchBaseClasse
 
 const overridesResolver = (props, styles) => {
   return deepmerge(styles.root || {}, {
-    [`&.${switchBaseClasses.checked}`]: styles.checked,
-    [`&.${switchBaseClasses.disabled}`]: styles.disabled,
     [`& .${switchBaseClasses.input}`]: styles.input,
   });
 };

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -1,20 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType, deepmerge } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
-import useThemeProps from '../styles/useThemeProps';
 import useControlled from '../utils/useControlled';
 import useFormControl from '../FormControl/useFormControl';
 import IconButton from '../IconButton';
-import switchBaseClasses, { getSwitchBaseUtilityClass } from './switchBaseClasses';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(styles.root || {}, {
-    [`& .${switchBaseClasses.input}`]: styles.input,
-  });
-};
+import { getSwitchBaseUtilityClass } from './switchBaseClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { classes, checked, disabled } = styleProps;
@@ -33,7 +26,6 @@ const SwitchBaseRoot = experimentalStyled(
   {
     name: 'PrivateSwitchBase',
     slot: 'Root',
-    overridesResolver,
   },
 )({
   /* Styles applied to the root element. */
@@ -64,8 +56,7 @@ const SwitchBaseInput = experimentalStyled(
 /**
  * @ignore - internal component.
  */
-const SwitchBase = React.forwardRef(function SwitchBase(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'PrivateSwitchBase' });
+const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
   const {
     autoFocus,
     checked: checkedProp,

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -1,28 +1,27 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';
+import classes from './switchBaseClasses';
 
 describe('<SwitchBase />', () => {
   const render = createClientRender();
   const mount = createMount();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />);
-  });
-
-  describeConformance(
+  describeConformanceV5(
     <SwitchBase checkedIcon="checked" icon="unchecked" type="checkbox" />,
     () => ({
       classes,
       inheritComponent: IconButton,
       mount,
+      muiName: 'PrivateSwitchBase',
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
+      testVariantProps: { disabled: true },
+      skip: ['componentsProp', 'themeDefaultProps'],
     }),
   );
 

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -21,7 +21,7 @@ describe('<SwitchBase />', () => {
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
       testVariantProps: { disabled: true },
-       testThemeComponentsDefaultPropName: 'data-test',
+      testThemeComponentsDefaultPropName: 'data-test',
       skip: ['componentsProp'],
     }),
   );

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -17,11 +17,10 @@ describe('<SwitchBase />', () => {
       classes,
       inheritComponent: IconButton,
       mount,
-      muiName: 'PrivateSwitchBase',
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
       testVariantProps: { disabled: true },
-      skip: ['componentsProp', 'themeDefaultProps', 'themeStyleOverrides'],
+      skip: ['componentsProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
     }),
   );
 

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -22,7 +22,7 @@ describe('<SwitchBase />', () => {
       testComponentPropWith: 'div',
       testVariantProps: { disabled: true },
       testThemeComponentsDefaultPropName: 'data-test',
-      skip: ['componentsProp'],
+      skip: ['componentsProp', 'themeDefaultProps', 'themeStyleOverrides'],
     }),
   );
 

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -21,7 +21,8 @@ describe('<SwitchBase />', () => {
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
       testVariantProps: { disabled: true },
-      skip: ['componentsProp', 'themeDefaultProps'],
+       testThemeComponentsDefaultPropName: 'data-test',
+      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -21,7 +21,6 @@ describe('<SwitchBase />', () => {
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
       testVariantProps: { disabled: true },
-      testThemeComponentsDefaultPropName: 'data-test',
       skip: ['componentsProp', 'themeDefaultProps', 'themeStyleOverrides'],
     }),
   );

--- a/packages/material-ui/src/internal/switchBaseClasses.d.ts
+++ b/packages/material-ui/src/internal/switchBaseClasses.d.ts
@@ -1,0 +1,12 @@
+export interface SwitchBaseClasses {
+  root: string;
+  checked: string;
+  disabled: string;
+  input: string;
+}
+
+declare const switchBaseClasses: SwitchBaseClasses;
+
+export function getSwitchBaseUtilityClass(slot: string): string;
+
+export default switchBaseClasses;

--- a/packages/material-ui/src/internal/switchBaseClasses.js
+++ b/packages/material-ui/src/internal/switchBaseClasses.js
@@ -1,0 +1,14 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getSwitchBaseUtilityClass(slot) {
+  return generateUtilityClass('PrivateSwitchBase', slot);
+}
+
+const switchBaseClasses = generateUtilityClasses('PrivateSwitchBase', [
+  'root',
+  'checked',
+  'disabled',
+  'input',
+]);
+
+export default switchBaseClasses;

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -42,7 +42,8 @@ function testThemeDefaultProps(element, getOptions) {
 
   describe('theme: default components', () => {
     it("respect theme's defaultProps", () => {
-      const { muiName, testThemeComponentsDefaultPropName: testProp = 'id' } = getOptions();
+      const testProp = 'data-id';
+      const { muiName } = getOptions();
       const theme = createMuiTheme({
         components: {
           [muiName]: {


### PR DESCRIPTION
This PR migrates the `SwitchBase` component to the new emotion format as a part of #24405.  Additionally, since we're here, this fixes a typo in the component's TypeScript definition for the classes (`inpit` -> `input`).

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
