### PR TITLE
[BottomNavigation] Migrate to emotion

### DIFF
--- a/docs/pages/api-docs/bottom-navigation-action.json
+++ b/docs/pages/api-docs/bottom-navigation-action.json
@@ -5,6 +5,7 @@
     "icon": { "type": { "name": "node" } },
     "label": { "type": { "name": "node" } },
     "showLabel": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } },
     "value": { "type": { "name": "any" } }
   },
   "name": "BottomNavigationAction",
@@ -18,6 +19,6 @@
   "filename": "/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/api/button-base/" },
   "demos": "<ul><li><a href=\"/components/bottom-navigation/\">Bottom Navigation</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/pages/api-docs/bottom-navigation.json
+++ b/docs/pages/api-docs/bottom-navigation.json
@@ -5,6 +5,7 @@
     "component": { "type": { "name": "elementType" } },
     "onChange": { "type": { "name": "func" } },
     "showLabels": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } },
     "value": { "type": { "name": "any" } }
   },
   "name": "BottomNavigation",
@@ -14,6 +15,6 @@
   "filename": "/packages/material-ui/src/BottomNavigation/BottomNavigation.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/bottom-navigation/\">Bottom Navigation</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json
+++ b/docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json
@@ -6,6 +6,7 @@
     "icon": "The icon to display.",
     "label": "The label element.",
     "showLabel": "If <code>true</code>, the <code>BottomNavigationAction</code> will show its label. By default, only the selected <code>BottomNavigationAction</code> inside <code>BottomNavigation</code> will show its label.<br>The prop defaults to the value (<code>false</code>) inherited from the parent BottomNavigation component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "value": "You can provide your own value. Otherwise, we fallback to the child position index."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/bottom-navigation/bottom-navigation.json
+++ b/docs/translations/api-docs/bottom-navigation/bottom-navigation.json
@@ -6,6 +6,7 @@
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "onChange": "Callback fired when the value changes.<br><br><strong>Signature:</strong><br><code>function(event: object, value: any) =&gt; void</code><br><em>event:</em> The event source of the callback. <strong>Warning</strong>: This is a generic event not a change event.<br><em>value:</em> We default to the index of the child.",
     "showLabels": "If <code>true</code>, all <code>BottomNavigationAction</code>s will show their labels. By default, only the selected <code>BottomNavigationAction</code> will show its label.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "value": "The value of the currently selected <code>BottomNavigationAction</code>."
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } }

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -70,7 +70,7 @@ export const componentSettings = {
     template: 'badge.txt',
   },
   BottomNavigation: {
-    ignoredProps: ['children', 'onChange', 'ScrollButtonComponent', 'value'],
+    ignoredProps: ['children', 'onChange', 'ScrollButtonComponent', 'value', 'sx'],
     propValues: {
       icons: "['restore', 'favorite', 'location_on', 'folder']",
       labels: "['Recents', 'Favorites', 'Nearby', 'Saved']",

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.d.ts
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface BottomNavigationTypeMap<P = {}, D extends React.ElementType = 'div'> {
@@ -27,6 +29,10 @@ export interface BottomNavigationTypeMap<P = {}, D extends React.ElementType = '
      * @default false
      */
     showLabels?: boolean;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
     /**
      * The value of the currently selected `BottomNavigationAction`.
      */

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -2,32 +2,63 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
+import { getBottomNavigationUtilityClass } from './bottomNavigationClasses';
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    height: 56,
-    backgroundColor: theme.palette.background.paper,
+const overridesResolver = (props, styles) => styles.root || {};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes } = styleProps;
+
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getBottomNavigationUtilityClass, classes);
+};
+
+const BottomNavigationRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiBottomNavigation',
+    slot: 'Root',
+    overridesResolver,
   },
-});
+)(({ theme }) => ({
+  /* Styles applied to the root element. */
+  display: 'flex',
+  justifyContent: 'center',
+  height: 56,
+  backgroundColor: theme.palette.background.paper,
+}));
 
-const BottomNavigation = React.forwardRef(function BottomNavigation(props, ref) {
+const BottomNavigation = React.forwardRef(function BottomNavigation(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiBottomNavigation' });
   const {
     children,
-    classes,
     className,
-    component: Component = 'div',
+    component = 'div',
     onChange,
     showLabels = false,
     value,
     ...other
   } = props;
 
+  const styleProps = props;
+
+  const classes = useUtilityClasses(styleProps);
+
   return (
-    <Component className={clsx(classes.root, className)} ref={ref} {...other}>
+    <BottomNavigationRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      ref={ref}
+      styleProps={styleProps}
+      {...other}
+    >
       {React.Children.map(children, (child, childIndex) => {
         if (!React.isValidElement(child)) {
           return null;
@@ -53,7 +84,7 @@ const BottomNavigation = React.forwardRef(function BottomNavigation(props, ref) 
           onChange,
         });
       })}
-    </Component>
+    </BottomNavigationRoot>
   );
 });
 
@@ -93,9 +124,13 @@ BottomNavigation.propTypes = {
    */
   showLabels: PropTypes.bool,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The value of the currently selected `BottomNavigationAction`.
    */
   value: PropTypes.any,
 };
 
-export default withStyles(styles, { name: 'MuiBottomNavigation' })(BottomNavigation);
+export default BottomNavigation;

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -47,7 +47,11 @@ const BottomNavigation = React.forwardRef(function BottomNavigation(inProps, ref
     ...other
   } = props;
 
-  const styleProps = props;
+  const styleProps = {
+    ...props,
+    component,
+    showLabels,
+  };
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -1,35 +1,20 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  getClasses,
-  createMount,
-  describeConformance,
-  createClientRender,
-  fireEvent,
-} from 'test/utils';
+import { createMount, describeConformanceV5, createClientRender, fireEvent } from 'test/utils';
 import BottomNavigationAction from '../BottomNavigationAction';
 import Icon from '../Icon';
 import BottomNavigation from './BottomNavigation';
+import classes from './bottomNavigationClasses';
+import actionClasses from '../BottomNavigationAction/bottomNavigationActionClasses';
 
 describe('<BottomNavigation />', () => {
   const mount = createMount();
-  let classes;
-  let actionClasses;
   const render = createClientRender();
   const icon = <Icon>restore</Icon>;
   const getBottomNavigation = (container) => container.firstChild;
 
-  before(() => {
-    classes = getClasses(
-      <BottomNavigation showLabels value={0}>
-        <BottomNavigationAction icon={icon} />
-      </BottomNavigation>,
-    );
-    actionClasses = getClasses(<BottomNavigationAction icon={icon} />);
-  });
-
-  describeConformance(
+  describeConformanceV5(
     <BottomNavigation>
       <BottomNavigationAction label="One" />
     </BottomNavigation>,
@@ -37,8 +22,10 @@ describe('<BottomNavigation />', () => {
       classes,
       inheritComponent: 'div',
       mount,
+      muiName: 'BottomNavigation',
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'span',
+      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -22,10 +22,10 @@ describe('<BottomNavigation />', () => {
       classes,
       inheritComponent: 'div',
       mount,
-      muiName: 'BottomNavigation',
+      muiName: 'MuiBottomNavigation',
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'span',
-      skip: ['componentsProp'],
+      skip: ['componentsProp', 'themeVariants'],
     }),
   );
 

--- a/packages/material-ui/src/BottomNavigation/bottomNavigationClasses.d.ts
+++ b/packages/material-ui/src/BottomNavigation/bottomNavigationClasses.d.ts
@@ -1,0 +1,9 @@
+export interface BottomNavigationClasses {
+  root: string;
+}
+
+declare const bottomNavigationClasses: BottomNavigationClasses;
+
+export function getBottomNavigationUtilityClass(slot: string): string;
+
+export default bottomNavigationClasses;

--- a/packages/material-ui/src/BottomNavigation/bottomNavigationClasses.js
+++ b/packages/material-ui/src/BottomNavigation/bottomNavigationClasses.js
@@ -1,0 +1,9 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getBottomNavigationUtilityClass(slot) {
+  return generateUtilityClass('MuiBottomNavigation', slot);
+}
+
+const bottomNavigationClasses = generateUtilityClasses('MuiBottomNavigation', ['root']);
+
+export default bottomNavigationClasses;

--- a/packages/material-ui/src/BottomNavigation/index.d.ts
+++ b/packages/material-ui/src/BottomNavigation/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './BottomNavigation';
 export * from './BottomNavigation';
+
+export { default as bottomNavigationClasses } from './bottomNavigationClasses';
+export * from './bottomNavigationClasses';

--- a/packages/material-ui/src/BottomNavigation/index.js
+++ b/packages/material-ui/src/BottomNavigation/index.js
@@ -1,1 +1,4 @@
 export { default } from './BottomNavigation';
+
+export { default as bottomNavigationClasses } from './bottomNavigationClasses';
+export * from './bottomNavigationClasses';

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.d.ts
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '..';
 import { ButtonBaseTypeMap, ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 
@@ -43,6 +45,10 @@ export type BottomNavigationActionTypeMap<
      * The prop defaults to the value (`false`) inherited from the parent BottomNavigation component.
      */
     showLabel?: boolean;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
     /**
      * You can provide your own value. Otherwise, we fallback to the child position index.
      */

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -98,7 +98,7 @@ const BottomNavigationActionLabel = experimentalStyled(
     }),
   [`&.${bottomNavigationActionClasses.selected}`]: {
     fontSize: theme.typography.pxToRem(14),
-    },
+  },
   }),
 }));
 

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -123,7 +123,8 @@ const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(
     ...other
   } = props;
 
-  const styleProps = props;
+  // TODO: convert to simple assignment after the type error in defaultPropsHandler.js:60:6 is fixed
+  const styleProps = { ...props };
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -55,12 +55,10 @@ const BottomNavigationActionRoot = experimentalStyled(
     !styleProps.selected && {
       paddingTop: 16,
     }),
-  ...(styleProps.selected && {
-    [`&.${bottomNavigationActionClasses.selected}`]: {
-      paddingTop: 6,
-      color: theme.palette.primary.main,
-    },
-  }),
+  [`&.${bottomNavigationActionClasses.selected}`]: {
+    paddingTop: 6,
+    color: theme.palette.primary.main,
+  },
 }));
 
 const BottomNavigationActionWrapper = experimentalStyled(

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -123,11 +123,7 @@ const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(
     ...other
   } = props;
 
-  const styleProps = {
-    ...props,
-    selected,
-    showLabel,
-  };
+  const styleProps = props;
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -96,8 +96,7 @@ const BottomNavigationActionLabel = experimentalStyled(
       opacity: 0,
       transitionDelay: '0s',
     }),
-  ...(styleProps.selected && {
-    [`&.${bottomNavigationActionClasses.selected}`]: {
+  [`&.${bottomNavigationActionClasses.selected}`]: {
       fontSize: theme.typography.pxToRem(14),
     },
   }),

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -41,31 +41,25 @@ const BottomNavigationActionRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)(
-  ({ theme }) => ({
-    /* Styles applied to the root element. */
-    transition: theme.transitions.create(['color', 'padding-top'], {
-      duration: theme.transitions.duration.short,
+)(({ theme, styleProps }) => ({
+  /* Styles applied to the root element. */
+  transition: theme.transitions.create(['color', 'padding-top'], {
+    duration: theme.transitions.duration.short,
+  }),
+  padding: '6px 12px 8px',
+  minWidth: 80,
+  maxWidth: 168,
+  color: theme.palette.text.secondary,
+  flex: '1',
+  ...(!styleProps.showLabel &&
+    !styleProps.selected && {
+      paddingTop: 16,
     }),
-    padding: '6px 12px 8px',
-    minWidth: 80,
-    maxWidth: 168,
-    color: theme.palette.text.secondary,
-    flex: '1',
+  ...(styleProps.selected && {
+    paddingTop: 6,
+    color: theme.palette.primary.main,
   }),
-  ({ styleProps }) => ({
-    ...(!styleProps.showLabel &&
-      !styleProps.selected && {
-        paddingTop: 16,
-      }),
-  }),
-  ({ theme, styleProps }) => ({
-    ...(styleProps.selected && {
-      paddingTop: 6,
-      color: theme.palette.primary.main,
-    }),
-  }),
-);
+}));
 
 const BottomNavigationActionWrapper = experimentalStyled(
   'span',

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -100,8 +100,7 @@ const BottomNavigationActionLabel = experimentalStyled(
     }),
   ...(styleProps.selected && {
     [`&.${bottomNavigationActionClasses.selected}`]: {
-      paddingTop: 6,
-      color: theme.palette.primary.main,
+      fontSize: theme.typography.pxToRem(14),
     },
   }),
 }));

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -97,7 +97,7 @@ const BottomNavigationActionLabel = experimentalStyled(
       transitionDelay: '0s',
     }),
   [`&.${bottomNavigationActionClasses.selected}`]: {
-      fontSize: theme.typography.pxToRem(14),
+    fontSize: theme.typography.pxToRem(14),
     },
   }),
 }));

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -16,7 +16,6 @@ const overridesResolver = (props, styles) => {
 
   return deepmerge(styles.root || {}, {
     ...(!styleProps.showLabel && !styleProps.selected && styles.iconOnly),
-    ...(styleProps.selected && styles.selected),
     [`& .${bottomNavigationActionClasses.wrapper}`]: styles.wrapper,
     [`& .${bottomNavigationActionClasses.label}`]: styles.label,
   });

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -56,8 +56,10 @@ const BottomNavigationActionRoot = experimentalStyled(
       paddingTop: 16,
     }),
   ...(styleProps.selected && {
-    paddingTop: 6,
-    color: theme.palette.primary.main,
+    [`&.${bottomNavigationActionClasses.selected}`]: {
+      paddingTop: 6,
+      color: theme.palette.primary.main,
+    },
   }),
 }));
 

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -86,29 +86,25 @@ const BottomNavigationActionLabel = experimentalStyled(
     name: 'MuiBottomNavigationAction',
     slot: 'Label',
   },
-)(
-  ({ theme }) => ({
-    /* Styles applied to the label's span element. */
-    fontFamily: theme.typography.fontFamily,
-    fontSize: theme.typography.pxToRem(12),
-    opacity: 1,
-    transition: 'font-size 0.2s, opacity 0.2s',
-    transitionDelay: '0.1s',
-  }),
-  ({ styleProps }) => ({
-    ...(!styleProps.showLabel &&
-      !styleProps.selected && {
-        opacity: 0,
-        transitionDelay: '0s',
-      }),
-  }),
-  ({ theme, styleProps }) => ({
-    ...(styleProps.selected && {
+)(({ theme, styleProps }) => ({
+  /* Styles applied to the label's span element. */
+  fontFamily: theme.typography.fontFamily,
+  fontSize: theme.typography.pxToRem(12),
+  opacity: 1,
+  transition: 'font-size 0.2s, opacity 0.2s',
+  transitionDelay: '0.1s',
+  ...(!styleProps.showLabel &&
+    !styleProps.selected && {
+      opacity: 0,
+      transitionDelay: '0s',
+    }),
+  ...(styleProps.selected && {
+    [`&.${bottomNavigationActionClasses.selected}`]: {
       paddingTop: 6,
       color: theme.palette.primary.main,
-    }),
+    },
   }),
-);
+}));
 
 const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiBottomNavigationAction' });

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -99,7 +99,6 @@ const BottomNavigationActionLabel = experimentalStyled(
   [`&.${bottomNavigationActionClasses.selected}`]: {
     fontSize: theme.typography.pxToRem(14),
   },
-  }),
 }));
 
 const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(inProps, ref) {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -2,31 +2,29 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import {
-  getClasses,
   createMount,
-  describeConformance,
+  describeConformanceV5,
   createClientRender,
   within,
   fireEvent,
 } from 'test/utils';
 import ButtonBase from '../ButtonBase';
 import BottomNavigationAction from './BottomNavigationAction';
+import classes from './bottomNavigationActionClasses';
 
 describe('<BottomNavigationAction />', () => {
   const mount = createMount();
-  let classes;
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<BottomNavigationAction />);
-  });
-
-  describeConformance(<BottomNavigationAction />, () => ({
+  describeConformanceV5(<BottomNavigationAction />, () => ({
     classes,
     inheritComponent: ButtonBase,
     mount,
+    muiName: 'MuiBottomNavigationAction',
     refInstanceof: window.HTMLButtonElement,
-    skip: ['componentProp'],
+    testVariantProps: { showLabel: true },
+    testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('adds a `selected` class when selected', () => {

--- a/packages/material-ui/src/BottomNavigationAction/bottomNavigationActionClasses.d.ts
+++ b/packages/material-ui/src/BottomNavigationAction/bottomNavigationActionClasses.d.ts
@@ -1,0 +1,13 @@
+export interface BottomNavigationActionClasses {
+  root: string;
+  iconOnly: string;
+  selected: string;
+  wrapper: string;
+  label: string;
+}
+
+declare const bottomNavigationActionClasses: BottomNavigationActionClasses;
+
+export function getBottomNavigationActionUtilityClass(slot: string): string;
+
+export default bottomNavigationActionClasses;

--- a/packages/material-ui/src/BottomNavigationAction/bottomNavigationActionClasses.js
+++ b/packages/material-ui/src/BottomNavigationAction/bottomNavigationActionClasses.js
@@ -1,0 +1,15 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getBottomNavigationActionUtilityClass(slot) {
+  return generateUtilityClass('MuiBottomNavigationAction', slot);
+}
+
+const bottomNavigationActionClasses = generateUtilityClasses('MuiBottomNavigationAction', [
+  'root',
+  'iconOnly',
+  'selected',
+  'wrapper',
+  'label',
+]);
+
+export default bottomNavigationActionClasses;

--- a/packages/material-ui/src/BottomNavigationAction/index.d.ts
+++ b/packages/material-ui/src/BottomNavigationAction/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './BottomNavigationAction';
 export * from './BottomNavigationAction';
+
+export { default as bottomNavigationActionClasses } from './bottomNavigationActionClasses';
+export * from './bottomNavigationActionClasses';

--- a/packages/material-ui/src/BottomNavigationAction/index.js
+++ b/packages/material-ui/src/BottomNavigationAction/index.js
@@ -1,1 +1,4 @@
 export { default } from './BottomNavigationAction';
+
+export { default as bottomNavigationActionClasses } from './bottomNavigationActionClasses';
+export * from './bottomNavigationActionClasses';


### PR DESCRIPTION
This PR migrates the `BottomNavigation` and `BottomNavigationAction` components to the new emotion format as a part of #24405.

Notice: there's actually quite a number of failing builds for this one, such as with the docs generation.  Hoping to get some feedback on how to resolve said issues.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
