### PR TITLE
[Toolbar] Migrate to emotion

### DIFF
--- a/docs/pages/api-docs/toolbar.json
+++ b/docs/pages/api-docs/toolbar.json
@@ -4,6 +4,7 @@
     "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
     "disableGutters": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {
         "name": "union",
@@ -23,6 +24,6 @@
   "filename": "/packages/material-ui/src/Toolbar/Toolbar.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/app-bar/\">App Bar</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/toolbar/toolbar.json
+++ b/docs/translations/api-docs/toolbar/toolbar.json
@@ -5,6 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "disableGutters": "If <code>true</code>, disables gutter padding.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },
   "classDescriptions": {

--- a/packages/material-ui/src/Toolbar/Toolbar.d.ts
+++ b/packages/material-ui/src/Toolbar/Toolbar.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
 import { OverridableStringUnion } from '@material-ui/types';
+import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ToolbarPropsVariantOverrides {}
@@ -35,6 +37,10 @@ export interface ToolbarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * @default 'regular'
      */
     variant?: OverridableStringUnion<ToolbarVariantDefaults, ToolbarPropsVariantOverrides>;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -30,7 +30,7 @@ const ToolbarRoot = experimentalStyled(
   'div',
   {},
   {
-    name: 'MuiToobar',
+    name: 'MuiToolbar',
     slot: 'Root',
     overridesResolver,
   },

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -34,27 +34,29 @@ const ToolbarRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-  /* Styles applied to the root element unless `disableGutters={true}`. */
-  ...(!styleProps.disableGutters && {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    [theme.breakpoints.up('sm')]: {
-      paddingLeft: theme.spacing(3),
-      paddingRight: theme.spacing(3),
-    },
+)(
+  ({ theme, styleProps }) => ({
+    /* Styles applied to the root element. */
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    /* Styles applied to the root element unless `disableGutters={true}`. */
+    ...(!styleProps.disableGutters && {
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(2),
+      [theme.breakpoints.up('sm')]: {
+        paddingLeft: theme.spacing(3),
+        paddingRight: theme.spacing(3),
+      },
+    }),
+    /* Styles applied to the root element if `variant="dense"`. */
+    ...(styleProps.variant === 'dense' && {
+      minHeight: 48,
+    }),
   }),
   /* Styles applied to the root element if `variant="regular"`. */
-  ...(styleProps.variant === 'regular' && theme.mixins.toolbar),
-  /* Styles applied to the root element if `variant="dense"`. */
-  ...(styleProps.variant === 'dense' && {
-    minHeight: 48,
-  }),
-}));
+  ({ theme, styleProps }) => styleProps.variant === 'regular' && theme.mixins.toolbar,
+);
 
 const Toolbar = React.forwardRef(function Toolbar(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiToolbar' });

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -70,6 +70,7 @@ const Toolbar = React.forwardRef(function Toolbar(inProps, ref) {
 
   const styleProps = {
     ...props,
+    component,
     disableGutters,
     variant,
   };

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -11,8 +11,8 @@ const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
   return deepmerge(styles.root || {}, {
-    ...styleProps.variant,
     ...(!styleProps.disableGutters && styles.gutters),
+    ...styles[styleProps.variant],
   });
 };
 

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -1,22 +1,21 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import Toolbar from './Toolbar';
+import classes from './toolbarClasses';
 
 describe('<Toolbar />', () => {
   const mount = createMount();
   const render = createClientRender();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<Toolbar>foo</Toolbar>);
-  });
-
-  describeConformance(<Toolbar />, () => ({
+  describeConformanceV5(<Toolbar />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
+    muiName: 'MuiToolbar',
     refInstanceof: window.HTMLDivElement,
+    testVariantProps: { disableGutters: true, variant: 'regular' },
+    skip: ['componentsProps'],
   }));
 
   it('should render with gutters class', () => {

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -14,8 +14,9 @@ describe('<Toolbar />', () => {
     mount,
     muiName: 'MuiToolbar',
     refInstanceof: window.HTMLDivElement,
-    testVariantProps: { disableGutters: true, variant: 'regular' },
-    skip: ['componentsProps'],
+    testVariantProps: { variant: 'foo' },
+    testStateOverrides: { prop: 'variant', value: 'foo', styleKey: 'foo' },
+    skip: ['componentsProp'],
   }));
 
   it('should render with gutters class', () => {

--- a/packages/material-ui/src/Toolbar/index.d.ts
+++ b/packages/material-ui/src/Toolbar/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './Toolbar';
 export * from './Toolbar';
+
+export { default as toolbarClasses } from './toolbarClasses';
+export * from './toolbarClasses';

--- a/packages/material-ui/src/Toolbar/index.js
+++ b/packages/material-ui/src/Toolbar/index.js
@@ -1,1 +1,4 @@
 export { default } from './Toolbar';
+
+export { default as toolbarClasses } from './toolbarClasses';
+export * from './toolbarClasses';

--- a/packages/material-ui/src/Toolbar/toolbarClasses.d.ts
+++ b/packages/material-ui/src/Toolbar/toolbarClasses.d.ts
@@ -1,0 +1,12 @@
+export interface ToolbarClasses {
+  root: string;
+  dense: string;
+  regular: string;
+  gutters: string;
+}
+
+declare const toolbarClasses: ToolbarClasses;
+
+export function getToolbarUtilityClass(slot: string): string;
+
+export default toolbarClasses;

--- a/packages/material-ui/src/Toolbar/toolbarClasses.d.ts
+++ b/packages/material-ui/src/Toolbar/toolbarClasses.d.ts
@@ -1,8 +1,8 @@
 export interface ToolbarClasses {
   root: string;
-  dense: string;
-  regular: string;
   gutters: string;
+  regular: string;
+  dense: string;
 }
 
 declare const toolbarClasses: ToolbarClasses;

--- a/packages/material-ui/src/Toolbar/toolbarClasses.js
+++ b/packages/material-ui/src/Toolbar/toolbarClasses.js
@@ -1,0 +1,14 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getToolbarUtilityClass(slot) {
+  return generateUtilityClass('MuiToolbar', slot);
+}
+
+const toolbarClasses = generateUtilityClasses('MuiToolbar', [
+  'root',
+  'gutters',
+  'dense',
+  'regular',
+]);
+
+export default toolbarClasses;

--- a/packages/material-ui/src/Toolbar/toolbarClasses.js
+++ b/packages/material-ui/src/Toolbar/toolbarClasses.js
@@ -7,8 +7,8 @@ export function getToolbarUtilityClass(slot) {
 const toolbarClasses = generateUtilityClasses('MuiToolbar', [
   'root',
   'gutters',
-  'dense',
   'regular',
+  'dense',
 ]);
 
 export default toolbarClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

MIgrates `Toolbar` to emotion #24405 

This PR may need some help with the testing as I was not able to get it working.
Was curious if I could get pointed in the right direction.
