### PR TITLE
[List] Migrate ListItemSecondaryAction to emotion

### DIFF
--- a/docs/pages/api-docs/list-item-secondary-action.json
+++ b/docs/pages/api-docs/list-item-secondary-action.json
@@ -1,7 +1,8 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } }
+    "classes": { "type": { "name": "object" } },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "ListItemSecondaryAction",
   "styles": {
@@ -14,6 +15,6 @@
   "filename": "/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/lists/\">Lists</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/list-item-secondary-action/list-item-secondary-action.json
+++ b/docs/translations/api-docs/list-item-secondary-action/list-item-secondary-action.json
@@ -2,7 +2,8 @@
   "componentDescription": "Must be used as the last child of ListItem to function properly.",
   "propDescriptions": {
     "children": "The content of the component, normally an <code>IconButton</code> or selection control.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details."
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/framer/Material-UI.framerfx/code/ListItem.tsx
+++ b/framer/Material-UI.framerfx/code/ListItem.tsx
@@ -20,6 +20,7 @@ interface Props {
   disableGutters: boolean;
   divider: boolean;
   selected: boolean;
+  sx?: object;
   width: number | string;
   height: number;
   inset: boolean;
@@ -165,6 +166,10 @@ addPropertyControls(ListItem, {
   selected: {
     type: ControlType.Boolean,
     title: 'Selected',
+  },
+  sx: {
+    type: ControlType.Object,
+    title: 'Sx',
   },
   inset: {
     type: ControlType.Boolean,

--- a/framer/Material-UI.framerfx/code/ListItem.tsx
+++ b/framer/Material-UI.framerfx/code/ListItem.tsx
@@ -20,7 +20,6 @@ interface Props {
   disableGutters: boolean;
   divider: boolean;
   selected: boolean;
-  sx?: object;
   width: number | string;
   height: number;
   inset: boolean;
@@ -166,10 +165,6 @@ addPropertyControls(ListItem, {
   selected: {
     type: ControlType.Boolean,
     title: 'Selected',
-  },
-  sx: {
-    type: ControlType.Object,
-    title: 'Sx',
   },
   inset: {
     type: ControlType.Boolean,

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -1,4 +1,5 @@
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 
 export interface ListItemSecondaryActionProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
@@ -15,6 +16,10 @@ export interface ListItemSecondaryActionProps
     /** Styles applied to the root element when the parent `ListItem` has `disableGutters={true}`. */
     disableGutters?: string;
   };
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type ListItemSecondaryActionClassKey = keyof NonNullable<

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,24 +1,21 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import ListItemSecondaryAction from './ListItemSecondaryAction';
 import ListItem from '../ListItem';
+import classes from './listItemSecondaryActionClasses';
 
 describe('<ListItemSecondaryAction />', () => {
   const mount = createMount();
   const render = createClientRender();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<ListItemSecondaryAction />);
-  });
-
-  describeConformance(<ListItemSecondaryAction />, () => ({
+  describeConformanceV5(<ListItemSecondaryAction />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiListItemSecondaryAction',
+    skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
   it('should render without classes that disable gutters', () => {

--- a/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.d.ts
+++ b/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.d.ts
@@ -1,0 +1,10 @@
+export interface ListItemSecondaryActionClasses {
+  root: string;
+  disableGutters: string;
+}
+
+declare const listItemSecondaryActionClasses: ListItemSecondaryActionClasses;
+
+export function getListItemSecondaryActionClassesUtilityClass(slot: string): string;
+
+export default listItemSecondaryActionClasses;

--- a/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.js
@@ -1,0 +1,12 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getListItemSecondaryActionClassesUtilityClass(slot) {
+  return generateUtilityClass('MuiButton', slot);
+}
+
+const listItemSecondaryActionClasses = generateUtilityClasses('MuiButton', [
+  'root',
+  'disableGutters',
+]);
+
+export default listItemSecondaryActionClasses;

--- a/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.js
@@ -4,7 +4,7 @@ export function getListItemSecondaryActionClassesUtilityClass(slot) {
   return generateUtilityClass('MuiListItemSecondaryAction', slot);
 }
 
-const listItemSecondaryActionClasses = generateUtilityClasses('MuiButton', [
+const listItemSecondaryActionClasses = generateUtilityClasses('MuiListItemSecondaryAction', [
   'root',
   'disableGutters',
 ]);

--- a/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/listItemSecondaryActionClasses.js
@@ -1,7 +1,7 @@
 import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
 
 export function getListItemSecondaryActionClassesUtilityClass(slot) {
-  return generateUtilityClass('MuiButton', slot);
+  return generateUtilityClass('MuiListItemSecondaryAction', slot);
 }
 
 const listItemSecondaryActionClasses = generateUtilityClasses('MuiButton', [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR migrates the`ListItemSecondaryAction` component to the new emotion format as a part of #24405.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
