### PR TITLE
[examples] Add `locale` prop to the Nextjs Link component

### DIFF
--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -16,7 +16,18 @@ interface NextLinkComposedProps
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, ...other } = props;
+    const {
+      to,
+      linkAs,
+      href,
+      replace,
+      scroll,
+      passHref,
+      shallow,
+      prefetch,
+      locale,
+      ...other
+    } = props;
 
     return (
       <NextLink
@@ -27,6 +38,7 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         scroll={scroll}
         shallow={shallow}
         passHref={passHref}
+        locale={locale}
       >
         <a ref={ref} {...other} />
       </NextLink>

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -15,7 +15,7 @@ interface NextLinkComposedProps
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, ...other } = props;
+    const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, locale, ...other } = props;
 
     return (
       <NextLink
@@ -26,6 +26,7 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         scroll={scroll}
         shallow={shallow}
         passHref={passHref}
+        locale={locale}
       >
         <a ref={ref} {...other} />
       </NextLink>

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -15,7 +15,18 @@ interface NextLinkComposedProps
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, locale, ...other } = props;
+    const {
+      to,
+      linkAs,
+      href,
+      replace,
+      scroll,
+      passHref,
+      shallow,
+      prefetch,
+      locale,
+      ...other
+    } = props;
 
     return (
       <NextLink

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -7,7 +7,18 @@ import NextLink from 'next/link';
 import MuiLink from '@material-ui/core/Link';
 
 export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props, ref) {
-  const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, locale, ...other } = props;
+  const {
+    to,
+    linkAs,
+    href,
+    replace,
+    scroll,
+    passHref,
+    shallow,
+    prefetch,
+    locale,
+    ...other
+  } = props;
 
   return (
     <NextLink

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -7,7 +7,7 @@ import NextLink from 'next/link';
 import MuiLink from '@material-ui/core/Link';
 
 export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props, ref) {
-  const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, ...other } = props;
+  const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, locale, ...other } = props;
 
   return (
     <NextLink
@@ -18,6 +18,7 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
       scroll={scroll}
       shallow={shallow}
       passHref={passHref}
+      locale={locale}
     >
       <a ref={ref} {...other} />
     </NextLink>
@@ -27,6 +28,7 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
 NextLinkComposed.propTypes = {
   href: PropTypes.any,
   linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  locale: PropTypes.string,
   passHref: PropTypes.bool,
   prefetch: PropTypes.bool,
   replace: PropTypes.bool,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I have found that Link component in nextjs example was ignoring the `locale` prop. 
