### PR TITLE
[Card] Migrate CardActions to emotion

### DIFF
--- a/docs/pages/api-docs/card-actions.json
+++ b/docs/pages/api-docs/card-actions.json
@@ -2,7 +2,8 @@
   "props": {
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "disableSpacing": { "type": { "name": "bool" } }
+    "disableSpacing": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "CardActions",
   "styles": { "classes": ["root", "spacing"], "globalClasses": {}, "name": "MuiCardActions" },
@@ -11,6 +12,6 @@
   "filename": "/packages/material-ui/src/CardActions/CardActions.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/cards/\">Cards</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/card-actions/card-actions.json
+++ b/docs/translations/api-docs/card-actions/card-actions.json
@@ -3,7 +3,8 @@
   "propDescriptions": {
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
-    "disableSpacing": "If <code>true</code>, the actions do not have additional margin."
+    "disableSpacing": "If <code>true</code>, the actions do not have additional margin.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -37,7 +37,7 @@
     "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true yarn build:modern",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",
-    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/src/CardActions/CardActions.test.{js,ts,tsx}'",
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
   },

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -37,7 +37,7 @@
     "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true yarn build:modern",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",
-    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.{js,ts,tsx}'",
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/src/CardActions/CardActions.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
   },

--- a/packages/material-ui/src/CardActions/CardActions.d.ts
+++ b/packages/material-ui/src/CardActions/CardActions.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 
 export interface CardActionsProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**
@@ -15,6 +16,10 @@ export interface CardActionsProps extends StandardProps<React.HTMLAttributes<HTM
     /** Styles applied to the root element unless `disableSpacing={true}`. */
     spacing?: string;
   };
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
   /**
    * If `true`, the actions do not have additional margin.
    * @default false

--- a/packages/material-ui/src/CardActions/CardActions.js
+++ b/packages/material-ui/src/CardActions/CardActions.js
@@ -1,29 +1,67 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
+import { getCardActionsUtilityClass } from './cardActionsClasses';
 
-export const styles = {
-  /* Styles applied to the root element. */
-  root: {
-    display: 'flex',
-    alignItems: 'center',
-    padding: 8,
-  },
-  /* Styles applied to the root element unless `disableSpacing={true}`. */
-  spacing: {
-    '& > :not(:first-child)': {
-      marginLeft: 8,
-    },
-  },
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(styles.root || {}, {
+    ...(!styleProps.disableSpacing && styles.spacing),
+  });
 };
 
-const CardActions = React.forwardRef(function CardActions(props, ref) {
-  const { disableSpacing = false, classes, className, ...other } = props;
+const useUtilityClasses = (styleProps) => {
+  const { classes, disableSpacing } = styleProps;
+
+  const slots = {
+    root: ['root', !disableSpacing && 'spacing'],
+  };
+
+  return composeClasses(slots, getCardActionsUtilityClass, classes);
+};
+
+const CardActionsRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiCardActions',
+    slot: 'Root',
+    overridesResolver,
+  },
+)(({ styleProps }) => ({
+  /* Styles applied to the root element. */
+  display: 'flex',
+  alignItems: 'center',
+  padding: 8,
+  /* Styles applied to the root element unless `disableSpacing={true}`. */
+  ...(!styleProps.disableSpacing && {
+    '& > :not(:first-of-type)': {
+      marginLeft: 8,
+    },
+  }),
+}));
+
+const CardActions = React.forwardRef(function CardActions(inProps, ref) {
+  const props = useThemeProps({
+    props: inProps,
+    name: 'MuiCardActions',
+  });
+
+  const { disableSpacing = false, className, ...other } = props;
+
+  const styleProps = { ...props, disableSpacing };
+
+  const classes = useUtilityClasses(styleProps);
 
   return (
-    <div
-      className={clsx(classes.root, { [classes.spacing]: !disableSpacing }, className)}
+    <CardActionsRoot
+      className={clsx(classes.root, className)}
+      styleProps={styleProps}
       ref={ref}
       {...other}
     />
@@ -52,6 +90,10 @@ CardActions.propTypes = {
    * @default false
    */
   disableSpacing: PropTypes.bool,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiCardActions' })(CardActions);
+export default CardActions;

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -1,20 +1,18 @@
 import * as React from 'react';
-import { getClasses, createMount, describeConformance } from 'test/utils';
+import { createMount, describeConformanceV5 } from 'test/utils';
 import CardActions from './CardActions';
+import classes from './cardActionsClasses';
 
 describe('<CardActions />', () => {
   const mount = createMount();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<CardActions />);
-  });
-
-  describeConformance(<CardActions />, () => ({
+  describeConformanceV5(<CardActions />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
+    muiName: 'MuiCardActions',
+    testVariantProps: { disableSpacing: true },
     skip: ['componentProp'],
   }));
 });

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -13,6 +13,6 @@ describe('<CardActions />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiCardActions',
     testVariantProps: { disableSpacing: true },
-    skip: ['componentProp'],
+    skip: ['componentProp', 'componentsProp'],
   }));
 });

--- a/packages/material-ui/src/CardActions/cardActionsClasses.d.ts
+++ b/packages/material-ui/src/CardActions/cardActionsClasses.d.ts
@@ -1,0 +1,10 @@
+export interface CardActionsClasses {
+  root: string;
+  spacing: string;
+}
+
+declare const cardActionsClasses: CardActionsClasses;
+
+export function getCardActionsUtilityClass(slot: string): string;
+
+export default cardActionsClasses;

--- a/packages/material-ui/src/CardActions/cardActionsClasses.js
+++ b/packages/material-ui/src/CardActions/cardActionsClasses.js
@@ -1,0 +1,9 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getCardActionsUtilityClass(slot) {
+  return generateUtilityClass('MuiCardActions', slot);
+}
+
+const cardActionsClasses = generateUtilityClasses('MuiCardActions', ['root', 'spacing']);
+
+export default cardActionsClasses;

--- a/packages/material-ui/src/CardActions/index.d.ts
+++ b/packages/material-ui/src/CardActions/index.d.ts
@@ -1,2 +1,4 @@
 export { default } from './CardActions';
 export * from './CardActions';
+export { default as cardContentClasses } from './cardActionsClasses';
+export * from './cardActionsClasses';

--- a/packages/material-ui/src/CardActions/index.js
+++ b/packages/material-ui/src/CardActions/index.js
@@ -1,1 +1,3 @@
 export { default } from './CardActions';
+export { default as cardClasses } from './cardActionsClasses';
+export * from './cardActionsClasses';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

One of #24405

💡 In which scenario should `disableSpacing` work? doing the migration I realized that it does not work, this came from before.