### PR TITLE
[docs] Add missing newline in component JSDOC

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -563,6 +563,10 @@ async function annotateComponentDefinition(context: {
   }
 
   const markdownLines = (await computeApiDescription(api, { host: HOST })).split('\n');
+  // Ensure a newline between manual and generated description.
+  if (markdownLines[markdownLines.length - 1] !== '') {
+    markdownLines.push('');
+  }
   if (demos.length > 0) {
     markdownLines.push(
       'Demos:',

--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -112,6 +112,7 @@ export type ExtendButtonBase<M extends OverridableTypeMap> = ((
  * `ButtonBase` contains as few styles as possible.
  * It aims to be a simple building block for creating a button.
  * It contains a load of style reset and some focus/ripple logic.
+ *
  * Demos:
  *
  * - [Buttons](https://material-ui.com/components/buttons/)

--- a/packages/material-ui/src/Chip/Chip.d.ts
+++ b/packages/material-ui/src/Chip/Chip.d.ts
@@ -137,6 +137,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
 
 /**
  * Chips represent complex entities in small blocks, such as a contact.
+ *
  * Demos:
  *
  * - [Chips](https://material-ui.com/components/chips/)

--- a/packages/material-ui/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.d.ts
@@ -73,6 +73,7 @@ export type CircularProgressClassKey = keyof NonNullable<CircularProgressProps['
  * If the progress bar is describing the loading progress of a particular region of a page,
  * you should use `aria-describedby` to point to the progress bar, and set the `aria-busy`
  * attribute to `true` on that region until it has finished loading.
+ *
  * Demos:
  *
  * - [Progress](https://material-ui.com/components/progress/)

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.d.ts
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.d.ts
@@ -30,6 +30,7 @@ export interface ClickAwayListenerProps {
 /**
  * Listen for click events that occur somewhere in the document, outside of the element itself.
  * For instance, if you need to hide a menu when people click anywhere else on your page.
+ *
  * Demos:
  *
  * - [Click Away Listener](https://material-ui.com/components/click-away-listener/)

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -65,6 +65,7 @@ export type CollapseClassKey = keyof NonNullable<CollapseProps['classes']>;
  * The Collapse transition is used by the
  * [Vertical Stepper](https://material-ui.com/components/steppers/#vertical-stepper) StepContent component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
+ *
  * Demos:
  *
  * - [Cards](https://material-ui.com/components/cards/)

--- a/packages/material-ui/src/CssBaseline/CssBaseline.d.ts
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.d.ts
@@ -10,6 +10,7 @@ export interface CssBaselineProps extends StyledComponentProps<never> {
 
 /**
  * Kickstart an elegant, consistent, and simple baseline to build upon.
+ *
  * Demos:
  *
  * - [Css Baseline](https://material-ui.com/components/css-baseline/)

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -132,6 +132,7 @@ export type DialogClassKey = keyof NonNullable<DialogProps['classes']>;
 
 /**
  * Dialogs are overlaid modal paper based components with a backdrop.
+ *
  * Demos:
  *
  * - [Dialogs](https://material-ui.com/components/dialogs/)

--- a/packages/material-ui/src/Drawer/Drawer.d.ts
+++ b/packages/material-ui/src/Drawer/Drawer.d.ts
@@ -93,6 +93,7 @@ export type DrawerClassKey = keyof NonNullable<DrawerProps['classes']>;
 /**
  * The props of the [Modal](https://material-ui.com/api/modal/) component are available
  * when `variant="temporary"` is set.
+ *
  * Demos:
  *
  * - [Drawers](https://material-ui.com/components/drawers/)

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -32,6 +32,7 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
 /**
  * The Fade transition is used by the [Modal](https://material-ui.com/components/modal/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
+ *
  * Demos:
  *
  * - [Transitions](https://material-ui.com/components/transitions/)

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -98,6 +98,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
  *
  * ⚠️ Only one `InputBase` can be used within a FormControl because it create visual inconsistencies.
  * For instance, only one input can be focused at the same time, the state shouldn't be shared.
+ *
  * Demos:
  *
  * - [Checkboxes](https://material-ui.com/components/checkboxes/)

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -64,6 +64,7 @@ export type FormControlLabelClassKey = keyof NonNullable<FormControlLabelProps['
 /**
  * Drop-in replacement of the `Radio`, `Switch` and `Checkbox` component.
  * Use this component if you want to display an extra label.
+ *
  * Demos:
  *
  * - [Checkboxes](https://material-ui.com/components/checkboxes/)

--- a/packages/material-ui/src/FormGroup/FormGroup.d.ts
+++ b/packages/material-ui/src/FormGroup/FormGroup.d.ts
@@ -28,6 +28,7 @@ export type FormGroupClassKey = keyof NonNullable<FormGroupProps['classes']>;
  * `FormGroup` wraps controls such as `Checkbox` and `Switch`.
  * It provides compact row layout.
  * For the `Radio`, you should be using the `RadioGroup` component instead of this one.
+ *
  * Demos:
  *
  * - [Checkboxes](https://material-ui.com/components/checkboxes/)

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -32,6 +32,7 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
  * The Grow transition is used by the [Tooltip](https://material-ui.com/components/tooltips/) and
  * [Popover](https://material-ui.com/components/popover/) components.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
+ *
  * Demos:
  *
  * - [Popover](https://material-ui.com/components/popover/)

--- a/packages/material-ui/src/Hidden/Hidden.d.ts
+++ b/packages/material-ui/src/Hidden/Hidden.d.ts
@@ -82,6 +82,7 @@ export interface HiddenProps {
 
 /**
  * Responsively hides children based on the selected implementation.
+ *
  * Demos:
  *
  * - [Hidden](https://material-ui.com/components/hidden/)

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -76,6 +76,7 @@ export type IconButtonTypeMap<
 /**
  * Refer to the [Icons](https://material-ui.com/components/icons/) section of the documentation
  * regarding the available icon options.
+ *
  * Demos:
  *
  * - [Buttons](https://material-ui.com/components/buttons/)

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -215,6 +215,7 @@ export type InputBaseClassKey = keyof NonNullable<InputBaseProps['classes']>;
  * `InputBase` contains as few styles as possible.
  * It aims to be a simple building block for creating an input.
  * It contains a load of style reset and some state logic.
+ *
  * Demos:
  *
  * - [Text Fields](https://material-ui.com/components/text-fields/)

--- a/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
@@ -75,6 +75,7 @@ export type LinearProgressClassKey = keyof NonNullable<LinearProgressProps['clas
  * If the progress bar is describing the loading progress of a particular region of a page,
  * you should use `aria-describedby` to point to the progress bar, and set the `aria-busy`
  * attribute to `true` on that region until it has finished loading.
+ *
  * Demos:
  *
  * - [Progress](https://material-ui.com/components/progress/)

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -95,6 +95,7 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
 
 /**
  * Uses an additional container component if `ListItemSecondaryAction` is the last child.
+ *
  * Demos:
  *
  * - [Lists](https://material-ui.com/components/lists/)

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -20,6 +20,7 @@ export type ListItemAvatarClassKey = keyof NonNullable<ListItemAvatarProps['clas
 
 /**
  * A simple wrapper to apply `List` styles to an `Avatar`.
+ *
  * Demos:
  *
  * - [Lists](https://material-ui.com/components/lists/)

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -21,6 +21,7 @@ export type ListItemIconClassKey = keyof NonNullable<ListItemIconProps['classes'
 
 /**
  * A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
+ *
  * Demos:
  *
  * - [Lists](https://material-ui.com/components/lists/)

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -23,6 +23,7 @@ export type ListItemSecondaryActionClassKey = keyof NonNullable<
 
 /**
  * Must be used as the last child of ListItem to function properly.
+ *
  * Demos:
  *
  * - [Lists](https://material-ui.com/components/lists/)

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -42,6 +42,7 @@ export type MenuListClassKey = keyof NonNullable<MenuListProps['classes']>;
  * It's exposed to help customization of the [`Menu`](https://material-ui.com/api/menu/) component if you
  * use it separately you need to move focus into the component manually. Once
  * the focus is placed inside the component it is fully keyboard accessible.
+ *
  * Demos:
  *
  * - [Menus](https://material-ui.com/components/menus/)

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -114,6 +114,7 @@ export interface ModalProps
  * rather than directly using Modal.
  *
  * This component shares many concepts with [react-overlays](https://react-bootstrap.github.io/react-overlays/#modals).
+ *
  * Demos:
  *
  * - [Modal](https://material-ui.com/components/modal/)

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -72,6 +72,7 @@ export type NativeSelectClassKey = keyof NonNullable<NativeSelectProps['classes'
 
 /**
  * An alternative to `<Select native />` with a much smaller bundle size footprint.
+ *
  * Demos:
  *
  * - [Selects](https://material-ui.com/components/selects/)

--- a/packages/material-ui/src/NoSsr/NoSsr.d.ts
+++ b/packages/material-ui/src/NoSsr/NoSsr.d.ts
@@ -27,6 +27,7 @@ export interface NoSsrProps {
  * *   Improve the time-to-first paint on the client by only rendering above the fold.
  * *   Reduce the rendering time on the server.
  * *   Under too heavy server load, you can turn on service degradation.
+ *
  * Demos:
  *
  * - [No Ssr](https://material-ui.com/components/no-ssr/)

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -84,6 +84,7 @@ export interface PopperProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
 
 /**
  * Poppers rely on the 3rd party library [Popper.js](https://popper.js.org/docs/v2/) for positioning.
+ *
  * Demos:
  *
  * - [Autocomplete](https://material-ui.com/components/autocomplete/)

--- a/packages/material-ui/src/Portal/Portal.d.ts
+++ b/packages/material-ui/src/Portal/Portal.d.ts
@@ -23,6 +23,7 @@ export interface PortalProps {
 /**
  * Portals provide a first-class way to render children into a DOM node
  * that exists outside the DOM hierarchy of the parent component.
+ *
  * Demos:
  *
  * - [Portal](https://material-ui.com/components/portal/)

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -36,6 +36,7 @@ export interface SlideProps extends TransitionProps {
 /**
  * The Slide transition is used by the [Drawer](https://material-ui.com/components/drawers/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
+ *
  * Demos:
  *
  * - [Dialogs](https://material-ui.com/components/dialogs/)

--- a/packages/material-ui/src/TableCell/TableCell.d.ts
+++ b/packages/material-ui/src/TableCell/TableCell.d.ts
@@ -94,6 +94,7 @@ export type TableCellClassKey = keyof NonNullable<TableCellProps['classes']>;
 /**
  * The component renders a `<th>` element when the parent context is a header
  * or otherwise a `<td>` element.
+ *
  * Demos:
  *
  * - [Tables](https://material-ui.com/components/tables/)

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -142,6 +142,7 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
 
 /**
  * A `TableCell` based component for placing inside `TableFooter` for pagination.
+ *
  * Demos:
  *
  * - [Tables](https://material-ui.com/components/tables/)

--- a/packages/material-ui/src/TableRow/TableRow.d.ts
+++ b/packages/material-ui/src/TableRow/TableRow.d.ts
@@ -38,6 +38,7 @@ export interface TableRowTypeMap<P = {}, D extends React.ElementType = 'tr'> {
 /**
  * Will automatically set dynamic row height
  * based on the material table element parent (head, body, etc).
+ *
  * Demos:
  *
  * - [Tables](https://material-ui.com/components/tables/)

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -52,7 +52,7 @@ export type TableSortLabelTypeMap<
 
 /**
  * A button based label for placing inside `TableCell` for column sorting.
-
+ *
  * Demos:
  *
  * - [Tables](https://material-ui.com/components/tables/)

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -52,6 +52,7 @@ export type TableSortLabelTypeMap<
 
 /**
  * A button based label for placing inside `TableCell` for column sorting.
+
  * Demos:
  *
  * - [Tables](https://material-ui.com/components/tables/)

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -247,6 +247,7 @@ export type TextFieldClassKey = keyof NonNullable<TextFieldProps['classes']>;
  *
  * *   using the upper case props for passing values directly to the components
  * *   using the underlying components directly as shown in the demos
+ *
  * Demos:
  *
  * - [Autocomplete](https://material-ui.com/components/autocomplete/)

--- a/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.d.ts
+++ b/packages/material-ui/src/Unstable_TrapFocus/Unstable_TrapFocus.d.ts
@@ -54,6 +54,7 @@ export interface TrapFocusProps {
 
 /**
  * Utility component that locks focus inside the component.
+ *
  * Demos:
  *
  * - [Trap Focus](https://material-ui.com/components/trap-focus/)

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -32,6 +32,7 @@ export interface ZoomProps extends TransitionProps {
  * The Zoom transition can be used for the floating variant of the
  * [Button](https://material-ui.com/components/buttons/#floating-action-buttons) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
+ *
  * Demos:
  *
  * - [Transitions](https://material-ui.com/components/transitions/)


### PR DESCRIPTION
We need to make sure we have a newline between manual and generated description. This was only guaranteed when we had no manual description due to `''.split('\n')` creating `['']`.

Before:
![screenshot of "[...] for column sorting. Demos"](https://i.ibb.co/250S1zf/component-jsdoc-description-newline-before.png)


After:
![screenshot of "[...] for column sorting. \n Demos""](https://i.ibb.co/xHx8NYR/component-jsdoc-description-newline-after.png)