### PR TITLE
[TextField] Migrate FilledInput to emotion

### DIFF
--- a/docs/pages/api-docs/filled-input.json
+++ b/docs/pages/api-docs/filled-input.json
@@ -25,6 +25,7 @@
     "required": { "type": { "name": "bool" } },
     "rows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
     "startAdornment": { "type": { "name": "node" } },
+    "sx": { "type": { "name": "object" } },
     "type": { "type": { "name": "string" }, "default": "'text'" },
     "value": { "type": { "name": "any" } }
   },
@@ -57,6 +58,6 @@
   "filename": "/packages/material-ui/src/FilledInput/FilledInput.js",
   "inheritance": { "component": "InputBase", "pathname": "/api/input-base/" },
   "demos": "<ul><li><a href=\"/components/text-fields/\">Text Fields</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/filled-input/filled-input.json
+++ b/docs/translations/api-docs/filled-input/filled-input.json
@@ -26,6 +26,7 @@
     "required": "If <code>true</code>, the <code>input</code> element is required. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component.",
     "rows": "Number of rows to display when multiline option is set to true.",
     "startAdornment": "Start <code>InputAdornment</code> for this component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "type": "Type of the <code>input</code> element. It should be <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types\">a valid HTML5 input type</a>.",
     "value": "The value of the <code>input</code> element, required for a controlled component."
   },

--- a/packages/material-ui/src/FilledInput/FilledInput.d.ts
+++ b/packages/material-ui/src/FilledInput/FilledInput.d.ts
@@ -1,4 +1,6 @@
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+
+import { InternalStandardProps as StandardProps, Theme } from '..';
 import { InputBaseProps } from '../InputBase';
 
 export interface FilledInputProps extends StandardProps<InputBaseProps> {
@@ -45,6 +47,10 @@ export interface FilledInputProps extends StandardProps<InputBaseProps> {
    * If `true`, the input will not have an underline.
    */
   disableUnderline?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type FilledInputClassKey = keyof NonNullable<FilledInputProps['classes']>;

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -1,64 +1,27 @@
 import * as React from 'react';
 import { deepmerge, refType } from '@material-ui/utils';
 import PropTypes from 'prop-types';
-
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import InputBase from '../InputBase';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
-import filledInputClasses, { getFilledInputUtilityClass } from './filledInputClasses';
+import useThemeProps from '../styles/useThemeProps';
+import { getFilledInputUtilityClass } from './filledInputClasses';
+import { inputBaseClasses } from '../InputBase';
+import { overridesResolver as inputBaseOverridesResolver } from '../InputBase/InputBase';
 
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
-
-  return deepmerge(styles.root || {}, {
-    [`&.${filledInputClasses.colorSecondary}`]: styles.colorSecondary,
+  return deepmerge(inputBaseOverridesResolver(props, styles), {
     ...(!styleProps.disableUnderline && styles.undeline),
-    ...(styleProps.startAdornment && styles.adornedStart),
-    ...(styleProps.endAdornment && styles.adornedEnd),
-    [`&.${filledInputClasses.error}`]: styles.error,
-    [`&.${filledInputClasses.sizeSmall}`]: styles.sizeSmall,
-    ...(styleProps.multiline && styles.multiline),
-    [`&.${filledInputClasses.hiddenLabel}`]: styles.hiddenLabel,
-    [`& .${filledInputClasses.input}`]: {
-      ...styles.input,
-      ...(styleProps.multiline && styles.inputMultiline),
-      ...(styleProps.startAdornment && styles.inputAdornedStart),
-      ...(styleProps.endAdornment && styles.inputAdornedEnd),
-    },
-    [`& .${filledInputClasses.inputSizeSmall}`]: styles.inputSizeSmall,
-    [`& .${filledInputClasses.inputHiddenLabel}`]: styles.inputHiddenLabel,
   });
 };
+
 const useUtilityClasses = (styleProps) => {
-  const {
-    classes,
-    disableUnderline,
-    disabled,
-    startAdornment,
-    endAdornment,
-    multiline,
-  } = styleProps;
+  const { classes, disableUnderline } = styleProps;
 
   const slots = {
-    root: [
-      'root',
-      !disableUnderline && 'underline',
-      disabled && 'disabled',
-      startAdornment && 'adornedStart',
-      endAdornment && 'adornedEnd',
-      multiline && 'multiline',
-    ],
-    input: [
-      'input',
-      multiline && 'inputMultiline',
-      startAdornment && 'inputAdornedStart',
-      endAdornment && 'inputAdornedEnd',
-    ],
-    sizeSmall: ['sizeSmall'],
-    colorSecondary: ['colorSecondary'],
-    hiddenLabel: ['hiddenLabel'],
-    inputHiddenLabel: ['inputHiddenLabel'],
-    inputSizeSmall: ['inputSizeSmall'],
+    root: ['root', !disableUnderline && 'underline'],
+    input: ['input'],
   };
 
   return composeClasses(slots, getFilledInputUtilityClass, classes);
@@ -69,14 +32,13 @@ const FilledInputRoot = experimentalStyled(
   {
     shouldForwardProp: (prop) => shouldForwardProp(prop) || prop === 'classes',
   },
-  { named: 'MuiFilledInput', slot: 'Root', overridesResolver },
+  { name: 'MuiFilledInput', slot: 'Root', overridesResolver },
 )(({ theme, styleProps }) => {
   const light = theme.palette.mode === 'light';
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
   const backgroundColor = light ? 'rgba(0, 0, 0, 0.09)' : 'rgba(255, 255, 255, 0.09)';
   return {
     /* Styles applied to the root element. */
-
     position: 'relative',
     backgroundColor,
     borderTopLeftRadius: theme.shape.borderRadius,
@@ -99,11 +61,6 @@ const FilledInputRoot = experimentalStyled(
       backgroundColor: light ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.12)',
     },
     ...(!styleProps.disableUnderline && {
-      [`&.${filledInputClasses.colorSecondary}:after`]: {
-        borderBottomColor: theme.palette.secondary.main,
-      },
-    }),
-    ...(!styleProps.disableUnderline && {
       '&:after': {
         borderBottom: `2px solid ${theme.palette.primary.main}`,
         left: 0,
@@ -118,6 +75,9 @@ const FilledInputRoot = experimentalStyled(
           easing: theme.transitions.easing.easeOut,
         }),
         pointerEvents: 'none', // Transparent to the hover style.
+        [`&.${inputBaseClasses.colorSecondary}`]: {
+          borderBottomColor: theme.palette.secondary.main,
+        },
       },
       '&.Mui-focused:after': {
         transform: 'scaleX(1)',
@@ -139,7 +99,7 @@ const FilledInputRoot = experimentalStyled(
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      '&:hover:not($disabled):before': {
+      '&:hover:not(.Mui-disabled):before': {
         borderBottom: `1px solid ${theme.palette.text.primary}`,
       },
       '&.Mui-disabled:before': {
@@ -148,28 +108,23 @@ const FilledInputRoot = experimentalStyled(
     }),
     ...(styleProps.startAdornment && {
       paddingLeft: 12,
-      [`& .${filledInputClasses.adornedStart}`]: {
-        paddingLeft: 0,
-      },
     }),
     ...(styleProps.endAdornment && {
       paddingRight: 12,
-      [`& .${filledInputClasses.endAdornment}`]: {
-        paddingRight: 0,
-      },
     }),
     ...(styleProps.multiline && {
       padding: '25px 12px 8px',
-      [`&.${filledInputClasses.hiddenLabel}`]: {
+      [`&.${inputBaseClasses.hiddenLabel}`]: {
         paddingTop: 16,
         paddingBottom: 17,
       },
-      [`&.${filledInputClasses.sizeSmall}`]: {
+      [`&.${inputBaseClasses.sizeSmall}`]: {
         paddingTop: 21,
         paddingBottom: 4,
       },
     }),
-    [`& .${filledInputClasses.input}`]: {
+    // input styles
+    [`& .${inputBaseClasses.input}`]: {
       padding: '25px 12px 8px',
       '&:-webkit-autofill': {
         WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
@@ -178,28 +133,34 @@ const FilledInputRoot = experimentalStyled(
         borderTopLeftRadius: 'inherit',
         borderTopRightRadius: 'inherit',
       },
-    },
-    [`& .${filledInputClasses.inputSizeSmall}`]: {
-      paddingTop: 21,
-      paddingBottom: 4,
-    },
-    ...(styleProps.multiline && {
-      [`& .${filledInputClasses.inputMultiline}`]: {
+      ...(styleProps.multiline && {
         padding: 0,
+      }),
+      ...(styleProps.startAdornment && {
+        paddingLeft: 0,
+      }),
+      ...(styleProps.endAdornment && {
+        paddingRight: 0,
+      }),
+      [`&.${inputBaseClasses.inputSizeSmall}`]: {
+        paddingTop: 21,
+        paddingBottom: 4,
       },
-    }),
-    [`& .${filledInputClasses.inputHiddenLabel}`]: {
-      paddingTop: 16,
-      paddingBottom: 17,
-    },
-    [`& .${filledInputClasses.inputHiddenLabel}.${filledInputClasses.inputSizeSmall}`]: {
-      paddingTop: 8,
-      paddingBottom: 9,
+      [`&.${inputBaseClasses.inputHiddenLabel}`]: {
+        paddingTop: 16,
+        paddingBottom: 17,
+        [`&.${inputBaseClasses.inputSizeSmall}`]: {
+          paddingTop: 8,
+          paddingBottom: 9,
+        },
+      },
     },
   };
 });
 
-const FilledInput = React.forwardRef(function FilledInput(props, ref) {
+const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiFilledInput' });
+
   const {
     disableUnderline,
     fullWidth = false,
@@ -211,7 +172,6 @@ const FilledInput = React.forwardRef(function FilledInput(props, ref) {
 
   const styleProps = {
     ...other,
-    disableUnderline,
     fullWidth,
     inputComponent,
     multiline,

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -6,7 +6,6 @@ import InputBase from '../InputBase';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getFilledInputUtilityClass } from './filledInputClasses';
-import { inputBaseClasses } from '../InputBase';
 import { overridesResolver as inputBaseOverridesResolver } from '../InputBase/InputBase';
 
 const overridesResolver = (props, styles) => {

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { deepmerge, refType } from '@material-ui/utils';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import InputBase from '../InputBase';
+import InputBase, { inputBaseClasses  } from '../InputBase';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getFilledInputUtilityClass } from './filledInputClasses';

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -15,7 +15,9 @@ describe('<FilledInput />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiFilledInput',
-    testVariantProps: { size: 'small' },
+    testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
+    testVariantProps: { size: 'small', color: 'secondary' },
+    testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
     skip: ['componentProp', 'componentsProp'],
   }));
 

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -1,24 +1,22 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import FilledInput from './FilledInput';
 import InputBase from '../InputBase';
+import classes from './filledInputClasses';
 
 describe('<FilledInput />', () => {
-  let classes;
   const mount = createMount();
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<FilledInput />);
-  });
-
-  describeConformance(<FilledInput open />, () => ({
+  describeConformanceV5(<FilledInput open />, () => ({
     classes,
     inheritComponent: InputBase,
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiFilledInput',
+    testVariantProps: { size: 'small' },
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('should have the underline class', () => {

--- a/packages/material-ui/src/FilledInput/filledInputClasses.d.ts
+++ b/packages/material-ui/src/FilledInput/filledInputClasses.d.ts
@@ -1,0 +1,25 @@
+export interface FilledInputClasses {
+  root: string;
+  colorSecondary: string;
+  underline: string;
+  focused: string;
+  disabled: string;
+  adornedStart: string;
+  adornedEnd: string;
+  error: string;
+  sizeSmall: string;
+  multiline: string;
+  hiddenLabel: string;
+  input: string;
+  inputSizeSmall: string;
+  inputHiddenLabel: string;
+  inputMultiline: string;
+  inputAdornedStart: string;
+  inputAdornedEnd: string;
+}
+
+declare const filledInputClasses: FilledInputClasses;
+
+export function getFilledInputUtilityClass(slot: string): string;
+
+export default filledInputClasses;

--- a/packages/material-ui/src/FilledInput/filledInputClasses.d.ts
+++ b/packages/material-ui/src/FilledInput/filledInputClasses.d.ts
@@ -1,21 +1,7 @@
 export interface FilledInputClasses {
   root: string;
-  colorSecondary: string;
   underline: string;
-  focused: string;
-  disabled: string;
-  adornedStart: string;
-  adornedEnd: string;
-  error: string;
-  sizeSmall: string;
-  multiline: string;
-  hiddenLabel: string;
   input: string;
-  inputSizeSmall: string;
-  inputHiddenLabel: string;
-  inputMultiline: string;
-  inputAdornedStart: string;
-  inputAdornedEnd: string;
 }
 
 declare const filledInputClasses: FilledInputClasses;

--- a/packages/material-ui/src/FilledInput/filledInputClasses.js
+++ b/packages/material-ui/src/FilledInput/filledInputClasses.js
@@ -1,16 +1,9 @@
-import {
-  generateUtilityClasses,
-  generateUtilityClass,
-} from '@material-ui/unstyled';
+import { generateUtilityClasses, generateUtilityClass } from '@material-ui/unstyled';
 
 export function getFilledInputUtilityClass(slot) {
   return generateUtilityClass('MuiFilledInput', slot);
 }
 
-const filledInputClasses = generateUtilityClasses('MuiFilledInput', [
-  'root',
-  'underline',
-  'input',
-]);
+const filledInputClasses = generateUtilityClasses('MuiFilledInput', ['root', 'underline', 'input']);
 
 export default filledInputClasses;

--- a/packages/material-ui/src/FilledInput/filledInputClasses.js
+++ b/packages/material-ui/src/FilledInput/filledInputClasses.js
@@ -1,0 +1,31 @@
+import {
+  generateUtilityClasses,
+  generateUtilityClass,
+} from '@material-ui/unstyled';
+
+export function getFilledInputUtilityClass(slot) {
+  return generateUtilityClass('MuiFilledInput', slot);
+}
+
+const filledInputClasses = generateUtilityClasses('MuiInputBase', [
+  'root',
+  'colorSecondary',
+  'focused',
+  'underline',
+  'focused',
+  'disabled',
+  'adornedStart',
+  'adornedEnd',
+  'error',
+  'sizeSmall',
+  'multiline',
+  'hiddenLabel',
+  'input',
+  'inputSizeSmall',
+  'inputHiddenLabel',
+  'inputMultiline',
+  'inputAdornedStart',
+  'inputAdornedEnd',
+]);
+
+export default filledInputClasses;

--- a/packages/material-ui/src/FilledInput/filledInputClasses.js
+++ b/packages/material-ui/src/FilledInput/filledInputClasses.js
@@ -7,25 +7,10 @@ export function getFilledInputUtilityClass(slot) {
   return generateUtilityClass('MuiFilledInput', slot);
 }
 
-const filledInputClasses = generateUtilityClasses('MuiInputBase', [
+const filledInputClasses = generateUtilityClasses('MuiFilledInput', [
   'root',
-  'colorSecondary',
-  'focused',
   'underline',
-  'focused',
-  'disabled',
-  'adornedStart',
-  'adornedEnd',
-  'error',
-  'sizeSmall',
-  'multiline',
-  'hiddenLabel',
   'input',
-  'inputSizeSmall',
-  'inputHiddenLabel',
-  'inputMultiline',
-  'inputAdornedStart',
-  'inputAdornedEnd',
 ]);
 
 export default filledInputClasses;

--- a/packages/material-ui/src/FilledInput/index.d.ts
+++ b/packages/material-ui/src/FilledInput/index.d.ts
@@ -1,2 +1,4 @@
 export { default } from './FilledInput';
 export * from './FilledInput';
+export { default as filledInputClasses } from './filledInputClasses';
+export * from './filledInputClasses';

--- a/packages/material-ui/src/FilledInput/index.js
+++ b/packages/material-ui/src/FilledInput/index.js
@@ -1,1 +1,3 @@
 export { default } from './FilledInput';
+export { default as filledInputClasses } from './filledInputClasses';
+export * from './filledInputClasses';

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -16,7 +16,7 @@ import GlobalStyles from '../GlobalStyles';
 import { isFilled } from './utils';
 import inputBaseClasses, { getInputBaseUtilityClass } from './inputBaseClasses';
 
-const overridesResolver = (props, styles) => {
+export const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
   return deepmerge(styles.root || {}, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR migrates the FilledInput component to the new emotion format as a part of #24405.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
