### PR TITLE
[ImageList] Migrate ImageListItem to emotion

### DIFF
--- a/docs/pages/api-docs/image-list-item.json
+++ b/docs/pages/api-docs/image-list-item.json
@@ -1,13 +1,18 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
+    "classes": { "type": { "name": "object" } },
     "cols": { "type": { "name": "number" }, "default": "1" },
     "component": { "type": { "name": "elementType" } },
     "rows": { "type": { "name": "number" }, "default": "1" },
     "sx": { "type": { "name": "object" } }
   },
   "name": "ImageListItem",
-  "styles": { "classes": [], "globalClasses": {}, "name": null },
+  "styles": {
+    "classes": ["root", "img", "standard", "woven"],
+    "globalClasses": {},
+    "name": "MuiImageListItem"
+  },
   "spread": true,
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/material-ui/src/ImageListItem/ImageListItem.js",

--- a/docs/pages/api-docs/image-list-item.json
+++ b/docs/pages/api-docs/image-list-item.json
@@ -9,7 +9,7 @@
   },
   "name": "ImageListItem",
   "styles": {
-    "classes": ["root", "img", "standard", "woven"],
+    "classes": ["root", "img", "standard", "woven", "masonry", "quilted"],
     "globalClasses": {},
     "name": "MuiImageListItem"
   },

--- a/docs/pages/api-docs/image-list-item.json
+++ b/docs/pages/api-docs/image-list-item.json
@@ -1,22 +1,18 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } },
     "cols": { "type": { "name": "number" }, "default": "1" },
     "component": { "type": { "name": "elementType" } },
-    "rows": { "type": { "name": "number" }, "default": "1" }
+    "rows": { "type": { "name": "number" }, "default": "1" },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "ImageListItem",
-  "styles": {
-    "classes": ["root", "img", "standard", "woven"],
-    "globalClasses": {},
-    "name": "MuiImageListItem"
-  },
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
   "spread": true,
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/material-ui/src/ImageListItem/ImageListItem.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/image-list/\">Image List</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/image-list-item/image-list-item.json
+++ b/docs/translations/api-docs/image-list-item/image-list-item.json
@@ -2,26 +2,10 @@
   "componentDescription": "",
   "propDescriptions": {
     "children": "The content of the component, normally an <code>&lt;img&gt;</code>.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "cols": "Width of the item in number of grid columns.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
-    "rows": "Height of the item in number of grid rows."
+    "rows": "Height of the item in number of grid rows.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
-  "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
-    "img": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "an `img` element to ensure it covers the item"
-    },
-    "standard": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>variant=\"standard\"</code>"
-    },
-    "woven": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>variant=\"woven\"</code>"
-    }
-  }
+  "classDescriptions": {}
 }

--- a/docs/translations/api-docs/image-list-item/image-list-item.json
+++ b/docs/translations/api-docs/image-list-item/image-list-item.json
@@ -2,10 +2,27 @@
   "componentDescription": "",
   "propDescriptions": {
     "children": "The content of the component, normally an <code>&lt;img&gt;</code>.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "cols": "Width of the item in number of grid columns.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "rows": "Height of the item in number of grid rows.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
-  "classDescriptions": {}
+  "classDescriptions": {
+    "root": { "description": "Styles applied to the root element." },
+    "img": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "an `img` element to ensure it covers the item"
+    },
+    "standard": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"standard\"</code>"
+    },
+    "woven": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"woven\"</code>"
+    }
+  }
 }

--- a/docs/translations/api-docs/image-list-item/image-list-item.json
+++ b/docs/translations/api-docs/image-list-item/image-list-item.json
@@ -23,6 +23,16 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>variant=\"woven\"</code>"
+    },
+    "masonry": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"masonry\"</code>"
+    },
+    "quilted": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"quilted\"</code>"
     }
   }
 }

--- a/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
@@ -25,7 +25,7 @@ export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'
       masonry?: string;
       /** Styles applied to the root element if `variant="quilted"`. */
       quilted?: string;
-    }
+    };
     /**
      * Width of the item in number of grid columns.
      * @default 1

--- a/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
@@ -1,4 +1,6 @@
+import { SxProps } from '@material-ui/system';
 import * as React from 'react';
+import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'> {
@@ -17,6 +19,10 @@ export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'
      * @default 1
      */
     rows?: number;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
   classKey: ImageListItemClassKey;

--- a/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
@@ -10,6 +10,19 @@ export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'
      */
     children?: React.ReactNode;
     /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: {
+      /** Styles applied to the root element. */
+      root?: string;
+      /* Styles applied to an `img` element to ensure it covers the item. */
+      img?: string;
+      /* Styles applied to the root element if `variant="standard"`. */
+      standard?: string;
+      /* Styles applied to the root element if `variant="woven"`. */
+      woven?: string;
+    }
+    /**
      * Width of the item in number of grid columns.
      * @default 1
      */
@@ -25,7 +38,6 @@ export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'
     sx?: SxProps<Theme>;
   };
   defaultComponent: D;
-  classKey: ImageListItemClassKey;
 }
 /**
  *

--- a/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.d.ts
@@ -21,6 +21,10 @@ export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'
       standard?: string;
       /* Styles applied to the root element if `variant="woven"`. */
       woven?: string;
+      /** Styles applied to the root element if `variant="masonry"`. */
+      masonry?: string;
+      /** Styles applied to the root element if `variant="quilted"`. */
+      quilted?: string;
     }
     /**
      * Width of the item in number of grid columns.

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -96,7 +96,15 @@ const ImageListItem = React.forwardRef(function ImageListItem(inProps, ref) {
     height = rowHeight * rows + gap * (rows - 1);
   }
 
-  const styleProps = { ...props, component, variant };
+  const styleProps = { 
+    ...props,
+    cols,
+    component,
+    gap,
+    rowHeight,
+    rows,
+    variant,
+  };
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -96,7 +96,7 @@ const ImageListItem = React.forwardRef(function ImageListItem(inProps, ref) {
     height = rowHeight * rows + gap * (rows - 1);
   }
 
-  const styleProps = { 
+  const styleProps = {
     ...props,
     cols,
     component,

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -48,7 +48,7 @@ const ImageListItemRoot = experimentalStyled(
       // For titlebar under list item
       display: 'flex',
       flexDirection: 'column',
-      '& $img': {
+      [`& .${imageListItemClasses.img}`]: {
         height: 'auto',
         flexGrow: 1,
       },

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -38,44 +38,33 @@ const ImageListItemRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)(({ styleProps }) => {
-  return {
-    display: 'inline-block',
-    position: 'relative',
-    lineHeight: 0, // 🤷🏻‍♂️Fixes masonry item gap
-    /* Styles applied to the root element if `variant="standard"`. */
+)(({ styleProps }) => ({
+  display: 'inline-block',
+  position: 'relative',
+  lineHeight: 0, // 🤷🏻‍♂️Fixes masonry item gap
+  /* Styles applied to the root element if `variant="standard"`. */
+  ...(styleProps.variant === 'standard' && {
+    // For titlebar under list item
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  /* Styles applied to the root element if `variant="woven"`. */
+  ...(styleProps.variant === 'woven' && {
+    height: '100%',
+    alignSelf: 'center',
+    '&:nth-of-type(even)': {
+      height: '70%',
+    },
+  }),
+  [`& .${imageListItemClasses.img}`]: {
+    objectFit: 'cover',
+    width: '100%',
+    height: '100%',
     ...(styleProps.variant === 'standard' && {
-      // For titlebar under list item
-      display: 'flex',
-      flexDirection: 'column',
-      [`& .${imageListItemClasses.img}`]: {
-        height: 'auto',
-        flexGrow: 1,
-      },
+      height: 'auto',
+      flexGrow: 1,
     }),
-    /* Styles applied to the root element if `variant="woven"`. */
-    ...(styleProps.variant === 'woven' && {
-      height: '100%',
-      alignSelf: 'center',
-      '&:nth-of-type(even)': {
-        height: '70%',
-      },
-    }),
-  };
-});
-
-experimentalStyled(
-  'img',
-  {},
-  {
-    name: 'MuiImageListItem',
-    slot: 'Img',
-    overridesResolver,
   },
-)(() => ({
-  objectFit: 'cover',
-  width: '100%',
-  height: '100%',
 }));
 
 const ImageListItem = React.forwardRef(function ImageListItem(inProps, ref) {

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -153,6 +153,10 @@ ImageListItem.propTypes = {
    */
   children: PropTypes.node,
   /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/material-ui/src/ImageListItem/ImageListItem.test.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.test.js
@@ -16,7 +16,7 @@ describe('<ImageListItem />', () => {
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'div',
     muiName: 'MuiImageListItem',
-    testVariantProps: { variant: 'standard' },
+    testVariantProps: { variant: 'masonry' },
     skip: ['componentProp', 'componentsProp'],
   }));
 

--- a/packages/material-ui/src/ImageListItem/ImageListItem.test.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.test.js
@@ -1,24 +1,23 @@
-import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+import * as React from 'react';
+import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import ImageList from '../ImageList';
 import ImageListItem from './ImageListItem';
+import classes from './imageListItemClasses';
 
 describe('<ImageListItem />', () => {
-  let classes;
   const mount = createMount();
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<ImageListItem />);
-  });
-
-  describeConformance(<ImageListItem />, () => ({
+  describeConformanceV5(<ImageListItem />, () => ({
     classes,
     inheritComponent: 'li',
     mount,
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'div',
+    muiName: 'MuiImageListItem',
+    testVariantProps: { variant: 'standard' },
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   const itemData = {

--- a/packages/material-ui/src/ImageListItem/imageListItemClasses.d.ts
+++ b/packages/material-ui/src/ImageListItem/imageListItemClasses.d.ts
@@ -1,0 +1,12 @@
+export interface ImageListItemClasses {
+  root: string;
+  img: string;
+  standard: string;
+  woven: string;
+}
+
+declare const imageListItemClasses: ImageListItemClasses;
+
+export function getImageListItemUtilityClass(slot: string): string;
+
+export default imageListItemClasses;

--- a/packages/material-ui/src/ImageListItem/imageListItemClasses.d.ts
+++ b/packages/material-ui/src/ImageListItem/imageListItemClasses.d.ts
@@ -3,6 +3,8 @@ export interface ImageListItemClasses {
   img: string;
   standard: string;
   woven: string;
+  masonry: string;
+  quilted: string;
 }
 
 declare const imageListItemClasses: ImageListItemClasses;

--- a/packages/material-ui/src/ImageListItem/imageListItemClasses.js
+++ b/packages/material-ui/src/ImageListItem/imageListItemClasses.js
@@ -1,0 +1,14 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getImageListItemUtilityClass(slot) {
+  return generateUtilityClass('MuiImageListItem', slot);
+}
+
+const imageListItemClasses = generateUtilityClasses('MuiImageListItem', [
+  'root',
+  'img',
+  'standard',
+  'woven',
+]);
+
+export default imageListItemClasses;

--- a/packages/material-ui/src/ImageListItem/imageListItemClasses.js
+++ b/packages/material-ui/src/ImageListItem/imageListItemClasses.js
@@ -9,6 +9,8 @@ const imageListItemClasses = generateUtilityClasses('MuiImageListItem', [
   'img',
   'standard',
   'woven',
+  'masonry',
+  'quilted',
 ]);
 
 export default imageListItemClasses;

--- a/packages/material-ui/src/ImageListItem/index.d.ts
+++ b/packages/material-ui/src/ImageListItem/index.d.ts
@@ -1,2 +1,4 @@
-export { default } from './ImageListItem';
 export * from './ImageListItem';
+export { default } from './ImageListItem';
+export * from './imageListItemClasses';
+export { default as imageListItemClasses } from './imageListItemClasses';

--- a/packages/material-ui/src/ImageListItem/index.js
+++ b/packages/material-ui/src/ImageListItem/index.js
@@ -1,1 +1,3 @@
 export { default } from './ImageListItem';
+export * from './imageListItemClasses';
+export { default as imageListItemClasses } from './imageListItemClasses';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR migrates the `ImageListItem` component to the new emotion format as a part of #24405.

Because `classes` props was not in `ImageListItem.d.ts`, it was delete by running `yarn proptypes`. Should I fix this here?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
