### PR TITLE
[core] Skip downloading browser binaries in codesandbox/ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "build:codesandbox",
-  "installCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install",
+  "installCommand": "install:codesandbox",
   "packages": [
     "packages/material-ui",
     "packages/material-ui-icons",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "build:codesandbox",
+  "installCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install",
   "packages": [
     "packages/material-ui",
     "packages/material-ui-icons",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs:mdicons:synonyms": "babel-node --config-file ./babel.config.js ./docs/scripts/updateIconSynonyms",
     "extract-error-codes": "lerna run --parallel extract-error-codes",
     "framer:build": "yarn workspace framer build",
+    "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install",
     "jsonlint": "node ./scripts/jsonlint.js",
     "lint": "eslint . --cache --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",
     "lint:ci": "eslint . --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",


### PR DESCRIPTION
Fixes https://ci.codesandbox.io/status/mui-org/material-ui/pr/24565/builds/95546

Note: This doesn't fix the more common "EACCES: permission denied, mkdir '/tmp/output/@material-ui'" (e.g. https://ci.codesandbox.io/status/mui-org/material-ui/pr/24628/builds/95578).