### PR TITLE
[Menu] Migrate MenuItem to emotion

### DIFF
--- a/docs/pages/api-docs/list-item.json
+++ b/docs/pages/api-docs/list-item.json
@@ -9,6 +9,11 @@
     "children": { "type": { "name": "custom", "description": "node" } },
     "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
+    "components": {
+      "type": { "name": "shape", "description": "{ Root?: elementType }" },
+      "default": "{}"
+    },
+    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
     "ContainerComponent": {
       "type": { "name": "custom", "description": "element type" },
       "default": "'li'"

--- a/docs/pages/api-docs/menu-item.json
+++ b/docs/pages/api-docs/menu-item.json
@@ -5,7 +5,8 @@
     "component": { "type": { "name": "elementType" } },
     "dense": { "type": { "name": "bool" } },
     "disableGutters": { "type": { "name": "bool" } },
-    "ListItemClasses": { "type": { "name": "object" } }
+    "ListItemClasses": { "type": { "name": "object" } },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "MenuItem",
   "styles": {
@@ -18,6 +19,6 @@
   "filename": "/packages/material-ui/src/MenuItem/MenuItem.js",
   "inheritance": { "component": "ListItem", "pathname": "/api/list-item/" },
   "demos": "<ul><li><a href=\"/components/menus/\">Menus</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -35,7 +35,7 @@ export default function MenuListComposition() {
   };
 
   function handleListKeyDown(event) {
-    if (event.key === 'Tab') {
+    if (event.key === 'Tab' || event.key === 'Escape') {
       event.preventDefault();
       setOpen(false);
     }

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -40,7 +40,7 @@ export default function MenuListComposition() {
   };
 
   function handleListKeyDown(event: React.KeyboardEvent) {
-    if (event.key === 'Tab') {
+    if (event.key === 'Tab' || event.key === 'Escape') {
       event.preventDefault();
       setOpen(false);
     }

--- a/docs/translations/api-docs/list-item/list-item.json
+++ b/docs/translations/api-docs/list-item/list-item.json
@@ -7,6 +7,8 @@
     "children": "The content of the component if a <code>ListItemSecondaryAction</code> is used it must be the last child.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
+    "components": "The components used for each slot inside the InputBase. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside the Input.",
     "ContainerComponent": "The container component used when a <code>ListItemSecondaryAction</code> is the last child.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "ContainerProps": "Props applied to the container component if used.",
     "dense": "If <code>true</code>, compact vertical padding designed for keyboard and mouse input is used. The prop defaults to the value inherited from the parent List component.",

--- a/docs/translations/api-docs/menu-item/menu-item.json
+++ b/docs/translations/api-docs/menu-item/menu-item.json
@@ -6,7 +6,8 @@
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "dense": "If <code>true</code>, compact vertical padding designed for keyboard and mouse input is used. The prop defaults to the value inherited from the parent List component.",
     "disableGutters": "If <code>true</code>, the left and right padding is removed.",
-    "ListItemClasses": "<code>classes</code> prop applied to the <a href=\"/api/list-item/\"><code>ListItem</code></a> element."
+    "ListItemClasses": "<code>classes</code> prop applied to the <a href=\"/api/list-item/\"><code>ListItem</code></a> element.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -201,7 +201,14 @@ export const componentSettings = {
     template: 'icon_button.txt',
   },
   ListItem: {
-    ignoredProps: ['children', 'ContainerComponent', 'ContainerProps', 'sx'],
+    ignoredProps: [
+      'children',
+      'ContainerComponent',
+      'ContainerProps',
+      'components',
+      'componentsProps',
+      'sx',
+    ],
     propValues: {
       width: 568,
       height: 48,

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -101,7 +101,6 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
       components?: {
         Root?: React.ElementType;
       };
-
       /**
        * The props used for each slot inside the Input.
        * @default {}

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -4,7 +4,7 @@ import { Theme } from '@material-ui/core/styles';
 import { ExtendButtonBase } from '../ButtonBase';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-interface ListItemBaseProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ListItemBaseProps {
   /**
    * Defines the `align-items` style property.
    * @default 'center'

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -50,6 +50,27 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
       selected?: string;
     };
     /**
+     * The components used for each slot inside the InputBase.
+     * Either a string to use a HTML element or a component.
+     * @default {}
+     */
+    components?: {
+      Root?: React.ElementType;
+    };
+
+    /**
+     * The props used for each slot inside the Input.
+     * @default {}
+     */
+    componentsProps?: {
+      root?: {
+        as: React.ElementType;
+        styleProps?: Omit<ListItemTypeMap<P, D>, 'components' | 'componentsProps'> & {
+          dense?: boolean;
+        };
+      };
+    };
+    /**
      * The container component used when a `ListItemSecondaryAction` is the last child.
      * @default 'li'
      */

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -4,113 +4,117 @@ import { Theme } from '@material-ui/core/styles';
 import { ExtendButtonBase } from '../ButtonBase';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-export interface ListItemTypeMap<P, D extends React.ElementType> {
-  props: P & {
-    /**
-     * Defines the `align-items` style property.
-     * @default 'center'
-     */
-    alignItems?: 'flex-start' | 'center';
-    /**
-     * If `true`, the list item is focused during the first mount.
-     * Focus will also be triggered if the value changes from false to true.
-     * @default false
-     */
-    autoFocus?: boolean;
-    /**
-     * The content of the component if a `ListItemSecondaryAction` is used it must
-     * be the last child.
-     */
-    children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: {
-      /** Styles applied to the (normally root) `component` element. May be wrapped by a `container`. */
-      root?: string;
-      /** Styles applied to the container element if `children` includes `ListItemSecondaryAction`. */
-      container?: string;
-      /** Pseudo-class applied to the `component`'s `focusVisibleClassName` prop if `button={true}`. */
-      focusVisible?: string;
-      /** Styles applied to the component element if dense. */
-      dense?: string;
-      /** Styles applied to the component element if `alignItems="flex-start"`. */
-      alignItemsFlexStart?: string;
-      /** Pseudo-class applied to the inner `component` element if `disabled={true}`. */
-      disabled?: string;
-      /** Styles applied to the inner `component` element if `divider={true}`. */
-      divider?: string;
-      /** Styles applied to the inner `component` element unless `disableGutters={true}`. */
-      gutters?: string;
-      /** Styles applied to the inner `component` element if `button={true}`. */
-      button?: string;
-      /** Styles applied to the component element if `children` includes `ListItemSecondaryAction`. */
-      secondaryAction?: string;
-      /** Pseudo-class applied to the root element if `selected={true}`. */
-      selected?: string;
-    };
-    /**
-     * The components used for each slot inside the InputBase.
-     * Either a string to use a HTML element or a component.
-     * @default {}
-     */
-    components?: {
-      Root?: React.ElementType;
-    };
+interface ListItemBaseProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Defines the `align-items` style property.
+   * @default 'center'
+   */
+  alignItems?: 'flex-start' | 'center';
+  /**
+   * If `true`, the list item is focused during the first mount.
+   * Focus will also be triggered if the value changes from false to true.
+   * @default false
+   */
+  autoFocus?: boolean;
+  /**
+   * The content of the component if a `ListItemSecondaryAction` is used it must
+   * be the last child.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: {
+    /** Styles applied to the (normally root) `component` element. May be wrapped by a `container`. */
+    root?: string;
+    /** Styles applied to the container element if `children` includes `ListItemSecondaryAction`. */
+    container?: string;
+    /** Pseudo-class applied to the `component`'s `focusVisibleClassName` prop if `button={true}`. */
+    focusVisible?: string;
+    /** Styles applied to the component element if dense. */
+    dense?: string;
+    /** Styles applied to the component element if `alignItems="flex-start"`. */
+    alignItemsFlexStart?: string;
+    /** Pseudo-class applied to the inner `component` element if `disabled={true}`. */
+    disabled?: string;
+    /** Styles applied to the inner `component` element if `divider={true}`. */
+    divider?: string;
+    /** Styles applied to the inner `component` element unless `disableGutters={true}`. */
+    gutters?: string;
+    /** Styles applied to the inner `component` element if `button={true}`. */
+    button?: string;
+    /** Styles applied to the component element if `children` includes `ListItemSecondaryAction`. */
+    secondaryAction?: string;
+    /** Pseudo-class applied to the root element if `selected={true}`. */
+    selected?: string;
+  };
+  /**
+   * The container component used when a `ListItemSecondaryAction` is the last child.
+   * @default 'li'
+   */
+  ContainerComponent?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
+  /**
+   * Props applied to the container component if used.
+   * @default {}
+   */
+  ContainerProps?: React.HTMLAttributes<HTMLDivElement>;
+  /**
+   * If `true`, compact vertical padding designed for keyboard and mouse input is used.
+   * The prop defaults to the value inherited from the parent List component.
+   * @default false
+   */
+  dense?: boolean;
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the left and right padding is removed.
+   * @default false
+   */
+  disableGutters?: boolean;
+  /**
+   * If `true`, a 1px light border is added to the bottom of the list item.
+   * @default false
+   */
+  divider?: boolean;
+  /**
+   * Use to apply selected styling.
+   * @default false
+   */
+  selected?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+}
 
-    /**
-     * The props used for each slot inside the Input.
-     * @default {}
-     */
-    componentsProps?: {
-      root?: {
-        as: React.ElementType;
-        styleProps?: Omit<ListItemTypeMap<P, D>, 'components' | 'componentsProps'> & {
-          dense?: boolean;
+export interface ListItemTypeMap<P, D extends React.ElementType> {
+  props: P &
+    ListItemBaseProps & {
+      /**
+       * The components used for each slot inside the InputBase.
+       * Either a string to use a HTML element or a component.
+       * @default {}
+       */
+      components?: {
+        Root?: React.ElementType;
+      };
+
+      /**
+       * The props used for each slot inside the Input.
+       * @default {}
+       */
+      componentsProps?: {
+        root?: {
+          as: React.ElementType;
+          styleProps?: Omit<ListItemBaseProps, 'components' | 'componentsProps'> & {
+            dense?: boolean;
+          };
         };
       };
     };
-    /**
-     * The container component used when a `ListItemSecondaryAction` is the last child.
-     * @default 'li'
-     */
-    ContainerComponent?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
-    /**
-     * Props applied to the container component if used.
-     * @default {}
-     */
-    ContainerProps?: React.HTMLAttributes<HTMLDivElement>;
-    /**
-     * If `true`, compact vertical padding designed for keyboard and mouse input is used.
-     * The prop defaults to the value inherited from the parent List component.
-     * @default false
-     */
-    dense?: boolean;
-    /**
-     * If `true`, the component is disabled.
-     * @default false
-     */
-    disabled?: boolean;
-    /**
-     * If `true`, the left and right padding is removed.
-     * @default false
-     */
-    disableGutters?: boolean;
-    /**
-     * If `true`, a 1px light border is added to the bottom of the list item.
-     * @default false
-     */
-    divider?: boolean;
-    /**
-     * Use to apply selected styling.
-     * @default false
-     */
-    selected?: boolean;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
-  };
   defaultComponent: D;
 }
 

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -13,7 +13,7 @@ import useForkRef from '../utils/useForkRef';
 import ListContext from '../List/ListContext';
 import listItemClasses, { getListItemUtilityClass } from './listItemClasses';
 
-const overridesResolver = (props, styles) => {
+export const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
   return deepmerge(styles.root || {}, {
@@ -57,7 +57,7 @@ const useUtilityClasses = (styleProps) => {
   return composeClasses(slots, getListItemUtilityClass, classes);
 };
 
-const ListItemRoot = experimentalStyled(
+export const ListItemRoot = experimentalStyled(
   'div',
   {},
   {
@@ -166,6 +166,8 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     children: childrenProp,
     className,
     component: componentProp,
+    components = {},
+    componentsProps = {},
     ContainerComponent = 'li',
     ContainerProps: { className: ContainerClassName, ...ContainerProps } = {},
     dense = false,
@@ -236,6 +238,9 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     Component = ButtonBase;
   }
 
+  const Root = components.Root || ListItemRoot;
+  const rootProps = componentsProps.root || {};
+
   if (hasSecondaryAction) {
     // Use div by default.
     Component = !componentProps.component && !componentProp ? 'div' : Component;
@@ -257,9 +262,9 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
           ref={handleRef}
           {...ContainerProps}
         >
-          <ListItemRoot as={Component} styleProps={styleProps} {...componentProps}>
+          <Root {...rootProps} as={Component} styleProps={styleProps} {...componentProps}>
             {children}
-          </ListItemRoot>
+          </Root>
           {children.pop()}
         </ListItemContainer>
       </ListContext.Provider>
@@ -268,9 +273,15 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
 
   return (
     <ListContext.Provider value={childContext}>
-      <ListItemRoot as={Component} ref={handleRef} styleProps={styleProps} {...componentProps}>
+      <Root
+        {...rootProps}
+        as={Component}
+        ref={handleRef}
+        styleProps={styleProps}
+        {...componentProps}
+      >
         {children}
-      </ListItemRoot>
+      </Root>
     </ListContext.Provider>
   );
 });
@@ -338,6 +349,19 @@ ListItem.propTypes = {
    * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
+  /**
+   * The components used for each slot inside the InputBase.
+   * Either a string to use a HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    Root: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside the Input.
+   * @default {}
+   */
+  componentsProps: PropTypes.object,
   /**
    * The container component used when a `ListItemSecondaryAction` is the last child.
    * @default 'li'

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import { unstable_composeClasses as composeClasses, isHostComponent } from '@material-ui/unstyled';
 import { deepmerge, chainPropTypes, elementTypeAcceptingRef } from '@material-ui/utils';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -220,8 +220,11 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
 
   const handleRef = useForkRef(listItemRef, ref);
 
+  const Root = components.Root || ListItemRoot;
+  const rootProps = componentsProps.root || {};
+
   const componentProps = {
-    className: clsx(classes.root, className),
+    className: clsx(classes.root, rootProps.className, className),
     disabled,
     ...other,
   };
@@ -237,9 +240,6 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
 
     Component = ButtonBase;
   }
-
-  const Root = components.Root || ListItemRoot;
-  const rootProps = componentsProps.root || {};
 
   if (hasSecondaryAction) {
     // Use div by default.
@@ -262,7 +262,15 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
           ref={handleRef}
           {...ContainerProps}
         >
-          <Root {...rootProps} as={Component} styleProps={styleProps} {...componentProps}>
+          <Root
+            {...rootProps}
+            as={Component}
+            styleProps={styleProps}
+            {...(!isHostComponent(Root) && {
+              styleProps: { ...styleProps, ...rootProps.styleProps },
+            })}
+            {...componentProps}
+          >
             {children}
           </Root>
           {children.pop()}
@@ -278,6 +286,9 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
         as={Component}
         ref={handleRef}
         styleProps={styleProps}
+        {...(!isHostComponent(Root) && {
+          styleProps: { ...styleProps, ...rootProps.styleProps },
+        })}
         {...componentProps}
       >
         {children}

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -28,15 +28,15 @@ export const overridesResolver = (props, styles) => {
 
 const useUtilityClasses = (styleProps) => {
   const {
-    dense,
     alignItems,
-    divider,
-    disableGutters,
-    hasSecondaryAction,
-    selected,
-    disabled,
     button,
     classes,
+    dense,
+    disabled,
+    disableGutters,
+    divider,
+    hasSecondaryAction,
+    selected,
   } = styleProps;
 
   const slots = {

--- a/packages/material-ui/src/MenuItem/MenuItem.d.ts
+++ b/packages/material-ui/src/MenuItem/MenuItem.d.ts
@@ -1,3 +1,5 @@
+import { SxProps } from '@material-ui/system';
+import { Theme } from '@material-ui/core/styles';
 import { DistributiveOmit } from '@material-ui/types';
 import { ListItemTypeMap, ListItemProps } from '../ListItem';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
@@ -29,6 +31,10 @@ export interface MenuItemTypeMap<P = {}, D extends React.ElementType = 'li'> {
        * `classes` prop applied to the [`ListItem`](/api/list-item/) element.
        */
       ListItemClasses?: ListItemProps['classes'];
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps<Theme>;
     };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -83,10 +83,10 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
       component={component}
       selected={selected}
       disableGutters={disableGutters}
-      classes={ListItemClasses}
       className={clsx(classes.root, className)}
       ref={ref}
       {...other}
+      classes={ListItemClasses}
     />
   );
 });

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -55,20 +55,20 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
   const {
     className,
     component = 'li',
+    dense = false,
     disableGutters = false,
     ListItemClasses,
     role = 'menuitem',
     selected,
     tabIndex: tabIndexProp,
-    dense = false,
     ...other
   } = props;
 
   const styleProps = {
     ...props,
-    selected,
-    disableGutters,
     dense,
+    disableGutters,
+    selected,
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { deepmerge } from '@material-ui/utils';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
@@ -6,9 +7,14 @@ import experimentalStyled, { shouldForwardProp } from '../styles/experimentalSty
 import useThemeProps from '../styles/useThemeProps';
 import { getMenuItemUtilityClass } from './menuItemClasses';
 import ListItem from '../ListItem';
-import listItemClasses from '../ListItem/listItemClasses';
+import { overridesResolver as listItemOverridesResolver, ListItemRoot } from '../ListItem/ListItem';
 
-const overridesResolver = (props, styles) => styles.root || {};
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+  return deepmerge(listItemOverridesResolver(props, styles), {
+    ...(styleProps.dense && styles.dense),
+  });
+};
 
 const useUtilityClasses = (styleProps) => {
   const { selected, disableGutters, classes } = styleProps;
@@ -20,14 +26,14 @@ const useUtilityClasses = (styleProps) => {
 };
 
 const MenuItemRoot = experimentalStyled(
-  ListItem,
+  ListItemRoot,
   { shouldForwardProp: (prop) => shouldForwardProp(prop) || prop === 'classes' },
   {
     name: 'MuiMenuItem',
     slot: 'Root',
     overridesResolver,
   },
-)(({ theme }) => ({
+)(({ theme, styleProps }) => ({
   ...theme.typography.body1,
   minHeight: 48,
   paddingTop: 6,
@@ -38,10 +44,10 @@ const MenuItemRoot = experimentalStyled(
   [theme.breakpoints.up('sm')]: {
     minHeight: 'auto',
   },
-  [`&.${listItemClasses.dense}`]: {
+  ...(styleProps.dense && {
     ...theme.typography.body2,
     minHeight: 'auto',
-  },
+  }),
 }));
 
 const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
@@ -71,7 +77,9 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
   }
 
   return (
-    <MenuItemRoot
+    <ListItem
+      components={{ Root: MenuItemRoot }}
+      componentsProps={{ root: { styleProps } }}
       styleProps={styleProps}
       button
       role={role}

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -64,12 +64,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     ...other
   } = props;
 
-  const styleProps = {
-    ...props,
-    dense,
-    disableGutters,
-    selected,
-  };
+  const styleProps = { dense };
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -17,9 +17,9 @@ const overridesResolver = (props, styles) => {
 };
 
 const useUtilityClasses = (styleProps) => {
-  const { selected, disableGutters, dense, classes } = styleProps;
+  const { selected, dense, classes } = styleProps;
   const slots = {
-    root: ['root', selected && 'selected', !disableGutters && 'gutters', dense && 'dense'],
+    root: ['root', selected && 'selected', dense && 'dense'],
   };
 
   return composeClasses(slots, getMenuItemUtilityClass, classes);

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -156,7 +156,7 @@ MenuItem.propTypes = {
   /**
    * @ignore
    */
-  tabIndex: PropTypes.number,
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default MenuItem;

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -60,7 +60,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     role = 'menuitem',
     selected,
     tabIndex: tabIndexProp,
-    dense,
+    dense = false,
     ...other
   } = props;
 
@@ -82,7 +82,6 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     <ListItem
       components={{ Root: MenuItemRoot }}
       componentsProps={{ root: { styleProps } }}
-      styleProps={styleProps}
       button
       role={role}
       tabIndex={tabIndex}
@@ -157,7 +156,7 @@ MenuItem.propTypes = {
   /**
    * @ignore
    */
-  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  tabIndex: PropTypes.number,
 };
 
 export default MenuItem;

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -17,9 +17,9 @@ const overridesResolver = (props, styles) => {
 };
 
 const useUtilityClasses = (styleProps) => {
-  const { selected, disableGutters, classes } = styleProps;
+  const { selected, disableGutters, dense, classes } = styleProps;
   const slots = {
-    root: ['root', selected && 'selected', !disableGutters && 'gutters'],
+    root: ['root', selected && 'selected', !disableGutters && 'gutters', dense && 'dense'],
   };
 
   return composeClasses(slots, getMenuItemUtilityClass, classes);
@@ -60,6 +60,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     role = 'menuitem',
     selected,
     tabIndex: tabIndexProp,
+    dense,
     ...other
   } = props;
 
@@ -67,6 +68,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     ...props,
     selected,
     disableGutters,
+    dense,
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -66,7 +66,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
 
   const styleProps = { dense };
 
-  const classes = useUtilityClasses(styleProps);
+  const classes = useUtilityClasses(props);
 
   let tabIndex;
   if (!props.disabled) {

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -3,9 +3,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
-  getClasses,
   createMount,
-  describeConformance,
+  describeConformanceV5,
   createClientRender,
   fireEvent,
   screen,
@@ -13,25 +12,21 @@ import {
 import ListItem from '../ListItem';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import MenuItem from './MenuItem';
+import classes from './menuItemClasses';
 
 describe('<MenuItem />', () => {
-  /**
-   * @type {Record<string, string>}
-   */
-  let classes;
   const mount = createMount();
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<MenuItem />);
-  });
-
-  describeConformance(<MenuItem />, () => ({
+  describeConformanceV5(<MenuItem />, () => ({
     classes,
     inheritComponent: ListItem,
     mount,
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'a',
+    muiName: 'MuiMenuItem',
+    testVariantProps: { disableGutters: true },
+    skip: ['componentsProp'],
   }));
 
   it('should render a focusable menuitem', () => {

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -9,10 +9,9 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-import ListItem from '../ListItem';
-import ListItemSecondaryAction from '../ListItemSecondaryAction';
-import MenuItem from './MenuItem';
-import classes from './menuItemClasses';
+import MenuItem, { menuItemClasses as classes } from '@material-ui/core/MenuItem';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 
 describe('<MenuItem />', () => {
   const mount = createMount();

--- a/packages/material-ui/src/MenuItem/index.d.ts
+++ b/packages/material-ui/src/MenuItem/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './MenuItem';
 export * from './MenuItem';
+
+export * from './menuItemClasses';
+export { default as menuItemClasses } from './menuItemClasses';

--- a/packages/material-ui/src/MenuItem/index.js
+++ b/packages/material-ui/src/MenuItem/index.js
@@ -1,1 +1,4 @@
 export { default } from './MenuItem';
+
+export * from './menuItemClasses';
+export { default as menuItemClasses } from './menuItemClasses';

--- a/packages/material-ui/src/MenuItem/menuItemClasses.d.ts
+++ b/packages/material-ui/src/MenuItem/menuItemClasses.d.ts
@@ -2,6 +2,7 @@ export interface MenuItemClasses {
   root: string;
   gutters: string;
   selected: string;
+  dense: string;
 }
 
 declare const menuItemClasses: MenuItemClasses;

--- a/packages/material-ui/src/MenuItem/menuItemClasses.d.ts
+++ b/packages/material-ui/src/MenuItem/menuItemClasses.d.ts
@@ -1,0 +1,11 @@
+export interface MenuItemClasses {
+  root: string;
+  gutters: string;
+  selected: string;
+}
+
+declare const menuItemClasses: MenuItemClasses;
+
+export function getMenuItemUtilityClass(slot: string): string;
+
+export default menuItemClasses;

--- a/packages/material-ui/src/MenuItem/menuItemClasses.d.ts
+++ b/packages/material-ui/src/MenuItem/menuItemClasses.d.ts
@@ -1,11 +1,6 @@
-export interface MenuItemClasses {
-  root: string;
-  gutters: string;
-  selected: string;
-  dense: string;
-}
+import { MenuItemClassKey } from './MenuItem';
 
-declare const menuItemClasses: MenuItemClasses;
+declare const menuItemClasses: Record<MenuItemClassKey, string>;
 
 export function getMenuItemUtilityClass(slot: string): string;
 

--- a/packages/material-ui/src/MenuItem/menuItemClasses.js
+++ b/packages/material-ui/src/MenuItem/menuItemClasses.js
@@ -1,0 +1,9 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getMenuItemUtilityClass(slot) {
+  return generateUtilityClass('MuiMenuItem', slot);
+}
+
+const menuItemClasses = generateUtilityClasses('MuiMenuItem', ['root', 'gutters', 'selected']);
+
+export default menuItemClasses;

--- a/packages/material-ui/src/MenuItem/menuItemClasses.js
+++ b/packages/material-ui/src/MenuItem/menuItemClasses.js
@@ -4,6 +4,11 @@ export function getMenuItemUtilityClass(slot) {
   return generateUtilityClass('MuiMenuItem', slot);
 }
 
-const menuItemClasses = generateUtilityClasses('MuiMenuItem', ['root', 'gutters', 'selected']);
+const menuItemClasses = generateUtilityClasses('MuiMenuItem', [
+  'root',
+  'gutters',
+  'selected',
+  'dense',
+]);
 
 export default menuItemClasses;


### PR DESCRIPTION
This PR migrates the `MenuItem` component  to the new emotion format as a part of #24405.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
