### PR TITLE
[ImageList] Migrate ImageListItemBar to emotion

### DIFF
--- a/docs/pages/api-docs/image-list-item-bar.json
+++ b/docs/pages/api-docs/image-list-item-bar.json
@@ -14,6 +14,7 @@
       "default": "'bottom'"
     },
     "subtitle": { "type": { "name": "node" } },
+    "sx": { "type": { "name": "object" } },
     "title": { "type": { "name": "node" } }
   },
   "name": "ImageListItemBar",
@@ -40,6 +41,6 @@
   "filename": "/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/image-list/\">Image List</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/image-list-item-bar/image-list-item-bar.json
+++ b/docs/translations/api-docs/image-list-item-bar/image-list-item-bar.json
@@ -6,6 +6,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "position": "Position of the title bar.",
     "subtitle": "String or element serving as subtitle (support text).",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "title": "Title to be displayed."
   },
   "classDescriptions": {

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.d.ts
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.d.ts
@@ -1,5 +1,6 @@
+import { SxProps } from '@material-ui/system';
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 
 export interface ImageListItemBarProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'title'> {
@@ -51,6 +52,10 @@ export interface ImageListItemBarProps
    * String or element serving as subtitle (support text).
    */
   subtitle?: React.ReactNode;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
   /**
    * Title to be displayed.
    */

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -54,6 +54,7 @@ const ImageListItemBarRoot = experimentalStyled(
   },
 )(({ theme, styleProps }) => {
   return {
+    /* Styles applied to the root element. */
     position: 'absolute',
     left: 0,
     right: 0,
@@ -61,12 +62,15 @@ const ImageListItemBarRoot = experimentalStyled(
     display: 'flex',
     alignItems: 'center',
     fontFamily: theme.typography.fontFamily,
+    /* Styles applied to the root element if `position="bottom"`. */
     ...(styleProps.position === 'bottom' && {
       bottom: 0,
     }),
+    /* Styles applied to the root element if `position="top"`. */
     ...(styleProps.position === 'top' && {
       top: 0,
     }),
+    /* Styles applied to the root element if `position="below"`. */
     ...(styleProps.position === 'below' && {
       position: 'relative',
       background: 'transparent',
@@ -85,18 +89,22 @@ const ImageListItemBarTitleWrap = experimentalStyled(
   },
 )(({ theme, styleProps }) => {
   return {
+    /* Styles applied to the title and subtitle container element. */
     flexGrow: 1,
     padding: '12px 16px',
     color: theme.palette.common.white,
     overflow: 'hidden',
+    /* Styles applied to the title and subtitle container element if `position="below"`. */
     ...(styleProps.position === 'below' && {
       padding: '6px 0 12px',
       color: 'inherit',
     }),
+    /* Styles applied to the container element if `actionPosition="left"`. */
     ...(styleProps.actionIcon &&
       styleProps.actionPosition === 'left' && {
         paddingLeft: 0,
       }),
+    /* Styles applied to the container element if `actionPosition="right"`. */
     ...(styleProps.actionIcon &&
       styleProps.actionPosition === 'right' && {
         paddingRight: 0,
@@ -114,6 +122,7 @@ const ImageListItemBarTitle = experimentalStyled(
   },
 )(({ theme }) => {
   return {
+    /* Styles applied to the title container element. */
     fontSize: theme.typography.pxToRem(16),
     lineHeight: '24px',
     textOverflow: 'ellipsis',
@@ -132,6 +141,7 @@ const ImageListItemBarSubtitle = experimentalStyled(
   },
 )(({ theme }) => {
   return {
+    /* Styles applied to the subtitle container element. */
     fontSize: theme.typography.pxToRem(12),
     lineHeight: 1,
     textOverflow: 'ellipsis',
@@ -150,6 +160,7 @@ const ImageListItemBarActionIcon = experimentalStyled(
   },
 )(({ styleProps }) => {
   return {
+    /* Styles applied to the actionIcon if `actionPosition="left"`. */
     ...(styleProps.actionIcon &&
       styleProps.actionPosition === 'left' && {
         order: -1,

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -15,26 +15,30 @@ const overridesResolver = (props, styles) => {
 
   return deepmerge(styles.root || {}, {
     ...styles[`position${capitalize(styleProps.position)}`],
-    ...styles[`titleWrap${capitalize(styleProps.position)}`],
-    ...(styleProps.actionIcon &&
-      styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
-    ...(styleProps.actionIcon &&
-      styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`]),
+    [`& .${imageListItemBarClasses.titleWrap}`]: {
+      ...styles.titleWrap,
+      ...styles[`titleWrap${capitalize(styleProps.position)}`],
+      ...(styleProps.actionIcon &&
+        styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
+    },
     [`& .${imageListItemBarClasses.title}`]: styles.title,
     [`& .${imageListItemBarClasses.subtitle}`]: styles.subtitle,
-    [`& .${imageListItemBarClasses.actionIcon}`]: styles.actionIcon,
+    [`& .${imageListItemBarClasses.actionIcon}`]: {
+      ...styles.actionIcon,
+      ...styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`],
+    },
   });
 };
 
 const useUtilityClasses = (styleProps) => {
-  const { classes, position, actionPosition } = styleProps;
+  const { classes, position, actionIcon, actionPosition } = styleProps;
 
   const slots = {
     root: ['root', `position${capitalize(position)}`],
     titleWrap: [
       'titleWrap',
       `titleWrap${capitalize(position)}`,
-      `titleWrapActionPos${capitalize(actionPosition)}`,
+      actionIcon && `titleWrapActionPos${capitalize(actionPosition)}`,
     ],
     title: ['title'],
     subtitle: ['subtitle'],
@@ -85,7 +89,6 @@ const ImageListItemBarTitleWrap = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'TitleWrap',
-    overridesResolver,
   },
 )(({ theme, styleProps }) => {
   return {
@@ -118,7 +121,6 @@ const ImageListItemBarTitle = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'Title',
-    overridesResolver,
   },
 )(({ theme }) => {
   return {
@@ -137,7 +139,6 @@ const ImageListItemBarSubtitle = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'Subtitle',
-    overridesResolver,
   },
 )(({ theme }) => {
   return {
@@ -156,15 +157,13 @@ const ImageListItemBarActionIcon = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'ActionIcon',
-    overridesResolver,
   },
 )(({ styleProps }) => {
   return {
     /* Styles applied to the actionIcon if `actionPosition="left"`. */
-    ...(styleProps.actionIcon &&
-      styleProps.actionPosition === 'left' && {
-        order: -1,
-      }),
+    ...(styleProps.actionPosition === 'left' && {
+      order: -1,
+    }),
   };
 });
 
@@ -184,8 +183,6 @@ const ImageListItemBar = React.forwardRef(function ImageListItemBar(inProps, ref
     ...other
   } = props;
 
-  const actionPos = actionIcon && actionPosition;
-
   const styleProps = { ...props, position, actionPosition };
 
   const classes = useUtilityClasses(styleProps);
@@ -193,26 +190,11 @@ const ImageListItemBar = React.forwardRef(function ImageListItemBar(inProps, ref
   return (
     <ImageListItemBarRoot
       styleProps={styleProps}
-      className={clsx(
-        classes.root,
-        {
-          [classes.positionBelow]: position === 'below',
-          [classes.positionBottom]: position === 'bottom',
-          [classes.positionTop]: position === 'top',
-        },
-        className,
-      )}
+      className={clsx(classes.root, className)}
       ref={ref}
       {...other}
     >
-      <ImageListItemBarTitleWrap
-        styleProps={styleProps}
-        className={clsx(classes.titleWrap, {
-          [classes.titleWrapBelow]: position === 'below',
-          [classes.titleWrapActionPosLeft]: actionPos === 'left',
-          [classes.titleWrapActionPosRight]: actionPos === 'right',
-        })}
-      >
+      <ImageListItemBarTitleWrap styleProps={styleProps} className={classes.titleWrap}>
         <ImageListItemBarTitle className={classes.title}>{title}</ImageListItemBarTitle>
         {subtitle ? (
           <ImageListItemBarSubtitle className={classes.subtitle}>
@@ -221,12 +203,7 @@ const ImageListItemBar = React.forwardRef(function ImageListItemBar(inProps, ref
         ) : null}
       </ImageListItemBarTitleWrap>
       {actionIcon ? (
-        <ImageListItemBarActionIcon
-          styleProps={styleProps}
-          className={clsx(classes.actionIcon, {
-            [classes.actionIconActionPosLeft]: actionPos === 'left',
-          })}
-        >
+        <ImageListItemBarActionIcon styleProps={styleProps} className={classes.actionIcon}>
           {actionIcon}
         </ImageListItemBarActionIcon>
       ) : null}

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -1,11 +1,55 @@
-import * as React from 'react';
-import PropTypes from 'prop-types';
+import { capitalize } from '@material-ui/core/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import { deepmerge } from '@material-ui/utils';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
+import imageListItemBarClasses, { getImageListItemBarUtilityClass } from './imageListItemBarClasses';
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(styles.root || {}, {
+    ...styles[`position${capitalize(styleProps.position)}`],
+    ...styles[`titleWrap${capitalize(styleProps.position)}`],
+    ...(styleProps.actionIcon && styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
+    ...(styleProps.actionIcon && styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`]),
+    [`& .${imageListItemBarClasses.title}`]: styles.title,
+    [`& .${imageListItemBarClasses.subtitle}`]: styles.subtitle,
+    [`& .${imageListItemBarClasses.actionIcon}`]: styles.actionIcon,
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes, position, actionPosition } = styleProps;
+
+  const slots = {
+    root: ['root', `position${capitalize(position)}`],
+    titleWrap: [
+      'titleWrap',
+      `titleWrap${capitalize(position)}`,
+      `titleWrapActionPos${capitalize(actionPosition)}`,
+    ],
+    title: ['title'],
+    subtitle: ['subtitle'],
+    actionIcon: ['actionIcon', `actionIconActionPos${capitalize(actionPosition)}`,],
+  };
+
+  return composeClasses(slots, getImageListItemBarUtilityClass, classes);
+};
+
+const ImageListItemBarRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiImageListItemBar',
+    slot: 'Root',
+    overridesResolver,
+  },
+)(({ theme, styleProps }) => {
+  return {
     position: 'absolute',
     left: 0,
     right: 0,
@@ -13,70 +57,108 @@ export const styles = (theme) => ({
     display: 'flex',
     alignItems: 'center',
     fontFamily: theme.typography.fontFamily,
+    ...(styleProps.position === 'bottom' && {
+      bottom: 0,
+    }),
+    ...(styleProps.position === 'top' && {
+      top: 0,
+    }),
+    ...(styleProps.position === 'below' && {
+      position: 'relative',
+      background: 'transparent',
+      alignItems: 'normal',
+    }),
+  };
+});
+
+const ImageListItemBarTitleWrap = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiImageListItemBar',
+    slot: 'TitleWrap',
+    overridesResolver,
   },
-  /* Styles applied to the root element if `position="bottom"`. */
-  positionBottom: {
-    bottom: 0,
-  },
-  /* Styles applied to the root element if `position="top"`. */
-  positionTop: {
-    top: 0,
-  },
-  /* Styles applied to the root element if `position="below"`. */
-  positionBelow: {
-    position: 'relative',
-    background: 'transparent',
-    alignItems: 'normal',
-  },
-  /* Styles applied to the title and subtitle container element. */
-  titleWrap: {
+)(({ theme, styleProps }) => {
+  return {
     flexGrow: 1,
     padding: '12px 16px',
     color: theme.palette.common.white,
     overflow: 'hidden',
+    ...(styleProps.position === 'below' && {
+      padding: '6px 0 12px',
+      color: 'inherit',
+    }),
+    ...(styleProps.actionIcon && styleProps.actionPosition === 'left' && {
+      paddingLeft: 0,
+    }),
+    ...(styleProps.actionIcon && styleProps.actionPosition === 'right' && {
+      paddingRight: 0,
+    }),
+  };
+});
+
+const ImageListItemBarTitle = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiImageListItemBar',
+    slot: 'Title',
+    overridesResolver,
   },
-  /* Styles applied to the title and subtitle container element if `position="below"`. */
-  titleWrapBelow: {
-    padding: '6px 0 12px',
-    color: 'inherit',
-  },
-  /* Styles applied to the container element if `actionPosition="left"`. */
-  titleWrapActionPosLeft: {
-    paddingLeft: 0,
-  },
-  /* Styles applied to the container element if `actionPosition="right"`. */
-  titleWrapActionPosRight: {
-    paddingRight: 0,
-  },
-  /* Styles applied to the title container element. */
-  title: {
+)(({ theme }) => {
+  return {
     fontSize: theme.typography.pxToRem(16),
     lineHeight: '24px',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
+  };
+});
+
+const ImageListItemBarSubtitle = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiImageListItemBar',
+    slot: 'Subtitle',
+    overridesResolver,
   },
-  /* Styles applied to the subtitle container element. */
-  subtitle: {
+)(({ theme }) => {
+  return {
     fontSize: theme.typography.pxToRem(12),
     lineHeight: 1,
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
-  },
-  /* Styles applied to the actionIcon if supplied. */
-  actionIcon: {},
-  /* Styles applied to the actionIcon if `actionPosition="left"`. */
-  actionIconActionPosLeft: {
-    order: -1,
-  },
+  };
 });
 
-const ImageListItemBar = React.forwardRef(function ImageListItemBar(props, ref) {
+const ImageListItemBarActionIcon = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiImageListItemBar',
+    slot: 'ActionIcon',
+    overridesResolver,
+  },
+)(({ styleProps }) => {
+  return {
+    ...(styleProps.actionIcon && styleProps.actionPosition === 'left' && {
+      order: -1,
+    }),
+  };
+});
+
+const ImageListItemBar = React.forwardRef(function ImageListItemBar(inProps, ref) {
+  const props = useThemeProps({
+    props: inProps,
+    name: 'MuiImageListItemBar',
+  });
+
   const {
     actionIcon,
     actionPosition = 'right',
-    classes,
     className,
     subtitle,
     title,
@@ -86,8 +168,13 @@ const ImageListItemBar = React.forwardRef(function ImageListItemBar(props, ref) 
 
   const actionPos = actionIcon && actionPosition;
 
+  const styleProps = { ...props, position, actionPosition };
+
+  const classes = useUtilityClasses(styleProps);
+
   return (
-    <div
+    <ImageListItemBarRoot
+      styleProps={styleProps}
       className={clsx(
         classes.root,
         {
@@ -100,26 +187,32 @@ const ImageListItemBar = React.forwardRef(function ImageListItemBar(props, ref) 
       ref={ref}
       {...other}
     >
-      <div
+      <ImageListItemBarTitleWrap
+        styleProps={styleProps}
         className={clsx(classes.titleWrap, {
           [classes.titleWrapBelow]: position === 'below',
           [classes.titleWrapActionPosLeft]: actionPos === 'left',
           [classes.titleWrapActionPosRight]: actionPos === 'right',
         })}
       >
-        <div className={classes.title}>{title}</div>
-        {subtitle ? <div className={classes.subtitle}>{subtitle}</div> : null}
-      </div>
+        <ImageListItemBarTitle className={classes.title}>{title}</ImageListItemBarTitle>
+        {subtitle ? (
+          <ImageListItemBarSubtitle className={classes.subtitle}>
+            {subtitle}
+          </ImageListItemBarSubtitle>
+        ) : null}
+      </ImageListItemBarTitleWrap>
       {actionIcon ? (
-        <div
+        <ImageListItemBarActionIcon
+          styleProps={styleProps}
           className={clsx(classes.actionIcon, {
             [classes.actionIconActionPosLeft]: actionPos === 'left',
           })}
         >
           {actionIcon}
-        </div>
+        </ImageListItemBarActionIcon>
       ) : null}
-    </div>
+    </ImageListItemBarRoot>
   );
 });
 
@@ -160,9 +253,13 @@ ImageListItemBar.propTypes = {
    */
   subtitle: PropTypes.node,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * Title to be displayed.
    */
   title: PropTypes.node,
 };
 
-export default withStyles(styles, { name: 'MuiImageListItemBar' })(ImageListItemBar);
+export default ImageListItemBar;

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -6,7 +6,9 @@ import * as React from 'react';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
-import imageListItemBarClasses, { getImageListItemBarUtilityClass } from './imageListItemBarClasses';
+import imageListItemBarClasses, {
+  getImageListItemBarUtilityClass,
+} from './imageListItemBarClasses';
 
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
@@ -14,8 +16,10 @@ const overridesResolver = (props, styles) => {
   return deepmerge(styles.root || {}, {
     ...styles[`position${capitalize(styleProps.position)}`],
     ...styles[`titleWrap${capitalize(styleProps.position)}`],
-    ...(styleProps.actionIcon && styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
-    ...(styleProps.actionIcon && styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`]),
+    ...(styleProps.actionIcon &&
+      styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
+    ...(styleProps.actionIcon &&
+      styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`]),
     [`& .${imageListItemBarClasses.title}`]: styles.title,
     [`& .${imageListItemBarClasses.subtitle}`]: styles.subtitle,
     [`& .${imageListItemBarClasses.actionIcon}`]: styles.actionIcon,
@@ -34,7 +38,7 @@ const useUtilityClasses = (styleProps) => {
     ],
     title: ['title'],
     subtitle: ['subtitle'],
-    actionIcon: ['actionIcon', `actionIconActionPos${capitalize(actionPosition)}`,],
+    actionIcon: ['actionIcon', `actionIconActionPos${capitalize(actionPosition)}`],
   };
 
   return composeClasses(slots, getImageListItemBarUtilityClass, classes);
@@ -89,12 +93,14 @@ const ImageListItemBarTitleWrap = experimentalStyled(
       padding: '6px 0 12px',
       color: 'inherit',
     }),
-    ...(styleProps.actionIcon && styleProps.actionPosition === 'left' && {
-      paddingLeft: 0,
-    }),
-    ...(styleProps.actionIcon && styleProps.actionPosition === 'right' && {
-      paddingRight: 0,
-    }),
+    ...(styleProps.actionIcon &&
+      styleProps.actionPosition === 'left' && {
+        paddingLeft: 0,
+      }),
+    ...(styleProps.actionIcon &&
+      styleProps.actionPosition === 'right' && {
+        paddingRight: 0,
+      }),
   };
 });
 
@@ -144,9 +150,10 @@ const ImageListItemBarActionIcon = experimentalStyled(
   },
 )(({ styleProps }) => {
   return {
-    ...(styleProps.actionIcon && styleProps.actionPosition === 'left' && {
-      order: -1,
-    }),
+    ...(styleProps.actionIcon &&
+      styleProps.actionPosition === 'left' && {
+        order: -1,
+      }),
   };
 });
 

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -1,4 +1,3 @@
-import { capitalize } from '@material-ui/core/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { deepmerge } from '@material-ui/utils';
 import clsx from 'clsx';
@@ -6,6 +5,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
+import capitalize from '../utils/capitalize';
 import imageListItemBarClasses, { getImageListItemBarUtilityClass } from './imageListItemBarClasses';
 
 const overridesResolver = (props, styles) => {

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
@@ -14,6 +14,7 @@ describe('<ImageListItemBar />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiImageListItemBar',
+    testDeepOverrides: { slotName: 'titleWrap', slotClassName: classes.titleWrap },
     testVariantProps: { position: 'top', actionPosition: 'left' },
     skip: ['componentProp', 'componentsProp'],
   }));

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
@@ -14,7 +14,7 @@ describe('<ImageListItemBar />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiImageListItemBar',
-    testVariantProps: { position: 'top' ,actionPosition: 'left' },
+    testVariantProps: { position: 'top', actionPosition: 'left' },
     skip: ['componentProp', 'componentsProp'],
   }));
 

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
@@ -1,23 +1,21 @@
-import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, getClasses, createMount, describeConformance } from 'test/utils';
+import * as React from 'react';
+import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import ImageListItemBar from './ImageListItemBar';
+import classes from './imageListItemBarClasses';
 
 describe('<ImageListItemBar />', () => {
-  let classes;
   const mount = createMount();
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<ImageListItemBar title="classes" />);
-  });
-
-  describeConformance(<ImageListItemBar title="conform?" />, () => ({
+  describeConformanceV5(<ImageListItemBar title="conform?" />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiImageListItemBar',
+    testVariantProps: { position: 'top' ,actionPosition: 'left' },
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   const itemData = {

--- a/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.d.ts
+++ b/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.d.ts
@@ -4,6 +4,8 @@ export interface ImageListItemBarClasses {
   positionTop: string;
   positionBelow: string;
   titleWrap: string;
+  titleWrapBottom: string;
+  titleWrapTop: string;
   titleWrapBelow: string;
   titleWrapActionPosLeft: string;
   titleWrapActionPosRight: string;
@@ -11,6 +13,7 @@ export interface ImageListItemBarClasses {
   subtitle: string;
   actionIcon: string;
   actionIconActionPosLeft: string;
+  actionIconActionPosRight: string;
 }
 
 declare const imageListItemBarClasses: ImageListItemBarClasses;

--- a/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.d.ts
+++ b/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.d.ts
@@ -1,0 +1,20 @@
+export interface ImageListItemBarClasses {
+  root: string;
+  positionBottom: string;
+  positionTop: string;
+  positionBelow: string;
+  titleWrap: string;
+  titleWrapBelow: string;
+  titleWrapActionPosLeft: string;
+  titleWrapActionPosRight: string;
+  title: string;
+  subtitle: string;
+  actionIcon: string;
+  actionIconActionPosLeft: string;
+}
+
+declare const imageListItemBarClasses: ImageListItemBarClasses;
+
+export function getImageListItemBarUtilityClass(slot: string): string;
+
+export default imageListItemBarClasses;

--- a/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.js
+++ b/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.js
@@ -10,6 +10,8 @@ const imageListItemBarClasses = generateUtilityClasses('MuiImageListItemBar', [
   'positionTop',
   'positionBelow',
   'titleWrap',
+  'titleWrapBottom',
+  'titleWrapTop',
   'titleWrapBelow',
   'titleWrapActionPosLeft',
   'titleWrapActionPosRight',
@@ -17,6 +19,7 @@ const imageListItemBarClasses = generateUtilityClasses('MuiImageListItemBar', [
   'subtitle',
   'actionIcon',
   'actionIconActionPosLeft',
+  'actionIconActionPosRight',
 ]);
 
 export default imageListItemBarClasses; /* Styles applied to the root element. */

--- a/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.js
+++ b/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.js
@@ -1,0 +1,22 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getImageListItemBarUtilityClass(slot) {
+  return generateUtilityClass('MuiImageListItemBar', slot);
+}
+
+const imageListItemBarClasses = generateUtilityClasses('MuiImageListItemBar', [
+  'root',
+  'positionBottom',
+  'positionTop',
+  'positionBelow',
+  'titleWrap',
+  'titleWrapBelow',
+  'titleWrapActionPosLeft',
+  'titleWrapActionPosRight',
+  'title',
+  'subtitle',
+  'actionIcon',
+  'actionIconActionPosLeft',
+]);
+
+export default imageListItemBarClasses; /* Styles applied to the root element. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR migrates the `ImageListItemBar` component to the new emotion format as a part of #24405.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
