### PR TITLE
[Pickers] Fix `showTodayButton` not returning the current time

### DIFF
--- a/docs/src/pages/components/date-picker/BasicDatePicker.js
+++ b/docs/src/pages/components/date-picker/BasicDatePicker.js
@@ -15,7 +15,7 @@ export default function BasicDatePicker() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} variant="standard" />}
+        renderInput={(params) => <TextField {...params} />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/BasicDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/BasicDatePicker.tsx
@@ -15,7 +15,7 @@ export default function BasicDatePicker() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} variant="standard" />}
+        renderInput={(params) => <TextField {...params} />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/CustomDay.js
+++ b/docs/src/pages/components/date-picker/CustomDay.js
@@ -66,7 +66,7 @@ export default function CustomDay() {
         value={selectedDate}
         onChange={handleDateChange}
         renderDay={renderWeekPickerDay}
-        renderInput={(params) => <TextField {...params} variant="standard" />}
+        renderInput={(params) => <TextField {...params} />}
         inputFormat="'Week of' MMM d"
       />
     </LocalizaitonProvider>

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -70,7 +70,7 @@ export default function CustomDay() {
         value={selectedDate}
         onChange={handleDateChange}
         renderDay={renderWeekPickerDay as any}
-        renderInput={(params) => <TextField {...params} variant="standard" />}
+        renderInput={(params) => <TextField {...params} />}
         inputFormat="'Week of' MMM d"
       />
     </LocalizaitonProvider>

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.js
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.js
@@ -35,14 +35,6 @@ export default function LocalizedDatePicker() {
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} locale={localeMap[locale]}>
       <div style={{ width: 300 }}>
-        <DatePicker
-          mask={maskMap[locale]}
-          value={selectedDate}
-          onChange={(date) => handleDateChange(date)}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
-        />
         <ToggleButtonGroup value={locale} exclusive>
           {Object.keys(localeMap).map((localeItem) => (
             <ToggleButton
@@ -54,6 +46,12 @@ export default function LocalizedDatePicker() {
             </ToggleButton>
           ))}
         </ToggleButtonGroup>
+        <DatePicker
+          mask={maskMap[locale]}
+          value={selectedDate}
+          onChange={(date) => handleDateChange(date)}
+          renderInput={(params) => <TextField {...params} />}
+        />
       </div>
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
@@ -35,14 +35,6 @@ export default function LocalizedDatePicker() {
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} locale={localeMap[locale]}>
       <div style={{ width: 300 }}>
-        <DatePicker
-          mask={maskMap[locale]}
-          value={selectedDate}
-          onChange={(date) => handleDateChange(date)}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
-        />
         <ToggleButtonGroup value={locale} exclusive>
           {Object.keys(localeMap).map((localeItem) => (
             <ToggleButton
@@ -54,6 +46,12 @@ export default function LocalizedDatePicker() {
             </ToggleButton>
           ))}
         </ToggleButtonGroup>
+        <DatePicker
+          mask={maskMap[locale]}
+          value={selectedDate}
+          onChange={(date) => handleDateChange(date)}
+          renderInput={(params) => <TextField {...params} />}
+        />
       </div>
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
@@ -18,9 +18,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DesktopDatePicker
           label="For desktop"
@@ -29,9 +27,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DatePicker
           disableFuture
@@ -42,9 +38,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
@@ -18,9 +18,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DesktopDatePicker
           label="For desktop"
@@ -29,9 +27,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DatePicker
           disableFuture
@@ -42,9 +38,7 @@ export default function ResponsiveDatePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/ServerRequestDatePicker.js
+++ b/docs/src/pages/components/date-picker/ServerRequestDatePicker.js
@@ -81,7 +81,7 @@ export default function ServerRequestDatePicker() {
           setValue(newValue);
         }}
         onMonthChange={handleMonthChange}
-        renderInput={(params) => <TextField {...params} variant="standard" />}
+        renderInput={(params) => <TextField {...params} />}
         renderLoading={() => <PickersCalendarSkeleton />}
         renderDay={(day, _value, DayComponentProps) => {
           const isSelected =

--- a/docs/src/pages/components/date-picker/ServerRequestDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/ServerRequestDatePicker.tsx
@@ -81,7 +81,7 @@ export default function ServerRequestDatePicker() {
           setValue(newValue);
         }}
         onMonthChange={handleMonthChange}
-        renderInput={(params) => <TextField {...params} variant="standard" />}
+        renderInput={(params) => <TextField {...params} />}
         renderLoading={() => <PickersCalendarSkeleton />}
         renderDay={(day, _value, DayComponentProps) => {
           const isSelected =

--- a/docs/src/pages/components/date-picker/date-picker.md
+++ b/docs/src/pages/components/date-picker/date-picker.md
@@ -37,7 +37,7 @@ function App() {
 
 ## Basic usage
 
-The date picker will be rendered as a modal dialog on mobile, and a textfield with a popover on desktop.
+The date picker is rendered as a modal dialog on mobile, and a textbox with a popup on desktop.
 
 {{"demo": "pages/components/date-picker/BasicDatePicker.js"}}
 

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -294,7 +294,7 @@ describe('<MobileDatePicker />', () => {
       );
       const start = adapterToUse.date();
       fireEvent.click(screen.getByRole('textbox'));
-      clock.tick(10)
+      clock.tick(10);
       fireEvent.click(screen.getByText(/today/i));
 
       expect(onCloseMock.callCount).to.equal(1);

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers, SinonFakeTimers } from 'sinon';
 import TextField from '@material-ui/core/TextField';
 import { fireEvent, screen } from 'test/utils';
 import PickersDay from '@material-ui/lab/PickersDay';
@@ -176,28 +176,6 @@ describe('<MobileDatePicker />', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('January');
   });
 
-  it('prop `showTodayButton` – accept current date when "today" button is clicked', () => {
-    const onCloseMock = spy();
-    const onChangeMock = spy();
-    render(
-      <MobileDatePicker
-        renderInput={(params) => <TextField {...params} />}
-        showTodayButton
-        cancelText="stream"
-        onClose={onCloseMock}
-        onChange={onChangeMock}
-        value={adapterToUse.date('2018-01-01T00:00:00.000')}
-        DialogProps={{ TransitionComponent: FakeTransitionComponent }}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('textbox'));
-    fireEvent.click(screen.getByText(/today/i));
-
-    expect(onCloseMock.callCount).to.equal(1);
-    expect(onChangeMock.callCount).to.equal(1);
-  });
-
   it('prop `onMonthChange` – dispatches callback when months switching', () => {
     const onMonthChangeMock = spy();
     render(
@@ -287,5 +265,41 @@ describe('<MobileDatePicker />', () => {
     );
 
     expect(screen.getByText('July')).toBeVisible();
+  });
+
+  describe('mock time', () => {
+    let clock: SinonFakeTimers;
+
+    beforeEach(() => {
+      clock = useFakeTimers(new Date());
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('prop `showTodayButton` – accept current date when "today" button is clicked', () => {
+      const onCloseMock = spy();
+      const handleChange = spy();
+      render(
+        <MobileDatePicker
+          renderInput={(params) => <TextField {...params} />}
+          showTodayButton
+          cancelText="stream"
+          onClose={onCloseMock}
+          onChange={handleChange}
+          value={adapterToUse.date('2018-01-01T00:00:00.000')}
+          DialogProps={{ TransitionComponent: FakeTransitionComponent }}
+        />,
+      );
+      const start = adapterToUse.date();
+      fireEvent.click(screen.getByRole('textbox'));
+      clock.tick(10)
+      fireEvent.click(screen.getByText(/today/i));
+
+      expect(onCloseMock.callCount).to.equal(1);
+      expect(handleChange.callCount).to.equal(1);
+      expect(adapterToUse.getDiff(handleChange.args[0][0], start)).to.equal(10);
+    });
   });
 });

--- a/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
@@ -44,7 +44,7 @@ export interface ExportedPickerModalProps {
   DialogProps?: Partial<MuiDialogProps>;
 }
 
-export interface PickerModalDialogProps extends ExportedPickerModalProps {
+export interface PickersModalDialogProps extends ExportedPickerModalProps {
   onAccept: () => void;
   onClear: () => void;
   onDismiss: () => void;
@@ -83,7 +83,7 @@ export const styles: MuiStyles<PickersModalDialogClassKey> = {
   },
 };
 
-const PickersModalDialog: React.FC<PickerModalDialogProps & WithStyles<typeof styles>> = (
+const PickersModalDialog: React.FC<PickersModalDialoggProps & WithStyles<typeof styles>> = (
   props,
 ) => {
   const {

--- a/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersModalDialog.tsx
@@ -83,7 +83,7 @@ export const styles: MuiStyles<PickersModalDialogClassKey> = {
   },
 };
 
-const PickersModalDialog: React.FC<PickersModalDialoggProps & WithStyles<typeof styles>> = (
+const PickersModalDialog: React.FC<PickersModalDialogProps & WithStyles<typeof styles>> = (
   props,
 ) => {
   const {

--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useOpenState } from './useOpenState';
 import { WrapperVariant } from '../wrappers/Wrapper';
 import { BasePickerProps } from '../typings/BasePicker';
-import { useUtils, useNow, MuiPickersAdapter } from './useUtils';
+import { useUtils, MuiPickersAdapter } from './useUtils';
 
 export interface PickerStateValueManager<TInputValue, TDateValue> {
   parseInput: (utils: MuiPickersAdapter, value: TInputValue) => TDateValue;
@@ -44,7 +44,6 @@ export function usePickerState<TInput, TDateValue>(
     throw new Error('inputFormat prop is required');
   }
 
-  const now = useNow<TDateValue>();
   const utils = useUtils();
   const { isOpen, setIsOpen } = useOpenState(props);
 
@@ -100,6 +99,7 @@ export function usePickerState<TInput, TDateValue>(
       onAccept: () => acceptDate(draftState.draft, true),
       onDismiss: () => setIsOpen(false),
       onSetToday: () => {
+        const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });
         acceptDate(now, !disableCloseOnSelect);
       },
@@ -108,7 +108,7 @@ export function usePickerState<TInput, TDateValue>(
       acceptDate,
       disableCloseOnSelect,
       isOpen,
-      now,
+      utils,
       draftState.draft,
       setIsOpen,
       valueManager.emptyValue,

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
@@ -24,7 +24,7 @@ export function useUtils<T = unknown>() {
 
 export function useNow<TDate = unknown>(): TDate {
   const utils = useUtils<TDate>();
-  const now = React.useRef(utils.date());
+  const now = React.useRef();
 
-  return now.current!;
+  return now.currenutils.date()!;
 }

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
@@ -24,7 +24,5 @@ export function useUtils<T = unknown>() {
 
 export function useNow<TDate = unknown>(): TDate {
   const utils = useUtils<TDate>();
-  const now = React.useRef();
-
-  return now.currenutils.date()!;
+  return utils.date()!;
 }

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
@@ -24,5 +24,7 @@ export function useUtils<T = unknown>() {
 
 export function useNow<TDate = unknown>(): TDate {
   const utils = useUtils<TDate>();
-  return utils.date()!;
+  const now = React.useRef(utils.date());
+
+  return now.current!;
 }


### PR DESCRIPTION
## Problem
When clicking on the "Today" button in MobileDate[Time]Picker, the returned value is always the same => the moment at which the component was first mounted.

## How to reproduce
Example: https://codesandbox.io/s/62sdn
- Load the page
- Open the DateTimePicker
- Click on the "Now" button
- Wait for 5 sec
- Open the DateTimePicker
- Click on the "Now" button
- **The date has not changed at all, because the useNow() always return the same value**

## Expected behaviour
The "Now" value should represent the current time when the user click the button, and not the time when the component was first mounted.

## Describe the changes
Somehow, removing the useReft fix the issue, i suspect some hook cache magic being used somewhere in React, but i don't know enough about the Hook implementation so...

Here is a sandbox using the fix proposed in the PR: https://codesandbox.io/s/funny-liskov-8pdp7

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).