### PR TITLE
[Pickers] Dismiss on clickaway when using the desktop variant

### DIFF
--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -62,6 +62,42 @@ describe('<DesktopDatePicker />', () => {
     expect(screen.queryByRole('dialog')).not.to.equal(null);
   });
 
+  it('closes on clickaway', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDatePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+        TransitionComponent={FakeTransitionComponent}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(1);
+  });
+
+  it('does not close on click inside', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDatePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+        TransitionComponent={FakeTransitionComponent}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Next month'));
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('accepts date on day button click', () => {
     const onChangeMock = spy();
     render(
@@ -171,5 +207,33 @@ describe('<DesktopDatePicker />', () => {
     );
 
     expect(getByMuiTest('picker-toolbar')).toBeVisible();
+  });
+
+  describe('prop: PopperProps', () => {
+    it('forwards onClick and onTouchStart', () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <DesktopDatePicker
+          open
+          onChange={() => {}}
+          PopperProps={{
+            onClick: handleClick,
+            onTouchStart: handleTouchStart,
+            // @ts-expect-error `data-*` attributes are not recognized in props objects
+            'data-testid': 'popper',
+          }}
+          renderInput={(params) => <TextField {...params} />}
+          value={null}
+        />,
+      );
+      const popper = screen.getByTestId('popper');
+
+      fireEvent.click(popper);
+      fireEvent.touchStart(popper);
+
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
   });
 });

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -80,6 +80,22 @@ describe('<DesktopDatePicker />', () => {
     expect(handleClose.callCount).to.equal(1);
   });
 
+  it('does not close on clickaway when it is not open', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDatePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('does not close on click inside', () => {
     const handleClose = spy();
     render(

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -48,6 +48,22 @@ describe('<DesktopDateRangePicker />', () => {
     expect(handleClose.callCount).to.equal(1);
   });
 
+  it('does not close on clickaway when it is not open', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateRangePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={[null, null]}
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('does not close on click inside', () => {
     const handleClose = spy();
     render(

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -31,6 +31,40 @@ describe('<DesktopDateRangePicker />', () => {
     }
   });
 
+  it('closes on clickaway', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateRangePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={[null, null]}
+        open
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(1);
+  });
+
+  it('does not close on click inside', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateRangePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={[null, null]}
+        open
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByLabelText('Previous month')[0]);
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('allows to select date range end-to-end', () => {
     function RangePickerTest() {
       const [range, changeRange] = React.useState<DateRange<Date>>([
@@ -312,5 +346,33 @@ describe('<DesktopDateRangePicker />', () => {
     );
 
     expect(getAllByMuiTest('pickers-calendar')).to.have.length(3);
+  });
+
+  describe('prop: PopperProps', () => {
+    it('forwards onClick and onTouchStart', () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <DesktopDateRangePicker
+          open
+          onChange={() => {}}
+          PopperProps={{
+            onClick: handleClick,
+            onTouchStart: handleTouchStart,
+            // @ts-expect-error `data-*` attributes are not recognized in props objects
+            'data-testid': 'popper',
+          }}
+          renderInput={(params) => <TextField {...params} />}
+          value={[null, null]}
+        />,
+      );
+      const popper = screen.getByTestId('popper');
+
+      fireEvent.click(popper);
+      fireEvent.touchStart(popper);
+
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
   });
 });

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -52,6 +52,22 @@ describe('<DesktopDateTimePicker />', () => {
     expect(handleClose.callCount).to.equal(1);
   });
 
+  it('does not close on clickaway when it is not open', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('does not close on click inside', () => {
     const handleClose = spy();
     render(

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import { expect } from 'chai';
-import { useFakeTimers, SinonFakeTimers } from 'sinon';
+import { useFakeTimers, SinonFakeTimers, spy } from 'sinon';
 import { fireEvent, screen } from 'test/utils';
 import 'dayjs/locale/ru';
 import dayjs from 'dayjs';
@@ -22,7 +22,7 @@ describe('<DesktopDateTimePicker />', () => {
 
   const render = createPickerRender({ strict: false });
 
-  it('opens dialog on calendar button click for Mobile mode', () => {
+  it('opens dialog on calendar button click', () => {
     render(
       <DesktopDateTimePicker
         value={null}
@@ -33,6 +33,40 @@ describe('<DesktopDateTimePicker />', () => {
 
     fireEvent.click(screen.getByLabelText(/choose date/i));
     expect(screen.getByRole('dialog')).toBeVisible();
+  });
+
+  it('closes on clickaway', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(1);
+  });
+
+  it('does not close on click inside', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('pick time'));
+
+    expect(handleClose.callCount).to.equal(0);
   });
 
   it('prop: dateAdapter – allows to override date adapter with prop', () => {
@@ -131,5 +165,33 @@ describe('<DesktopDateTimePicker />', () => {
 
     fireEvent.click(screen.getByLabelText('open next view'));
     expect(screen.getByLabelText('open next view')).to.have.attribute('disabled');
+  });
+
+  describe('prop: PopperProps', () => {
+    it('forwards onClick and onTouchStart', () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <DesktopDateTimePicker
+          open
+          onChange={() => {}}
+          PopperProps={{
+            onClick: handleClick,
+            onTouchStart: handleTouchStart,
+            // @ts-expect-error `data-*` attributes are not recognized in props objects
+            'data-testid': 'popper',
+          }}
+          renderInput={(params) => <TextField {...params} />}
+          value={null}
+        />,
+      );
+      const popper = screen.getByTestId('popper');
+
+      fireEvent.click(popper);
+      fireEvent.touchStart(popper);
+
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
   });
 });

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -47,6 +47,22 @@ describe('<DesktopTimePicker />', () => {
     expect(handleClose.callCount).to.equal(1);
   });
 
+  it('does not close on clickaway when it is not open', () => {
+    const handleClose = spy();
+    render(
+      <DesktopTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('does not close on click inside', () => {
     const handleClose = spy();
     render(

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -30,6 +30,40 @@ describe('<DesktopTimePicker />', () => {
     }),
   );
 
+  it('closes on clickaway', () => {
+    const handleClose = spy();
+    render(
+      <DesktopTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(document.body);
+
+    expect(handleClose.callCount).to.equal(1);
+  });
+
+  it('does not close on click inside', () => {
+    const handleClose = spy();
+    render(
+      <DesktopTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('open next view'));
+
+    expect(handleClose.callCount).to.equal(0);
+  });
+
   it('allows to navigate between timepicker views using arrow switcher', () => {
     render(
       <DesktopTimePicker
@@ -106,6 +140,34 @@ describe('<DesktopTimePicker />', () => {
         expect(onErrorMock.callCount).to.equal(1);
         expect(onErrorMock.args[0][0]).to.equal(expectedError);
       });
+    });
+  });
+
+  describe('prop: PopperProps', () => {
+    it('forwards onClick and onTouchStart', () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <DesktopTimePicker
+          open
+          onChange={() => {}}
+          PopperProps={{
+            onClick: handleClick,
+            onTouchStart: handleTouchStart,
+            // @ts-expect-error `data-*` attributes are not recognized in props objects
+            'data-testid': 'popper',
+          }}
+          renderInput={(params) => <TextField {...params} />}
+          value={null}
+        />,
+      );
+      const popper = screen.getByTestId('popper');
+
+      fireEvent.click(popper);
+      fireEvent.touchStart(popper);
+
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
     });
   });
 });

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -6,11 +6,10 @@ import Popper, { PopperProps as MuiPopperProps } from '@material-ui/core/Popper'
 import TrapFocus, {
   TrapFocusProps as MuiTrapFocusProps,
 } from '@material-ui/core/Unstable_TrapFocus';
-import { useForkRef, setRef, useEventCallback } from '@material-ui/core/utils';
+import { useForkRef, setRef, useEventCallback, ownerDocument } from '@material-ui/core/utils';
 import { MuiStyles, StyleRules, WithStyles, withStyles } from '@material-ui/core/styles';
 import { TransitionProps as MuiTransitionProps } from '@material-ui/core/transitions';
 import { useGlobalKeyDown, keycode } from './hooks/useKeyDown';
-import { executeInTheNextEventLoopTick } from './utils';
 
 export interface ExportedPickerPopperProps {
   /**
@@ -50,6 +49,110 @@ export const styles: MuiStyles<PickersPopperClassKey> = (
   },
 });
 
+function clickedRootScrollbar(event: MouseEvent, doc: Document) {
+  return (
+    doc.documentElement.clientWidth < event.clientX ||
+    doc.documentElement.clientHeight < event.clientY
+  );
+}
+
+/**
+ * Based on @material-ui/core/ClickAwayListener without the customization.
+ * We can probably strip away even more since children won't be portaled.
+ *
+ * @param onClickAway
+ * @param onClick
+ * @param onTouchStart
+ */
+function useClickAwayListener(
+  onClickAway: (event: MouseEvent | TouchEvent) => void,
+): [React.Ref<Element>, React.MouseEventHandler, React.TouchEventHandler] {
+  const movedRef = React.useRef(false);
+  const syntheticEventRef = React.useRef(false);
+
+  const nodeRef = React.useRef<Element>(null);
+
+  // The handler doesn't take event.defaultPrevented into account:
+  //
+  // event.preventDefault() is meant to stop default behaviors like
+  // clicking a checkbox to check it, hitting a button to submit a form,
+  // and hitting left arrow to move the cursor in a text input etc.
+  // Only special HTML elements have these default behaviors.
+  const handleClickAway = useEventCallback((event: MouseEvent | TouchEvent) => {
+    // Given developers can stop the propagation of the synthetic event,
+    // we can only be confident with a positive value.
+    const insideReactTree = syntheticEventRef.current;
+    syntheticEventRef.current = false;
+
+    const doc = ownerDocument(nodeRef.current);
+
+    // 1. IE11 support, which trigger the handleClickAway even after the unbind
+    // 2. The child might render null.
+    // 3. Behave like a blur listener.
+    if (
+      !nodeRef.current ||
+      // is a TouchEvent?
+      ('clientX' in event && clickedRootScrollbar(event, doc))
+    ) {
+      return;
+    }
+
+    // Do not act if user performed touchmove
+    if (movedRef.current) {
+      movedRef.current = false;
+      return;
+    }
+
+    let insideDOM;
+
+    // If not enough, can use https://github.com/DieterHolvoet/event-propagation-path/blob/master/propagationPath.js
+    if (event.composedPath) {
+      insideDOM = event.composedPath().indexOf(nodeRef.current) > -1;
+    } else {
+      insideDOM =
+        !doc.documentElement.contains(event.target as Node | null) ||
+        nodeRef.current.contains(event.target as Node | null);
+    }
+
+    if (!insideDOM && !insideReactTree) {
+      onClickAway(event);
+    }
+  });
+
+  // Keep track of mouse/touch events that bubbled up through the portal.
+  const handleSynthetic = () => {
+    syntheticEventRef.current = true;
+  };
+
+  React.useEffect(() => {
+    const doc = ownerDocument(nodeRef.current);
+
+    const handleTouchMove = () => {
+      movedRef.current = true;
+    };
+
+    doc.addEventListener('touchstart', handleClickAway);
+    doc.addEventListener('touchmove', handleTouchMove);
+
+    return () => {
+      doc.removeEventListener('touchstart', handleClickAway);
+      doc.removeEventListener('touchmove', handleTouchMove);
+    };
+  }, [handleClickAway]);
+
+  React.useEffect(() => {
+    const doc = ownerDocument(nodeRef.current);
+
+    doc.addEventListener('click', handleClickAway);
+
+    return () => {
+      doc.removeEventListener('click', handleClickAway);
+    };
+  }, [handleClickAway]);
+
+  return [nodeRef, handleSynthetic, handleSynthetic];
+}
+
 const PickersPopper: React.FC<PickerPopperProps & WithStyles<typeof styles>> = (props) => {
   const {
     anchorEl,
@@ -64,22 +167,12 @@ const PickersPopper: React.FC<PickerPopperProps & WithStyles<typeof styles>> = (
     TransitionComponent = Grow,
     TrapFocusProps,
   } = props;
-  const paperRef = React.useRef<HTMLElement>(null);
-  const handleRef = useForkRef(paperRef, containerRef);
-  const lastFocusedElementRef = React.useRef<Element | null>(null);
-
-  const handlePaperRef = useEventCallback((node: HTMLElement) => {
-    setRef(handleRef, node);
-
-    if (node) {
-      onOpen();
-    }
-  });
 
   useGlobalKeyDown(open, {
     [keycode.Esc]: onClose,
   });
 
+  const lastFocusedElementRef = React.useRef<Element | null>(null);
   React.useEffect(() => {
     if (role === 'tooltip') {
       return;
@@ -95,20 +188,18 @@ const PickersPopper: React.FC<PickerPopperProps & WithStyles<typeof styles>> = (
     }
   }, [open, role]);
 
-  const handleBlur = () => {
-    if (!open) {
-      return;
+  const [clickAwayRef, onPaperClick, onPaperTouchStart] = useClickAwayListener(onClose);
+  const paperRef = React.useRef<HTMLElement>(null);
+  const handleRef = useForkRef(paperRef, containerRef);
+
+  const handlePaperRef = useEventCallback((node: HTMLElement) => {
+    setRef(handleRef, node);
+    setRef(clickAwayRef, node);
+
+    if (node) {
+      onOpen();
     }
-
-    // document.activeElement is updating on the next tick after `blur` called
-    executeInTheNextEventLoopTick(() => {
-      if (paperRef.current?.contains(document.activeElement)) {
-        return;
-      }
-
-      onClose();
-    });
-  };
+  });
 
   return (
     <Popper
@@ -136,7 +227,8 @@ const PickersPopper: React.FC<PickerPopperProps & WithStyles<typeof styles>> = (
               className={clsx(classes.paper, {
                 [classes.topTransition]: placement === 'top',
               })}
-              onBlur={handleBlur}
+              onClick={onPaperClick}
+              onTouchStart={onPaperTouchStart}
             >
               {children}
             </Paper>


### PR DESCRIPTION
The pickers currently rely on click-focus behavior to detect "click-away". However, this is platform dependant behavior and relies on the container being focusable which we want to avoid in the future anyway.

We're now using a stripped-down variant of ClickAwayListener. We can't use this component directly due to how we pass props via cloneElement.

A shared hook might make more sense in the long run but we can work with a much simpler variant in PickersPopper so I'm waiting a bit more. Especially considering how complicated this logic is in React right now.

The main UX difference right now compared to https://github.com/mui-org/material-ui/pull/24444 (which also fixes the missing click-away logic) is observable when clicking on the button that opens the picker. On #24444 the datepicker will flicker. In this PR it works as an actual toggle: Click when closed -> open, Click when opened -> close. So this PR works like `<input type="time" />` (in Chrome 88).

Preview:
- [TimePicker](https://deploy-preview-24653--material-ui.netlify.app/components/time-picker/#main-content)
- [DatePicker](https://deploy-preview-24653--material-ui.netlify.app/components/date-picker/#main-content)
- [DateTimePicker](https://deploy-preview-24653--material-ui.netlify.app/components/date-time-picker/)
