### PR TITLE
[TextField] Migrate FormControl to emotion

### DIFF
--- a/docs/pages/api-docs/form-control.json
+++ b/docs/pages/api-docs/form-control.json
@@ -24,6 +24,7 @@
       "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
       "default": "'medium'"
     },
+    "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {
         "name": "enum",
@@ -43,6 +44,6 @@
   "filename": "/packages/material-ui/src/FormControl/FormControl.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/checkboxes/\">Checkboxes</a></li>\n<li><a href=\"/components/radio-buttons/\">Radio Buttons</a></li>\n<li><a href=\"/components/switches/\">Switches</a></li>\n<li><a href=\"/components/text-fields/\">Text Fields</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/form-control/form-control.json
+++ b/docs/translations/api-docs/form-control/form-control.json
@@ -13,6 +13,7 @@
     "margin": "If <code>dense</code> or <code>normal</code>, will adjust vertical spacing of this and contained components.",
     "required": "If <code>true</code>, the label will indicate that the <code>input</code> is required.",
     "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },
   "classDescriptions": {

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { Theme } from '../styles';
 
 export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -66,6 +68,10 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
      * @default 'medium'
      */
     size?: 'small' | 'medium';
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
     /**
      * The variant to use.
      * @default 'standard'

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -103,8 +103,16 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
 
   const styleProps = {
     ...props,
-    margin,
+    color,
+    component,
+    disabled,
+    error,
     fullWidth,
+    hiddenLabel,
+    margin,
+    required,
+    size,
+    variant,
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -88,7 +88,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     children,
     className,
     color = 'primary',
-    component: Component = 'div',
+    component = 'div',
     disabled = false,
     error = false,
     focused: visuallyFocused,

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -1,40 +1,62 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import useThemeProps from '../styles/useThemeProps';
+import experimentalStyled from '../styles/experimentalStyled';
 import { isFilled, isAdornedStart } from '../InputBase/utils';
-import withStyles from '../styles/withStyles';
 import capitalize from '../utils/capitalize';
 import isMuiElement from '../utils/isMuiElement';
 import FormControlContext from './FormControlContext';
+import { getFormControlUtilityClasses } from './formControlClasses';
 
-export const styles = {
-  /* Styles applied to the root element. */
-  root: {
-    display: 'inline-flex',
-    flexDirection: 'column',
-    position: 'relative',
-    // Reset fieldset default style.
-    minWidth: 0,
-    padding: 0,
-    margin: 0,
-    border: 0,
-    verticalAlign: 'top', // Fix alignment issue on Safari.
+const overridesResolver = ({ styleProps }, styles) => {
+  return deepmerge(styles.root || {}, {
+    ...styles[`margin${capitalize(styleProps.margin)}`],
+    ...(styleProps.fullWidth && styles.fullWidth),
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes, margin, fullWidth } = styleProps;
+  const slots = {
+    root: ['root', `margin${capitalize(margin)}`, fullWidth && 'fullWidth'],
+  };
+
+  return composeClasses(slots, getFormControlUtilityClasses, classes);
+};
+
+const FormControlRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiFormControl',
+    slot: 'Root',
+    overridesResolver,
   },
-  /* Styles applied to the root element if `margin="normal"`. */
-  marginNormal: {
+)(({ styleProps }) => ({
+  display: 'inline-flex',
+  flexDirection: 'column',
+  position: 'relative',
+  // Reset fieldset default style.
+  minWidth: 0,
+  padding: 0,
+  margin: 0,
+  border: 0,
+  verticalAlign: 'top', // Fix alignment issue on Safari.
+  ...(styleProps.margin === 'normal' && {
     marginTop: 16,
     marginBottom: 8,
-  },
-  /* Styles applied to the root element if `margin="dense"`. */
-  marginDense: {
+  }),
+  ...(styleProps.dense === 'dense' && {
     marginTop: 8,
     marginBottom: 4,
-  },
-  /* Styles applied to the root element if `fullWidth={true}`. */
-  fullWidth: {
+  }),
+  ...(styleProps.fullWidth && {
     width: '100%',
-  },
-};
+  }),
+}));
 
 /**
  * Provides context such as filled/focused/error/required for form inputs.
@@ -60,10 +82,10 @@ export const styles = {
  * ⚠️ Only one `InputBase` can be used within a FormControl because it create visual inconsistencies.
  * For instance, only one input can be focused at the same time, the state shouldn't be shared.
  */
-const FormControl = React.forwardRef(function FormControl(props, ref) {
+const FormControl = React.forwardRef(function FormControl(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiFormControl' });
   const {
     children,
-    classes,
     className,
     color = 'primary',
     component: Component = 'div',
@@ -78,6 +100,14 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
     variant = 'standard',
     ...other
   } = props;
+
+  const styleProps = {
+    ...props,
+    margin,
+    fullWidth,
+  };
+
+  const classes = useUtilityClasses(styleProps);
 
   const [adornedStart, setAdornedStart] = React.useState(() => {
     // We need to iterate through the children and find the Input in order
@@ -182,20 +212,15 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
 
   return (
     <FormControlContext.Provider value={childContext}>
-      <Component
-        className={clsx(
-          classes.root,
-          {
-            [classes[`margin${capitalize(margin)}`]]: margin !== 'none',
-            [classes.fullWidth]: fullWidth,
-          },
-          className,
-        )}
+      <FormControlRoot
+        as={Component}
+        styleProps={styleProps}
+        className={clsx(classes.root, className)}
         ref={ref}
         {...other}
       >
         {children}
-      </Component>
+      </FormControlRoot>
     </FormControlContext.Provider>
   );
 });
@@ -269,10 +294,14 @@ FormControl.propTypes = {
    */
   size: PropTypes.oneOf(['medium', 'small']),
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The variant to use.
    * @default 'standard'
    */
   variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
 };
 
-export default withStyles(styles, { name: 'MuiFormControl' })(FormControl);
+export default FormControl;

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -49,7 +49,7 @@ const FormControlRoot = experimentalStyled(
     marginTop: 16,
     marginBottom: 8,
   }),
-  ...(styleProps.dense === 'dense' && {
+  ...(styleProps.margin === 'dense' && {
     marginTop: 8,
     marginBottom: 4,
   }),

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -221,7 +221,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
   return (
     <FormControlContext.Provider value={childContext}>
       <FormControlRoot
-        as={Component}
+        as={component}
         styleProps={styleProps}
         className={clsx(classes.root, className)}
         ref={ref}

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getClasses, createMount, describeConformance, act, createClientRender } from 'test/utils';
+import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
 import Input from '../Input';
 import Select from '../Select';
 import FormControl from './FormControl';
 import useFormControl from './useFormControl';
+import classes from './formControlClasses';
 
 describe('<FormControl />', () => {
   const mount = createMount();
   const render = createClientRender();
-  let classes;
 
   function TestComponent(props) {
     const context = useFormControl();
@@ -20,16 +20,15 @@ describe('<FormControl />', () => {
     return null;
   }
 
-  before(() => {
-    classes = getClasses(<FormControl />);
-  });
-
-  describeConformance(<FormControl />, () => ({
+  describeConformanceV5(<FormControl />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'fieldset',
+    muiName: 'MuiFormControl',
+    testVariantProps: { margin: 'dense' },
+    skip: ['componentsProp'],
   }));
 
   describe('initial state', () => {

--- a/packages/material-ui/src/FormControl/formControlClasses.d.ts
+++ b/packages/material-ui/src/FormControl/formControlClasses.d.ts
@@ -1,5 +1,6 @@
 export interface FormControlClasses {
   root: string;
+  marginNone: string;
   marginNormal: string;
   marginDense: string;
   fullWidth: string;

--- a/packages/material-ui/src/FormControl/formControlClasses.d.ts
+++ b/packages/material-ui/src/FormControl/formControlClasses.d.ts
@@ -1,0 +1,12 @@
+export interface FormControlClasses {
+  root: string;
+  marginNormal: string;
+  marginDense: string;
+  fullWidth: string;
+}
+
+declare const formControlClasses: FormControlClasses;
+
+export function getFormControlUtilityClasses(slot: string): string;
+
+export default formControlClasses;

--- a/packages/material-ui/src/FormControl/formControlClasses.js
+++ b/packages/material-ui/src/FormControl/formControlClasses.js
@@ -6,6 +6,7 @@ export function getFormControlUtilityClasses(slot) {
 
 const formControlClasses = generateUtilityClasses('MuiFormControl', [
   'root',
+  'marginNone',
   'marginNormal',
   'marginDense',
   'fullWidth',

--- a/packages/material-ui/src/FormControl/formControlClasses.js
+++ b/packages/material-ui/src/FormControl/formControlClasses.js
@@ -1,0 +1,14 @@
+import { generateUtilityClasses, generateUtilityClass } from '@material-ui/unstyled';
+
+export function getFormControlUtilityClasses(slot) {
+  return generateUtilityClass('MuiFormControl', slot);
+}
+
+const formControlClasses = generateUtilityClasses('MuiFormControl', [
+  'root',
+  'marginNormal',
+  'marginDense',
+  'fullWidth',
+]);
+
+export default formControlClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR migrates the FormControl component to the new emotion format as a part of #24405.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
