### PR TITLE
[Paper] Improve warning on invalid combinations of variant and elevation

### DIFF
--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -136,9 +136,10 @@ Paper.propTypes = {
    * @default 1
    */
   elevation: chainPropTypes(PropTypes.number, (props) => {
-    if (props.elevation > 0 && props.variant === 'outlined') {
+    const { elevation, variant } = props;
+    if (elevation > 0 && variant === 'outlined') {
       return new Error(
-        'Material-UI: Combining `elevation={>0}` with `variant="outlined"` has no effect.',
+        `Material-UI: Combining \`elevation={${elevation}}\` with \`variant="${variant}"\` has no effect. Either use \`elevation={0}\` or use a different \`variant\`.`,
       );
     }
 

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import * as PropTypes from 'prop-types';
 import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import Paper from './Paper';
 import classes from './paperClasses';
@@ -82,11 +83,30 @@ describe('<Paper />', () => {
     expect(getByTestId('root')).to.have.class('custom-elevation');
   });
 
-  it('warns if the given `elevation` is not implemented in the theme', () => {
-    expect(() => {
-      render(<Paper elevation={25} />);
-    }).toErrorDev(
-      'Material-UI: The elevation provided <Paper elevation={25}> is not available in the theme.',
-    );
+  describe('warnings', () => {
+    beforeEach(() => {
+      PropTypes.resetWarningCache();
+    });
+
+    it('warns if the given `elevation` is not implemented in the theme', () => {
+      expect(() => {
+        render(<Paper elevation={25} />);
+      }).toErrorDev(
+        'Material-UI: The elevation provided <Paper elevation={25}> is not available in the theme.',
+      );
+    });
+
+    it('warns if `elevation={numberGreaterThanZero}` is used with `variant="outlined"`', () => {
+      expect(() => {
+        PropTypes.checkPropTypes(
+          Paper.propTypes,
+          { elevation: 5, variant: 'outlined' },
+          'prop',
+          'MockedName',
+        );
+      }).toErrorDev([
+        'Material-UI: Combining `elevation={5}` with `variant="outlined"` has no effect. Either use `elevation={0}` or use a different `variant`.',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
- include what can be done to fix this warning
- include used `elevation` value to find the warning easier