### PR TITLE
[styled-engine] Fix GlobalStyles not to throw when no theme is available

### DIFF
--- a/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.js
+++ b/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.js
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import { createGlobalStyle } from 'styled-components';
 
 function isEmpty(obj) {
-  return obj === udnefined || obj === null || Object.keys(obj).length === 0;
+  return obj === undefined || obj === null || Object.keys(obj).length === 0;
 }
 
 const GlobalStyles = createGlobalStyle((props) => {
-  const { styles, defaultTheme } = props;
+  const { styles, defaultTheme = {} } = props;
 
   if (typeof styles === 'function') {
     return styles(isEmpty(props.theme) ? defaultTheme : props.theme);

--- a/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.js
+++ b/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { createGlobalStyle } from 'styled-components';
 
 function isEmpty(obj) {
-  return Object.keys(obj).length === 0;
+  return obj === udnefined || obj === null || Object.keys(obj).length === 0;
 }
 
 const GlobalStyles = createGlobalStyle((props) => {

--- a/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.test.js
@@ -53,6 +53,12 @@ describe('GlobalStyles', () => {
     });
   });
 
+  it('should not throw if no theme is available', () => {
+    expect(() => render(
+      <GlobalStyles defaultTheme={{ color: 'rgb(0, 0, 255)' }} styles={(theme) => ({ span: { color: theme.color } })} />
+    )).not.to.throw();
+  });
+
   it('should give presedence to styled()', function test() {
     if (/jsdom/.test(window.navigator.userAgent)) this.skip();
 

--- a/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/material-ui-styled-engine-sc/src/GlobalStyles/GlobalStyles.test.js
@@ -54,9 +54,14 @@ describe('GlobalStyles', () => {
   });
 
   it('should not throw if no theme is available', () => {
-    expect(() => render(
-      <GlobalStyles defaultTheme={{ color: 'rgb(0, 0, 255)' }} styles={(theme) => ({ span: { color: theme.color } })} />
-    )).not.to.throw();
+    expect(() =>
+      render(
+        <GlobalStyles
+          defaultTheme={{ color: 'rgb(0, 0, 255)' }}
+          styles={(theme) => ({ span: { color: theme.color } })}
+        />,
+      ),
+    ).not.to.throw();
   });
 
   it('should give presedence to styled()', function test() {

--- a/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.js
+++ b/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { Global } from '@emotion/react';
 
 function isEmpty(obj) {
-  return obj === udnefined || obj === null || Object.keys(obj).length === 0;
+  return obj === undefined || obj === null || Object.keys(obj).length === 0;
 }
 
 export default function GlobalStyles(props) {
-  const { styles, defaultTheme } = props;
+  const { styles, defaultTheme = {} } = props;
 
   const globalStyles =
     typeof styles === 'function'

--- a/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.js
+++ b/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Global } from '@emotion/react';
 
 function isEmpty(obj) {
-  return Object.keys(obj).length === 0;
+  return obj === udnefined || obj === null || Object.keys(obj).length === 0;
 }
 
 export default function GlobalStyles(props) {

--- a/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.test.js
@@ -53,6 +53,12 @@ describe('GlobalStyles', () => {
     });
   });
 
+  it('should not throw if no theme is available', () => {
+    expect(() => render(
+      <GlobalStyles defaultTheme={{ color: 'rgb(0, 0, 255)' }} styles={(theme) => ({ span: { color: theme.color } })} />
+    )).not.to.throw();
+  });
+
   it('should give presedence to styled()', function test() {
     if (/jsdom/.test(window.navigator.userAgent)) this.skip();
 

--- a/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/material-ui-styled-engine/src/GlobalStyles/GlobalStyles.test.js
@@ -54,9 +54,14 @@ describe('GlobalStyles', () => {
   });
 
   it('should not throw if no theme is available', () => {
-    expect(() => render(
-      <GlobalStyles defaultTheme={{ color: 'rgb(0, 0, 255)' }} styles={(theme) => ({ span: { color: theme.color } })} />
-    )).not.to.throw();
+    expect(() =>
+      render(
+        <GlobalStyles
+          defaultTheme={{ color: 'rgb(0, 0, 255)' }}
+          styles={(theme) => ({ span: { color: theme.color } })}
+        />,
+      ),
+    ).not.to.throw();
   });
 
   it('should give presedence to styled()', function test() {


### PR DESCRIPTION
Fixes the following issue found in https://github.com/mui-org/material-ui/pull/24489#issuecomment-769059791

![image](https://user-images.githubusercontent.com/4512430/106149083-20da1680-617a-11eb-8eb5-72a6d66f976a.png)
