### PR TITLE
[TextField] Migrate OutlinedInput to emotion

### DIFF
--- a/docs/pages/api-docs/outlined-input.json
+++ b/docs/pages/api-docs/outlined-input.json
@@ -27,6 +27,7 @@
     "required": { "type": { "name": "bool" } },
     "rows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
     "startAdornment": { "type": { "name": "node" } },
+    "sx": { "type": { "name": "object" } },
     "type": { "type": { "name": "string" }, "default": "'text'" },
     "value": { "type": { "name": "any" } }
   },
@@ -57,6 +58,6 @@
   "filename": "/packages/material-ui/src/OutlinedInput/OutlinedInput.js",
   "inheritance": { "component": "InputBase", "pathname": "/api/input-base/" },
   "demos": "<ul><li><a href=\"/components/text-fields/\">Text Fields</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/outlined-input/outlined-input.json
+++ b/docs/translations/api-docs/outlined-input/outlined-input.json
@@ -28,6 +28,7 @@
     "required": "If <code>true</code>, the <code>input</code> element is required. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component.",
     "rows": "Number of rows to display when multiline option is set to true.",
     "startAdornment": "Start <code>InputAdornment</code> for this component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "type": "Type of the <code>input</code> element. It should be <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types\">a valid HTML5 input type</a>.",
     "value": "The value of the <code>input</code> element, required for a controlled component."
   },

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -167,7 +167,7 @@ const AutocompleteRoot = experimentalStyled(
       [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 52 + 4 + 9,
       },
-      '& .MuiOutlinedInput-input': {
+      [`& .${autocompleteClasses.input}`]: {
         padding: '7.5px 4px 7.5px 6px',
       },
       [`& .${autocompleteClasses.endAdornment}`]: {
@@ -176,7 +176,7 @@ const AutocompleteRoot = experimentalStyled(
     },
     '&.MuiOutlinedInput-root.MuiInputBase-sizeSmall': {
       padding: 6,
-      '& .MuiOutlinedInput-input': {
+      [`& .${autocompleteClasses.input}`]: {
         padding: '2.5px 4px 2.5px 6px',
       },
     },

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -177,7 +177,7 @@ const AutocompleteRoot = experimentalStyled(
     '&.MuiOutlinedInput-root.MuiInputBase-sizeSmall': {
       padding: 6,
       '& .MuiOutlinedInput-input': {
-        padding: '2.5px 4px 2.5 6px',
+        padding: '2.5px 4px 2.5px 6px',
       },
     },
     '&.MuiFilledInput-root': {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -159,7 +159,7 @@ const AutocompleteRoot = experimentalStyled(
         padding: '2px 4px 3px 0',
       },
     },
-    '&[class*="MuiOutlinedInput-root"]': {
+    '&.MuiOutlinedInput-root': {
       padding: 9,
       [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 26 + 4 + 9,
@@ -167,17 +167,20 @@ const AutocompleteRoot = experimentalStyled(
       [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 52 + 4 + 9,
       },
-      [`& .${autocompleteClasses.input}`]: {
-        padding: '7.5px 4px 7.5px 6px',
+      '& .MuiOutlinedInput-input': {
+        padding: '7.5px 4px',
       },
-      [`& .${autocompleteClasses.endAdornment}`]: {
+      '& .MuiOutlinedInput-input:first-child': {
+        paddingLeft: 6,
+      },
+      '& $endAdornment': {
         right: 9,
       },
     },
-    '&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-sizeSmall"]': {
+    '&.MuiOutlinedInput-root.MuiInputBase-sizeSmall': {
       padding: 6,
-      [`& .${autocompleteClasses.input}`]: {
-        padding: '2.5px 4px 2.5px 6px',
+      '& .MuiOutlinedInput-input': {
+        padding: '2.5px 4px',
       },
     },
     '&.MuiFilledInput-root': {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -170,7 +170,7 @@ const AutocompleteRoot = experimentalStyled(
       '& .MuiOutlinedInput-input': {
         padding: '7.5px 4px 7.5px 6px',
       },
-      [`& .${autocompleteClasses.input}`]: {
+      [`& .${autocompleteClasses.endAdornment}`]: {
         right: 9,
       },
     },

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -168,7 +168,7 @@ const AutocompleteRoot = experimentalStyled(
         paddingRight: 52 + 4 + 9,
       },
       '& .MuiOutlinedInput-input': {
-        padding: '7.5px 4px',
+        padding: '7.5px 4px 7.5px 6px',
       },
       '& .MuiOutlinedInput-input:first-child': {
         paddingLeft: 6,
@@ -180,7 +180,7 @@ const AutocompleteRoot = experimentalStyled(
     '&.MuiOutlinedInput-root.MuiInputBase-sizeSmall': {
       padding: 6,
       '& .MuiOutlinedInput-input': {
-        padding: '2.5px 4px',
+        padding: '2.5px 4px 2.5 6px',
       },
     },
     '&.MuiFilledInput-root': {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -170,10 +170,7 @@ const AutocompleteRoot = experimentalStyled(
       '& .MuiOutlinedInput-input': {
         padding: '7.5px 4px 7.5px 6px',
       },
-      '& .MuiOutlinedInput-input:first-child': {
-        paddingLeft: 6,
-      },
-      '& $endAdornment': {
+      [`& .${autocompleteClasses.input}`]: {
         right: 9,
       },
     },

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.js
@@ -5,14 +5,7 @@ import { emphasize } from '../styles/colorManipulator';
 import MoreHorizIcon from '../internal/svg-icons/MoreHoriz';
 import ButtonBase from '../ButtonBase';
 
-const BreadcrumbCollapsedButton = experimentalStyled(
-  ButtonBase,
-  {},
-  {
-    name: 'PrivateBreadcrumbCollapsed',
-    slot: 'Button',
-  },
-)(({ theme }) => ({
+const BreadcrumbCollapsedButton = experimentalStyled(ButtonBase)(({ theme }) => ({
   display: 'flex',
   marginLeft: theme.spacing(0.5),
   marginRight: theme.spacing(0.5),
@@ -33,14 +26,7 @@ const BreadcrumbCollapsedButton = experimentalStyled(
   },
 }));
 
-const BreadcrumbCollapsedIcon = experimentalStyled(
-  MoreHorizIcon,
-  {},
-  {
-    name: 'PrivateBreadcrumbCollapsed',
-    slot: 'Icon',
-  },
-)({
+const BreadcrumbCollapsedIcon = experimentalStyled(MoreHorizIcon)({
   width: 24,
   height: 16,
 });

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -28,11 +28,11 @@ const useUtilityClasses = (styleProps) => {
     root: ['root', indeterminate && 'indeterminate', `color${capitalize(color)}`],
   };
 
-  const finalClasses = composeClasses(slots, getCheckboxUtilityClass, classes);
+  const composedClasses = composeClasses(slots, getCheckboxUtilityClass, classes);
 
   return {
     ...classes, // forward the disabled and checked classes to the SwitchBase
-    ...finalClasses,
+    ...composedClasses,
   };
 };
 

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -26,7 +26,12 @@ const useUtilityClasses = (styleProps) => {
     input: ['input'],
   };
 
-  return composeClasses(slots, getInputUtilityClass, classes);
+  const composedClasses = composeClasses(slots, getInputUtilityClass, classes);
+
+  return {
+    ...classes, // forward classes to the InputBase
+    ...composedClasses,
+  };
 };
 
 const InputRoot = experimentalStyled(

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -114,9 +114,12 @@ const Input = React.forwardRef(function Input(inProps, ref) {
 
   const classes = useUtilityClasses(props);
 
+  const styleProps = { disableUnderline };
+
   return (
     <InputBase
       components={{ Root: InputRoot }}
+      componentsProps={{ root: { styleProps } }}
       fullWidth={fullWidth}
       inputComponent={inputComponent}
       multiline={multiline}

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -107,20 +107,11 @@ const Input = React.forwardRef(function Input(inProps, ref) {
     ...other
   } = props;
 
-  const styleProps = {
-    ...props,
-    fullWidth,
-    inputComponent,
-    multiline,
-    type,
-  };
-
   const classes = useUtilityClasses(props);
 
   return (
     <InputBase
       components={{ Root: InputRoot }}
-      componentsProps={{ root: { styleProps } }}
       fullWidth={fullWidth}
       inputComponent={inputComponent}
       multiline={multiline}

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -34,11 +34,11 @@ const useUtilityClasses = (styleProps) => {
     ],
   };
 
-  const finalClasses = composeClasses(slots, getInputLabelUtilityClasses, classes);
+  const composedClasses = composeClasses(slots, getInputLabelUtilityClasses, classes);
 
   return {
     ...classes, // forward the focused, disabled, etc. classes to the FormLabel
-    ...finalClasses,
+    ...composedClasses,
   };
 };
 

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -1,39 +1,43 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
 import useTheme from '../styles/useTheme';
 import capitalize from '../utils/capitalize';
+import experimentalStyled from '../styles/experimentalStyled';
 
-export const styles = (theme) => {
+const NotchedOutlineRoot = experimentalStyled(
+  'fieldset',
+  {},
+  { name: 'PrivateNotchedOutline', slot: 'Root' },
+)(() => ({
+  textAlign: 'left',
+  position: 'absolute',
+  bottom: 0,
+  right: 0,
+  top: -5,
+  left: 0,
+  margin: 0,
+  padding: '0 8px',
+  pointerEvents: 'none',
+  borderRadius: 'inherit',
+  borderStyle: 'solid',
+  borderWidth: 1,
+  overflow: 'hidden',
+}));
+const Legend = experimentalStyled(
+  'legend',
+  {},
+  { name: 'PrivateNotchedOutline', slot: 'Legend' },
+)(({ styleProps, theme }) => {
   return {
-    /* Styles applied to the root element. */
-    root: {
-      textAlign: 'left',
-      position: 'absolute',
-      bottom: 0,
-      right: 0,
-      top: -5,
-      left: 0,
-      margin: 0,
-      padding: '0 8px',
-      pointerEvents: 'none',
-      borderRadius: 'inherit',
-      borderStyle: 'solid',
-      borderWidth: 1,
-      overflow: 'hidden',
-    },
-    /* Styles applied to the legend element when `labelWidth` is provided. */
-    legend: {
+    ...(styleProps.label === undefined && {
       padding: 0,
       lineHeight: '11px', // sync with `height` in `legend` styles
       transition: theme.transitions.create('width', {
         duration: 150,
         easing: theme.transitions.easing.easeOut,
       }),
-    },
-    /* Styles applied to the legend element. */
-    legendLabelled: {
+    }),
+    ...(styleProps.label !== undefined && {
       display: 'block',
       width: 'auto',
       padding: 0,
@@ -50,18 +54,17 @@ export const styles = (theme) => {
         paddingRight: 5,
         display: 'inline-block',
       },
-    },
-    /* Styles applied to the legend element is notched. */
-    legendNotched: {
-      maxWidth: 1000,
-      transition: theme.transitions.create('max-width', {
-        duration: 100,
-        easing: theme.transitions.easing.easeOut,
-        delay: 50,
+      ...(styleProps.notched && {
+        maxWidth: 1000,
+        transition: theme.transitions.create('max-width', {
+          duration: 100,
+          easing: theme.transitions.easing.easeOut,
+          delay: 50,
+        }),
       }),
-    },
+    }),
   };
-};
+});
 
 /**
  * @ignore - internal component.
@@ -82,18 +85,8 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
 
   if (label !== undefined) {
     return (
-      <fieldset
-        aria-hidden
-        className={clsx(classes.root, className)}
-        ref={ref}
-        style={style}
-        {...other}
-      >
-        <legend
-          className={clsx(classes.legendLabelled, {
-            [classes.legendNotched]: notched,
-          })}
-        >
+      <NotchedOutlineRoot aria-hidden className={className} ref={ref} style={style} {...other}>
+        <Legend styleProps={{ notched, label }}>
           {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
           {label ? (
             <span>{label}</span>
@@ -102,8 +95,8 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
             // eslint-disable-next-line react/no-danger
             <span className="notranslate" dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
           )}
-        </legend>
-      </fieldset>
+        </Legend>
+      </NotchedOutlineRoot>
     );
   }
 
@@ -111,18 +104,18 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
 
   // TODO remove this branch
   return (
-    <fieldset
+    <NotchedOutlineRoot
       aria-hidden
       style={{
         [`padding${capitalize(align)}`]: 8,
         ...style,
       }}
-      className={clsx(classes.root, className)}
+      className={className}
       ref={ref}
       {...other}
     >
-      <legend
-        className={classes.legend}
+      <Legend
+        styleProps={{ label }}
         style={{
           // IE11: fieldset with legend does not render
           // a border radius. This maintains consistency
@@ -134,8 +127,8 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
         {/* notranslate needed while Google Translate will not fix zero-width space issue */}
         {/* eslint-disable-next-line react/no-danger */}
         <span className="notranslate" dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
-      </legend>
-    </fieldset>
+      </Legend>
+    </NotchedOutlineRoot>
   );
 });
 
@@ -171,4 +164,4 @@ NotchedOutline.propTypes = {
   style: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'PrivateNotchedOutline' })(NotchedOutline);
+export default NotchedOutline;

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -123,10 +123,11 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
       }}
       className={className}
       ref={ref}
+      styleProps={styleProps}
       {...other}
     >
-      <Legend
-        styleProps={{ label }}
+      <NotchedOutlineLegend
+        styleProps={styleProps}
         style={{
           // IE11: fieldset with legend does not render
           // a border radius. This maintains consistency
@@ -138,7 +139,7 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
         {/* notranslate needed while Google Translate will not fix zero-width space issue */}
         {/* eslint-disable-next-line react/no-danger */}
         <span className="notranslate" dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
-      </Legend>
+      </NotchedOutlineLegend>
     </NotchedOutlineRoot>
   );
 });

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -23,7 +23,7 @@ const NotchedOutlineRoot = experimentalStyled(
   borderWidth: 1,
   overflow: 'hidden',
 }));
-const Legend = experimentalStyled(
+const NotchedOutlineLegend = experimentalStyled(
   'legend',
   {},
   { name: 'PrivateNotchedOutline', slot: 'Legend' },
@@ -82,11 +82,22 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
   } = props;
   const theme = useTheme();
   const align = theme.direction === 'rtl' ? 'right' : 'left';
-
+  const styleProps = {
+    ...props,
+    notched,
+    label,
+  };
   if (label !== undefined) {
     return (
-      <NotchedOutlineRoot aria-hidden className={className} ref={ref} style={style} {...other}>
-        <Legend styleProps={{ notched, label }}>
+      <NotchedOutlineRoot
+        aria-hidden
+        className={className}
+        ref={ref}
+        style={style}
+        styleProps={styleProps}
+        {...other}
+      >
+        <NotchedOutlineLegend styleProps={styleProps}>
           {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
           {label ? (
             <span>{label}</span>
@@ -95,7 +106,7 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
             // eslint-disable-next-line react/no-danger
             <span className="notranslate" dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
           )}
-        </Legend>
+        </NotchedOutlineLegend>
       </NotchedOutlineRoot>
     );
   }

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -60,7 +60,7 @@ const NotchedOutlineLegend = experimentalStyled('legend')(({ styleProps, theme }
 /**
  * @ignore - internal component.
  */
-function NotchedOutline(props) {
+export default function NotchedOutline(props) {
   const {
     children,
     classes,
@@ -164,5 +164,3 @@ NotchedOutline.propTypes = {
    */
   style: PropTypes.object,
 };
-
-export default NotchedOutline;

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -4,11 +4,7 @@ import useTheme from '../styles/useTheme';
 import capitalize from '../utils/capitalize';
 import experimentalStyled from '../styles/experimentalStyled';
 
-const NotchedOutlineRoot = experimentalStyled(
-  'fieldset',
-  {},
-  { name: 'PrivateNotchedOutline', slot: 'Root' },
-)(() => ({
+const NotchedOutlineRoot = experimentalStyled('fieldset')({
   textAlign: 'left',
   position: 'absolute',
   bottom: 0,
@@ -22,54 +18,49 @@ const NotchedOutlineRoot = experimentalStyled(
   borderStyle: 'solid',
   borderWidth: 1,
   overflow: 'hidden',
-}));
-const NotchedOutlineLegend = experimentalStyled(
-  'legend',
-  {},
-  { name: 'PrivateNotchedOutline', slot: 'Legend' },
-)(({ styleProps, theme }) => {
-  return {
-    ...(styleProps.label === undefined && {
-      padding: 0,
-      lineHeight: '11px', // sync with `height` in `legend` styles
-      transition: theme.transitions.create('width', {
-        duration: 150,
-        easing: theme.transitions.easing.easeOut,
-      }),
-    }),
-    ...(styleProps.label !== undefined && {
-      display: 'block',
-      width: 'auto',
-      padding: 0,
-      height: 11, // sync with `lineHeight` in `legend` styles
-      fontSize: '0.75em',
-      visibility: 'hidden',
-      maxWidth: 0.01,
-      transition: theme.transitions.create('max-width', {
-        duration: 50,
-        easing: theme.transitions.easing.easeOut,
-      }),
-      '& > span': {
-        paddingLeft: 5,
-        paddingRight: 5,
-        display: 'inline-block',
-      },
-      ...(styleProps.notched && {
-        maxWidth: 1000,
-        transition: theme.transitions.create('max-width', {
-          duration: 100,
-          easing: theme.transitions.easing.easeOut,
-          delay: 50,
-        }),
-      }),
-    }),
-  };
 });
+
+const NotchedOutlineLegend = experimentalStyled('legend')(({ styleProps, theme }) => ({
+  ...(styleProps.label === undefined && {
+    padding: 0,
+    lineHeight: '11px', // sync with `height` in `legend` styles
+    transition: theme.transitions.create('width', {
+      duration: 150,
+      easing: theme.transitions.easing.easeOut,
+    }),
+  }),
+  ...(styleProps.label !== undefined && {
+    display: 'block',
+    width: 'auto',
+    padding: 0,
+    height: 11, // sync with `lineHeight` in `legend` styles
+    fontSize: '0.75em',
+    visibility: 'hidden',
+    maxWidth: 0.01,
+    transition: theme.transitions.create('max-width', {
+      duration: 50,
+      easing: theme.transitions.easing.easeOut,
+    }),
+    '& > span': {
+      paddingLeft: 5,
+      paddingRight: 5,
+      display: 'inline-block',
+    },
+    ...(styleProps.notched && {
+      maxWidth: 1000,
+      transition: theme.transitions.create('max-width', {
+        duration: 100,
+        easing: theme.transitions.easing.easeOut,
+        delay: 50,
+      }),
+    }),
+  }),
+}));
 
 /**
  * @ignore - internal component.
  */
-const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
+function NotchedOutline(props) {
   const {
     children,
     classes,
@@ -92,7 +83,6 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
       <NotchedOutlineRoot
         aria-hidden
         className={className}
-        ref={ref}
         style={style}
         styleProps={styleProps}
         {...other}
@@ -122,7 +112,6 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
         ...style,
       }}
       className={className}
-      ref={ref}
       styleProps={styleProps}
       {...other}
     >
@@ -142,7 +131,7 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
       </NotchedOutlineLegend>
     </NotchedOutlineRoot>
   );
-});
+}
 
 NotchedOutline.propTypes = {
   /**

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createClientRender } from 'test/utils';
+import { createClientRender } from 'test/utils';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import NotchedOutline from './NotchedOutline';
 
 describe('<NotchedOutline />', () => {
   const render = createClientRender();
 
-  let classes;
   const defaultProps = {
     labelWidth: 36,
     notched: true,
     label: 'My label',
   };
-
-  before(() => {
-    classes = getClasses(<NotchedOutline {...defaultProps} />);
-  });
 
   it('should pass props', () => {
     const { container } = render(
@@ -31,7 +26,6 @@ describe('<NotchedOutline />', () => {
 
     expect(container.querySelector('fieldset')).to.have.class('notched-outline');
     expect(container.querySelector('fieldset').style.width).to.equal('17px');
-    expect(container.querySelector('legend')).to.have.class(classes.legendNotched);
   });
 
   it('should set alignment rtl', () => {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { SxProps } from '@material-ui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 import { InputBaseProps } from '../InputBase';
 
 export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
@@ -53,6 +54,10 @@ export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
    * If `true`, the outline is notched to accommodate the label.
    */
   notched?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type OutlinedInputClassKey = keyof NonNullable<OutlinedInputProps['classes']>;

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -35,41 +35,58 @@ const OutlinedInputRoot = experimentalStyled(
   InputBaseRoot,
   { shouldForwardProp: (prop) => shouldForwardProp(prop) || prop === 'classes' },
   { name: 'MuiOutlinedInput', slot: 'Root', overridesResolver },
-)(({ theme, styleProps }) => {
-  const borderColor =
-    theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
-  return {
-    position: 'relative',
-    borderRadius: theme.shape.borderRadius,
-    '&:hover': {
-      [`& .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.text.primary,
-      },
-    },
-    // Reset on touch devices, it doesn't add specificity
-    '@media (hover: none)': {
+)(
+  ({ theme, styleProps }) => {
+    const borderColor =
+      theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+    return {
+      position: 'relative',
+      borderRadius: theme.shape.borderRadius,
       '&:hover': {
         [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor,
+          borderColor: theme.palette.text.primary,
         },
       },
-    },
-    [`&.Mui-focused`]: {
-      [`& .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.primary.main,
-        borderWidth: 2,
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        '&:hover': {
+          [`& .${outlinedInputClasses.notchedOutline}`]: {
+            borderColor,
+          },
+        },
       },
-    },
-    '&.Mui-error': {
-      [`& .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.error.main,
+      [`&.Mui-focused`]: {
+        [`& .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: theme.palette.primary.main,
+          borderWidth: 2,
+        },
       },
-    },
-    '&.Mui-disabled': {
-      [`& .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.action.disabled,
+      '&.Mui-error': {
+        [`& .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: theme.palette.error.main,
+        },
       },
-    },
+      '&.Mui-disabled': {
+        [`& .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: theme.palette.action.disabled,
+        },
+      },
+      ...(styleProps.startAdornment && {
+        paddingLeft: 14,
+      }),
+      ...(styleProps.endAdornment && {
+        paddingRight: 14,
+      }),
+      ...(styleProps.multiline && {
+        padding: '16.5px 14px',
+        ...(styleProps.size === 'small' && {
+          paddingTop: 10.5,
+          paddingBottom: 10.5,
+        }),
+      }),
+    };
+  },
+  ({ styleProps, theme }) => ({
     ...(styleProps.color === 'secondary' && {
       '&.Mui-focused': {
         [`& .${outlinedInputClasses.notchedOutline}`]: {
@@ -77,21 +94,8 @@ const OutlinedInputRoot = experimentalStyled(
         },
       },
     }),
-    ...(styleProps.startAdornment && {
-      paddingLeft: 14,
-    }),
-    ...(styleProps.endAdornment && {
-      paddingRight: 14,
-    }),
-    ...(styleProps.multiline && {
-      padding: '16.5px 14px',
-      ...(styleProps.size === 'small' && {
-        paddingTop: 10.5,
-        paddingBottom: 10.5,
-      }),
-    }),
-  };
-});
+  }),
+);
 
 const NotchedOutlineRoot = experimentalStyled(
   NotchedOutline,
@@ -148,10 +152,8 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
     ...props,
     fullWidth,
     inputComponent,
-    label,
     labelWidth,
     multiline,
-    notched,
     type,
   };
 

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -174,7 +174,10 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
       ref={ref}
       type={type}
       {...other}
-      classes={classes}
+      classes={{
+        ...classes,
+        notchedOutline: null,
+      }}
     />
   );
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -39,69 +39,54 @@ const OutlinedInputRoot = experimentalStyled(
   InputBaseRoot,
   { shouldForwardProp: (prop) => shouldForwardProp(prop) || prop === 'classes' },
   { name: 'MuiOutlinedInput', slot: 'Root', overridesResolver },
-)(
-  ({ theme, styleProps }) => {
-    const borderColor =
-      theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
-    return {
-      position: 'relative',
-      borderRadius: theme.shape.borderRadius,
+)(({ theme, styleProps }) => {
+  const borderColor =
+    theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+  return {
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
+      borderColor: theme.palette.text.primary,
+    },
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
       [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.text.primary,
+        borderColor,
       },
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor,
-        },
-      },
-      [`&.Mui-focused .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.primary.main,
-        borderWidth: 2,
-      },
-      [`&.Mui-error .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.error.main,
-      },
-      '&.Mui-disabled': {
-        [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: theme.palette.action.disabled,
-        },
-      },
-      ...(styleProps.startAdornment && {
-        paddingLeft: 14,
-      }),
-      ...(styleProps.endAdornment && {
-        paddingRight: 14,
-      }),
-      ...(styleProps.multiline && {
-        padding: '16.5px 14px',
-        ...(styleProps.size === 'small' && {
-          paddingTop: 10.5,
-          paddingBottom: 10.5,
-        }),
-      }),
-    };
-  },
-  ({ styleProps, theme }) => ({
-    ...(styleProps.color === 'secondary' && {
-      '&.Mui-focused': {
-        [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: theme.palette.secondary.main,
-        },
-      },
+    },
+    [`&.Mui-focused .${outlinedInputClasses.notchedOutline}`]: {
+      borderColor: theme.palette[styleProps.color].main,
+      borderWidth: 2,
+    },
+    [`&.Mui-error .${outlinedInputClasses.notchedOutline}`]: {
+      borderColor: theme.palette.error.main,
+    },
+    [`&.Mui-disabled .${outlinedInputClasses.notchedOutline}`]: {
+      borderColor: theme.palette.action.disabled,
+    },
+    ...(styleProps.startAdornment && {
+      paddingLeft: 14,
     }),
-  }),
-);
+    ...(styleProps.endAdornment && {
+      paddingRight: 14,
+    }),
+    ...(styleProps.multiline && {
+      padding: '16.5px 14px',
+      ...(styleProps.size === 'small' && {
+        paddingTop: 10.5,
+        paddingBottom: 10.5,
+      }),
+    }),
+  };
+});
 
 const NotchedOutlineRoot = experimentalStyled(
   NotchedOutline,
   {},
   { name: 'MuiOutlinedInput', slot: 'NotchedOutline' },
-)(({ theme }) => {
-  const borderColor =
-    theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
-  return { borderColor };
-});
+)(({ theme }) => ({
+  borderColor: theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)',
+}));
 
 const OutlinedInputInput = experimentalStyled(
   InputBaseInput,

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -147,21 +147,11 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
     ...other
   } = props;
 
-  const styleProps = {
-    ...props,
-    fullWidth,
-    inputComponent,
-    labelWidth,
-    multiline,
-    type,
-  };
-
   const classes = useUtilityClasses(props);
 
   return (
     <InputBase
       components={{ Root: OutlinedInputRoot, Input: OutlinedInputInput }}
-      componentsProps={{ root: { styleProps }, input: { styleProps } }}
       renderSuffix={(state) => (
         <NotchedOutlineRoot
           className={classes.notchedOutline}

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -80,7 +80,7 @@ const OutlinedInputRoot = experimentalStyled(
     ...(styleProps.startAdornment && {
       paddingLeft: 14,
     }),
-    ...(styleProps.startAdornment && {
+    ...(styleProps.endAdornment && {
       paddingRight: 14,
     }),
     ...(styleProps.multiline && {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
 import { deepmerge, refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import NotchedOutline from './NotchedOutline';

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -46,29 +46,21 @@ const OutlinedInputRoot = experimentalStyled(
     return {
       position: 'relative',
       borderRadius: theme.shape.borderRadius,
-      '&:hover': {
-        [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: theme.palette.text.primary,
-        },
+      [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
+        borderColor: theme.palette.text.primary,
       },
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
-        '&:hover': {
-          [`& .${outlinedInputClasses.notchedOutline}`]: {
-            borderColor,
-          },
+        [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor,
         },
       },
-      [`&.Mui-focused`]: {
-        [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: theme.palette.primary.main,
-          borderWidth: 2,
-        },
+      [`&.Mui-focused .${outlinedInputClasses.notchedOutline}`]: {
+        borderColor: theme.palette.primary.main,
+        borderWidth: 2,
       },
-      '&.Mui-error': {
-        [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: theme.palette.error.main,
-        },
+      [`&.Mui-error .${outlinedInputClasses.notchedOutline}`]: {
+        borderColor: theme.palette.error.main,
       },
       '&.Mui-disabled': {
         [`& .${outlinedInputClasses.notchedOutline}`]: {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -140,7 +140,6 @@ const OutlinedInputInput = experimentalStyled(
 
 const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiOutlinedInput' });
-
   const {
     fullWidth = false,
     inputComponent = 'input',

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -27,7 +27,12 @@ const useUtilityClasses = (styleProps) => {
     input: ['input'],
   };
 
-  return composeClasses(slots, getOutlinedInputUtilityClass, classes);
+  const composedClasses = composeClasses(slots, getOutlinedInputUtilityClass, classes);
+
+  return {
+    ...classes, // forward classes to the InputBase
+    ...composedClasses,
+  };
 };
 
 const OutlinedInputRoot = experimentalStyled(
@@ -164,13 +169,13 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
           }
         />
       )}
-      classes={classes}
       fullWidth={fullWidth}
       inputComponent={inputComponent}
       multiline={multiline}
       ref={ref}
       type={type}
       {...other}
+      classes={classes}
     />
   );
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -1,111 +1,139 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
-import { refType } from '@material-ui/utils';
-import InputBase from '../InputBase';
-import NotchedOutline from './NotchedOutline';
-import withStyles from '../styles/withStyles';
 
-export const styles = (theme) => {
+import { deepmerge, refType } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import NotchedOutline from './NotchedOutline';
+import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
+import outlinedInputClasses, { getOutlinedInputUtilityClass } from './outlinedInputClasses';
+import InputBase, {
+  overridesResolver as inputBaseOverridesResolver,
+  InputBaseRoot,
+  InputBaseComponent as InputBaseInput,
+} from '../InputBase/InputBase';
+import useThemeProps from '../styles/useThemeProps';
+
+const overridesResolver = (props, styles) => {
+  return deepmerge(inputBaseOverridesResolver(props, styles), {
+    ...styles.notchedOutline,
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes } = styleProps;
+
+  const slots = {
+    root: ['root'],
+    notchedOutline: ['notchedOutline'],
+    input: ['input'],
+  };
+
+  return composeClasses(slots, getOutlinedInputUtilityClass, classes);
+};
+
+const OutlinedInputRoot = experimentalStyled(
+  InputBaseRoot,
+  { shouldForwardProp: (prop) => shouldForwardProp(prop) || prop === 'classes' },
+  { name: 'MuiOutlinedInput', slot: 'Root', overridesResolver },
+)(({ theme, styleProps }) => {
   const borderColor =
     theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
-
   return {
-    /* Styles applied to the root element. */
-    root: {
-      position: 'relative',
-      borderRadius: theme.shape.borderRadius,
-      '&:hover $notchedOutline': {
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    '&:hover': {
+      [`& .${outlinedInputClasses.notchedOutline}`]: {
         borderColor: theme.palette.text.primary,
       },
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        '&:hover $notchedOutline': {
+    },
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
+      '&:hover': {
+        [`& .${outlinedInputClasses.notchedOutline}`]: {
           borderColor,
         },
       },
-      '&$focused $notchedOutline': {
+    },
+    [`&.Mui-focused`]: {
+      [`& .${outlinedInputClasses.notchedOutline}`]: {
         borderColor: theme.palette.primary.main,
         borderWidth: 2,
       },
-      '&$error $notchedOutline': {
+    },
+    '&.Mui-error': {
+      [`& .${outlinedInputClasses.notchedOutline}`]: {
         borderColor: theme.palette.error.main,
       },
-      '&$disabled $notchedOutline': {
+    },
+    '&.Mui-disabled': {
+      [`& .${outlinedInputClasses.notchedOutline}`]: {
         borderColor: theme.palette.action.disabled,
       },
     },
-    /* Styles applied to the root element if the color is secondary. */
-    colorSecondary: {
-      '&$focused $notchedOutline': {
-        borderColor: theme.palette.secondary.main,
+    ...(styleProps.color === 'secondary' && {
+      '&.Mui-focused': {
+        [`& .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: theme.palette.secondary.main,
+        },
       },
-      '&$error $notchedOutline': {
-        // To remove once we migrate to emotion
-        borderColor: theme.palette.error.main,
-      },
-    },
-    /* Styles applied to the root element if the component is focused. */
-    focused: {},
-    /* Styles applied to the root element if `disabled={true}`. */
-    disabled: {},
-    /* Styles applied to the root element if `startAdornment` is provided. */
-    adornedStart: {
+    }),
+    ...(styleProps.startAdornment && {
       paddingLeft: 14,
-    },
-    /* Styles applied to the root element if `endAdornment` is provided. */
-    adornedEnd: {
+    }),
+    ...(styleProps.startAdornment && {
       paddingRight: 14,
-    },
-    /* Pseudo-class applied to the root element if `error={true}`. */
-    error: {},
-    /* Styles applied to the input element if `size="small"`. */
-    sizeSmall: {},
-    /* Styles applied to the root element if `multiline={true}`. */
-    multiline: {
+    }),
+    ...(styleProps.multiline && {
       padding: '16.5px 14px',
-      '&$sizeSmall': {
+      ...(styleProps.size === 'small' && {
         paddingTop: 10.5,
         paddingBottom: 10.5,
-      },
-    },
-    /* Styles applied to the NotchedOutline element. */
-    notchedOutline: {
-      borderColor,
-    },
-    /* Styles applied to the input element. */
-    input: {
-      padding: '16.5px 14px',
-      '&:-webkit-autofill': {
-        WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
-        WebkitTextFillColor: theme.palette.mode === 'light' ? null : '#fff',
-        caretColor: theme.palette.mode === 'light' ? null : '#fff',
-        borderRadius: 'inherit',
-      },
-    },
-    /* Styles applied to the input element if `size="small"`. */
-    inputSizeSmall: {
-      paddingTop: 8.5,
-      paddingBottom: 8.5,
-    },
-    /* Styles applied to the input element if `multiline={true}`. */
-    inputMultiline: {
-      padding: 0,
-    },
-    /* Styles applied to the input element if `startAdornment` is provided. */
-    inputAdornedStart: {
-      paddingLeft: 0,
-    },
-    /* Styles applied to the input element if `endAdornment` is provided. */
-    inputAdornedEnd: {
-      paddingRight: 0,
-    },
+      }),
+    }),
   };
-};
+});
 
-const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
+const NotchedOutlineRoot = experimentalStyled(
+  NotchedOutline,
+  {},
+  { name: 'MuiOutlinedInput', slot: 'NotchedOutline' },
+)(({ theme }) => {
+  const borderColor =
+    theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+  return { borderColor };
+});
+
+const OutlinedInputInput = experimentalStyled(
+  InputBaseInput,
+  { shouldForwardProp: (prop) => shouldForwardProp(prop) || prop === 'classes' },
+  { name: 'MuiOutlinedInput', slot: 'Input' },
+)(({ theme, styleProps }) => ({
+  padding: '16.5px 14px',
+  '&:-webkit-autofill': {
+    WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
+    WebkitTextFillColor: theme.palette.mode === 'light' ? null : '#fff',
+    caretColor: theme.palette.mode === 'light' ? null : '#fff',
+    borderRadius: 'inherit',
+  },
+  ...(styleProps.size === 'small' && {
+    paddingTop: 8.5,
+    paddingBottom: 8.5,
+  }),
+  ...(styleProps.multiline && {
+    padding: 0,
+  }),
+  ...(styleProps.startAdornment && {
+    paddingLeft: 0,
+  }),
+  ...(styleProps.endAdornment && {
+    paddingRight: 0,
+  }),
+}));
+
+const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiOutlinedInput' });
+
   const {
-    classes,
     fullWidth = false,
     inputComponent = 'input',
     label,
@@ -116,10 +144,25 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
     ...other
   } = props;
 
+  const styleProps = {
+    ...props,
+    fullWidth,
+    inputComponent,
+    label,
+    labelWidth,
+    multiline,
+    notched,
+    type,
+  };
+
+  const classes = useUtilityClasses(props);
+
   return (
     <InputBase
+      components={{ Root: OutlinedInputRoot, Input: OutlinedInputInput }}
+      componentsProps={{ root: { styleProps }, input: { styleProps } }}
       renderSuffix={(state) => (
-        <NotchedOutline
+        <NotchedOutlineRoot
           className={classes.notchedOutline}
           label={label}
           labelWidth={labelWidth}
@@ -130,11 +173,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(props, ref) {
           }
         />
       )}
-      classes={{
-        ...classes,
-        root: clsx(classes.root, classes.underline),
-        notchedOutline: null,
-      }}
+      classes={classes}
       fullWidth={fullWidth}
       inputComponent={inputComponent}
       multiline={multiline}
@@ -279,6 +318,10 @@ OutlinedInput.propTypes = {
    */
   startAdornment: PropTypes.node,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
    * @default 'text'
    */
@@ -291,4 +334,4 @@ OutlinedInput.propTypes = {
 
 OutlinedInput.muiName = 'Input';
 
-export default withStyles(styles, { name: 'MuiOutlinedInput' })(OutlinedInput);
+export default OutlinedInput;

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -1,24 +1,24 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import OutlinedInput from './OutlinedInput';
 import InputBase from '../InputBase';
+import classes from './outlinedInputClasses';
 
 describe('<OutlinedInput />', () => {
-  let classes;
   const mount = createMount();
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<OutlinedInput />);
-  });
-
-  describeConformance(<OutlinedInput labelWidth={0} />, () => ({
+  describeConformanceV5(<OutlinedInput labelWidth={0} />, () => ({
     classes,
     inheritComponent: InputBase,
     mount,
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp'],
+    muiName: 'MuiOutlinedInput',
+    testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
+    testVariantProps: { variant: 'contained', fullWidth: true },
+    testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('should render a NotchedOutline', () => {

--- a/packages/material-ui/src/OutlinedInput/index.d.ts
+++ b/packages/material-ui/src/OutlinedInput/index.d.ts
@@ -1,2 +1,4 @@
 export { default } from './OutlinedInput';
 export * from './OutlinedInput';
+export { default as outlinedInputClasses } from './outlinedInputClasses';
+export * from './outlinedInputClasses';

--- a/packages/material-ui/src/OutlinedInput/index.d.ts
+++ b/packages/material-ui/src/OutlinedInput/index.d.ts
@@ -1,4 +1,5 @@
 export { default } from './OutlinedInput';
 export * from './OutlinedInput';
+
 export { default as outlinedInputClasses } from './outlinedInputClasses';
 export * from './outlinedInputClasses';

--- a/packages/material-ui/src/OutlinedInput/index.js
+++ b/packages/material-ui/src/OutlinedInput/index.js
@@ -1,1 +1,3 @@
 export { default } from './OutlinedInput';
+export { default as outlinedInputClasses } from './outlinedInputClasses';
+export * from './outlinedInputClasses';

--- a/packages/material-ui/src/OutlinedInput/index.js
+++ b/packages/material-ui/src/OutlinedInput/index.js
@@ -1,3 +1,4 @@
 export { default } from './OutlinedInput';
+
 export { default as outlinedInputClasses } from './outlinedInputClasses';
 export * from './outlinedInputClasses';

--- a/packages/material-ui/src/OutlinedInput/outlinedInputClasses.d.ts
+++ b/packages/material-ui/src/OutlinedInput/outlinedInputClasses.d.ts
@@ -1,0 +1,7 @@
+import { OutlinedInputClassKey } from './OutlinedInput';
+
+declare const outlinedInputClasses: Record<OutlinedInputClassKey, string>;
+
+export function getOutlinedInputUtilityClasses(slot: string): string;
+
+export default outlinedInputClasses;

--- a/packages/material-ui/src/OutlinedInput/outlinedInputClasses.js
+++ b/packages/material-ui/src/OutlinedInput/outlinedInputClasses.js
@@ -1,0 +1,13 @@
+import { generateUtilityClasses, generateUtilityClass } from '@material-ui/unstyled';
+
+export function getOutlinedInputUtilityClass(slot) {
+  return generateUtilityClass('MuiOutlinedInput', slot);
+}
+
+const outlinedInputClasses = generateUtilityClasses('MuiOutlinedInput', [
+  'root',
+  'notchedOutline',
+  'input',
+]);
+
+export default outlinedInputClasses;

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
 import FormControl from '../FormControl';
-import OutlinedInput from '../OutlinedInput';
 import TextField from './TextField';
 import MenuItem from '../MenuItem';
 import { inputBaseClasses } from '../InputBase';
+import { outlinedInputClasses } from '../OutlinedInput';
 
 describe('<TextField />', () => {
   let classes;
@@ -126,7 +126,6 @@ describe('<TextField />', () => {
     });
 
     it('should set shrink prop on outline from label', () => {
-      const outlinedInputClasses = getClasses(<OutlinedInput />);
       const { container } = render(<TextField InputLabelProps={{ shrink: true }} classes={{}} />);
 
       expect(container.querySelector('fieldset')).to.have.class(

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -20,26 +20,12 @@ const useUtilityClasses = (styleProps) => {
   return composeClasses(slots, getSwitchBaseUtilityClass, classes);
 };
 
-const SwitchBaseRoot = experimentalStyled(
-  IconButton,
-  {},
-  {
-    name: 'PrivateSwitchBase',
-    slot: 'Root',
-  },
-)({
+const SwitchBaseRoot = experimentalStyled(IconButton)({
   /* Styles applied to the root element. */
   padding: 9,
 });
 
-const SwitchBaseInput = experimentalStyled(
-  'input',
-  {},
-  {
-    name: 'PrivateSwitchBase',
-    slot: 'Input',
-  },
-)({
+const SwitchBaseInput = experimentalStyled('input')({
   /* Styles applied to the internal input element. */
   cursor: 'inherit',
   position: 'absolute',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR migrates the OutlinedInput component to the new emotion format as a part of #24405.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
