### PR TITLE
[Autocomplete] Migrate to emotion

### DIFF
--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -72,6 +72,7 @@
       "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
       "default": "'medium'"
     },
+    "sx": { "type": { "name": "object" } },
     "value": { "type": { "name": "custom", "description": "any" } }
   },
   "name": "Autocomplete",
@@ -82,6 +83,7 @@
       "focused",
       "tag",
       "tagSizeSmall",
+      "tagSizeMedium",
       "hasPopupIcon",
       "hasClearIcon",
       "inputRoot",
@@ -109,6 +111,6 @@
   "filename": "/packages/material-ui/src/Autocomplete/Autocomplete.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/autocomplete/\">Autocomplete</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/src/pages/components/autocomplete/GitHubLabel.js
+++ b/docs/src/pages/components/autocomplete/GitHubLabel.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { useTheme, alpha, makeStyles } from '@material-ui/core/styles';
 import Popper from '@material-ui/core/Popper';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
@@ -14,6 +15,12 @@ function PopperComponent(props) {
   const { disablePortal, anchorEl, open, ...other } = props;
   return <div {...other} />;
 }
+
+PopperComponent.propTypes = {
+  anchorEl: PropTypes.any.isRequired,
+  disablePortal: PropTypes.bool.isRequired,
+  open: PropTypes.bool.isRequired,
+};
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/docs/src/pages/components/autocomplete/GitHubLabel.js
+++ b/docs/src/pages/components/autocomplete/GitHubLabel.js
@@ -10,6 +10,11 @@ import Autocomplete from '@material-ui/core/Autocomplete';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import InputBase from '@material-ui/core/InputBase';
 
+function PopperComponent(props) {
+  const { disablePortal, anchorEl, open, ...other } = props;
+  return <div {...other} />;
+}
+
 const useStyles = makeStyles((theme) => ({
   root: {
     width: 221,
@@ -79,17 +84,20 @@ const useStyles = makeStyles((theme) => ({
     color: '#586069',
     fontSize: 13,
   },
-  option: {
-    minHeight: 'auto',
-    alignItems: 'flex-start',
-    padding: 8,
-    '&[aria-selected="true"]': {
-      backgroundColor: 'transparent',
-    },
-    '&[data-focus="true"]': {
-      backgroundColor: theme.palette.action.hover,
+  listbox: {
+    '& $option': {
+      minHeight: 'auto',
+      alignItems: 'flex-start',
+      padding: 8,
+      '&[aria-selected="true"]': {
+        backgroundColor: 'transparent',
+      },
+      '&[data-focus="true"], &[data-focus="true"][aria-selected="true"]': {
+        backgroundColor: theme.palette.action.hover,
+      },
     },
   },
+  option: {},
   popperDisablePortal: {
     position: 'relative',
   },
@@ -185,6 +193,7 @@ export default function GitHubLabel() {
               }}
               classes={{
                 paper: classes.paper,
+                listbox: classes.listbox,
                 option: classes.option,
                 popperDisablePortal: classes.popperDisablePortal,
               }}
@@ -200,7 +209,7 @@ export default function GitHubLabel() {
                 setPendingValue(newValue);
               }}
               disableCloseOnSelect
-              disablePortal
+              PopperComponent={PopperComponent}
               renderTags={() => null}
               noOptionsText="No labels"
               renderOption={(props, option, { selected }) => (

--- a/docs/src/pages/components/autocomplete/GitHubLabel.js
+++ b/docs/src/pages/components/autocomplete/GitHubLabel.js
@@ -17,8 +17,8 @@ function PopperComponent(props) {
 }
 
 PopperComponent.propTypes = {
-  anchorEl: PropTypes.any.isRequired,
-  disablePortal: PropTypes.bool.isRequired,
+  anchorEl: PropTypes.any,
+  disablePortal: PropTypes.bool,
   open: PropTypes.bool.isRequired,
 };
 

--- a/docs/src/pages/components/autocomplete/GitHubLabel.tsx
+++ b/docs/src/pages/components/autocomplete/GitHubLabel.tsx
@@ -18,6 +18,11 @@ import Autocomplete, {
 import ButtonBase from '@material-ui/core/ButtonBase';
 import InputBase from '@material-ui/core/InputBase';
 
+function PopperComponent(props: any) {
+  const { disablePortal, anchorEl, open, ...other } = props;
+  return <div {...other} />;
+}
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
@@ -88,17 +93,20 @@ const useStyles = makeStyles((theme: Theme) =>
       color: '#586069',
       fontSize: 13,
     },
-    option: {
-      minHeight: 'auto',
-      alignItems: 'flex-start',
-      padding: 8,
-      '&[aria-selected="true"]': {
-        backgroundColor: 'transparent',
-      },
-      '&[data-focus="true"]': {
-        backgroundColor: theme.palette.action.hover,
+    listbox: {
+      '& $option': {
+        minHeight: 'auto',
+        alignItems: 'flex-start',
+        padding: 8,
+        '&[aria-selected="true"]': {
+          backgroundColor: 'transparent',
+        },
+        '&[data-focus="true"], &[data-focus="true"][aria-selected="true"]': {
+          backgroundColor: theme.palette.action.hover,
+        },
       },
     },
+    option: {},
     popperDisablePortal: {
       position: 'relative',
     },
@@ -198,6 +206,7 @@ export default function GitHubLabel() {
               }}
               classes={{
                 paper: classes.paper,
+                listbox: classes.listbox,
                 option: classes.option,
                 popperDisablePortal: classes.popperDisablePortal,
               }}
@@ -213,7 +222,7 @@ export default function GitHubLabel() {
                 setPendingValue(newValue);
               }}
               disableCloseOnSelect
-              disablePortal
+              PopperComponent={PopperComponent}
               renderTags={() => null}
               noOptionsText="No labels"
               renderOption={(props, option, { selected }) => (

--- a/docs/src/pages/components/autocomplete/GitHubLabel.tsx
+++ b/docs/src/pages/components/autocomplete/GitHubLabel.tsx
@@ -18,7 +18,13 @@ import Autocomplete, {
 import ButtonBase from '@material-ui/core/ButtonBase';
 import InputBase from '@material-ui/core/InputBase';
 
-function PopperComponent(props: any) {
+interface PopperComponentProps {
+  anchorEl: any;
+  disablePortal: boolean;
+  open: boolean;
+}
+
+function PopperComponent(props: PopperComponentProps) {
   const { disablePortal, anchorEl, open, ...other } = props;
   return <div {...other} />;
 }

--- a/docs/src/pages/components/autocomplete/GitHubLabel.tsx
+++ b/docs/src/pages/components/autocomplete/GitHubLabel.tsx
@@ -19,8 +19,8 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 import InputBase from '@material-ui/core/InputBase';
 
 interface PopperComponentProps {
-  anchorEl: any;
-  disablePortal: boolean;
+  anchorEl?: any;
+  disablePortal?: boolean;
   open: boolean;
 }
 

--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -58,11 +58,11 @@
     "renderTags": "Render the selected value.<br><br><strong>Signature:</strong><br><code>function(value: T[], getTagProps: function) =&gt; ReactNode</code><br><em>value:</em> The <code>value</code> provided to the component.<br><em>getTagProps:</em> A tag props getter.",
     "selectOnFocus": "If <code>true</code>, the input&#39;s text is selected on focus. It helps the user clear the selected value.",
     "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "value": "The value of the autocomplete.<br>The value must have reference equality with the option in order to be selected. You can customize the equality behavior with the <code>getOptionSelected</code> prop."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },
-    "@media (pointer": { "description": "Avoid double tap issue on iOS" },
     "fullWidth": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -82,6 +82,11 @@
       "description": "Styles applied to {{nodeName}}, {{conditions}}.",
       "nodeName": "the tag elements",
       "conditions": "e.g. the chips if <code>size=\"small\"</code>"
+    },
+    "tagSizeMedium": {
+      "description": "Styles applied to {{nodeName}}, {{conditions}}.",
+      "nodeName": "the tag elements",
+      "conditions": "e.g. the chips if <code>size=\"medium\"</code>"
     },
     "hasPopupIcon": { "description": "Styles applied when the popup icon is rendered." },
     "hasClearIcon": { "description": "Styles applied when the clear icon is rendered." },

--- a/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '@material-ui/core';
+import { InternalStandardProps as StandardProps, Theme } from '@material-ui/core';
 import { ChipProps, ChipTypeMap } from '@material-ui/core/Chip';
 import { PopperProps } from '@material-ui/core/Popper';
+import { SxProps } from '@material-ui/system';
 import useAutocomplete, {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,
@@ -73,6 +74,8 @@ export interface AutocompleteProps<
     tag?: string;
     /** Styles applied to the tag elements, e.g. the chips if `size="small"`. */
     tagSizeSmall?: string;
+    /** Styles applied to the tag elements, e.g. the chips if `size="medium"`. */
+    tagSizeMedium?: string;
     /** Styles applied when the popup icon is rendered. */
     hasPopupIcon?: string;
     /** Styles applied when the clear icon is rendered. */
@@ -253,6 +256,10 @@ export interface AutocompleteProps<
    * @default 'medium'
    */
   size?: 'small' | 'medium';
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type AutocompleteClassKey = keyof NonNullable<

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -138,10 +138,10 @@ const AutocompleteRoot = experimentalStyled(
   /* Styles applied to the Input element. */
   [`& .${autocompleteClasses.inputRoot}`]: {
     flexWrap: 'wrap',
-    [`.${autocompleteClasses.hasPopupIcon} &, .${autocompleteClasses.hasClearIcon} &`]: {
+    [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
       paddingRight: 26 + 4,
     },
-    [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} &`]: {
+    [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon}&`]: {
       paddingRight: 52 + 4,
     },
     [`& .${autocompleteClasses.input}`]: {
@@ -167,10 +167,10 @@ const AutocompleteRoot = experimentalStyled(
     },
     '&[class*="MuiOutlinedInput-root"]': {
       padding: 9,
-      [`.${autocompleteClasses.hasPopupIcon} &, .${autocompleteClasses.hasClearIcon} &`]: {
+      [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 26 + 4 + 9,
       },
-      [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} &`]: {
+      [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 52 + 4 + 9,
       },
       [`& .${autocompleteClasses.input}`]: {
@@ -192,10 +192,10 @@ const AutocompleteRoot = experimentalStyled(
     '&.MuiFilledInput-root': {
       paddingTop: 19,
       paddingLeft: 8,
-      [`.${autocompleteClasses.hasPopupIcon} &, .${autocompleteClasses.hasClearIcon} &`]: {
+      [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 26 + 4 + 9,
       },
-      [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} &`]: {
+      [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon}&`]: {
         paddingRight: 52 + 4 + 9,
       },
       '& .MuiFilledInput-input': {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -151,18 +151,12 @@ const AutocompleteRoot = experimentalStyled(
     '&.MuiInput-root': {
       paddingBottom: 1,
       '& .MuiInput-input': {
-        padding: 4,
-      },
-      '& .MuiInput-input:first-child': {
-        padding: '6px 0',
+        padding: '6px 4px 6px 0px',
       },
     },
     '&.MuiInput-root.MuiInputBase-sizeSmall': {
       '& .MuiInput-input': {
-        padding: '2px 4px 3px',
-      },
-      '& .MuiInput-input:first-child': {
-        padding: '1px 0 4px',
+        padding: '2px 4px 3px 0',
       },
     },
     '&[class*="MuiOutlinedInput-root"]': {
@@ -174,10 +168,7 @@ const AutocompleteRoot = experimentalStyled(
         paddingRight: 52 + 4 + 9,
       },
       [`& .${autocompleteClasses.input}`]: {
-        padding: '7.5px 4px',
-      },
-      [`& .${autocompleteClasses.input}:first-child`]: {
-        paddingLeft: 6,
+        padding: '7.5px 4px 7.5px 6px',
       },
       [`& .${autocompleteClasses.endAdornment}`]: {
         right: 9,
@@ -186,10 +177,7 @@ const AutocompleteRoot = experimentalStyled(
     '&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-sizeSmall"]': {
       padding: 6,
       [`& .${autocompleteClasses.input}`]: {
-        padding: '2.5px 4px',
-      },
-      [`& .${autocompleteClasses.input}:first-child`]: {
-        paddingLeft: 6,
+        padding: '2.5px 4px 2.5px 6px',
       },
     },
     '&.MuiFilledInput-root': {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -524,9 +524,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
 
   if (multiple && value.length > 0) {
     const getCustomizedTagProps = (params) => ({
-      className: clsx(classes.tag, {
-        [classes.tagSizeSmall]: size === 'small',
-      }),
+      className: clsx(classes.tag),
       disabled,
       ...getTagProps(params),
     });

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -33,6 +33,10 @@ const overridesResolver = (props, styles) => {
     ...(fullWidth && styles.fullWidth),
     ...(hasPopupIcon && styles.hasPopupIcon),
     ...(hasClearIcon && styles.hasClearIcon),
+    [`& .${autocompleteClasses.tag}`]: {
+      ...styles.tag,
+      ...styles[`tagSize${capitalize(size)}`],
+    },
     [`& .${autocompleteClasses.inputRoot}`]: {
       ...styles.inputRoot,
       ...(hasPopupIcon && styles.hasPopupIcon),
@@ -41,10 +45,6 @@ const overridesResolver = (props, styles) => {
     [`& .${autocompleteClasses.input}`]: {
       ...styles.input,
       ...(inputFocused && styles.inputFocused),
-    },
-    [`& .${autocompleteClasses.tag}`]: {
-      ...styles.tag,
-      ...styles[`tagSize${capitalize(size)}`],
     },
     [`& .${autocompleteClasses.endAdornment}`]: styles.endAdornment,
     [`& .${autocompleteClasses.clearIndicator}`]: styles.clearIndicator,

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -78,12 +78,12 @@ const useUtilityClasses = (styleProps) => {
   const slots = {
     root: [
       'root',
-      fullWidth && 'fullWidth',
       focused && 'focused',
-      hasPopupIcon && 'hasPopupIcon',
+      fullWidth && 'fullWidth',
       hasClearIcon && 'hasClearIcon',
+      hasPopupIcon && 'hasPopupIcon',
     ],
-    inputRoot: ['inputRoot', hasPopupIcon && 'hasPopupIcon', hasClearIcon && 'hasClearIcon'],
+    inputRoot: ['inputRoot'],
     input: ['input', inputFocused && 'inputFocused'],
     tag: ['tag', `tagSize${capitalize(size)})`],
     endAdornment: ['endAdornment'],

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes } from '@material-ui/utils';
-import { withStyles } from '../styles';
+import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { alpha } from '../styles/colorManipulator';
 import Popper from '../Popper';
 import ListSubheader from '../ListSubheader';
@@ -12,52 +12,143 @@ import Chip from '../Chip';
 import ClearIcon from '../internal/svg-icons/Close';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
 import useAutocomplete, { createFilterOptions } from '../useAutocomplete';
+import useThemeProps from '../styles/useThemeProps';
+import experimentalStyled from '../styles/experimentalStyled';
+import autocompleteClasses, { getAutocompleteUtilityClass } from './autocompleteClasses';
+import { capitalize } from '../utils';
 
-export { createFilterOptions };
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+  const {
+    fullWidth,
+    size,
+    hasPopupIcon,
+    hasClearIcon,
+    inputFocused,
+    popupOpen,
+    disablePortal,
+  } = styleProps;
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    '&$focused $clearIndicator': {
-      visibility: 'visible',
+  return deepmerge(styles.root || {}, {
+    ...(fullWidth && styles.fullWidth),
+    ...(hasPopupIcon && styles.hasPopupIcon),
+    ...(hasClearIcon && styles.hasClearIcon),
+    [`& .${autocompleteClasses.inputRoot}`]: {
+      ...styles.inputRoot,
+      ...(hasPopupIcon && styles.hasPopupIcon),
+      ...(hasClearIcon && styles.hasClearIcon),
     },
-    /* Avoid double tap issue on iOS */
-    '@media (pointer: fine)': {
-      '&:hover $clearIndicator': {
-        visibility: 'visible',
-      },
+    [`& .${autocompleteClasses.input}`]: {
+      ...styles.input,
+      ...(inputFocused && styles.inputFocused),
+    },
+    [`& .${autocompleteClasses.tag}`]: {
+      ...styles.tag,
+      ...styles[`tagSize${capitalize(size)}`],
+    },
+    [`& .${autocompleteClasses.endAdornment}`]: styles.endAdornment,
+    [`& .${autocompleteClasses.clearIndicator}`]: styles.clearIndicator,
+    [`& .${autocompleteClasses.popupIndicator}`]: {
+      ...styles.popupIndicator,
+      ...(popupOpen && styles.popupIndicatorOpen),
+    },
+    [`& .${autocompleteClasses.popper}`]: {
+      ...styles.popper,
+      ...(disablePortal && styles.popperDisablePortal),
+    },
+    [`& .${autocompleteClasses.paper}`]: styles.paper,
+    [`& .${autocompleteClasses.listbox}`]: styles.listbox,
+    [`& .${autocompleteClasses.loading}`]: styles.loading,
+    [`& .${autocompleteClasses.noOptions}`]: styles.noOptions,
+    [`& .${autocompleteClasses.option}`]: styles.option,
+    [`& .${autocompleteClasses.groupLabel}`]: styles.groupLabel,
+    [`& .${autocompleteClasses.groupUl}`]: styles.groupUl,
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const {
+    classes,
+    fullWidth,
+    focused,
+    size,
+    hasPopupIcon,
+    hasClearIcon,
+    inputFocused,
+    popupOpen,
+    disablePortal,
+  } = styleProps;
+
+  const slots = {
+    root: [
+      'root',
+      fullWidth && 'fullWidth',
+      focused && 'focused',
+      hasPopupIcon && 'hasPopupIcon',
+      hasClearIcon && 'hasClearIcon',
+    ],
+    inputRoot: ['inputRoot', hasPopupIcon && 'hasPopupIcon', hasClearIcon && 'hasClearIcon'],
+    input: ['input', inputFocused && 'inputFocused'],
+    tag: ['tag', `tagSize${capitalize(size)})`],
+    endAdornment: ['endAdornment'],
+    clearIndicator: ['clearIndicator'],
+    popupIndicator: ['popupIndicator', popupOpen && 'popupIndicatorOpen'],
+    popper: ['popper', disablePortal && 'popperDisablePortal'],
+    paper: ['paper'],
+    listbox: ['listbox'],
+    loading: ['loading'],
+    noOptions: ['noOptions'],
+    option: ['option'],
+    groupLabel: ['groupLabel'],
+    groupUl: ['groupUl'],
+  };
+
+  return composeClasses(slots, getAutocompleteUtilityClass, classes);
+};
+
+const AutocompleteRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'Root',
+    overridesResolver,
+  },
+)(({ theme, styleProps }) => ({
+  /* Styles applied to the root element. */
+  [`&.Mui-focused .${autocompleteClasses.clearIndicator}`]: {
+    visibility: 'visible',
+  },
+  /* Avoid double tap issue on iOS */
+  '@media (pointer: fine)': {
+    [`&:hover .${autocompleteClasses.clearIndicator}`]: {
+      visibility: 'visible',
     },
   },
   /* Styles applied to the root element if `fullWidth={true}`. */
-  fullWidth: {
+  ...(styleProps.fullWidth && {
     width: '100%',
-  },
-  /* Pseudo-class applied to the root element if focused. */
-  focused: {},
+  }),
   /* Styles applied to the tag elements, e.g. the chips. */
-  tag: {
+  [`& .${autocompleteClasses.tag}`]: {
     margin: 3,
     maxWidth: 'calc(100% - 6px)',
+    /* Styles applied to the tag elements, e.g. the chips if `size="small"`. */
+    ...(styleProps.size === 'small' && {
+      margin: 2,
+      maxWidth: 'calc(100% - 4px)',
+    }),
   },
-  /* Styles applied to the tag elements, e.g. the chips if `size="small"`. */
-  tagSizeSmall: {
-    margin: 2,
-    maxWidth: 'calc(100% - 4px)',
-  },
-  /* Styles applied when the popup icon is rendered. */
-  hasPopupIcon: {},
-  /* Styles applied when the clear icon is rendered. */
-  hasClearIcon: {},
   /* Styles applied to the Input element. */
-  inputRoot: {
+  [`& .${autocompleteClasses.inputRoot}`]: {
     flexWrap: 'wrap',
-    '$hasPopupIcon &, $hasClearIcon &': {
+    [`.${autocompleteClasses.hasPopupIcon} &, .${autocompleteClasses.hasClearIcon} &`]: {
       paddingRight: 26 + 4,
     },
-    '$hasPopupIcon$hasClearIcon &': {
+    [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} &`]: {
       paddingRight: 52 + 4,
     },
-    '& $input': {
+    [`& .${autocompleteClasses.input}`]: {
       width: 0,
       minWidth: 30,
     },
@@ -80,41 +171,41 @@ export const styles = (theme) => ({
     },
     '&[class*="MuiOutlinedInput-root"]': {
       padding: 9,
-      '$hasPopupIcon &, $hasClearIcon &': {
+      [`.${autocompleteClasses.hasPopupIcon} &, .${autocompleteClasses.hasClearIcon} &`]: {
         paddingRight: 26 + 4 + 9,
       },
-      '$hasPopupIcon$hasClearIcon &': {
+      [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} &`]: {
         paddingRight: 52 + 4 + 9,
       },
-      '& $input': {
+      [`& .${autocompleteClasses.input}`]: {
         padding: '7.5px 4px',
       },
-      '& $input:first-child': {
+      [`& .${autocompleteClasses.input}:first-child`]: {
         paddingLeft: 6,
       },
-      '& $endAdornment': {
+      [`& .${autocompleteClasses.endAdornment}`]: {
         right: 9,
       },
     },
     '&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-sizeSmall"]': {
       padding: 6,
-      '& $input': {
+      [`& .${autocompleteClasses.input}`]: {
         padding: '2.5px 4px',
       },
     },
     '&.MuiFilledInput-root': {
       paddingTop: 19,
       paddingLeft: 8,
-      '$hasPopupIcon &, $hasClearIcon &': {
+      [`.${autocompleteClasses.hasPopupIcon} &, .${autocompleteClasses.hasClearIcon} &`]: {
         paddingRight: 26 + 4 + 9,
       },
-      '$hasPopupIcon$hasClearIcon &': {
+      [`.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} &`]: {
         paddingRight: 52 + 4 + 9,
       },
       '& .MuiFilledInput-input': {
         padding: '7px 4px',
       },
-      '& $endAdornment': {
+      [`& .${autocompleteClasses.endAdornment}`]: {
         right: 9,
       },
     },
@@ -126,71 +217,17 @@ export const styles = (theme) => ({
     },
   },
   /* Styles applied to the input element. */
-  input: {
+  [`& .${autocompleteClasses.input}`]: {
     flexGrow: 1,
     textOverflow: 'ellipsis',
     opacity: 0,
-  },
-  /* Styles applied to the input element if tag focused. */
-  inputFocused: {
-    opacity: 1,
-  },
-  /* Styles applied to the endAdornment element. */
-  endAdornment: {
-    // We use a position absolute to support wrapping tags.
-    position: 'absolute',
-    right: 0,
-    top: 'calc(50% - 14px)', // Center vertically
-  },
-  /* Styles applied to the clear indicator. */
-  clearIndicator: {
-    marginRight: -2,
-    padding: 4,
-    visibility: 'hidden',
-  },
-  /* Styles applied to the popup indicator. */
-  popupIndicator: {
-    padding: 2,
-    marginRight: -2,
-  },
-  /* Styles applied to the popup indicator if the popup is open. */
-  popupIndicatorOpen: {
-    transform: 'rotate(180deg)',
-  },
-  /* Styles applied to the popper element. */
-  popper: {
-    zIndex: theme.zIndex.modal,
-  },
-  /* Styles applied to the popper element if `disablePortal={true}`. */
-  popperDisablePortal: {
-    position: 'absolute',
-  },
-  /* Styles applied to the Paper component. */
-  paper: {
-    ...theme.typography.body1,
-    overflow: 'auto',
-    margin: '4px 0',
-  },
-  /* Styles applied to the listbox component. */
-  listbox: {
-    listStyle: 'none',
-    margin: 0,
-    padding: '8px 0',
-    maxHeight: '40vh',
-    overflow: 'auto',
-  },
-  /* Styles applied to the loading wrapper. */
-  loading: {
-    color: theme.palette.text.secondary,
-    padding: '14px 16px',
-  },
-  /* Styles applied to the no option wrapper. */
-  noOptions: {
-    color: theme.palette.text.secondary,
-    padding: '14px 16px',
+    /* Styles applied to the input element if tag focused. */
+    ...(styleProps.inputFocused && {
+      opacity: 1,
+    }),
   },
   /* Styles applied to the option elements. */
-  option: {
+  [`& .${autocompleteClasses.option}`]: {
     minHeight: 48,
     display: 'flex',
     overflow: 'hidden',
@@ -241,21 +278,146 @@ export const styles = (theme) => ({
       },
     },
   },
-  /* Styles applied to the group's label elements. */
-  groupLabel: {
-    backgroundColor: theme.palette.background.paper,
-    top: -8,
+}));
+
+const AutocompleteEndAdornment = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'EndAdornment',
   },
+)({
+  /* Styles applied to the endAdornment element. */
+  // We use a position absolute to support wrapping tags.
+  position: 'absolute',
+  right: 0,
+  top: 'calc(50% - 14px)', // Center vertically
+});
+
+const AutocompleteClearIndicator = experimentalStyled(
+  IconButton,
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'ClearIndicator',
+  },
+)({
+  /* Styles applied to the clear indicator. */
+  marginRight: -2,
+  padding: 4,
+  visibility: 'hidden',
+});
+
+const AutocompletePopupIndicator = experimentalStyled(
+  IconButton,
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'PopupIndicator',
+  },
+)(({ styleProps }) => ({
+  /* Styles applied to the popup indicator. */
+  padding: 2,
+  marginRight: -2,
+  /* Styles applied to the popup indicator if the popup is open. */
+  ...(styleProps.popupOpen && {
+    transform: 'rotate(180deg)',
+  }),
+}));
+
+const AutocompletePopper = experimentalStyled(
+  Popper,
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'Popper',
+  },
+)(({ theme, styleProps }) => ({
+  /* Styles applied to the popper element. */
+  zIndex: theme.zIndex.modal,
+  /* Styles applied to the popper element if `disablePortal={true}`. */
+  ...(styleProps.disablePortal && {
+    position: 'absolute',
+  }),
+}));
+
+const AutocompletePaper = experimentalStyled(
+  Paper,
+  {},
+  { name: 'MuiAutocomplete', slot: 'Paper' },
+)(({ theme }) => ({
+  /* Styles applied to the Paper component. */
+  ...theme.typography.body1,
+  overflow: 'auto',
+  margin: '4px 0',
+}));
+
+const AutocompleteLoading = experimentalStyled(
+  'div',
+  {},
+  { name: 'MuiAutocomplete', slot: 'Loading' },
+)(({ theme }) => ({
+  /* Styles applied to the loading wrapper. */
+  color: theme.palette.text.secondary,
+  padding: '14px 16px',
+}));
+
+const AutocompleteNoOptions = experimentalStyled(
+  'div',
+  {},
+  { name: 'MuiAutocomplete', slot: 'NoOptions' },
+)(({ theme }) => ({
+  /* Styles applied to the no option wrapper. */
+  color: theme.palette.text.secondary,
+  padding: '14px 16px',
+}));
+
+const AutocompleteListbox = experimentalStyled(
+  'div',
+  {},
+  { name: 'MuiAutocomplete', slot: 'Listbox' },
+)({
+  /* Styles applied to the listbox component. */
+  listStyle: 'none',
+  margin: 0,
+  padding: '8px 0',
+  maxHeight: '40vh',
+  overflow: 'auto',
+});
+
+const AutocompleteGroupLabel = experimentalStyled(
+  ListSubheader,
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'GroupLabel',
+  },
+)(({ theme }) => ({
+  /* Styles applied to the group's label elements. */
+  backgroundColor: theme.palette.background.paper,
+  top: -8,
+}));
+
+const AutocompleteGroupUl = experimentalStyled(
+  'ul',
+  {},
+  {
+    name: 'MuiAutocomplete',
+    slot: 'GroupUl',
+  },
+)({
   /* Styles applied to the group's ul elements. */
-  groupUl: {
-    padding: 0,
-    '& $option': {
-      paddingLeft: 24,
-    },
+  padding: 0,
+  [`& .${autocompleteClasses.option}`]: {
+    paddingLeft: 24,
   },
 });
 
-const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
+export { createFilterOptions };
+
+const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiAutocomplete' });
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
     autoComplete = false,
@@ -263,7 +425,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     autoSelect = false,
     blurOnSelect = false,
     ChipProps,
-    classes,
     className,
     clearIcon = <ClearIcon fontSize="small" />,
     clearOnBlur = !props.freeSolo,
@@ -342,6 +503,23 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     groupedOptions,
   } = useAutocomplete({ ...props, componentName: 'Autocomplete' });
 
+  const hasClearIcon = !disableClearable && !disabled && dirty;
+  const hasPopupIcon = (!freeSolo || forcePopupIcon === true) && forcePopupIcon !== false;
+
+  const styleProps = {
+    ...props,
+    focused,
+    fullWidth,
+    hasClearIcon,
+    hasPopupIcon,
+    popupOpen,
+    inputFocused: focusedTag === -1,
+    disablePortal,
+    size,
+  };
+
+  const classes = useUtilityClasses(styleProps);
+
   let startAdornment;
 
   if (multiple && value.length > 0) {
@@ -381,10 +559,16 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
 
   const defaultRenderGroup = (params) => (
     <li key={params.key}>
-      <ListSubheader className={classes.groupLabel} component="div">
+      <AutocompleteGroupLabel
+        className={classes.groupLabel}
+        styleProps={styleProps}
+        component="div"
+      >
         {params.group}
-      </ListSubheader>
-      <ul className={classes.groupUl}>{params.children}</ul>
+      </AutocompleteGroupLabel>
+      <AutocompleteGroupUl className={classes.groupUl} styleProps={styleProps}>
+        {params.children}
+      </AutocompleteGroupUl>
     </li>
   );
 
@@ -401,23 +585,12 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     });
   };
 
-  const hasClearIcon = !disableClearable && !disabled && dirty;
-  const hasPopupIcon = (!freeSolo || forcePopupIcon === true) && forcePopupIcon !== false;
-
   return (
     <React.Fragment>
-      <div
+      <AutocompleteRoot
         ref={ref}
-        className={clsx(
-          classes.root,
-          {
-            [classes.focused]: focused,
-            [classes.fullWidth]: fullWidth,
-            [classes.hasClearIcon]: hasClearIcon,
-            [classes.hasPopupIcon]: hasPopupIcon,
-          },
-          className,
-        )}
+        className={clsx(classes.root, className)}
+        styleProps={styleProps}
         {...getRootProps(other)}
       >
         {renderInput({
@@ -431,66 +604,69 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
             className: classes.inputRoot,
             startAdornment,
             endAdornment: (
-              <div className={classes.endAdornment}>
+              <AutocompleteEndAdornment className={classes.endAdornment} styleProps={styleProps}>
                 {hasClearIcon ? (
-                  <IconButton
+                  <AutocompleteClearIndicator
                     {...getClearProps()}
                     aria-label={clearText}
                     title={clearText}
                     className={classes.clearIndicator}
+                    styleProps={styleProps}
                   >
                     {clearIcon}
-                  </IconButton>
+                  </AutocompleteClearIndicator>
                 ) : null}
 
                 {hasPopupIcon ? (
-                  <IconButton
+                  <AutocompletePopupIndicator
                     {...getPopupIndicatorProps()}
                     disabled={disabled}
                     aria-label={popupOpen ? closeText : openText}
                     title={popupOpen ? closeText : openText}
-                    className={clsx(classes.popupIndicator, {
-                      [classes.popupIndicatorOpen]: popupOpen,
-                    })}
+                    className={clsx(classes.popupIndicator)}
+                    styleProps={styleProps}
                   >
                     {popupIcon}
-                  </IconButton>
+                  </AutocompletePopupIndicator>
                 ) : null}
-              </div>
+              </AutocompleteEndAdornment>
             ),
           },
           inputProps: {
-            className: clsx(classes.input, {
-              [classes.inputFocused]: focusedTag === -1,
-            }),
+            className: clsx(classes.input),
             disabled,
             ...getInputProps(),
           },
         })}
-      </div>
+      </AutocompleteRoot>
       {popupOpen && anchorEl ? (
-        <PopperComponent
-          className={clsx(classes.popper, {
-            [classes.popperDisablePortal]: disablePortal,
-          })}
+        <AutocompletePopper
+          component={PopperComponent}
+          className={clsx(classes.popper)}
           disablePortal={disablePortal}
           style={{
             width: anchorEl ? anchorEl.clientWidth : null,
           }}
+          styleProps={styleProps}
           role="presentation"
           anchorEl={anchorEl}
           open
         >
-          <PaperComponent className={classes.paper}>
+          <AutocompletePaper className={classes.paper} styleProps={styleProps}>
             {loading && groupedOptions.length === 0 ? (
-              <div className={classes.loading}>{loadingText}</div>
+              <AutocompleteLoading className={classes.loading} styleProps={styleProps}>
+                {loadingText}
+              </AutocompleteLoading>
             ) : null}
             {groupedOptions.length === 0 && !freeSolo && !loading ? (
-              <div className={classes.noOptions}>{noOptionsText}</div>
+              <AutocompleteNoOptions className={classes.noOptions} styleProps={styleProps}>
+                {noOptionsText}
+              </AutocompleteNoOptions>
             ) : null}
             {groupedOptions.length > 0 ? (
-              <ListboxComponent
+              <AutocompleteListbox
                 className={classes.listbox}
+                styleProps={styleProps}
                 {...getListboxProps()}
                 {...ListboxProps}
               >
@@ -506,10 +682,10 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
                   }
                   return renderListOption(option, index);
                 })}
-              </ListboxComponent>
+              </AutocompleteListbox>
             ) : null}
-          </PaperComponent>
-        </PopperComponent>
+          </AutocompletePaper>
+        </AutocompletePopper>
       ) : null}
     </React.Fragment>
   );
@@ -875,6 +1051,10 @@ Autocomplete.propTypes = {
    */
   size: PropTypes.oneOf(['medium', 'small']),
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The value of the autocomplete.
    *
    * The value must have reference equality with the option in order to be selected.
@@ -889,9 +1069,8 @@ Autocomplete.propTypes = {
         ].join('\n'),
       );
     }
-
     return null;
   }),
 };
 
-export default withStyles(styles, { name: 'MuiAutocomplete' })(Autocomplete);
+export default Autocomplete;

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -37,11 +37,7 @@ const overridesResolver = (props, styles) => {
       ...styles.tag,
       ...styles[`tagSize${capitalize(size)}`],
     },
-    [`& .${autocompleteClasses.inputRoot}`]: {
-      ...styles.inputRoot,
-      ...(hasPopupIcon && styles.hasPopupIcon),
-      ...(hasClearIcon && styles.hasClearIcon),
-    },
+    [`& .${autocompleteClasses.inputRoot}`]: styles.inputRoot,
     [`& .${autocompleteClasses.input}`]: {
       ...styles.input,
       ...(inputFocused && styles.inputFocused),

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -188,6 +188,9 @@ const AutocompleteRoot = experimentalStyled(
       [`& .${autocompleteClasses.input}`]: {
         padding: '2.5px 4px',
       },
+      [`& .${autocompleteClasses.input}:first-child`]: {
+        paddingLeft: 6,
+      },
     },
     '&.MuiFilledInput-root': {
       paddingTop: 19,

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -20,13 +20,13 @@ import { capitalize } from '../utils';
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
   const {
+    disablePortal,
     fullWidth,
-    size,
-    hasPopupIcon,
     hasClearIcon,
+    hasPopupIcon,
     inputFocused,
     popupOpen,
-    disablePortal,
+    size,
   } = styleProps;
 
   return deepmerge(styles.root || {}, {
@@ -65,14 +65,14 @@ const overridesResolver = (props, styles) => {
 const useUtilityClasses = (styleProps) => {
   const {
     classes,
-    fullWidth,
+    disablePortal,
     focused,
-    size,
-    hasPopupIcon,
+    fullWidth,
     hasClearIcon,
+    hasPopupIcon,
     inputFocused,
     popupOpen,
-    disablePortal,
+    size,
   } = styleProps;
 
   const slots = {
@@ -504,13 +504,13 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
 
   const styleProps = {
     ...props,
+    disablePortal,
     focused,
     fullWidth,
     hasClearIcon,
     hasPopupIcon,
-    popupOpen,
     inputFocused: focusedTag === -1,
-    disablePortal,
+    popupOpen,
     size,
   };
 

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -560,7 +560,11 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
       >
         {params.group}
       </AutocompleteGroupLabel>
-      <AutocompleteGroupUl className={classes.groupUl} styleProps={styleProps}>
+      <AutocompleteGroupUl
+        as={ListboxComponent}
+        className={classes.groupUl}
+        styleProps={styleProps}
+      >
         {params.children}
       </AutocompleteGroupUl>
     </li>
@@ -646,7 +650,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
           anchorEl={anchorEl}
           open
         >
-          <AutocompletePaper className={classes.paper} styleProps={styleProps}>
+          <AutocompletePaper as={PaperComponent} className={classes.paper} styleProps={styleProps}>
             {loading && groupedOptions.length === 0 ? (
               <AutocompleteLoading className={classes.loading} styleProps={styleProps}>
                 {loadingText}

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -635,7 +635,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
       </AutocompleteRoot>
       {popupOpen && anchorEl ? (
         <AutocompletePopper
-          component={PopperComponent}
+          as={PopperComponent}
           className={clsx(classes.popper)}
           disablePortal={disablePortal}
           style={{

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -110,7 +110,7 @@ const AutocompleteRoot = experimentalStyled(
     slot: 'Root',
     overridesResolver,
   },
-)(({ theme, styleProps }) => ({
+)(({ styleProps }) => ({
   /* Styles applied to the root element. */
   [`&.Mui-focused .${autocompleteClasses.clearIndicator}`]: {
     visibility: 'visible',
@@ -222,58 +222,6 @@ const AutocompleteRoot = experimentalStyled(
       opacity: 1,
     }),
   },
-  /* Styles applied to the option elements. */
-  [`& .${autocompleteClasses.option}`]: {
-    minHeight: 48,
-    display: 'flex',
-    overflow: 'hidden',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    cursor: 'pointer',
-    paddingTop: 6,
-    boxSizing: 'border-box',
-    outline: '0',
-    WebkitTapHighlightColor: 'transparent',
-    paddingBottom: 6,
-    paddingLeft: 16,
-    paddingRight: 16,
-    [theme.breakpoints.up('sm')]: {
-      minHeight: 'auto',
-    },
-    '&[data-focus="true"]': {
-      backgroundColor: theme.palette.action.hover,
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: 'transparent',
-      },
-    },
-    '&[aria-disabled="true"]': {
-      opacity: theme.palette.action.disabledOpacity,
-      pointerEvents: 'none',
-    },
-    '&.Mui-focusVisible': {
-      backgroundColor: theme.palette.action.focus,
-    },
-    '&[aria-selected="true"]': {
-      backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
-      '&[data-focus="true"]': {
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
-        ),
-        // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
-          backgroundColor: theme.palette.action.selected,
-        },
-      },
-      '&.Mui-focusVisible': {
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
-        ),
-      },
-    },
-  },
 }));
 
 const AutocompleteEndAdornment = experimentalStyled(
@@ -373,14 +321,66 @@ const AutocompleteListbox = experimentalStyled(
   'div',
   {},
   { name: 'MuiAutocomplete', slot: 'Listbox' },
-)({
+)(({ theme }) => ({
   /* Styles applied to the listbox component. */
   listStyle: 'none',
   margin: 0,
   padding: '8px 0',
   maxHeight: '40vh',
   overflow: 'auto',
-});
+  /* Styles applied to the option elements. */
+  [`& .${autocompleteClasses.option}`]: {
+    minHeight: 48,
+    display: 'flex',
+    overflow: 'hidden',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    cursor: 'pointer',
+    paddingTop: 6,
+    boxSizing: 'border-box',
+    outline: '0',
+    WebkitTapHighlightColor: 'transparent',
+    paddingBottom: 6,
+    paddingLeft: 16,
+    paddingRight: 16,
+    [theme.breakpoints.up('sm')]: {
+      minHeight: 'auto',
+    },
+    '&[data-focus="true"]': {
+      backgroundColor: theme.palette.action.hover,
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+    '&[aria-disabled="true"]': {
+      opacity: theme.palette.action.disabledOpacity,
+      pointerEvents: 'none',
+    },
+    '&.Mui-focusVisible': {
+      backgroundColor: theme.palette.action.focus,
+    },
+    '&[aria-selected="true"]': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+      '&[data-focus="true"]': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+        ),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: theme.palette.action.selected,
+        },
+      },
+      '&.Mui-focusVisible': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+        ),
+      },
+    },
+  },
+}));
 
 const AutocompleteGroupLabel = experimentalStyled(
   ListSubheader,

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -12,8 +12,10 @@ import {
 import { spy } from 'sinon';
 import TextField from '@material-ui/core/TextField';
 import Chip from '@material-ui/core/Chip';
-import Autocomplete, { createFilterOptions } from '@material-ui/core/Autocomplete';
-import classes from './autocompleteClasses';
+import Autocomplete, {
+  autocompleteClasses as classes,
+  createFilterOptions,
+} from '@material-ui/core/Autocomplete';
 
 function checkHighlightIs(listbox, expected) {
   const focused = listbox.querySelector('[role="option"][data-focus]');

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -36,18 +36,21 @@ describe('<Autocomplete />', () => {
   const mount = createMount();
   const render = createClientRender();
 
-  describeConformanceV5(<Autocomplete options={[]} renderInput={() => null} />, () => ({
-    classes,
-    inheritComponent: 'div',
-    mount,
-    muiName: 'MuiAutocomplete',
-    testVariantProps: { variant: 'foo' },
-    testDeepOverrides: { slotName: 'inputRoot', slotClassName: classes.inputRoot },
-    testStateOverrides: { prop: 'size', value: 'small', styleKey: 'tagSizeSmall' },
-    refInstanceof: window.HTMLDivElement,
-    testComponentPropWith: 'div',
-    skip: ['componentProp', 'componentsProp'],
-  }));
+  describeConformanceV5(
+    <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
+    () => ({
+      classes,
+      inheritComponent: 'div',
+      mount,
+      muiName: 'MuiAutocomplete',
+      testVariantProps: { variant: 'foo' },
+      testDeepOverrides: { slotName: 'inputRoot', slotClassName: classes.inputRoot },
+      testStateOverrides: { prop: 'fullWidth', value: true, styleKey: 'fullWidth' },
+      refInstanceof: window.HTMLDivElement,
+      testComponentPropWith: 'div',
+      skip: ['componentProp', 'componentsProp'],
+    }),
+  );
 
   describe('combobox', () => {
     it('should clear the input when blur', () => {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -2,9 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import {
-  getClasses,
   createMount,
-  describeConformance,
+  describeConformanceV5,
   act,
   createClientRender,
   fireEvent,
@@ -14,6 +13,7 @@ import { spy } from 'sinon';
 import TextField from '@material-ui/core/TextField';
 import Chip from '@material-ui/core/Chip';
 import Autocomplete, { createFilterOptions } from '@material-ui/core/Autocomplete';
+import classes from './autocompleteClasses';
 
 function checkHighlightIs(listbox, expected) {
   const focused = listbox.querySelector('[role="option"][data-focus]');
@@ -32,19 +32,19 @@ function checkHighlightIs(listbox, expected) {
 
 describe('<Autocomplete />', () => {
   const mount = createMount();
-  let classes;
   const render = createClientRender();
 
-  before(() => {
-    classes = getClasses(<Autocomplete options={[]} renderInput={() => null} />);
-  });
-
-  describeConformance(<Autocomplete options={[]} renderInput={() => null} />, () => ({
+  describeConformanceV5(<Autocomplete options={[]} renderInput={() => null} />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
+    muiName: 'MuiAutocomplete',
+    testVariantProps: { variant: 'foo' },
+    testDeepOverrides: { slotName: 'inputRoot', slotClassName: classes.inputRoot },
+    testStateOverrides: { prop: 'size', value: 'small', styleKey: 'tagSizeSmall' },
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'div',
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   describe('combobox', () => {
@@ -1290,7 +1290,7 @@ describe('<Autocomplete />', () => {
     it('warn if the type of the value is wrong', () => {
       expect(() => {
         PropTypes.checkPropTypes(
-          Autocomplete.Naked.propTypes,
+          Autocomplete.propTypes,
           { multiple: true, value: null, options: [], renderInput: () => null },
           'prop',
           'Autocomplete',
@@ -1509,7 +1509,7 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
-    it('should mantain list box open clicking on input when it is not empty', () => {
+    it('should maintain list box open clicking on input when it is not empty', () => {
       const { getByRole, getAllByRole } = render(
         <Autocomplete options={['one']} renderInput={(params) => <TextField {...params} />} />,
       );

--- a/packages/material-ui/src/Autocomplete/autocompleteClasses.d.ts
+++ b/packages/material-ui/src/Autocomplete/autocompleteClasses.d.ts
@@ -1,0 +1,7 @@
+import { AutocompleteClassKey } from './Autocomplete';
+
+declare const autocompleteClasses: Record<AutocompleteClassKey, string>;
+
+export function getAutocompleteUtilityClass(slot: string): string;
+
+export default autocompleteClasses;

--- a/packages/material-ui/src/Autocomplete/autocompleteClasses.js
+++ b/packages/material-ui/src/Autocomplete/autocompleteClasses.js
@@ -12,6 +12,7 @@ const autocompleteClasses = generateUtilityClasses('MuiAutocomplete', [
   'tagSizeSmall',
   'tagSizeMedium',
   'hasPopupIcon',
+  'hasClearIcon',
   'inputRoot',
   'input',
   'inputFocused',

--- a/packages/material-ui/src/Autocomplete/autocompleteClasses.js
+++ b/packages/material-ui/src/Autocomplete/autocompleteClasses.js
@@ -1,0 +1,33 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getAutocompleteUtilityClass(slot) {
+  return generateUtilityClass('MuiAutocomplete', slot);
+}
+
+const autocompleteClasses = generateUtilityClasses('MuiAutocomplete', [
+  'root',
+  'fullWidth',
+  'focused',
+  'tag',
+  'tagSizeSmall',
+  'tagSizeMedium',
+  'hasPopupIcon',
+  'inputRoot',
+  'input',
+  'inputFocused',
+  'endAdornment',
+  'clearIndicator',
+  'popupIndicator',
+  'popupIndicatorOpen',
+  'popper',
+  'popperDisablePortal',
+  'paper',
+  'listbox',
+  'loading',
+  'noOptions',
+  'option',
+  'groupLabel',
+  'groupUl',
+]);
+
+export default autocompleteClasses;

--- a/packages/material-ui/src/Autocomplete/index.d.ts
+++ b/packages/material-ui/src/Autocomplete/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './Autocomplete';
 export * from './Autocomplete';
+
+export { default as autocompleteClasses } from './autocompleteClasses';
+export * from './autocompleteClasses';

--- a/packages/material-ui/src/Autocomplete/index.js
+++ b/packages/material-ui/src/Autocomplete/index.js
@@ -1,1 +1,4 @@
 export { default, createFilterOptions } from './Autocomplete';
+
+export { default as autocompleteClasses } from './autocompleteClasses';
+export * from './autocompleteClasses';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

#24405

Have some failing tests due to:

Using `first-child` instead of `first-of-type`. Says first-child not save in SSR. Just not sure how you would like this handled. 

~~The other is to do with the icon classes test. `hasPopupIcon` and `hasClearIcon`~~
