### PR TITLE
[Snackbar] Shouldn't be light in dark mode

### DIFF
--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -6,7 +6,7 @@ import Paper from '../Paper';
 import { emphasize } from '../styles/colorManipulator';
 
 export const styles = (theme) => {
-  const emphasis = theme.palette.mode === 'light' ? 0.8 : 0.98;
+  const emphasis = theme.palette.mode === 'light' ? 0.02 : 0.2;
   const backgroundColor = emphasize(theme.palette.background.default, emphasis);
 
   return {

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -6,7 +6,7 @@ import Paper from '../Paper';
 import { emphasize } from '../styles/colorManipulator';
 
 export const styles = (theme) => {
-  const emphasis = theme.palette.mode === 'light' ? 0.02 : 0.2;
+  const emphasis = theme.palette.mode === 'light' ? 0.8 : 0.2;
   const backgroundColor = emphasize(theme.palette.background.default, emphasis);
 
   return {


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://deploy-preview-24704--material-ui.netlify.app/components/snackbars/

Closes  #24438