### PR TITLE
[Typography] Remove align inherit noise

### DIFF
--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -14,11 +14,28 @@ const overridesResolver = (props, styles) => {
 
   return deepmerge(styles.root || {}, {
     ...(styleProps.variant && styles[styleProps.variant]),
-    ...(styleProps.align && styles[`align${capitalize(styleProps.align)}`]),
+    ...(styleProps.align !== 'inherit' && styles[`align${capitalize(styleProps.align)}`]),
     ...(styleProps.noWrap && styles.noWrap),
     ...(styleProps.gutterBottom && styles.gutterBottom),
     ...(styleProps.paragraph && styles.paragraph),
   });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { align, gutterBottom, noWrap, paragraph, variant, classes } = styleProps;
+
+  const slots = {
+    root: [
+      'root',
+      variant,
+      styleProps.align !== 'inherit' && `align${capitalize(align)}`,
+      gutterBottom && 'gutterBottom',
+      noWrap && 'noWrap',
+      paragraph && 'paragraph',
+    ],
+  };
+
+  return composeClasses(slots, getTypographyUtilityClass, classes);
 };
 
 export const TypographyRoot = experimentalStyled(
@@ -56,23 +73,6 @@ const defaultVariantMapping = {
   body1: 'p',
   body2: 'p',
   inherit: 'p',
-};
-
-const useUtilityClasses = (styleProps) => {
-  const { align, gutterBottom, noWrap, paragraph, variant, classes } = styleProps;
-
-  const slots = {
-    root: [
-      'root',
-      variant,
-      `align${capitalize(align)}`,
-      gutterBottom && 'gutterBottom',
-      noWrap && 'noWrap',
-      paragraph && 'paragraph',
-    ],
-  };
-
-  return composeClasses(slots, getTypographyUtilityClass, classes);
 };
 
 // TODO v6: deprecate these color values in v5.x and remove the transformation in v6


### PR DESCRIPTION
During the migration of Typography to emotion we added a new class that I believe only has downsides: `alignInherit`. It adds noise (the important signal is MuiTypography-h1) in the DOM without helping with customizability.

<img width="492" alt="Capture d’écran 2021-01-31 à 11 19 13" src="https://user-images.githubusercontent.com/3165635/106381038-5ec37e80-63b6-11eb-845a-919587725706.png">

I have also change the position of the `useUtilityClasses` method to match the source template.