### PR TITLE
[Card] Use the default elevation

### DIFF
--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -50,7 +50,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
   return (
     <CardRoot
       className={clsx(classes.root, className)}
-      elevation={raised ? 8 : 1}
+      elevation={raised ? 8 : undefined}
       ref={ref}
       styleProps={styleProps}
       {...other}

--- a/packages/material-ui/src/Card/Card.test.js
+++ b/packages/material-ui/src/Card/Card.test.js
@@ -23,4 +23,9 @@ describe('<Card />', () => {
     const { container } = render(<Card raised />);
     expect(container.firstChild).to.have.class('MuiPaper-elevation8');
   });
+
+  it('should support variant="outlined"', () => {
+    const { container } = render(<Card variant="outlined" />);
+    expect(container.firstChild).to.have.class('MuiPaper-outlined');
+  });
 });


### PR DESCRIPTION
#24667 introduces a warning when using a card outlined. I have added a test to catch the issue as well as fixed the default prop logic. Now, developers, when changing the default elevation of the Paper, don't need to customize the Card too. 

<img width="603" alt="Capture d’écran 2021-01-31 à 18 39 05" src="https://user-images.githubusercontent.com/3165635/106392758-9f8db880-63f3-11eb-86bc-b40c0c6f9cbe.png">

http://0.0.0.0:3000/components/cards/