### PR TITLE
[Pickers] Fix more name inconsistencies

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -430,6 +430,6 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
   view: PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired,
 };
 
-export default withStyles(styles, { name: 'MuiPickersClockView' })(ClockPicker) as <TDate>(
+export default withStyles(styles, { name: 'MuiClockPicker' })(ClockPicker) as <TDate>(
   props: ClockPickerProps<TDate>,
 ) => JSX.Element;

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -6,7 +6,7 @@ import { makeDateRangePicker } from './makeDateRangePicker';
  * @ignore - do not document.
  */
 /* @typescript-to-proptypes-generate */
-const DateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', ResponsiveTooltipWrapper);
+const DateRangePicker = makeDateRangePicker('MuiDateRangePicker', ResponsiveTooltipWrapper);
 
 if (process.env.NODE_ENV !== 'production') {
   (DateRangePicker as any).displayName = 'DateRangePicker';

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerInput.tsx
@@ -184,4 +184,4 @@ const DateRangePickerInput: React.FC<DateRangeInputProps & WithStyles<typeof sty
   );
 };
 
-export default withStyles(styles, { name: 'MuiPickersDateRangePickerInput' })(DateRangePickerInput);
+export default withStyles(styles, { name: 'MuiDateRangePickerInput' })(DateRangePickerInput);

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -84,6 +84,4 @@ const DateRangePickerToolbar: React.FC<DateRangePickerToolbarProps & WithStyles<
   );
 };
 
-export default withStyles(styles, { name: 'MuiPickersDateRangePickerToolbarProps' })(
-  DateRangePickerToolbar,
-);
+export default withStyles(styles, { name: 'MuiDateRangePickerToolbar' })(DateRangePickerToolbar);

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -212,6 +212,6 @@ function DateRangePickerViewDesktop<TDate>(
   );
 }
 
-export default withStyles(styles, { name: 'MuiPickersDesktopDateRangeCalendar' })(
+export default withStyles(styles, { name: 'MuiDateRangePickerViewDesktop' })(
   DateRangePickerViewDesktop,
 ) as <TDate>(props: DesktopDateRangeCalendarProps<TDate>) => JSX.Element;

--- a/packages/material-ui-lab/src/DayPicker/PickersFadeTransitionGroup.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersFadeTransitionGroup.tsx
@@ -89,4 +89,4 @@ const FadeTransitionGroup: React.FC<FadeTransitionProps & WithStyles<typeof styl
   );
 };
 
-export default withStyles(styles, { name: 'MuiPickersFadeTransition' })(FadeTransitionGroup);
+export default withStyles(styles, { name: 'MuiPickersFadeTransitionGroup' })(FadeTransitionGroup);

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -257,7 +257,7 @@ describe('<DesktopDateRangePicker />', () => {
   it("respect theme's defaultProps", () => {
     const theme = createMuiTheme({
       components: {
-        MuiPickersDateRangePicker: {
+        MuiDesktopDateRangePicker: {
           defaultProps: { startText: 'Início', endText: 'Fim' },
         },
       } as any,

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -7,7 +7,7 @@ import DesktopTooltipWrapper from '../internal/pickers/wrappers/DesktopTooltipWr
  */
 /* @typescript-to-proptypes-generate */
 const DesktopDateRangePicker = makeDateRangePicker(
-  'MuiPickersDateRangePicker',
+  'MuiDesktopDateRangePicker',
   DesktopTooltipWrapper,
 );
 

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -6,7 +6,7 @@ import MobileWrapper from '../internal/pickers/wrappers/MobileWrapper';
  * @ignore - do not document.
  */
 /* @typescript-to-proptypes-generate */
-const MobileDateRangePicker = makeDateRangePicker('MuiPickersDateRangePicker', MobileWrapper);
+const MobileDateRangePicker = makeDateRangePicker('MuiMobileDateRangePicker', MobileWrapper);
 
 if (process.env.NODE_ENV !== 'production') {
   (MobileDateRangePicker as any).displayName = 'MobileDateRangePicker';

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
@@ -234,6 +234,6 @@ const YearPicker = React.forwardRef(function YearPicker<TDate>(
   shouldDisableYear: PropTypes.func,
 };
 
-export default withStyles(styles, { name: 'MuiPickersYearSelection' })(YearPicker) as <TDate>(
+export default withStyles(styles, { name: 'MuiYearPicker' })(YearPicker) as <TDate>(
   props: YearPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element;


### PR DESCRIPTION
As asked by @eps1lon in #24705. I'm moving the changes into a dedicated PR. It's somewhat a breaking change.

The motivation: enforce a constraint we have defined for the components, the name of the file should match, the import, the stylesheets, the default props, etc.