### PR TITLE
[docs] Follow similar demo pattern for date and time pickers

### DIFF
--- a/docs/src/pages/components/time-picker/BasicTimePicker.js
+++ b/docs/src/pages/components/time-picker/BasicTimePicker.js
@@ -5,33 +5,18 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import TimePicker from '@material-ui/lab/TimePicker';
 
 export default function BasicTimePicker() {
-  const [value, setValue] = React.useState(new Date());
+  const [value, setValue] = React.useState(null);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <div style={{ width: 300 }}>
-        <TimePicker
-          label="12 hours"
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
-        />
-        <TimePicker
-          ampm={false}
-          label="24 hours"
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
-        />
-      </div>
+      <TimePicker
+        label="Basic example"
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        renderInput={(params) => <TextField {...params} />}
+      />
     </LocalizationProvider>
   );
 }

--- a/docs/src/pages/components/time-picker/BasicTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/BasicTimePicker.tsx
@@ -5,33 +5,18 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import TimePicker from '@material-ui/lab/TimePicker';
 
 export default function BasicTimePicker() {
-  const [value, setValue] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Date | null>(null);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <div style={{ width: 300 }}>
-        <TimePicker
-          label="12 hours"
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
-        />
-        <TimePicker
-          ampm={false}
-          label="24 hours"
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
-        />
-      </div>
+      <TimePicker
+        label="Basic example"
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        renderInput={(params) => <TextField {...params} />}
+      />
     </LocalizationProvider>
   );
 }

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.js
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.js
@@ -36,9 +36,7 @@ export default function LocalizedTimePicker() {
           <TimePicker
             value={selectedDate}
             onChange={(date) => handleDateChange(date)}
-            renderInput={(params) => (
-              <TextField {...params} margin="normal" variant="standard" />
-            )}
+            renderInput={(params) => <TextField {...params} />}
           />
           <ToggleButtonGroup value={locale} exclusive>
             {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
@@ -36,9 +36,7 @@ export default function LocalizedTimePicker() {
           <TimePicker
             value={selectedDate}
             onChange={(date) => handleDateChange(date)}
-            renderInput={(params) => (
-              <TextField {...params} margin="normal" variant="standard" />
-            )}
+            renderInput={(params) => <TextField {...params} />}
           />
           <ToggleButtonGroup value={locale} exclusive>
             {Object.keys(localeMap).map((localeItem) => (

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
@@ -18,9 +18,7 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -28,16 +26,12 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.js
@@ -18,7 +18,7 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -26,12 +26,12 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
@@ -20,9 +20,7 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -30,16 +28,12 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
+++ b/docs/src/pages/components/time-picker/ResponsiveTimePickers.tsx
@@ -20,7 +20,7 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <DesktopTimePicker
           label="For desktop"
@@ -28,12 +28,12 @@ export default function ResponsiveTimePickers() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <TimePicker
           value={value}
           onChange={setValue}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.js
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.js
@@ -21,9 +21,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
         <TimePicker
           ampmInClock
@@ -35,9 +33,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.js
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.js
@@ -21,7 +21,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <TimePicker
           ampmInClock
@@ -33,7 +33,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
@@ -21,9 +21,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
         <TimePicker
           ampmInClock
@@ -35,9 +33,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/SecondsTimePicker.tsx
@@ -21,7 +21,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
         <TimePicker
           ampmInClock
@@ -33,7 +33,7 @@ export default function SecondsTimePicker() {
           onChange={(newValue) => {
             setValue(newValue);
           }}
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
         />
       </div>
     </LocalizationProvider>

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
@@ -11,7 +11,7 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -21,7 +21,7 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.js
@@ -11,9 +11,7 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -23,9 +21,7 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
@@ -13,9 +13,7 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -25,9 +23,7 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => (
-            <TextField {...params} margin="normal" variant="standard" />
-          )}
+          renderInput={(params) => <TextField {...params} />}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/TimeValidationTimePicker.tsx
@@ -13,7 +13,7 @@ export default function TimeValidationTimePicker() {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <div style={{ width: 300 }}>
         <TimePicker
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
           value={value}
           label="min/max time"
           onChange={(newValue) => {
@@ -23,7 +23,7 @@ export default function TimeValidationTimePicker() {
           maxTime={new Date(0, 0, 0, 18, 45)}
         />
         <TimePicker
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => <TextField {...params} margin="normal" />}
           label="Disable odd hours"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/time-picker/time-picker.md
+++ b/docs/src/pages/components/time-picker/time-picker.md
@@ -35,13 +35,14 @@ function App() {
 
 ## Basic usage
 
-The time picker will automatically adjust to the locale's time setting, i.e. the 12-hour or 24-hour format. This can be controlled with `ampm` prop.
+The date picker is rendered as a modal dialog on mobile, and a textbox with a popup on desktop.
 
 {{"demo": "pages/components/time-picker/BasicTimePicker.js"}}
 
 ## Localization
 
-Use `LocalizationProvider` to change the date-engine locale that is used to render the time picker. Note that `am/pm` setting is switched automatically:
+Use `LocalizationProvider` to change the date-engine locale that is used to render the time picker.
+The time picker will automatically adjust to the locale's time setting, i.e. the 12-hour or 24-hour format. This can be controlled with `ampm` prop.
 
 {{"demo": "pages/components/time-picker/LocalizedTimePicker.js"}}
 


### PR DESCRIPTION
Preview: http://deploy-preview-24739--material-ui.netlify.app/components/time-picker/ (modelled after [/components/date-picker](https://next--material-ui.netlify.app/components/date-picker/)


- basic example for TimePicker no longer includes `ampm` usage
   I guess in general we want to ensure that the very first/"basic" demo displays the JSX inline.
   Though I would not enforce this explicitly but implicitly by keeping the demo small (as few chars as possible).
- basic example for TimePicker uses no value as a default (following the other 3 picker basic demos)
- use default TextField variant (`outlined`) (was `standard`)