### PR TITLE
[TextField] Improve baseline alignment with start adornment

### DIFF
--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -90,7 +90,15 @@ const InputAdornment = React.forwardRef(function InputAdornment(props, ref) {
         {typeof children === 'string' && !disableTypography ? (
           <Typography color="textSecondary">{children}</Typography>
         ) : (
-          children
+          <React.Fragment>
+            {/* To have the correct vertical alignment baseline */}
+            {position === 'start' ? (
+              /* notranslate needed while Google Translate will not fix zero-width space issue */
+              /* eslint-disable-next-line react/no-danger */
+              <span className="notranslate" dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
+            ) : null}
+            {children}
+          </React.Fragment>
         )}
       </Component>
     </FormControlContext.Provider>

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -166,13 +166,28 @@ describe('<InputAdornment />', () => {
 
   it('should render children', () => {
     const { container } = render(
-      <InputAdornment position="start">
+      <InputAdornment position="end">
         <div>foo</div>
       </InputAdornment>,
     );
     const adornment = container.firstChild;
 
     expect(adornment.firstChild).to.have.property('nodeName', 'DIV');
+  });
+
+  describe('prop: position', () => {
+    it('should render span for vertical baseline alignment', () => {
+      const { container } = render(
+        <InputAdornment position="start">
+          <div>foo</div>
+        </InputAdornment>,
+      );
+      const adornment = container.firstChild;
+
+      expect(adornment.firstChild).to.have.property('nodeName', 'SPAN');
+      expect(adornment.firstChild).to.have.property('className', 'notranslate');
+      expect(adornment.childNodes[1]).to.have.property('nodeName', 'DIV');
+    });
   });
 
   it('applies a size small class inside <FormControl size="small" />', () => {

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -166,28 +166,13 @@ describe('<InputAdornment />', () => {
 
   it('should render children', () => {
     const { container } = render(
-      <InputAdornment position="end">
+      <InputAdornment position="start">
         <div>foo</div>
       </InputAdornment>,
     );
     const adornment = container.firstChild;
 
     expect(adornment.firstChild).to.have.property('nodeName', 'DIV');
-  });
-
-  describe('prop: position', () => {
-    it('should render span for vertical baseline alignment', () => {
-      const { container } = render(
-        <InputAdornment position="start">
-          <div>foo</div>
-        </InputAdornment>,
-      );
-      const adornment = container.firstChild;
-
-      expect(adornment.firstChild).to.have.property('nodeName', 'SPAN');
-      expect(adornment.firstChild).to.have.property('className', 'notranslate');
-      expect(adornment.childNodes[1]).to.have.property('nodeName', 'DIV');
-    });
   });
 
   it('applies a size small class inside <FormControl size="small" />', () => {

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -184,9 +184,9 @@ describe('<InputAdornment />', () => {
       );
       const adornment = container.firstChild;
 
-      expect(adornment.firstChild).to.have.property('nodeName', 'SPAN');
-      expect(adornment.firstChild).to.have.property('className', 'notranslate');
-      expect(adornment.childNodes[1]).to.have.property('nodeName', 'DIV');
+      expect(adornment.firstChild).to.have.tagName('span');
+      expect(adornment.firstChild).to.have.class('notranslate');
+      expect(adornment.childNodes[1]).to.have.tagName('div');
     });
   });
 

--- a/test/regressions/tests/TextField/BaselineAlignTextField.js
+++ b/test/regressions/tests/TextField/BaselineAlignTextField.js
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import Visibility from '@material-ui/icons/Visibility';
+import InputAdornment from '@material-ui/core/InputAdornment';
+
+export default function BaselineAlignTextField() {
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'baseline',
+        }}
+      >
+        Base
+        <TextField
+          label="label"
+          placeholder="placeholder"
+          variant="standard"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Visibility />
+              </InputAdornment>
+            ),
+          }}
+        />
+        Base
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'baseline',
+        }}
+      >
+        Base
+        <TextField
+          label="label"
+          placeholder="placeholder"
+          variant="standard"
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <Visibility />
+              </InputAdornment>
+            ),
+          }}
+        />
+        Base
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?
Adds a span html element as child node inside input adornment.

### Why is it needed?
Fixes to have the correct vertical alignment baseline for input adornment.

### Related issue(s)/PR(s)
Closes #24706 