### PR TITLE
[types] Remove implicit children from PropInjector

### DIFF
--- a/docs/src/pages/components/tabs/CustomizedTabs.tsx
+++ b/docs/src/pages/components/tabs/CustomizedTabs.tsx
@@ -54,6 +54,7 @@ const AntTab = withStyles((theme: Theme) =>
 )((props: StyledTabProps) => <Tab disableRipple {...props} />);
 
 interface StyledTabsProps {
+  children?: React.ReactNode;
   value: number;
   onChange: (event: React.SyntheticEvent, newValue: number) => void;
 }

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -23,10 +23,10 @@ export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
  * additional {AdditionalProps}
  */
 export type PropInjector<InjectedProps, AdditionalProps = {}> = <
-  C extends React.ComponentType<ConsistentWith<React.ComponentProps<C>, InjectedProps>>
+  C extends React.JSXElementConstructor<ConsistentWith<React.ComponentProps<C>, InjectedProps>>
 >(
   component: C
-) => React.ComponentType<
+) => React.JSXElementConstructor<
   Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
     AdditionalProps
 >;


### PR DESCRIPTION
Will affect all higher-order components. `withStyles` and `styled` will likely cause breakage.

Change is necessary to be forwards compatible with the removal of implicit children and it avoids overly strict type-checking when using `typeof ComponentDecoratedWithWithStyles`. This would previously require `.propTypes` to match as well.