### PR TITLE
[core] Disable type-checking of .propTypes

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -306,7 +306,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
   );
 }
 
-(ClockPicker as any).propTypes = {
+ClockPicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -428,7 +428,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
    * @ignore
    */
   view: PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired,
-};
+} as any;
 
 export default withStyles(styles, { name: 'MuiClockPicker' })(ClockPicker) as <TDate>(
   props: ClockPickerProps<TDate>,

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -306,7 +306,7 @@ DatePicker.propTypes = {
     PropTypes.number,
     PropTypes.string,
   ]),
-};
+} as any;
 
 export type DatePickerProps = React.ComponentProps<typeof DatePicker>;
 

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DateRangePicker as any).displayName = 'DateRangePicker';
 }
 
-(DateRangePicker as any).propTypes = {
+DateRangePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -373,7 +373,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.string,
     ]),
   ).isRequired,
-};
+} as any;
 
 export type DateRangePickerProps = React.ComponentProps<typeof DateRangePicker>;
 

--- a/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
@@ -34,12 +34,12 @@ export interface BaseDateRangePickerProps<TDate>
   endText?: React.ReactNode;
 }
 
-export type DateRangePickerComponent<TWrapper extends SomeWrapper> = <TDate>(
+export type DateRangePickerComponent<TWrapper extends SomeWrapper> = (<TDate>(
   props: BaseDateRangePickerProps<TDate> &
     PublicWrapperProps<TWrapper> &
     AllSharedDateRangePickerProps<TDate> &
     React.RefAttributes<HTMLDivElement>,
-) => JSX.Element;
+) => JSX.Element) & { propTypes: unknown };
 
 export const useDateRangeValidation = makeValidationHook<
   DateRangeValidationError,

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -177,7 +177,7 @@ const DateRangePickerDay = React.forwardRef(function DateRangePickerDay<TDate>(
   );
 });
 
-(DateRangePickerDay as any).propTypes = {
+DateRangePickerDay.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -230,7 +230,7 @@ const DateRangePickerDay = React.forwardRef(function DateRangePickerDay<TDate>(
    * If `true`, renders as selected.
    */
   selected: PropTypes.bool,
-};
+} as any;
 
 /**
  *

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -125,9 +125,9 @@ export const dateTimePickerConfig = {
   DefaultToolbarComponent: DateTimePickerToolbar,
 };
 
-export type DateTimePickerGenericComponent<TWrapper extends SomeWrapper> = <TDate>(
+export type DateTimePickerGenericComponent<TWrapper extends SomeWrapper> = (<TDate>(
   props: BaseDateTimePickerProps<TDate> & SharedPickerProps<TDate, TWrapper>,
-) => JSX.Element;
+) => JSX.Element) & { propTypes?: unknown };
 
 /**
  * @ignore - do not document.
@@ -145,7 +145,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DateTimePicker as any).displayName = 'DateTimePicker';
 }
 
-(DateTimePicker as any).propTypes = {
+DateTimePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -573,7 +573,7 @@ if (process.env.NODE_ENV !== 'production') {
   views: PropTypes.arrayOf(
     PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
-};
+} as any;
 
 export type DateTimePickerProps = React.ComponentProps<typeof DateTimePicker>;
 

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -244,7 +244,7 @@ const DayPicker = React.forwardRef(function DayPicker<
   );
 });
 
-(DayPicker as any).propTypes = {
+DayPicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -340,7 +340,7 @@ const DayPicker = React.forwardRef(function DayPicker<
    * Views for day picker.
    */
   views: PropTypes.arrayOf(PropTypes.oneOf(['date', 'month', 'year']).isRequired),
-};
+} as any;
 
 export default withStyles(styles, { name: 'MuiDayPicker' })(DayPicker) as <TDate>(
   props: DayPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -220,7 +220,7 @@ DesktopDatePicker.propTypes = {
     PropTypes.number,
     PropTypes.string,
   ]),
-};
+} as any;
 
 export type DesktopDatePickerProps = React.ComponentProps<typeof DesktopDatePicker>;
 

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DesktopDateRangePicker as any).displayName = 'DesktopDateRangePicker';
 }
 
-(DesktopDateRangePicker as any).propTypes = {
+DesktopDateRangePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -336,7 +336,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.string,
     ]),
   ).isRequired,
-};
+} as any;
 
 export type DesktopDateRangePickerProps = React.ComponentProps<typeof DesktopDateRangePicker>;
 

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DesktopDateTimePicker as any).displayName = 'DesktopDateTimePicker';
 }
 
-(DesktopDateTimePicker as any).propTypes = {
+DesktopDateTimePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -411,7 +411,7 @@ if (process.env.NODE_ENV !== 'production') {
   views: PropTypes.arrayOf(
     PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
-};
+} as any;
 
 export type DesktopDateTimePickerProps = React.ComponentProps<typeof DesktopDateTimePicker>;
 

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -260,7 +260,7 @@ DesktopTimePicker.propTypes = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
-};
+} as any;
 
 export type DesktopTimePickerProps = React.ComponentProps<typeof DesktopTimePicker>;
 

--- a/packages/material-ui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/material-ui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -38,7 +38,7 @@ const LocalizationProvider: React.FC<LocalizationProviderProps> = (props) => {
   );
 };
 
-(LocalizationProvider as any).propTypes = {
+LocalizationProvider.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -94,6 +94,6 @@ const LocalizationProvider: React.FC<LocalizationProviderProps> = (props) => {
    * Locale for the date library you are using
    */
   locale: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-};
+} as any;
 
 export default LocalizationProvider;

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -246,7 +246,7 @@ MobileDatePicker.propTypes = {
     PropTypes.number,
     PropTypes.string,
   ]),
-};
+} as any;
 
 export type MobileDatePickerProps = React.ComponentProps<typeof MobileDatePicker>;
 

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV !== 'production') {
   (MobileDateRangePicker as any).displayName = 'MobileDateRangePicker';
 }
 
-(MobileDateRangePicker as any).propTypes = {
+MobileDateRangePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -359,7 +359,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.string,
     ]),
   ).isRequired,
-};
+} as any;
 
 export type MobileDateRangePickerProps = React.ComponentProps<typeof MobileDateRangePicker>;
 

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (MobileDateTimePicker as any).displayName = 'MobileDateTimePicker';
 }
 
-(MobileDateTimePicker as any).propTypes = {
+MobileDateTimePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -437,7 +437,7 @@ if (process.env.NODE_ENV !== 'production') {
   views: PropTypes.arrayOf(
     PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
-};
+} as any;
 
 export type MobileDateTimePickerProps = React.ComponentProps<typeof MobileDateTimePicker>;
 

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -286,7 +286,7 @@ MobileTimePicker.propTypes = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
-};
+} as any;
 
 export type MobileTimePickerProps = React.ComponentProps<typeof MobileTimePicker>;
 

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.tsx
@@ -103,7 +103,7 @@ const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
   );
 });
 
-(MonthPicker as any).propTypes = {
+MonthPicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -144,7 +144,7 @@ const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
    * @ignore
    */
   onMonthChange: PropTypes.func,
-};
+} as any;
 
 export default withStyles(styles, { name: 'MuiMonthPicker' })(MonthPicker) as <TDate>(
   props: MonthPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,

--- a/packages/material-ui-lab/src/PickersCalendarSkeleton/PickersCalendarSkeleton.tsx
+++ b/packages/material-ui-lab/src/PickersCalendarSkeleton/PickersCalendarSkeleton.tsx
@@ -65,7 +65,7 @@ const PickersCalendarSkeleton: React.FC<
   );
 };
 
-(PickersCalendarSkeleton as any).propTypes = {
+PickersCalendarSkeleton.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -82,6 +82,6 @@ const PickersCalendarSkeleton: React.FC<
    * @ignore
    */
   className: PropTypes.string,
-};
+} as any;
 
 export default withStyles(styles, { name: 'MuiCalendarSkeleton' })(PickersCalendarSkeleton);

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -266,7 +266,7 @@ export const areDayPropsEqual = (
   );
 };
 
-(PickersDay as any).propTypes = {
+PickersDay.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -362,7 +362,7 @@ export const areDayPropsEqual = (
    * If `true`, renders as today date.
    */
   today: PropTypes.bool,
-};
+} as any;
 
 export default withStyles(styles, { name: 'MuiPickersDay' })(
   React.memo(PickersDay, areDayPropsEqual),

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -217,7 +217,7 @@ StaticDatePicker.propTypes = {
     PropTypes.number,
     PropTypes.string,
   ]),
-};
+} as any;
 
 export type StaticDatePickerProps = React.ComponentProps<typeof StaticDatePicker>;
 

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV !== 'production') {
   (StaticDateRangePicker as any).displayName = 'StaticDateRangePicker';
 }
 
-(StaticDateRangePicker as any).propTypes = {
+StaticDateRangePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -330,7 +330,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.string,
     ]),
   ).isRequired,
-};
+} as any;
 
 export type StaticDateRangePickerProps = React.ComponentProps<typeof StaticDateRangePicker>;
 

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (StaticDateTimePicker as any).displayName = 'StaticDateTimePicker';
 }
 
-(StaticDateTimePicker as any).propTypes = {
+StaticDateTimePicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -408,7 +408,7 @@ if (process.env.NODE_ENV !== 'production') {
   views: PropTypes.arrayOf(
     PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
-};
+} as any;
 
 export type StaticDateTimePickerProps = React.ComponentProps<typeof StaticDateTimePicker>;
 

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -257,7 +257,7 @@ StaticTimePicker.propTypes = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
-};
+} as any;
 
 export type StaticTimePickerProps = React.ComponentProps<typeof StaticTimePicker>;
 

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -371,7 +371,7 @@ TimePicker.propTypes = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
-};
+} as any;
 
 export type TimePickerProps = React.ComponentProps<typeof TimePicker>;
 

--- a/packages/material-ui-lab/src/Timeline/Timeline.tsx
+++ b/packages/material-ui-lab/src/Timeline/Timeline.tsx
@@ -92,7 +92,7 @@ Timeline.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
-};
+} as any;
 
 /**
  *

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
@@ -174,7 +174,7 @@ const YearPicker = React.forwardRef(function YearPicker<TDate>(
   );
 });
 
-(YearPicker as any).propTypes = {
+YearPicker.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
@@ -232,7 +232,7 @@ const YearPicker = React.forwardRef(function YearPicker<TDate>(
    * Works like `shouldDisableDate` but for year selection view. @DateIOType.
    */
   shouldDisableYear: PropTypes.func,
-};
+} as any;
 
 export default withStyles(styles, { name: 'MuiYearPicker' })(YearPicker) as <TDate>(
   props: YearPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.tsx
@@ -236,7 +236,7 @@ ClickAwayListener.propTypes = {
    * @default 'onTouchEnd'
    */
   touchEvent: PropTypes.oneOf(['onTouchEnd', 'onTouchStart', false]),
-};
+} as any;
 
 if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line

--- a/packages/typescript-to-proptypes/src/generator.ts
+++ b/packages/typescript-to-proptypes/src/generator.ts
@@ -9,7 +9,7 @@ export interface GenerateOptions {
    * .propTypes = { ... } as any
    * ```
    */
-  disableTypescriptPropTypesValidation?: boolean;
+  disablePropTypesTypeChecking?: boolean;
   /**
    * Enable/disable the default sorting (ascending) or provide your own sort function
    * @default true
@@ -94,7 +94,7 @@ function defaultSortLiteralUnions(a: t.LiteralType, b: t.LiteralType) {
  */
 export function generate(component: t.Component, options: GenerateOptions = {}): string {
   const {
-    disableTypescriptPropTypesValidation = false,
+    disablePropTypesTypeChecking = false,
     importedName = 'PropTypes',
     includeJSDoc = true,
     sortProptypes = true,
@@ -316,11 +316,7 @@ export function generate(component: t.Component, options: GenerateOptions = {}):
     options.comment &&
     `// ${options.comment.split(/\r?\n/gm).reduce((prev, curr) => `${prev}\n// ${curr}`)}\n`;
 
-  const componentNameNode = disableTypescriptPropTypesValidation
-    ? `(${component.name} as any)`
-    : component.name;
-
-  return `${componentNameNode}.propTypes = {\n${
-    comment !== undefined ? comment : ''
-  }${generated}\n}`;
+  return `${component.name}.propTypes = {\n${comment !== undefined ? comment : ''}${generated}\n}${
+    disablePropTypesTypeChecking ? ' as any' : ''
+  }`;
 }

--- a/packages/typescript-to-proptypes/src/injector.ts
+++ b/packages/typescript-to-proptypes/src/injector.ts
@@ -4,15 +4,15 @@ import { v4 as uuid } from 'uuid';
 import * as t from './types';
 import { generate, GenerateOptions } from './generator';
 
-export type InjectOptions = {
-  /**
-   * If source itself written in typescript prop-types disable prop-types validation
-   * by injecting propTypes as
-   * ```jsx
-   * .propTypes = { ... } as any
-   * ```
-   */
-  disableTypescriptPropTypesValidation?: boolean;
+export interface InjectOptions
+  extends Pick<
+    GenerateOptions,
+    | 'sortProptypes'
+    | 'includeJSDoc'
+    | 'comment'
+    | 'disablePropTypesTypeChecking'
+    | 'reconcilePropTypes'
+  > {
   /**
    * By default all unused props are omitted from the result.
    * Set this to true to include them instead.
@@ -52,7 +52,7 @@ export type InjectOptions = {
    * Options passed to babel.transformSync
    */
   babelOptions?: babel.TransformOptions;
-} & Pick<GenerateOptions, 'sortProptypes' | 'includeJSDoc' | 'comment' | 'reconcilePropTypes'>;
+}
 
 /**
  * Gets used props from path

--- a/packages/typescript-to-proptypes/src/injector.ts
+++ b/packages/typescript-to-proptypes/src/injector.ts
@@ -3,7 +3,6 @@ import * as babelTypes from '@babel/types';
 import { v4 as uuid } from 'uuid';
 import * as t from './types';
 import { generate, GenerateOptions } from './generator';
-import { isConstructorTypeNode } from 'typescript';
 
 export interface InjectOptions
   extends Pick<

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -25,25 +25,6 @@ enum GenerateResult {
  */
 const todoComponents: string[] = [];
 
-const todoComponentsTs: string[] = [
-  'ClockPicker',
-  'DateRangePicker',
-  'DateRangePickerDay',
-  'DayPicker',
-  'DesktopDateRangePicker',
-  'StaticDateRangePicker',
-  'MobileDateRangePicker',
-  'DateTimePicker',
-  'DesktopDateTimePicker',
-  'LocalizationProvider',
-  'MobileDateTimePicker',
-  'MonthPicker',
-  'PickersCalendarSkeleton',
-  'PickersDay',
-  'StaticDateTimePicker',
-  'YearPicker',
-];
-
 const useExternalPropsFromInputBase = [
   'autoComplete',
   'autoFocus',
@@ -193,7 +174,6 @@ async function generateProptypes(
   program: ttp.ts.Program,
   sourceFile: string,
   tsFile: string = sourceFile,
-  tsTodo: boolean = false,
 ): Promise<GenerateResult> {
   const proptypes = ttp.parseFromProgram(tsFile, program, {
     shouldResolveObject: ({ name }) => {
@@ -227,8 +207,9 @@ async function generateProptypes(
 
   const unstyledFile = getUnstyledFilename(tsFile, true);
 
+  const generatedForTypeScriptFile = sourceFile === tsFile;
   const result = ttp.inject(proptypes, sourceContent, {
-    disableTypescriptPropTypesValidation: tsTodo,
+    disablePropTypesTypeChecking: generatedForTypeScriptFile,
     removeExistingPropTypes: true,
     babelOptions: {
       filename: sourceFile,
@@ -357,10 +338,8 @@ async function run(argv: HandlerArgv) {
       return GenerateResult.TODO;
     }
 
-    const tsTodo = todoComponentsTs.includes(componentName);
-
     const sourceFile = tsFile.includes('.d.ts') ? tsFile.replace('.d.ts', '.js') : tsFile;
-    return generateProptypes(program, sourceFile, tsFile, tsTodo);
+    return generateProptypes(program, sourceFile, tsFile);
   });
 
   const results = await Promise.all(promises);


### PR DESCRIPTION
`(Component as any).propTypes` is not recognized by `react-docgen`. 
Update: Considering the bundle size reduction it's probably also not recognized by `babel-plugin-transform-react-remove-prop-types`
Update: .propTypes were not removed before: https://unpkg.com/browse/@material-ui/lab@5.0.0-alpha.24/ClockPicker/ClockPicker

We can achieve sounder types with `Component.propTypes = {} as any` by adjusting the type of `Component`. .propTypes and Props types need to match exactly which breaks down when .propTypes need the actual runtime or we didn't resolve a big object (e.g. `classes`).