### PR TITLE
[typescript] Replace Omit type with the built-in one

### DIFF
--- a/docs/src/pages/css-in-js/basics/AdaptingHook.tsx
+++ b/docs/src/pages/css-in-js/basics/AdaptingHook.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Button, { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
-import { Omit } from '@material-ui/types';
 
 interface Props {
   color: 'red' | 'blue';

--- a/docs/src/pages/css-in-js/basics/AdaptingStyledComponents.tsx
+++ b/docs/src/pages/css-in-js/basics/AdaptingStyledComponents.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { styled } from '@material-ui/core/styles';
 import Button, { ButtonProps } from '@material-ui/core/Button';
-import { Omit } from '@material-ui/types';
 
 interface MyButtonProps {
   color: 'red' | 'blue';

--- a/docs/src/pages/guides/composition/ButtonRouter.tsx
+++ b/docs/src/pages/guides/composition/ButtonRouter.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { MemoryRouter as Router } from 'react-router';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
-import { Omit } from '@material-ui/types';
 
 const LinkBehavior = React.forwardRef<any, Omit<RouterLinkProps, 'to'>>(
   (props, ref) => (

--- a/docs/src/pages/guides/composition/LinkRouter.tsx
+++ b/docs/src/pages/guides/composition/LinkRouter.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { MemoryRouter as Router } from 'react-router';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
 import Link from '@material-ui/core/Link';
-import { Omit } from '@material-ui/types';
 
 const LinkBehavior = React.forwardRef<any, Omit<RouterLinkProps, 'to'>>(
   (props, ref) => (

--- a/docs/src/pages/guides/composition/ListRouter.tsx
+++ b/docs/src/pages/guides/composition/ListRouter.tsx
@@ -11,7 +11,6 @@ import DraftsIcon from '@material-ui/icons/Drafts';
 import Typography from '@material-ui/core/Typography';
 import { Route, MemoryRouter } from 'react-router';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
-import { Omit } from '@material-ui/types';
 
 interface ListItemLinkProps {
   icon?: React.ReactElement;

--- a/docs/src/pages/premium-themes/paperbase/Navigator.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Navigator.tsx
@@ -22,7 +22,6 @@ import SettingsInputComponentIcon from '@material-ui/icons/SettingsInputComponen
 import TimerIcon from '@material-ui/icons/Timer';
 import SettingsIcon from '@material-ui/icons/Settings';
 import PhonelinkSetupIcon from '@material-ui/icons/PhonelinkSetup';
-import { Omit } from '@material-ui/types';
 
 const categories = [
   {

--- a/docs/src/pages/styles/basics/AdaptingHOC.tsx
+++ b/docs/src/pages/styles/basics/AdaptingHOC.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
 import Button, { ButtonProps } from '@material-ui/core/Button';
-import { Omit } from '@material-ui/types';
 
 const styles = createStyles({
   root: {

--- a/docs/src/pages/styles/basics/AdaptingHook.tsx
+++ b/docs/src/pages/styles/basics/AdaptingHook.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Button, { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
-import { Omit } from '@material-ui/types';
 
 interface Props {
   color: 'red' | 'blue';

--- a/docs/src/pages/styles/basics/AdaptingStyledComponents.tsx
+++ b/docs/src/pages/styles/basics/AdaptingStyledComponents.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { styled } from '@material-ui/core/styles';
 import Button, { ButtonProps } from '@material-ui/core/Button';
-import { Omit } from '@material-ui/types';
 
 interface MyButtonProps {
   color: 'red' | 'blue';

--- a/packages/material-ui-lab/src/TabList/TabList.d.ts
+++ b/packages/material-ui-lab/src/TabList/TabList.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { TabsTypeMap } from '@material-ui/core/Tabs';
-import { Omit } from '@material-ui/types';
 import { OverridableComponent, OverrideProps } from '@material-ui/core/OverridableComponent';
 
 export interface TabListTypeMap<

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -1,5 +1,4 @@
 import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
-import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
 export default function makeStyles<

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -1,4 +1,4 @@
-import { Omit, Overwrite } from '@material-ui/types';
+import { Overwrite } from '@material-ui/types';
 import {
   CreateCSSProperties,
   StyledComponentProps,

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ConsistentWith, Omit, PropInjector } from '@material-ui/types';
+import { ConsistentWith, PropInjector } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
 export interface WithThemeCreatorOption<Theme = DefaultTheme> {

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -18,6 +18,15 @@ export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
 };
 
 /**
+ * PropInjector relies on the distributive effect of the legacy Omit implementation,
+ * which, unlike the stock implementation includes T extends any ? : never
+ * Explained here: https://stackoverflow.com/a/57103940/1009797
+ *
+ * @internal
+ */
+type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
+/**
  * a function that takes {component} and returns a component that passes along
  * all the props to {component} except the {InjectedProps} and will accept
  * additional {AdditionalProps}
@@ -27,16 +36,9 @@ export type PropInjector<InjectedProps, AdditionalProps = {}> = <
 >(
   component: C
 ) => React.ComponentType<
-  Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
+  DistributiveOmit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
     AdditionalProps
 >;
-
-/**
- * Remove properties `K` from `T`.
- *
- * @internal
- */
-export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
 /**
  * Generate a set of string literal types with the given default record `T` and

--- a/packages/material-ui-unstyled/src/OverridableComponent.d.ts
+++ b/packages/material-ui-unstyled/src/OverridableComponent.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 
 /**
  * A component whose root component can be controlled via a `component` prop.

--- a/packages/material-ui/src/Backdrop/Backdrop.d.ts
+++ b/packages/material-ui/src/Backdrop/Backdrop.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
-import { Omit, InternalStandardProps as StandardProps, Theme } from '..';
+import { InternalStandardProps as StandardProps, Theme } from '..';
 import { FadeProps } from '../Fade';
 import { TransitionProps } from '../transitions/transition';
 

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '..';
 import { TransitionProps } from '../transitions/transition';
 
 export interface FadeProps extends Omit<TransitionProps, 'children'> {

--- a/packages/material-ui/src/GlobalStyles/GlobalStyles.d.ts
+++ b/packages/material-ui/src/GlobalStyles/GlobalStyles.d.ts
@@ -1,5 +1,4 @@
 import { GlobalStylesProps } from '@material-ui/styled-engine';
-import { Omit } from '@material-ui/types';
 /**
  *
  * API:

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import { TransitionProps } from '../transitions/transition';
 
 export interface GrowProps extends Omit<TransitionProps, 'timeout'> {

--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import { SxProps } from '@material-ui/system';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { Theme } from '../styles';

--- a/packages/material-ui/src/MenuItem/MenuItem.d.ts
+++ b/packages/material-ui/src/MenuItem/MenuItem.d.ts
@@ -1,4 +1,3 @@
-import { Omit } from '@material-ui/types';
 import { ListItemTypeMap, ListItemProps } from '../ListItem';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ExtendButtonBase } from '../ButtonBase';

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import { StyledComponentProps } from './styles';
 
 /**

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Instance, VirtualElement, Options, OptionsGeneric } from '@popperjs/core';
-import { Omit } from '..';
 import { PortalProps } from '../Portal';
 
 export type PopperPlacementType = Options['placement'];

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.d.ts
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import { DrawerProps } from '../Drawer';
 
 export interface SwipeableDrawerProps extends Omit<DrawerProps, 'onClose' | 'open'> {

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { TablePaginationActionsProps } from './TablePaginationActions';
 import { TableCellProps } from '../TableCell';

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.d.ts
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '..';
 
 export interface TextareaAutosizeProps
   extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'children' | 'rows'> {

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -1,16 +1,7 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import { StyledComponentProps } from './styles';
 
 export { StyledComponentProps };
-
-/**
- * @deprecated
- * Import from `@material-ui/types` instead
- *
- * TODO: to remove in v5
- */
-export { Omit };
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -1,5 +1,4 @@
 import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
-import { Omit } from '@material-ui/types';
 import { Theme as DefaultTheme } from './createMuiTheme';
 
 export default function makeStyles<

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
 import {
   CreateCSSProperties,
   StyledComponentProps,


### PR DESCRIPTION
The home-grown Omit was a distributive one - tests caught that. However, I am not sure if this won't break cause more troubles than worth. A more conservative approach would be to keep and rename the home-grown one to `DistributiveOmit`. 

[The test that started failing was testing DecoratedUnionProps](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/test/typescript/stylingComparison.spec.tsx#L76).

[Good SO question and answer on distributive omits](https://stackoverflow.com/a/57103940/1009797).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
