### PR TITLE
[test] Allow setting react-dist-tag via pipeline parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,10 @@
 version: 2.1
 
 parameters:
+  react-dist-tag:
+    description: The dist-tag of react to be used
+    type: string
+    default: stable
   workflow:
     description: The name of the workflow to run
     type: string
@@ -11,7 +15,7 @@ defaults: &defaults
     react-dist-tag:
       description: The dist-tag of react to be used
       type: string
-      default: stable
+      default: << pipeline.parameters.react-dist-tag >>
     test-gate:
       description: A particular type of tests that should be run
       type: string


### PR DESCRIPTION
Allows triggering a pipeline (e.g. via CircleCI API) with a specific `react-dist-tag` e.g.
```json
{
    "branch": "next",
    "parameters": {
        "react-dist-tag": "next",
        "workflow": "profile"
    }
}
```

Previously the above API payload would result in https://app.circleci.com/pipelines/github/mui-org/material-ui/37601/workflows/046681f0-3760-45a3-a4b0-f719c8a6c327/jobs/222354
