### PR TITLE
[Popper] Fix scroll-jump when focusing in a passive effect

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -82,6 +82,11 @@ const Popper = React.forwardRef(function Popper(props, ref) {
     }
   });
 
+  const [isPopperPositioned, setIsPopperPositioned] = React.useState(false);
+  if (isPopperPositioned && !open) {
+    setIsPopperPositioned(false);
+  }
+
   const handleOpen = React.useCallback(() => {
     if (!tooltipRef.current || !anchorEl || !open) {
       return;
@@ -154,6 +159,10 @@ const Popper = React.forwardRef(function Popper(props, ref) {
       placement: rtlPlacement,
       ...popperOptions,
       modifiers: popperModifiers,
+      onFirstUpdate: (...args) => {
+        popperOptions.onFirstUpdate?.(...args);
+        setIsPopperPositioned(true);
+      },
     });
 
     handlePopperRefRef.current(popper);
@@ -206,7 +215,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
 
   if (transition) {
     childProps.TransitionProps = {
-      in: open,
+      in: open && isPopperPositioned,
       onEnter: handleEnter,
       onExited: handleExited,
     };


### PR DESCRIPTION
Alternate to https://github.com/mui-org/material-ui/pull/24444


The comments surrounding this code seem fishy to me. PopperJS is adding `position: absolute` while we render with `position: fixed`.

## Test plan

- [ ] [Repro for the current bug](https://codesandbox.io/s/popper-scroll-jump-on-focus-p9kz9) is fixed: https://codesandbox.io/s/fixedpopper-scroll-jump-on-focus-forked-hq94m
- [ ] Verify that https://github.com/mui-org/material-ui/issues/16740 is still fixed 
- [ ] Write an automated test since that line has received quite a bit of changes over time and the behavior it implements is noticeable if broken.
- [x] Fixes https://github.com/mui-org/material-ui/issues/23899: https://deploy-preview-24760--material-ui.netlify.app/components/date-picker/#basic-usage