### PR TITLE
[docs] Add ImageTooltips demo

### DIFF
--- a/docs/src/pages/components/tooltips/ImageTooltips.js
+++ b/docs/src/pages/components/tooltips/ImageTooltips.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import Avatar from '@material-ui/core/Avatar';
+
+export default function NotInteractiveTooltips() {
+  const img = <img src="/static/images/avatar/1.jpg" alt="Enlarged Remy Sharp"/>;
+  return (
+    <Tooltip placement="left" title={img}>
+      <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg"/>
+    </Tooltip>
+  );
+}

--- a/docs/src/pages/components/tooltips/ImageTooltips.js
+++ b/docs/src/pages/components/tooltips/ImageTooltips.js
@@ -3,10 +3,10 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Avatar from '@material-ui/core/Avatar';
 
 export default function NotInteractiveTooltips() {
-  const img = <img src="/static/images/avatar/1.jpg" alt="Enlarged Remy Sharp"/>;
+  const img = <img src="/static/images/avatar/1.jpg" alt="Enlarged Remy Sharp" />;
   return (
     <Tooltip placement="left" title={img}>
-      <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg"/>
+      <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
     </Tooltip>
   );
 }

--- a/docs/src/pages/components/tooltips/ImageTooltips.tsx
+++ b/docs/src/pages/components/tooltips/ImageTooltips.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import Avatar from "@material-ui/core/Avatar";
+
+export default function NotInteractiveTooltips() {
+  const img = <img src="/static/images/avatar/1.jpg" alt="Enlarged Remy Sharp"/>;
+  return (
+    <Tooltip placement="left" title={img}>
+      <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg"/>
+    </Tooltip>
+  );
+}

--- a/docs/src/pages/components/tooltips/ImageTooltips.tsx
+++ b/docs/src/pages/components/tooltips/ImageTooltips.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
-import Avatar from "@material-ui/core/Avatar";
+import Avatar from '@material-ui/core/Avatar';
 
 export default function NotInteractiveTooltips() {
-  const img = <img src="/static/images/avatar/1.jpg" alt="Enlarged Remy Sharp"/>;
+  const img = <img src="/static/images/avatar/1.jpg" alt="Enlarged Remy Sharp" />;
   return (
     <Tooltip placement="left" title={img}>
-      <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg"/>
+      <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
     </Tooltip>
   );
 }

--- a/docs/src/pages/components/tooltips/tooltips.md
+++ b/docs/src/pages/components/tooltips/tooltips.md
@@ -118,7 +118,7 @@ You can enable the tooltip to follow the cursor by setting `followCursor={true}`
 
 ## Image tooltips
 
-You can also include images within tooltips in cases where you wish to show an enlarged 
+You can also include images within tooltips in cases where you wish to show an enlarged
 version.
 
 {{"demo": "pages/components/tooltips/ImageTooltips.js"}}

--- a/docs/src/pages/components/tooltips/tooltips.md
+++ b/docs/src/pages/components/tooltips/tooltips.md
@@ -116,6 +116,13 @@ You can enable the tooltip to follow the cursor by setting `followCursor={true}`
 
 {{"demo": "pages/components/tooltips/FollowCursorTooltips.js"}}
 
+## Image tooltips
+
+You can also include images within tooltips in cases where you wish to show an enlarged 
+version.
+
+{{"demo": "pages/components/tooltips/ImageTooltips.js"}}
+
 ## Virtual element
 
 In the event you need to implement a custom placement, you can use the `anchorEl` prop:


### PR DESCRIPTION
Add a demo to tooltips to demonstrate that you can use images within tooltips as it is not obvious or stated elsewhere that you can.
I discovered this myself when I was just mucking around and wondering if it was even possible, and low and behold it was.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://deploy-preview-24766--material-ui.netlify.app/components/tooltips/#image-tooltips