### PR TITLE
[system] Use spacing unit in gap, row-gap, and column-gap

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -272,11 +272,27 @@ const classes = makeStyles(theme => ({
 
 ### System
 
-- The following system functions (and properties) were renamed, because they are considered deprecated CSS:
+- The following system functions (and properties) were renamed because they are considered deprecated CSS:
 
-1. `gridGap` to `gap`
-2. `gridColumnGap` to `columnGap`
-3. `gridRowGap` to `rowGap`
+  1. `gridGap` to `gap`
+  1. `gridRowGap` to `rowGap`
+  1. `gridColumnGap` to `columnGap`
+
+- Use spacing unit in `gap`, `rowGap`, and `columnGap`. If you were using a number previously, you need to mention the px to bypass the new transformation with `theme.spacing`.
+
+  ```diff
+  <Box
+  - gap={2}
+  + gap="2px"
+  >
+  ```
+
+- Replace `css` prop with `sx` to avoid collision with styled-components & emotion CSS props.
+
+```diff
+-<Box css={{ color: 'primary.main' }} />
++<Box sx={{ color: 'primary.main' }} />
+```
 
 ### Core components
 
@@ -1250,12 +1266,3 @@ As the core components use emotion as a styled engine, the props used by emotion
     },
   });
   ```
-
-### System
-
-- Replace `css` prop with `sx` to avoid collision with styled-components & emotion CSS props.
-
-```diff
--<Box css={{ color: 'primary.main' }} />
-+<Box sx={{ color: 'primary.main' }} />
-```

--- a/docs/src/pages/system/grid/Gap.js
+++ b/docs/src/pages/system/grid/Gap.js
@@ -31,7 +31,7 @@ export default function Gap() {
       <Box
         sx={{
           display: 'grid',
-          gap: '8px',
+          gap: 1,
           gridTemplateColumns: 'repeat(2, 0.5fr)',
         }}
       >

--- a/docs/src/pages/system/grid/Gap.tsx
+++ b/docs/src/pages/system/grid/Gap.tsx
@@ -26,7 +26,7 @@ export default function Gap() {
       <Box
         sx={{
           display: 'grid',
-          gap: '8px',
+          gap: 1,
           gridTemplateColumns: 'repeat(2, 0.5fr)',
         }}
       >

--- a/docs/src/pages/system/grid/GridAutoColumns.js
+++ b/docs/src/pages/system/grid/GridAutoColumns.js
@@ -34,7 +34,7 @@ export default function GridAutoColumns() {
           p: 1,
           height: '60px',
           gridAutoColumns: '0.2fr',
-          gap: '8px',
+          gap: 1,
         }}
       >
         <GridItem sx={{ gridRow: '1', gridColumn: '1 / 3' }}>1 / 3</GridItem>

--- a/docs/src/pages/system/grid/GridAutoColumns.tsx
+++ b/docs/src/pages/system/grid/GridAutoColumns.tsx
@@ -29,7 +29,7 @@ export default function GridAutoColumns() {
           p: 1,
           height: '60px',
           gridAutoColumns: '0.2fr',
-          gap: '8px',
+          gap: 1,
         }}
       >
         <GridItem sx={{ gridRow: '1', gridColumn: '1 / 3' }}>1 / 3</GridItem>

--- a/docs/src/pages/system/grid/GridAutoFlow.js
+++ b/docs/src/pages/system/grid/GridAutoFlow.js
@@ -34,7 +34,7 @@ export default function GridAutoFlow() {
           gridAutoFlow: 'row',
           gridTemplateColumns: 'repeat(5, 0.2fr)',
           gridTemplateRows: 'repeat(2, 50px)',
-          gap: '8px',
+          gap: 1,
         }}
       >
         <GridItem sx={{ gridColumn: '1', gridRow: '1 / 3', border: 1 }}>1</GridItem>

--- a/docs/src/pages/system/grid/GridAutoFlow.tsx
+++ b/docs/src/pages/system/grid/GridAutoFlow.tsx
@@ -29,7 +29,7 @@ export default function GridAutoFlow() {
           gridAutoFlow: 'row',
           gridTemplateColumns: 'repeat(5, 0.2fr)',
           gridTemplateRows: 'repeat(2, 50px)',
-          gap: '8px',
+          gap: 1,
         }}
       >
         <GridItem sx={{ gridColumn: '1', gridRow: '1 / 3', border: 1 }}>1</GridItem>

--- a/docs/src/pages/system/grid/GridAutoRows.js
+++ b/docs/src/pages/system/grid/GridAutoRows.js
@@ -33,7 +33,7 @@ export default function GridAutoColumns() {
           display: 'grid',
           p: 1,
           gridAutoRows: '40px',
-          gap: '8px',
+          gap: 1,
         }}
       >
         <GridItem sx={{ gridColumn: '1', gridRow: '1 / 3' }}>1 / 3</GridItem>

--- a/docs/src/pages/system/grid/GridAutoRows.tsx
+++ b/docs/src/pages/system/grid/GridAutoRows.tsx
@@ -28,7 +28,7 @@ export default function GridAutoColumns() {
           display: 'grid',
           p: 1,
           gridAutoRows: '40px',
-          gap: '8px',
+          gap: 1,
         }}
       >
         <GridItem sx={{ gridColumn: '1', gridRow: '1 / 3' }}>1 / 3</GridItem>

--- a/docs/src/pages/system/grid/GridTemplateAreas.js
+++ b/docs/src/pages/system/grid/GridTemplateAreas.js
@@ -8,7 +8,7 @@ export default function GridTemplateAreas() {
         sx={{
           display: 'grid',
           gridTemplateColumns: 'repeat(4, 80px)',
-          gap: '8px',
+          gap: 1,
           gridTemplateRows: 'auto',
           gridTemplateAreas: `"header header header header"
         "main main . sidebar"

--- a/docs/src/pages/system/grid/GridTemplateAreas.tsx
+++ b/docs/src/pages/system/grid/GridTemplateAreas.tsx
@@ -8,7 +8,7 @@ export default function GridTemplateAreas() {
         sx={{
           display: 'grid',
           gridTemplateColumns: 'repeat(4, 80px)',
-          gap: '8px',
+          gap: 1,
           gridTemplateRows: 'auto',
           gridTemplateAreas: `"header header header header"
         "main main . sidebar"

--- a/docs/src/pages/system/grid/RowAndColumnGap.js
+++ b/docs/src/pages/system/grid/RowAndColumnGap.js
@@ -31,8 +31,8 @@ export default function RowAndColumnGap() {
       <Box
         sx={{
           display: 'grid',
-          columnGap: '16px',
-          rowGap: '8px',
+          columnGap: 2,
+          rowGap: 1,
           gridTemplateColumns: 'repeat(2, 0.5fr)',
         }}
       >

--- a/docs/src/pages/system/grid/RowAndColumnGap.tsx
+++ b/docs/src/pages/system/grid/RowAndColumnGap.tsx
@@ -26,8 +26,8 @@ export default function RowAndColumnGap() {
       <Box
         sx={{
           display: 'grid',
-          columnGap: '16px',
-          rowGap: '8px',
+          columnGap: 2,
+          rowGap: 1,
           gridTemplateColumns: 'repeat(2, 0.5fr)',
         }}
       >

--- a/docs/src/pages/system/grid/grid.md
+++ b/docs/src/pages/system/grid/grid.md
@@ -52,7 +52,7 @@ The `gap: size` property specifies the gap between the different items inside th
 {{"demo": "pages/system/grid/Gap.js", "defaultCodeOpen": false, "bg": true}}
 
 ```jsx
-<Box sx={{ gap: '8px', gridTemplateColumns: 'repeat(2, 0.5fr)' }}>
+<Box sx={{ gap: 1, gridTemplateColumns: 'repeat(2, 0.5fr)' }}>
   <div>1</div>
   <div>2</div>
   <div>3</div>
@@ -67,9 +67,7 @@ The `row-gap` and `column-gap` gives the possibility for specifying the row and 
 {{"demo": "pages/system/grid/RowAndColumnGap.js", "defaultCodeOpen": false, "bg": true}}
 
 ```jsx
-<Box
-  sx={{ columnGap: '8px', rowGap: '16px', gridTemplateColumns: 'repeat(2, 0.5fr)' }}
->
+<Box sx={{ columnGap: 1, rowGap: 2, gridTemplateColumns: 'repeat(2, 0.5fr)' }}>
   <div>1</div>
   <div>2</div>
   <div>3</div>

--- a/packages/material-ui-system/src/borders.js
+++ b/packages/material-ui-system/src/borders.js
@@ -1,7 +1,7 @@
 import responsivePropType from './responsivePropType';
 import style from './style';
 import compose from './compose';
-import { createUnaryUnit, getStyleFromPropValue } from './spacing';
+import { createUnaryUnit, getValue } from './spacing';
 import { handleBreakpoints } from './breakpoints';
 
 function getBorder(value) {
@@ -47,21 +47,18 @@ export const borderColor = style({
   themeKey: 'palette',
 });
 
-function resolveCssProperty(props, prop, transformer) {
-  const cssProperties = ['borderRadius'];
-  const styleFromPropValue = getStyleFromPropValue(cssProperties, transformer);
-
-  const propValue = props[prop];
-  return handleBreakpoints(props, propValue, styleFromPropValue);
-}
-
 export const borderRadius = (props) => {
-  if (props.borderRadius) {
+  const propValue = props.borderRadius;
+
+  if (propValue) {
     const transformer = createUnaryUnit(props.theme, 'shape.borderRadius', 4, 'borderRadius');
-    return resolveCssProperty(props, 'borderRadius', transformer);
+    const styleFromPropValue = () => ({
+      borderRadius: getValue(transformer, propValue),
+    });
+    return handleBreakpoints(props, propValue, styleFromPropValue);
   }
 
-  return {};
+  return null;
 };
 
 borderRadius.propTypes =

--- a/packages/material-ui-system/src/borders.js
+++ b/packages/material-ui-system/src/borders.js
@@ -48,12 +48,6 @@ export const borderColor = style({
 });
 
 function resolveCssProperty(props, prop, transformer) {
-  // Using a hash computation over an array iteration could be faster, but with only 28 items,
-  // it isn't worth the bundle size.
-  if (prop !== 'borderRadius') {
-    return null;
-  }
-
   const cssProperties = ['borderRadius'];
   const styleFromPropValue = getStyleFromPropValue(cssProperties, transformer);
 
@@ -62,9 +56,12 @@ function resolveCssProperty(props, prop, transformer) {
 }
 
 export const borderRadius = (props) => {
-  const transformer = createUnaryUnit(props.theme, 'shape.borderRadius', 4, 'borderRadius');
+  if (props.borderRadius) {
+    const transformer = createUnaryUnit(props.theme, 'shape.borderRadius', 4, 'borderRadius');
+    return resolveCssProperty(props, 'borderRadius', transformer);
+  }
 
-  return props.borderRadius ? resolveCssProperty(props, 'borderRadius', transformer) : {};
+  return {};
 };
 
 borderRadius.propTypes =

--- a/packages/material-ui-system/src/borders.test.js
+++ b/packages/material-ui-system/src/borders.test.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import borders from './borders';
+
+describe('borders', () => {
+  it('should work', () => {
+    const output = borders({
+      theme: {},
+      borderRadius: 1,
+    });
+    expect(output).to.deep.equal({
+      borderRadius: 4,
+    });
+  });
+});

--- a/packages/material-ui-system/src/grid.js
+++ b/packages/material-ui-system/src/grid.js
@@ -1,37 +1,63 @@
 import style from './style';
 import compose from './compose';
-import { createUnaryUnit, getStyleFromPropValue } from './spacing';
+import { createUnaryUnit, getValue } from './spacing';
 import { handleBreakpoints } from './breakpoints';
 import responsivePropType from './responsivePropType';
 
-function resolveCssProperty(props, prop, transformer) {
-  const cssProperties = ['gap'];
-  const styleFromPropValue = getStyleFromPropValue(cssProperties, transformer);
-
-  const propValue = props[prop];
-  return handleBreakpoints(props, propValue, styleFromPropValue);
-}
-
 export const gap = (props) => {
-  if (props.gap) {
+  const propValue = props.gap;
+
+  if (propValue) {
     const transformer = createUnaryUnit(props.theme, 'spacing', 8, 'gap');
-    return resolveCssProperty(props, 'gap', transformer);
+    const styleFromPropValue = () => ({
+      gap: getValue(transformer, propValue),
+    });
+    return handleBreakpoints(props, propValue, styleFromPropValue);
   }
 
-  return {};
+  return null;
 };
 
 gap.propTypes = process.env.NODE_ENV !== 'production' ? { gap: responsivePropType } : {};
 
 gap.filterProps = ['gap'];
 
-export const columnGap = style({
-  prop: 'columnGap',
-});
+export const columnGap = (props) => {
+  const propValue = props.columnGap;
 
-export const rowGap = style({
-  prop: 'rowGap',
-});
+  if (propValue) {
+    const transformer = createUnaryUnit(props.theme, 'spacing', 8, 'columnGap');
+    const styleFromPropValue = () => ({
+      columnGap: getValue(transformer, propValue),
+    });
+    return handleBreakpoints(props, propValue, styleFromPropValue);
+  }
+
+  return null;
+};
+
+columnGap.propTypes =
+  process.env.NODE_ENV !== 'production' ? { columnGap: responsivePropType } : {};
+
+columnGap.filterProps = ['columnGap'];
+
+export const rowGap = (props) => {
+  const propValue = props.rowGap;
+
+  if (propValue) {
+    const transformer = createUnaryUnit(props.theme, 'spacing', 8, 'rowGap');
+    const styleFromPropValue = () => ({
+      rowGap: getValue(transformer, propValue),
+    });
+    return handleBreakpoints(props, propValue, styleFromPropValue);
+  }
+
+  return null;
+};
+
+rowGap.propTypes = process.env.NODE_ENV !== 'production' ? { rowGap: responsivePropType } : {};
+
+rowGap.filterProps = ['rowGap'];
 
 export const gridColumn = style({
   prop: 'gridColumn',

--- a/packages/material-ui-system/src/grid.js
+++ b/packages/material-ui-system/src/grid.js
@@ -21,8 +21,7 @@ export const gap = (props) => {
   return {};
 };
 
-gap.propTypes =
-  process.env.NODE_ENV !== 'production' ? { gap: responsivePropType } : {};
+gap.propTypes = process.env.NODE_ENV !== 'production' ? { gap: responsivePropType } : {};
 
 gap.filterProps = ['gap'];
 

--- a/packages/material-ui-system/src/grid.js
+++ b/packages/material-ui-system/src/grid.js
@@ -1,9 +1,30 @@
 import style from './style';
 import compose from './compose';
+import { createUnaryUnit, getStyleFromPropValue } from './spacing';
+import { handleBreakpoints } from './breakpoints';
+import responsivePropType from './responsivePropType';
 
-export const gap = style({
-  prop: 'gap',
-});
+function resolveCssProperty(props, prop, transformer) {
+  const cssProperties = ['gap'];
+  const styleFromPropValue = getStyleFromPropValue(cssProperties, transformer);
+
+  const propValue = props[prop];
+  return handleBreakpoints(props, propValue, styleFromPropValue);
+}
+
+export const gap = (props) => {
+  if (props.gap) {
+    const transformer = createUnaryUnit(props.theme, 'spacing', 8, 'gap');
+    return resolveCssProperty(props, 'gap', transformer);
+  }
+
+  return {};
+};
+
+gap.propTypes =
+  process.env.NODE_ENV !== 'production' ? { gap: responsivePropType } : {};
+
+gap.filterProps = ['gap'];
 
 export const columnGap = style({
   prop: 'columnGap',

--- a/packages/material-ui-system/src/grid.test.js
+++ b/packages/material-ui-system/src/grid.test.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import grid from './grid';
+
+describe('grid', () => {
+  it('should work', () => {
+    const output = grid({
+      theme: {},
+      gap: 1,
+    });
+    expect(output).to.deep.equal({
+      gap: 8,
+    });
+  });
+});


### PR DESCRIPTION
### Breaking changes

- [system] Use spacing unit in `gap`, `rowGap`, and `columnGap`. If you were using a number previously, you need to mention the px to bypass the new transformation with `theme.spacing`. 

  ```diff
  <Box
  - gap={2}
  + gap="2px"
  >
  ```

---

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

After the change, `<Box gap={1}>` behaves like `<Grid spacing={1}>`.

Fix #24773