### PR TITLE
[examples] Align more with the v5 recommended approach

### DIFF
--- a/docs/src/pages/getting-started/templates/album/Album.js
+++ b/docs/src/pages/getting-started/templates/album/Album.js
@@ -16,7 +16,7 @@ import Link from '@material-ui/core/Link';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/getting-started/templates/album/Album.tsx
+++ b/docs/src/pages/getting-started/templates/album/Album.tsx
@@ -16,7 +16,7 @@ import Link from '@material-ui/core/Link';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/getting-started/templates/blog/Footer.js
+++ b/docs/src/pages/getting-started/templates/blog/Footer.js
@@ -7,7 +7,7 @@ import Link from '@material-ui/core/Link';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/getting-started/templates/blog/Footer.tsx
+++ b/docs/src/pages/getting-started/templates/blog/Footer.tsx
@@ -6,7 +6,7 @@ import Link from '@material-ui/core/Link';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/getting-started/templates/checkout/Checkout.js
+++ b/docs/src/pages/getting-started/templates/checkout/Checkout.js
@@ -17,7 +17,7 @@ import Review from './Review';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/getting-started/templates/checkout/Checkout.tsx
+++ b/docs/src/pages/getting-started/templates/checkout/Checkout.tsx
@@ -17,7 +17,7 @@ import Review from './Review';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/premium-themes/paperbase/Paperbase.js
+++ b/docs/src/pages/premium-themes/paperbase/Paperbase.js
@@ -11,7 +11,7 @@ import Header from './Header';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/docs/src/pages/premium-themes/paperbase/Paperbase.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Paperbase.tsx
@@ -16,7 +16,7 @@ import Header from './Header';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -70,7 +70,7 @@ function ProTip() {
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/create-react-app-with-styled-components/src/App.js
+++ b/examples/create-react-app-with-styled-components/src/App.js
@@ -7,7 +7,7 @@ import ProTip from './ProTip';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/create-react-app-with-styled-components/src/ProTip.js
+++ b/examples/create-react-app-with-styled-components/src/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/create-react-app-with-typescript/src/App.tsx
+++ b/examples/create-react-app-with-typescript/src/App.tsx
@@ -7,7 +7,7 @@ import ProTip from './ProTip';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/create-react-app-with-typescript/src/ProTip.tsx
+++ b/examples/create-react-app-with-typescript/src/ProTip.tsx
@@ -13,7 +13,7 @@ function LightBulbIcon(props: SvgIconProps) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -7,7 +7,7 @@ import ProTip from './ProTip';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/create-react-app/src/ProTip.js
+++ b/examples/create-react-app/src/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/gatsby-theme/src/components/Copyright.js
+++ b/examples/gatsby-theme/src/components/Copyright.js
@@ -4,7 +4,7 @@ import { Link } from 'gatsby-theme-material-ui';
 
 export default function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/gatsby-theme/src/components/ProTip.js
+++ b/examples/gatsby-theme/src/components/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/gatsby/src/components/Copyright.js
+++ b/examples/gatsby/src/components/Copyright.js
@@ -4,7 +4,7 @@ import MuiLink from '@material-ui/core/Link';
 
 export default function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <MuiLink color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/gatsby/src/components/ProTip.js
+++ b/examples/gatsby/src/components/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/nextjs-with-typescript/src/Copyright.tsx
+++ b/examples/nextjs-with-typescript/src/Copyright.tsx
@@ -4,7 +4,7 @@ import MuiLink from '@material-ui/core/Link';
 
 export default function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <MuiLink color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/nextjs-with-typescript/src/ProTip.tsx
+++ b/examples/nextjs-with-typescript/src/ProTip.tsx
@@ -13,7 +13,7 @@ function LightBulbIcon(props: SvgIconProps) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/nextjs/src/Copyright.js
+++ b/examples/nextjs/src/Copyright.js
@@ -4,7 +4,7 @@ import MuiLink from '@material-ui/core/Link';
 
 export default function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <MuiLink color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/nextjs/src/ProTip.js
+++ b/examples/nextjs/src/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/preact/src/Copyright.js
+++ b/examples/preact/src/Copyright.js
@@ -4,7 +4,7 @@ import MuiLink from '@material-ui/core/Link';
 
 export default function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <MuiLink color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/preact/src/ProTip.js
+++ b/examples/preact/src/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the

--- a/examples/ssr/App.js
+++ b/examples/ssr/App.js
@@ -7,7 +7,7 @@ import Link from '@material-ui/core/Link';
 
 function Copyright() {
   return (
-    <Typography variant="body2" color="textSecondary" align="center">
+    <Typography variant="body2" color="text.secondary" align="center">
       {'Copyright © '}
       <Link color="inherit" href="https://material-ui.com/">
         Your Website

--- a/examples/ssr/ProTip.js
+++ b/examples/ssr/ProTip.js
@@ -13,7 +13,7 @@ function LightBulbIcon(props) {
 
 export default function ProTip() {
   return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="textSecondary">
+    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
       <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
       Pro tip: See more{' '}
       <Link href="https://material-ui.com/getting-started/templates/">templates</Link> on the


### PR DESCRIPTION
Edit by @oliviertassinari

#24496 removes the inconsistency of the value accepted by the Typography `color` prop. The changes update the examples. These examples are important as they serve as a baseline for developers learning the library.

In the future, we will need to:

- Migrate all the codebase from `color="textSecondary"` to `color="text.secondary"`
- Add a depreciation for the older API along the lifecycle of v5 stable
- Consider providing a codemod for making the migration
- Agree on when to use the flat props over the `sx`. So far, we have added the flat props because of the strong demand from developers. However, we haven't yet agreed on a standard.