### PR TITLE
[Autocomplete]: prevent warning for empty string value

### DIFF
--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -209,7 +209,7 @@ export default function useAutocomplete(props) {
   const listboxAvailable = open && filteredOptions.length > 0;
 
   if (process.env.NODE_ENV !== 'production') {
-    if (value !== null && !freeSolo && options.length > 0) {
+    if (value !== null && value !== '' && !freeSolo && options.length > 0) {
       const missingValue = (multiple ? value : [value]).filter(
         (value2) => !options.some((option) => getOptionSelected(option, value2)),
       );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Since reacts default way of setting an empty value for an input is using an empty string, the Autocomplete component should not throw a warning in that case.