### PR TITLE
[test] Don't run dev CI for dependabot pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      # Dependabot branches are always Pull Requests.
+      # We don't need to run CI twice (push+pull_request)
+      - 'dependabot/*'
+  pull_request:
 
 jobs:
   # Tests dev-only scripts across all supported dev environments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       # Dependabot branches are always Pull Requests.
       # We don't need to run CI twice (push+pull_request)
-      - 'dependabot/*'
+      - 'dependabot/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
We're already running it for `pull_request` events.

## Test plan
- dev CI is run for `push` + `pull_request` of this branch since I deliberately pushed it to `upstream` instead of my own fork