### PR TITLE
[test] Clear emotion cache between tests

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -74,21 +74,17 @@ describe('<Avatar />', () => {
   });
 
   describe('font icon avatar', () => {
-    let container;
-    let avatar;
-    let icon;
-
-    before(() => {
-      container = render(
-        <Avatar className="my-avatar" data-my-prop="woofAvatar">
-          <span className="my-icon-font">icon</span>
-        </Avatar>,
-      ).container;
-      avatar = container.firstChild;
-      icon = avatar.firstChild;
-    });
-
     it('should render a div containing an font icon', () => {
+      const { container } = render(
+        <Avatar>
+          <span className="my-icon-font" data-testid="icon">
+            icon
+          </span>
+        </Avatar>,
+      );
+      const avatar = container.firstChild;
+      const icon = avatar.firstChild;
+
       expect(avatar).to.have.tagName('div');
       expect(icon).to.have.tagName('span');
       expect(icon).to.have.class('my-icon-font');
@@ -96,100 +92,125 @@ describe('<Avatar />', () => {
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
+      const { container } = render(
+        <Avatar className="my-avatar" data-my-prop="woofAvatar">
+          <span>icon</span>
+        </Avatar>,
+      );
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.root);
       expect(avatar).to.have.class('my-avatar');
       expect(avatar).to.have.attribute('data-my-prop', 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
+      const { container } = render(
+        <Avatar data-testid="avatar">
+          <span>icon</span>
+        </Avatar>,
+      );
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.colorDefault);
     });
   });
 
   describe('svg icon avatar', () => {
-    let container;
-    let avatar;
-
-    before(() => {
-      container = render(
-        <Avatar className="my-avatar" data-my-prop="woofAvatar">
+    it('should render a div containing an svg icon', () => {
+      const container = render(
+        <Avatar>
           <CancelIcon />
         </Avatar>,
       ).container;
-      avatar = container.firstChild;
-    });
+      const avatar = container.firstChild;
 
-    it('should render a div containing an svg icon', () => {
       expect(avatar).to.have.tagName('div');
       const cancelIcon = avatar.firstChild;
       expect(cancelIcon).to.have.attribute('data-testid', 'CancelIcon');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
+      const container = render(
+        <Avatar className="my-avatar" data-my-prop="woofAvatar">
+          <CancelIcon />
+        </Avatar>,
+      ).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.root);
       expect(avatar).to.have.class('my-avatar');
       expect(avatar).to.have.attribute('data-my-prop', 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
+      const container = render(
+        <Avatar>
+          <CancelIcon />
+        </Avatar>,
+      ).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.colorDefault);
     });
   });
 
   describe('text avatar', () => {
-    let container;
-    let avatar;
-
-    before(() => {
-      container = render(
-        <Avatar className="my-avatar" data-my-prop="woofAvatar">
-          OT
-        </Avatar>,
-      ).container;
-      avatar = container.firstChild;
-    });
-
     it('should render a div containing a string', () => {
+      const container = render(<Avatar>OT</Avatar>).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.tagName('div');
       expect(avatar.firstChild).to.text('OT');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
+      const container = render(
+        <Avatar className="my-avatar" data-my-prop="woofAvatar">
+          OT
+        </Avatar>,
+      ).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.root);
       expect(avatar).to.have.class('my-avatar');
       expect(avatar).to.have.attribute('data-my-prop', 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
+      const container = render(<Avatar>OT</Avatar>).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.colorDefault);
     });
   });
 
   describe('falsey avatar', () => {
-    let container;
-    let avatar;
-
-    before(() => {
-      container = render(
-        <Avatar className="my-avatar" data-my-prop="woofAvatar">
-          {0}
-        </Avatar>,
-      ).container;
-      avatar = container.firstChild;
-    });
-
     it('should render with defaultColor class when supplied with a child with falsey value', () => {
+      const container = render(<Avatar>{0}</Avatar>).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.tagName('div');
       expect(avatar.firstChild).to.text('0');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
+      const container = render(
+        <Avatar className="my-avatar" data-my-prop="woofAvatar">
+          {0}
+        </Avatar>,
+      ).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.root);
       expect(avatar).to.have.class('my-avatar');
       expect(avatar).to.have.attribute('data-my-prop', 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
+      const container = render(<Avatar>{0}</Avatar>).container;
+      const avatar = container.firstChild;
+
       expect(avatar).to.have.class(classes.colorDefault);
     });
   });

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -18,88 +18,71 @@ describe('<Ripple />', () => {
   });
 
   describe('starting and stopping', () => {
-    let wrapper;
-
-    before(() => {
-      wrapper = render(
+    it('should start the ripple', () => {
+      const { container, setProps } = render(
         <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} />,
       );
-    });
 
-    it('should start the ripple', () => {
-      wrapper.setProps({ in: true });
-      const ripple = wrapper.container.querySelector('span');
+      setProps({ in: true });
+
+      const ripple = container.querySelector('span');
       expect(ripple).to.have.class(classes.rippleVisible);
     });
 
     it('should stop the ripple', () => {
-      wrapper.setProps({ in: true });
-      wrapper.setProps({ in: false });
-      const child = wrapper.container.querySelector('span > span');
+      const { container, setProps } = render(
+        <Ripple classes={classes} in timeout={0} rippleX={0} rippleY={0} rippleSize={11} />,
+      );
+
+      setProps({ in: false });
+
+      const child = container.querySelector('span > span');
       expect(child).to.have.class(classes.childLeaving);
     });
   });
 
   describe('pulsating and stopping 1', () => {
-    let wrapper;
-
-    before(() => {
-      wrapper = render(
-        <Ripple
-          classes={classes}
-          timeout={0}
-          in={false}
-          rippleX={0}
-          rippleY={0}
-          rippleSize={11}
-          pulsate
-        />,
-      );
-    });
-
     it('should render the ripple inside a pulsating Ripple', () => {
-      const ripple = wrapper.container.querySelector('span');
+      const { container } = render(
+        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} pulsate />,
+      );
+
+      const ripple = container.querySelector('span');
       expect(ripple).to.have.class(classes.ripple);
       expect(ripple).to.have.class(classes.ripplePulsate);
-      const child = wrapper.container.querySelector('span > span');
+      const child = container.querySelector('span > span');
       expect(child).to.have.class(classes.childPulsate);
     });
 
     it('should start the ripple', () => {
-      wrapper.setProps({ in: true });
-      const ripple = wrapper.container.querySelector('span');
+      const { container, setProps } = render(
+        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} pulsate />,
+      );
+
+      setProps({ in: true });
+
+      const ripple = container.querySelector('span');
       expect(ripple).to.have.class(classes.rippleVisible);
-      const child = wrapper.container.querySelector('span > span');
+      const child = container.querySelector('span > span');
       expect(child).to.have.class(classes.childPulsate);
     });
 
     it('should stop the ripple', () => {
-      wrapper.setProps({ in: true });
-      wrapper.setProps({ in: false });
-      const child = wrapper.container.querySelector('span > span');
+      const { container, setProps } = render(
+        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} pulsate />,
+      );
+
+      setProps({ in: true });
+      setProps({ in: false });
+      const child = container.querySelector('span > span');
       expect(child).to.have.class(classes.childLeaving);
     });
   });
 
   describe('pulsating and stopping 2', () => {
-    let wrapper;
     let clock;
-    let callbackSpy;
 
     beforeEach(() => {
-      callbackSpy = spy();
-      wrapper = render(
-        <Ripple
-          classes={classes}
-          timeout={550}
-          in
-          onExited={callbackSpy}
-          rippleX={0}
-          rippleY={0}
-          rippleSize={11}
-          pulsate
-        />,
-      );
       clock = useFakeTimers();
     });
 
@@ -108,18 +91,46 @@ describe('<Ripple />', () => {
     });
 
     it('handleExit should trigger a timer', () => {
-      wrapper.setProps({ in: false });
+      const handleExited = spy();
+      const { setProps } = render(
+        <Ripple
+          classes={classes}
+          timeout={550}
+          in
+          onExited={handleExited}
+          rippleX={0}
+          rippleY={0}
+          rippleSize={11}
+          pulsate
+        />,
+      );
+
+      setProps({ in: false });
       clock.tick(549);
-      expect(callbackSpy.callCount).to.equal(0);
+      expect(handleExited.callCount).to.equal(0);
       clock.tick(1);
-      expect(callbackSpy.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(1);
     });
 
     it('unmount should defuse the handleExit timer', () => {
-      wrapper.setProps({ in: false });
-      wrapper.unmount();
+      const handleExited = spy();
+      const { setProps, unmount } = render(
+        <Ripple
+          classes={classes}
+          timeout={550}
+          in
+          onExited={handleExited}
+          rippleX={0}
+          rippleY={0}
+          rippleSize={11}
+          pulsate
+        />,
+      );
+
+      setProps({ in: false });
+      unmount();
       clock.tick(550);
-      expect(callbackSpy.callCount).to.equal(0);
+      expect(handleExited.callCount).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
WARNING: We no longer allow `render` in `before` or `beforeEach` hooks. It was always problematic since it lead to bloated tests or tests that could not be run in isolation.

Emotion caches the created rules i.e. retains `<style>` elements after unmounting. While I would generally consider this leaky behavior, they haven't seen any reports that this affects performance so it seems ok to do in a browser: https://github.com/emotion-js/emotion/issues/488.

However, in a test we generally want each test to be as isolated as possible and specifically for JSDOM we want to keep the number of CSS rules in the DOM as low as possible since `getComputedStyles` iterates over each rule.

Did two runs of `CI=true yarn test:unit` in `next` and this PR. `next` clocked in at **125s and 131s** while this PR clocked in at **105s** for both runs. It's more noticeable the more tests using emotion are executed hence why tests like the ones for Tooltip (that are already expensive) got even slower until they started to time out. 

This may help in speeding up CircleCI if the recent slowdown is an instance where we just hit a breakpoint where we starve all resources.