### PR TITLE
[docs] Fix formatting of `mask` prop description

### DIFF
--- a/docs/translations/api-docs/date-picker/date-picker.json
+++ b/docs/translations/api-docs/date-picker/date-picker.json
@@ -15,7 +15,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "okText": "Ok button text.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
     "onChange": "Callback fired when the value (the selected date) changes. @DateIOType.",

--- a/docs/translations/api-docs/desktop-date-picker/desktop-date-picker.json
+++ b/docs/translations/api-docs/desktop-date-picker/desktop-date-picker.json
@@ -11,7 +11,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
     "onChange": "Callback fired when the value (the selected date) changes. @DateIOType.",
     "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",

--- a/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
+++ b/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
@@ -16,7 +16,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "minutesStep": "Step over minutes.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
     "onChange": "Callback fired when the value (the selected date) changes. @DateIOType.",

--- a/docs/translations/api-docs/mobile-date-picker/mobile-date-picker.json
+++ b/docs/translations/api-docs/mobile-date-picker/mobile-date-picker.json
@@ -15,7 +15,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "okText": "Ok button text.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
     "onChange": "Callback fired when the value (the selected date) changes. @DateIOType.",

--- a/docs/translations/api-docs/mobile-time-picker/mobile-time-picker.json
+++ b/docs/translations/api-docs/mobile-time-picker/mobile-time-picker.json
@@ -20,7 +20,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "minutesStep": "Step over minutes.",
     "okText": "Ok button text.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",

--- a/docs/translations/api-docs/static-date-picker/static-date-picker.json
+++ b/docs/translations/api-docs/static-date-picker/static-date-picker.json
@@ -12,7 +12,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
     "onChange": "Callback fired when the value (the selected date) changes. @DateIOType.",
     "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",

--- a/docs/translations/api-docs/static-time-picker/static-time-picker.json
+++ b/docs/translations/api-docs/static-time-picker/static-time-picker.json
@@ -17,7 +17,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "minutesStep": "Step over minutes.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
     "onChange": "Callback fired when the value (the selected date) changes. @DateIOType.",

--- a/docs/translations/api-docs/time-picker/time-picker.json
+++ b/docs/translations/api-docs/time-picker/time-picker.json
@@ -21,7 +21,7 @@
     "getOpenDialogAriaText": "Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType",
     "InputAdornmentProps": "Props to pass to keyboard input adornment.",
     "inputFormat": "Format string.",
-    "mask": "Custom mask. Can be used to override generate from format. (e.g. <strong>/</strong>/<strong>__ __:</strong> or <strong>/</strong>/<strong>__ __:</strong> _M).",
+    "mask": "Custom mask. Can be used to override generate from format. (e.g. <code>__/__/____ __:__</code> or <code>__/__/____ __:__ _M</code>).",
     "minutesStep": "Step over minutes.",
     "okText": "Ok button text.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -179,7 +179,7 @@ DatePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -188,7 +188,7 @@ DateRangePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -334,7 +334,7 @@ DateTimePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -100,7 +100,7 @@ DesktopDatePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -166,7 +166,7 @@ DesktopDateRangePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -187,7 +187,7 @@ DesktopDateTimePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -122,7 +122,7 @@ DesktopTimePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -119,7 +119,7 @@ MobileDatePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -182,7 +182,7 @@ MobileDateRangePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -206,7 +206,7 @@ MobileDateTimePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -141,7 +141,7 @@ MobileTimePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -105,7 +105,7 @@ StaticDatePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -168,7 +168,7 @@ StaticDateRangePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -192,7 +192,7 @@ StaticDateTimePicker.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -127,7 +127,7 @@ StaticTimePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -218,7 +218,7 @@ TimePicker.propTypes = {
    */
   label: PropTypes.node,
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask: PropTypes.string,
   /**

--- a/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
@@ -41,7 +41,7 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = unknown
    */
   openPickerIcon?: React.ReactNode;
   /**
-   * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M).
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
    */
   mask?: string;
   /**


### PR DESCRIPTION
The wording seems non-sensical to me at the moment. But I'm not bothering with it for now until we have an actual demo.
Revealed in https://github.com/mui-org/material-ui/pull/24835

[current `next`](https://6021ded8b2baf900070b63de--material-ui.netlify.app/api/desktop-date-picker/#:~:text=Can%20be%20used%20to%20override%20generate%20from%20format.%20(e.g.%20//__%20__:%20or%20//__%20__:%20_M).) vs [this PR](http://deploy-preview-24842--material-ui.netlify.app/api/desktop-date-picker)