### PR TITLE
[core] save/restore actual  yarn cache folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,7 @@ commands:
             - v1-playwright-
       - run:
           name: Install js dependencies
-          # Sync with `v3-yarn-sha-` save_cache
-          command: yarn install --cache-folder ${YARN_CACHE_FOLDER}
+          command: yarn install --cache-folder ${YARN_CACHE_FOLDER} --verbose
 
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ defaults: &defaults
     # expose it globally otherwise we have to thread it from each job to the install command
     REACT_DIST_TAG: << parameters.react-dist-tag >>
     TEST_GATE: << parameters.test-gate >>
-    YARN_CACHE_FOLDER: ~/.cache/yarn
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:10
@@ -53,12 +52,13 @@ commands:
             git --no-pager diff HEAD
       - restore_cache:
           keys:
-            - v5-yarn-sha-{{ checksum "yarn.lock" }}
-            - v5-yarn-sha-
+            - v6-yarn-sha-{{ checksum "yarn.lock" }}
+            - v6-yarn-sha-
       - run:
           name: Set yarn cache folder
           command: |
-            yarn config set cache-folder $YARN_CACHE_FOLDER
+            # Keep path in sync with `save_cache` for key "v6-yarn-sha-"
+            yarn config set cache-folder ~/.cache/yarn
             # Debug information
             yarn cache dir
             yarn cache list
@@ -88,9 +88,11 @@ jobs:
           paths:
             - ~/.cache/ms-playwright
       - save_cache:
-          key: v5-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v6-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
-            - $YARN_CACHE_FOLDER
+          # Keep path in sync with "Set yarn cache folder"
+          # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+            - ~/.cache/yarn
   test_unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,12 @@ commands:
             git --no-pager diff HEAD
       - restore_cache:
           keys:
-            - v4-yarn-sha-{{ checksum "yarn.lock" }}
-            - v4-yarn-sha-
+            - v5-yarn-sha-{{ checksum "yarn.lock" }}
+            - v5-yarn-sha-
       - run:
           name: Set yarn cache folder
           command: |
-            yarn config set cache-folder ~/.cache/yarn
+            yarn config set cache-folder $YARN_CACHE_FOLDER
             # Debug information
             yarn cache dir
             yarn cache list
@@ -88,9 +88,9 @@ jobs:
           paths:
             - ~/.cache/ms-playwright
       - save_cache:
-          key: v4-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v5-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
+            - $YARN_CACHE_FOLDER
   test_unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,15 @@ commands:
             git --no-pager diff HEAD
       - restore_cache:
           keys:
-            - v3-yarn-sha-{{ checksum "yarn.lock" }}
-            - v3-yarn-sha-
+            - v4-yarn-sha-{{ checksum "yarn.lock" }}
+            - v4-yarn-sha-
+      - run:
+          name: Set yarn cache folder
+          command: |
+            yarn config set cache-folder ~/.cache/yarn
+            # Debug information
+            yarn cache dir
+            yarn cache list
       - restore_cache:
           keys:
             - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
@@ -62,7 +69,7 @@ commands:
             - v1-playwright-
       - run:
           name: Install js dependencies
-          command: yarn install --cache-folder ~/.cache/yarn --verbose
+          command: yarn install --verbose
 
 jobs:
   checkout:
@@ -81,7 +88,7 @@ jobs:
           paths:
             - ~/.cache/ms-playwright
       - save_cache:
-          key: v3-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v4-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
   test_unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ defaults: &defaults
     # expose it globally otherwise we have to thread it from each job to the install command
     REACT_DIST_TAG: << parameters.react-dist-tag >>
     TEST_GATE: << parameters.test-gate >>
+    YARN_CACHE_FOLDER: ~/.cache/yarn
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:10
@@ -52,8 +53,8 @@ commands:
             git --no-pager diff HEAD
       - restore_cache:
           keys:
-            - v2-yarn-sha-{{ checksum "yarn.lock" }}
-            - v2-yarn-sha-
+            - v3-yarn-sha-{{ checksum "yarn.lock" }}
+            - v3-yarn-sha-
       - restore_cache:
           keys:
             - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
@@ -61,7 +62,8 @@ commands:
             - v1-playwright-
       - run:
           name: Install js dependencies
-          command: yarn
+          # Sync with `v3-yarn-sha-` save_cache
+          command: yarn install --cache-folder ${YARN_CACHE_FOLDER}
 
 jobs:
   checkout:
@@ -80,9 +82,9 @@ jobs:
           paths:
             - ~/.cache/ms-playwright
       - save_cache:
-          key: v2-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v3-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn/v4
+            - ${YARN_CACHE_FOLDER}
   test_unit:
     <<: *defaults
     steps:
@@ -247,7 +249,7 @@ jobs:
             # without --no-bail we only see at most a single failing package
             yarn typescript --no-bail
             exit 0
-      
+
       - restore_cache:
           name: Restore generated declaration files
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
             - v1-playwright-
       - run:
           name: Install js dependencies
-          command: yarn install --cache-folder ${YARN_CACHE_FOLDER} --verbose
+          command: yarn install --cache-folder ~/.cache/yarn --verbose
 
 jobs:
   checkout:
@@ -83,7 +83,7 @@ jobs:
       - save_cache:
           key: v3-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
-            - ${YARN_CACHE_FOLDER}
+            - ~/.cache/yarn
   test_unit:
     <<: *defaults
     steps:


### PR DESCRIPTION
Started inspecting `yarn cache dir` in https://github.com/mui-org/material-ui/pull/24843 and it [turns out it's `~/.yarn/cache/v6`](https://app.circleci.com/pipelines/github/mui-org/material-ui/37807/workflows/a4d5e213-08d2-4459-834b-1e57a19a6789/jobs/223338/parallel-runs/0/steps/0-111) while we're saving and restoring `~/.yarn/cache/v4`.

We're now explicitly restoring and saving the same folder we pass to `yarn install --cache-folder` following the [documented example for "Caching dependencies" in CircleCI](https://circleci.com/docs/2.0/caching/#yarn-node).

Cleared the existing cache explicitly to have a clean slate.

install with the old workflow: https://circleci.com/api/v1.1/project/github/mui-org/material-ui/223338/output/107/0?file=true&allocation-id=6022615d6e280926e352902f-0-build%2FFABE096 
install on this PR (notice how we no longer perform all the GET requests and "[2/4] Fetching packages..." finishes immediately): https://circleci.com/api/v1.1/project/github/mui-org/material-ui/223363/output/107/0?file=true&allocation-id=60226b5e6e280926e352a474-0-build%2FB505EC5

Follow-up: 
- [ ] `~` points to `/root` in `test_browser`
   Figure out why the playwright docker image changes `~`