### PR TITLE
[Pickers] Fix useState related console warnings in examples

### DIFF
--- a/docs/src/pages/components/date-picker/CustomDay.js
+++ b/docs/src/pages/components/date-picker/CustomDay.js
@@ -32,15 +32,15 @@ const useStyles = makeStyles((theme) => ({
 
 export default function CustomDay() {
   const classes = useStyles();
-  const [selectedDate, handleDateChange] = React.useState(new Date());
+  const [value, setValue] = React.useState(new Date());
 
   const renderWeekPickerDay = (date, _selectedDates, PickersDayComponentProps) => {
-    if (!selectedDate) {
+    if (!value) {
       return <PickersDay {...PickersDayComponentProps} />;
     }
 
-    const start = startOfWeek(selectedDate);
-    const end = endOfWeek(selectedDate);
+    const start = startOfWeek(value);
+    const end = endOfWeek(value);
 
     const dayIsBetween = isWithinInterval(date, { start, end });
     const isFirstDay = isSameDay(date, start);
@@ -63,8 +63,10 @@ export default function CustomDay() {
     <LocalizaitonProvider dateAdapter={AdapterDateFns}>
       <DatePicker
         label="Week picker"
-        value={selectedDate}
-        onChange={handleDateChange}
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
         renderDay={renderWeekPickerDay}
         renderInput={(params) => <TextField {...params} />}
         inputFormat="'Week of' MMM d"

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -32,19 +32,19 @@ const useStyles = makeStyles((theme) => ({
 
 export default function CustomDay() {
   const classes = useStyles();
-  const [selectedDate, handleDateChange] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Date | null>(new Date());
 
   const renderWeekPickerDay = (
     date: Date,
     _selectedDates: Date[],
     PickersDayComponentProps: PickersDayProps<Date>,
   ) => {
-    if (!selectedDate) {
+    if (!value) {
       return <PickersDay {...PickersDayComponentProps} />;
     }
 
-    const start = startOfWeek(selectedDate);
-    const end = endOfWeek(selectedDate);
+    const start = startOfWeek(value);
+    const end = endOfWeek(value);
 
     const dayIsBetween = isWithinInterval(date, { start, end });
     const isFirstDay = isSameDay(date, start);
@@ -67,8 +67,10 @@ export default function CustomDay() {
     <LocalizaitonProvider dateAdapter={AdapterDateFns}>
       <DatePicker
         label="Week picker"
-        value={selectedDate}
-        onChange={handleDateChange}
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
         renderDay={renderWeekPickerDay as any}
         renderInput={(params) => <TextField {...params} />}
         inputFormat="'Week of' MMM d"

--- a/docs/src/pages/components/date-time-picker/BasicDateTimePicker.js
+++ b/docs/src/pages/components/date-time-picker/BasicDateTimePicker.js
@@ -5,15 +5,17 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateTimePicker from '@material-ui/lab/DateTimePicker';
 
 export default function BasicDateTimePicker() {
-  const [selectedDate, handleDateChange] = React.useState(new Date());
+  const [value, setValue] = React.useState(new Date());
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DateTimePicker
         renderInput={(props) => <TextField {...props} />}
         label="DateTimePicker"
-        value={selectedDate}
-        onChange={handleDateChange}
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-time-picker/BasicDateTimePicker.tsx
+++ b/docs/src/pages/components/date-time-picker/BasicDateTimePicker.tsx
@@ -14,7 +14,7 @@ export default function BasicDateTimePicker() {
         label="DateTimePicker"
         value={value}
         onChange={(newValue) => {
-          setValue(newValue)
+          setValue(newValue);
         }}
       />
     </LocalizationProvider>

--- a/docs/src/pages/components/date-time-picker/BasicDateTimePicker.tsx
+++ b/docs/src/pages/components/date-time-picker/BasicDateTimePicker.tsx
@@ -5,15 +5,17 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateTimePicker from '@material-ui/lab/DateTimePicker';
 
 export default function BasicDateTimePicker() {
-  const [selectedDate, handleDateChange] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Date | null>(new Date());
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DateTimePicker
         renderInput={(props) => <TextField {...props} />}
         label="DateTimePicker"
-        value={selectedDate}
-        onChange={handleDateChange}
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue)
+        }}
       />
     </LocalizationProvider>
   );


### PR DESCRIPTION
Fixed onChange handlers for DatePiker examples mentioned in #24169

Closes #24169
