### PR TITLE
[test] Increase timeout to 4000ms for screenshots

### DIFF
--- a/test/regressions/.mocharc.js
+++ b/test/regressions/.mocharc.js
@@ -1,5 +1,6 @@
 module.exports = {
   recursive: true,
+  timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
   require: [require.resolve('@babel/register')],
 };


### PR DESCRIPTION
Take into account flaky cases like https://app.circleci.com/pipelines/github/mui-org/material-ui/37825/workflows/31dd01a6-6f4f-4c73-86ce-f28e6292730f/jobs/223444. 

I have seen this one a couple of times. I think that we can assume that the main value of the timeout here is to 1. help debug when we forget the done() call 2. avoid making ridiculously slow async tasks.