### PR TITLE
[docs] Add read synonym to drafts

### DIFF
--- a/docs/src/pages/components/material-icons/synonyms.js
+++ b/docs/src/pages/components/material-icons/synonyms.js
@@ -206,7 +206,7 @@ const synonyms = {
   DonutLarge: 'chart circle complete graph inprogress,',
   DonutSmall: 'chart circle',
   DoubleArrow: 'chevron right',
-  Drafts: 'email envelope letter',
+  Drafts: 'email envelope letter read',
   DragHandle: 'lines',
   DragIndicator: 'circle dots drop move shape shift',
   DriveEta: 'car transport vehicle',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When you search "unread" in icons you find a closed envelope (Markunread), but when you search "read" you don't find its opposite e.g. an open envelope.
This additional synonym will fix this behaviour by adding the read synonym to its counterpart, the open envelope. 