### PR TITLE
[test] Increase BrowserStack timeout to 6min

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function setKarmaConfig(config) {
     browsers: ['chromeHeadless'],
     browserDisconnectTimeout: 120000, // default 2000
     browserDisconnectTolerance: 1, // default 0
-    browserNoActivityTimeout: 300000, // default 10000
+    browserNoActivityTimeout: 6 * 60 * 1000, // default 10000
     colors: true,
     client: {
       mocha: {


### PR DESCRIPTION
A follow-up on #24801, add 60s to the current timeout value (5min). I hope it's just enough to avoid the timeout to trigger in most of the cases:

<img width="894" alt="Capture d’écran 2021-02-11 à 11 56 48" src="https://user-images.githubusercontent.com/3165635/107627975-4a0da300-6c60-11eb-8ece-425fafa49972.png">

An example of a build failing: https://app.circleci.com/jobs/github/mui-org/material-ui/223286?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

It could be interesting to look at why Firefox is a lot slower.