### PR TITLE
[test] Initial workspace definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "packages/*",
     "docs",
     "docs/packages/*",
-    "framer"
+    "framer",
+    "test"
   ]
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "test",
+  "version": "0.0.1",
+  "scripts": {
+    "typescript": "tsc -p tsconfig.json"
+  }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,4 +1,3 @@
-/* Only used to enable the language server */
 {
   "extends": "../tsconfig.json",
   "include": ["regressions/**/*", "utils/**/*"],


### PR DESCRIPTION
First version only has a dedicated task for type-checking utils. Over time we'll consolidate dependencies to make it clearer what utils you should import from where (e.g. `fireEvent` from `@testing-library/react` or `test/utils`?).