### PR TITLE
[core] Support /r/issue-template back

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -17,6 +17,7 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /r/caveat-with-refs-guide /guides/composition/#caveat-with-refs 302
 /r/pseudo-classes-guide /customization/components/#pseudo-classes 302
 /r/input-component-ref-interface /components/text-fields/#integration-with-3rd-party-input-libraries 302
+/r/issue-template https://codesandbox.io/s/material-ui-issue-dh2yh
 /r/issue-template-next https://codesandbox.io/s/material-ui-issue-dh2yh
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-931qt
 /r/ts-issue-template https://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEMhhYowZABsAtHOCdhlMnToE5o-MAii4AESwgIACgBKVnYuHgBNeSghCBUsDSA 302


### PR DESCRIPTION
The URL was changed to support v4 and v5 at the same time, this a requirement for mui-org/material-ui-x. It's not something we need to worry about much in this repository.

In https://github.com/mui-org/material-ui/issues/21801#issuecomment-778042700, I have noticed that some of our templates/habits haven't been updated. I have personally been sharing a number of 404 links too in the past. Now, considering that we will also need to change the templates and habits once we move to v5 stable, I propose that we aim to use the HEAD version */r/issue-template* as much as possible. I will update my saved replies if approved.