### PR TITLE
[test] Dedupe missing act warnings by component name

### DIFF
--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -87,9 +87,10 @@ function createUnexpectedConsoleMessagesHooks(Mocha, methodName, expectedMatcher
   });
 
   mochaHooks.afterEach.push(function flushUnexpectedCalls() {
-    const hadUnexpectedCalls = unexpectedCalls.length > 0;
+    const unexpectedCallCount = unexpectedCalls.length;
     const formattedCalls = unexpectedCalls.map(
-      ([stack, message]) => `console.${methodName} message:\n  ${message}\n\nStack:\n${stack}`,
+      ([stack, message], index) =>
+        `console.${methodName} message #${index + 1}:\n  ${message}\n\nStack:\n${stack}`,
     );
     unexpectedCalls.length = 0;
 
@@ -97,13 +98,13 @@ function createUnexpectedConsoleMessagesHooks(Mocha, methodName, expectedMatcher
     if (console[methodName] !== logUnexpectedConsoleCalls) {
       throw new Error(`Did not tear down spy or stub of console.${methodName} in your test.`);
     }
-    if (hadUnexpectedCalls) {
+    if (unexpectedCallCount > 0) {
       // In karma `file` is `null`.
       // We still have the stacktrace though
       // @ts-expect-error -- this.currentTest being undefined would be a bug
       const location = this.currentTest.file ?? '(unknown file)';
       const message =
-        `Expected test not to call console.${methodName}()\n\n` +
+        `Expected test not to call console.${methodName}() but instead received ${unexpectedCallCount} calls.\n\n` +
         'If the warning is expected, test for it explicitly by ' +
         // Don't add any punctuation after the location.
         // Otherwise it's not clickable in IDEs

--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -120,12 +120,12 @@ function createUnexpectedConsoleMessagesHooks(Mocha, methodName, expectedMatcher
 
   mochaHooks.afterEach.push(function flushUnexpectedCalls() {
     const actionableCalls = dedupeActWarningsByComponent(unexpectedCalls);
-    unexpectedCalls.length = 0;
     const actionableCallCount = actionableCalls.length;
     const formattedCalls = actionableCalls.map(
       ([stack, message], index) =>
         `console.${methodName} message #${index + 1}:\n  ${message}\n\nStack:\n${stack}`,
     );
+    unexpectedCalls.length = 0;
 
     // eslint-disable-next-line no-console
     if (console[methodName] !== logUnexpectedConsoleCalls) {

--- a/test/utils/mochaHooks.test.js
+++ b/test/utils/mochaHooks.test.js
@@ -1,0 +1,46 @@
+import * as Mocha from 'mocha';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { createMochaHooks } from './mochaHooks';
+
+describe('mochaHooks', () => {
+  // one block per hook.
+  describe('afterEach', () => {
+    describe('throws on unexpected console.(warn|error) in afterEach', function suite() {
+      const mochaHooks = createMochaHooks(Mocha);
+
+      beforeEach(function beforeEachHook() {
+        mochaHooks.beforeAll.forEach((beforeAllMochaHook) => {
+          beforeAllMochaHook.call(this);
+        });
+        mochaHooks.beforeEach.forEach((beforeEachMochaHook) => {
+          beforeEachMochaHook.call(this);
+        });
+      });
+
+      it('', () => {
+        console.warn('unexpected warning');
+        console.error('unexpected error');
+      });
+
+      afterEach(function afterEachHook() {
+        const errorStub = stub(this.test, 'error');
+        mochaHooks.afterEach.forEach((afterEachMochaHook) => {
+          afterEachMochaHook.call(this);
+        });
+
+        expect(errorStub.callCount).to.equal(2);
+        expect(String(errorStub.firstCall.args[0])).to.include(
+          'console.warn message:\n  unexpected warning\n\nStack:',
+        );
+        expect(String(errorStub.secondCall.args[0])).to.include(
+          'console.error message:\n  unexpected error\n\nStack:',
+        );
+
+        mochaHooks.afterAll.forEach((afterAllMochaHook) => {
+          afterAllMochaHook.call(this);
+        });
+      });
+    });
+  });
+});

--- a/test/utils/mochaHooks.test.js
+++ b/test/utils/mochaHooks.test.js
@@ -28,13 +28,16 @@ describe('mochaHooks', () => {
         mochaHooks.afterEach.forEach((afterEachMochaHook) => {
           afterEachMochaHook.call(this);
         });
+        mochaHooks.afterAll.forEach((afterAllMochaHook) => {
+          afterAllMochaHook.call(this);
+        });
 
         expect(errorStub.callCount).to.equal(2);
         expect(String(errorStub.firstCall.args[0])).to.include(
-          'console.warn message:\n  unexpected warning\n\nStack:',
+          'console.warn message #1:\n  unexpected warning\n\nStack:',
         );
         expect(String(errorStub.secondCall.args[0])).to.include(
-          'console.error message:\n  unexpected error\n\nStack:',
+          'console.error message #1:\n  unexpected error\n\nStack:',
         );
 
         mochaHooks.afterAll.forEach((afterAllMochaHook) => {

--- a/test/utils/mochaHooks.test.js
+++ b/test/utils/mochaHooks.test.js
@@ -93,14 +93,12 @@ describe('mochaHooks', () => {
         expect(
           error.match(/An update to Parent inside a test was not wrapped in act/g),
         ).to.have.lengthOf(1);
-        // StrictMode renders twice
         expect(
           error.match(/An update to Parent ran an effect, but was not wrapped in act/g),
-        ).to.have.lengthOf(4);
-        // StrictMode renders twice
+        ).to.have.lengthOf(1);
         expect(
           error.match(/An update to Child ran an effect, but was not wrapped in act/g),
-        ).to.have.lengthOf(4);
+        ).to.have.lengthOf(1);
       });
     });
   });


### PR DESCRIPTION
Adds an experimental poylfill for https://github.com/facebook/react/issues/19416. Experimental in the sense of "let's see if deduping this hides important information".

TL;DR; of https://github.com/facebook/react/issues/19416: We get closer to "one warning per action required".

Summary of  https://github.com/facebook/react/issues/19416:
When we get the warning for "missing act" we usually just want to find out which expression we have to wrap in act(). In that case we only need the stack once. Right now we get a warning per effect which is redundant.

Ideally we would dedupe them by update but I suspect this will get a lot harder with timers. Deduping consecutive of a single component name is a good enough heuristic for now. It would produce a single warning if we get two unrelated but consecutive updates to a single component but this seems better than getting flooded with one warning per effect.

Changes in this PR:

1. Add tests for unexpected console calls (JSDOM only)
1. Add a counter to the unexpected messages 
   Otherwise messages might get mixed up
1. Dedupe "An update to %s ran an effect, but was not wrapped in act" by component name
   Implementation: [`64f755e` (#24871)](https://github.com/mui-org/material-ui/pull/24871/commits/64f755eb5c7420f5ac8acdb7d6d14565ef60314c)