### PR TITLE
[test] Enable type-unaware versions of disabled typed-aware lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,12 +89,15 @@ module.exports = {
     // Destructuring harm grep potential.
     'prefer-destructuring': 'off',
 
-    // TODO performance consideration
+    // disabled type-aware linting due to performance considerations
     '@typescript-eslint/dot-notation': 'off',
-    // TODO performance consideration
+    'dot-notation': 'error',
+    // disabled type-aware linting due to performance considerations
     '@typescript-eslint/no-implied-eval': 'off',
-    // TODO performance consideration
+    'no-implied-eval': 'error',
+    // disabled type-aware linting due to performance considerations
     '@typescript-eslint/no-throw-literal': 'off',
+    'no-throw-literal': 'error',
 
     // Not sure why it doesn't work
     'import/named': 'off',

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Paper.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Paper.js
@@ -11,13 +11,13 @@ const backgroundStyleMapping = {
 };
 
 const styles = (theme) => ({
-  [backgroundStyleMapping['light']]: {
+  [backgroundStyleMapping.light]: {
     backgroundColor: theme.palette.secondary.light,
   },
-  [backgroundStyleMapping['main']]: {
+  [backgroundStyleMapping.main]: {
     backgroundColor: theme.palette.secondary.main,
   },
-  [backgroundStyleMapping['dark']]: {
+  [backgroundStyleMapping.dark]: {
     backgroundColor: theme.palette.secondary.dark,
   },
   padding: {

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Paper.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Paper.tsx
@@ -10,13 +10,13 @@ const backgroundStyleMapping = {
 };
 
 const styles = (theme: Theme) => ({
-  [backgroundStyleMapping['light']]: {
+  [backgroundStyleMapping.light]: {
     backgroundColor: theme.palette.secondary.light,
   },
-  [backgroundStyleMapping['main']]: {
+  [backgroundStyleMapping.main]: {
     backgroundColor: theme.palette.secondary.main,
   },
-  [backgroundStyleMapping['dark']]: {
+  [backgroundStyleMapping.dark]: {
     backgroundColor: theme.palette.secondary.dark,
   },
   padding: {

--- a/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
@@ -32,22 +32,22 @@ const styles = (theme) => ({
     },
   },
   disabled: {},
-  [inputSyleMapping['small']]: {
+  [inputSyleMapping.small]: {
     fontSize: 14,
     padding: theme.spacing(1),
     width: `calc(100% - ${theme.spacing(2)})`,
   },
-  [inputSyleMapping['medium']]: {
+  [inputSyleMapping.medium]: {
     fontSize: 16,
     padding: theme.spacing(2),
     width: `calc(100% - ${theme.spacing(4)})`,
   },
-  [inputSyleMapping['large']]: {
+  [inputSyleMapping.large]: {
     fontSize: 18,
     padding: 20,
     width: `calc(100% - ${20 * 2}px)`,
   },
-  [inputSyleMapping['xlarge']]: {
+  [inputSyleMapping.xlarge]: {
     fontSize: 20,
     padding: 25,
     width: `calc(100% - ${25 * 2}px)`,

--- a/docs/src/pages/premium-themes/onepirate/modules/components/TextField.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/TextField.tsx
@@ -35,22 +35,22 @@ const styles = (theme: any) =>
       },
     },
     disabled: {},
-    [inputSyleMapping['small']]: {
+    [inputSyleMapping.small]: {
       fontSize: 14,
       padding: theme.spacing(1),
       width: `calc(100% - ${theme.spacing(2)})`,
     },
-    [inputSyleMapping['medium']]: {
+    [inputSyleMapping.medium]: {
       fontSize: 16,
       padding: theme.spacing(2),
       width: `calc(100% - ${theme.spacing(4)})`,
     },
-    [inputSyleMapping['large']]: {
+    [inputSyleMapping.large]: {
       fontSize: 18,
       padding: 20,
       width: `calc(100% - ${20 * 2}px)`,
     },
-    [inputSyleMapping['xlarge']]: {
+    [inputSyleMapping.xlarge]: {
       fontSize: 20,
       padding: 25,
       width: `calc(100% - ${25 * 2}px)`,

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Typography.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Typography.js
@@ -31,28 +31,28 @@ const markSyleMapping = {
 };
 
 const styles = (theme) => ({
-  [markSyleMapping['center']['h2']]: {
+  [markSyleMapping.center.h2]: {
     height: 4,
     width: 73,
     display: 'block',
     margin: `${theme.spacing(1)} auto 0`,
     backgroundColor: theme.palette.secondary.main,
   },
-  [markSyleMapping['center']['h3']]: {
+  [markSyleMapping.center.h3]: {
     height: 4,
     width: 55,
     display: 'block',
     margin: `${theme.spacing(1)} auto 0`,
     backgroundColor: theme.palette.secondary.main,
   },
-  [markSyleMapping['center']['h4']]: {
+  [markSyleMapping.center.h4]: {
     height: 4,
     width: 55,
     display: 'block',
     margin: `${theme.spacing(1)} auto 0`,
     backgroundColor: theme.palette.secondary.main,
   },
-  [markSyleMapping['left']['h6']]: {
+  [markSyleMapping.left.h6]: {
     height: 2,
     width: 28,
     display: 'block',

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Typography.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Typography.tsx
@@ -38,28 +38,28 @@ const markSyleMapping: {
 
 const styles = (theme: Theme) =>
   createStyles({
-    [markSyleMapping['center']['h2']]: {
+    [markSyleMapping.center.h2]: {
       height: 4,
       width: 73,
       display: 'block',
       margin: `${theme.spacing(1)} auto 0`,
       backgroundColor: theme.palette.secondary.main,
     },
-    [markSyleMapping['center']['h3']]: {
+    [markSyleMapping.center.h3]: {
       height: 4,
       width: 55,
       display: 'block',
       margin: `${theme.spacing(1)} auto 0`,
       backgroundColor: theme.palette.secondary.main,
     },
-    [markSyleMapping['center']['h4']]: {
+    [markSyleMapping.center.h4]: {
       height: 4,
       width: 55,
       display: 'block',
       margin: `${theme.spacing(1)} auto 0`,
       backgroundColor: theme.palette.secondary.main,
     },
-    [markSyleMapping['left']['h6']]: {
+    [markSyleMapping.left.h6]: {
       height: 2,
       width: 28,
       display: 'block',

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -708,8 +708,8 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                 onMouseLeave={handleMouseLeave}
                 {...thumbProps}
                 className={clsx(utilityClasses.thumb, thumbProps.className, {
-                  [utilityClasses['active']]: active === index,
-                  [utilityClasses['focusVisible']]: focusVisible === index,
+                  [utilityClasses.active]: active === index,
+                  [utilityClasses.focusVisible]: focusVisible === index,
                 })}
                 {...(!isHostComponent(Thumb) && {
                   styleProps: { ...styleProps, ...thumbProps.styleProps },

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -455,7 +455,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   const nameOrDescProps = {};
   const titleIsString = typeof title === 'string';
   if (describeChild) {
-    nameOrDescProps['title'] = !open && titleIsString && !disableHoverListener ? title : null;
+    nameOrDescProps.title = !open && titleIsString && !disableHoverListener ? title : null;
     nameOrDescProps['aria-describedby'] = open ? id : null;
   } else {
     nameOrDescProps['aria-label'] = titleIsString ? title : null;

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -376,7 +376,7 @@ describe('<SwitchBase />', () => {
 
   describe('check transitioning between controlled states throws errors', () => {
     it('should error when uncontrolled and changed to controlled', function test() {
-      if (global['didWarnControlledToUncontrolled']) {
+      if (global.didWarnControlledToUncontrolled) {
         this.skip();
       }
 
@@ -389,7 +389,7 @@ describe('<SwitchBase />', () => {
 
       expect(() => {
         setProps({ checked: true });
-        global['didWarnControlledToUncontrolled'] = true;
+        global.didWarnControlledToUncontrolled = true;
       }).toErrorDev([
         'Warning: A component is changing an uncontrolled input of type checkbox to be controlled.',
         'Material-UI: A component is changing the uncontrolled checked state of SwitchBase to be controlled.',
@@ -397,7 +397,7 @@ describe('<SwitchBase />', () => {
     });
 
     it('should error when controlled and changed to uncontrolled', function test() {
-      if (global['didWarnControlledToUncontrolled']) {
+      if (global.didWarnControlledToUncontrolled) {
         this.skip();
       }
 
@@ -410,7 +410,7 @@ describe('<SwitchBase />', () => {
 
       expect(() => {
         setProps({ checked: undefined });
-        global['didWarnControlledToUncontrolled'] = true;
+        global.didWarnControlledToUncontrolled = true;
       }).toErrorDev([
         'Warning: A component is changing a controlled input of type checkbox to be uncontrolled.',
         'Material-UI: A component is changing the controlled checked state of SwitchBase to be uncontrolled.',


### PR DESCRIPTION
## Summary

Re-enable the following lint rules:
- `dot-notation`
- `no-implied-eval`
- `no-throw-literal`

## Context

Noticed during https://github.com/mui-org/material-ui/pull/24810 that we have disabled some type-aware lint rules for "performance considerations". I suspect this actually refers to the required type checking not because the rules themselves are slow.

If they were in fact only disabled to avoid type-ware linting, we should enable their type-unaware counterparts. The typescript-eslint repo says these versions "don't work with typescript" but it's unclear what they mean: do these versions have false-negatives or false-positives<sup>1</sup>? False positives would be fine since we don't expect linting to catch every error anyway. false-negatives would be more problematic but I haven't seen false-negatives yet.

<sup>1</sup>
false-negative: error reported that isn't one
false-positive: no error reported even though it is one