### PR TITLE
[generateProptypes] Change order of file extensions in glob pattern

### DIFF
--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -308,7 +308,7 @@ async function run(argv: HandlerArgv) {
       path.resolve(__dirname, '../packages/material-ui/src'),
       path.resolve(__dirname, '../packages/material-ui-lab/src'),
     ].map((folderPath) =>
-      glob('+([A-Z])*/+([A-Z])*.*@(d.ts|ts|tsx)', {
+      glob('+([A-Z])*/+([A-Z])*.*@(d.ts|tsx|ts)', {
         absolute: true,
         cwd: folderPath,
       }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I think having `ts` first means `tsx` isn't matched, this switches it so that `tsx` is used. I could just remove, if useful.

- ✅ I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
