### PR TITLE
[core] listChangedFiles returns an empty list with no changed files

### DIFF
--- a/scripts/listChangedFiles.js
+++ b/scripts/listChangedFiles.js
@@ -16,7 +16,11 @@ function execFile(command, args) {
 
 async function execGitCmd(args) {
   const gitResults = await execFile('git', args);
-  return gitResults.stdout.trim().toString().split('\n');
+  const stdout = gitResults.stdout.trim();
+  if (stdout === '') {
+    return [];
+  }
+  return stdout.split('\n');
 }
 
 async function listChangedFiles({ branch }) {

--- a/scripts/listChangedFiles.test.js
+++ b/scripts/listChangedFiles.test.js
@@ -9,13 +9,14 @@ const rimrafAsync = promisify(rimraf);
 
 describe('listChangedFiles', () => {
   it('should detect changes', async () => {
-    const changesBefore = await listChangedFiles({ branch: 'next' });
-    const testFile = 'someTestFile.js';
+    const changesBeforeAdd = await listChangedFiles({ branch: 'next' });
+    const testFile = 'someTestFile.yml';
     try {
       await writeFileAsync(testFile, 'console.log("hello");');
       const changesAfterAdd = await listChangedFiles({ branch: 'next' });
-      const addedFiles = Array.from(changesAfterAdd).filter((file) => !changesBefore.has(file));
-      expect(addedFiles).to.deep.equal([testFile]);
+      expect(changesBeforeAdd).not.to.contain(testFile);
+      expect(changesAfterAdd).to.contain(testFile);
+      expect(changesAfterAdd.size - changesBeforeAdd.size).to.equal(1);
     } finally {
       await rimrafAsync(testFile);
     }


### PR DESCRIPTION
Motivated by improving the test I discovered that the logic is not desireable one of the git commands returned no files. It would return `['']` instead of `[]` due to `''.split('\n')` returning `['']`.

The test isn't linear but faster since we no longer calculate the difference but derive it from 3 assertions.