### PR TITLE
[core] Remove dead code in docs:dev

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production next build --profile",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "rimraf ./node_modules/.cache/babel-loader && next dev",
+    "dev": "next dev",
     "deploy": "git push material-ui-docs next:next",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",


### PR DESCRIPTION
This line was meant to workaround https://github.com/kentcdodds/babel-plugin-preval/issues/19, a problem we do no longer have since the dependency was removed.