### PR TITLE
[test] Consolidate on a single API

### DIFF
--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -135,7 +135,7 @@ describe('<DesktopDateTimePicker />', () => {
     );
 
     expect(screen.getByLabelText('25 minutes')).to.have.class('Mui-disabled');
-    expect(screen.getByLabelText('35 minutes')).to.not.have.class('Mui-disabled');
+    expect(screen.getByLabelText('35 minutes')).not.to.have.class('Mui-disabled');
   });
 
   it('prop: minDateTime – hours is disabled by date part', () => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -132,7 +132,7 @@ describe('<TreeItem />', () => {
     expect(getByTestId('1')).to.have.attribute('aria-expanded', 'true');
     expect(getByTestId('2')).not.to.equal(null);
     fireEvent.click(getByTestId('button'));
-    expect(getByTestId('1')).to.not.have.attribute('aria-expanded');
+    expect(getByTestId('1')).not.to.have.attribute('aria-expanded');
     expect(queryByTestId('2')).to.equal(null);
   });
 
@@ -147,7 +147,7 @@ describe('<TreeItem />', () => {
       </TreeView>,
     );
 
-    expect(getByTestId('2')).to.not.have.attribute('aria-expanded');
+    expect(getByTestId('2')).not.to.have.attribute('aria-expanded');
   });
 
   it('should not call onClick when children are clicked', () => {
@@ -235,7 +235,7 @@ describe('<TreeItem />', () => {
           </TreeView>,
         );
 
-        expect(getByTestId('test')).to.not.have.attribute('aria-expanded');
+        expect(getByTestId('test')).not.to.have.attribute('aria-expanded');
       });
     });
 
@@ -270,7 +270,7 @@ describe('<TreeItem />', () => {
             </TreeView>,
           );
 
-          expect(getByTestId('test')).to.not.have.attribute('aria-selected');
+          expect(getByTestId('test')).not.to.have.attribute('aria-selected');
         });
 
         it('should have the attribute `aria-selected={true}` if selected', () => {
@@ -1071,7 +1071,7 @@ describe('<TreeItem />', () => {
             getByRole('tree').focus();
           });
 
-          expect(getByTestId('one')).to.not.have.attribute('aria-selected');
+          expect(getByTestId('one')).not.to.have.attribute('aria-selected');
 
           fireEvent.keyDown(getByRole('tree'), { key: ' ' });
 
@@ -1121,7 +1121,7 @@ describe('<TreeItem />', () => {
             </TreeView>,
           );
 
-          expect(getByTestId('one')).to.not.have.attribute('aria-selected');
+          expect(getByTestId('one')).not.to.have.attribute('aria-selected');
           fireEvent.click(getByText('one'));
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
         });

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -218,17 +218,17 @@ describe('<TreeView />', () => {
 
     const { getByTestId, getByText } = render(<MyComponent />);
 
-    expect(getByTestId('one')).to.not.have.attribute('aria-selected');
-    expect(getByTestId('two')).to.not.have.attribute('aria-selected');
+    expect(getByTestId('one')).not.to.have.attribute('aria-selected');
+    expect(getByTestId('two')).not.to.have.attribute('aria-selected');
 
     fireEvent.click(getByText('one'));
 
     expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-    expect(getByTestId('two')).to.not.have.attribute('aria-selected');
+    expect(getByTestId('two')).not.to.have.attribute('aria-selected');
 
     fireEvent.click(getByText('two'));
 
-    expect(getByTestId('one')).to.not.have.attribute('aria-selected');
+    expect(getByTestId('one')).not.to.have.attribute('aria-selected');
     expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
   });
 

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -68,7 +68,7 @@ describe('StylesProvider', () => {
     };
 
     function assertRendering(markup, sheetsRegistry) {
-      expect(markup.match('Hello World')).to.not.equal(null);
+      expect(markup.match('Hello World')).not.to.equal(null);
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.toString().length > 10).to.equal(true);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -171,7 +171,7 @@ describe('makeStyles', () => {
         classes: { root: 'bar' },
       });
       const classes2 = output.classes;
-      expect(classes1).to.not.equal(classes2);
+      expect(classes1).not.to.equal(classes2);
       expect(classes2).to.deep.equal({
         root: `${classes.root} bar`,
       });

--- a/packages/material-ui/src/Accordion/Accordion.test.js
+++ b/packages/material-ui/src/Accordion/Accordion.test.js
@@ -26,7 +26,7 @@ describe('<Accordion />', () => {
 
   it('should render and not be controlled', () => {
     const { container } = render(<Accordion>{minimalChildren}</Accordion>);
-    expect(container.firstChild).to.not.have.class(classes.expanded);
+    expect(container.firstChild).not.to.have.class(classes.expanded);
   });
 
   it('should handle defaultExpanded prop', () => {
@@ -50,7 +50,7 @@ describe('<Accordion />', () => {
     const panel = container.firstChild;
     expect(panel).to.have.class(classes.expanded);
     setProps({ expanded: false });
-    expect(panel).to.not.have.class(classes.expanded);
+    expect(panel).not.to.have.class(classes.expanded);
   });
 
   it('should call onChange when clicking the summary element', () => {

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -25,7 +25,7 @@ describe('<AppBar />', () => {
     const appBar = container.firstChild;
     expect(appBar).to.have.class(classes.root);
     expect(appBar).to.have.class(classes.colorPrimary);
-    expect(appBar).to.not.have.class(classes.colorSecondary);
+    expect(appBar).not.to.have.class(classes.colorSecondary);
   });
 
   it('should render a primary app bar', () => {
@@ -33,14 +33,14 @@ describe('<AppBar />', () => {
     const appBar = container.firstChild;
     expect(appBar).to.have.class(classes.root);
     expect(appBar).to.have.class(classes.colorPrimary);
-    expect(appBar).to.not.have.class(classes.colorSecondary);
+    expect(appBar).not.to.have.class(classes.colorSecondary);
   });
 
   it('should render an secondary app bar', () => {
     const { container } = render(<AppBar color="secondary">Hello World</AppBar>);
     const appBar = container.firstChild;
     expect(appBar).to.have.class(classes.root);
-    expect(appBar).to.not.have.class(classes.colorPrimary);
+    expect(appBar).not.to.have.class(classes.colorPrimary);
     expect(appBar).to.have.class(classes.colorSecondary);
   });
 

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -1374,8 +1374,8 @@ describe('<Autocomplete />', () => {
       const combobox = getByRole('combobox');
       const textbox = getByRole('textbox');
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      expect(combobox).to.not.have.attribute('aria-owns');
-      expect(textbox).to.not.have.attribute('aria-controls');
+      expect(combobox).not.to.have.attribute('aria-owns');
+      expect(textbox).not.to.have.attribute('aria-controls');
       expect(document.querySelector(`.${classes.paper}`)).to.have.text('No options');
     });
   });
@@ -2042,13 +2042,13 @@ describe('<Autocomplete />', () => {
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       expect(handleHighlightChange.callCount).to.equal(3);
-      expect(handleHighlightChange.args[2][0]).to.not.equal(undefined);
+      expect(handleHighlightChange.args[2][0]).not.to.equal(undefined);
       expect(handleHighlightChange.args[2][1]).to.equal(options[0]);
       expect(handleHighlightChange.args[2][2]).to.equal('keyboard');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       expect(handleHighlightChange.callCount).to.equal(4);
-      expect(handleHighlightChange.args[3][0]).to.not.equal(undefined);
+      expect(handleHighlightChange.args[3][0]).not.to.equal(undefined);
       expect(handleHighlightChange.args[3][1]).to.equal(options[1]);
       expect(handleHighlightChange.args[3][2]).to.equal('keyboard');
     });
@@ -2067,7 +2067,7 @@ describe('<Autocomplete />', () => {
       const firstOption = getAllByRole('option')[0];
       fireEvent.mouseOver(firstOption);
       expect(handleHighlightChange.callCount).to.equal(3);
-      expect(handleHighlightChange.args[2][0]).to.not.equal(undefined);
+      expect(handleHighlightChange.args[2][0]).not.to.equal(undefined);
       expect(handleHighlightChange.args[2][1]).to.equal(options[0]);
       expect(handleHighlightChange.args[2][2]).to.equal('mouse');
     });

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -40,7 +40,7 @@ describe('<Avatar />', () => {
       expect(avatar).to.have.class(classes.root);
       expect(avatar).to.have.class('my-avatar');
       expect(avatar).to.have.attribute('data-my-prop', 'woofAvatar');
-      expect(avatar).to.not.have.class(classes.colorDefault);
+      expect(avatar).not.to.have.class(classes.colorDefault);
       expect(img).to.have.class(classes.img);
       expect(img).to.have.attribute('alt', 'Hello World!');
       expect(img).to.have.attribute('src', '/fake.png');

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.test.js
@@ -64,8 +64,8 @@ describe('<AvatarGroup />', () => {
       avatarGroup.childNodes.length,
     );
     expect(avatar).to.have.class('MuiAvatar-circular');
-    expect(avatar).to.not.have.class('MuiAvatar-rounded');
-    expect(avatar).to.not.have.class('MuiAvatar-square');
+    expect(avatar).not.to.have.class('MuiAvatar-rounded');
+    expect(avatar).not.to.have.class('MuiAvatar-square');
   });
 
   it('should display all avatars with the specified variant', () => {
@@ -80,8 +80,8 @@ describe('<AvatarGroup />', () => {
       avatarGroup.childNodes.length,
     );
     expect(avatar).to.have.class('MuiAvatar-square');
-    expect(avatar).to.not.have.class('MuiAvatar-circular');
-    expect(avatar).to.not.have.class('MuiAvatar-rounded');
+    expect(avatar).not.to.have.class('MuiAvatar-circular');
+    expect(avatar).not.to.have.class('MuiAvatar-rounded');
   });
 
   it("should respect child's avatar variant prop if specified", () => {
@@ -93,7 +93,7 @@ describe('<AvatarGroup />', () => {
     const avatarGroup = container.firstChild;
     const roundedAvatar = avatarGroup.firstChild;
     expect(roundedAvatar).to.have.class('MuiAvatar-rounded');
-    expect(roundedAvatar).to.not.have.class('MuiAvatar-circular');
-    expect(roundedAvatar).to.not.have.class('MuiAvatar-square');
+    expect(roundedAvatar).not.to.have.class('MuiAvatar-circular');
+    expect(roundedAvatar).not.to.have.class('MuiAvatar-square');
   });
 });

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -76,12 +76,12 @@ describe('<Badge />', () => {
   describe('prop: invisible', () => {
     it('should default to false', () => {
       const { container } = render(<Badge {...defaultProps} />);
-      expect(findBadge(container)).to.not.have.class(classes.invisible);
+      expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
 
     it('should render without the invisible class when set to false', () => {
       const { container } = render(<Badge {...defaultProps} invisible={false} />);
-      expect(findBadge(container)).to.not.have.class(classes.invisible);
+      expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
 
     it('should render with the invisible class when set to true', () => {
@@ -97,7 +97,7 @@ describe('<Badge />', () => {
       expect(findBadge(container)).to.have.class(classes.invisible);
       container = render(<Badge {...defaultProps} badgeContent={undefined} variant="dot" />)
         .container;
-      expect(findBadge(container)).to.not.have.class(classes.invisible);
+      expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
   });
 
@@ -109,12 +109,12 @@ describe('<Badge />', () => {
 
     it('should render without the invisible class when false and badgeContent is not 0', () => {
       const { container } = render(<Badge {...defaultProps} showZero />);
-      expect(findBadge(container)).to.not.have.class(classes.invisible);
+      expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
 
     it('should render without the invisible class when true and badgeContent is 0', () => {
       const { container } = render(<Badge {...defaultProps} badgeContent={0} showZero />);
-      expect(findBadge(container)).to.not.have.class(classes.invisible);
+      expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
 
     it('should render with the invisible class when false and badgeContent is 0', () => {
@@ -127,13 +127,13 @@ describe('<Badge />', () => {
     it('should default to standard', () => {
       const { container } = render(<Badge {...defaultProps} />);
       expect(findBadge(container)).to.have.class(classes.badge);
-      expect(findBadge(container)).to.not.have.class(classes.dot);
+      expect(findBadge(container)).not.to.have.class(classes.dot);
     });
 
     it('should render with the standard class when variant="standard"', () => {
       const { container } = render(<Badge {...defaultProps} variant="standard" />);
       expect(findBadge(container)).to.have.class(classes.badge);
-      expect(findBadge(container)).to.not.have.class(classes.dot);
+      expect(findBadge(container)).not.to.have.class(classes.dot);
     });
 
     it('should not render badgeContent when variant="dot"', () => {

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -47,7 +47,7 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
-    expect(getBottomNavigation(container).childNodes[0]).to.not.have.class(actionClasses.selected);
+    expect(getBottomNavigation(container).childNodes[0]).not.to.have.class(actionClasses.selected);
     expect(getBottomNavigation(container).childNodes[1]).to.have.class(actionClasses.selected);
   });
 
@@ -58,7 +58,7 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} showLabel={false} data-testid="withoutLabel" />
       </BottomNavigation>,
     );
-    expect(getByTestId('withLabel')).to.not.have.class(actionClasses.iconOnly);
+    expect(getByTestId('withLabel')).not.to.have.class(actionClasses.iconOnly);
     expect(getByTestId('withoutLabel')).to.have.class(actionClasses.iconOnly);
   });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -66,7 +66,7 @@ describe('<ButtonBase />', () => {
 
     it('should not apply role="button" if type="button"', () => {
       const { getByText } = render(<ButtonBase type="button">Hello</ButtonBase>);
-      expect(getByText('Hello')).to.not.have.attribute('role');
+      expect(getByText('Hello')).not.to.have.attribute('role');
     });
 
     it('should change the button type to span and set role="button"', () => {
@@ -74,7 +74,7 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       expect(button).to.have.property('nodeName', 'SPAN');
-      expect(button).to.not.have.attribute('type');
+      expect(button).not.to.have.attribute('type');
     });
 
     it('should automatically change the button to an anchor element when href is provided', () => {
@@ -444,7 +444,7 @@ describe('<ButtonBase />', () => {
       }));
       fireEvent.mouseDown(getByRole('button'), { clientX: 10, clientY: 10 });
       const rippleRipple = container.querySelector('.touch-ripple-ripple');
-      expect(rippleRipple).to.not.equal(null);
+      expect(rippleRipple).not.to.equal(null);
       // @ts-ignore
       const rippleSyle = window.getComputedStyle(rippleRipple);
       expect(rippleSyle).to.have.property('height', '101px');
@@ -469,11 +469,11 @@ describe('<ButtonBase />', () => {
       }));
       fireEvent.mouseDown(getByRole('button'), { clientX: 10, clientY: 10 });
       const rippleRipple = container.querySelector('.touch-ripple-ripple');
-      expect(rippleRipple).to.not.equal(null);
+      expect(rippleRipple).not.to.equal(null);
       // @ts-ignore
       const rippleSyle = window.getComputedStyle(rippleRipple);
-      expect(rippleSyle).to.not.have.property('height', '101px');
-      expect(rippleSyle).to.not.have.property('width', '101px');
+      expect(rippleSyle).not.to.have.property('height', '101px');
+      expect(rippleSyle).not.to.have.property('width', '101px');
     });
   });
 

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -34,8 +34,8 @@ describe('<ButtonGroup />', () => {
     );
     const buttonGroup = container.firstChild;
     expect(buttonGroup).to.have.class(classes.root);
-    expect(buttonGroup).to.not.have.class(classes.contained);
-    expect(buttonGroup).to.not.have.class(classes.fullWidth);
+    expect(buttonGroup).not.to.have.class(classes.contained);
+    expect(buttonGroup).not.to.have.class(classes.fullWidth);
   });
 
   it('should render an outlined button', () => {
@@ -49,7 +49,7 @@ describe('<ButtonGroup />', () => {
     expect(button).to.have.class(classes.grouped);
     expect(button).to.have.class(classes.groupedOutlined);
     expect(button).to.have.class(classes.groupedOutlinedPrimary);
-    expect(button).to.not.have.class(classes.groupedOutlinedSecondary);
+    expect(button).not.to.have.class(classes.groupedOutlinedSecondary);
   });
 
   it('can render an outlined primary button', () => {
@@ -63,7 +63,7 @@ describe('<ButtonGroup />', () => {
     expect(button).to.have.class(classes.grouped);
     expect(button).to.have.class(classes.groupedOutlined);
     expect(button).to.have.class(classes.groupedOutlinedPrimary);
-    expect(button).to.not.have.class(classes.groupedOutlinedSecondary);
+    expect(button).not.to.have.class(classes.groupedOutlinedSecondary);
   });
 
   it('can render a contained button', () => {
@@ -77,7 +77,7 @@ describe('<ButtonGroup />', () => {
     expect(button).to.have.class(classes.grouped);
     expect(button).to.have.class(classes.groupedContained);
     expect(button).to.have.class(classes.groupedContainedPrimary);
-    expect(button).to.not.have.class(classes.groupedContainedSecondary);
+    expect(button).not.to.have.class(classes.groupedContainedSecondary);
   });
 
   it('can render a small button', () => {
@@ -106,7 +106,7 @@ describe('<ButtonGroup />', () => {
         <Button TouchRippleProps={{ classes: { root: 'touchRipple' } }}>Hello World</Button>
       </ButtonGroup>,
     );
-    expect(container.querySelector('.touchRipple')).to.not.equal(null);
+    expect(container.querySelector('.touchRipple')).not.to.equal(null);
   });
 
   it('can disable the elevation', () => {
@@ -136,8 +136,8 @@ describe('<ButtonGroup />', () => {
     );
     const button = getByRole('button');
     const buttonGroup = container.firstChild;
-    expect(buttonGroup).to.not.have.class(classes.fullWidth);
-    expect(button).to.not.have.class('MuiButton-fullWidth');
+    expect(buttonGroup).not.to.have.class(classes.fullWidth);
+    expect(button).not.to.have.class('MuiButton-fullWidth');
   });
 
   it('can pass fullWidth to Button', () => {

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -56,7 +56,7 @@ describe('<CardMedia />', () => {
         </CardMedia>,
       );
       const cardMedia = container.firstChild;
-      expect(cardMedia).to.not.have.attribute('src');
+      expect(cardMedia).not.to.have.attribute('src');
     });
 
     it('should not have default inline style when media component specified', () => {
@@ -68,7 +68,7 @@ describe('<CardMedia />', () => {
     it('should not have `src` prop if not media component specified', () => {
       const { container } = render(<CardMedia image="/fake.png" component="table" />);
       const cardMedia = container.firstChild;
-      expect(cardMedia).to.not.have.attribute('src');
+      expect(cardMedia).not.to.have.attribute('src');
     });
   });
 

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -79,7 +79,7 @@ describe('<CircularProgress />', () => {
       expect(circularProgress).to.have.class(classes.root);
       const svg = circularProgress.firstChild;
       expect(svg).to.have.tagName('svg');
-      expect(svg).to.not.have.class(
+      expect(svg).not.to.have.class(
         classes.svgIndeterminate,
         'should not have the svgIndeterminate class',
       );
@@ -111,7 +111,7 @@ describe('<CircularProgress />', () => {
       const svg = circularProgress.firstChild;
       const circle = svg.firstChild;
       expect(circle).to.have.tagName('circle');
-      expect(circle).to.not.have.class(classes.circleDisableShrink);
+      expect(circle).not.to.have.class(classes.circleDisableShrink);
     });
 
     it('should render without disableShrink class when set to false', () => {
@@ -123,7 +123,7 @@ describe('<CircularProgress />', () => {
       const svg = circularProgress.firstChild;
       const circle = svg.firstChild;
       expect(circle).to.have.tagName('circle');
-      expect(circle).to.not.have.class(classes.circleDisableShrink);
+      expect(circle).not.to.have.class(classes.circleDisableShrink);
     });
 
     it('should render with disableShrink class when set to true', () => {

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -89,8 +89,8 @@ describe('<Divider />', () => {
   describe('prop: variant', () => {
     it('should default to variant="fullWidth"', () => {
       const { container } = render(<Divider />);
-      expect(container.firstChild).to.not.have.class(classes.inset);
-      expect(container.firstChild).to.not.have.class(classes.middle);
+      expect(container.firstChild).not.to.have.class(classes.inset);
+      expect(container.firstChild).not.to.have.class(classes.middle);
     });
 
     describe('prop: variant="fullWidth" ', () => {
@@ -118,7 +118,7 @@ describe('<Divider />', () => {
   describe('role', () => {
     it('avoids adding implicit aria semantics', () => {
       const { container } = render(<Divider />);
-      expect(container.firstChild).to.not.have.attribute('role');
+      expect(container.firstChild).not.to.have.attribute('role');
     });
 
     it('adds a proper role if none is specified', () => {

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -25,6 +25,6 @@ describe('<FormGroup />', () => {
       </FormGroup>,
     );
 
-    expect(queryByTestId('test-children')).to.not.equal(null);
+    expect(queryByTestId('test-children')).not.to.equal(null);
   });
 });

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -51,7 +51,7 @@ describe('<HiddenCss />', () => {
       const root = container.firstChild;
 
       expect(root).to.have.tagName('div');
-      Object.keys(classes).forEach((className) => expect(root).to.not.have.class(className));
+      Object.keys(classes).forEach((className) => expect(root).not.to.have.class(className));
     });
 
     it('should be ok with mdDown', () => {
@@ -104,7 +104,7 @@ describe('<HiddenCss />', () => {
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
-      expect(queryByText('foo')).to.not.equal(null);
+      expect(queryByText('foo')).not.to.equal(null);
     });
 
     it('should work when Element', () => {
@@ -117,7 +117,7 @@ describe('<HiddenCss />', () => {
 
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
-      expect(queryByTestId('test-child')).to.not.equal(null);
+      expect(queryByTestId('test-child')).not.to.equal(null);
     });
 
     it('should work when mixed ChildrenArray', () => {
@@ -134,7 +134,7 @@ describe('<HiddenCss />', () => {
       expect(root).to.have.tagName('div');
       expect(root).to.have.class(classes.mdUp);
       expect(children.length).to.equal(2);
-      expect(queryByText('foo')).to.not.equal(null);
+      expect(queryByText('foo')).not.to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/Hidden/HiddenJs.test.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.test.js
@@ -54,7 +54,7 @@ describe('<HiddenJs />', () => {
         );
 
         expect(container.firstChild).to.have.tagName('div');
-        expect(queryByText('foo')).to.not.equal(null);
+        expect(queryByText('foo')).not.to.equal(null);
       });
     });
   }

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -72,7 +72,7 @@ describe('<Icon />', () => {
         </Icon>,
       );
 
-      expect(getByTestId('root')).to.not.have.class('material-icons');
+      expect(getByTestId('root')).not.to.have.class('material-icons');
     });
 
     it('should render with the supplied base class', () => {

--- a/packages/material-ui/src/ImageListItem/ImageListItem.test.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.test.js
@@ -105,7 +105,7 @@ describe('<ImageListItem />', () => {
         </ImageListItem>,
       );
 
-      expect(getByTestId('test-children')).to.not.have.class(classes.img);
+      expect(getByTestId('test-children')).not.to.have.class(classes.img);
     });
   });
 });

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -32,7 +32,7 @@ describe('<Link />', () => {
   it('should render children', () => {
     const { queryByText } = render(<Link href="/">Home</Link>);
 
-    expect(queryByText('Home')).to.not.equal(null);
+    expect(queryByText('Home')).not.to.equal(null);
   });
 
   it('should pass props to the <Typography> component', () => {
@@ -73,7 +73,7 @@ describe('<Link />', () => {
       const { container } = render(<Link href="/">Home</Link>);
       const anchor = container.querySelector('a');
 
-      expect(anchor).to.not.have.class(classes.focusVisible);
+      expect(anchor).not.to.have.class(classes.focusVisible);
 
       focusVisible(anchor);
 
@@ -83,7 +83,7 @@ describe('<Link />', () => {
         anchor.blur();
       });
 
-      expect(anchor).to.not.have.class(classes.focusVisible);
+      expect(anchor).not.to.have.class(classes.focusVisible);
     });
   });
 });

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -42,7 +42,7 @@ describe('<ListSubheader />', () => {
     it('should not display sticky class', () => {
       const { container } = render(<ListSubheader disableSticky />);
 
-      expect(container.firstChild).to.not.have.class(classes.sticky);
+      expect(container.firstChild).not.to.have.class(classes.sticky);
     });
   });
 
@@ -50,7 +50,7 @@ describe('<ListSubheader />', () => {
     it('should not display gutters class', () => {
       const { container } = render(<ListSubheader disableGutters />);
 
-      expect(container.firstChild).to.not.have.class(classes.gutters);
+      expect(container.firstChild).not.to.have.class(classes.gutters);
     });
 
     it('should display gutters class', () => {

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -158,7 +158,7 @@ describe('<Menu />', () => {
     const popover = wrapper.find(Popover);
     expect(popover.props().open).to.equal(true);
     const menuEl = document.querySelector('[role="menu"]');
-    expect(document.activeElement).to.not.equal(menuEl);
+    expect(document.activeElement).not.to.equal(menuEl);
     expect(false).to.equal(menuEl.contains(document.activeElement));
   });
 

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -68,15 +68,15 @@ describe('<MobileStepper />', () => {
   it('should render the back button', () => {
     const { queryByTestId, getByRole } = render(<MobileStepper {...defaultProps} />);
     const backButton = getByRole('button', { name: 'back' });
-    expect(backButton).to.not.equal(null);
-    expect(queryByTestId('KeyboardArrowLeftIcon')).to.not.equal(null);
+    expect(backButton).not.to.equal(null);
+    expect(queryByTestId('KeyboardArrowLeftIcon')).not.to.equal(null);
   });
 
   it('should render next button', () => {
     const { getByRole, queryByTestId } = render(<MobileStepper {...defaultProps} />);
     const nextButton = getByRole('button', { name: 'next' });
-    expect(nextButton).to.not.equal(null);
-    expect(queryByTestId('KeyboardArrowRightIcon')).to.not.equal(null);
+    expect(nextButton).not.to.equal(null);
+    expect(queryByTestId('KeyboardArrowRightIcon')).not.to.equal(null);
   });
 
   it('should render two buttons and text displaying progress when supplied with variant text', () => {
@@ -108,7 +108,7 @@ describe('<MobileStepper />', () => {
 
   it('should render a <LinearProgress /> when supplied with variant progress', () => {
     render(<MobileStepper {...defaultProps} variant="progress" />);
-    expect(screen.queryByRole('progressbar')).to.not.equal(null);
+    expect(screen.queryByRole('progressbar')).not.to.equal(null);
   });
 
   it('should calculate the <LinearProgress /> value correctly', () => {

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -31,7 +31,7 @@ describe('<NoSsr />', () => {
           <span id="client-only" />
         </NoSsr>,
       );
-      expect(document.querySelector('#client-only')).to.not.equal(null);
+      expect(document.querySelector('#client-only')).not.to.equal(null);
     });
   });
 
@@ -61,7 +61,7 @@ describe('<NoSsr />', () => {
           <span id="client-only">Hello</span>
         </NoSsr>,
       );
-      expect(document.querySelector('#client-only')).to.not.equal(null);
+      expect(document.querySelector('#client-only')).not.to.equal(null);
     });
   });
 });

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -610,7 +610,7 @@ describe('<Popover />', () => {
         left: element.style.left,
         transformOrigin: element.style.transformOrigin,
       };
-      expect(JSON.stringify(beforeStyle)).to.not.equal(JSON.stringify(afterStyle));
+      expect(JSON.stringify(beforeStyle)).not.to.equal(JSON.stringify(afterStyle));
     });
 
     it('should not recalculate position if the popover is closed', () => {
@@ -653,7 +653,7 @@ describe('<Popover />', () => {
         left: element.style.left,
         transformOrigin: element.style.transformOrigin,
       };
-      expect(JSON.stringify(beforeStyle)).to.not.equal(JSON.stringify(afterStyle));
+      expect(JSON.stringify(beforeStyle)).not.to.equal(JSON.stringify(afterStyle));
     });
   });
 

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -257,7 +257,7 @@ describe('<Popper />', () => {
         <Popper {...defaultProps} disablePortal popperRef={popperRef} />,
       );
       // renders
-      expect(getByRole('tooltip')).to.not.equal(null);
+      expect(getByRole('tooltip')).not.to.equal(null);
       // correctly sets modifiers
       expect(popperRef.current.state.options.modifiers[0].options.altBoundary).to.equal(true);
     });
@@ -266,7 +266,7 @@ describe('<Popper />', () => {
       const popperRef = React.createRef();
       const { getByRole } = render(<Popper {...defaultProps} popperRef={popperRef} />);
       // renders
-      expect(getByRole('tooltip')).to.not.equal(null);
+      expect(getByRole('tooltip')).not.to.equal(null);
       // correctly sets modifiers
       expect(popperRef.current.state.options.modifiers[0].options.altBoundary).to.equal(false);
     });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -474,7 +474,7 @@ describe('<Select />', () => {
       const { getByRole } = render(<Select value="" />);
 
       // TODO what is the accessible name actually?
-      expect(getByRole('button')).to.not.have.attribute('aria-labelledby');
+      expect(getByRole('button')).not.to.have.attribute('aria-labelledby');
     });
 
     it('is labelled by itself when it has a name', () => {

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -167,7 +167,7 @@ describe('<Slide />', () => {
       });
 
       const transition2 = child.style.transform;
-      expect(transition1).to.not.equal(transition2);
+      expect(transition1).not.to.equal(transition2);
     });
   });
 
@@ -429,7 +429,7 @@ describe('<Slide />', () => {
       const transition = childRef.current;
 
       expect(transition.style.visibility).to.equal('hidden');
-      expect(transition.style.transform).to.not.equal(undefined);
+      expect(transition.style.transform).not.to.equal(undefined);
     });
   });
 
@@ -455,7 +455,7 @@ describe('<Slide />', () => {
       clock.tick(166);
       const child = container.querySelector('#testChild');
 
-      expect(child.style.transform).to.not.equal(undefined);
+      expect(child.style.transform).not.to.equal(undefined);
     });
 
     it('should take existing transform into account', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -479,7 +479,7 @@ describe('<Slider />', () => {
     it('should render the disabled classes', () => {
       const { container, getByRole } = render(<Slider disabled value={0} />);
       expect(container.firstChild).to.have.class(classes.disabled);
-      expect(getByRole('slider')).to.not.have.attribute('tabIndex');
+      expect(getByRole('slider')).not.to.have.attribute('tabIndex');
     });
 
     it('should not respond to drag events after becoming disabled', function test() {
@@ -509,7 +509,7 @@ describe('<Slider />', () => {
 
       setProps({ disabled: true });
       expect(thumb).not.toHaveFocus();
-      expect(thumb).to.not.have.class(classes.active);
+      expect(thumb).not.to.have.class(classes.active);
 
       fireEvent.touchMove(
         container.firstChild,
@@ -533,7 +533,7 @@ describe('<Slider />', () => {
       });
       setProps({ disabled: true });
       expect(thumb).not.toHaveFocus();
-      expect(thumb).to.not.have.class(classes.focusVisible);
+      expect(thumb).not.to.have.class(classes.focusVisible);
     });
   });
 

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -40,15 +40,15 @@ describe('<SpeedDialIcon />', () => {
   it('should render the icon with the icon class', () => {
     const { container } = render(<SpeedDialIcon />);
     expect(container.querySelector('svg')).to.have.class(classes.icon);
-    expect(container.querySelector('svg')).to.not.have.class(classes.iconOpen);
-    expect(container.querySelector('svg')).to.not.have.class(classes.iconWithOpenIconOpen);
+    expect(container.querySelector('svg')).not.to.have.class(classes.iconOpen);
+    expect(container.querySelector('svg')).not.to.have.class(classes.iconWithOpenIconOpen);
   });
 
   it('should render the icon with the icon and iconOpen classes', () => {
     const { container } = render(<SpeedDialIcon open />);
     expect(container.querySelector('svg')).to.have.class(classes.icon);
     expect(container.querySelector('svg')).to.have.class(classes.iconOpen);
-    expect(container.querySelector('svg')).to.not.have.class(classes.iconWithOpenIconOpen);
+    expect(container.querySelector('svg')).not.to.have.class(classes.iconWithOpenIconOpen);
   });
 
   it('should render the icon with the icon, iconOpen iconWithOpenIconOpen classes', () => {
@@ -61,7 +61,7 @@ describe('<SpeedDialIcon />', () => {
   it('should render the openIcon with the openIcon class', () => {
     const { container } = render(<SpeedDialIcon openIcon={icon} />);
     expect(container.firstChild.querySelector('span')).to.have.class(classes.openIcon);
-    expect(container.firstChild.querySelector('span')).to.not.have.class(classes.openIconOpen);
+    expect(container.firstChild.querySelector('span')).not.to.have.class(classes.openIconOpen);
   });
 
   it('should render the openIcon with the openIcon, openIconOpen classes', () => {

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -28,8 +28,8 @@ describe('<StepConnector />', () => {
 
       const stepConnector = container.querySelector(`.${classes.root}`);
       const span = stepConnector.querySelector('span');
-      expect(stepConnector).to.not.equal(null);
-      expect(span).to.not.equal(null);
+      expect(stepConnector).not.to.equal(null);
+      expect(span).not.to.equal(null);
     });
 
     it('has the class when horizontal', () => {

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -44,8 +44,8 @@ describe('<StepContent />', () => {
     const collapse = container.querySelector(`.${collapseClasses.root}`);
     const innerDiv = container.querySelector(`.test-content`);
 
-    expect(collapse).to.not.equal(null);
-    expect(innerDiv).to.not.equal(null);
+    expect(collapse).not.to.equal(null);
+    expect(innerDiv).not.to.equal(null);
     getByText('This is my content!');
   });
 
@@ -62,7 +62,7 @@ describe('<StepContent />', () => {
       );
 
       const collapse = container.querySelector(`.${collapseClasses.root}`);
-      expect(collapse).to.not.equal(null);
+      expect(collapse).not.to.equal(null);
     });
 
     it('should use custom TransitionComponent', () => {

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -62,8 +62,8 @@ describe('<StepLabel />', () => {
       const label = container.querySelector(`.${classes.label}`);
 
       getByTestId('custom-icon');
-      expect(icon).to.not.equal(null);
-      expect(icon).to.not.have.attribute('data-testid').equal('CheckCircleIcon');
+      expect(icon).not.to.equal(null);
+      expect(icon).not.to.have.attribute('data-testid').equal('CheckCircleIcon');
       expect(label).to.have.class(classes.active);
       expect(label).to.have.class(classes.completed);
     });
@@ -113,7 +113,7 @@ describe('<StepLabel />', () => {
       );
 
       const typography = container.querySelector(`.${typographyClasses.root}`);
-      expect(typography).to.not.have.class(classes.active);
+      expect(typography).not.to.have.class(classes.active);
     });
   });
 

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -62,18 +62,18 @@ describe('<Stepper />', () => {
       const steps = container.querySelectorAll(`.${stepClasses.root}`);
       const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
 
-      expect(steps[0]).to.not.have.class(stepClasses.completed);
-      expect(steps[1]).to.not.have.class(stepClasses.completed);
-      expect(steps[2]).to.not.have.class(stepClasses.completed);
+      expect(steps[0]).not.to.have.class(stepClasses.completed);
+      expect(steps[1]).not.to.have.class(stepClasses.completed);
+      expect(steps[2]).not.to.have.class(stepClasses.completed);
       expect(connectors[0]).to.have.class(stepConnectorClasses.disabled);
       expect(connectors[1]).to.have.class(stepConnectorClasses.disabled);
 
       setProps({ activeStep: 1 });
 
       expect(steps[0]).to.have.class(stepClasses.completed);
-      expect(steps[1]).to.not.have.class(stepClasses.completed);
-      expect(steps[2]).to.not.have.class(stepClasses.completed);
-      expect(connectors[0]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(steps[1]).not.to.have.class(stepClasses.completed);
+      expect(steps[2]).not.to.have.class(stepClasses.completed);
+      expect(connectors[0]).not.to.have.class(stepConnectorClasses.disabled);
       expect(connectors[0]).to.have.class(stepConnectorClasses.active);
       expect(connectors[1]).to.have.class(stepConnectorClasses.disabled);
     });
@@ -90,28 +90,28 @@ describe('<Stepper />', () => {
       const steps = container.querySelectorAll(`.${stepClasses.root}`);
       const connectors = container.querySelectorAll(`.${stepConnectorClasses.root}`);
 
-      expect(steps[0]).to.not.have.class(stepClasses.completed);
-      expect(steps[1]).to.not.have.class(stepClasses.completed);
-      expect(steps[2]).to.not.have.class(stepClasses.completed);
+      expect(steps[0]).not.to.have.class(stepClasses.completed);
+      expect(steps[1]).not.to.have.class(stepClasses.completed);
+      expect(steps[2]).not.to.have.class(stepClasses.completed);
       expect(connectors[0]).not.to.have.class(stepConnectorClasses.disabled);
       expect(connectors[1]).not.to.have.class(stepConnectorClasses.disabled);
 
       setProps({ activeStep: 1 });
 
-      expect(steps[0]).to.not.have.class(stepClasses.completed);
-      expect(steps[1]).to.not.have.class(stepClasses.completed);
-      expect(steps[2]).to.not.have.class(stepClasses.completed);
-      expect(connectors[0]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(steps[0]).not.to.have.class(stepClasses.completed);
+      expect(steps[1]).not.to.have.class(stepClasses.completed);
+      expect(steps[2]).not.to.have.class(stepClasses.completed);
+      expect(connectors[0]).not.to.have.class(stepConnectorClasses.disabled);
       expect(connectors[0]).to.have.class(stepConnectorClasses.active);
       expect(connectors[1]).not.to.have.class(stepConnectorClasses.disabled);
 
       setProps({ activeStep: 2 });
 
-      expect(steps[0]).to.not.have.class(stepClasses.completed);
-      expect(steps[1]).to.not.have.class(stepClasses.completed);
-      expect(steps[2]).to.not.have.class(stepClasses.completed);
-      expect(connectors[0]).to.not.have.class(stepConnectorClasses.disabled);
-      expect(connectors[1]).to.not.have.class(stepConnectorClasses.disabled);
+      expect(steps[0]).not.to.have.class(stepClasses.completed);
+      expect(steps[1]).not.to.have.class(stepClasses.completed);
+      expect(steps[2]).not.to.have.class(stepClasses.completed);
+      expect(connectors[0]).not.to.have.class(stepConnectorClasses.disabled);
+      expect(connectors[1]).not.to.have.class(stepConnectorClasses.disabled);
       expect(connectors[1]).to.have.class(stepConnectorClasses.active);
     });
 
@@ -219,7 +219,7 @@ describe('<Stepper />', () => {
 
       expect(connectors).to.have.length(2);
       expect(connectors[0]).to.have.class(stepConnectorClasses.active);
-      expect(connectors[0]).to.not.have.class(stepConnectorClasses.completed);
+      expect(connectors[0]).not.to.have.class(stepConnectorClasses.completed);
 
       expect(connectors[1]).to.have.class(stepConnectorClasses.active);
       expect(connectors[1]).to.have.class(stepConnectorClasses.completed);
@@ -250,9 +250,9 @@ describe('<Stepper />', () => {
 
     const steps = container.querySelectorAll(`.${stepClasses.root}`);
 
-    expect(steps[0]).to.not.have.class(stepClasses.active);
-    expect(steps[1]).to.not.have.class(stepClasses.active);
-    expect(steps[2]).to.not.have.class(stepClasses.active);
+    expect(steps[0]).not.to.have.class(stepClasses.active);
+    expect(steps[1]).not.to.have.class(stepClasses.active);
+    expect(steps[2]).not.to.have.class(stepClasses.active);
   });
 
   it('should hide the last connector', () => {
@@ -273,7 +273,7 @@ describe('<Stepper />', () => {
 
     const stepContent = container.querySelectorAll(`.${stepContentClasses.root}`);
 
-    expect(stepContent[0]).to.not.have.class(stepContentClasses.last);
+    expect(stepContent[0]).not.to.have.class(stepContentClasses.last);
     expect(stepContent[1]).to.have.class(stepContentClasses.last);
   });
 });

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -41,7 +41,7 @@ describe('<SvgIcon />', () => {
   it('renders children by default', () => {
     const { container, queryByTestId } = render(<SvgIcon>{path}</SvgIcon>);
 
-    expect(queryByTestId('test-path')).to.not.equal(null);
+    expect(queryByTestId('test-path')).not.to.equal(null);
     expect(container.firstChild).to.have.attribute('aria-hidden', 'true');
   });
 
@@ -53,8 +53,8 @@ describe('<SvgIcon />', () => {
         </SvgIcon>,
       );
 
-      expect(queryByText('Network')).to.not.equal(null);
-      expect(container.firstChild).to.not.have.attribute('aria-hidden');
+      expect(queryByText('Network')).not.to.equal(null);
+      expect(container.firstChild).not.to.have.attribute('aria-hidden');
     });
   });
 

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -351,7 +351,7 @@ describe('<SwipeableDrawer />', () => {
             touches: [new Touch({ identifier: 0, target: swipeArea, ...params.edgeTouch })],
           });
           const drawer = screen.getByTestId('drawer');
-          expect(drawer).to.not.equal(null);
+          expect(drawer).not.to.equal(null);
 
           fireEvent.touchEnd(swipeArea, {
             changedTouches: [new Touch({ identifier: 0, target: swipeArea, ...params.edgeTouch })],
@@ -462,11 +462,11 @@ describe('<SwipeableDrawer />', () => {
       );
 
       // variant is 'temporary' by default
-      expect(document.querySelector('[class*=PrivateSwipeArea-root]')).to.not.equal(null);
+      expect(document.querySelector('[class*=PrivateSwipeArea-root]')).not.to.equal(null);
       setProps({ variant: 'persistent' });
       expect(document.querySelector('[class*=PrivateSwipeArea-root]')).to.equal(null);
       setProps({ variant: 'temporary' });
-      expect(document.querySelector('[class*=PrivateSwipeArea-root]')).to.not.equal(null);
+      expect(document.querySelector('[class*=PrivateSwipeArea-root]')).not.to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -43,7 +43,7 @@ describe('<TableCell />', () => {
   describe('prop: padding', () => {
     it('doesn not have a class for padding by default', () => {
       const { container } = renderInTable(<TableCell padding="default" />);
-      expect(container.querySelector('td')).to.not.have.class(classes.paddingDefault);
+      expect(container.querySelector('td')).not.to.have.class(classes.paddingDefault);
     });
 
     it('has a class when `none`', () => {
@@ -65,7 +65,7 @@ describe('<TableCell />', () => {
   it('should render children', () => {
     const children = <p data-testid="hello">Hello</p>;
     const { getByTestId } = renderInTable(<TableCell>{children}</TableCell>);
-    expect(getByTestId('hello')).to.not.equal(null);
+    expect(getByTestId('hello')).not.to.equal(null);
   });
 
   it('should render aria-sort="ascending" when prop sortDirection="asc" provided', () => {

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -269,7 +269,7 @@ describe('<TablePagination />', () => {
         </table>,
       );
 
-      expect(container).to.not.include.text('Rows per page');
+      expect(container).not.to.include.text('Rows per page');
       expect(queryByRole('listbox')).to.equal(null);
     });
   });

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -31,7 +31,7 @@ describe('<TableSortLabel />', () => {
   it('should not set the active class when not active', () => {
     const activeFlag = false;
     const { container } = render(<TableSortLabel active={activeFlag} />);
-    expect(container.firstChild).to.not.have.class(classes.active);
+    expect(container.firstChild).not.to.have.class(classes.active);
   });
 
   describe('has an icon', () => {
@@ -44,20 +44,20 @@ describe('<TableSortLabel />', () => {
     it('when given direction desc should have desc direction class', () => {
       const { container } = render(<TableSortLabel direction="desc" />);
       const icon = container.querySelector(`.${classes.icon}`);
-      expect(icon).to.not.have.class(classes.iconDirectionAsc);
+      expect(icon).not.to.have.class(classes.iconDirectionAsc);
       expect(icon).to.have.class(classes.iconDirectionDesc);
     });
 
     it('when given direction asc should have asc direction class', () => {
       const { container } = render(<TableSortLabel direction="asc" />);
       const icon = container.querySelector(`.${classes.icon}`);
-      expect(icon).to.not.have.class(classes.iconDirectionDesc);
+      expect(icon).not.to.have.class(classes.iconDirectionDesc);
       expect(icon).to.have.class(classes.iconDirectionAsc);
     });
 
     it('should accept a custom icon for the sort icon', () => {
       const { getAllByTestId } = render(<TableSortLabel IconComponent={SortIcon} />);
-      expect(getAllByTestId('SortIcon')).to.not.equal(null);
+      expect(getAllByTestId('SortIcon')).not.to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -182,7 +182,7 @@ describe('<Tabs />', () => {
     it('should accept any value as selected tab value', () => {
       const tab0 = {};
       const tab1 = {};
-      expect(tab0).to.not.equal(tab1);
+      expect(tab0).not.to.equal(tab1);
 
       const { getAllByRole } = render(
         <Tabs value={tab0}>

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -92,7 +92,7 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      expect(getByRole('button')).to.not.have.attribute('title', 'Hello World');
+      expect(getByRole('button')).not.to.have.attribute('title', 'Hello World');
     });
   });
 

--- a/packages/material-ui/src/styles/createMuiTheme.test.js
+++ b/packages/material-ui/src/styles/createMuiTheme.test.js
@@ -19,7 +19,7 @@ describe('createMuiTheme', () => {
 
   it('should allow providing a partial structure', () => {
     const muiTheme = createMuiTheme({ transitions: { duration: { shortest: 150 } } });
-    expect(muiTheme.transitions.duration.shorter).to.not.equal(undefined);
+    expect(muiTheme.transitions.duration.shorter).not.to.equal(undefined);
   });
 
   describe('shadows', () => {

--- a/packages/material-ui/src/styles/createPalette.test.js
+++ b/packages/material-ui/src/styles/createPalette.test.js
@@ -137,8 +137,8 @@ describe('createPalette()', () => {
   it('should create a palette with unique object references', () => {
     const redPalette = createPalette({ background: { paper: 'red' } });
     const bluePalette = createPalette({ background: { paper: 'blue' } });
-    expect(redPalette).to.not.equal(bluePalette);
-    expect(redPalette.background).to.not.equal(bluePalette.background);
+    expect(redPalette).not.to.equal(bluePalette);
+    expect(redPalette.background).not.to.equal(bluePalette.background);
   });
 
   describe('warnings', () => {

--- a/packages/material-ui/src/styles/createTypography.test.js
+++ b/packages/material-ui/src/styles/createTypography.test.js
@@ -68,7 +68,7 @@ describe('createTypography', () => {
   });
 
   it('only defines letter-spacing if the font-family is not overwritten', () => {
-    expect(createTypography(palette, {}).h1.letterSpacing).to.not.equal(undefined);
+    expect(createTypography(palette, {}).h1.letterSpacing).not.to.equal(undefined);
     expect(createTypography(palette, { fontFamily: 'Gotham' }).h1.letterSpacing).to.equal(
       undefined,
     );

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -93,7 +93,7 @@ describe('<Menu /> integration', () => {
   it('does not gain any focus when mounted ', () => {
     const { getByRole } = render(<ButtonMenu />);
 
-    expect(getByRole('menu', { hidden: true })).to.not.contain(document.activeElement);
+    expect(getByRole('menu', { hidden: true })).not.to.contain(document.activeElement);
   });
 
   it('should focus the first item on open', () => {

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -57,7 +57,7 @@ describe('<TableRow> integration', () => {
       TableFooter,
     );
     expect(getByTestId('cell')).to.have.class(classes.head);
-    expect(getByTestId('cell')).to.not.have.attribute('scope');
+    expect(getByTestId('cell')).not.to.have.attribute('scope');
   });
 
   it('should render without head class when variant is body, overriding context', () => {


### PR DESCRIPTION
A follow-up on https://github.com/mui-org/material-ui/pull/24782#discussion_r572691575

<img width="797" alt="Capture d’écran 2021-02-12 à 16 24 16" src="https://user-images.githubusercontent.com/3165635/107786958-c7174600-6d4e-11eb-98f5-6420bae94bc6.png">

Searching more on the difference, it seems that the two forms have no difference in meaning, so we might as well consolidate on the most popular as well as [not splitting the infinitive](https://www.quora.com/Whats-the-difference-between-not-to-and-to-not).