### PR TITLE
[test] Run more tests at the same time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,11 +376,7 @@ workflows:
             - checkout
       - test_regressions:
           requires:
-            - test_unit
-            - test_lint
-            - test_static
-            - test_types
-            - test_browser
+            - checkout
   profile:
     when:
       equal: [profile, << pipeline.parameters.workflow >>]
@@ -401,9 +397,6 @@ workflows:
       - test_browser:
           react-dist-tag: next
       - test_regressions:
-          requires:
-            - test_unit
-            - test_browser
           react-dist-tag: next
   typescript-next:
     triggers:


### PR DESCRIPTION
So far, `test_regressions` has been a dependency of the 4 other steps to

1. stay in the 4 runs free concurrency limit of Circle CI 
2. to not put too much pressure on Argos CI

None of these two concerns seem relevant anymore.
We have upgraded to performant build with CircleCI (x4 -> x80).
A new Argos-CI worker **cost nothing**: $7/month, we could have x10 more workers. One worker can handle more than 1 image/s, easily 2m screenshots/month (60 * 60 * 24 * 30). More workers are mostly to absorb more parallelism, to have faster builds.

The CircleCI build now runs in ~8min instead of ~11min. The slowest tasks seem to be Netlify or Azure now.