### PR TITLE
[docs] Fix prefers-color-scheme switch

### DIFF
--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -59,15 +59,15 @@ function AppSettingsDrawer(props) {
 
   const handleChangeThemeMode = (event, paletteMode) => {
     if (paletteMode === null) {
-      paletteMode = mode;
+      return;
     }
 
+    setMode(paletteMode);
+
     if (paletteMode === 'system') {
-      setMode('system');
-      document.cookie = 'paletteMode=; expires = Thu, 01 Jan 1970 00:00:00 GMT';
+      document.cookie = `paletteMode=;path=/;max-age=31536000`;
       changeTheme({ paletteMode: preferredMode });
     } else {
-      setMode(paletteMode);
       document.cookie = `paletteMode=${paletteMode};path=/;max-age=31536000`;
       changeTheme({ paletteMode });
     }


### PR DESCRIPTION
To reproduce the issue:

1. Open https://next.material-ui.com/getting-started/installation/
2. Open the "Settings" panel, set the *dark* mode
3. Reload
4. Open the "Settings" panel, set the *system* mode
5. Reload 💥 (it's still in dark mode)

This bug has been bugging me for some time, finally dedicate time to fix it.