### PR TITLE
[SwipeableDrawer] Fix detection of native scroll container

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -115,7 +115,7 @@ function computeHasNativeHandler({ domTreeShapes, start, current, anchor }) {
       goingForward = !goingForward;
     }
     const axis = anchor === 'left' || anchor === 'right' ? 'x' : 'y';
-    const scrollPosition = shape[axisProperties.scrollPosition[axis]];
+    const scrollPosition = Math.round(shape[axisProperties.scrollPosition[axis]]);
 
     const areNotAtStart = scrollPosition > 0;
     const areNotAtEnd =


### PR DESCRIPTION
Apply the same fix as in https://github.com/oliviertassinari/react-swipeable-views/pull/614.

`scrollTop`, `scrollLeft` might not be an integer https://github.com/oliviertassinari/react-swipeable-views/pull/614#discussion_r463814843, when it's not, it can make the `areNotAtEnd` to fail, not handling the swipe events correctly.