### PR TITLE
[chip] Fix focus-visible regression

### DIFF
--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -417,7 +417,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const clickable = clickableProp !== false && onClick ? true : clickableProp;
   const small = size === 'small';
 
-  const component = ComponentProp || (clickable || onDelete ? ButtonBase : 'div');
+  const component = clickable || onDelete ? ButtonBase : ComponentProp || 'div';
 
   const styleProps = {
     ...props,
@@ -435,7 +435,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const moreProps =
     component === ButtonBase
       ? {
-          component: 'div',
+          component: ComponentProp || 'div',
           focusVisibleClassName: classes.focusVisible,
           disableRipple: Boolean(onDelete),
         }

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -84,6 +84,13 @@ describe('<Chip />', () => {
       expect(button).toHaveAccessibleName('My Chip');
     });
 
+    it('should render link with the button base', () => {
+      const { container } = render(<Chip component="a" clickable label="My text Chip" />);
+
+      expect(container.firstChild).to.have.class('MuiButtonBase-root');
+      expect(container.firstChild).to.have.tagName('a');
+    });
+
     it('should apply user value of tabIndex', () => {
       const { getByRole } = render(<Chip label="My Chip" onClick={() => {}} tabIndex={5} />);
 


### PR DESCRIPTION
The regression comes indirectly from #22430. You can experience it in the documentation. For instance, the chips of https://next.material-ui.com/components/alert/ (WAI-ARIA, Figma, etc.) have no visual indicator when keyboard focused.