### PR TITLE
[test] Avoid Rate Limit Exceeded

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function setKarmaConfig(config) {
     browserDisconnectTimeout: 120000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 6 * 60 * 1000, // default 10000
-    pollingTimeout: (80 / 5 * 4) / (1600 / (60 * 5)) * 1000,
+    pollingTimeout: (((80 / 5) * 4) / (1600 / (60 * 5))) * 1000,
     colors: true,
     client: {
       mocha: {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -9,9 +9,10 @@ const browserStack = {
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();
 
-// per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
+// BrowserStack rate limit after 1600 calls every 5 minutes.
+// Per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
 const MAX_REQUEST_BROWSERSTACK = 1600 / (60 * 5);
-// estimate the max number of concurrent karma builds
+// Estimate the max number of concurrent karma builds.
 // CircleCI accepts up to 80 concurrent builds, for each PR, 6 concurrent builds are used.
 const MAX_KARMA_CONCURRENT_BUILD = 80 / 6;
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -9,6 +9,10 @@ const browserStack = {
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();
 
+// per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
+const MAX_REQUEST_BROWSERSTACK = 1600 / (60 * 5);
+const MAX_KARMA_CONCURRENT_BUILD = 80 / 6;
+
 // Karma configuration
 module.exports = function setKarmaConfig(config) {
   const baseConfig = {
@@ -17,7 +21,6 @@ module.exports = function setKarmaConfig(config) {
     browserDisconnectTimeout: 120000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 6 * 60 * 1000, // default 10000
-    pollingTimeout: (((80 / 5) * 4) / (1600 / (60 * 5))) * 1000,
     colors: true,
     client: {
       mocha: {
@@ -145,6 +148,11 @@ module.exports = function setKarmaConfig(config) {
         },
       },
     };
+
+    // default 1000, Avoid Rate Limit Exceeded
+    newConfig.pollingTimeout =
+      ((MAX_KARMA_CONCURRENT_BUILD * (newConfig.browsers.length - 1)) / MAX_REQUEST_BROWSERSTACK) *
+      1000;
   }
 
   config.set(newConfig);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -152,10 +152,12 @@ module.exports = function setKarmaConfig(config) {
       },
     };
 
+    // -1 because chrome headless runs in the local machine
+    const browserstackBrowsersUsed = newConfig.browsers.length - 1;
+
     // default 1000, Avoid Rate Limit Exceeded
     newConfig.pollingTimeout =
-      ((MAX_KARMA_CONCURRENT_BUILD * (newConfig.browsers.length - 1)) / MAX_REQUEST_BROWSERSTACK) *
-      1000;
+      ((MAX_KARMA_CONCURRENT_BUILD * browserstackBrowsersUsed) / MAX_REQUEST_BROWSERSTACK) * 1000;
   }
 
   config.set(newConfig);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -11,7 +11,7 @@ process.env.CHROME_BIN = playwright.chromium.executablePath();
 
 // BrowserStack rate limit after 1600 calls every 5 minutes.
 // Per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
-const MAX_REQUEST_BROWSERSTACK = 1600 / (60 * 5);
+const MAX_REQUEST_PER_SECOND_BROWSERSTACK = 1600 / (60 * 5);
 // Estimate the max number of concurrent karma builds.
 // CircleCI accepts up to 80 concurrent builds, for each PR, 6 concurrent builds are used.
 const MAX_KARMA_CONCURRENT_BUILD = 80 / 6;
@@ -157,7 +157,9 @@ module.exports = function setKarmaConfig(config) {
 
     // default 1000, Avoid Rate Limit Exceeded
     newConfig.pollingTimeout =
-      ((MAX_KARMA_CONCURRENT_BUILD * browserstackBrowsersUsed) / MAX_REQUEST_BROWSERSTACK) * 1000;
+      ((MAX_KARMA_CONCURRENT_BUILD * browserstackBrowsersUsed) /
+        MAX_REQUEST_PER_SECOND_BROWSERSTACK) *
+      1000;
   }
 
   config.set(newConfig);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function setKarmaConfig(config) {
     browserDisconnectTimeout: 120000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 6 * 60 * 1000, // default 10000
+    pollingTimeout: (80 / 5 * 4) / (1600 / (60 * 5)) * 1000,
     colors: true,
     client: {
       mocha: {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -11,6 +11,8 @@ process.env.CHROME_BIN = playwright.chromium.executablePath();
 
 // per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
 const MAX_REQUEST_BROWSERSTACK = 1600 / (60 * 5);
+// estimate the max number of concurrent karma builds
+// CircleCI accepts up to 80 concurrent builds, for each PR, 6 concurrent builds are used.
 const MAX_KARMA_CONCURRENT_BUILD = 80 / 6;
 
 // Karma configuration

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -12,9 +12,11 @@ process.env.CHROME_BIN = playwright.chromium.executablePath();
 // BrowserStack rate limit after 1600 calls every 5 minutes.
 // Per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
 const MAX_REQUEST_PER_SECOND_BROWSERSTACK = 1600 / (60 * 5);
-// Estimate the max number of concurrent karma builds.
-// CircleCI accepts up to 80 concurrent builds, for each PR, 6 concurrent builds are used.
-const MAX_KARMA_CONCURRENT_BUILD = 80 / 6;
+// Estimate the max number of concurrent karma builds
+// For each PR, 6 concurrent builds are used, only one is usng BrowserStack.
+const AVERAGE_KARMA_BUILD = 1 / 6;
+// CircleCI accepts up to 83 concurrent builds.
+const MAX_CIRCLE_CI_CONCURRENCY = 83;
 
 // Karma configuration
 module.exports = function setKarmaConfig(config) {
@@ -157,7 +159,7 @@ module.exports = function setKarmaConfig(config) {
 
     // default 1000, Avoid Rate Limit Exceeded
     newConfig.pollingTimeout =
-      ((MAX_KARMA_CONCURRENT_BUILD * browserstackBrowsersUsed) /
+      ((MAX_CIRCLE_CI_CONCURRENCY * AVERAGE_KARMA_BUILD * browserstackBrowsersUsed) /
         MAX_REQUEST_PER_SECOND_BROWSERSTACK) *
       1000;
   }


### PR DESCRIPTION
- The problem I'm trying to fix: https://app.circleci.com/pipelines/github/mui-org/material-ui/37981/workflows/933e76b5-fa9c-4b6d-a5d6-3b2d9ef1d2f7/jobs/224165
- Leads on the solution I could find:
  - https://github.com/karma-runner/karma-browserstack-launcher/issues/30 "Use higher default pollingTimeout"
  - https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects "You can make up to 1600 API requests per 5 minutes per user"
  - the config https://github.com/karma-runner/karma-browserstack-launcher/blob/4547fd7660fa47721f8ec43808b369c7aa077c0b/index.js#L83