### PR TITLE
[core] Disable page size tracking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,20 +98,6 @@ jobs:
           artifactName: 'canaries'
           targetPath: 'material-ui-core.tgz'
 
-      - task: Cache@2
-        inputs:
-          key: 'nextjs-build | yarn.lock'
-          path: $(DOCS_NEXT_CACHE_FOLDER)
-        displayName: Cache nextjs build
-
-      - script: |
-          set -o pipefail
-          mkdir -p scripts/sizeSnapshot/build	
-          yarn docs:build | tee scripts/sizeSnapshot/build/docs.next
-        displayName: 'build docs for size snapshot'
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-
       - script: |
           yarn size:snapshot
         displayName: 'create a size snapshot'

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -66,101 +66,6 @@ async function getWebpackSizes(webpackEnvironment) {
   return sizes;
 }
 
-// waiting for String.prototype.matchAll in node 10
-function* matchAll(string, regex) {
-  let match = null;
-  do {
-    match = regex.exec(string);
-    if (match !== null) {
-      yield match;
-    }
-  } while (match !== null);
-}
-
-/**
- * Inverse to `pretty-bytes`
- * @param {string} n
- * @param {'B', 'kB' | 'MB' | 'GB' | 'TB' | 'PB'} unit
- * @returns {number}
- */
-
-function prettyBytesInverse(n, unit) {
-  const metrixPrefix = unit.length < 2 ? '' : unit[0];
-  const metricPrefixes = ['', 'k', 'M', 'G', 'T', 'P'];
-  const metrixPrefixIndex = metricPrefixes.indexOf(metrixPrefix);
-  if (metrixPrefixIndex === -1) {
-    throw new TypeError(
-      `unrecognized metric prefix '${metrixPrefix}' in unit '${unit}'. only '${metricPrefixes.join(
-        "', '",
-      )}' are allowed`,
-    );
-  }
-
-  const power = metrixPrefixIndex * 3;
-  return n * 10 ** power;
-}
-
-/**
- * parses output from next build to size snapshot format
- * @returns {[string, { gzip: number, files: number, packages: number }][]}
- */
-
-async function getNextPagesSize() {
-  const consoleOutput = await fse.readFile(path.join(__dirname, 'build/docs.next'), {
-    encoding: 'utf8',
-  });
-  const pageRegex = /(?<treeViewPresentation>┌|├|└)\s+((?<fileType>λ|○|●)\s+)?(?<pageUrl>[^\s]+)\s+(?<sizeFormatted>[0-9.]+)\s+(?<sizeUnit>\w+)/gm;
-
-  const sharedChunks = [];
-
-  const entries = Array.from(matchAll(consoleOutput, pageRegex), (match) => {
-    const { pageUrl, sizeFormatted, sizeUnit } = match.groups;
-
-    let snapshotId = `docs:${pageUrl}`;
-    // used to be tracked with custom logic hence the different ids
-    if (pageUrl === '/') {
-      snapshotId = 'docs.landing';
-      // chunks contain a content hash that makes the names
-      // unsuitable for tracking. Using stable name instead:
-    } else if (/^chunks\/pages\/_app\.(.+)\.js$/.test(pageUrl)) {
-      snapshotId = 'docs.main';
-    } else if (/^chunks\/main\.(.+)\.js$/.test(pageUrl)) {
-      snapshotId = 'docs:shared:runtime/main';
-    } else if (/^chunks\/webpack\.(.+)\.js$/.test(pageUrl)) {
-      snapshotId = 'docs:shared:runtime/webpack';
-    } else if (/^chunks\/commons\.(.+)\.js$/.test(pageUrl)) {
-      snapshotId = 'docs:shared:chunk/commons';
-    } else if (/^chunks\/framework\.(.+)\.js$/.test(pageUrl)) {
-      snapshotId = 'docs:shared:chunk/framework';
-    } else if (/^chunks\/(.*)\.js$/.test(pageUrl)) {
-      // shared chunks are unnamed and only have a hash
-      // we just track their tally and summed size
-      sharedChunks.push(prettyBytesInverse(sizeFormatted, sizeUnit));
-      // and not each chunk individually
-      return null;
-    }
-
-    return [
-      snapshotId,
-      {
-        parsed: prettyBytesInverse(sizeFormatted, sizeUnit),
-        gzip: -1,
-      },
-    ];
-  }).filter((entry) => entry !== null);
-
-  entries.push([
-    'docs:chunk:shared',
-    {
-      parsed: sharedChunks.reduce((sum, size) => sum + size, 0),
-      gzip: -1,
-      tally: sharedChunks.length,
-    },
-  ]);
-
-  return entries;
-}
-
 async function run(argv) {
   const { analyze, accurateBundles } = argv;
 
@@ -168,7 +73,6 @@ async function run(argv) {
   const bundleSizes = lodash.fromPairs([
     ...(await getWebpackSizes({ analyze, accurateBundles })),
     ...lodash.flatten(await Promise.all(rollupBundles.map(getRollupSize))),
-    ...(await getNextPagesSize()),
   ]);
 
   await fse.writeJSON(snapshotDestPath, bundleSizes, { spaces: 2 });


### PR DESCRIPTION
I feel like we rarely ever use this unless we specifically look into reducing size. In these cases we can now compare the logs of netlify deploys since next started logging the size of each individual page. And we could always look at the size in browser devtools anyway.

Seeing differences down to a single byte is not that useful to begin with for whole pages (while it's definitely interesting for a package). Considering this tracking costs us ~10minutes of pipeline time and `sizeSnapshot` is now our bottleneck I think we should drop it.