### PR TITLE
[core] Prevent out-of-memory when type-checking in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
           command: git add -A && git diff --exit-code --staged
       - run:
           name: Tests TypeScript definitions
-          command: yarn typescript
+          command: yarn typescript:ci
       - run:
           name: Test module augmenation
           command: yarn workspace @material-ui/core typescript:module-augmentation

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:watch": "yarn test:unit --watch",
     "test:argos": "node ./scripts/pushArgos.js",
-    "typescript": "lerna run --no-bail --parallel typescript"
+    "typescript": "lerna run --no-bail --parallel typescript",
+    "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/mui-org/material-ui/37989/workflows/a381c496-224f-42ef-ad3e-6a13dde8db6a/jobs/224216/parallel-runs/0/steps/0-110

Exit code 137 usually means the process ran out of memory. [Node has a default memory limit of 512 MB](https://medium.com/@vuongtran/how-to-solve-process-out-of-memory-in-node-js-5f0de8f8464c) while the [default docker containers has 4 GB of RAM](https://circleci.com/docs/2.0/configuration-reference/#docker-executor). This means that we're testing these limits when running >= 8 node processes. `yarn lerna run --parallel typescript` currently runs 12 parallel tasks so it's likely that `yarn lerna` runs out of memory.

We're now limiting type-checking to 7 concurrent tasks which should give us ample room. Locally I didn't notice much of a slowdown between `--parallel` and `--concurrency 7 --no-sort`