### PR TITLE
[test] Link CircleCI URL in BS

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,10 +1,16 @@
 const playwright = require('playwright');
 const webpack = require('webpack');
 
+let build = `material-ui local ${new Date().toISOString()}`;
+
+if (process.env.CIRCLE_BUILD_URL) {
+  build = process.env.CIRCLE_BUILD_URL;
+}
+
 const browserStack = {
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
-  build: `material-ui-${new Date().toISOString()}`,
+  build,
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();


### PR DESCRIPTION
Help debug runs in BrowserStack

- top is the proposal
- bottom is current

<img width="243" alt="Capture d’écran 2021-02-14 à 15 42 06" src="https://user-images.githubusercontent.com/3165635/107879811-65d0ad80-6edb-11eb-9640-dc2a3edc4f5a.png">

It seems that we have an issue with BrowserStack. It looks like it's not able to handle the pressure CircleCI puts on him. I couldn't find any option to set a max concurrence on a CircleCI workflow. This change should help debug the issue we currently have. It seems that after 3-4 concurrent builds trying to access BrowserStack, things go sideways: never-ending builds, timeout, etc.