### PR TITLE
[docs] Separate simple and nested modal demos

### DIFF
--- a/docs/src/pages/components/modal/BasicModal.js
+++ b/docs/src/pages/components/modal/BasicModal.js
@@ -1,23 +1,22 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Modal from '@material-ui/core/Modal';
 
-const useStyles = makeStyles((theme) => ({
-  paper: {
-    position: 'absolute',
-    top: `50%`,
-    left: `50%`,
-    transform: `translate(-50%, -50%)`,
-    width: 400,
-    backgroundColor: theme.palette.background.paper,
-    border: '2px solid #000',
-    boxShadow: theme.shadows[5],
-    padding: theme.spacing(2, 4, 3),
-  },
-}));
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  pt: 2,
+  px: 4,
+  pb: 3,
+};
 
 export default function BasicModal() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => {
@@ -39,12 +38,12 @@ export default function BasicModal() {
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
       >
-        <div className={classes.paper}>
+        <Box sx={style}>
           <h2 id="modal-modal-title">Text in a modal</h2>
           <p id="modal-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>
-        </div>
+        </Box>
       </Modal>
     </div>
   );

--- a/docs/src/pages/components/modal/BasicModal.js
+++ b/docs/src/pages/components/modal/BasicModal.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function SimpleModal() {
+export default function BasicModal() {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
@@ -36,12 +36,12 @@ export default function SimpleModal() {
       <Modal
         open={open}
         onClose={handleClose}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
       >
         <div className={classes.paper}>
-          <h2 id="simple-modal-title">Text in a modal</h2>
-          <p id="simple-modal-description">
+          <h2 id="modal-modal-title">Text in a modal</h2>
+          <p id="modal-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>
         </div>

--- a/docs/src/pages/components/modal/BasicModal.tsx
+++ b/docs/src/pages/components/modal/BasicModal.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-export default function SimpleModal() {
+export default function BasicModal() {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
@@ -38,12 +38,12 @@ export default function SimpleModal() {
       <Modal
         open={open}
         onClose={handleClose}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
       >
         <div className={classes.paper}>
-          <h2 id="simple-modal-title">Text in a modal</h2>
-          <p id="simple-modal-description">
+          <h2 id="modal-modal-title">Text in a modal</h2>
+          <p id="modal-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>
         </div>

--- a/docs/src/pages/components/modal/BasicModal.tsx
+++ b/docs/src/pages/components/modal/BasicModal.tsx
@@ -1,25 +1,22 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Modal from '@material-ui/core/Modal';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paper: {
-      position: 'absolute',
-      top: `50%`,
-      left: `50%`,
-      transform: `translate(-50%, -50%)`,
-      width: 400,
-      backgroundColor: theme.palette.background.paper,
-      border: '2px solid #000',
-      boxShadow: theme.shadows[5],
-      padding: theme.spacing(2, 4, 3),
-    },
-  }),
-);
+const style = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  pt: 2,
+  px: 4,
+  pb: 3,
+};
 
 export default function BasicModal() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => {
@@ -41,12 +38,12 @@ export default function BasicModal() {
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
       >
-        <div className={classes.paper}>
+        <Box sx={style}>
           <h2 id="modal-modal-title">Text in a modal</h2>
           <p id="modal-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>
-        </div>
+        </Box>
       </Modal>
     </div>
   );

--- a/docs/src/pages/components/modal/NestedModal.js
+++ b/docs/src/pages/components/modal/NestedModal.js
@@ -1,47 +1,32 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Modal from '@material-ui/core/Modal';
 
-const useStyles = makeStyles((theme) => {
-  const sharedModalStyles = {
-    position: 'absolute',
-    maxWidth: '100%',
-    backgroundColor: theme.palette.background.paper,
-    border: '2px solid #000',
-    boxShadow: theme.shadows[5],
-    padding: theme.spacing(2, 4, 3),
-    top: `50%`,
-    left: `50%`,
-    transform: `translate(-50%, -50%)`,
-  };
-
-  return {
-    parentModal: {
-      ...sharedModalStyles,
-      width: '400px',
-    },
-    childModal: {
-      ...sharedModalStyles,
-      width: '200px',
-    },
-  };
-});
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  pt: 2,
+  px: 4,
+  pb: 3,
+};
 
 function ChildModal() {
-  const classes = useStyles();
-
   const [open, setOpen] = React.useState(false);
-
   const handleOpen = () => {
     setOpen(true);
   };
-
   const handleClose = () => {
     setOpen(false);
   };
 
   return (
-    <div>
+    <React.Fragment>
       <button type="button" onClick={handleOpen}>
         Open Child Modal
       </button>
@@ -52,7 +37,7 @@ function ChildModal() {
         aria-labelledby="child-modal-title"
         aria-describedby="child-modal-description"
       >
-        <div className={classes.childModal}>
+        <Box sx={{ ...style, width: 200 }}>
           <h2 id="child-modal-title">Text in a child modal</h2>
           <p id="child-modal-description">
             Lorem ipsum, dolor sit amet consectetur adipisicing elit.
@@ -60,21 +45,17 @@ function ChildModal() {
           <button type="button" onClick={handleClose}>
             Close Child Modal
           </button>
-        </div>
+        </Box>
       </Modal>
-    </div>
+    </React.Fragment>
   );
 }
 
-export default function ParentModal() {
-  const classes = useStyles();
-
+export default function NestedModal() {
   const [open, setOpen] = React.useState(false);
-
   const handleOpen = () => {
     setOpen(true);
   };
-
   const handleClose = () => {
     setOpen(false);
   };
@@ -90,13 +71,13 @@ export default function ParentModal() {
         aria-labelledby="parent-modal-title"
         aria-describedby="parent-modal-description"
       >
-        <div className={classes.parentModal}>
+        <Box sx={{ ...style, width: 400 }}>
           <h2 id="parent-modal-title">Text in a modal</h2>
           <p id="parent-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>
           <ChildModal />
-        </div>
+        </Box>
       </Modal>
     </div>
   );

--- a/docs/src/pages/components/modal/NestedModal.js
+++ b/docs/src/pages/components/modal/NestedModal.js
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Modal from '@material-ui/core/Modal';
+
+const useStyles = makeStyles((theme) => {
+  const sharedModalStyles = {
+    position: 'absolute',
+    maxWidth: '100%',
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+    top: `50%`,
+    left: `50%`,
+    transform: `translate(-50%, -50%)`,
+  };
+
+  return {
+    parentModal: {
+      ...sharedModalStyles,
+      width: '400px',
+    },
+    childModal: {
+      ...sharedModalStyles,
+      width: '200px',
+    },
+  };
+});
+
+function ChildModal() {
+  const classes = useStyles();
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        Open Child Modal
+      </button>
+      <Modal
+        hideBackdrop
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="child-modal-title"
+        aria-describedby="child-modal-description"
+      >
+        <div className={classes.childModal}>
+          <h2 id="child-modal-title">Text in a child modal</h2>
+          <p id="child-modal-description">
+            Lorem ipsum, dolor sit amet consectetur adipisicing elit.
+          </p>
+          <button type="button" onClick={handleClose}>
+            Close Child Modal
+          </button>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+export default function ParentModal() {
+  const classes = useStyles();
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        Open Modal
+      </button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="parent-modal-title"
+        aria-describedby="parent-modal-description"
+      >
+        <div className={classes.parentModal}>
+          <h2 id="parent-modal-title">Text in a modal</h2>
+          <p id="parent-modal-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </p>
+          <ChildModal />
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/docs/src/pages/components/modal/NestedModal.tsx
+++ b/docs/src/pages/components/modal/NestedModal.tsx
@@ -1,47 +1,32 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Modal from '@material-ui/core/Modal';
 
-const useStyles = makeStyles((theme: Theme) => {
-  const sharedModalStyles: React.CSSProperties = {
-    position: 'absolute',
-    maxWidth: '100%',
-    backgroundColor: theme.palette.background.paper,
-    border: '2px solid #000',
-    boxShadow: theme.shadows[5],
-    padding: theme.spacing(2, 4, 3),
-    top: `50%`,
-    left: `50%`,
-    transform: `translate(-50%, -50%)`,
-  };
-
-  return createStyles({
-    parentModal: {
-      ...sharedModalStyles,
-      width: '400px',
-    },
-    childModal: {
-      ...sharedModalStyles,
-      width: '200px',
-    },
-  });
-});
+const style = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  pt: 2,
+  px: 4,
+  pb: 3,
+};
 
 function ChildModal() {
-  const classes = useStyles();
-
   const [open, setOpen] = React.useState(false);
-
   const handleOpen = () => {
     setOpen(true);
   };
-
   const handleClose = () => {
     setOpen(false);
   };
 
   return (
-    <div>
+    <React.Fragment>
       <button type="button" onClick={handleOpen}>
         Open Child Modal
       </button>
@@ -52,7 +37,7 @@ function ChildModal() {
         aria-labelledby="child-modal-title"
         aria-describedby="child-modal-description"
       >
-        <div className={classes.childModal}>
+        <Box sx={{ ...style, width: 200 }}>
           <h2 id="child-modal-title">Text in a child modal</h2>
           <p id="child-modal-description">
             Lorem ipsum, dolor sit amet consectetur adipisicing elit.
@@ -60,21 +45,17 @@ function ChildModal() {
           <button type="button" onClick={handleClose}>
             Close Child Modal
           </button>
-        </div>
+        </Box>
       </Modal>
-    </div>
+    </React.Fragment>
   );
 }
 
-export default function ParentModal() {
-  const classes = useStyles();
-
+export default function NestedModal() {
   const [open, setOpen] = React.useState(false);
-
   const handleOpen = () => {
     setOpen(true);
   };
-
   const handleClose = () => {
     setOpen(false);
   };
@@ -90,13 +71,13 @@ export default function ParentModal() {
         aria-labelledby="parent-modal-title"
         aria-describedby="parent-modal-description"
       >
-        <div className={classes.parentModal}>
+        <Box sx={{ ...style, width: 400 }}>
           <h2 id="parent-modal-title">Text in a modal</h2>
           <p id="parent-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>
           <ChildModal />
-        </div>
+        </Box>
       </Modal>
     </div>
   );

--- a/docs/src/pages/components/modal/NestedModal.tsx
+++ b/docs/src/pages/components/modal/NestedModal.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Modal from '@material-ui/core/Modal';
+
+const useStyles = makeStyles((theme: Theme) => {
+  const sharedModalStyles: React.CSSProperties = {
+    position: 'absolute',
+    maxWidth: '100%',
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+    top: `50%`,
+    left: `50%`,
+    transform: `translate(-50%, -50%)`,
+  };
+
+  return createStyles({
+    parentModal: {
+      ...sharedModalStyles,
+      width: '400px',
+    },
+    childModal: {
+      ...sharedModalStyles,
+      width: '200px',
+    },
+  });
+});
+
+function ChildModal() {
+  const classes = useStyles();
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        Open Child Modal
+      </button>
+      <Modal
+        hideBackdrop
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="child-modal-title"
+        aria-describedby="child-modal-description"
+      >
+        <div className={classes.childModal}>
+          <h2 id="child-modal-title">Text in a child modal</h2>
+          <p id="child-modal-description">
+            Lorem ipsum, dolor sit amet consectetur adipisicing elit.
+          </p>
+          <button type="button" onClick={handleClose}>
+            Close Child Modal
+          </button>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+export default function ParentModal() {
+  const classes = useStyles();
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        Open Modal
+      </button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="parent-modal-title"
+        aria-describedby="parent-modal-description"
+      >
+        <div className={classes.parentModal}>
+          <h2 id="parent-modal-title">Text in a modal</h2>
+          <p id="parent-modal-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </p>
+          <ChildModal />
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/docs/src/pages/components/modal/SimpleModal.js
+++ b/docs/src/pages/components/modal/SimpleModal.js
@@ -2,24 +2,12 @@ import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 
-function rand() {
-  return Math.round(Math.random() * 20) - 10;
-}
-
-function getModalStyle() {
-  const top = 50 + rand();
-  const left = 50 + rand();
-
-  return {
-    top: `${top}%`,
-    left: `${left}%`,
-    transform: `translate(-${top}%, -${left}%)`,
-  };
-}
-
 const useStyles = makeStyles((theme) => ({
   paper: {
     position: 'absolute',
+    top: `50%`,
+    left: `50%`,
+    transform: `translate(-50%, -50%)`,
     width: 400,
     backgroundColor: theme.palette.background.paper,
     border: '2px solid #000',
@@ -30,8 +18,6 @@ const useStyles = makeStyles((theme) => ({
 
 export default function SimpleModal() {
   const classes = useStyles();
-  // getModalStyle is not a pure function, we roll the style only on the first render
-  const [modalStyle] = React.useState(getModalStyle);
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => {
@@ -41,16 +27,6 @@ export default function SimpleModal() {
   const handleClose = () => {
     setOpen(false);
   };
-
-  const body = (
-    <div style={modalStyle} className={classes.paper}>
-      <h2 id="simple-modal-title">Text in a modal</h2>
-      <p id="simple-modal-description">
-        Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
-      </p>
-      <SimpleModal />
-    </div>
-  );
 
   return (
     <div>
@@ -63,7 +39,12 @@ export default function SimpleModal() {
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
       >
-        {body}
+        <div className={classes.paper}>
+          <h2 id="simple-modal-title">Text in a modal</h2>
+          <p id="simple-modal-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </p>
+        </div>
       </Modal>
     </div>
   );

--- a/docs/src/pages/components/modal/SimpleModal.tsx
+++ b/docs/src/pages/components/modal/SimpleModal.tsx
@@ -2,25 +2,13 @@ import * as React from 'react';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 
-function rand() {
-  return Math.round(Math.random() * 20) - 10;
-}
-
-function getModalStyle() {
-  const top = 50 + rand();
-  const left = 50 + rand();
-
-  return {
-    top: `${top}%`,
-    left: `${left}%`,
-    transform: `translate(-${top}%, -${left}%)`,
-  };
-}
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     paper: {
       position: 'absolute',
+      top: `50%`,
+      left: `50%`,
+      transform: `translate(-50%, -50%)`,
       width: 400,
       backgroundColor: theme.palette.background.paper,
       border: '2px solid #000',
@@ -32,8 +20,6 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function SimpleModal() {
   const classes = useStyles();
-  // getModalStyle is not a pure function, we roll the style only on the first render
-  const [modalStyle] = React.useState(getModalStyle);
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => {
@@ -43,16 +29,6 @@ export default function SimpleModal() {
   const handleClose = () => {
     setOpen(false);
   };
-
-  const body = (
-    <div style={modalStyle} className={classes.paper}>
-      <h2 id="simple-modal-title">Text in a modal</h2>
-      <p id="simple-modal-description">
-        Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
-      </p>
-      <SimpleModal />
-    </div>
-  );
 
   return (
     <div>
@@ -65,7 +41,12 @@ export default function SimpleModal() {
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
       >
-        {body}
+        <div className={classes.paper}>
+          <h2 id="simple-modal-title">Text in a modal</h2>
+          <p id="simple-modal-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </p>
+        </div>
       </Modal>
     </div>
   );

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -36,11 +36,15 @@ Modal is a lower-level construct that is leveraged by the following components:
 
 ## Simple modal
 
-This demo stacks Modals, but it is strongly discouraged to do so in practice.
-
 {{"demo": "pages/components/modal/SimpleModal.js"}}
 
 Notice that you can disable the outline (often blue or gold) with the `outline: 0` CSS property.
+
+## Nested modal
+
+Modals can be nested, for example a select within a dialog, but stacking of more than two modals, or any two modals with a backdrop is discouraged.
+
+{{"demo": "pages/components/modal/NestedModal.js"}}
 
 ## Transitions
 

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -34,7 +34,7 @@ Modal is a lower-level construct that is leveraged by the following components:
 - [Menu](/components/menus/)
 - [Popover](/components/popover/)
 
-## Simple modal
+## Basic modal
 
 {{"demo": "pages/components/modal/SimpleModal.js"}}
 

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -36,7 +36,7 @@ Modal is a lower-level construct that is leveraged by the following components:
 
 ## Basic modal
 
-{{"demo": "pages/components/modal/SimpleModal.js"}}
+{{"demo": "pages/components/modal/BasicModal.js"}}
 
 Notice that you can disable the outline (often blue or gold) with the `outline: 0` CSS property.
 


### PR DESCRIPTION
Separated out nested modal demo from the simple modal demo.

Fixes #23903 

Please verify text, because english is not my primary lang.

![Screenshot 2021-02-14 at 21 07 57](https://user-images.githubusercontent.com/13312113/107887805-fc679380-6f08-11eb-9702-efbecacff320.png)
![Screenshot 2021-02-14 at 21 09 02](https://user-images.githubusercontent.com/13312113/107887814-07222880-6f09-11eb-9f69-9deb540bcfc9.png)

![Screenshot 2021-02-14 at 21 08 43](https://user-images.githubusercontent.com/13312113/107887806-ff628400-6f08-11eb-9fa8-e7424b802161.png)
![Screenshot 2021-02-14 at 21 08 49](https://user-images.githubusercontent.com/13312113/107887809-04bfce80-6f09-11eb-847e-3b3cfa8e3e17.png)