### PR TITLE
[core] Fix cache miss when using playwright docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,7 @@ jobs:
       - image: mcr.microsoft.com/playwright:bionic
         environment:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
+      - image: circleci/node:10
     steps:
       - checkout
       - install_js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,15 @@ commands:
       chrome:
         type: boolean
         default: false
-        description: 'Set to true if you intend to use chrome (e.g. with playwright)'
+        description: 'Set to true if you intend to use chrome (e.g. with playwright).'
       firefox:
         type: boolean
         default: false
-        description: 'Set to true if you intend to use firefox (e.g. with playwright)'
+        description: 'Set to true if you intend to use firefox (e.g. with playwright).'
+      video:
+        type: boolean
+        default: false
+        description: 'Set to true if you need video playback support in any browser.'
 
     steps:
       - run:
@@ -112,7 +116,10 @@ commands:
                     libharfbuzz-icu0
             - run:
                 name: Install gstreamer and plugins to support video playback in WebKit.
-                if: << parameters.chrome >>
+                if:
+                  and:
+                    - << parameters.chrome >>
+                    - << parameters.video >>
                 command: |
                   sudo apt-get install -y --no-install-recommends \
                     libgstreamer-plugins-bad1.0-0 \
@@ -137,7 +144,10 @@ commands:
                     libxt6
             - run:
                 name: Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-                if: << parameters.firefox >>
+                if:
+                  and:
+                    - << parameters.firefox >>
+                    - << parameters.video >>
                 command: |
                   sudo apt-get install -y --no-install-recommends \
                     ffmpeg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,14 @@ defaults: &defaults
 #     key: v1-repo-{{ .Branch }}-{{ .Revision }}
 
 commands:
+  # Always call before install_*
+  restore_browser_binaries:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v1-playwright-{{ arch }}-
+            - v1-playwright-
   install_js:
     steps:
       - run:
@@ -62,20 +70,102 @@ commands:
             # Debug information
             yarn cache dir
             yarn cache list
-      - restore_cache:
-          keys:
-            - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-playwright-{{ arch }}-
-            - v1-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
+  install_browsers:
+    parameters:
+      # Set to true if you intend to use firefox in playwright
+      firefox:
+        type: boolean
+        default: false
+      # Set to true if you intend to run playwright in headful mode
+      headful:
+        type: boolean
+        default: false
+      # Set to true if you need to support video playback
+      video:
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: Update apt
+          command: apt-get update
+      - run:
+          name: Install WebKit dependencies
+          command: |
+            apt-get install -y --no-install-recommends \
+              libwoff1 \
+              libopus0 \
+              libwebp6 \
+              libwebpdemux2 \
+              libenchant1c2a \
+              libgudev-1.0-0 \
+              libsecret-1-0 \
+              libhyphen0 \
+              libgdk-pixbuf2.0-0 \
+              libegl1 \
+              libnotify4 \
+              libxslt1.1 \
+              libevent-2.1-6 \
+              libgles2 \
+              libvpx5 \
+              libxcomposite1 \
+              libatk1.0-0 \
+              libatk-bridge2.0-0 \
+              libepoxy0 \
+              libgtk-3-0 \
+              libharfbuzz-icu0
+      - run:
+          name: Install gstreamer and plugins to support video playback in WebKit.
+          command: |
+            apt-get install -y --no-install-recommends \
+              libgstreamer-gl1.0-0 \
+              libgstreamer-plugins-bad1.0-0 \
+              gstreamer1.0-plugins-good \
+              gstreamer1.0-libav
+          if: << parameters.video >>
+      - run:
+          name: Install Chromium dependencies
+          command: |
+            apt-get install -y --no-install-recommends \
+              fonts-liberation \
+              libnss3 \
+              libxss1 \
+              libasound2 \
+              fonts-noto-color-emoji \
+              libxtst6
+      - run:
+          name: Install Firefox dependencies
+          command: |
+            apt-get install -y --no-install-recommends \
+              libdbus-glib-1-2 \
+              libxt6
+          if: << parameters.firefox >>
+      - run:
+          name: Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+          command: |
+            apt-get install -y --no-install-recommends \
+              ffmpeg
+          if:
+            and:
+              - << parameters.firefox >>
+              - << parameters.video >>
+      - run:
+          name: (Optional) Install XVFB if there's a need to run browsers in headful mode
+          command: |
+            apt-get install -y --no-install-recommends \
+              xvfb
+          if: << parameters.headful >>
+
+      - restore_browser_binaries
 
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
+      - restore_browser_binaries
       - install_js
       - run:
           name: Should not have any git not staged
@@ -290,13 +380,9 @@ jobs:
             exit 0
   test_browser:
     <<: *defaults
-    docker:
-      - image: mcr.microsoft.com/playwright:bionic
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
-      - image: circleci/node:10
     steps:
       - checkout
+      - install_browsers
       - install_js
       - run:
           name: Tests real browsers
@@ -313,13 +399,9 @@ jobs:
           command: yarn test:umd
   test_profile:
     <<: *defaults
-    docker:
-      - image: mcr.microsoft.com/playwright:bionic
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
-
     steps:
       - checkout
+      - install_browsers
       - install_js
       - run:
           name: Tests real browsers
@@ -340,12 +422,10 @@ jobs:
           destination: react-profiler-report/karma
   test_regressions:
     <<: *defaults
-    docker:
-      - image: mcr.microsoft.com/playwright:bionic
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
+      - install_browsers:
+          headful: true
       - install_js
       - run:
           name: Run visual regression tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,6 @@ commands:
           name: Install WebKit dependencies
           command: |
             sudo apt-get install -y --no-install-recommends \
-              libwoff1 \
               libopus0 \
               libwebp6 \
               libwebpdemux2 \
@@ -104,12 +103,9 @@ commands:
               libsecret-1-0 \
               libhyphen0 \
               libgdk-pixbuf2.0-0 \
-              libegl1 \
               libnotify4 \
               libxslt1.1 \
-              libevent-2.1-6 \
               libgles2 \
-              libvpx5 \
               libxcomposite1 \
               libatk1.0-0 \
               libatk-bridge2.0-0 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,10 @@ commands:
         type: boolean
         default: false
         description: 'Set to true if you intend to use firefox (e.g. with playwright).'
+      headful:
+        type: boolean
+        default: false
+        description: 'Set to true if you intend run any browsers in headful mode.'
       video:
         type: boolean
         default: false
@@ -151,6 +155,12 @@ commands:
                 command: |
                   sudo apt-get install -y --no-install-recommends \
                     ffmpeg
+            - run:
+                name: Install XVFB
+                if: << parameters.headful >>
+                command: |
+                  sudo apt-get install -y --no-install-recommends \
+                    xvfb
       - run:
           name: Install js dependencies
           command: yarn install --verbose
@@ -422,6 +432,7 @@ jobs:
       - checkout
       - install_js:
           chrome: true
+          headful: true
       - run:
           name: Run visual regression tests
           command: xfvb-run yarn test:regressions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,13 @@ commands:
       - restore_cache:
           name: Restore yarn cache
           keys:
-            - v6-yarn-sha-{{ checksum "yarn.lock" }}
-            - v6-yarn-sha-
+            - v7-yarn-{{ checksum "yarn.lock" }}
+            - v7-yarn-
       - run:
           name: Set yarn cache folder
           command: |
-            # Keep path in sync with `save_cache` for key "v6-yarn-sha-"
-            yarn config set cache-folder ~/.cache/yarn
+            # Keep path in sync with `save_cache` for key "v7-yarn-"
+            yarn config set cache-folder /tmp/yarn-cache
             # Debug information
             yarn cache dir
             yarn cache list
@@ -81,29 +81,32 @@ commands:
             - restore_cache:
                 name: Restore playwright cache
                 keys:
-                  - v4-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
-                  - v4-playwright-{{ arch }}-
-                  - v4-playwright-
+                  - v5-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+                  - v5-playwright-{{ arch }}-
+                  - v5-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
           environment:
+            PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
       - save_cache:
           name: Save yarn cache
-          key: v6-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v7-yarn-{{ checksum "yarn.lock" }}
           paths:
             # Keep path in sync with "Set yarn cache folder"
             # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
-            - ~/.cache/yarn
+            - /tmp/yarn-cache
       - when:
           condition: << parameters.browsers >>
           steps:
             - save_cache:
                 name: Save playwright cache
-                key: v4-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+                key: v5-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
                 paths:
-                  - ~/.cache/ms-playwright
+            # Keep path in sync with "Install js dependencies"
+            # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+                  - /tmp/pw-browsers
 
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,8 @@ commands:
       - run:
           name: Install js dependencies
           command: yarn install --verbose
+          environment:
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
       - save_cache:
           name: Save yarn cache
           key: v6-yarn-sha-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,6 @@ commands:
                 if: << parameters.chrome >>
                 command: |
                   sudo apt-get install -y --no-install-recommends \
-                    libgstreamer-gl1.0-0 \
                     libgstreamer-plugins-bad1.0-0 \
                     gstreamer1.0-plugins-good \
                     gstreamer1.0-libav

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,18 +39,10 @@ defaults: &defaults
 commands:
   install_js:
     parameters:
-      chrome:
+      browsers:
         type: boolean
         default: false
-        description: 'Set to true if you intend to use chrome (e.g. with playwright).'
-      firefox:
-        type: boolean
-        default: false
-        description: 'Set to true if you intend to use firefox (e.g. with playwright).'
-      video:
-        type: boolean
-        default: false
-        description: 'Set to true if you need video playback support in any browser.'
+        description: 'Set to true if you intend to any browser (e.g. with playwright).'
 
     steps:
       - run:
@@ -78,107 +70,45 @@ commands:
             yarn cache dir
             yarn cache list
       - when:
-          condition:
-            or:
-              - << parameters.chrome >>
-              - << parameters.firefox >>
+          condition: << parameters.browsers >>
           steps:
             - restore_cache:
                 name: Restore playwright cache
                 keys:
-                  - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
-                  - v1-playwright-{{ arch }}-
-                  - v1-playwright-
-            - run:
-                name: Update apt
-                command: sudo apt-get update
-            - run:
-                name: Install WebKit dependencies
-                if: << parameters.chrome >>
-                command: |
-                  sudo apt-get install -y --no-install-recommends \
-                    libopus0 \
-                    libwebp6 \
-                    libwebpdemux2 \
-                    libenchant1c2a \
-                    libgudev-1.0-0 \
-                    libsecret-1-0 \
-                    libhyphen0 \
-                    libgdk-pixbuf2.0-0 \
-                    libnotify4 \
-                    libxslt1.1 \
-                    libgles2 \
-                    libxcomposite1 \
-                    libatk1.0-0 \
-                    libatk-bridge2.0-0 \
-                    libepoxy0 \
-                    libgtk-3-0 \
-                    libharfbuzz-icu0
-            - run:
-                name: Install gstreamer and plugins to support video playback in WebKit.
-                if:
-                  and:
-                    - << parameters.chrome >>
-                    - << parameters.video >>
-                command: |
-                  sudo apt-get install -y --no-install-recommends \
-                    libgstreamer-plugins-bad1.0-0 \
-                    gstreamer1.0-plugins-good \
-                    gstreamer1.0-libav
-            - run:
-                name: Install Chromium dependencies
-                if: << parameters.chrome >>
-                command: |
-                  sudo apt-get install -y --no-install-recommends \
-                    fonts-liberation \
-                    libnss3 \
-                    libxss1 \
-                    libasound2 \
-                    libxtst6
-            - run:
-                name: Install Firefox dependencies
-                if: << parameters.firefox >>
-                command: |
-                  sudo apt-get install -y --no-install-recommends \
-                    libdbus-glib-1-2 \
-                    libxt6
-            - run:
-                name: Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-                if:
-                  and:
-                    - << parameters.firefox >>
-                    - << parameters.video >>
-                command: |
-                  sudo apt-get install -y --no-install-recommends \
-                    ffmpeg
+                  - v2-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+                  - v2-playwright-{{ arch }}-
+                  - v2-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
+      - save_cache:
+          name: Save yarn cache
+          key: v6-yarn-sha-{{ checksum "yarn.lock" }}
+          paths:
+            # Keep path in sync with "Set yarn cache folder"
+            # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+            - ~/.cache/yarn
+      - when:
+          condition: << parameters.browsers >>
+          steps:
+            - save_cache:
+                name: Save playwright cache
+                key: v2-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+                paths:
+                  - ~/.cache/ms-playwright
 
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
-      - install_js:
-          # To prepare the cache for subsequent jobs
-          chrome: true
+      - install_js
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
       - run:
           name: Check for duplicated packages
           command: yarn deduplicate
-      - save_cache:
-          key: v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/ms-playwright
-      - save_cache:
-          key: v6-yarn-sha-{{ checksum "yarn.lock" }}
-          paths:
-            # Keep path in sync with "Set yarn cache folder"
-            # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
-            - ~/.cache/yarn
   test_unit:
     <<: *defaults
     steps:
@@ -376,10 +306,14 @@ jobs:
             exit 0
   test_browser:
     <<: *defaults
+    docker:
+      - image: mcr.microsoft.com/playwright:bionic
+        environment:
+          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
-          chrome: true
+          browsers: true
       - run:
           name: Tests real browsers
           command: yarn test:karma
@@ -395,10 +329,14 @@ jobs:
           command: yarn test:umd
   test_profile:
     <<: *defaults
+    docker:
+      - image: mcr.microsoft.com/playwright:bionic
+        environment:
+          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
-          chrome: true
+          browsers: true
       - run:
           name: Tests real browsers
           # Run a couple of times for a better sample.
@@ -418,10 +356,14 @@ jobs:
           destination: react-profiler-report/karma
   test_regressions:
     <<: *defaults
+    docker:
+      - image: mcr.microsoft.com/playwright:bionic
+        environment:
+          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
-          chrome: true
+          browsers: true
       - run:
           name: Run visual regression tests
           command: xvfb-run yarn test:regressions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,8 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - install_js
+      - install_js:
+          browsers: true
       - run:
           name: Tests real browsers
           command: yarn test:karma
@@ -328,7 +329,8 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - install_js
+      - install_js:
+          browsers: true
       - run:
           name: Tests real browsers
           # Run a couple of times for a better sample.
@@ -352,7 +354,8 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - install_js
+      - install_js:
+          browsers: true
       - run:
           name: Install headful dependencies
           command: sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,12 +72,18 @@ commands:
       - when:
           condition: << parameters.browsers >>
           steps:
+            - run:
+                name: Prepare playwright hash
+                command: yarn --json list --pattern playwright > /tmp/playwright_info.json
+            - store_artifacts:
+                name: Debug playwright hash
+                path: /tmp/playwright_info.json
             - restore_cache:
                 name: Restore playwright cache
                 keys:
-                  - v3-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
-                  - v3-playwright-{{ arch }}-
-                  - v3-playwright-
+                  - v4-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+                  - v4-playwright-{{ arch }}-
+                  - v4-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
@@ -93,7 +99,7 @@ commands:
           steps:
             - save_cache:
                 name: Save playwright cache
-                key: v3-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+                key: v4-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
                 paths:
                   - ~/.cache/ms-playwright
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,11 @@ commands:
     steps:
       - run:
           name: Update apt
-          command: apt-get update
+          command: sudo apt-get update
       - run:
           name: Install WebKit dependencies
           command: |
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
               libwoff1 \
               libopus0 \
               libwebp6 \
@@ -119,7 +119,7 @@ commands:
       - run:
           name: Install gstreamer and plugins to support video playback in WebKit.
           command: |
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
               libgstreamer-gl1.0-0 \
               libgstreamer-plugins-bad1.0-0 \
               gstreamer1.0-plugins-good \
@@ -128,7 +128,7 @@ commands:
       - run:
           name: Install Chromium dependencies
           command: |
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
               fonts-liberation \
               libnss3 \
               libxss1 \
@@ -138,14 +138,14 @@ commands:
       - run:
           name: Install Firefox dependencies
           command: |
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
               libdbus-glib-1-2 \
               libxt6
           if: << parameters.firefox >>
       - run:
           name: Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
           command: |
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
               ffmpeg
           if:
             and:
@@ -154,7 +154,7 @@ commands:
       - run:
           name: (Optional) Install XVFB if there's a need to run browsers in headful mode
           command: |
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
               xvfb
           if: << parameters.headful >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,12 +357,8 @@ jobs:
       - install_js:
           browsers: true
       - run:
-          name: Install headful dependencies
-          command: sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            xvfb-run
-      - run:
           name: Run visual regression tests
-          command: xvfb-run yarn test:regressions
+          command: yarn test:regressions
       - run:
           name: Upload screenshots to Argos CI
           command: yarn test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
       - run:
           name: Install headful dependencies
           command: sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            xvfb
+            xvfb-run
       - run:
           name: Run visual regression tests
           command: xvfb-run yarn test:regressions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,15 @@ defaults: &defaults
 commands:
   install_js:
     parameters:
-      browsers:
+      chrome:
         type: boolean
-        description: 'Set to true if you intend to use actual browsers.'
         default: false
+        description: 'Set to true if you intend to use chrome (e.g. with playwright)'
+      firefox:
+        type: boolean
+        default: false
+        description: 'Set to true if you intend to use firefox (e.g. with playwright)'
+
     steps:
       - run:
           name: View install environment
@@ -69,7 +74,10 @@ commands:
             yarn cache dir
             yarn cache list
       - when:
-          condition: << parameters.browsers >>
+          condition:
+            or:
+              - << parameters.chrome >>
+              - << parameters.firefox >>
           steps:
             - restore_cache:
                 name: Restore playwright cache
@@ -77,11 +85,67 @@ commands:
                   - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
                   - v1-playwright-{{ arch }}-
                   - v1-playwright-
+            - run:
+                name: Update apt
+                command: sudo apt-get update
+            - run:
+                name: Install WebKit dependencies
+                if: << parameters.chrome >>
+                command: |
+                  sudo apt-get install -y --no-install-recommends \
+                    libopus0 \
+                    libwebp6 \
+                    libwebpdemux2 \
+                    libenchant1c2a \
+                    libgudev-1.0-0 \
+                    libsecret-1-0 \
+                    libhyphen0 \
+                    libgdk-pixbuf2.0-0 \
+                    libnotify4 \
+                    libxslt1.1 \
+                    libgles2 \
+                    libxcomposite1 \
+                    libatk1.0-0 \
+                    libatk-bridge2.0-0 \
+                    libepoxy0 \
+                    libgtk-3-0 \
+                    libharfbuzz-icu0
+            - run:
+                name: Install gstreamer and plugins to support video playback in WebKit.
+                if: << parameters.chrome >>
+                command: |
+                  sudo apt-get install -y --no-install-recommends \
+                    libgstreamer-gl1.0-0 \
+                    libgstreamer-plugins-bad1.0-0 \
+                    gstreamer1.0-plugins-good \
+                    gstreamer1.0-libav
+            - run:
+                name: Install Chromium dependencies
+                if: << parameters.chrome >>
+                command: |
+                  sudo apt-get install -y --no-install-recommends \
+                    fonts-liberation \
+                    libnss3 \
+                    libxss1 \
+                    libasound2 \
+                    fonts-noto-color-emoji \
+                    libxtst6
+            - run:
+                name: Install Firefox dependencies
+                if: << parameters.firefox >>
+                command: |
+                  sudo apt-get install -y --no-install-recommends \
+                    libdbus-glib-1-2 \
+                    libxt6
+            - run:
+                name: Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+                if: << parameters.firefox >>
+                command: |
+                  sudo apt-get install -y --no-install-recommends \
+                    ffmpeg
       - run:
           name: Install js dependencies
           command: yarn install --verbose
-          environment:
-            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
 
 jobs:
   checkout:
@@ -90,7 +154,7 @@ jobs:
       - checkout
       - install_js:
           # To prepare the cache for subsequent jobs
-          browsers: true
+          chrome: true
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
@@ -304,12 +368,10 @@ jobs:
             exit 0
   test_browser:
     <<: *defaults
-    docker:
-      - image: circleci/node:10-browsers
     steps:
       - checkout
       - install_js:
-          browsers: true
+          chrome: true
       - run:
           name: Tests real browsers
           command: yarn test:karma
@@ -325,12 +387,10 @@ jobs:
           command: yarn test:umd
   test_profile:
     <<: *defaults
-    docker:
-      - image: circleci/node:10-browsers
     steps:
       - checkout
       - install_js:
-          browsers: true
+          chrome: true
       - run:
           name: Tests real browsers
           # Run a couple of times for a better sample.
@@ -350,15 +410,13 @@ jobs:
           destination: react-profiler-report/karma
   test_regressions:
     <<: *defaults
-    docker:
-      - image: circleci/node:10-browsers
     steps:
       - checkout
       - install_js:
-          browsers: true
+          chrome: true
       - run:
           name: Run visual regression tests
-          command: yarn test:regressions
+          command: xfvb-run yarn test:regressions
       - run:
           name: Upload screenshots to Argos CI
           command: yarn test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,6 @@ defaults: &defaults
 #     key: v1-repo-{{ .Branch }}-{{ .Revision }}
 
 commands:
-  # Always call before install_*
-  restore_browser_binaries:
-    steps:
-      - restore_cache:
-          keys:
-            - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-playwright-{{ arch }}-
-            - v1-playwright-
   install_js:
     parameters:
       browsers:
@@ -64,6 +56,7 @@ commands:
             # log a patch for maintainers who want to check out this change
             git --no-pager diff HEAD
       - restore_cache:
+          name: Restore yarn cache
           keys:
             - v6-yarn-sha-{{ checksum "yarn.lock" }}
             - v6-yarn-sha-
@@ -79,6 +72,7 @@ commands:
           condition: << parameters.browsers >>
           steps:
             - restore_cache:
+                name: Restore playwright cache
                 keys:
                   - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
                   - v1-playwright-{{ arch }}-
@@ -94,8 +88,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_browser_binaries
-      - install_js
+      - install_js:
+          # To prepare the cache for subsequent jobs
+          browsers: true
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
@@ -313,7 +308,6 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - restore_browser_binaries
       - install_js
       - run:
           name: Tests real browsers
@@ -334,7 +328,6 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - restore_browser_binaries
       - install_js
       - run:
           name: Tests real browsers
@@ -359,8 +352,11 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - restore_browser_binaries
       - install_js
+      - run:
+          name: Install headful dependencies
+          command: sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+            xvfb
       - run:
           name: Run visual regression tests
           command: xvfb-run yarn test:regressions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,6 @@ commands:
         type: boolean
         default: false
         description: 'Set to true if you intend to use firefox (e.g. with playwright).'
-      headful:
-        type: boolean
-        default: false
-        description: 'Set to true if you intend run any browsers in headful mode.'
       video:
         type: boolean
         default: false
@@ -155,12 +151,6 @@ commands:
                 command: |
                   sudo apt-get install -y --no-install-recommends \
                     ffmpeg
-            - run:
-                name: Install XVFB
-                if: << parameters.headful >>
-                command: |
-                  sudo apt-get install -y --no-install-recommends \
-                    xvfb
       - run:
           name: Install js dependencies
           command: yarn install --verbose
@@ -432,10 +422,9 @@ jobs:
       - checkout
       - install_js:
           chrome: true
-          headful: true
       - run:
           name: Run visual regression tests
-          command: xfvb-run yarn test:regressions
+          command: xvfb-run yarn test:regressions
       - run:
           name: Upload screenshots to Argos CI
           command: yarn test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,6 @@ commands:
                     libnss3 \
                     libxss1 \
                     libasound2 \
-                    fonts-noto-color-emoji \
                     libxtst6
             - run:
                 name: Install Firefox dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,11 @@ commands:
             - v1-playwright-{{ arch }}-
             - v1-playwright-
   install_js:
+    parameters:
+      browsers:
+        type: boolean
+        description: 'Set to true if you intend to use actual browsers.'
+        default: false
     steps:
       - run:
           name: View install environment
@@ -70,91 +75,19 @@ commands:
             # Debug information
             yarn cache dir
             yarn cache list
+      - when:
+          condition: << parameters.browsers >>
+          steps:
+            - restore_cache:
+                keys:
+                  - v1-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+                  - v1-playwright-{{ arch }}-
+                  - v1-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
-  install_browsers:
-    parameters:
-      # Set to true if you intend to use firefox in playwright
-      firefox:
-        type: boolean
-        default: false
-      # Set to true if you intend to run playwright in headful mode
-      headful:
-        type: boolean
-        default: false
-      # Set to true if you need to support video playback
-      video:
-        type: boolean
-        default: false
-    steps:
-      - run:
-          name: Update apt
-          command: sudo apt-get update
-      - run:
-          name: Install WebKit dependencies
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              libopus0 \
-              libwebp6 \
-              libwebpdemux2 \
-              libenchant1c2a \
-              libgudev-1.0-0 \
-              libsecret-1-0 \
-              libhyphen0 \
-              libgdk-pixbuf2.0-0 \
-              libnotify4 \
-              libxslt1.1 \
-              libgles2 \
-              libxcomposite1 \
-              libatk1.0-0 \
-              libatk-bridge2.0-0 \
-              libepoxy0 \
-              libgtk-3-0 \
-              libharfbuzz-icu0
-      - run:
-          name: Install gstreamer and plugins to support video playback in WebKit.
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              libgstreamer-gl1.0-0 \
-              libgstreamer-plugins-bad1.0-0 \
-              gstreamer1.0-plugins-good \
-              gstreamer1.0-libav
-          if: << parameters.video >>
-      - run:
-          name: Install Chromium dependencies
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              fonts-liberation \
-              libnss3 \
-              libxss1 \
-              libasound2 \
-              fonts-noto-color-emoji \
-              libxtst6
-      - run:
-          name: Install Firefox dependencies
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              libdbus-glib-1-2 \
-              libxt6
-          if: << parameters.firefox >>
-      - run:
-          name: Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              ffmpeg
-          if:
-            and:
-              - << parameters.firefox >>
-              - << parameters.video >>
-      - run:
-          name: (Optional) Install XVFB if there's a need to run browsers in headful mode
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              xvfb
-          if: << parameters.headful >>
-
-      - restore_browser_binaries
+          environment:
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
 
 jobs:
   checkout:
@@ -376,9 +309,11 @@ jobs:
             exit 0
   test_browser:
     <<: *defaults
+    docker:
+      - image: circleci/node:10-browsers
     steps:
       - checkout
-      - install_browsers
+      - restore_browser_binaries
       - install_js
       - run:
           name: Tests real browsers
@@ -395,9 +330,11 @@ jobs:
           command: yarn test:umd
   test_profile:
     <<: *defaults
+    docker:
+      - image: circleci/node:10-browsers
     steps:
       - checkout
-      - install_browsers
+      - restore_browser_binaries
       - install_js
       - run:
           name: Tests real browsers
@@ -418,10 +355,11 @@ jobs:
           destination: react-profiler-report/karma
   test_regressions:
     <<: *defaults
+    docker:
+      - image: circleci/node:10-browsers
     steps:
       - checkout
-      - install_browsers:
-          headful: true
+      - restore_browser_binaries
       - install_js
       - run:
           name: Run visual regression tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ commands:
             - restore_cache:
                 name: Restore playwright cache
                 keys:
-                  - v2-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
-                  - v2-playwright-{{ arch }}-
-                  - v2-playwright-
+                  - v3-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+                  - v3-playwright-{{ arch }}-
+                  - v3-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
@@ -93,7 +93,7 @@ commands:
           steps:
             - save_cache:
                 name: Save playwright cache
-                key: v2-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
+                key: v3-playwright-{{ arch }}-{{ checksum "yarn.lock" }}
                 paths:
                   - ~/.cache/ms-playwright
 

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -7,7 +7,7 @@ async function main() {
   const screenshotDir = path.resolve(__dirname, './screenshots/chrome');
 
   const browser = await playwright.chromium.launch({
-    args: ['--disable-dev-shm-usage', '--font-render-hinting=none'],
+    args: ['--font-render-hinting=none'],
     // otherwise the loaded google Roboto font isn't applied
     headless: false,
   });

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -7,7 +7,7 @@ async function main() {
   const screenshotDir = path.resolve(__dirname, './screenshots/chrome');
 
   const browser = await playwright.chromium.launch({
-    args: ['--font-render-hinting=none'],
+    args: ['--disable-dev-shm-usage', '--font-render-hinting=none'],
     // otherwise the loaded google Roboto font isn't applied
     headless: false,
   });


### PR DESCRIPTION
First follow-up to from https://github.com/mui-org/material-ui/pull/24844

## Summary

1. Fix playwright cache miss when we actually used it
1. Skip browser download when we don't need it
1. use playwright version in cache hash instead of lockfile
   This is actually how it's recommended. It should reduce the overall number of cache misses.
   > [...] cache this location in your CI configuration, against a hash of the Playwright version.
   -- https://playwright.dev/docs/ci#directories-to-cache
1. Name save/restore cache tasks (we have two caches and identifying the relevant steps became confusing)


### Explainer

Due to https://github.com/microsoft/playwright/issues/5372 we can't save the cache once in `checkout` since restore and save will mismatch. We have to store the cache in the same container as we populate it. I think this is generally better anyway. CI providers like azure already take away control over save/restore and just have a single cache task.

This will lead to one more cache miss if a PR creates a cache miss (both `test_browser` and `test_regressions` will mismatch) but the majority of jobs will have cache hit anyway.

We'll use the same approach (always restore and save) with the yarn cache as well. `save_cache` has virtually no cost on a hit anyway (0s).

workflow with a playwright cache miss: https://app.circleci.com/pipelines/github/mui-org/material-ui/38088/workflows/2fe948f3-32b1-49e0-b46f-415700633dfd
workflow with a cache hit: https://app.circleci.com/pipelines/github/mui-org/material-ui/38088/workflows/e3bc2b33-25e7-4e28-b4d0-c7428fea51ef

## Failed approaches

### playwright + circleci image
Pulling the default image after the playwright image (c7617a78d47c9cca9d34015ddc146b2c74b77990) does not work: https://app.circleci.com/pipelines/github/mui-org/material-ui/38060/workflows/6f35dca6-2cb8-4bd7-b491-1f7e54069a3f/jobs/224706/parallel-runs/0/steps/0-105

### `circleci/node:10` + `apt-get install` or just `circleci/node:10-browsers`

Can't use the circleci browser images since they're based on debian stretch where `libwoff1` is not available. It seems to me this package is required to render `woff2` fonts. Using the circleci iamges leads to https://www.argos-ci.com/mui-org/material-ui/builds/248