### PR TITLE
[test] Dedupe missing act warnings for HoC

### DIFF
--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -34,7 +34,7 @@ function dedupeActWarningsByComponent(consoleCalls) {
 
   consoleCalls.forEach(([stack, message]) => {
     const componentName = message.match(
-      /An update to (\w+) ran an effect, but was not wrapped in act/,
+      /An update to (.+?) ran an effect, but was not wrapped in act/,
     )?.[1];
 
     const duplicateMissingActWarning =

--- a/test/utils/mochaHooks.test.js
+++ b/test/utils/mochaHooks.test.js
@@ -58,11 +58,11 @@ describe('mochaHooks', () => {
       });
 
       it('', () => {
-        function Child() {
+        const Child = React.forwardRef(function Child() {
           React.useEffect(() => {});
           React.useEffect(() => {});
           return null;
-        }
+        });
 
         let setState;
         function Parent() {
@@ -97,7 +97,9 @@ describe('mochaHooks', () => {
           error.match(/An update to Parent ran an effect, but was not wrapped in act/g),
         ).to.have.lengthOf(1);
         expect(
-          error.match(/An update to Child ran an effect, but was not wrapped in act/g),
+          error.match(
+            /An update to ForwardRef\(Child\) ran an effect, but was not wrapped in act/g,
+          ),
         ).to.have.lengthOf(1);
       });
     });


### PR DESCRIPTION
Higher-order components don't match `\w+` e.g. `WithStyles(ForwardRef(Foo))`. For example, in https://app.circleci.com/pipelines/github/mui-org/material-ui/38098/workflows/515c0f2f-1cd9-4760-ae83-474fa95b51b9/jobs/224949/parallel-runs/0/steps/0-108 not all act warnings where as deduped as the could be using the "dedupe by component name" heuristic.