### PR TITLE
[TextField] Fix focused={true} disabled={true} infinite render

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -161,7 +161,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
   const [focusedState, setFocused] = React.useState(false);
   const focused = visuallyFocused !== undefined ? visuallyFocused : focusedState;
 
-  if (disabled && focused) {
+  if (disabled && focusedState) {
     setFocused(false);
   }
 

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -159,11 +159,11 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
   });
 
   const [focusedState, setFocused] = React.useState(false);
-  const focused = visuallyFocused !== undefined ? visuallyFocused : focusedState;
-
   if (disabled && focusedState) {
     setFocused(false);
   }
+
+  const focused = visuallyFocused !== undefined ? visuallyFocused : focusedState;
 
   let registerEffect;
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -163,7 +163,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     setFocused(false);
   }
 
-  const focused = visuallyFocused !== undefined ? visuallyFocused : focusedState;
+  const focused = visuallyFocused !== undefined && !disabled ? visuallyFocused : focusedState;
 
   let registerEffect;
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -120,7 +120,7 @@ describe('<FormControl />', () => {
       expect(readContext.args[0][0]).to.have.property('focused', true);
     });
 
-    it('should give disabled more priority of focused', () => {
+    it('ignores focused when disabled', () => {
       const readContext = spy();
       render(
         <FormControl focused disabled>
@@ -128,7 +128,7 @@ describe('<FormControl />', () => {
           <TestComponent contextCallback={readContext} />
         </FormControl>,
       );
-      expect(readContext.args[0][0]).to.have.property('focused', false);
+      expect(readContext.args[0][0]).to.include({ disabled: true, focused: false });
     });
   });
 
@@ -141,6 +141,7 @@ describe('<FormControl />', () => {
           <TestComponent contextCallback={readContext} />
         </FormControl>,
       );
+
       expect(readContext.args[0][0]).to.have.property('filled', true);
     });
 

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -120,12 +120,15 @@ describe('<FormControl />', () => {
       expect(readContext.args[0][0]).to.have.property('focused', true);
     });
 
-    it('should not go in an infinite loop', () => {
+    it('should give disabled more priority of focused', () => {
+      const readContext = spy();
       render(
         <FormControl focused disabled>
           <Input />
+          <TestComponent contextCallback={readContext} />
         </FormControl>,
       );
+      expect(readContext.args[0][0]).to.have.property('focused', false);
     });
   });
 

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -119,6 +119,14 @@ describe('<FormControl />', () => {
       container.querySelector('input').blur();
       expect(readContext.args[0][0]).to.have.property('focused', true);
     });
+
+    it('should not go in an infinite loop', () => {
+      render(
+        <FormControl focused disabled>
+          <Input />
+        </FormControl>,
+      );
+    });
   });
 
   describe('input', () => {

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -141,7 +141,6 @@ describe('<FormControl />', () => {
           <TestComponent contextCallback={readContext} />
         </FormControl>,
       );
-
       expect(readContext.args[0][0]).to.have.property('filled', true);
     });
 


### PR DESCRIPTION
Fix the pain point raised by @ameem91 in #24777. The TextField focused state is about DOM focus, the TextField focused prop is about the active view, the notions are different, the branch is not correct.

If we feel a test case is needed, happy to provide one.