### PR TITLE
[test] Improve various timer related issues

### DIFF
--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -6,7 +6,7 @@ import MonthPicker from '../MonthPicker/MonthPicker';
 import { useCalendarState } from './useCalendarState';
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import FadeTransitionGroup from './PickersFadeTransitionGroup';
-import Calendar, { ExportedCalendarProps } from './PickersCalendar';
+import PickersCalendar, { ExportedCalendarProps } from './PickersCalendar';
 import { PickerOnChangeFn, useViews } from '../internal/pickers/hooks/useViews';
 import { DAY_SIZE, DAY_MARGIN } from '../internal/pickers/constants/dimensions';
 import PickersCalendarHeader, { ExportedCalendarHeaderProps } from './PickersCalendarHeader';
@@ -224,7 +224,7 @@ const DayPicker = React.forwardRef(function DayPicker<
           )}
 
           {openView === 'date' && (
-            <Calendar
+            <PickersCalendar
               {...other}
               {...calendarState}
               onMonthSwitchingAnimationEnd={onMonthSwitchingAnimationEnd}

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePickerKeyboard.test.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { useFakeTimers } from 'sinon';
 import TextField from '@material-ui/core/TextField';
 import { fireEvent, screen } from 'test/utils';
 import StaticDatePicker from '@material-ui/lab/StaticDatePicker';
 import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<StaticDatePicker /> keyboard interactions', () => {
+  let clock: ReturnType<typeof useFakeTimers>;
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+  afterEach(() => {
+    clock.restore();
+  });
   const render = createPickerRender();
 
   describe('Calendar keyboard navigation', () => {

--- a/packages/material-ui-lab/src/internal/pickers/PickersArrowSwitcher.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersArrowSwitcher.tsx
@@ -61,10 +61,10 @@ export const styles: MuiStyles<PickersArrowSwitcherClassKey> = (
   },
 });
 
-const PickersArrowSwitcher = React.forwardRef<
-  HTMLDivElement,
-  ArrowSwitcherProps & WithStyles<typeof styles>
->((props, ref) => {
+const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitcher(
+  props: ArrowSwitcherProps & WithStyles<typeof styles>,
+  ref: React.Ref<HTMLDivElement>,
+) {
   const {
     children,
     classes,

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -32,7 +32,7 @@ describe('<ClickAwayListener />', () => {
    */
   function render(...args) {
     const result = clientRender(...args);
-    clock.next();
+    clock.tick(0);
     return result;
   }
 

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -166,19 +166,30 @@ describe('<SpeedDial />', () => {
     let actionButtons;
     let fabButton;
 
+    function NoTransition(props) {
+      const { children, in: inProp } = props;
+
+      if (!inProp) {
+        return null;
+      }
+      return children;
+    }
+
     const renderSpeedDial = (direction = 'up', actionCount = 4) => {
       actionButtons = [];
       fabButton = undefined;
 
       render(
         <SpeedDial
-          {...defaultProps}
+          ariaLabel={`${direction}-actions-${actionCount}`}
           FabProps={{
             ref: (element) => {
               fabButton = element;
             },
           }}
+          open
           direction={direction}
+          TransitionComponent={NoTransition}
         >
           {Array.from({ length: actionCount }, (_, index) => (
             <SpeedDialAction

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -358,14 +358,19 @@ describe('<Tooltip />', () => {
   });
 
   it('is dismissable by pressing Escape', () => {
+    const handleClose = spy();
     const transitionTimeout = 0;
     render(
-      <Tooltip enterDelay={0} TransitionProps={{ timeout: transitionTimeout }} title="Movie quote">
-        <button autoFocus>Hello, Dave!</button>
+      <Tooltip
+        enterDelay={0}
+        onClose={handleClose}
+        open
+        TransitionProps={{ timeout: transitionTimeout }}
+        title="Movie quote"
+      >
+        <button />
       </Tooltip>,
     );
-
-    expect(screen.getByRole('tooltip')).not.toBeInaccessible();
 
     act(() => {
       fireEvent.keyDown(
@@ -379,7 +384,7 @@ describe('<Tooltip />', () => {
       clock.tick(transitionTimeout);
     });
 
-    expect(screen.queryByRole('tooltip')).to.equal(null);
+    expect(handleClose.callCount).to.equal(1);
   });
 
   describe('touch screen', () => {

--- a/scripts/listChangedFiles.test.js
+++ b/scripts/listChangedFiles.test.js
@@ -7,8 +7,9 @@ const listChangedFiles = require('./listChangedFiles');
 const writeFileAsync = promisify(fs.writeFile);
 const rimrafAsync = promisify(rimraf);
 
-describe('listChangedFiles', () => {
+describe('listChangedFiles', function listChangedFilesSuite() {
   // This test oftentimes times out after 4s but it's unclear why considering `listChangedFiles` is used in CI tasks that only take <1s.
+  this.timeout(10000);
   const noop = () => {};
   // eslint-disable-next-line no-console
   const time = process.env.CI ? console.time : noop;

--- a/scripts/listChangedFiles.test.js
+++ b/scripts/listChangedFiles.test.js
@@ -18,22 +18,22 @@ describe('listChangedFiles', function listChangedFilesSuite() {
   // eslint-disable-next-line no-console
   const timeEnd = process.env.CI ? console.timeEnd : noop;
   it('should detect changes', async () => {
-    time();
+    time('should detect changes');
     const changesBeforeAdd = await listChangedFiles({ branch: 'next' });
-    timeLog();
+    timeLog('should detect changes');
     const testFile = 'someTestFile.yml';
     try {
       await writeFileAsync(testFile, 'console.log("hello");');
-      timeLog();
+      timeLog('should detect changes');
       const changesAfterAdd = await listChangedFiles({ branch: 'next' });
-      timeLog();
+      timeLog('should detect changes');
       expect(changesBeforeAdd).not.to.contain(testFile);
       expect(changesAfterAdd).to.contain(testFile);
       expect(changesAfterAdd.size - changesBeforeAdd.size).to.equal(1);
-      timeLog();
+      timeLog('should detect changes');
     } finally {
       await rimrafAsync(testFile);
-      timeEnd();
+      timeEnd('should detect changes');
     }
   });
 });

--- a/scripts/listChangedFiles.test.js
+++ b/scripts/listChangedFiles.test.js
@@ -8,17 +8,31 @@ const writeFileAsync = promisify(fs.writeFile);
 const rimrafAsync = promisify(rimraf);
 
 describe('listChangedFiles', () => {
+  // This test oftentimes times out after 4s but it's unclear why considering `listChangedFiles` is used in CI tasks that only take <1s.
+  const noop = () => {};
+  // eslint-disable-next-line no-console
+  const time = process.env.CI ? console.time : noop;
+  // eslint-disable-next-line no-console
+  const timeLog = process.env.CI ? console.timeLog : noop;
+  // eslint-disable-next-line no-console
+  const timeEnd = process.env.CI ? console.timeEnd : noop;
   it('should detect changes', async () => {
+    time();
     const changesBeforeAdd = await listChangedFiles({ branch: 'next' });
+    timeLog();
     const testFile = 'someTestFile.yml';
     try {
       await writeFileAsync(testFile, 'console.log("hello");');
+      timeLog();
       const changesAfterAdd = await listChangedFiles({ branch: 'next' });
+      timeLog();
       expect(changesBeforeAdd).not.to.contain(testFile);
       expect(changesAfterAdd).to.contain(testFile);
       expect(changesAfterAdd.size - changesBeforeAdd.size).to.equal(1);
+      timeLog();
     } finally {
       await rimrafAsync(testFile);
+      timeEnd();
     }
   });
 });


### PR DESCRIPTION
1. increase timeout for listChangedFiles
   Timed out fairly often but it's unclear why this is slow in tests. Added monitoring for future investigation
1. Fix https://app.circleci.com/pipelines/github/mui-org/material-ui/38098/workflows/515c0f2f-1cd9-4760-ae83-474fa95b51b9/jobs/224949/parallel-runs/0/steps/0-108
   `StaticDatePicker` uses `Fade` in its tree so if the test was slow those scheduled updates got executed resulting in unwrapped act. 
   We're now just not advancing the timers relevant for these updates since we don't care about the updates in those tests.
1. speed up a Tooltip test which had redundant assertions
   We already have tests for checking role+a11y tree inclusion. `onClose` is an equivalent assertion if the role+a11y tests pass.
1. Fix https://app.circleci.com/pipelines/github/mui-org/material-ui/38055/workflows/8b4e781b-86c7-40ed-be0e-68937f8e45f3/jobs/224666/parallel-runs/0/steps/0-108
