### PR TITLE
[test] Reduce compile time of test:karma in watchmode drastically

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,6 +1,8 @@
 const playwright = require('playwright');
 const webpack = require('webpack');
 
+const CI = Boolean(process.env.CI);
+
 let build = `material-ui local ${new Date().toISOString()}`;
 
 if (process.env.CIRCLE_BUILD_URL) {
@@ -66,7 +68,7 @@ module.exports = function setKarmaConfig(config) {
     reporters: ['dots'],
     webpack: {
       mode: 'development',
-      devtool: 'inline-source-map',
+      devtool: CI ? 'inline-source-map' : 'eval-source-map',
       plugins: [
         new webpack.DefinePlugin({
           'process.env.NODE_ENV': JSON.stringify('test'),
@@ -97,7 +99,7 @@ module.exports = function setKarmaConfig(config) {
     },
     webpackMiddleware: {
       noInfo: true,
-      writeToDisk: Boolean(process.env.CI),
+      writeToDisk: CI,
     },
     customLaunchers: {
       chromeHeadless: {
@@ -105,7 +107,7 @@ module.exports = function setKarmaConfig(config) {
         flags: ['--no-sandbox'],
       },
     },
-    singleRun: Boolean(process.env.CI),
+    singleRun: CI,
   };
 
   let newConfig = baseConfig;


### PR DESCRIPTION
When running `yarn test:karma` locally compilation on rebuild should now be dramatically faster in the best case scenario (minimal number of files changed).

The initial build is still "slow". Though I did some quick testing locally and re-building went from 20s to <1s when changing a test file.

Following the recommendation in https://webpack.js.org/configuration/devtool/#devtool for `eval-source-map`:
> Recommended choice for development builds with high quality SourceMaps.