### PR TITLE
[docs] Improve error message when GitHub API fail

### DIFF
--- a/docs/pages/versions.js
+++ b/docs/pages/versions.js
@@ -27,8 +27,13 @@ async function getBranches() {
       Authorization: `Basic ${Buffer.from(githubAuthorizationToken).toString('base64')}`,
     },
   });
-  const branches = await result.json();
-  return branches;
+  const text = await result.text();
+
+  if (result.status !== 200) {
+    throw new Error(text);
+  }
+
+  return JSON.parse(text);
 }
 
 Page.getInitialProps = async () => {


### PR DESCRIPTION
**Before**

> TypeError: branches.map is not a function

https://app.netlify.com/teams/mui-org/builds/602cf181598034000877dc3b

**After**

<img width="685" alt="Capture d’écran 2021-02-17 à 11 50 51" src="https://user-images.githubusercontent.com/3165635/108194274-b97b0b00-7116-11eb-9ec3-6a8a8adbf34d.png">
