### PR TITLE
[pickers] Fix picker components not opening on click in React 17

### DIFF
--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { describeConformance, fireEvent, screen } from 'test/utils';
+import { describeConformance, fireEvent, fireDiscreteEvent, screen } from 'test/utils';
+import { TransitionProps } from '@material-ui/core/transitions';
 import { TimePickerProps } from '@material-ui/lab/TimePicker';
 import DesktopTimePicker from '@material-ui/lab/DesktopTimePicker';
 import {
@@ -29,6 +30,36 @@ describe('<DesktopTimePicker />', () => {
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),
   );
+
+  function NoTransition(props: TransitionProps & { children?: React.ReactNode }) {
+    const { children, in: inProp } = props;
+
+    if (!inProp) {
+      return null;
+    }
+    return children;
+  }
+
+  it('opens on click', () => {
+    const handleClose = spy();
+    const handleOpen = spy();
+    render(
+      <DesktopTimePicker
+        value={null}
+        onChange={() => {}}
+        onClose={handleClose}
+        onOpen={handleOpen}
+        renderInput={(params) => <TextField {...params} />}
+        // @ts-expect-error TODO make this pass
+        TransitionComponent={NoTransition}
+      />,
+    );
+
+    fireDiscreteEvent.click(screen.getByLabelText(/choose time/i));
+
+    expect(handleClose.callCount).to.equal(0);
+    expect(handleOpen.callCount).to.equal(1);
+  });
 
   it('closes on clickaway', () => {
     const handleClose = spy();

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import { expect } from 'chai';
 import { describeConformance, fireEvent, fireDiscreteEvent, screen } from 'test/utils';
 import { TransitionProps } from '@material-ui/core/transitions';
@@ -13,6 +13,15 @@ import {
 } from '../internal/pickers/test-utils';
 
 describe('<DesktopTimePicker />', () => {
+  let clock: ReturnType<typeof useFakeTimers>;
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
   const render = createPickerRender();
   const mount = createPickerMount();
 
@@ -31,14 +40,21 @@ describe('<DesktopTimePicker />', () => {
     }),
   );
 
-  function NoTransition(props: TransitionProps & { children?: React.ReactNode }) {
+  const NoTransition = React.forwardRef(function NoTransition(
+    props: TransitionProps & { children?: React.ReactNode },
+    ref: React.Ref<HTMLDivElement>,
+  ) {
     const { children, in: inProp } = props;
 
     if (!inProp) {
       return null;
     }
-    return children;
-  }
+    return (
+      <div ref={ref} tabIndex={-1}>
+        {children}
+      </div>
+    );
+  });
 
   it('opens on click', () => {
     const handleClose = spy();
@@ -50,7 +66,6 @@ describe('<DesktopTimePicker />', () => {
         onClose={handleClose}
         onOpen={handleOpen}
         renderInput={(params) => <TextField {...params} />}
-        // @ts-expect-error TODO make this pass
         TransitionComponent={NoTransition}
       />,
     );

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -73,6 +73,24 @@ function useClickAwayListener(
 
   const nodeRef = React.useRef<Element>(null);
 
+  const activatedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+
+    function handleClickCapture() {
+      activatedRef.current = true;
+    }
+
+    document.addEventListener('click', handleClickCapture, { capture: true, once: true });
+
+    return () => {
+      activatedRef.current = false;
+      document.removeEventListener('click', handleClickCapture, { capture: true });
+    };
+  }, [active]);
+
   // The handler doesn't take event.defaultPrevented into account:
   //
   // event.preventDefault() is meant to stop default behaviors like
@@ -80,6 +98,10 @@ function useClickAwayListener(
   // and hitting left arrow to move the cursor in a text input etc.
   // Only special HTML elements have these default behaviors.
   const handleClickAway = useEventCallback((event: MouseEvent | TouchEvent) => {
+    if (!activatedRef.current) {
+      return;
+    }
+
     // Given developers can stop the propagation of the synthetic event,
     // we can only be confident with a positive value.
     const insideReactTree = syntheticEventRef.current;


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/24874

We're hitting https://github.com/facebook/react/issues/20074 again. 

Trying a different fix than the one in ClickAwayListener. In the lab we can experiment a bit more. Getting rid of the timers would make this logic easier to follow 

I think I didn't fully grasp the implications of that bug since I thought https://github.com/facebook/react/issues/20074 only had implications for components **inside** a Portal. But that's not true since it'll flush all effects in a React root (all roots?) not just in a particular subtree of a component.

## Test plan
- [x] Verify test fails in React 17
   - [test_unit fail](https://app.circleci.com/pipelines/github/mui-org/material-ui/38202/workflows/73660994-7dbe-400c-a8e1-bfb8b709632e/jobs/225523)
   - [test_browser fail](https://app.circleci.com/pipelines/github/mui-org/material-ui/38202/workflows/73660994-7dbe-400c-a8e1-bfb8b709632e/jobs/225523/parallel-runs/0/steps/0-112)
- [x] [CI green with React 17](https://app.circleci.com/pipelines/github/mui-org/material-ui/38308/workflows/285b9f16-0061-4a33-baa3-bdb485fac354)
- [x] [CI green with React 16](https://app.circleci.com/pipelines/github/mui-org/material-ui/38306/workflows/d762a2f4-abb9-4664-9781-db193bdd06bd)
- [x] Codesandboxes of the linked issues pass (see ci/codesandbox)
- [x] Codesandboxes of the linked issues pass with React 16 (were passing before)
  - https://codesandbox.io/s/basicdatetimepicker-material-demo-forked-fhl1o
  - https://codesandbox.io/s/viewsdatepicker-material-demo-forked-7b85e