### PR TITLE
[Skeleton] Fix global theme customization 

### DIFF
--- a/packages/material-ui/src/Skeleton/Skeleton.js
+++ b/packages/material-ui/src/Skeleton/Skeleton.js
@@ -70,8 +70,7 @@ const waveKeyframe = keyframes`
 const SkeletonRoot = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSkeleton', slot: 'Root' },
-  overridesResolver,
+  { name: 'MuiSkeleton', slot: 'Root', overridesResolver },
 )(
   ({ theme, styleProps }) => {
     const radiusUnit = getUnit(theme.shape.borderRadius) || 'px';

--- a/packages/material-ui/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui/src/Skeleton/Skeleton.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createClientRender, createMount, describeConformance } from 'test/utils';
+import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import Skeleton from './Skeleton';
 import classes from './skeletonClasses';
 
@@ -8,14 +8,14 @@ describe('<Skeleton />', () => {
   const mount = createMount();
   const render = createClientRender();
 
-  describeConformance(<Skeleton />, () => ({
+  describeConformanceV5(<Skeleton />, () => ({
     classes,
     inheritComponent: 'span',
     mount,
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSkeleton',
     testVariantProps: { variant: 'circular', animation: 'wave' },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentsProp'],
   }));
 
   it('should render', () => {

--- a/packages/material-ui/src/styles/components.d.ts
+++ b/packages/material-ui/src/styles/components.d.ts
@@ -316,6 +316,10 @@ export interface Components {
     defaultProps?: ComponentsProps['MuiSelect'];
     styleOverrides?: ComponentsOverrides['MuiSelect'];
   };
+  MuiSkeleton?: {
+    defaultProps?: ComponentsProps['MuiSkeleton'];
+    styleOverrides?: ComponentsOverrides['MuiSkeleton'];
+  };
   MuiSlider?: {
     defaultProps?: ComponentsProps['MuiSlider'];
     styleOverrides?: ComponentsOverrides['MuiSlider'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #24959.

The Skeleton component doesn't pick up global theme `styleOverrides`; this PR fixes the issue.