### PR TITLE
NOT FOR MERGE deploy with `enableSetImmediate`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -46,7 +46,7 @@ module.exports = function getBabelConfig(api) {
       '@babel/preset-react',
       {
         // default in Babel 8
-        runtime: 'automatic',
+        runtime: 'classic',
       },
     ],
     '@babel/preset-typescript',

--- a/babel.config.js
+++ b/babel.config.js
@@ -42,7 +42,13 @@ module.exports = function getBabelConfig(api) {
         shippedProposals: api.env('modern'),
       },
     ],
-    '@babel/preset-react',
+    [
+      '@babel/preset-react',
+      {
+        // default in Babel 8
+        runtime: 'automatic',
+      },
+    ],
     '@babel/preset-typescript',
   ];
 

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -38,7 +38,13 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
 module.exports = {
   presets: [
     // backport of https://github.com/zeit/next.js/pull/9511
-    ['next/babel', { 'transform-runtime': { corejs: 2, version: transformRuntimeVersion } }],
+    [
+      'next/babel',
+      {
+        'preset-react': { runtime: 'classic' },
+        'transform-runtime': { corejs: 2, version: transformRuntimeVersion },
+      },
+    ],
   ],
   plugins: [
     [

--- a/package.json
+++ b/package.json
@@ -196,9 +196,9 @@
     "**/dot-prop": "^5.2.0",
     "**/react-is": "^16.13.1",
     "**/webpack": "^4.44.1",
-    "scheduler": "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler",
-    "react": "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react",
-    "react-dom": "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react-dom",
+    "scheduler": "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/scheduler",
+    "react": "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/react",
+    "react-dom": "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/react-dom",
     "react-test-renderer": "0.0.0-e2fd460cc",
     "react-is": "0.0.0-e2fd460cc"
   },

--- a/package.json
+++ b/package.json
@@ -195,7 +195,12 @@
     "**/cross-fetch": "^3.0.5",
     "**/dot-prop": "^5.2.0",
     "**/react-is": "^16.13.1",
-    "**/webpack": "^4.44.1"
+    "**/webpack": "^4.44.1",
+    "scheduler": "0.0.0-e2fd460cc",
+    "react": "0.0.0-e2fd460cc",
+    "react-dom": "0.0.0-e2fd460cc",
+    "react-test-renderer": "0.0.0-e2fd460cc",
+    "react-is": "0.0.0-e2fd460cc"
   },
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -196,9 +196,9 @@
     "**/dot-prop": "^5.2.0",
     "**/react-is": "^16.13.1",
     "**/webpack": "^4.44.1",
-    "scheduler": "0.0.0-e2fd460cc",
-    "react": "0.0.0-e2fd460cc",
-    "react-dom": "0.0.0-e2fd460cc",
+    "scheduler": "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler",
+    "react": "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react",
+    "react-dom": "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react-dom",
     "react-test-renderer": "0.0.0-e2fd460cc",
     "react-is": "0.0.0-e2fd460cc"
   },

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -122,11 +122,7 @@ describe('ThemeProvider', () => {
             <div />
           </ThemeProvider>,
         );
-      }).toErrorDev([
-        'However, no outer theme is present.',
-        // strict mode renders twice
-        'However, no outer theme is present.',
-      ]);
+      }).toErrorDev(['However, no outer theme is present.']);
     });
 
     it('should warn about wrong theme function', () => {
@@ -139,11 +135,7 @@ describe('ThemeProvider', () => {
             ,
           </ThemeProvider>,
         );
-      }).toErrorDev([
-        'Material-UI: You should return an object from your theme function',
-        // strict mode renders twice
-        'Material-UI: You should return an object from your theme function',
-      ]);
+      }).toErrorDev(['Material-UI: You should return an object from your theme function']);
     });
   });
 });

--- a/packages/material-ui-styles/src/useThemeVariants/useThemeVariants.test.js
+++ b/packages/material-ui-styles/src/useThemeVariants/useThemeVariants.test.js
@@ -135,11 +135,6 @@ describe('useThemeVariants', () => {
         </ThemeProvider>,
       ),
     ).toErrorDev([
-      // strict mode renders twice
-      [
-        `Material-UI: You are using a variant value \`test\` for which you didn't define styles.`,
-        `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://next.material-ui.com/r/custom-component-variants.`,
-      ].join('\n'),
       [
         `Material-UI: You are using a variant value \`test\` for which you didn't define styles.`,
         `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://next.material-ui.com/r/custom-component-variants.`,

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -1198,10 +1198,6 @@ describe('<Autocomplete />', () => {
         fireEvent.keyDown(textbox, { key: 'Enter' });
       }).toErrorDev([
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
-        // strict mode renders twice
-        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
-        // strict mode renders twice
-        'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
@@ -1255,9 +1251,6 @@ describe('<Autocomplete />', () => {
         );
       }).toWarnDev([
         'None of the options match with `"not a good value"`',
-        // strict mode renders twice
-        'None of the options match with `"not a good value"`',
-        'None of the options match with `"not a good value"`',
         'None of the options match with `"not a good value"`',
       ]);
     });
@@ -1282,11 +1275,7 @@ describe('<Autocomplete />', () => {
             groupBy={(option) => option.group}
           />,
         );
-      }).toWarnDev([
-        // strict mode renders twice
-        'returns duplicated headers',
-        'returns duplicated headers',
-      ]);
+      }).toWarnDev(['returns duplicated headers']);
       const options = screen.getAllByRole('option').map((el) => el.textContent);
       expect(options).to.have.length(7);
       expect(options).to.deep.equal(['A', 'D', 'E', 'B', 'G', 'F', 'C']);

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -88,7 +88,6 @@ describe('<Breadcrumbs />', () => {
       );
     }).toErrorDev([
       'Material-UI: You have provided an invalid combination of props to the Breadcrumbs.\nitemsAfterCollapse={2} + itemsBeforeCollapse={2} >= maxItems={3}',
-      'Material-UI: You have provided an invalid combination of props to the Breadcrumbs.\nitemsAfterCollapse={2} + itemsBeforeCollapse={2} >= maxItems={3}',
     ]);
     expect(screen.getAllByRole('listitem', { hidden: false })).to.have.length(4);
     expect(screen.getByRole('list')).to.have.text('first/second/third/fourth');

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -160,8 +160,7 @@ describe('<ClickAwayListener />', () => {
       expect(handleClickAway.callCount).to.equal(0);
 
       fireEvent.click(getByText('Stop inside a portal'));
-      // True-negative, we don't have enough information to do otherwise.
-      expect(handleClickAway.callCount).to.equal(1);
+      expect(handleClickAway.callCount).to.equal(0);
     });
 
     it('should not be called during the same event that mounted the ClickAwayListener', () => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -92,9 +92,6 @@ describe('<Tabs />', () => {
         render(<Tabs value={0} centered variant="scrollable" />);
       }).toErrorDev([
         'Material-UI: You can not use the `centered={true}` and `variant="scrollable"`',
-        // StrictMode renders twice
-        'Material-UI: You can not use the `centered={true}` and `variant="scrollable"`',
-        'Material-UI: You can not use the `centered={true}` and `variant="scrollable"`',
         'Material-UI: You can not use the `centered={true}` and `variant="scrollable"`',
       ]);
     });

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -286,12 +286,7 @@ describe('<TextareaAutosize />', () => {
 
         expect(() => {
           forceUpdate();
-        }).toErrorDev([
-          'Material-UI: Too many re-renders.',
-          // strict mode renders twice
-          'Material-UI: Too many re-renders.',
-          'Material-UI: Too many re-renders.',
-        ]);
+        }).toErrorDev(['Material-UI: Too many re-renders.']);
       });
     });
   });

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -391,7 +391,7 @@ describe('<SwitchBase />', () => {
         setProps({ checked: true });
         global.didWarnControlledToUncontrolled = true;
       }).toErrorDev([
-        'Warning: A component is changing an uncontrolled input of type checkbox to be controlled.',
+        'Warning: A component is changing an uncontrolled input to be controlled.',
         'Material-UI: A component is changing the uncontrolled checked state of SwitchBase to be controlled.',
       ]);
     });
@@ -412,7 +412,7 @@ describe('<SwitchBase />', () => {
         setProps({ checked: undefined });
         global.didWarnControlledToUncontrolled = true;
       }).toErrorDev([
-        'Warning: A component is changing a controlled input of type checkbox to be uncontrolled.',
+        'Warning: A component is changing a controlled input to be uncontrolled',
         'Material-UI: A component is changing the controlled checked state of SwitchBase to be uncontrolled.',
       ]);
     });

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -283,11 +283,7 @@ describe('useMediaQuery', () => {
 
       expect(() => {
         render(<MyComponent />);
-      }).toErrorDev([
-        'Material-UI: The `query` argument provided is invalid',
-        // logs warning twice in StrictMode
-        'Material-UI: The `query` argument provided is invalid',
-      ]);
+      }).toErrorDev(['Material-UI: The `query` argument provided is invalid']);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -13452,15 +13452,14 @@ react-docgen@^5.0.0-beta.1:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@0.0.0-e2fd460cc, react-dom@^16.14.0:
+  version "0.0.0-e2fd460cc"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-e2fd460cc.tgz#07d0a452f5aa3b1e6669eb4f9895a278b3e73f1d"
+  integrity sha512-knNnIu6vsYsD/uRiDi7mm8qK7OBdbfzxQMfsuxmDpuxNsGKCjeVnEDohWcrtPhWagdC7C+M+LjmSTMJ6taUmKQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "0.0.0-e2fd460cc"
 
 react-draggable@^4.0.3:
   version "4.4.3"
@@ -13491,7 +13490,7 @@ react-final-form@^6.3.0:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-react-is@16.13.1, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, "react-is@^16.8.0 || ^17.0.0", react-is@^16.8.1, react-is@^16.8.6, react-is@^17.0.1:
+react-is@0.0.0-e2fd460cc, react-is@16.13.1, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, "react-is@^16.8.0 || ^17.0.0", react-is@^16.8.1, react-is@^16.8.6, react-is@^17.0.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13580,6 +13579,14 @@ react-router@5.2.0, react-router@^5.0.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-shallow-renderer@^16.13.1:
+  version "16.14.1"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
+  integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0"
+
 react-smooth@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.6.tgz#18b964f123f7bca099e078324338cd8739346d0a"
@@ -13629,15 +13636,15 @@ react-swipeable-views@^0.13.9:
     react-swipeable-views-utils "^0.13.9"
     warning "^4.0.1"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
-  integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
+react-test-renderer@0.0.0-e2fd460cc, react-test-renderer@^16.0.0-0, react-test-renderer@^16.14.0:
+  version "0.0.0-e2fd460cc"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-0.0.0-e2fd460cc.tgz#79e2d4583e3c8279cc1c2399c7f60afe09267828"
+  integrity sha512-7ixhtPmeNWcwVwi21SaLQCdsi2uXD2Y0Hyy+d14M3grIGXUuRwry6hYBIHtD5ZOuEv4z3Pd3CQcJRoi6VEUbIw==
   dependencies:
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.19.1"
+    react-is "0.0.0-e2fd460cc"
+    react-shallow-renderer "^16.13.1"
+    scheduler "0.0.0-e2fd460cc"
 
 react-text-mask@^5.0.2:
   version "5.4.3"
@@ -13686,14 +13693,13 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@0.0.0-e2fd460cc, react@^16.14.0:
+  version "0.0.0-e2fd460cc"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-e2fd460cc.tgz#a5ba66b0b536144e5861b824837709d15c89377b"
+  integrity sha512-se4N5U5rGC1BzB0KMgkZkJAzNo01Y5riOwHxGRsgd7Xs2Mk/rIEJhwiPXtxA3aknMKuX8PlY8pLXTiwTeii6YQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -14506,10 +14512,10 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@0.0.0-e2fd460cc, scheduler@^0.19.1:
+  version "0.0.0-e2fd460cc"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-e2fd460cc.tgz#88a9553a2f501a04c16ea3bef867407891a11f28"
+  integrity sha512-sldfKBMXBZazBvK73BlBN/MGsWFhvwJhO3l0vyKhyOp069Qy/TEuThoEpV70O2le9iwvbxQiYpncsjl8VxiXqQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13452,13 +13452,13 @@ react-docgen@^5.0.0-beta.1:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.14.0, "react-dom@https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react-dom":
+react-dom@^16.14.0, "react-dom@https://pkg.csb.dev/eps1lon/react/commit/28aa026f/react-dom":
   version "17.0.2"
-  resolved "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react-dom#b642a8674bcc01af2417c52cda61777897e467df"
+  resolved "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/react-dom#7855908d71665bab873bd8808ffa48e2e4b3743f"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler"
+    scheduler "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/scheduler"
 
 react-draggable@^4.0.3:
   version "4.4.3"
@@ -13692,9 +13692,9 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.14.0, "react@https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react":
+react@^16.14.0, "react@https://pkg.csb.dev/eps1lon/react/commit/28aa026f/react":
   version "17.0.2"
-  resolved "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react#38e0fc89826d6b8d028ad5789d9197abe086cd4c"
+  resolved "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/react#38e0fc89826d6b8d028ad5789d9197abe086cd4c"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -14510,9 +14510,9 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.0.0-e2fd460cc, scheduler@^0.19.1, "scheduler@https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler":
+scheduler@0.0.0-e2fd460cc, scheduler@^0.19.1, "scheduler@https://pkg.csb.dev/eps1lon/react/commit/28aa026f/scheduler":
   version "0.20.1"
-  resolved "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler#bdbc22e3c1e0018a5756a72f30ca052f219c4d25"
+  resolved "https://pkg.csb.dev/eps1lon/react/commit/28aa026f/scheduler#86d0cff6c7c9f49e44b2fb0bce049b1841d4b1f7"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13452,14 +13452,13 @@ react-docgen@^5.0.0-beta.1:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@0.0.0-e2fd460cc, react-dom@^16.14.0:
-  version "0.0.0-e2fd460cc"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-e2fd460cc.tgz#07d0a452f5aa3b1e6669eb4f9895a278b3e73f1d"
-  integrity sha512-knNnIu6vsYsD/uRiDi7mm8qK7OBdbfzxQMfsuxmDpuxNsGKCjeVnEDohWcrtPhWagdC7C+M+LjmSTMJ6taUmKQ==
+react-dom@^16.14.0, "react-dom@https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react-dom":
+  version "17.0.2"
+  resolved "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react-dom#b642a8674bcc01af2417c52cda61777897e467df"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.0.0-e2fd460cc"
+    scheduler "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler"
 
 react-draggable@^4.0.3:
   version "4.4.3"
@@ -13693,10 +13692,9 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@0.0.0-e2fd460cc, react@^16.14.0:
-  version "0.0.0-e2fd460cc"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-e2fd460cc.tgz#a5ba66b0b536144e5861b824837709d15c89377b"
-  integrity sha512-se4N5U5rGC1BzB0KMgkZkJAzNo01Y5riOwHxGRsgd7Xs2Mk/rIEJhwiPXtxA3aknMKuX8PlY8pLXTiwTeii6YQ==
+react@^16.14.0, "react@https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react":
+  version "17.0.2"
+  resolved "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/react#38e0fc89826d6b8d028ad5789d9197abe086cd4c"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -14512,10 +14510,9 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.0.0-e2fd460cc, scheduler@^0.19.1:
-  version "0.0.0-e2fd460cc"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-e2fd460cc.tgz#88a9553a2f501a04c16ea3bef867407891a11f28"
-  integrity sha512-sldfKBMXBZazBvK73BlBN/MGsWFhvwJhO3l0vyKhyOp069Qy/TEuThoEpV70O2le9iwvbxQiYpncsjl8VxiXqQ==
+scheduler@0.0.0-e2fd460cc, scheduler@^0.19.1, "scheduler@https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler":
+  version "0.20.1"
+  resolved "https://pkg.csb.dev/eps1lon/react/commit/d379f34e/scheduler#bdbc22e3c1e0018a5756a72f30ca052f219c4d25"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Not related to Material-UI.

Disregard the changes to the tests. They're automatically applied to pass `react@next`.

Using a build from [`28aa026f` (#2)](https://github.com/eps1lon/react/pull/2/commits/28aa026f) (enables `enableSetImmediate` and includes a build for `scheduler/unstable_mock`) for testing in IE 11.
- [next.material-ui.com with React 09916479219a61ae86d2ec8ce159a161337b9007 and `enableSetImmediate`](https://deploy-preview-24987--material-ui.netlify.app/)
- [next.material-ui.com with React 16.14](https://602d7c356da2ff0007753313--material-ui.netlify.app/)
