### PR TITLE
[test] Test with ClickAwayListener mount on onClickCapture

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -164,29 +164,31 @@ describe('<ClickAwayListener />', () => {
       expect(handleClickAway.callCount).to.equal(1);
     });
 
-    it('should not be called during the same event that mounted the ClickAwayListener', () => {
-      function Test() {
-        const [open, setOpen] = React.useState(false);
+    ['onClick', 'onClickCapture'].forEach((eventListenerName) => {
+      it(`should not be called when ${eventListenerName} mounted the listener`, () => {
+        function Test() {
+          const [open, setOpen] = React.useState(false);
 
-        return (
-          <React.Fragment>
-            <button data-testid="trigger" onClick={() => setOpen(true)} />
-            {open &&
-              ReactDOM.createPortal(
-                <ClickAwayListener onClickAway={() => setOpen(false)}>
-                  <div data-testid="child" />
-                </ClickAwayListener>,
-                // Needs to be an element between the react root we render into and the element where CAL attaches its native listener (now: `document`).
-                document.body,
-              )}
-          </React.Fragment>
-        );
-      }
-      render(<Test />);
+          return (
+            <React.Fragment>
+              <button data-testid="trigger" {...{ [eventListenerName]: () => setOpen(true) }} />
+              {open &&
+                ReactDOM.createPortal(
+                  <ClickAwayListener onClickAway={() => setOpen(false)}>
+                    <div data-testid="child" />
+                  </ClickAwayListener>,
+                  // Needs to be an element between the react root we render into and the element where CAL attaches its native listener (now: `document`).
+                  document.body,
+                )}
+            </React.Fragment>
+          );
+        }
+        render(<Test />);
 
-      fireDiscreteEvent.click(screen.getByTestId('trigger'));
+        fireDiscreteEvent.click(screen.getByTestId('trigger'));
 
-      expect(screen.getByTestId('child')).not.to.equal(null);
+        expect(screen.getByTestId('child')).not.to.equal(null);
+      });
     });
   });
 

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
-import { spy, stub, useFakeTimers } from 'sinon';
-import { act, createClientRender, fireEvent, screen } from 'test/utils';
+import { spy, useFakeTimers } from 'sinon';
+import { act, createClientRender, fireEvent, fireDiscreteEvent, screen } from 'test/utils';
 import Portal from '../Portal';
 import ClickAwayListener from './ClickAwayListener';
 
@@ -184,26 +184,9 @@ describe('<ClickAwayListener />', () => {
       }
       render(<Test />);
 
-      const consoleSpy = stub(console, 'error');
-      try {
-        // can't wrap in `act()` since that changes update semantics.
-        // We want to simulate a discrete update.
-        // `act()` currently triggers a batched update: https://github.com/facebook/react/blob/3fbd47b86285b6b7bdeab66d29c85951a84d4525/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L1061-L1064
-        screen.getByTestId('trigger').click();
+      fireDiscreteEvent.click(screen.getByTestId('trigger'));
 
-        const missingActWarningsEnabled = typeof jest !== 'undefined';
-        if (missingActWarningsEnabled) {
-          expect(
-            consoleSpy.alwaysCalledWithMatch('not wrapped in act(...)'),
-            consoleSpy.args,
-          ).to.equal(true);
-        } else {
-          expect(consoleSpy.callCount).to.equal(0);
-        }
-        expect(screen.getByTestId('child')).not.to.equal(null);
-      } finally {
-        consoleSpy.restore();
-      }
+      expect(screen.getByTestId('child')).not.to.equal(null);
     });
   });
 

--- a/scripts/react-next.diff
+++ b/scripts/react-next.diff
@@ -64,10 +64,10 @@ index 1360442ce6..462c67a27f 100644
          `Material-UI: You are using a variant value \`test\` for which you didn't define styles.`,
          `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://next.material-ui.com/r/custom-component-variants.`,
 diff --git a/packages/material-ui/src/Autocomplete/Autocomplete.test.js b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
-index 2556f4d94d..787fc72d3b 100644
+index 450f50b9ce..e260a93e81 100644
 --- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
 +++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
-@@ -1192,10 +1192,6 @@ describe('<Autocomplete />', () => {
+@@ -1197,10 +1197,6 @@ describe('<Autocomplete />', () => {
          fireEvent.change(textbox, { target: { value: 'a' } });
          fireEvent.keyDown(textbox, { key: 'Enter' });
        }).toErrorDev([
@@ -78,7 +78,7 @@ index 2556f4d94d..787fc72d3b 100644
          'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
          'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
          'Material-UI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
-@@ -1249,9 +1245,6 @@ describe('<Autocomplete />', () => {
+@@ -1254,9 +1250,6 @@ describe('<Autocomplete />', () => {
            />,
          );
        }).toWarnDev([
@@ -88,7 +88,7 @@ index 2556f4d94d..787fc72d3b 100644
          'None of the options match with `"not a good value"`',
          'None of the options match with `"not a good value"`',
        ]);
-@@ -1277,11 +1270,7 @@ describe('<Autocomplete />', () => {
+@@ -1282,11 +1275,7 @@ describe('<Autocomplete />', () => {
              groupBy={(option) => option.group}
            />,
          );
@@ -114,7 +114,7 @@ index acf662d0d9..4f5b503653 100644
      expect(screen.getAllByRole('listitem', { hidden: false })).to.have.length(4);
      expect(screen.getByRole('list')).to.have.text('first/second/third/fourth');
 diff --git a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
-index fe9020d480..52d53b4bea 100644
+index ac5be8c7df..e5ffdd0260 100644
 --- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
 +++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
 @@ -160,8 +160,7 @@ describe('<ClickAwayListener />', () => {
@@ -126,9 +126,9 @@ index fe9020d480..52d53b4bea 100644
 +      expect(handleClickAway.callCount).to.equal(0);
      });
  
-     it('should not be called during the same event that mounted the ClickAwayListener', () => {
+     ['onClick', 'onClickCapture'].forEach((eventListenerName) => {
 diff --git a/packages/material-ui/src/Tabs/Tabs.test.js b/packages/material-ui/src/Tabs/Tabs.test.js
-index 50e4f67d73..70e07d3da7 100644
+index f42bc20110..7ac9b86566 100644
 --- a/packages/material-ui/src/Tabs/Tabs.test.js
 +++ b/packages/material-ui/src/Tabs/Tabs.test.js
 @@ -91,9 +91,6 @@ describe('<Tabs />', () => {

--- a/test/utils/fireDiscreteEvent.js
+++ b/test/utils/fireDiscreteEvent.js
@@ -1,0 +1,30 @@
+function withMissingActWarningsIgnored(callback) {
+  const originalConsoleError = console.error;
+  console.error = function silenceMissingActWarnings(message, ...args) {
+    const isMissingActWarning = /not wrapped in act\(...\)/.test(message);
+    if (!isMissingActWarning) {
+      originalConsoleError.call(console, message, ...args);
+    }
+  };
+  try {
+    callback();
+  } finally {
+    console.error = originalConsoleError;
+  }
+}
+
+// -----------------------------------------
+// WARNING ⚠️ WARNING ⚠️ WARNING ⚠️ WARNING
+//
+// Do not add events here because you want to ignore "missing act()" warnings.
+// Only add events if you made sure that React actually considers these as "discrete".
+// Be aware that "discrete events" are an implementation detail of React.
+// To test discrete events we cannot use `fireEvent` from `@testing-library/react` because they are all wrapped in `act`.
+// `act` overrides the "discrete event" semantics with "batching" semantics: https://github.com/facebook/react/blob/3fbd47b86285b6b7bdeab66d29c85951a84d4525/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L1061-L1064
+// -----------------------------------------
+
+// eslint-disable-next-line import/prefer-default-export -- there are more than one discrete events.
+export function click(element) {
+  // TODO: Why are there different semantics between `element.click` and `dtlFireEvent.click`
+  return withMissingActWarningsIgnored(() => element.click());
+}

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -13,3 +13,4 @@ export {
 } from './focusVisible';
 export { default as getClasses } from './getClasses';
 export {} from './initMatchers';
+export * as fireDiscreteEvent from './fireDiscreteEvent';


### PR DESCRIPTION
1. cherry-pick discrete event helper from https://github.com/mui-org/material-ui/pull/24981
2. add a test motivated by a different approach for "arming" the clickawaylistener
   The approach is used in https://github.com/mui-org/material-ui/pull/24981 but might not work if earlier events for mounting are chosen. 
   This is especially interesting if one decides to mount the ClickAwayListener on mousedown (e.g. for `<select />` implementations) where the timer approach will break down as well.
