### PR TITLE
[core] Fix missing codecov report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ commands:
                 name: Save playwright cache
                 key: v5-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
                 paths:
-            # Keep path in sync with "Install js dependencies"
-            # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+                  # Keep path in sync with "Install js dependencies"
+                  # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
                   - /tmp/pw-browsers
 
 jobs:
@@ -168,7 +168,7 @@ jobs:
             fi
       - run:
           name: Coverage
-          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
+          command: bash <(curl -s https://codecov.io/bash) -Z
   test_lint:
     <<: *defaults
     steps:


### PR DESCRIPTION
codecov status checks have been missing on our commits and it's unclear why. Opened https://community.codecov.io/t/github-checks-missing/2579. 

Meanwhile I'm trying to be as default as possible assuming that the more options we use, the more likely it is we trigger bugs. We were also told that we no longer need the option anyway so this is a good opportunity to verify that claim (https://github.com/codecov/codecov-bash/issues/134).