### PR TITLE
docs: updating how-to use styled-components with RTL

### DIFF
--- a/docs/src/pages/guides/right-to-left/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left.md
@@ -103,6 +103,8 @@ function RTL(props) {
 }
 ```
 
+For `styled-component` v5 make sure to install `stylis-plugin-rtl@^1.1.0` and not v2. [more info](https://github.com/styled-components/stylis-plugin-rtl)
+
 ## Demo
 
 _Use the direction toggle button on the top right corner to flip the whole documentation_


### PR DESCRIPTION
This is needed since the default installation of `stylis-plugin-rtl` is `2.0.0` which will not work.

https://github.com/styled-components/stylis-plugin-rtl