### PR TITLE
[Pickers] Clean up code

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -16,7 +16,7 @@ import {
   defaultMaxDate,
 } from '../internal/pickers/constants/prop-types';
 import {
-  makePickerWithStateAndWrapper,
+  makePickerWithState,
   AllPickerProps,
   SharedPickerProps,
 } from '../internal/pickers/Picker/makePickerWithState';
@@ -77,7 +77,7 @@ export type DatePickerGenericComponent<TWrapper extends SomeWrapper> = (<TDate>(
  * - [DatePicker API](https://material-ui.com/api/date-picker/)
  */
 // @typescript-to-proptypes-generate
-const DatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(ResponsiveWrapper, {
+const DatePicker = makePickerWithState<BaseDatePickerProps<unknown>>(ResponsiveWrapper, {
   name: 'MuiDatePicker',
   ...datePickerConfig,
 }) as DatePickerGenericComponent<typeof MobileWrapper>;

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -11,7 +11,7 @@ import {
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ExportedDayPickerProps } from '../DayPicker/DayPicker';
 import {
-  makePickerWithStateAndWrapper,
+  makePickerWithState,
   SharedPickerProps,
 } from '../internal/pickers/Picker/makePickerWithState';
 import { SomeWrapper } from '../internal/pickers/wrappers/Wrapper';
@@ -133,13 +133,10 @@ export type DateTimePickerGenericComponent<TWrapper extends SomeWrapper> = (<TDa
  * @ignore - do not document.
  */
 /* @typescript-to-proptypes-generate */
-const DateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unknown>>(
-  ResponsiveWrapper,
-  {
-    name: 'MuiDateTimePicker',
-    ...dateTimePickerConfig,
-  },
-) as DateTimePickerGenericComponent<typeof ResponsiveWrapper>;
+const DateTimePicker = makePickerWithState<BaseDateTimePickerProps<unknown>>(ResponsiveWrapper, {
+  name: 'MuiDateTimePicker',
+  ...dateTimePickerConfig,
+}) as DateTimePickerGenericComponent<typeof ResponsiveWrapper>;
 
 if (process.env.NODE_ENV !== 'production') {
   (DateTimePicker as any).displayName = 'DateTimePicker';

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { MuiStyles, WithStyles, withStyles } from '@material-ui/core/styles';
 import PickersToolbarText from '../internal/pickers/PickersToolbarText';
 import PickersToolbar from '../internal/pickers/PickersToolbar';
-import ToolbarButton from '../internal/pickers/PickersToolbarButton';
+import PickersToolbarButton from '../internal/pickers/PickersToolbarButton';
 import DateTimePickerTabs from './DateTimePickerTabs';
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
@@ -97,7 +97,7 @@ const DateTimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof 
           isLandscape={false}
         >
           <div className={classes.dateContainer}>
-            <ToolbarButton
+            <PickersToolbarButton
               tabIndex={-1}
               variant="subtitle1"
               data-mui-test="datetimepicker-toolbar-year"
@@ -105,7 +105,7 @@ const DateTimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof 
               selected={openView === 'year'}
               value={date ? utils.format(date, 'year') : '–'}
             />
-            <ToolbarButton
+            <PickersToolbarButton
               tabIndex={-1}
               variant="h4"
               data-mui-test="datetimepicker-toolbar-date"
@@ -115,7 +115,7 @@ const DateTimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof 
             />
           </div>
           <div className={classes.timeContainer}>
-            <ToolbarButton
+            <PickersToolbarButton
               variant="h3"
               data-mui-test="hours"
               onClick={() => setOpenView('hours')}
@@ -124,7 +124,7 @@ const DateTimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof 
               typographyClassName={classes.timeTypography}
             />
             <PickersToolbarText variant="h3" value=":" className={classes.separator} />
-            <ToolbarButton
+            <PickersToolbarButton
               variant="h3"
               data-mui-test="minutes"
               onClick={() => setOpenView('minutes')}

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -5,7 +5,7 @@ import {
   BaseDatePickerProps,
 } from '../DatePicker/DatePicker';
 import { DesktopWrapper } from '../internal/pickers/wrappers/Wrapper';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 
 /**
  *
@@ -14,13 +14,10 @@ import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePi
  * - [DesktopDatePicker API](https://material-ui.com/api/desktop-date-picker/)
  */
 // @typescript-to-proptypes-generate
-const DesktopDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(
-  DesktopWrapper,
-  {
-    name: 'MuiDesktopDatePicker',
-    ...datePickerConfig,
-  },
-) as DatePickerGenericComponent<typeof DesktopWrapper>;
+const DesktopDatePicker = makePickerWithState<BaseDatePickerProps<unknown>>(DesktopWrapper, {
+  name: 'MuiDesktopDatePicker',
+  ...datePickerConfig,
+}) as DatePickerGenericComponent<typeof DesktopWrapper>;
 
 if (process.env.NODE_ENV !== 'production') {
   (DesktopDatePicker as any).displayName = 'DesktopDatePicker';

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseDateTimePickerProps,
   dateTimePickerConfig,
@@ -11,7 +11,7 @@ import { DesktopWrapper } from '../internal/pickers/wrappers/Wrapper';
  * @ignore - do not document.
  */
 /* @typescript-to-proptypes-generate */
-const DesktopDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unknown>>(
+const DesktopDateTimePicker = makePickerWithState<BaseDateTimePickerProps<unknown>>(
   DesktopWrapper,
   {
     name: 'MuiDesktopDateTimePicker',

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseTimePickerProps,
   timePickerConfig,
@@ -14,7 +14,7 @@ import { DesktopWrapper } from '../internal/pickers/wrappers/Wrapper';
  *
  * - [DesktopTimePicker API](https://material-ui.com/api/desktop-time-picker/)
  */
-const DesktopTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(DesktopWrapper, {
+const DesktopTimePicker = makePickerWithState<BaseTimePickerProps>(DesktopWrapper, {
   name: 'MuiDesktopTimePicker',
   ...timePickerConfig,
 }) as TimePickerGenericComponent<typeof DesktopWrapper>;

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseDatePickerProps,
   datePickerConfig,
@@ -14,13 +14,10 @@ import { MobileWrapper } from '../internal/pickers/wrappers/Wrapper';
  * - [MobileDatePicker API](https://material-ui.com/api/mobile-date-picker/)
  */
 // @typescript-to-proptypes-generate
-const MobileDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(
-  MobileWrapper,
-  {
-    name: 'MuiMobileDatePicker',
-    ...datePickerConfig,
-  },
-) as DatePickerGenericComponent<typeof MobileWrapper>;
+const MobileDatePicker = makePickerWithState<BaseDatePickerProps<unknown>>(MobileWrapper, {
+  name: 'MuiMobileDatePicker',
+  ...datePickerConfig,
+}) as DatePickerGenericComponent<typeof MobileWrapper>;
 
 if (process.env.NODE_ENV !== 'production') {
   (MobileDatePicker as any).displayName = 'MobileDatePicker';

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseDateTimePickerProps,
   dateTimePickerConfig,
@@ -11,13 +11,10 @@ import { MobileWrapper } from '../internal/pickers/wrappers/Wrapper';
  * @ignore - do not document.
  */
 /* @typescript-to-proptypes-generate */
-const MobileDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unknown>>(
-  MobileWrapper,
-  {
-    name: 'MuiMobileDateTimePicker',
-    ...dateTimePickerConfig,
-  },
-) as DateTimePickerGenericComponent<typeof MobileWrapper>;
+const MobileDateTimePicker = makePickerWithState<BaseDateTimePickerProps<unknown>>(MobileWrapper, {
+  name: 'MuiMobileDateTimePicker',
+  ...dateTimePickerConfig,
+}) as DateTimePickerGenericComponent<typeof MobileWrapper>;
 
 if (process.env.NODE_ENV !== 'production') {
   (MobileDateTimePicker as any).displayName = 'MobileDateTimePicker';

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseTimePickerProps,
   timePickerConfig,
@@ -14,7 +14,7 @@ import { MobileWrapper } from '../internal/pickers/wrappers/Wrapper';
  *
  * - [MobileTimePicker API](https://material-ui.com/api/mobile-time-picker/)
  */
-const MobileTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(MobileWrapper, {
+const MobileTimePicker = makePickerWithState<BaseTimePickerProps>(MobileWrapper, {
   name: 'MuiMobileTimePicker',
   ...timePickerConfig,
 }) as TimePickerGenericComponent<typeof MobileWrapper>;

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseDatePickerProps,
   datePickerConfig,
@@ -14,13 +14,10 @@ import { StaticWrapper } from '../internal/pickers/wrappers/Wrapper';
  * - [StaticDatePicker API](https://material-ui.com/api/static-date-picker/)
  */
 // @typescript-to-proptypes-generate
-const StaticDatePicker = makePickerWithStateAndWrapper<BaseDatePickerProps<unknown>>(
-  StaticWrapper,
-  {
-    name: 'MuiStaticDatePicker',
-    ...datePickerConfig,
-  },
-) as DatePickerGenericComponent<typeof StaticWrapper>;
+const StaticDatePicker = makePickerWithState<BaseDatePickerProps<unknown>>(StaticWrapper, {
+  name: 'MuiStaticDatePicker',
+  ...datePickerConfig,
+}) as DatePickerGenericComponent<typeof StaticWrapper>;
 
 if (process.env.NODE_ENV !== 'production') {
   (StaticDatePicker as any).displayName = 'StaticDatePicker';

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseDateTimePickerProps,
   dateTimePickerConfig,
@@ -11,13 +11,10 @@ import { StaticWrapper } from '../internal/pickers/wrappers/Wrapper';
  * @ignore - do not document.
  */
 /* @typescript-to-proptypes-generate */
-const StaticDateTimePicker = makePickerWithStateAndWrapper<BaseDateTimePickerProps<unknown>>(
-  StaticWrapper,
-  {
-    name: 'MuiStaticDateTimePicker',
-    ...dateTimePickerConfig,
-  },
-) as DateTimePickerGenericComponent<typeof StaticWrapper>;
+const StaticDateTimePicker = makePickerWithState<BaseDateTimePickerProps<unknown>>(StaticWrapper, {
+  name: 'MuiStaticDateTimePicker',
+  ...dateTimePickerConfig,
+}) as DateTimePickerGenericComponent<typeof StaticWrapper>;
 
 if (process.env.NODE_ENV !== 'production') {
   (StaticDateTimePicker as any).displayName = 'StaticDateTimePicker';

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makePickerWithStateAndWrapper } from '../internal/pickers/Picker/makePickerWithState';
+import { makePickerWithState } from '../internal/pickers/Picker/makePickerWithState';
 import {
   BaseTimePickerProps,
   timePickerConfig,
@@ -14,7 +14,7 @@ import { StaticWrapper } from '../internal/pickers/wrappers/Wrapper';
  *
  * - [StaticTimePicker API](https://material-ui.com/api/static-time-picker/)
  */
-const StaticTimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(StaticWrapper, {
+const StaticTimePicker = makePickerWithState<BaseTimePickerProps>(StaticWrapper, {
   name: 'MuiStaticTimePicker',
   ...timePickerConfig,
 }) as TimePickerGenericComponent<typeof StaticWrapper>;

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -17,7 +17,7 @@ import {
 import { SomeWrapper } from '../internal/pickers/wrappers/Wrapper';
 import {
   SharedPickerProps,
-  makePickerWithStateAndWrapper,
+  makePickerWithState,
 } from '../internal/pickers/Picker/makePickerWithState';
 
 export interface BaseTimePickerProps<TDate = unknown>
@@ -89,7 +89,7 @@ export type TimePickerGenericComponent<TWrapper extends SomeWrapper> = (<TDate>(
  * - [TimePicker API](https://material-ui.com/api/time-picker/)
  */
 // @typescript-to-proptypes-generate
-const TimePicker = makePickerWithStateAndWrapper<BaseTimePickerProps>(ResponsiveWrapper, {
+const TimePicker = makePickerWithState<BaseTimePickerProps>(ResponsiveWrapper, {
   name: 'MuiTimePicker',
   ...timePickerConfig,
 }) as TimePickerGenericComponent<typeof ResponsiveWrapper>;

--- a/packages/material-ui-lab/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePickerToolbar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { MuiStyles, useTheme, WithStyles, withStyles } from '@material-ui/core/styles';
 import PickersToolbarText from '../internal/pickers/PickersToolbarText';
-import ToolbarButton from '../internal/pickers/PickersToolbarButton';
+import PickersToolbarButton from '../internal/pickers/PickersToolbarButton';
 import PickersToolbar from '../internal/pickers/PickersToolbar';
 import { arrayIncludes } from '../internal/pickers/utils';
 import { useUtils } from '../internal/pickers/hooks/useUtils';
@@ -112,7 +112,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
         })}
       >
         {arrayIncludes(views, 'hours') && (
-          <ToolbarButton
+          <PickersToolbarButton
             data-mui-test="hours"
             tabIndex={-1}
             variant={clockTypographyVariant}
@@ -123,7 +123,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
         )}
         {arrayIncludes(views, ['hours', 'minutes']) && separator}
         {arrayIncludes(views, 'minutes') && (
-          <ToolbarButton
+          <PickersToolbarButton
             data-mui-test="minutes"
             tabIndex={-1}
             variant={clockTypographyVariant}
@@ -134,7 +134,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
         )}
         {arrayIncludes(views, ['minutes', 'seconds']) && separator}
         {arrayIncludes(views, 'seconds') && (
-          <ToolbarButton
+          <PickersToolbarButton
             data-mui-test="seconds"
             variant={clockTypographyVariant}
             onClick={() => setOpenView('seconds')}
@@ -149,7 +149,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
             [classes.ampmLandscape]: isLandscape,
           })}
         >
-          <ToolbarButton
+          <PickersToolbarButton
             disableRipple
             variant="subtitle2"
             data-mui-test="toolbar-am-btn"
@@ -158,7 +158,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
             value={utils.getMeridiemText('am')}
             onClick={() => handleMeridiemChange('am')}
           />
-          <ToolbarButton
+          <PickersToolbarButton
             disableRipple
             variant="subtitle2"
             data-mui-test="toolbar-pm-btn"

--- a/packages/material-ui-lab/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePickerToolbar.tsx
@@ -56,8 +56,6 @@ export const styles: MuiStyles<TimePickerToolbarClassKey> = {
   },
 };
 
-const clockTypographyVariant = 'h3';
-
 /**
  * @ignore - internal component.
  */
@@ -89,7 +87,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
     <PickersToolbarText
       tabIndex={-1}
       value=":"
-      variant={clockTypographyVariant}
+      variant="h3"
       selected={false}
       className={classes.separator}
     />
@@ -115,7 +113,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
           <PickersToolbarButton
             data-mui-test="hours"
             tabIndex={-1}
-            variant={clockTypographyVariant}
+            variant="h3"
             onClick={() => setOpenView('hours')}
             selected={openView === 'hours'}
             value={date ? formatHours(date) : '--'}
@@ -126,7 +124,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
           <PickersToolbarButton
             data-mui-test="minutes"
             tabIndex={-1}
-            variant={clockTypographyVariant}
+            variant="h3"
             onClick={() => setOpenView('minutes')}
             selected={openView === 'minutes'}
             value={date ? utils.format(date, 'minutes') : '--'}
@@ -136,7 +134,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
         {arrayIncludes(views, 'seconds') && (
           <PickersToolbarButton
             data-mui-test="seconds"
-            variant={clockTypographyVariant}
+            variant="h3"
             onClick={() => setOpenView('seconds')}
             selected={openView === 'seconds'}
             value={date ? utils.format(date, 'seconds') : '--'}

--- a/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
@@ -18,7 +18,7 @@ export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
     InputAdornmentProps,
     InputProps,
     inputRef = null,
-    openPicker: onOpen,
+    openPicker,
     OpenPickerButtonProps,
     openPickerIcon = <CalendarIcon />,
     renderInput,
@@ -43,7 +43,7 @@ export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
             disabled={other.disabled}
             aria-label={getOpenDialogAriaText(other.rawValue, utils)}
             {...OpenPickerButtonProps}
-            onClick={onOpen}
+            onClick={openPicker}
           >
             {openPickerIcon}
           </IconButton>

--- a/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
@@ -9,20 +9,21 @@ import { useMaskedInput } from './hooks/useMaskedInput';
 import { DateInputProps, DateInputRefs } from './PureDateInput';
 import { getTextFieldAriaText } from './text-field-helper';
 
-export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
-  containerRef,
-  inputRef = null,
-  forwardedRef = null,
-  disableOpenPicker: hideOpenPickerButton,
-  getOpenDialogAriaText = getTextFieldAriaText,
-  InputAdornmentProps,
-  InputProps,
-  openPicker: onOpen,
-  OpenPickerButtonProps,
-  openPickerIcon = <CalendarIcon />,
-  renderInput,
-  ...other
-}) => {
+export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
+  const {
+    containerRef,
+    disableOpenPicker: hideOpenPickerButton,
+    forwardedRef = null,
+    getOpenDialogAriaText = getTextFieldAriaText,
+    InputAdornmentProps,
+    InputProps,
+    inputRef = null,
+    openPicker: onOpen,
+    OpenPickerButtonProps,
+    openPickerIcon = <CalendarIcon />,
+    renderInput,
+    ...other
+  } = props;
   const utils = useUtils();
   const inputRefHandle = useForkRef(inputRef, forwardedRef);
   const textFieldProps = useMaskedInput(other);
@@ -50,7 +51,7 @@ export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
       ),
     },
   });
-};
+}
 
 KeyboardDateInput.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),

--- a/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
@@ -12,7 +12,7 @@ import { getTextFieldAriaText } from './text-field-helper';
 export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
   const {
     containerRef,
-    disableOpenPicker: hideOpenPickerButton,
+    disableOpenPicker,
     forwardedRef = null,
     getOpenDialogAriaText = getTextFieldAriaText,
     InputAdornmentProps,
@@ -35,7 +35,7 @@ export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
     ...textFieldProps,
     InputProps: {
       ...InputProps,
-      [`${adornmentPosition}Adornment`]: hideOpenPickerButton ? undefined : (
+      [`${adornmentPosition}Adornment`]: disableOpenPicker ? undefined : (
         <InputAdornment position={adornmentPosition} {...InputAdornmentProps}>
           <IconButton
             edge={adornmentPosition}

--- a/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
@@ -49,7 +49,7 @@ type PickerComponent<
   TWrapper extends SomeWrapper
 > = (props: TViewProps & SharedPickerProps<unknown, TWrapper>) => JSX.Element;
 
-export function makePickerWithStateAndWrapper<
+export function makePickerWithState<
   T extends AllAvailableForOverrideProps,
   TWrapper extends SomeWrapper = typeof ResponsiveWrapper
 >(

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -106,6 +106,7 @@ export function useMaskedInput({
     disabled,
     error: validationError,
     helperText: formatHelperText,
+    placeholder: formatHelperText,
     inputProps: {
       ...inputStateArgs,
       disabled, // make spreading in custom input easier
@@ -119,7 +120,6 @@ export function useMaskedInput({
         isFocusedRef.current = false;
       }, inputProps?.onBlur),
     },
-    placeholder: formatHelperText,
     ...TextFieldProps,
   };
 }

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -106,10 +106,10 @@ export function useMaskedInput({
     disabled,
     error: validationError,
     helperText: formatHelperText,
-    placeholder: formatHelperText,
     inputProps: {
       ...inputStateArgs,
-      disabled, // make spreading in custom input easier
+      disabled,
+      placeholder: formatHelperText,
       readOnly,
       type: shouldUseMaskedInput ? 'tel' : 'text',
       ...inputProps,

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -109,7 +109,6 @@ export function useMaskedInput({
     inputProps: {
       ...inputStateArgs,
       disabled, // make spreading in custom input easier
-      placeholder: formatHelperText,
       readOnly,
       type: shouldUseMaskedInput ? 'tel' : 'text',
       ...inputProps,
@@ -120,6 +119,7 @@ export function useMaskedInput({
         isFocusedRef.current = false;
       }, inputProps?.onBlur),
     },
+    placeholder: formatHelperText,
     ...TextFieldProps,
   };
 }


### PR DESCRIPTION
Edit @oliviertassinari, won't fix. Instead, use this as an opportunity to clean more code in the pickers. It still feels like there is lot of work. The level of indirection with all the wrappers is frightening. 

---

Timepicker/datepicker placeholder overrides didn't work on the text field.  This is because the masked input was directly putting the placeholder on the input, rather than passing it through text field props.  By adding it as a text field prop we can now override it in the renderInput function on pickers.

```jsx
    <TimePicker
        renderInput={props => (
          <TextField
            {...props}
            helperText="override works today"
            placeholder="override now works due to this pr"
          />
        )}
        label={'Label'}
        // No longer uses this as placeholder if placeholder is overriden in renderInput
        inputFormat={'h:mm a'}
      />
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related to #25021