### PR TITLE
Bump yarn to 1.22.10

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -3,4 +3,4 @@
 
 
 network-timeout 150000
-yarn-path ".yarn/releases/yarn-1.22.4.js"
+yarn-path ".yarn/releases/yarn-1.22.10.js"


### PR DESCRIPTION
<details><summary>changelog</summary>

>## 1.22.10 (and prior)
>
>- Tweak the preinstall check to not cause errors when Node is installed as root (as a downside, it won't run at all on Windows, which should be an acceptable tradeoff): https://github.com/yarnpkg/yarn/issues/8358
>
>## 1.22.7
>
>This release doesn't change anything and was caused by a publish issue.
>
>## 1.22.6
>
>- Running `yarn init` with the `-2` flag won't print the `set version` output anymore.
>
>- A new preinstall check will ensure that `npm install -g yarn` works even under [Corepack](https://github.com/arcanis/corepack). It doesn't have any effect on other setups.
>
>## 1.22.5
>
>- Headers won't be printed when calling `yarn init` with the `-2` flag
>
>  [**Maël Nison**](https://twitter.com/arcanis)
>
>- Files with the `.cjs` extension will be spawned by `yarnPath` using `execPath
>
>  [#8144](https://github.com/yarnpkg/yarn/pull/8144) - [**bgotink**](https://github.com/bgotink)
>
>- Generates local yarn verions as `.cjs` files when calling `yarn set version`
>
>  [#8145](https://github.com/yarnpkg/yarn/pull/8145) - [**bgotink**](https://github.com/bgotink)
>
>- Sorts files when running `yarn pack` to produce identical layout on Windows and Unix systems
>
>  [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
</details>

[changelog](https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md#changelog)