### PR TITLE
[test] Improve BrowserStack configuration

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,6 +13,8 @@ const browserStack = {
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
+  // https://github.com/browserstack/api#timeout300
+  timeout: 5.5 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();
@@ -31,9 +33,9 @@ module.exports = function setKarmaConfig(config) {
   const baseConfig = {
     basePath: '../',
     browsers: ['chromeHeadless'],
-    browserDisconnectTimeout: 120000, // default 2000
+    browserDisconnectTimeout: 3 * 60 * 1000, // default 2000
     browserDisconnectTolerance: 1, // default 0
-    browserNoActivityTimeout: 6 * 60 * 1000, // default 10000
+    browserNoActivityTimeout: 3 * 60 * 1000, // default 30000
     colors: true,
     client: {
       mocha: {
@@ -166,7 +168,7 @@ module.exports = function setKarmaConfig(config) {
     const browserstackBrowsersUsed = newConfig.browsers.length - 1;
 
     // default 1000, Avoid Rate Limit Exceeded
-    newConfig.pollingTimeout =
+    newConfig.browserStack.pollingTimeout =
       ((MAX_CIRCLE_CI_CONCURRENCY * AVERAGE_KARMA_BUILD * browserstackBrowsersUsed) /
         MAX_REQUEST_PER_SECOND_BROWSERSTACK) *
       1000;


### PR DESCRIPTION
- Apply `pollingTimeout` in the right place https://github.com/karma-runner/karma/blob/a14a24ef81348b29daf70e0ea8406588fdd01f19/test/client/karma.conf.js#L157. I could still see requests being rate limited. It was definitely not working. From this weekend: https://app.circleci.com/pipelines/github/mui-org/material-ui/38379/workflows/fd8828d1-742b-4c3e-8642-2de896135298/jobs/226555
- Set `browserNoActivityTimeout` to the recommended default: https://github.com/karma-runner/karma/blob/a14a24ef81348b29daf70e0ea8406588fdd01f19/test/client/karma.conf.js#L129. We don't need the value to be this long. If after 3 minutes, there is no activity, we can likely conclude it has crashed and stop the worker. This is the default @eps1lon reported in https://docs.travis-ci.com/user/gui-and-headless-browsers/#karma-and-firefox-inactivity-timeouts.
- Set `browserDisconnectTimeout` to the recommended default: https://github.com/karma-runner/karma/blob/a14a24ef81348b29daf70e0ea8406588fdd01f19/test/client/karma.conf.js#L127. It seems to frequently disconnect with 2 minutes, hope 3 will make things be smoother. From this weekend: https://app.circleci.com/pipelines/github/mui-org/material-ui/38358/workflows/fd6d1d37-3bca-47c6-a75e-2d3604a49096/jobs/226731.
- There is a hard limit of 5 minutes for the run. It seems that Firefox can sometimes not be too far. Increase it to 5.5 minutes to be safe. https://automate.browserstack.com/dashboard/v2/builds/b532d65fc20e890ca34699a6bb732a1265e6c521. I will reduce the value for Material-UI X, to use fewer resources in the worse case. We should be very careful when increasing this amount. As of right now, it's our safeguard. It's easy to end-up with a 5 minutes build on BrowserStack doing nothing.

---

A problem I didn't solve: starvation. I have seen a bunch of builds that fail with 

> Too long with no output (exceeded 10m0s): context deadline exceeded

For instance https://app.circleci.com/pipelines/github/mui-org/material-ui/38358/workflows/64de1ea2-e2a2-4664-bb5c-46fd69c083cb/jobs/226428. CircleCI stop the build if nothing is outputted after [10 minutes](https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit). The issue is that the worker on BrowserStack was started and will be run, as soon as there are free slots. In the event of a large loan, it takes time for these slots to be free, more than 10 minutes. So, once the worker run, the CircleCI's build has stopped. [A 404 is generated](https://automate.browserstack.com/dashboard/v2/builds/883ce6e81252383b18a2aec54e07afea5eaadce8/sessions/8509a6b5e792d661b7038ee16321cdf905e727ea) when the browser tries to load the page. The worker still waits 5 minutes, doing nothing, before a timeout.
For the solution, we could potentially finish the implementation of the capture logic BrowserStack [gave up on](https://github.com/karma-runner/karma-browserstack-launcher/issues/26). Meaning, if the browser didn't capture in x time, then stop the BS worker and fail the build.