### PR TITLE
[docs] Add codesandbox example for styled-components

### DIFF
--- a/examples/create-react-app-with-styled-components/README.md
+++ b/examples/create-react-app-with-styled-components/README.md
@@ -22,7 +22,7 @@ Note that CodeSandbox is not supporting react-app-rewired, yet you can [still se
 
 The following link leverages this demo: https://next.material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-forked-guoes)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-interoperability-w9z9d)
 
 
 ## The idea behind the example

--- a/examples/create-react-app-with-styled-components/README.md
+++ b/examples/create-react-app-with-styled-components/README.md
@@ -16,9 +16,14 @@ npm install
 npm start
 ```
 
-or:
+## CodeSandbox
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-styled-components)
+Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-styled-components).
+
+The following link leverages this demo: https://next.material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-forked-guoes)
+
 
 ## The idea behind the example
 

--- a/examples/create-react-app-with-styled-components/README.md
+++ b/examples/create-react-app-with-styled-components/README.md
@@ -24,7 +24,6 @@ The following link leverages this demo: https://next.material-ui.com/guides/inte
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-interoperability-w9z9d)
 
-
 ## The idea behind the example
 
 This example demonstrates how you can setup [Create React App](https://github.com/facebookincubator/create-react-app) with [styled-components](https://styled-components.com/) as a style engine for your application.


### PR DESCRIPTION
Closes #25019 I've added a working example in codesandbox with `styled-componetns` as an engine.