### PR TITLE
[Paper] Fix type support of overridable component

### DIFF
--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -3,79 +3,91 @@ import { SxProps } from '@material-ui/system';
 import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '..';
+import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 
 export interface PaperPropsVariantOverrides {}
 export type PaperVariantDefaults = Record<'elevation' | 'outlined', true>;
 
-export interface PaperProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
-  /**
-   * The content of the component.
-   */
-  children?: React.ReactNode;
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: {
-    /** Styles applied to the root element. */
-    root?: string;
-    /** Styles applied to the root element unless `square={true}`. */
-    rounded?: string;
-    /** Styles applied to the root element if `variant="outlined"`. */
-    outlined?: string;
-    /** Styles applied to the root element if `variant="elevation"`. */
-    elevation?: string;
-    elevation0?: string;
-    elevation1?: string;
-    elevation2?: string;
-    elevation3?: string;
-    elevation4?: string;
-    elevation5?: string;
-    elevation6?: string;
-    elevation7?: string;
-    elevation8?: string;
-    elevation9?: string;
-    elevation10?: string;
-    elevation11?: string;
-    elevation12?: string;
-    elevation13?: string;
-    elevation14?: string;
-    elevation15?: string;
-    elevation16?: string;
-    elevation17?: string;
-    elevation18?: string;
-    elevation19?: string;
-    elevation20?: string;
-    elevation21?: string;
-    elevation22?: string;
-    elevation23?: string;
-    elevation24?: string;
-  };
-  /**
-   * The component used for the root node.
-   * Either a string to use a HTML element or a component.
-   */
-  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
-  /**
-   * Shadow depth, corresponds to `dp` in the spec.
-   * It accepts values between 0 and 24 inclusive.
-   * @default 1
-   */
-  elevation?: number;
-  /**
-   * If `true`, rounded corners are disabled.
-   * @default false
-   */
-  square?: boolean;
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx?: SxProps<Theme>;
-  /**
-   * The variant to use.
-   * @default 'elevation'
-   */
-  variant?: OverridableStringUnion<PaperVariantDefaults, PaperPropsVariantOverrides>;
+export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P &
+    StandardProps<React.HTMLAttributes<HTMLElement>> & {
+      /**
+       * The content of the component.
+       */
+      children?: React.ReactNode;
+      /**
+       * Override or extend the styles applied to the component.
+       */
+      classes?: {
+        /** Styles applied to the root element. */
+        root?: string;
+        /** Styles applied to the root element unless `square={true}`. */
+        rounded?: string;
+        /** Styles applied to the root element if `variant="outlined"`. */
+        outlined?: string;
+        /** Styles applied to the root element if `variant="elevation"`. */
+        elevation?: string;
+        elevation0?: string;
+        elevation1?: string;
+        elevation2?: string;
+        elevation3?: string;
+        elevation4?: string;
+        elevation5?: string;
+        elevation6?: string;
+        elevation7?: string;
+        elevation8?: string;
+        elevation9?: string;
+        elevation10?: string;
+        elevation11?: string;
+        elevation12?: string;
+        elevation13?: string;
+        elevation14?: string;
+        elevation15?: string;
+        elevation16?: string;
+        elevation17?: string;
+        elevation18?: string;
+        elevation19?: string;
+        elevation20?: string;
+        elevation21?: string;
+        elevation22?: string;
+        elevation23?: string;
+        elevation24?: string;
+      };
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
+      /**
+       * Shadow depth, corresponds to `dp` in the spec.
+       * It accepts values between 0 and 24 inclusive.
+       * @default 1
+       */
+      elevation?: number;
+      /**
+       * If `true`, rounded corners are disabled.
+       * @default false
+       */
+      square?: boolean;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps<Theme>;
+      /**
+       * The variant to use.
+       * @default 'elevation'
+       */
+      variant?: OverridableStringUnion<PaperVariantDefaults, PaperPropsVariantOverrides>;
+    };
+  defaultComponent: D;
 }
+
+declare const Paper: OverridableComponent<PaperTypeMap>;
+
+export type PaperProps<
+  D extends React.ElementType = PaperTypeMap['defaultComponent'],
+  P = {}
+> = OverrideProps<PaperTypeMap<P, D>, D>;
 
 export type PaperClassKey = keyof NonNullable<PaperProps['classes']>;
 
@@ -90,4 +102,4 @@ export type PaperClassKey = keyof NonNullable<PaperProps['classes']>;
  *
  * - [Paper API](https://material-ui.com/api/paper/)
  */
-export default function Paper(props: PaperProps): JSX.Element;
+export default Paper;

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -82,15 +82,6 @@ export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
   defaultComponent: D;
 }
 
-declare const Paper: OverridableComponent<PaperTypeMap>;
-
-export type PaperProps<
-  D extends React.ElementType = PaperTypeMap['defaultComponent'],
-  P = {}
-> = OverrideProps<PaperTypeMap<P, D>, D>;
-
-export type PaperClassKey = keyof NonNullable<PaperProps['classes']>;
-
 /**
  *
  * Demos:
@@ -102,4 +93,13 @@ export type PaperClassKey = keyof NonNullable<PaperProps['classes']>;
  *
  * - [Paper API](https://material-ui.com/api/paper/)
  */
+declare const Paper: OverridableComponent<PaperTypeMap>;
+
+export type PaperProps<
+  D extends React.ElementType = PaperTypeMap['defaultComponent'],
+  P = {}
+> = OverrideProps<PaperTypeMap<P, D>, D>;
+
+export type PaperClassKey = keyof NonNullable<PaperProps['classes']>;
+
 export default Paper;

--- a/packages/material-ui/src/Paper/Paper.spec.tsx
+++ b/packages/material-ui/src/Paper/Paper.spec.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import Paper from '@material-ui/core/Paper';
+
+const PaperTest = () => (
+  <div>
+    <Paper elevation={4} />
+    <Paper component="a" href="test" />
+  </div>
+);

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -625,20 +625,6 @@ const MenuTest = () => {
   );
 };
 
-const PaperTest = () => (
-  <div>
-    <Paper elevation={4}>
-      <Typography variant="h5" component="h3">
-        This is a sheet of paper.
-      </Typography>
-      <Typography variant="body1" component="p">
-        Paper can be used to build surface or other elements for your application.
-      </Typography>
-    </Paper>
-    <Paper component="a" href="test" />
-  </div>
-);
-
 const CircularProgressTest = () => (
   <div>
     <CircularProgress />

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -626,14 +626,17 @@ const MenuTest = () => {
 };
 
 const PaperTest = () => (
-  <Paper elevation={4}>
-    <Typography variant="h5" component="h3">
-      This is a sheet of paper.
-    </Typography>
-    <Typography variant="body1" component="p">
-      Paper can be used to build surface or other elements for your application.
-    </Typography>
-  </Paper>
+  <div>
+    <Paper elevation={4}>
+      <Typography variant="h5" component="h3">
+        This is a sheet of paper.
+      </Typography>
+      <Typography variant="body1" component="p">
+        Paper can be used to build surface or other elements for your application.
+      </Typography>
+    </Paper>
+    <Paper component="a" href="test" />
+  </div>
 );
 
 const CircularProgressTest = () => (


### PR DESCRIPTION
Added the OverridableComponent to Paper.

It solves the TypeScript issue here: #21154

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
