### PR TITLE
Update CustomizedDialogs.tsx

### DIFF
--- a/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
@@ -72,7 +72,7 @@ export default function CustomizedDialogs() {
         Open dialog
       </Button>
       <Dialog onClose={handleClose} aria-labelledby="customized-dialog-title" open={open}>
-        <DialogTitle id="customized-dialog-title" onClose={handleClose}>
+        <DialogTitle id="customized-dialog-title">
           Modal title
         </DialogTitle>
         <DialogContent dividers>


### PR DESCRIPTION
Removed onClose event from DialogTitle from the example as it does not expose it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
