### PR TITLE
[docs] Add API of ClockPicker

### DIFF
--- a/docs/pages/api-docs/clock-picker.js
+++ b/docs/pages/api-docs/clock-picker.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './clock-picker.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+Page.getInitialProps = () => {
+  const req = require.context(
+    'docs/translations/api-docs/clock-picker',
+    false,
+    /clock-picker.*.json$/,
+  );
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    descriptions,
+    pageContent: jsonPageContent,
+  };
+};

--- a/docs/pages/api-docs/clock-picker.json
+++ b/docs/pages/api-docs/clock-picker.json
@@ -1,0 +1,48 @@
+{
+  "props": {
+    "date": { "type": { "name": "any" }, "required": true },
+    "onChange": { "type": { "name": "func" }, "required": true },
+    "allowKeyboardControl": { "type": { "name": "bool" } },
+    "ampm": { "type": { "name": "bool" } },
+    "ampmInClock": { "type": { "name": "bool" } },
+    "components": {
+      "type": {
+        "name": "shape",
+        "description": "{ LeftArrowButton?: elementType, LeftArrowIcon?: elementType, RightArrowButton?: elementType, RightArrowIcon?: elementType }"
+      }
+    },
+    "componentsProps": { "type": { "name": "object" } },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
+    "getClockLabelText": {
+      "type": { "name": "func" },
+      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+    },
+    "getHoursClockNumberText": {
+      "type": { "name": "func" },
+      "default": "(hours: string) => `${hours} hours`"
+    },
+    "getMinutesClockNumberText": {
+      "type": { "name": "func" },
+      "default": "(minutes: string) => `${minutes} minutes`"
+    },
+    "getSecondsClockNumberText": {
+      "type": { "name": "func" },
+      "default": "(seconds: string) => `${seconds} seconds`"
+    },
+    "leftArrowButtonText": { "type": { "name": "string" }, "default": "'open previous view'" },
+    "maxTime": { "type": { "name": "any" } },
+    "minTime": { "type": { "name": "any" } },
+    "minutesStep": { "type": { "name": "number" }, "default": "1" },
+    "rightArrowButtonText": { "type": { "name": "string" }, "default": "'open next view'" },
+    "shouldDisableTime": { "type": { "name": "func" } }
+  },
+  "name": "ClockPicker",
+  "styles": { "classes": ["arrowSwitcher"], "globalClasses": {}, "name": "MuiClockPicker" },
+  "spread": false,
+  "forwardsRefTo": "HTMLDivElement",
+  "filename": "/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx",
+  "inheritance": null,
+  "demos": "",
+  "styledComponent": false,
+  "cssComponent": false
+}

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -240,7 +240,7 @@ function createDescribeableProp(
   if (jsdocDefaultValue !== undefined && defaultValue === undefined) {
     if (!external) {
       throw new Error(
-        `Declared a @default annotation in JSDOC for prop '${propName}' but could not find a default value in the implementation.`,
+        `Declared a @default annotation in JSDOC for prop '${propName}' with value '${jsdocDefaultValue.value}' but could not find a default value in the implementation.`,
       );
     }
   } else if (jsdocDefaultValue === undefined && defaultValue !== undefined && renderDefaultValue) {

--- a/docs/src/pagesApi.js
+++ b/docs/src/pagesApi.js
@@ -29,6 +29,7 @@ module.exports = [
   { pathname: '/api-docs/chip' },
   { pathname: '/api-docs/circular-progress' },
   { pathname: '/api-docs/click-away-listener' },
+  { pathname: '/api-docs/clock-picker' },
   { pathname: '/api-docs/collapse' },
   { pathname: '/api-docs/container' },
   { pathname: '/api-docs/css-baseline' },

--- a/docs/translations/api-docs/clock-picker/clock-picker-de.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-de.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker-es.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-es.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker-fr.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-fr.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker-ja.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-ja.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker-pt.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-pt.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker-ru.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-ru.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker-zh.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker-zh.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/clock-picker/clock-picker.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker.json
@@ -1,0 +1,24 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
+    "ampm": "12h/24h view for hour selection clock.",
+    "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "components": "The components used for each slot. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside.",
+    "date": "Selected date @DateIOType.",
+    "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
+    "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.",
+    "getHoursClockNumberText": "Get clock number aria-text for hours.",
+    "getMinutesClockNumberText": "Get clock number aria-text for minutes.",
+    "getSecondsClockNumberText": "Get clock number aria-text for seconds.",
+    "leftArrowButtonText": "Left arrow icon aria-label text.",
+    "maxTime": "Max time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minTime": "Min time acceptable time. For input validation date part of passed object will be ignored if <code>disableIgnoringDatePartForTimeValidation</code> not specified.",
+    "minutesStep": "Step over minutes.",
+    "onChange": "On change callback @DateIOType.",
+    "rightArrowButtonText": "Right arrow icon aria-label text.",
+    "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/date-time-picker/date-time-picker.json
+++ b/docs/translations/api-docs/date-time-picker/date-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",

--- a/docs/translations/api-docs/desktop-date-time-picker/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/desktop-date-time-picker/desktop-date-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",

--- a/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
+++ b/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/mobile-date-time-picker/mobile-date-time-picker.json
+++ b/docs/translations/api-docs/mobile-date-time-picker/mobile-date-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",

--- a/docs/translations/api-docs/mobile-time-picker/mobile-time-picker.json
+++ b/docs/translations/api-docs/mobile-time-picker/mobile-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/static-date-time-picker/static-date-time-picker.json
+++ b/docs/translations/api-docs/static-date-time-picker/static-date-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",

--- a/docs/translations/api-docs/static-time-picker/static-time-picker.json
+++ b/docs/translations/api-docs/static-time-picker/static-time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/time-picker/time-picker.json
+++ b/docs/translations/api-docs/time-picker/time-picker.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar.",
+    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -23,9 +23,9 @@ export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
   isTimeDisabled: (timeValue: number, type: ClockViewType) => boolean;
   children: React.ReactNode[];
   onChange: (value: number, isFinish?: PickerSelectionState) => void;
-  ampm?: boolean;
+  ampm: boolean;
   minutesStep?: number;
-  ampmInClock?: boolean;
+  ampmInClock: boolean;
   allowKeyboardControl?: boolean;
   getClockLabelText: (
     view: 'hours' | 'minutes' | 'seconds',
@@ -114,7 +114,7 @@ function Clock<TDate>(props: ClockProps<TDate> & WithStyles<typeof styles>) {
   const {
     allowKeyboardControl,
     ampm,
-    ampmInClock = false,
+    ampmInClock,
     children: numbersElementsArray,
     classes,
     date,

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
@@ -4,7 +4,7 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import ClockPicker from '@material-ui/lab/ClockPicker';
 import { adapterToUse, AdapterClassToUse } from '../internal/pickers/test-utils';
 
-describe('<ClockPickerStandalone />', () => {
+describe('<ClockPicker />', () => {
   const mount = createMount();
 
   const localizedMount = (node: React.ReactNode) => {

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -5,9 +5,7 @@ import Clock from './Clock';
 import { pipe } from '../internal/pickers/utils';
 import { useUtils, useNow, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { getHourNumbers, getMinutesNumbers } from './ClockNumbers';
-import PickersArrowSwitcher, {
-  ExportedArrowSwitcherProps,
-} from '../internal/pickers/PickersArrowSwitcher';
+import PickersArrowSwitcher from '../internal/pickers/PickersArrowSwitcher';
 import {
   convertValueToMeridiem,
   createIsAfterIgnoreDatePart,
@@ -20,7 +18,7 @@ import { useMeridiemMode } from '../internal/pickers/hooks/date-helpers-hooks';
 export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDate> {
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm?: boolean;
   /**
@@ -35,12 +33,16 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
   ampmInClock?: boolean;
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl?: boolean;
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText?: (
     view: 'hours' | 'minutes' | 'seconds',
@@ -49,9 +51,26 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
   ) => string;
 }
 
-export interface ClockPickerProps<TDate>
-  extends ExportedClockPickerProps<TDate>,
-    ExportedArrowSwitcherProps {
+export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate> {
+  /**
+   * The components used for each slot.
+   * Either a string to use a HTML element or a component.
+   */
+  components?: {
+    LeftArrowButton?: React.ElementType;
+    LeftArrowIcon?: React.ElementType;
+    RightArrowButton?: React.ElementType;
+    RightArrowIcon?: React.ElementType;
+  };
+
+  /**
+   * The props used for each slot inside.
+   */
+  componentsProps?: {
+    leftArrowButton?: any;
+    rightArrowButton?: any;
+  };
+
   /**
    * Selected date @DateIOType.
    */
@@ -62,18 +81,32 @@ export interface ClockPickerProps<TDate>
   onChange: PickerOnChangeFn<TDate>;
   /**
    * Get clock number aria-text for hours.
+   * @default (hours: string) => `${hours} hours`
    */
-  getHoursClockNumberText?: (hoursText: string) => string;
+  getHoursClockNumberText?: (hours: string) => string;
   /**
    * Get clock number aria-text for minutes.
+   * @default (minutes: string) => `${minutes} minutes`
    */
-  getMinutesClockNumberText?: (minutesText: string) => string;
+  getMinutesClockNumberText?: (minutes: string) => string;
   /**
    * Get clock number aria-text for seconds.
+   * @default (seconds: string) => `${seconds} seconds`
    */
-  getSecondsClockNumberText?: (secondsText: string) => string;
+  getSecondsClockNumberText?: (seconds: string) => string;
+  /**
+   * Left arrow icon aria-label text.
+   * @default 'open previous view'
+   */
+  leftArrowButtonText?: string;
   openNextView: () => void;
   openPreviousView: () => void;
+
+  /**
+   * Right arrow icon aria-label text.
+   * @default 'open next view'
+   */
+  rightArrowButtonText?: string;
   view: 'hours' | 'minutes' | 'seconds';
   nextViewAvailable: boolean;
   previousViewAvailable: boolean;
@@ -88,35 +121,38 @@ export const styles: MuiStyles<'arrowSwitcher'> = {
   },
 };
 
-const getDefaultClockLabelText = <TDate extends any>(
+const defaultGetClockLabelText = <TDate extends any>(
   view: 'hours' | 'minutes' | 'seconds',
   time: TDate,
   adapter: MuiPickersAdapter<TDate>,
 ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`;
 
-const getMinutesAriaText = (minute: string) => `${minute} minutes`;
+const defaultGetMinutesClockNumberText = (minutes: string) => `${minutes} minutes`;
 
-const getHoursAriaText = (hour: string) => `${hour} hours`;
+const defaultGetHoursClockNumberText = (hours: string) => `${hours} hours`;
 
-const getSecondsAriaText = (seconds: string) => `${seconds} seconds`;
+const defaultGetSecondsClockNumberText = (seconds: string) => `${seconds} seconds`;
 
 /**
- * @ignore - do not document.
+ *
+ * API:
+ *
+ * - [ClockPicker API](https://material-ui.com/api/clock-picker/)
  */
 function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof styles>) {
   const {
     allowKeyboardControl,
-    ampm,
-    ampmInClock,
+    ampm = false,
+    ampmInClock = false,
     classes,
     components,
     componentsProps,
     date,
-    disableIgnoringDatePartForTimeValidation,
-    getClockLabelText = getDefaultClockLabelText,
-    getHoursClockNumberText = getHoursAriaText,
-    getMinutesClockNumberText = getMinutesAriaText,
-    getSecondsClockNumberText = getSecondsAriaText,
+    disableIgnoringDatePartForTimeValidation = false,
+    getClockLabelText = defaultGetClockLabelText,
+    getHoursClockNumberText = defaultGetHoursClockNumberText,
+    getMinutesClockNumberText = defaultGetMinutesClockNumberText,
+    getSecondsClockNumberText = defaultGetSecondsClockNumberText,
     leftArrowButtonText = 'open previous view',
     maxTime,
     minTime,
@@ -146,7 +182,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
 
       const validateTimeValue = (getRequestedTimePoint: (when: 'start' | 'end') => TDate) => {
         const isAfterComparingFn = createIsAfterIgnoreDatePart(
-          Boolean(disableIgnoringDatePartForTimeValidation),
+          disableIgnoringDatePartForTimeValidation,
           utils,
         );
 
@@ -159,7 +195,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
 
       switch (viewType) {
         case 'hours': {
-          const hoursWithMeridiem = convertValueToMeridiem(rawValue, meridiemMode, Boolean(ampm));
+          const hoursWithMeridiem = convertValueToMeridiem(rawValue, meridiemMode, ampm);
           return validateTimeValue((when: 'start' | 'end') =>
             pipe(
               (currentDate) => utils.setHours(currentDate, hoursWithMeridiem),
@@ -200,7 +236,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
     switch (view) {
       case 'hours': {
         const handleHoursChange = (value: number, isFinish?: PickerSelectionState) => {
-          const valueWithMeridiem = convertValueToMeridiem(value, meridiemMode, Boolean(ampm));
+          const valueWithMeridiem = convertValueToMeridiem(value, meridiemMode, ampm);
           onChange(utils.setHours(dateOrNow, valueWithMeridiem), isFinish);
         };
 
@@ -210,7 +246,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
           children: getHourNumbers({
             date,
             utils,
-            ampm: Boolean(ampm),
+            ampm,
             onChange: handleHoursChange,
             getClockNumberText: getHoursClockNumberText,
             isDisabled: (value) => isTimeDisabled(value, 'hours'),
@@ -313,12 +349,12 @@ ClockPicker.propTypes = {
   // ----------------------------------------------------------------------
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -333,7 +369,6 @@ ClockPicker.propTypes = {
   /**
    * The components used for each slot.
    * Either a string to use a HTML element or a component.
-   * @default {}
    */
   components: PropTypes.shape({
     LeftArrowButton: PropTypes.elementType,
@@ -343,7 +378,6 @@ ClockPicker.propTypes = {
   }),
   /**
    * The props used for each slot inside.
-   * @default {}
    */
   componentsProps: PropTypes.object,
   /**
@@ -357,23 +391,31 @@ ClockPicker.propTypes = {
   disableIgnoringDatePartForTimeValidation: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**
    * Get clock number aria-text for hours.
+   * @default (hours: string) => `${hours} hours`
    */
   getHoursClockNumberText: PropTypes.func,
   /**
    * Get clock number aria-text for minutes.
+   * @default (minutes: string) => `${minutes} minutes`
    */
   getMinutesClockNumberText: PropTypes.func,
   /**
    * Get clock number aria-text for seconds.
+   * @default (seconds: string) => `${seconds} seconds`
    */
   getSecondsClockNumberText: PropTypes.func,
   /**
    * Left arrow icon aria-label text.
+   * @default 'open previous view'
    */
   leftArrowButtonText: PropTypes.string,
   /**
@@ -413,6 +455,7 @@ ClockPicker.propTypes = {
   previousViewAvailable: PropTypes.bool.isRequired,
   /**
    * Right arrow icon aria-label text.
+   * @default 'open next view'
    */
   rightArrowButtonText: PropTypes.string,
   /**
@@ -430,6 +473,12 @@ ClockPicker.propTypes = {
   view: PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired,
 } as any;
 
+/**
+ *
+ * API:
+ *
+ * - [ClockPicker API](https://material-ui.com/api/clock-picker/)
+ */
 export default withStyles(styles, { name: 'MuiClockPicker' })(ClockPicker) as <TDate>(
   props: ClockPickerProps<TDate>,
 ) => JSX.Element;

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -161,7 +161,7 @@ DateTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
@@ -171,7 +171,7 @@ DateTimePicker.propTypes = {
   allowSameDateSelection: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -287,7 +287,11 @@ DateTimePicker.propTypes = {
   disablePast: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -42,7 +42,7 @@ DesktopDateTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
@@ -52,7 +52,7 @@ DesktopDateTimePicker.propTypes = {
   allowSameDateSelection: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -143,7 +143,11 @@ DesktopDateTimePicker.propTypes = {
   disablePast: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -35,12 +35,12 @@ DesktopTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -89,7 +89,11 @@ DesktopTimePicker.propTypes = {
   disableOpenPicker: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -39,7 +39,7 @@ MobileDateTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
@@ -49,7 +49,7 @@ MobileDateTimePicker.propTypes = {
   allowSameDateSelection: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -159,7 +159,11 @@ MobileDateTimePicker.propTypes = {
   disablePast: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -35,12 +35,12 @@ MobileTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -108,7 +108,11 @@ MobileTimePicker.propTypes = {
   disableOpenPicker: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -39,7 +39,7 @@ StaticDateTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
@@ -49,7 +49,7 @@ StaticDateTimePicker.propTypes = {
   allowSameDateSelection: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -145,7 +145,11 @@ StaticDateTimePicker.propTypes = {
   displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -35,12 +35,12 @@ StaticTimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -94,7 +94,11 @@ StaticTimePicker.propTypes = {
   displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -106,12 +106,12 @@ TimePicker.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
    * Enables keyboard listener for moving between days in calendar.
-   * @default currentWrapper !== 'static'
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
    */
   allowKeyboardControl: PropTypes.bool,
   /**
    * 12h/24h view for hour selection clock.
-   * @default true
+   * @default false
    */
   ampm: PropTypes.bool,
   /**
@@ -185,7 +185,11 @@ TimePicker.propTypes = {
   disableOpenPicker: PropTypes.bool,
   /**
    * Accessible text that helps user to understand which time and view is selected.
-   * @default (view, time) => `Select ${view}. Selected time is ${format(time, 'fullTime')}`
+   * @default <TDate extends any>(
+   *   view: 'hours' | 'minutes' | 'seconds',
+   *   time: TDate,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
   getClockLabelText: PropTypes.func,
   /**


### PR DESCRIPTION
Part of https://github.com/mui-org/material-ui/issues/23923

Preview: https://deploy-preview-25089--material-ui.netlify.app/api/clock-picker/

Affects other components as well so I'm opening this separately (goal was to do all misc picker components in one go).