### PR TITLE
[Autocomplete] Fix ListboxComponent slot regression

### DIFF
--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -6,7 +6,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import { useTheme, makeStyles } from '@material-ui/core/styles';
 import { VariableSizeList } from 'react-window';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 
 const LISTBOX_PADDING = 8; // px
 

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -7,7 +7,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import { useTheme, makeStyles } from '@material-ui/core/styles';
 import { VariableSizeList, ListChildComponentProps } from 'react-window';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 
 const LISTBOX_PADDING = 8; // px
 

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -551,11 +551,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
       >
         {params.group}
       </AutocompleteGroupLabel>
-      <AutocompleteGroupUl
-        as={ListboxComponent}
-        className={classes.groupUl}
-        styleProps={styleProps}
-      >
+      <AutocompleteGroupUl className={classes.groupUl} styleProps={styleProps}>
         {params.children}
       </AutocompleteGroupUl>
     </li>
@@ -654,6 +650,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
             ) : null}
             {groupedOptions.length > 0 ? (
               <AutocompleteListbox
+                as={ListboxComponent}
                 className={classes.listbox}
                 styleProps={styleProps}
                 {...getListboxProps()}


### PR DESCRIPTION
This one is impossible to miss: open https://next--material-ui.netlify.app/components/autocomplete/#virtualization, it's crazy slow. I have found this looking at #25096. It was broken in #24696, we didn't release it yet.