### PR TITLE
[Autocomplete] Prevent closing on no-option text click

### DIFF
--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -649,6 +649,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
                 styleProps={styleProps}
                 role="presentation"
                 onMouseDown={(event) => {
+                  // Prevent input blur when interacting with the "no options" content
                   event.preventDefault();
                 }}
               >

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -644,7 +644,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
               </AutocompleteLoading>
             ) : null}
             {groupedOptions.length === 0 && !freeSolo && !loading ? (
-              <AutocompleteNoOptions className={classes.noOptions} styleProps={styleProps}>
+              <AutocompleteNoOptions
+                className={classes.noOptions}
+                styleProps={styleProps}
+                role="presentation"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                }}
+              >
                 {noOptionsText}
               </AutocompleteNoOptions>
             ) : null}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Description**
Implement fix for click on no-option text when AutoComplete component is opened based on the suggestion of

Closes #24781

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
