### PR TITLE
[Table] Remove default role logic in TableCell

### DIFF
--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -161,15 +161,6 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
     scope = 'col';
   }
 
-  let role;
-  if (componentProp) {
-    if (isHeadCell) {
-      role = 'columnheader';
-    } else {
-      role = 'cell';
-    }
-  }
-
   const variant = variantProp || (tablelvl2 && tablelvl2.variant);
 
   const styleProps = {
@@ -196,7 +187,6 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
       ref={ref}
       className={clsx(classes.root, className)}
       aria-sort={ariaSort}
-      role={role}
       scope={scope}
       styleProps={styleProps}
       {...other}

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -163,11 +163,8 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
 
   let role;
   if (componentProp) {
-    const isHeadCellComponent = typeof componentProp === 'string' && componentProp === 'th';
-    if (scope === 'col' && isHeadCell) {
+    if (isHeadCell) {
       role = 'columnheader';
-    } else if (scope === 'row' && isHeadCellComponent) {
-      role = 'rowheader';
     } else {
       role = 'cell';
     }

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -148,11 +148,10 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
   const tablelvl2 = React.useContext(Tablelvl2Context);
 
   const isHeadCell = tablelvl2 && tablelvl2.variant === 'head';
-  let role;
+
   let component;
   if (componentProp) {
     component = componentProp;
-    role = isHeadCell ? 'columnheader' : 'cell';
   } else {
     component = isHeadCell ? 'th' : 'td';
   }
@@ -160,6 +159,18 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
   let scope = scopeProp;
   if (!scope && isHeadCell) {
     scope = 'col';
+  }
+
+  let role;
+  if (componentProp) {
+    const isHeadCellComponent = typeof componentProp === 'string' && componentProp === 'th';
+    if (scope === 'col' && isHeadCell) {
+      role = 'columnheader';
+    } else if (scope === 'row' && isHeadCellComponent) {
+      role = 'rowheader';
+    } else {
+      role = 'cell';
+    }
   }
 
   const variant = variantProp || (tablelvl2 && tablelvl2.variant);

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -90,4 +90,9 @@ describe('<TableCell />', () => {
     const { container } = renderInTable(<TableCell align="center" />);
     expect(container.querySelector('td')).to.have.class(classes.alignCenter);
   });
+
+  it('should allow the default role (rowheader) to trigger', () => {
+    const { container } = renderInTable(<TableCell component="th" scope="row" />);
+    expect(container.querySelector('th')).not.to.have.attribute('role');
+  });
 });

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -6,6 +6,7 @@ import Table from '@material-ui/core/Table';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+import TableBody from '@material-ui/core/TableBody';
 
 describe('<TableRow> integration', () => {
   const render = createClientRender();
@@ -77,5 +78,32 @@ describe('<TableRow> integration', () => {
     );
 
     expect(getByTestId('cell')).to.have.class(classes.footer);
+  });
+
+  it('does not set role="columnheader" when "component" prop is set and used in the context of table head', () => {
+    const { getByTestId } = render(
+      <TableHead component="div">
+        <TableCell component="div" data-testid="cell" />,
+      </TableHead>,
+    );
+    expect(getByTestId('cell')).not.to.have.attribute('role', 'columnheader');
+  });
+
+  it('does not set role="cell" when "component" prop is set and used in the context of table body ', () => {
+    const { getByTestId } = render(
+      <TableBody component="div">
+        <TableCell component="div" data-testid="cell" />,
+      </TableBody>,
+    );
+    expect(getByTestId('cell')).not.to.have.attribute('role', 'cell');
+  });
+
+  it('does not set role="cell" when "component" prop is set and used in the context of table footer ', () => {
+    const { getByTestId } = render(
+      <TableFooter component="div">
+        <TableCell component="div" data-testid="cell" />,
+      </TableFooter>,
+    );
+    expect(getByTestId('cell')).not.to.have.attribute('role', 'cell');
   });
 });

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -89,15 +89,6 @@ describe('<TableRow> integration', () => {
     expect(getByTestId('cell')).to.have.attribute('role', 'columnheader');
   });
 
-  it('sets role="rowheader" when "component" prop is set and "scope" prop is set and used in the context of table body ', () => {
-    const { getByTestId } = render(
-      <TableBody component="div">
-        <TableCell component="th" scope="row" data-testid="cell" />,
-      </TableBody>,
-    );
-    expect(getByTestId('cell')).to.have.attribute('role', 'rowheader');
-  });
-
   it('sets role="cell" when "component" prop is set and used in the context of table body ', () => {
     const { getByTestId } = render(
       <TableBody component="div">
@@ -114,5 +105,14 @@ describe('<TableRow> integration', () => {
       </TableFooter>,
     );
     expect(getByTestId('cell')).to.have.attribute('role', 'cell');
+  });
+
+  it('does not set role when "component" prop is not provided', () => {
+    const { getByTestId } = render(
+      <TableHead component="div">
+        <TableCell data-testid="cell" />,
+      </TableHead>,
+    );
+    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 });

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -80,30 +80,30 @@ describe('<TableRow> integration', () => {
     expect(getByTestId('cell')).to.have.class(classes.footer);
   });
 
-  it('does not set role="columnheader" when "component" prop is set and used in the context of table head', () => {
+  it('does not set `role` when `component` prop is set and used in the context of table head', () => {
     const { getByTestId } = render(
       <TableHead component="div">
         <TableCell component="div" data-testid="cell" />,
       </TableHead>,
     );
-    expect(getByTestId('cell')).not.to.have.attribute('role', 'columnheader');
+    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 
-  it('does not set role="cell" when "component" prop is set and used in the context of table body ', () => {
+  it('does not set `role` when `component` prop is set and used in the context of table body ', () => {
     const { getByTestId } = render(
       <TableBody component="div">
         <TableCell component="div" data-testid="cell" />,
       </TableBody>,
     );
-    expect(getByTestId('cell')).not.to.have.attribute('role', 'cell');
+    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 
-  it('does not set role="cell" when "component" prop is set and used in the context of table footer ', () => {
+  it('does not set `role` when `component` prop is set and used in the context of table footer ', () => {
     const { getByTestId } = render(
       <TableFooter component="div">
         <TableCell component="div" data-testid="cell" />,
       </TableFooter>,
     );
-    expect(getByTestId('cell')).not.to.have.attribute('role', 'cell');
+    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 });

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -26,6 +26,7 @@ describe('<TableRow> integration', () => {
     expect(getByTestId('cell')).to.have.class(classes.root);
     expect(getByTestId('cell')).to.have.class(classes.head);
     expect(getByTestId('cell')).to.have.attribute('scope', 'col');
+    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 
   it('should render specified scope attribute even when in the context of a table head', () => {
@@ -105,14 +106,5 @@ describe('<TableRow> integration', () => {
       </TableFooter>,
     );
     expect(getByTestId('cell')).to.have.attribute('role', 'cell');
-  });
-
-  it('does not set role when "component" prop is not provided', () => {
-    const { getByTestId } = render(
-      <TableHead component="div">
-        <TableCell data-testid="cell" />,
-      </TableHead>,
-    );
-    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 });

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -83,10 +83,19 @@ describe('<TableRow> integration', () => {
   it('sets role="columnheader" when "component" prop is set and used in the context of table head', () => {
     const { getByTestId } = render(
       <TableHead component="div">
-        <TableCell component="div" data-testid="cell" />,
+        <TableCell component="th" data-testid="cell" />,
       </TableHead>,
     );
     expect(getByTestId('cell')).to.have.attribute('role', 'columnheader');
+  });
+
+  it('sets role="rowheader" when "component" prop is set and "scope" prop is set and used in the context of table body ', () => {
+    const { getByTestId } = render(
+      <TableBody component="div">
+        <TableCell component="th" scope="row" data-testid="cell" />,
+      </TableBody>,
+    );
+    expect(getByTestId('cell')).to.have.attribute('role', 'rowheader');
   });
 
   it('sets role="cell" when "component" prop is set and used in the context of table body ', () => {

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -83,7 +83,7 @@ describe('<TableRow> integration', () => {
   it('sets role="columnheader" when "component" prop is set and used in the context of table head', () => {
     const { getByTestId } = render(
       <TableHead component="div">
-        <TableCell component="th" data-testid="cell" />,
+        <TableCell component="div" data-testid="cell" />,
       </TableHead>,
     );
     expect(getByTestId('cell')).to.have.attribute('role', 'columnheader');

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -6,7 +6,6 @@ import Table from '@material-ui/core/Table';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import TableBody from '@material-ui/core/TableBody';
 
 describe('<TableRow> integration', () => {
   const render = createClientRender();
@@ -26,7 +25,6 @@ describe('<TableRow> integration', () => {
     expect(getByTestId('cell')).to.have.class(classes.root);
     expect(getByTestId('cell')).to.have.class(classes.head);
     expect(getByTestId('cell')).to.have.attribute('scope', 'col');
-    expect(getByTestId('cell')).not.to.have.attribute('role');
   });
 
   it('should render specified scope attribute even when in the context of a table head', () => {
@@ -79,32 +77,5 @@ describe('<TableRow> integration', () => {
     );
 
     expect(getByTestId('cell')).to.have.class(classes.footer);
-  });
-
-  it('sets role="columnheader" when "component" prop is set and used in the context of table head', () => {
-    const { getByTestId } = render(
-      <TableHead component="div">
-        <TableCell component="div" data-testid="cell" />,
-      </TableHead>,
-    );
-    expect(getByTestId('cell')).to.have.attribute('role', 'columnheader');
-  });
-
-  it('sets role="cell" when "component" prop is set and used in the context of table body ', () => {
-    const { getByTestId } = render(
-      <TableBody component="div">
-        <TableCell component="div" data-testid="cell" />,
-      </TableBody>,
-    );
-    expect(getByTestId('cell')).to.have.attribute('role', 'cell');
-  });
-
-  it('sets role="cell" when "component" prop is set and used in the context of table footer ', () => {
-    const { getByTestId } = render(
-      <TableFooter component="div">
-        <TableCell component="div" data-testid="cell" />,
-      </TableFooter>,
-    );
-    expect(getByTestId('cell')).to.have.attribute('role', 'cell');
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Description**
Remove default role assignment logic from ``TableCell`` component.

Fix #21470

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
