### PR TITLE
[utils] Fix build with Parcel v2

### DIFF
--- a/packages/material-ui-utils/macros/MuiError.macro.js
+++ b/packages/material-ui-utils/macros/MuiError.macro.js
@@ -35,7 +35,7 @@ function muiError({ references, babel, config, source }) {
           babel.types.newExpression(babel.types.identifier('Error'), [devMessage]),
         );
         newExpressionPath.addComment(
-          'leading',
+          'trailing',
           ' FIXME (minify-errors-in-prod): Unminified error message in production build! ',
         );
       };

--- a/packages/material-ui-utils/macros/__fixtures__/no-error-code-annotation/output.js
+++ b/packages/material-ui-utils/macros/__fixtures__/no-error-code-annotation/output.js
@@ -1,5 +1,3 @@
-throw (
-  /* FIXME (minify-errors-in-prod): Unminified error message in production build! */
-  new Error(`Material-UI: Expected valid input target.
-Did you use inputComponent`)
-);
+throw new Error(`Material-UI: Expected valid input target.
+Did you use inputComponent`);
+/* FIXME (minify-errors-in-prod): Unminified error message in production build! */


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I ran into an error while building a webapp with Material UI 5.0.0-alpha.25 using [Parcel v2](https://v2.parceljs.org/) which relies on [Terser](https://github.com/terser/terser) to minify JS.

Here's what the error message looks like:
```
➜ yarn parcel build src/index.jsx --no-cache
🚨 Build failed.
@parcel/optimizer-terser: Illegal newline after 'throw'
/home/user/Development/project/.yarn/$$virtual/@material-ui-utils-virtual-bc8a155bc8/0/cache/@material-ui-utils-npm-5.0.0-alpha.25-4f8f056857-49c676c074.zip/node_modules/@material-ui/utils/esm/capitalize.js:9:10
   8 |       /* FIXME (minify-errors-in-prod): Unminified error message in production build! */
>  9 |       new Error(`Material-UI: \`capitalize(string)\` expects a string argument.`)
>    |          ^ Illegal newline after 'throw'
  10 |     );
  11 |   }
It's likely that Terser doesn't support this syntax yet.
```

Looking further into it I figured there must've been a throw statement right before the error, but the auto-generated comment gets inserted between them, which according to [this on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw#description:~:text=Also%20note%20that%20the%20throw%20statement,keyword%20and%20the%20expression%20is%20allowed.) automatically terminates the throw statement since no newline is allowed.

There might be something here for Terser to look into as well, but I figured it was right to come to Material UI with the issue since it seems like a syntax error rather than something for Terser to fix.