### PR TITLE
[styles] Use capitalize from utils

### DIFF
--- a/docs/public/static/error-codes.json
+++ b/docs/public/static/error-codes.json
@@ -5,7 +5,7 @@
   "4": "Material-UI: The color provided to augmentColor(color) is invalid.\nThe color object needs to have a `main` property or a `%s` property.",
   "5": "Material-UI: The color provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createMuiTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createMuiTheme({ palette: {\n  primary: { main: green[500] },\n} });",
   "6": "Material-UI: Unsupported non-unitless line height with grid alignment.\nUse unitless line heights instead.",
-  "7": "Material-UI: capitalize(string) expects a string argument.",
+  "7": "Material-UI: `capitalize(string)` expects a string argument.",
   "8": "Material-UI: Unsupported `%s` color.\nWe support the following formats: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().",
   "9": "Material-UI: Unsupported `%s` color.\nThe following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().",
   "10": "Material-UI: unsupported `%s` color space.\nThe following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rgb, rec-2020.",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "docs:typescript:check": "yarn workspace docs typescript",
     "docs:typescript:formatted": "cross-env BABEL_ENV=test babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/formattedTSDemos",
     "docs:mdicons:synonyms": "babel-node --config-file ./babel.config.js ./docs/scripts/updateIconSynonyms",
-    "extract-error-codes": "lerna run --parallel extract-error-codes",
+    "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true lerna run --parallel build:modern",
     "framer:build": "yarn workspace framer build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install",
     "jsonlint": "node ./scripts/jsonlint.js",

--- a/packages/material-ui-styles/src/propsToClassKey/propsToClassKey.js
+++ b/packages/material-ui-styles/src/propsToClassKey/propsToClassKey.js
@@ -1,13 +1,4 @@
-import MuiError from '@material-ui/utils/macros/MuiError.macro';
-
-// TODO: remove this once the capitalize method is moved to the @material-ui/utils package
-export function capitalize(string) {
-  if (typeof string !== 'string') {
-    throw new MuiError('Material-UI: capitalize(string) expects a string argument.');
-  }
-
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
+import { unstable_capitalize as capitalize } from '@material-ui/utils';
 
 function isEmpty(string) {
   return string.length === 0;

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -34,7 +34,6 @@
     "build:umd": "cross-env BABEL_ENV=stable rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
-    "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true yarn build:modern",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.{js,ts,tsx}'",


### PR DESCRIPTION
1. Make sure we extract error codes for all packages
2. use `capitalize` from utils in `propsToClassKey`
3. Update the message for existing error codes since it was just a formatting change. Generally, error messages should be additive since they're relevant to older contexts not current ones. 