### PR TITLE
[core] Modernize icons `builder:src`

### DIFF
--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -188,11 +188,7 @@ async function worker({ progress, svgPath, options, renameFilter, template }) {
   const destPath = renameFilter(svgPathObj, innerPath, options);
 
   const outputFileDir = path.dirname(path.join(options.outputDir, destPath));
-  const pathExists = await fse.pathExists(outputFileDir);
-
-  if (!pathExists) {
-    fse.mkdirpSync(outputFileDir);
-  }
+  await fse.ensureDir(outputFileDir);
 
   const data = await fse.readFile(svgPath, { encoding: 'utf8' });
   const paths = await cleanPaths({ svgPath, data });

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -227,9 +227,8 @@ export async function handler(options) {
 
     let renameFilter = options.renameFilter;
     if (typeof renameFilter === 'string') {
-      // TODO: use `await import(...)`
-      // eslint-disable-next-line global-require, import/no-dynamic-require
-      renameFilter = require(renameFilter).default;
+      const renameFilterModule = await import(renameFilter);
+      renameFilter = renameFilterModule.default;
     }
     if (typeof renameFilter !== 'function') {
       throw Error('renameFilter must be a function');

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -12,7 +12,7 @@ import SVGO from 'svgo';
 export const RENAME_FILTER_DEFAULT = './renameFilters/default';
 export const RENAME_FILTER_MUI = './renameFilters/material-design-icons';
 
-let blacklistedIcons = [
+const blacklistedIcons = [
   'AddChart', // Leads to inconsistent casing with `Addchart`
   '6FtApart', // Arbitrary covid related distance
   'MotionPhotosOn', // Google product
@@ -26,64 +26,15 @@ let blacklistedIcons = [
   'ExposureZero', // Google product
   'VerticalDistribute', // Advanced text editor
   'HorizontalDistribute', // Advanced text editor
-];
-
-blacklistedIcons = blacklistedIcons.reduce((acc, item) => {
-  acc = acc.concat([item, `${item}Outlined`, `${item}Rounded`, `${item}Sharp`, `${item}TwoTone`]);
-
-  return acc;
+].reduce((iconsWithVariants, icon) => {
+  return iconsWithVariants.concat([
+    icon,
+    `${icon}Outlined`,
+    `${icon}Rounded`,
+    `${icon}Sharp`,
+    `${icon}TwoTone`,
+  ]);
 }, []);
-
-const svgo = new SVGO({
-  floatPrecision: 4,
-  plugins: [
-    { cleanupAttrs: true },
-    { removeDoctype: true },
-    { removeXMLProcInst: true },
-    { removeComments: true },
-    { removeMetadata: true },
-    { removeTitle: true },
-    { removeDesc: true },
-    { removeUselessDefs: true },
-    { removeXMLNS: true },
-    { removeEditorsNSData: true },
-    { removeEmptyAttrs: true },
-    { removeHiddenElems: true },
-    { removeEmptyText: true },
-    { removeEmptyContainers: true },
-    { removeViewBox: true },
-    { cleanupEnableBackground: true },
-    { minifyStyles: true },
-    { convertStyleToAttrs: true },
-    { convertColors: true },
-    { convertPathData: true },
-    { convertTransform: true },
-    { removeUnknownsAndDefaults: true },
-    { removeNonInheritableGroupAttrs: true },
-    {
-      removeUselessStrokeAndFill: {
-        // https://github.com/svg/svgo/issues/727#issuecomment-303115276
-        removeNone: true,
-      },
-    },
-    { removeUnusedNS: true },
-    { cleanupIDs: true },
-    { cleanupNumericValues: true },
-    { cleanupListOfValues: true },
-    { moveElemsAttrsToGroup: true },
-    { moveGroupAttrsToElems: true },
-    { collapseGroups: true },
-    { removeRasterImages: true },
-    { mergePaths: true },
-    { convertShapeToPath: true },
-    { sortAttrs: true },
-    { removeDimensions: true },
-    { removeAttrs: true },
-    { removeElementsByAttr: true },
-    { removeStyleElement: true },
-    { removeScriptElement: true },
-  ],
-});
 
 /**
  * Return Pascal-Cased component name.
@@ -142,6 +93,56 @@ export async function cleanPaths({ svgPath, data }) {
     .replace(/<rect fill="none" width="24" height="24"\/>/g, '')
     .replace(/<rect id="SVGID_1_" width="24" height="24"\/>/g, '');
 
+  const svgo = new SVGO({
+    floatPrecision: 4,
+    plugins: [
+      { cleanupAttrs: true },
+      { removeDoctype: true },
+      { removeXMLProcInst: true },
+      { removeComments: true },
+      { removeMetadata: true },
+      { removeTitle: true },
+      { removeDesc: true },
+      { removeUselessDefs: true },
+      { removeXMLNS: true },
+      { removeEditorsNSData: true },
+      { removeEmptyAttrs: true },
+      { removeHiddenElems: true },
+      { removeEmptyText: true },
+      { removeEmptyContainers: true },
+      { removeViewBox: true },
+      { cleanupEnableBackground: true },
+      { minifyStyles: true },
+      { convertStyleToAttrs: true },
+      { convertColors: true },
+      { convertPathData: true },
+      { convertTransform: true },
+      { removeUnknownsAndDefaults: true },
+      { removeNonInheritableGroupAttrs: true },
+      {
+        removeUselessStrokeAndFill: {
+          // https://github.com/svg/svgo/issues/727#issuecomment-303115276
+          removeNone: true,
+        },
+      },
+      { removeUnusedNS: true },
+      { cleanupIDs: true },
+      { cleanupNumericValues: true },
+      { cleanupListOfValues: true },
+      { moveElemsAttrsToGroup: true },
+      { moveGroupAttrsToElems: true },
+      { collapseGroups: true },
+      { removeRasterImages: true },
+      { mergePaths: true },
+      { convertShapeToPath: true },
+      { sortAttrs: true },
+      { removeDimensions: true },
+      { removeAttrs: true },
+      { removeElementsByAttr: true },
+      { removeStyleElement: true },
+      { removeScriptElement: true },
+    ],
+  });
   const result = await svgo.optimize(input);
 
   // Extract the paths from the svg string

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -215,9 +215,9 @@ async function worker({ svgPath, options, renameFilter, template }) {
 }
 
 export async function main(options) {
-  try {
-    let originalWrite;
+  const originalWrite = process.stdout.write;
 
+  try {
     options.glob = options.glob || '/**/*.svg';
     options.innerPath = options.innerPath || '';
     options.renameFilter = options.renameFilter || RENAME_FILTER_DEFAULT;
@@ -225,7 +225,6 @@ export async function main(options) {
 
     // Disable console.log opt, used for tests
     if (options.disableLog) {
-      originalWrite = process.stdout.write;
       process.stdout.write = () => {};
     }
 
@@ -284,13 +283,11 @@ export async function main(options) {
     await fse.copy(path.join(__dirname, '/custom'), options.outputDir);
 
     await generateIndex(options);
-
-    if (options.disableLog) {
-      // bring back stdout
-      process.stdout.write = originalWrite;
-    }
   } catch (err) {
     console.log(err);
+  } finally {
+    // bring back stdout
+    process.stdout.write = originalWrite;
   }
 }
 

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -283,8 +283,6 @@ export async function main(options) {
     await fse.copy(path.join(__dirname, '/custom'), options.outputDir);
 
     await generateIndex(options);
-  } catch (err) {
-    console.log(err);
   } finally {
     // bring back stdout
     process.stdout.write = originalWrite;

--- a/packages/material-ui-icons/builder.test.js
+++ b/packages/material-ui-icons/builder.test.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import fse from 'fs-extra';
-import { RENAME_FILTER_MUI, RENAME_FILTER_DEFAULT, main, getComponentName } from './builder';
+import { RENAME_FILTER_MUI, RENAME_FILTER_DEFAULT, getComponentName, handler } from './builder';
 
 const DISABLE_LOG = true;
 
@@ -30,10 +30,6 @@ describe('builder', () => {
     expect(fs.lstatSync(MUI_ICONS_SVG_DIR).isDirectory()).to.equal(true);
   });
 
-  it('should have main', () => {
-    expect(typeof main).to.equal('function');
-  });
-
   describe('--output-dir', () => {
     const options = {
       svgDir: MUI_ICONS_SVG_DIR,
@@ -55,7 +51,7 @@ describe('builder', () => {
     });
 
     it('script outputs to directory', async () => {
-      await main(options);
+      await handler(options);
       expect(fs.lstatSync(options.outputDir).isDirectory()).to.equal(true);
       expect(fs.lstatSync(path.join(options.outputDir, 'index.js')).isFile()).to.equal(true);
     });
@@ -82,7 +78,7 @@ describe('builder', () => {
     });
 
     it('script outputs to directory', async () => {
-      await main(options);
+      await handler(options);
       expect(fs.lstatSync(options.outputDir).isDirectory()).to.equal(true);
       expect(fs.lstatSync(path.join(options.outputDir, 'delapouite')).isDirectory()).to.equal(true);
 
@@ -123,7 +119,7 @@ describe('builder', () => {
     });
 
     it('should produce the expected output', async () => {
-      await main(options);
+      await handler(options);
       expect(fs.lstatSync(options.outputDir).isDirectory()).to.equal(true);
 
       const cases = [


### PR DESCRIPTION
Review without whitespace diff advised. Modernization described in each commit message.

Motivated by failing tests when bumping svgo that did not offer any hint what was wrong.

Test plan
- [x] CI green
- [x] `yarn; yarn workspace @material-ui/icons src:download; yarn workspace @material-ui/icons src:icons` did not change any files 