### PR TITLE
[docs] Migrate Button demos to emotion

### DIFF
--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
 import MuiButton from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
@@ -13,7 +14,13 @@ const Button = styled(MuiButton)(
 
 export default function ButtonSizes() {
   return (
-    <div>
+    <Box
+      sx={{
+        '& button': {
+          m: 1,
+        },
+      }}
+    >
       <div>
         <Button size="small">Small</Button>
         <Button size="medium">Medium</Button>
@@ -55,6 +62,6 @@ export default function ButtonSizes() {
           <DeleteIcon fontSize="large" />
         </IconButton>
       </div>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -1,16 +1,9 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import MuiButton from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
-
-const Button = styled(MuiButton)(
-  ({ theme }) => `
-  margin: ${theme.spacing(1)}
-`,
-);
 
 export default function ButtonSizes() {
   return (

--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -1,65 +1,57 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import MuiButton from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
-const useStyles = makeStyles((theme) => ({
-  margin: {
-    margin: theme.spacing(1),
-  },
-}));
+const Button = styled(MuiButton)(
+  ({ theme }) => `
+  margin: ${theme.spacing(1)}
+`,
+);
 
 export default function ButtonSizes() {
-  const classes = useStyles();
-
   return (
     <div>
       <div>
-        <Button size="small" className={classes.margin}>
+        <Button size="small">Small</Button>
+        <Button size="medium">Medium</Button>
+        <Button size="large">Large</Button>
+      </div>
+      <div>
+        <Button variant="outlined" size="small">
           Small
         </Button>
-        <Button size="medium" className={classes.margin}>
+        <Button variant="outlined" size="medium">
           Medium
         </Button>
-        <Button size="large" className={classes.margin}>
+        <Button variant="outlined" size="large">
           Large
         </Button>
       </div>
       <div>
-        <Button variant="outlined" size="small" className={classes.margin}>
+        <Button variant="contained" size="small">
           Small
         </Button>
-        <Button variant="outlined" size="medium" className={classes.margin}>
+        <Button variant="contained" size="medium">
           Medium
         </Button>
-        <Button variant="outlined" size="large" className={classes.margin}>
+        <Button variant="contained" size="large">
           Large
         </Button>
       </div>
       <div>
-        <Button variant="contained" size="small" className={classes.margin}>
-          Small
-        </Button>
-        <Button variant="contained" size="medium" className={classes.margin}>
-          Medium
-        </Button>
-        <Button variant="contained" size="large" className={classes.margin}>
-          Large
-        </Button>
-      </div>
-      <div>
-        <IconButton aria-label="delete" className={classes.margin} size="small">
+        <IconButton aria-label="delete" size="small">
           <ArrowDownwardIcon fontSize="inherit" />
         </IconButton>
-        <IconButton aria-label="delete" className={classes.margin}>
+        <IconButton aria-label="delete">
           <DeleteIcon fontSize="small" />
         </IconButton>
-        <IconButton aria-label="delete" className={classes.margin}>
+        <IconButton aria-label="delete">
           <DeleteIcon />
         </IconButton>
-        <IconButton aria-label="delete" className={classes.margin}>
+        <IconButton aria-label="delete">
           <DeleteIcon fontSize="large" />
         </IconButton>
       </div>

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -1,67 +1,57 @@
 import * as React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import MuiButton from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    margin: {
-      margin: theme.spacing(1),
-    },
-  }),
+const Button = styled(MuiButton)(
+  ({ theme }) => `
+  margin: ${theme.spacing(1)}
+`,
 );
 
 export default function ButtonSizes() {
-  const classes = useStyles();
-
   return (
     <div>
       <div>
-        <Button size="small" className={classes.margin}>
+        <Button size="small">Small</Button>
+        <Button size="medium">Medium</Button>
+        <Button size="large">Large</Button>
+      </div>
+      <div>
+        <Button variant="outlined" size="small">
           Small
         </Button>
-        <Button size="medium" className={classes.margin}>
+        <Button variant="outlined" size="medium">
           Medium
         </Button>
-        <Button size="large" className={classes.margin}>
+        <Button variant="outlined" size="large">
           Large
         </Button>
       </div>
       <div>
-        <Button variant="outlined" size="small" className={classes.margin}>
+        <Button variant="contained" size="small">
           Small
         </Button>
-        <Button variant="outlined" size="medium" className={classes.margin}>
+        <Button variant="contained" size="medium">
           Medium
         </Button>
-        <Button variant="outlined" size="large" className={classes.margin}>
+        <Button variant="contained" size="large">
           Large
         </Button>
       </div>
       <div>
-        <Button variant="contained" size="small" className={classes.margin}>
-          Small
-        </Button>
-        <Button variant="contained" size="medium" className={classes.margin}>
-          Medium
-        </Button>
-        <Button variant="contained" size="large" className={classes.margin}>
-          Large
-        </Button>
-      </div>
-      <div>
-        <IconButton aria-label="delete" className={classes.margin} size="small">
+        <IconButton aria-label="delete" size="small">
           <ArrowDownwardIcon fontSize="inherit" />
         </IconButton>
-        <IconButton aria-label="delete" className={classes.margin}>
+        <IconButton aria-label="delete">
           <DeleteIcon fontSize="small" />
         </IconButton>
-        <IconButton aria-label="delete" className={classes.margin}>
+        <IconButton aria-label="delete">
           <DeleteIcon />
         </IconButton>
-        <IconButton aria-label="delete" className={classes.margin}>
+        <IconButton aria-label="delete">
           <DeleteIcon fontSize="large" />
         </IconButton>
       </div>

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import MuiButton from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
-const Button = styled(MuiButton)(
-  ({ theme }) => `
-  margin: ${theme.spacing(1)}
-`,
-);
-
 export default function ButtonSizes() {
   return (
-    <div>
+    <Box
+      sx={{
+        '& button': {
+          m: 1,
+        },
+      }}
+    >
       <div>
         <Button size="small">Small</Button>
         <Button size="medium">Medium</Button>
@@ -55,6 +55,6 @@ export default function ButtonSizes() {
           <DeleteIcon fontSize="large" />
         </IconButton>
       </div>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -6,7 +6,7 @@ export default function ContainedButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function ContainedButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <Button variant="contained">Primary</Button>
       <Button variant="contained" color="secondary">
         Secondary
@@ -25,6 +21,6 @@ export default function ContainedButtons() {
       <Button variant="contained" href="#contained-buttons">
         Link
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -1,22 +1,16 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function ContainedButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <Button variant="contained">Primary</Button>
       <Button variant="contained" color="secondary">
         Secondary
@@ -27,6 +21,6 @@ export default function ContainedButtons() {
       <Button variant="contained" href="#contained-buttons">
         Link
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -6,7 +6,7 @@ export default function ContainedButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/IconButtons.js
+++ b/docs/src/pages/components/buttons/IconButtons.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function IconButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <IconButton aria-label="delete">
         <DeleteIcon />
       </IconButton>
@@ -30,6 +26,6 @@ export default function IconButtons() {
       <IconButton color="primary" aria-label="add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtons.js
+++ b/docs/src/pages/components/buttons/IconButtons.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AlarmIcon from '@material-ui/icons/Alarm';
@@ -7,13 +6,7 @@ import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 
 export default function IconButtons() {
   return (
-    <Box
-      sx={{
-        '& > button': {
-          m: 1,
-        },
-      }}
-    >
+    <div>
       <IconButton aria-label="delete">
         <DeleteIcon />
       </IconButton>
@@ -26,6 +19,6 @@ export default function IconButtons() {
       <IconButton color="primary" aria-label="add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
-    </Box>
+    </div>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtons.tsx
+++ b/docs/src/pages/components/buttons/IconButtons.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AlarmIcon from '@material-ui/icons/Alarm';
@@ -7,13 +6,7 @@ import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 
 export default function IconButtons() {
   return (
-    <Box
-      sx={{
-        '& > button': {
-          m: 1,
-        },
-      }}
-    >
+    <div>
       <IconButton aria-label="delete">
         <DeleteIcon />
       </IconButton>
@@ -26,6 +19,6 @@ export default function IconButtons() {
       <IconButton color="primary" aria-label="add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
-    </Box>
+    </div>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtons.tsx
+++ b/docs/src/pages/components/buttons/IconButtons.tsx
@@ -1,25 +1,19 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function IconButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <IconButton aria-label="delete">
         <DeleteIcon />
       </IconButton>
@@ -32,6 +26,6 @@ export default function IconButtons() {
       <IconButton color="primary" aria-label="add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -8,7 +8,7 @@ export default function IconLabelButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -8,8 +8,8 @@ export default function IconLabelButtons() {
   return (
     <Box
       sx={{
-        '& > *': {
-          margin: 1,
+        '& > button': {
+          m: 1,
         },
       }}
     >

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -8,7 +8,7 @@ export default function IconLabelButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -8,8 +8,8 @@ export default function IconLabelButtons() {
   return (
     <Box
       sx={{
-        '& > *': {
-          margin: 1,
+        '& > button': {
+          m: 1,
         },
       }}
     >

--- a/docs/src/pages/components/buttons/LoadingButtons.js
+++ b/docs/src/pages/components/buttons/LoadingButtons.js
@@ -1,21 +1,17 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import LoadingButton from '@material-ui/lab/LoadingButton';
 import SaveIcon from '@material-ui/icons/Save';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& button': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function LoadingButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <LoadingButton pending variant="outlined">
         Submit
       </LoadingButton>
@@ -30,6 +26,6 @@ export default function LoadingButtons() {
       >
         Save
       </LoadingButton>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/LoadingButtons.js
+++ b/docs/src/pages/components/buttons/LoadingButtons.js
@@ -7,7 +7,7 @@ export default function LoadingButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/LoadingButtons.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtons.tsx
@@ -1,21 +1,17 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import LoadingButton from '@material-ui/lab/LoadingButton';
 import SaveIcon from '@material-ui/icons/Save';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& button': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function LoadingButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <LoadingButton pending variant="outlined">
         Submit
       </LoadingButton>
@@ -30,6 +26,6 @@ export default function LoadingButtons() {
       >
         Save
       </LoadingButton>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/LoadingButtons.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtons.tsx
@@ -7,7 +7,7 @@ export default function LoadingButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/LoadingButtonsTransition.js
+++ b/docs/src/pages/components/buttons/LoadingButtonsTransition.js
@@ -1,15 +1,10 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import LoadingButton from '@material-ui/lab/LoadingButton';
 import Box from '@material-ui/core/Box';
-import MuiFormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import SaveIcon from '@material-ui/icons/Save';
 import SendIcon from '@material-ui/icons/Send';
-
-const FormControlLabel = styled(MuiFormControlLabel)(`
-  display: block;
-`);
 
 export default function LoadingButtonsTransition() {
   const [pending, setPending] = React.useState(false);
@@ -26,6 +21,9 @@ export default function LoadingButtonsTransition() {
       }}
     >
       <FormControlLabel
+        sx={{
+          display: 'block',
+        }}
         control={
           <Switch
             checked={pending}

--- a/docs/src/pages/components/buttons/LoadingButtonsTransition.js
+++ b/docs/src/pages/components/buttons/LoadingButtonsTransition.js
@@ -1,32 +1,30 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import LoadingButton from '@material-ui/lab/LoadingButton';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Box from '@material-ui/core/Box';
+import MuiFormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import SaveIcon from '@material-ui/icons/Save';
 import SendIcon from '@material-ui/icons/Send';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& button': {
-      margin: theme.spacing(1),
-    },
-  },
-  switch: {
-    display: 'block',
-  },
-}));
+const FormControlLabel = styled(MuiFormControlLabel)(`
+  display: block;
+`);
 
 export default function LoadingButtonsTransition() {
-  const classes = useStyles();
-
   const [pending, setPending] = React.useState(false);
   function handleClick() {
     setPending(true);
   }
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <FormControlLabel
         control={
           <Switch
@@ -36,7 +34,6 @@ export default function LoadingButtonsTransition() {
             color="primary"
           />
         }
-        className={classes.switch}
         label="Pending"
       />
       <LoadingButton onClick={handleClick} pending={pending} variant="outlined">
@@ -69,6 +66,6 @@ export default function LoadingButtonsTransition() {
       >
         Save
       </LoadingButton>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/LoadingButtonsTransition.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtonsTransition.tsx
@@ -1,15 +1,10 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import LoadingButton from '@material-ui/lab/LoadingButton';
 import Box from '@material-ui/core/Box';
-import MuiFormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import SaveIcon from '@material-ui/icons/Save';
 import SendIcon from '@material-ui/icons/Send';
-
-const FormControlLabel = styled(MuiFormControlLabel)(`
-  display: block;
-`);
 
 export default function LoadingButtonsTransition() {
   const [pending, setPending] = React.useState(false);
@@ -26,6 +21,9 @@ export default function LoadingButtonsTransition() {
       }}
     >
       <FormControlLabel
+        sx={{
+          display: 'block',
+        }}
         control={
           <Switch
             checked={pending}

--- a/docs/src/pages/components/buttons/LoadingButtonsTransition.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtonsTransition.tsx
@@ -1,32 +1,30 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import LoadingButton from '@material-ui/lab/LoadingButton';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Box from '@material-ui/core/Box';
+import MuiFormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import SaveIcon from '@material-ui/icons/Save';
 import SendIcon from '@material-ui/icons/Send';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& button': {
-      margin: theme.spacing(1),
-    },
-  },
-  switch: {
-    display: 'block',
-  },
-}));
+const FormControlLabel = styled(MuiFormControlLabel)(`
+  display: block;
+`);
 
 export default function LoadingButtonsTransition() {
-  const classes = useStyles();
-
   const [pending, setPending] = React.useState(false);
   function handleClick() {
     setPending(true);
   }
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <FormControlLabel
         control={
           <Switch
@@ -36,7 +34,6 @@ export default function LoadingButtonsTransition() {
             color="primary"
           />
         }
-        className={classes.switch}
         label="Pending"
       />
       <LoadingButton onClick={handleClick} pending={pending} variant="outlined">
@@ -69,6 +66,6 @@ export default function LoadingButtonsTransition() {
       >
         Save
       </LoadingButton>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/OutlinedButtons.js
+++ b/docs/src/pages/components/buttons/OutlinedButtons.js
@@ -6,7 +6,7 @@ export default function OutlinedButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/OutlinedButtons.js
+++ b/docs/src/pages/components/buttons/OutlinedButtons.js
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function OutlinedButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <Button variant="outlined">Primary</Button>
       <Button variant="outlined" color="secondary">
         Secondary
@@ -25,6 +21,6 @@ export default function OutlinedButtons() {
       <Button variant="outlined" href="#outlined-buttons">
         Link
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/OutlinedButtons.tsx
+++ b/docs/src/pages/components/buttons/OutlinedButtons.tsx
@@ -6,7 +6,7 @@ export default function OutlinedButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/OutlinedButtons.tsx
+++ b/docs/src/pages/components/buttons/OutlinedButtons.tsx
@@ -1,22 +1,16 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function OutlinedButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <Button variant="outlined">Primary</Button>
       <Button variant="outlined" color="secondary">
         Secondary
@@ -27,6 +21,6 @@ export default function OutlinedButtons() {
       <Button variant="outlined" href="#outlined-buttons">
         Link
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/TextButtons.js
+++ b/docs/src/pages/components/buttons/TextButtons.js
@@ -1,24 +1,20 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function TextButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <Button>Primary</Button>
       <Button color="secondary">Secondary</Button>
       <Button disabled>Disabled</Button>
       <Button href="#text-buttons">Link</Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/TextButtons.js
+++ b/docs/src/pages/components/buttons/TextButtons.js
@@ -6,7 +6,7 @@ export default function TextButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/TextButtons.tsx
+++ b/docs/src/pages/components/buttons/TextButtons.tsx
@@ -6,7 +6,7 @@ export default function TextButtons() {
   return (
     <Box
       sx={{
-        '& > button': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/TextButtons.tsx
+++ b/docs/src/pages/components/buttons/TextButtons.tsx
@@ -1,26 +1,20 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function TextButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > button': {
+          m: 1,
+        },
+      }}
+    >
       <Button>Primary</Button>
       <Button color="secondary">Secondary</Button>
       <Button disabled>Disabled</Button>
       <Button href="#text-buttons">Link</Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -1,48 +1,35 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  input: {
-    display: 'none',
-  },
-}));
+const Input = styled('input')`
+  display: none;
+`;
 
 export default function UploadButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <input
-        accept="image/*"
-        className={classes.input}
-        id="contained-button-file"
-        multiple
-        type="file"
-      />
+    <Box
+      sx={{
+        '& > label': {
+          m: 1,
+        },
+      }}
+    >
+      <Input accept="image/*" id="contained-button-file" multiple type="file" />
       <label htmlFor="contained-button-file">
         <Button variant="contained" component="span">
           Upload
         </Button>
       </label>
-      <input
-        accept="image/*"
-        className={classes.input}
-        id="icon-button-file"
-        type="file"
-      />
+      <Input accept="image/*" id="icon-button-file" type="file" />
       <label htmlFor="icon-button-file">
         <IconButton color="primary" aria-label="upload picture" component="span">
           <PhotoCamera />
         </IconButton>
       </label>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -6,7 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
 const Input = styled('input')({
-  display: 'none'
+  display: 'none',
 });
 
 export default function UploadButtons() {

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -5,9 +5,9 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
-const Input = styled('input')`
-  display: none;
-`;
+const Input = styled('input')({
+  display: 'none'
+});
 
 export default function UploadButtons() {
   return (

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -13,7 +13,7 @@ export default function UploadButtons() {
   return (
     <Box
       sx={{
-        '& > label': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -6,7 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
 const Input = styled('input')({
-  display: 'none'
+  display: 'none',
 });
 
 export default function UploadButtons() {

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -5,9 +5,9 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
-const Input = styled('input')`
-  display: none;
-`;
+const Input = styled('input')({
+  display: 'none'
+});
 
 export default function UploadButtons() {
   return (

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -13,7 +13,7 @@ export default function UploadButtons() {
   return (
     <Box
       sx={{
-        '& > label': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -1,50 +1,35 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    input: {
-      display: 'none',
-    },
-  }),
-);
+const Input = styled('input')`
+  display: none;
+`;
 
 export default function UploadButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <input
-        accept="image/*"
-        className={classes.input}
-        id="contained-button-file"
-        multiple
-        type="file"
-      />
+    <Box
+      sx={{
+        '& > label': {
+          m: 1,
+        },
+      }}
+    >
+      <Input accept="image/*" id="contained-button-file" multiple type="file" />
       <label htmlFor="contained-button-file">
         <Button variant="contained" component="span">
           Upload
         </Button>
       </label>
-      <input
-        accept="image/*"
-        className={classes.input}
-        id="icon-button-file"
-        type="file"
-      />
+      <Input accept="image/*" id="icon-button-file" type="file" />
       <label htmlFor="icon-button-file">
         <IconButton color="primary" aria-label="upload picture" component="span">
           <PhotoCamera />
         </IconButton>
       </label>
-    </div>
+    </Box>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the `Button` component were migrated:

- [x] Contained buttons
- [x] Text buttons
- [x] Outlined buttons
- [x] Upload buttons
- [x] Sizes buttons
- [x] Icon label buttons
- [x] Icon  buttons
- [x] Loading buttons

Related to #16947