### PR TITLE
[docs] Migrate Divider demos to emotion

### DIFF
--- a/docs/src/pages/components/dividers/InsetDividers.js
+++ b/docs/src/pages/components/dividers/InsetDividers.js
@@ -15,7 +15,7 @@ export default function InsetDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
     >
       <ListItem>

--- a/docs/src/pages/components/dividers/InsetDividers.js
+++ b/docs/src/pages/components/dividers/InsetDividers.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -10,19 +9,15 @@ import WorkIcon from '@material-ui/icons/Work';
 import BeachAccessIcon from '@material-ui/icons/BeachAccess';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
-
 export default function InsetDividers() {
-  const classes = useStyles();
-
   return (
-    <List className={classes.root}>
+    <List
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+    >
       <ListItem>
         <ListItemAvatar>
           <Avatar>

--- a/docs/src/pages/components/dividers/InsetDividers.tsx
+++ b/docs/src/pages/components/dividers/InsetDividers.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -10,21 +9,15 @@ import WorkIcon from '@material-ui/icons/Work';
 import BeachAccessIcon from '@material-ui/icons/BeachAccess';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      maxWidth: 360,
-      backgroundColor: theme.palette.background.paper,
-    },
-  }),
-);
-
 export default function InsetDividers() {
-  const classes = useStyles();
-
   return (
-    <List className={classes.root}>
+    <List
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+    >
       <ListItem>
         <ListItemAvatar>
           <Avatar>

--- a/docs/src/pages/components/dividers/InsetDividers.tsx
+++ b/docs/src/pages/components/dividers/InsetDividers.tsx
@@ -15,7 +15,7 @@ export default function InsetDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
     >
       <ListItem>

--- a/docs/src/pages/components/dividers/ListDividers.js
+++ b/docs/src/pages/components/dividers/ListDividers.js
@@ -10,7 +10,7 @@ export default function ListDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
       component="nav"
       aria-label="mailbox folders"

--- a/docs/src/pages/components/dividers/ListDividers.js
+++ b/docs/src/pages/components/dividers/ListDividers.js
@@ -4,17 +4,15 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
 
+const style = {
+  width: '100%',
+  maxWidth: 360,
+  bgcolor: 'background.paper',
+};
+
 export default function ListDividers() {
   return (
-    <List
-      sx={{
-        width: '100%',
-        maxWidth: 360,
-        bgcolor: 'background.paper',
-      }}
-      component="nav"
-      aria-label="mailbox folders"
-    >
+    <List sx={style} component="nav" aria-label="mailbox folders">
       <ListItem button>
         <ListItemText primary="Inbox" />
       </ListItem>

--- a/docs/src/pages/components/dividers/ListDividers.js
+++ b/docs/src/pages/components/dividers/ListDividers.js
@@ -1,23 +1,20 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
-
 export default function ListDividers() {
-  const classes = useStyles();
-
   return (
-    <List component="nav" className={classes.root} aria-label="mailbox folders">
+    <List
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+      component="nav"
+      aria-label="mailbox folders"
+    >
       <ListItem button>
         <ListItemText primary="Inbox" />
       </ListItem>

--- a/docs/src/pages/components/dividers/ListDividers.tsx
+++ b/docs/src/pages/components/dividers/ListDividers.tsx
@@ -1,25 +1,20 @@
 import * as React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      maxWidth: 360,
-      backgroundColor: theme.palette.background.paper,
-    },
-  }),
-);
-
 export default function ListDividers() {
-  const classes = useStyles();
-
   return (
-    <List component="nav" className={classes.root} aria-label="mailbox folders">
+    <List
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+      component="nav"
+      aria-label="mailbox folders"
+    >
       <ListItem button>
         <ListItemText primary="Inbox" />
       </ListItem>

--- a/docs/src/pages/components/dividers/ListDividers.tsx
+++ b/docs/src/pages/components/dividers/ListDividers.tsx
@@ -10,7 +10,7 @@ export default function ListDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
       component="nav"
       aria-label="mailbox folders"

--- a/docs/src/pages/components/dividers/ListDividers.tsx
+++ b/docs/src/pages/components/dividers/ListDividers.tsx
@@ -4,17 +4,15 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
 
+const style = {
+  width: '100%',
+  maxWidth: 360,
+  bgcolor: 'background.paper',
+};
+
 export default function ListDividers() {
   return (
-    <List
-      sx={{
-        width: '100%',
-        maxWidth: 360,
-        bgcolor: 'background.paper',
-      }}
-      component="nav"
-      aria-label="mailbox folders"
-    >
+    <List sx={style} component="nav" aria-label="mailbox folders">
       <ListItem button>
         <ListItemText primary="Inbox" />
       </ListItem>

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -17,7 +17,8 @@ export default function MiddleDividers() {
     >
       <Box
         sx={{
-          m: (theme) => theme.spacing(3, 2),
+          my: 3,
+          mx: 2,
         }}
       >
         <Grid container alignItems="center">
@@ -61,7 +62,9 @@ export default function MiddleDividers() {
       </Box>
       <Box
         sx={{
-          m: (theme) => theme.spacing(3, 1, 1),
+          mt: 3,
+          ml: 1,
+          mb: 1,
         }}
       >
         <Button>Add to cart</Button>

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -12,7 +12,7 @@ export default function MiddleDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
     >
       <Box

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -1,37 +1,25 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Chip from '@material-ui/core/Chip';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-  chip: {
-    margin: theme.spacing(0.5),
-  },
-  section1: {
-    margin: theme.spacing(3, 2),
-  },
-  section2: {
-    margin: theme.spacing(2),
-  },
-  section3: {
-    margin: theme.spacing(3, 1, 1),
-  },
-}));
-
 export default function MiddleDividers() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <div className={classes.section1}>
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+    >
+      <Box
+        sx={{
+          m: (theme) => theme.spacing(3, 2),
+        }}
+      >
         <Grid container alignItems="center">
           <Grid item xs>
             <Typography gutterBottom variant="h4" component="div">
@@ -48,22 +36,36 @@ export default function MiddleDividers() {
           Pinstriped cornflower blue cotton blouse takes you on a walk to the park or
           just down the hall.
         </Typography>
-      </div>
+      </Box>
       <Divider variant="middle" />
-      <div className={classes.section2}>
+      <Box
+        sx={{
+          m: 2,
+        }}
+      >
         <Typography gutterBottom variant="body1">
           Select type
         </Typography>
-        <div>
-          <Chip className={classes.chip} label="Extra Soft" />
-          <Chip className={classes.chip} color="primary" label="Soft" />
-          <Chip className={classes.chip} label="Medium" />
-          <Chip className={classes.chip} label="Hard" />
-        </div>
-      </div>
-      <div className={classes.section3}>
+        <Box
+          sx={{
+            '& > .MuiChip-root': {
+              m: 0.5,
+            },
+          }}
+        >
+          <Chip label="Extra Soft" />
+          <Chip color="primary" label="Soft" />
+          <Chip label="Medium" />
+          <Chip label="Hard" />
+        </Box>
+      </Box>
+      <Box
+        sx={{
+          m: (theme) => theme.spacing(3, 1, 1),
+        }}
+      >
         <Button>Add to cart</Button>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -15,12 +15,7 @@ export default function MiddleDividers() {
         bgcolor: 'background.paper',
       }}
     >
-      <Box
-        sx={{
-          my: 3,
-          mx: 2,
-        }}
-      >
+      <Box sx={{ my: 3, mx: 2 }}>
         <Grid container alignItems="center">
           <Grid item xs>
             <Typography gutterBottom variant="h4" component="div">
@@ -33,24 +28,21 @@ export default function MiddleDividers() {
             </Typography>
           </Grid>
         </Grid>
-        <Typography color="textSecondary" variant="body2">
+        <Typography color="text.secondary" variant="body2">
           Pinstriped cornflower blue cotton blouse takes you on a walk to the park or
           just down the hall.
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <Box
-        sx={{
-          m: 2,
-        }}
-      >
+      <Box sx={{ m: 2 }}>
         <Typography gutterBottom variant="body1">
           Select type
         </Typography>
         <Box
           sx={{
-            '& > .MuiChip-root': {
-              m: 0.5,
+            // Replace with Stack
+            '& > :not(style) + :not(style)': {
+              ml: 1,
             },
           }}
         >
@@ -60,13 +52,7 @@ export default function MiddleDividers() {
           <Chip label="Hard" />
         </Box>
       </Box>
-      <Box
-        sx={{
-          mt: 3,
-          ml: 1,
-          mb: 1,
-        }}
-      >
+      <Box sx={{ mt: 3, ml: 1, mb: 1 }}>
         <Button>Add to cart</Button>
       </Box>
     </Box>

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -17,7 +17,8 @@ export default function MiddleDividers() {
     >
       <Box
         sx={{
-          m: (theme) => theme.spacing(3, 2),
+          my: 3,
+          mx: 2,
         }}
       >
         <Grid container alignItems="center">
@@ -61,7 +62,9 @@ export default function MiddleDividers() {
       </Box>
       <Box
         sx={{
-          m: (theme) => theme.spacing(3, 1, 1),
+          mt: 3,
+          ml: 1,
+          mb: 1,
         }}
       >
         <Button>Add to cart</Button>

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -12,7 +12,7 @@ export default function MiddleDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
     >
       <Box

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -1,39 +1,25 @@
 import * as React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Chip from '@material-ui/core/Chip';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      maxWidth: 360,
-      backgroundColor: theme.palette.background.paper,
-    },
-    chip: {
-      margin: theme.spacing(0.5),
-    },
-    section1: {
-      margin: theme.spacing(3, 2),
-    },
-    section2: {
-      margin: theme.spacing(2),
-    },
-    section3: {
-      margin: theme.spacing(3, 1, 1),
-    },
-  }),
-);
-
 export default function MiddleDividers() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <div className={classes.section1}>
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+    >
+      <Box
+        sx={{
+          m: (theme) => theme.spacing(3, 2),
+        }}
+      >
         <Grid container alignItems="center">
           <Grid item xs>
             <Typography gutterBottom variant="h4" component="div">
@@ -50,22 +36,36 @@ export default function MiddleDividers() {
           Pinstriped cornflower blue cotton blouse takes you on a walk to the park or
           just down the hall.
         </Typography>
-      </div>
+      </Box>
       <Divider variant="middle" />
-      <div className={classes.section2}>
+      <Box
+        sx={{
+          m: 2,
+        }}
+      >
         <Typography gutterBottom variant="body1">
           Select type
         </Typography>
-        <div>
-          <Chip className={classes.chip} label="Extra Soft" />
-          <Chip className={classes.chip} color="primary" label="Soft" />
-          <Chip className={classes.chip} label="Medium" />
-          <Chip className={classes.chip} label="Hard" />
-        </div>
-      </div>
-      <div className={classes.section3}>
+        <Box
+          sx={{
+            '& > .MuiChip-root': {
+              m: 0.5,
+            },
+          }}
+        >
+          <Chip label="Extra Soft" />
+          <Chip color="primary" label="Soft" />
+          <Chip label="Medium" />
+          <Chip label="Hard" />
+        </Box>
+      </Box>
+      <Box
+        sx={{
+          m: (theme) => theme.spacing(3, 1, 1),
+        }}
+      >
         <Button>Add to cart</Button>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -15,12 +15,7 @@ export default function MiddleDividers() {
         bgcolor: 'background.paper',
       }}
     >
-      <Box
-        sx={{
-          my: 3,
-          mx: 2,
-        }}
-      >
+      <Box sx={{ my: 3, mx: 2 }}>
         <Grid container alignItems="center">
           <Grid item xs>
             <Typography gutterBottom variant="h4" component="div">
@@ -33,24 +28,21 @@ export default function MiddleDividers() {
             </Typography>
           </Grid>
         </Grid>
-        <Typography color="textSecondary" variant="body2">
+        <Typography color="text.secondary" variant="body2">
           Pinstriped cornflower blue cotton blouse takes you on a walk to the park or
           just down the hall.
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <Box
-        sx={{
-          m: 2,
-        }}
-      >
+      <Box sx={{ m: 2 }}>
         <Typography gutterBottom variant="body1">
           Select type
         </Typography>
         <Box
           sx={{
-            '& > .MuiChip-root': {
-              m: 0.5,
+            // Replace with Stack
+            '& > :not(style) + :not(style)': {
+              ml: 1,
             },
           }}
         >
@@ -60,13 +52,7 @@ export default function MiddleDividers() {
           <Chip label="Hard" />
         </Box>
       </Box>
-      <Box
-        sx={{
-          mt: 3,
-          ml: 1,
-          mb: 1,
-        }}
-      >
+      <Box sx={{ mt: 3, ml: 1, mb: 1 }}>
         <Button>Add to cart</Button>
       </Box>
     </Box>

--- a/docs/src/pages/components/dividers/SubheaderDividers.js
+++ b/docs/src/pages/components/dividers/SubheaderDividers.js
@@ -23,7 +23,7 @@ export default function SubheaderDividers() {
       <Divider component="li" />
       <li>
         <Typography
-          sx={{ mt: '5px', ml: 2 }}
+          sx={{ mt: 0.5, ml: 2 }}
           color="textSecondary"
           display="block"
           variant="caption"
@@ -37,7 +37,7 @@ export default function SubheaderDividers() {
       <Divider component="li" variant="inset" />
       <li>
         <Typography
-          sx={{ mt: '5px', ml: 9 }}
+          sx={{ mt: 0.5, ml: 9 }}
           color="textSecondary"
           display="block"
           variant="caption"

--- a/docs/src/pages/components/dividers/SubheaderDividers.js
+++ b/docs/src/pages/components/dividers/SubheaderDividers.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
@@ -9,32 +8,24 @@ import BeachAccessIcon from '@material-ui/icons/BeachAccess';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-  dividerFullWidth: {
-    margin: `5px 0 0 ${theme.spacing(2)}`,
-  },
-  dividerInset: {
-    margin: `5px 0 0 ${theme.spacing(9)}`,
-  },
-}));
-
 export default function SubheaderDividers() {
-  const classes = useStyles();
-
   return (
-    <List className={classes.root}>
+    <List
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+    >
       <ListItem>
         <ListItemText primary="Photos" secondary="Jan 9, 2014" />
       </ListItem>
       <Divider component="li" />
       <li>
         <Typography
-          className={classes.dividerFullWidth}
+          sx={{
+            m: `5px 0 0 16px`,
+          }}
           color="textSecondary"
           display="block"
           variant="caption"
@@ -48,7 +39,9 @@ export default function SubheaderDividers() {
       <Divider component="li" variant="inset" />
       <li>
         <Typography
-          className={classes.dividerInset}
+          sx={{
+            m: `5px 0 0 72px`,
+          }}
           color="textSecondary"
           display="block"
           variant="caption"

--- a/docs/src/pages/components/dividers/SubheaderDividers.js
+++ b/docs/src/pages/components/dividers/SubheaderDividers.js
@@ -23,9 +23,7 @@ export default function SubheaderDividers() {
       <Divider component="li" />
       <li>
         <Typography
-          sx={{
-            m: `5px 0 0 16px`,
-          }}
+          sx={{ mt: '5px', ml: 2 }}
           color="textSecondary"
           display="block"
           variant="caption"
@@ -39,9 +37,7 @@ export default function SubheaderDividers() {
       <Divider component="li" variant="inset" />
       <li>
         <Typography
-          sx={{
-            m: `5px 0 0 72px`,
-          }}
+          sx={{ mt: '5px', ml: 9 }}
           color="textSecondary"
           display="block"
           variant="caption"

--- a/docs/src/pages/components/dividers/SubheaderDividers.js
+++ b/docs/src/pages/components/dividers/SubheaderDividers.js
@@ -14,7 +14,7 @@ export default function SubheaderDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
     >
       <ListItem>

--- a/docs/src/pages/components/dividers/SubheaderDividers.tsx
+++ b/docs/src/pages/components/dividers/SubheaderDividers.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
@@ -9,34 +8,24 @@ import BeachAccessIcon from '@material-ui/icons/BeachAccess';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      maxWidth: 360,
-      backgroundColor: theme.palette.background.paper,
-    },
-    dividerFullWidth: {
-      margin: `5px 0 0 ${theme.spacing(2)}`,
-    },
-    dividerInset: {
-      margin: `5px 0 0 ${theme.spacing(9)}`,
-    },
-  }),
-);
-
 export default function SubheaderDividers() {
-  const classes = useStyles();
-
   return (
-    <List className={classes.root}>
+    <List
+      sx={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: 'background.paper',
+      }}
+    >
       <ListItem>
         <ListItemText primary="Photos" secondary="Jan 9, 2014" />
       </ListItem>
       <Divider component="li" />
       <li>
         <Typography
-          className={classes.dividerFullWidth}
+          sx={{
+            m: `5px 0 0 16px`,
+          }}
           color="textSecondary"
           display="block"
           variant="caption"
@@ -50,7 +39,9 @@ export default function SubheaderDividers() {
       <Divider component="li" variant="inset" />
       <li>
         <Typography
-          className={classes.dividerInset}
+          sx={{
+            m: `5px 0 0 72px`,
+          }}
           color="textSecondary"
           display="block"
           variant="caption"

--- a/docs/src/pages/components/dividers/SubheaderDividers.tsx
+++ b/docs/src/pages/components/dividers/SubheaderDividers.tsx
@@ -23,7 +23,7 @@ export default function SubheaderDividers() {
       <Divider component="li" />
       <li>
         <Typography
-          sx={{ mt: '5px', ml: 2 }}
+          sx={{ mt: 0.5, ml: 2 }}
           color="textSecondary"
           display="block"
           variant="caption"
@@ -37,7 +37,7 @@ export default function SubheaderDividers() {
       <Divider component="li" variant="inset" />
       <li>
         <Typography
-          sx={{ mt: '5px', ml: 9 }}
+          sx={{ mt: 0.5, ml: 9 }}
           color="textSecondary"
           display="block"
           variant="caption"

--- a/docs/src/pages/components/dividers/SubheaderDividers.tsx
+++ b/docs/src/pages/components/dividers/SubheaderDividers.tsx
@@ -23,9 +23,7 @@ export default function SubheaderDividers() {
       <Divider component="li" />
       <li>
         <Typography
-          sx={{
-            m: `5px 0 0 16px`,
-          }}
+          sx={{ mt: '5px', ml: 2 }}
           color="textSecondary"
           display="block"
           variant="caption"
@@ -39,9 +37,7 @@ export default function SubheaderDividers() {
       <Divider component="li" variant="inset" />
       <li>
         <Typography
-          sx={{
-            m: `5px 0 0 72px`,
-          }}
+          sx={{ mt: '5px', ml: 9 }}
           color="textSecondary"
           display="block"
           variant="caption"

--- a/docs/src/pages/components/dividers/SubheaderDividers.tsx
+++ b/docs/src/pages/components/dividers/SubheaderDividers.tsx
@@ -14,7 +14,7 @@ export default function SubheaderDividers() {
       sx={{
         width: '100%',
         maxWidth: 360,
-        backgroundColor: 'background.paper',
+        bgcolor: 'background.paper',
       }}
     >
       <ListItem>

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
 import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
 import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
@@ -9,28 +8,26 @@ import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: 'fit-content',
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    backgroundColor: theme.palette.background.paper,
-    color: theme.palette.text.secondary,
-    '& svg': {
-      margin: theme.spacing(1.5),
-    },
-    '& hr': {
-      margin: theme.spacing(0, 0.5),
-    },
-  },
-}));
-
 export default function VerticalDividers() {
-  const classes = useStyles();
-
   return (
     <div>
-      <Grid container alignItems="center" className={classes.root}>
+      <Grid
+        sx={{
+          width: 'fit-content',
+          border: (theme) => `1px solid ${theme.palette.divider}`,
+          borderRadius: (theme) => theme.shape.borderRadius,
+          backgroundColor: (theme) => theme.palette.background.paper,
+          color: (theme) => theme.palette.text.secondary,
+          '& svg': {
+            m: 1.5,
+          },
+          '& hr': {
+            m: (theme) => theme.spacing(0, 0.5),
+          },
+        }}
+        container
+        alignItems="center"
+      >
         <FormatAlignLeftIcon />
         <FormatAlignCenterIcon />
         <FormatAlignRightIcon />

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -22,7 +22,7 @@ export default function VerticalDividers() {
             m: 1.5,
           },
           '& hr': {
-            m: (theme) => theme.spacing(0, 0.5),
+            mx: 0.5,
           },
         }}
         container

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -15,7 +15,7 @@ export default function VerticalDividers() {
         sx={{
           width: 'fit-content',
           border: (theme) => `1px solid ${theme.palette.divider}`,
-          borderRadius: (theme) => theme.shape.borderRadius,
+          borderRadius: 1,
           bgcolor: (theme) => theme.palette.background.paper,
           color: (theme) => theme.palette.text.secondary,
           '& svg': {

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -16,8 +16,8 @@ export default function VerticalDividers() {
           width: 'fit-content',
           border: (theme) => `1px solid ${theme.palette.divider}`,
           borderRadius: 1,
-          bgcolor: (theme) => theme.palette.background.paper,
-          color: (theme) => theme.palette.text.secondary,
+          bgcolor: 'background.paper',
+          color: 'text.secondary',
           '& svg': {
             m: 1.5,
           },

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -22,7 +22,7 @@ export default function VerticalDividers() {
             m: 1.5,
           },
           '& hr': {
-            my: 0.5,
+            mx: 0.5,
           },
         }}
         container

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -16,7 +16,7 @@ export default function VerticalDividers() {
           width: 'fit-content',
           border: (theme) => `1px solid ${theme.palette.divider}`,
           borderRadius: (theme) => theme.shape.borderRadius,
-          backgroundColor: (theme) => theme.palette.background.paper,
+          bgcolor: (theme) => theme.palette.background.paper,
           color: (theme) => theme.palette.text.secondary,
           '& svg': {
             m: 1.5,

--- a/docs/src/pages/components/dividers/VerticalDividers.js
+++ b/docs/src/pages/components/dividers/VerticalDividers.js
@@ -22,7 +22,7 @@ export default function VerticalDividers() {
             m: 1.5,
           },
           '& hr': {
-            mx: 0.5,
+            my: 0.5,
           },
         }}
         container

--- a/docs/src/pages/components/dividers/VerticalDividers.tsx
+++ b/docs/src/pages/components/dividers/VerticalDividers.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
 import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
 import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
@@ -9,30 +8,26 @@ import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: 'fit-content',
-      border: `1px solid ${theme.palette.divider}`,
-      borderRadius: theme.shape.borderRadius,
-      backgroundColor: theme.palette.background.paper,
-      color: theme.palette.text.secondary,
-      '& svg': {
-        margin: theme.spacing(1.5),
-      },
-      '& hr': {
-        margin: theme.spacing(0, 0.5),
-      },
-    },
-  }),
-);
-
 export default function VerticalDividers() {
-  const classes = useStyles();
-
   return (
     <div>
-      <Grid container alignItems="center" className={classes.root}>
+      <Grid
+        sx={{
+          width: 'fit-content',
+          border: (theme) => `1px solid ${theme.palette.divider}`,
+          borderRadius: (theme) => theme.shape.borderRadius,
+          backgroundColor: (theme) => theme.palette.background.paper,
+          color: (theme) => theme.palette.text.secondary,
+          '& svg': {
+            m: 1.5,
+          },
+          '& hr': {
+            m: (theme) => theme.spacing(0, 0.5),
+          },
+        }}
+        container
+        alignItems="center"
+      >
         <FormatAlignLeftIcon />
         <FormatAlignCenterIcon />
         <FormatAlignRightIcon />

--- a/docs/src/pages/components/dividers/VerticalDividers.tsx
+++ b/docs/src/pages/components/dividers/VerticalDividers.tsx
@@ -15,9 +15,9 @@ export default function VerticalDividers() {
         sx={{
           width: 'fit-content',
           border: (theme) => `1px solid ${theme.palette.divider}`,
-          borderRadius: (theme) => theme.shape.borderRadius,
-          bgcolor: (theme) => theme.palette.background.paper,
-          color: (theme) => theme.palette.text.secondary,
+          borderRadius: 1,
+          bgcolor: 'background.paper',
+          color: 'text.secondary',
           '& svg': {
             m: 1.5,
           },

--- a/docs/src/pages/components/dividers/VerticalDividers.tsx
+++ b/docs/src/pages/components/dividers/VerticalDividers.tsx
@@ -22,7 +22,7 @@ export default function VerticalDividers() {
             m: 1.5,
           },
           '& hr': {
-            my: 0.5,
+            mx: 0.5,
           },
         }}
         container

--- a/docs/src/pages/components/dividers/VerticalDividers.tsx
+++ b/docs/src/pages/components/dividers/VerticalDividers.tsx
@@ -16,7 +16,7 @@ export default function VerticalDividers() {
           width: 'fit-content',
           border: (theme) => `1px solid ${theme.palette.divider}`,
           borderRadius: (theme) => theme.shape.borderRadius,
-          backgroundColor: (theme) => theme.palette.background.paper,
+          bgcolor: (theme) => theme.palette.background.paper,
           color: (theme) => theme.palette.text.secondary,
           '& svg': {
             m: 1.5,

--- a/docs/src/pages/components/dividers/VerticalDividers.tsx
+++ b/docs/src/pages/components/dividers/VerticalDividers.tsx
@@ -22,7 +22,7 @@ export default function VerticalDividers() {
             m: 1.5,
           },
           '& hr': {
-            m: (theme) => theme.spacing(0, 0.5),
+            my: 0.5,
           },
         }}
         container


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the `Button` component were migrated:

- [x] List dividers
- [x] Inset dividers
- [x] Subheader dividers
- [x] Middle dividers
- [x] Vertical dividers

Related to #16947