### PR TITLE
[Autocomplete] Support readonly type for the options

### DIFF
--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -228,7 +228,7 @@ export interface UseAutocompleteProps<
   /**
    * Array of options.
    */
-  options: T[];
+  options: ReadonlyArray<T>;
   /**
    * If `true`, the input's text is selected on focus.
    * It helps the user clear the selected value.

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.spec.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.spec.ts
@@ -104,6 +104,14 @@ function Component() {
     onChange(event, value: Person[]) {},
   });
 
+  // options accepts const and value has correct type
+  useAutocomplete({
+    options: ['1', '2', '3'] as const,
+    onChange(event, value) {
+      expectType<'1' | '2' | '3' | null, typeof value>(value);
+    },
+  });
+
   // Disable clearable
 
   useAutocomplete({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR is aiming to fix: #24639

**Description**
- Enable Autocomplete component to use const types
- Add test for typing

**Additional information**
There is two possible solution to address this:
``ReadonlyArray<T>`` and ``T[] | Readonly<T[]>``

I took the former, but happy to change it to to latter if it is more aligned with the the project directives.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
