### PR TITLE
[test] Add (manual) visual regression test for icons

### DIFF
--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -57,7 +57,12 @@ async function main() {
     });
 
     routes.forEach((route, index) => {
-      it(`creates screenshots of ${route.replace(baseUrl, '')}`, async () => {
+      it(`creates screenshots of ${route.replace(baseUrl, '')}`, async function test() {
+        // With the playwright inspector we might want to call `page.pause` which would lead to a timeout.
+        if (process.env.PWDEBUG) {
+          this.timeout(0);
+        }
+
         // Use client-side routing which is much faster than full page navigation via page.goto().
         // Could become an issue with test isolation.
         // If tests are flaky due to global pollution switch to page.goto(route);

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -76,12 +76,10 @@ async function main() {
         const testcase = await page.waitForSelector(
           '[data-testid="testcase"]:not([aria-busy="true"])',
         );
-        const clip = await testcase.boundingBox();
 
         const screenshotPath = path.resolve(screenshotDir, `${route.replace(baseUrl, '.')}.png`);
         await fse.ensureDir(path.dirname(screenshotPath));
-        // Testcase.screenshot would resize the viewport to the element bbox.
-        await page.screenshot({ clip, path: screenshotPath, type: 'png' });
+        await testcase.screenshot({ path: screenshotPath, type: 'png' });
       });
     });
   });

--- a/test/regressions/manual/README.md
+++ b/test/regressions/manual/README.md
@@ -1,0 +1,4 @@
+# manual visual regression tests
+
+These are expensive tests that should only be consulted if you suspect that something changed.
+Move the test you want to check inside a temporary folder in `../test` and run the visual regression test suite to get a screenshot.

--- a/test/regressions/manual/icons/AllIcons.js
+++ b/test/regressions/manual/icons/AllIcons.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import * as icons from '@material-ui/icons';
+
+export default function AllIcons() {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      {Object.entries(icons).map(([name, Component]) => {
+        return <Component key={name} style={{ fontSize: '2.5rem' }} />;
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Requires capturing the full element. Considering the code comment this leaks into subsequent tests but I checked older puppeteer PRs and they claimed the viewport would be restored. ~Maybe this was fixed?~ Seems like this was fixed or we didn't do this initially to reduce changes when switching from vrtest to playwright.

All the changes look like a win to me. Though not approving until I get a second review.

Aside:
1. Don't time out when using the [playwright inspector](https://playwright.dev/docs/inspector/)