### PR TITLE
[docs] Migrate Typography demos to emotion

### DIFF
--- a/docs/src/pages/components/typography/Types.js
+++ b/docs/src/pages/components/typography/Types.js
@@ -1,19 +1,15 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles({
-  root: {
-    width: '100%',
-    maxWidth: 500,
-  },
-});
 
 export default function Types() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: 500,
+      }}
+    >
       <Typography variant="h1" component="div" gutterBottom>
         h1. Heading
       </Typography>
@@ -61,6 +57,6 @@ export default function Types() {
       <Typography variant="overline" display="block" gutterBottom>
         overline text
       </Typography>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/typography/Types.js
+++ b/docs/src/pages/components/typography/Types.js
@@ -4,12 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 export default function Types() {
   return (
-    <Box
-      sx={{
-        width: '100%',
-        maxWidth: 500,
-      }}
-    >
+    <Box sx={{ width: '100%', maxWidth: 500 }}>
       <Typography variant="h1" component="div" gutterBottom>
         h1. Heading
       </Typography>

--- a/docs/src/pages/components/typography/Types.tsx
+++ b/docs/src/pages/components/typography/Types.tsx
@@ -1,19 +1,15 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles({
-  root: {
-    width: '100%',
-    maxWidth: 500,
-  },
-});
 
 export default function Types() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: 500,
+      }}
+    >
       <Typography variant="h1" component="div" gutterBottom>
         h1. Heading
       </Typography>
@@ -61,6 +57,6 @@ export default function Types() {
       <Typography variant="overline" display="block" gutterBottom>
         overline text
       </Typography>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/typography/Types.tsx
+++ b/docs/src/pages/components/typography/Types.tsx
@@ -4,12 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 export default function Types() {
   return (
-    <Box
-      sx={{
-        width: '100%',
-        maxWidth: 500,
-      }}
-    >
+    <Box sx={{ width: '100%', maxWidth: 500 }}>
       <Typography variant="h1" component="div" gutterBottom>
         h1. Heading
       </Typography>

--- a/docs/src/pages/components/typography/TypographyTheme.js
+++ b/docs/src/pages/components/typography/TypographyTheme.js
@@ -1,16 +1,12 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+
+const Div = styled('div')(({ theme }) => ({
+  ...theme.typography.button,
+  backgroundColor: theme.palette.background.paper,
+  padding: theme.spacing(1),
+}));
 
 export default function TypographyTheme() {
-  return (
-    <Box
-      sx={{
-        typography: 'button',
-        bgcolor: 'background.paper',
-        p: 1,
-      }}
-    >
-      {"This div's text looks like that of a button."}
-    </Box>
-  );
+  return <Div>{"This div's text looks like that of a button."}</Div>;
 }

--- a/docs/src/pages/components/typography/TypographyTheme.js
+++ b/docs/src/pages/components/typography/TypographyTheme.js
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    ...theme.typography.button,
-    backgroundColor: theme.palette.background.paper,
-    padding: theme.spacing(1),
-  },
-}));
+import Box from '@material-ui/core/Box';
 
 export default function TypographyTheme() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        typography: 'button',
+        bgcolor: 'background.paper',
+        p: 1,
+      }}
+    >
       {"This div's text looks like that of a button."}
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/typography/TypographyTheme.tsx
+++ b/docs/src/pages/components/typography/TypographyTheme.tsx
@@ -1,22 +1,16 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      ...theme.typography.button,
-      backgroundColor: theme.palette.background.paper,
-      padding: theme.spacing(1),
-    },
-  }),
-);
+import Box from '@material-ui/core/Box';
 
 export default function TypographyTheme() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        typography: 'button',
+        bgcolor: 'background.paper',
+        p: 1,
+      }}
+    >
       {"This div's text looks like that of a button."}
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/typography/TypographyTheme.tsx
+++ b/docs/src/pages/components/typography/TypographyTheme.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import * as CSS from 'csstype';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+
+const Div = styled('div')(({ theme }) => ({
+  ...(theme.typography.button as CSS.Properties),
+  backgroundColor: theme.palette.background.paper,
+  padding: theme.spacing(1),
+}));
 
 export default function TypographyTheme() {
-  return (
-    <Box
-      sx={{
-        typography: 'button',
-        bgcolor: 'background.paper',
-        p: 1,
-      }}
-    >
-      {"This div's text looks like that of a button."}
-    </Box>
-  );
+  return <Div>{"This div's text looks like that of a button."}</Div>;
 }

--- a/docs/src/pages/components/typography/TypographyTheme.tsx
+++ b/docs/src/pages/components/typography/TypographyTheme.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import * as CSS from 'csstype';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
+import * as CSS from 'csstype';
 
 const Div = styled('div')(({ theme }) => ({
   ...(theme.typography.button as CSS.Properties),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Typography component were migrated:

 - [x] Types typography
 - [x] Theme typography

Related to #16947