### PR TITLE
[SpeedDial] Migrate to emotion

### DIFF
--- a/docs/pages/api-docs/speed-dial-action.json
+++ b/docs/pages/api-docs/speed-dial-action.json
@@ -6,6 +6,7 @@
     "icon": { "type": { "name": "node" } },
     "id": { "type": { "name": "string" } },
     "open": { "type": { "name": "bool" } },
+    "sx": { "type": { "name": "object" } },
     "TooltipClasses": { "type": { "name": "object" } },
     "tooltipOpen": { "type": { "name": "bool" } },
     "tooltipPlacement": {
@@ -36,6 +37,6 @@
   "filename": "/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js",
   "inheritance": { "component": "Tooltip", "pathname": "/api/tooltip/" },
   "demos": "<ul><li><a href=\"/components/speed-dial/\">Speed Dial</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/pages/api-docs/speed-dial-icon.json
+++ b/docs/pages/api-docs/speed-dial-icon.json
@@ -2,7 +2,8 @@
   "props": {
     "classes": { "type": { "name": "object" } },
     "icon": { "type": { "name": "node" } },
-    "openIcon": { "type": { "name": "node" } }
+    "openIcon": { "type": { "name": "node" } },
+    "sx": { "type": { "name": "object" } }
   },
   "name": "SpeedDialIcon",
   "styles": {
@@ -15,6 +16,6 @@
   "filename": "/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/speed-dial/\">Speed Dial</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/pages/api-docs/speed-dial.json
+++ b/docs/pages/api-docs/speed-dial.json
@@ -17,6 +17,7 @@
     "onOpen": { "type": { "name": "func" } },
     "open": { "type": { "name": "bool" } },
     "openIcon": { "type": { "name": "node" } },
+    "sx": { "type": { "name": "object" } },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Zoom" },
     "transitionDuration": {
       "type": {
@@ -47,6 +48,6 @@
   "filename": "/packages/material-ui/src/SpeedDial/SpeedDial.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/speed-dial/\">Speed Dial</a></li></ul>",
-  "styledComponent": false,
+  "styledComponent": true,
   "cssComponent": false
 }

--- a/docs/translations/api-docs/speed-dial-action/speed-dial-action.json
+++ b/docs/translations/api-docs/speed-dial-action/speed-dial-action.json
@@ -7,6 +7,7 @@
     "icon": "The icon to display in the SpeedDial Fab.",
     "id": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id.",
     "open": "If <code>true</code>, the component is shown.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "TooltipClasses": "<code>classes</code> prop applied to the <a href=\"/api/tooltip/\"><code>Tooltip</code></a> element.",
     "tooltipOpen": "Make the tooltip always visible when the SpeedDial is open.",
     "tooltipPlacement": "Placement of the tooltip.",

--- a/docs/translations/api-docs/speed-dial-icon/speed-dial-icon.json
+++ b/docs/translations/api-docs/speed-dial-icon/speed-dial-icon.json
@@ -3,7 +3,8 @@
   "propDescriptions": {
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "icon": "The icon to display.",
-    "openIcon": "The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open."
+    "openIcon": "The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/speed-dial/speed-dial.json
+++ b/docs/translations/api-docs/speed-dial/speed-dial.json
@@ -12,6 +12,7 @@
     "onOpen": "Callback fired when the component requests to be open.<br><br><strong>Signature:</strong><br><code>function(event: object, reason: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>reason:</em> Can be: <code>&quot;toggle&quot;</code>, <code>&quot;focus&quot;</code>, <code>&quot;mouseEnter&quot;</code>.",
     "open": "If <code>true</code>, the component is shown.",
     "openIcon": "The icon to display in the SpeedDial Fab when the SpeedDial is open.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "TransitionComponent": "The component used for the transition. <a href=\"/components/transitions/#transitioncomponent-prop\">Follow this guide</a> to learn more about the requirements for this component.",
     "transitionDuration": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.",
     "TransitionProps": "Props applied to the transition element. By default, the element is based on this <a href=\"http://reactcommunity.org/react-transition-group/transition\"><code>Transition</code></a> component."

--- a/packages/material-ui/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '..';
 import { FabProps } from '../Fab';
 import { TransitionHandlerProps, TransitionProps } from '../transitions';
@@ -83,6 +85,10 @@ export interface SpeedDialProps
    * The icon to display in the SpeedDial Fab when the SpeedDial is open.
    */
   openIcon?: React.ReactNode;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
   /**
    * The component used for the transition.
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -2,14 +2,43 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
 import { duration } from '../styles/transitions';
-import withStyles from '../styles/withStyles';
 import Zoom from '../Zoom';
 import Fab from '../Fab';
 import capitalize from '../utils/capitalize';
 import isMuiElement from '../utils/isMuiElement';
 import useForkRef from '../utils/useForkRef';
 import useControlled from '../utils/useControlled';
+import speedDialClasses, { getSpeedDialUtilityClass } from './speedDialClasses';
+
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(styles.root || {}, {
+    ...styles[`direction${capitalize(styleProps.direction)}`],
+    [`& .${speedDialClasses.fab}`]: styles.fab,
+    [`& .${speedDialClasses.actions}`]: {
+      ...styles.actions,
+      ...(!styleProps.open && styles.actionsClosed),
+    },
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes, open, direction } = styleProps;
+
+  const slots = {
+    root: ['root', `direction${capitalize(direction)}`],
+    fab: ['fab'],
+    actions: ['actions', !open && 'actionsClosed'],
+  };
+
+  return composeClasses(slots, getSpeedDialUtilityClass, classes);
+};
 
 function getOrientation(direction) {
   if (direction === 'up' || direction === 'down') {
@@ -34,72 +63,80 @@ function clamp(value, min, max) {
 const dialRadius = 32;
 const spacingActions = 16;
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    zIndex: theme.zIndex.speedDial,
-    display: 'flex',
-    alignItems: 'center',
-    pointerEvents: 'none',
+const SpeedDialRoot = experimentalStyled(
+  'div',
+  {},
+  {
+    name: 'MuiSpeedDial',
+    slot: 'Root',
+    overridesResolver,
   },
-  /* Styles applied to the Fab component. */
-  fab: {
-    pointerEvents: 'auto',
-  },
-  /* Styles applied to the root element if direction="up" */
-  directionUp: {
+)(({ theme, styleProps }) => ({
+  zIndex: theme.zIndex.speedDial,
+  display: 'flex',
+  alignItems: 'center',
+  pointerEvents: 'none',
+  ...(styleProps.direction === 'up' && {
     flexDirection: 'column-reverse',
-    '& $actions': {
+    [`& .${speedDialClasses.actions}`]: {
       flexDirection: 'column-reverse',
       marginBottom: -dialRadius,
       paddingBottom: spacingActions + dialRadius,
     },
-  },
-  /* Styles applied to the root element if direction="down" */
-  directionDown: {
+  }),
+  ...(styleProps.direction === 'down' && {
     flexDirection: 'column',
-    '& $actions': {
+    [`& .${speedDialClasses.actions}`]: {
       flexDirection: 'column',
       marginTop: -dialRadius,
       paddingTop: spacingActions + dialRadius,
     },
-  },
-  /* Styles applied to the root element if direction="left" */
-  directionLeft: {
+  }),
+  ...(styleProps.direction === 'left' && {
     flexDirection: 'row-reverse',
-    '& $actions': {
+    [`& .${speedDialClasses.actions}`]: {
       flexDirection: 'row-reverse',
       marginRight: -dialRadius,
       paddingRight: spacingActions + dialRadius,
     },
-  },
-  /* Styles applied to the root element if direction="right" */
-  directionRight: {
+  }),
+  ...(styleProps.direction === 'right' && {
     flexDirection: 'row',
-    '& $actions': {
+    [`& .${speedDialClasses.actions}`]: {
       flexDirection: 'row',
       marginLeft: -dialRadius,
       paddingLeft: spacingActions + dialRadius,
     },
-  },
-  /* Styles applied to the actions (`children` wrapper) element. */
-  actions: {
-    display: 'flex',
-    pointerEvents: 'auto',
-  },
-  /* Styles applied to the actions (`children` wrapper) element if `open={false}`. */
-  actionsClosed: {
+  }),
+}));
+
+const SpeedDialFab = experimentalStyled(
+  Fab,
+  {},
+  { name: 'MuiSpeedDial', slot: 'Fab' },
+)(() => ({
+  pointerEvents: 'auto',
+}));
+
+const SpeedDialActions = experimentalStyled(
+  'div',
+  {},
+  { name: 'MuiSpeedDial', slot: 'Actions' },
+)(({ styleProps }) => ({
+  display: 'flex',
+  pointerEvents: 'auto',
+  ...(!styleProps.open && {
     transition: 'top 0s linear 0.2s',
     pointerEvents: 'none',
-  },
-});
+  }),
+}));
 
-const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
+const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSpeedDial' });
   const {
     ariaLabel,
     FabProps: { ref: origDialButtonRef, ...FabProps } = {},
     children: childrenProp,
-    classes,
     className,
     direction = 'up',
     hidden = false,
@@ -128,6 +165,9 @@ const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
     name: 'SpeedDial',
     state: 'open',
   });
+
+  const styleProps = { ...props, open, direction };
+  const classes = useUtilityClasses(styleProps);
 
   const eventTimer = React.useRef();
 
@@ -331,8 +371,8 @@ const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
   });
 
   return (
-    <div
-      className={clsx(classes.root, classes[`direction${capitalize(direction)}`], className)}
+    <SpeedDialRoot
+      className={clsx(classes.root, className)}
       ref={ref}
       role="presentation"
       onKeyDown={handleKeyDown}
@@ -340,6 +380,7 @@ const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
       onFocus={handleOpen}
       onMouseEnter={handleOpen}
       onMouseLeave={handleClose}
+      styleProps={styleProps}
       {...other}
     >
       <TransitionComponent
@@ -348,7 +389,7 @@ const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
         unmountOnExit
         {...TransitionProps}
       >
-        <Fab
+        <SpeedDialFab
           color="primary"
           aria-label={ariaLabel}
           aria-haspopup="true"
@@ -358,21 +399,23 @@ const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
           onClick={handleClick}
           className={clsx(classes.fab, FabProps.className)}
           ref={handleFabRef}
+          styleProps={styleProps}
         >
           {React.isValidElement(icon) && isMuiElement(icon, ['SpeedDialIcon'])
             ? React.cloneElement(icon, { open })
             : icon}
-        </Fab>
+        </SpeedDialFab>
       </TransitionComponent>
-      <div
+      <SpeedDialActions
         id={`${id}-actions`}
         role="menu"
         aria-orientation={getOrientation(direction)}
         className={clsx(classes.actions, { [classes.actionsClosed]: !open })}
+        styleProps={styleProps}
       >
         {children}
-      </div>
-    </div>
+      </SpeedDialActions>
+    </SpeedDialRoot>
   );
 });
 
@@ -461,6 +504,10 @@ SpeedDial.propTypes = {
    */
   openIcon: PropTypes.node,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * The component used for the transition.
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Zoom
@@ -489,4 +536,4 @@ SpeedDial.propTypes = {
   TransitionProps: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiSpeedDial' })(SpeedDial);
+export default SpeedDial;

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -18,14 +18,14 @@ import speedDialClasses, { getSpeedDialUtilityClass } from './speedDialClasses';
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(styles.root || {}, {
+  return deepmerge({
     ...styles[`direction${capitalize(styleProps.direction)}`],
     [`& .${speedDialClasses.fab}`]: styles.fab,
     [`& .${speedDialClasses.actions}`]: {
       ...styles.actions,
       ...(!styleProps.open && styles.actionsClosed),
     },
-  });
+  }, styles.root || {});
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -18,14 +18,17 @@ import speedDialClasses, { getSpeedDialUtilityClass } from './speedDialClasses';
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge({
-    ...styles[`direction${capitalize(styleProps.direction)}`],
-    [`& .${speedDialClasses.fab}`]: styles.fab,
-    [`& .${speedDialClasses.actions}`]: {
-      ...styles.actions,
-      ...(!styleProps.open && styles.actionsClosed),
+  return deepmerge(
+    {
+      ...styles[`direction${capitalize(styleProps.direction)}`],
+      [`& .${speedDialClasses.fab}`]: styles.fab,
+      [`& .${speedDialClasses.actions}`]: {
+        ...styles.actions,
+        ...(!styleProps.open && styles.actionsClosed),
+      },
     },
-  }, styles.root || {});
+    styles.root || {},
+  );
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -2,23 +2,21 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import {
-  getClasses,
   createMount,
   createClientRender,
   act,
   fireEvent,
   screen,
-  describeConformance,
+  describeConformanceV5,
 } from 'test/utils';
 import Icon from '@material-ui/core/Icon';
-import SpeedDial from './SpeedDial';
-import SpeedDialAction from '../SpeedDialAction';
+import SpeedDial, { speedDialClasses as classes } from '@material-ui/core/SpeedDial';
+import SpeedDialAction from '@material-ui/core/SpeedDialAction';
 
 describe('<SpeedDial />', () => {
   // StrictModeViolation: not using act(), prefer test/utils/createClientRender
   const mount = createMount({ strict: false });
   const render = createClientRender({ strict: false });
-  let classes;
 
   const icon = <Icon>font_icon</Icon>;
   const FakeAction = () => <div />;
@@ -28,21 +26,17 @@ describe('<SpeedDial />', () => {
     ariaLabel: 'mySpeedDial',
   };
 
-  before(() => {
-    classes = getClasses(
-      <SpeedDial {...defaultProps}>
-        <div />
-      </SpeedDial>,
-    );
-  });
-
-  describeConformance(<SpeedDial {...defaultProps} />, () => ({
+  describeConformanceV5(<SpeedDial {...defaultProps} />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
+    render,
     refInstanceof: window.HTMLDivElement,
+    muiName: 'MuiSpeedDial',
+    testVariantProps: { direction: 'right' },
     skip: [
       'componentProp', // react-transition-group issue
+      'componentsProp',
       'reactTestRenderer',
     ],
   }));

--- a/packages/material-ui/src/SpeedDial/index.d.ts
+++ b/packages/material-ui/src/SpeedDial/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './SpeedDial';
 export * from './SpeedDial';
+
+export { default as speedDialClasses } from './speedDialClasses';
+export * from './speedDialClasses';

--- a/packages/material-ui/src/SpeedDial/index.js
+++ b/packages/material-ui/src/SpeedDial/index.js
@@ -1,1 +1,4 @@
 export { default } from './SpeedDial';
+
+export { default as speedDialClasses } from './speedDialClasses';
+export * from './speedDialClasses';

--- a/packages/material-ui/src/SpeedDial/speedDialClasses.d.ts
+++ b/packages/material-ui/src/SpeedDial/speedDialClasses.d.ts
@@ -1,0 +1,9 @@
+import { SpeedDialClassKey } from './SpeedDial';
+
+export type SpeedDialClasses = Record<SpeedDialClassKey, string>;
+
+declare const speedDialClasses: SpeedDialClasses;
+
+export function getSpeedDialUtilityClass(slot: string): string;
+
+export default speedDialClasses;

--- a/packages/material-ui/src/SpeedDial/speedDialClasses.js
+++ b/packages/material-ui/src/SpeedDial/speedDialClasses.js
@@ -1,0 +1,18 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getSpeedDialUtilityClass(slot) {
+  return generateUtilityClass('MuiSpeedDial', slot);
+}
+
+const speedDialClasses = generateUtilityClasses('MuiSpeedDial', [
+  'root',
+  'fab',
+  'directionUp',
+  'directionDown',
+  'directionLeft',
+  'directionRight',
+  'actions',
+  'actionsClosed',
+]);
+
+export default speedDialClasses;

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '..';
 import { FabProps } from '../Fab';
 import { TooltipProps } from '../Tooltip';
@@ -37,6 +39,10 @@ export interface SpeedDialActionProps extends StandardProps<Partial<TooltipProps
    * The icon to display in the SpeedDial Fab.
    */
   icon?: React.ReactNode;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
   /**
    * `classes` prop applied to the [`Tooltip`](/api/tooltip/) element.
    */

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -3,83 +3,125 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
 import { emphasize } from '../styles/colorManipulator';
 import Fab from '../Fab';
 import Tooltip from '../Tooltip';
 import capitalize from '../utils/capitalize';
+import speedDialActionClasses, { getSpeedDialActionUtilityClass } from './speedDialActionClasses';
 
-export const styles = (theme) => ({
-  /* Styles applied to the Fab component. */
-  fab: {
-    margin: 8,
-    color: theme.palette.text.secondary,
-    backgroundColor: theme.palette.background.paper,
-    '&:hover': {
-      backgroundColor: emphasize(theme.palette.background.paper, 0.15),
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(styles.fab || {}, {
+    ...(!styleProps.open && styles.fabClosed),
+    [`& .${speedDialActionClasses.staticTooltip}`]: {
+      ...styles.staticTooltip,
+      ...(!styleProps.open && styles.staticTooltipClosed),
+      ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
     },
-    transition: `${theme.transitions.create('transform', {
-      duration: theme.transitions.duration.shorter,
-    })}, opacity 0.8s`,
-    opacity: 1,
+    [`& .${speedDialActionClasses.staticTooltipLabel}`]: styles.staticTooltipLabel,
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { open, tooltipPlacement, classes } = styleProps;
+
+  const slots = {
+    fab: ['fab', !open && 'fabClosed'],
+    staticTooltip: [
+      'staticTooltip',
+      `tooltipPlacement${capitalize(tooltipPlacement)}`,
+      !open && 'staticTooltipClosed',
+    ],
+    staticTooltipLabel: ['staticTooltipLabel'],
+  };
+
+  return composeClasses(slots, getSpeedDialActionUtilityClass, classes);
+};
+
+const SpeedDialActionFab = experimentalStyled(
+  Fab,
+  {},
+  {
+    name: 'MuiSpeedDialAction',
+    slot: 'Fab',
+    overridesResolver,
   },
-  /* Styles applied to the Fab component if `open={false}`. */
-  fabClosed: {
+)(({ theme, styleProps }) => ({
+  margin: 8,
+  color: theme.palette.text.secondary,
+  backgroundColor: theme.palette.background.paper,
+  '&:hover': {
+    backgroundColor: emphasize(theme.palette.background.paper, 0.15),
+  },
+  transition: `${theme.transitions.create('transform', {
+    duration: theme.transitions.duration.shorter,
+  })}, opacity 0.8s`,
+  opacity: 1,
+  ...(!styleProps.open && {
     opacity: 0,
     transform: 'scale(0)',
+  }),
+}));
+
+const SpeedDialActionStaticTooltip = experimentalStyled(
+  'span',
+  {},
+  {
+    name: 'MuiSpeedDialAction',
+    slot: 'StaticTooltip',
   },
-  /* Styles applied to the root element if `tooltipOpen={true}`. */
-  staticTooltip: {
-    position: 'relative',
-    display: 'flex',
-    '& $staticTooltipLabel': {
-      transition: theme.transitions.create(['transform', 'opacity'], {
-        duration: theme.transitions.duration.shorter,
-      }),
-      opacity: 1,
-    },
-  },
-  /* Styles applied to the root element if `tooltipOpen={true}` and `open={false}`. */
-  staticTooltipClosed: {
-    '& $staticTooltipLabel': {
+)(({ theme, styleProps }) => ({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  [`& .${speedDialActionClasses.staticTooltipLabel}`]: {
+    transition: theme.transitions.create(['transform', 'opacity'], {
+      duration: theme.transitions.duration.shorter,
+    }),
+    opacity: 1,
+    ...(!styleProps.open && {
       opacity: 0,
       transform: 'scale(0.5)',
-    },
-  },
-  /* Styles applied to the static tooltip label if `tooltipOpen={true}`. */
-  staticTooltipLabel: {
-    position: 'absolute',
-    ...theme.typography.body1,
-    backgroundColor: theme.palette.background.paper,
-    borderRadius: theme.shape.borderRadius,
-    boxShadow: theme.shadows[1],
-    color: theme.palette.text.secondary,
-    padding: '4px 16px',
-    wordBreak: 'keep-all',
-  },
-  /* Styles applied to the root element if `tooltipOpen={true}` and `tooltipPlacement="left"`` */
-  tooltipPlacementLeft: {
-    alignItems: 'center',
-    '& $staticTooltipLabel': {
+    }),
+    ...(styleProps.tooltipPlacement === 'left' && {
       transformOrigin: '100% 50%',
       right: '100%',
       marginRight: 8,
-    },
-  },
-  /* Styles applied to the root element if `tooltipOpen={true}` and `tooltipPlacement="right"`` */
-  tooltipPlacementRight: {
-    alignItems: 'center',
-    '& $staticTooltipLabel': {
+    }),
+    ...(styleProps.tooltipPlacement === 'right' && {
       transformOrigin: '0% 50%',
       left: '100%',
       marginLeft: 8,
-    },
+    }),
   },
-});
+}));
 
-const SpeedDialAction = React.forwardRef(function SpeedDialAction(props, ref) {
+const SpeedDialActionStaticTooltipLabel = experimentalStyled(
+  'span',
+  {},
+  {
+    name: 'MuiSpeedDialAction',
+    slot: 'StaticTooltipLabel',
+  },
+)(({ theme }) => ({
+  position: 'absolute',
+  ...theme.typography.body1,
+  backgroundColor: theme.palette.background.paper,
+  borderRadius: theme.shape.borderRadius,
+  boxShadow: theme.shadows[1],
+  color: theme.palette.text.secondary,
+  padding: '4px 16px',
+  wordBreak: 'keep-all',
+}));
+
+const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSpeedDialAction' });
   const {
-    classes,
     className,
     delay = 0,
     FabProps = {},
@@ -92,6 +134,9 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(props, ref) {
     tooltipTitle,
     ...other
   } = props;
+
+  const styleProps = { ...props, tooltipPlacement };
+  const classes = useUtilityClasses(styleProps);
 
   const [tooltipOpen, setTooltipOpen] = React.useState(tooltipOpenProp);
 
@@ -106,12 +151,13 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(props, ref) {
   const transitionStyle = { transitionDelay: `${delay}ms` };
 
   const fab = (
-    <Fab
+    <SpeedDialActionFab
       size="small"
-      className={clsx(classes.fab, !open && classes.fabClosed, className)}
+      className={clsx(classes.fab, className)}
       tabIndex={-1}
       role="menuitem"
       aria-describedby={`${id}-label`}
+      styleProps={styleProps}
       {...FabProps}
       style={{
         ...transitionStyle,
@@ -119,26 +165,28 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(props, ref) {
       }}
     >
       {icon}
-    </Fab>
+    </SpeedDialActionFab>
   );
 
   if (tooltipOpenProp) {
     return (
-      <span
+      <SpeedDialActionStaticTooltip
         id={id}
         ref={ref}
-        className={clsx(
-          classes.staticTooltip,
-          !open && classes.staticTooltipClosed,
-          classes[`tooltipPlacement${capitalize(tooltipPlacement)}`],
-        )}
+        className={classes.staticTooltip}
+        styleProps={styleProps}
         {...other}
       >
-        <span style={transitionStyle} id={`${id}-label`} className={classes.staticTooltipLabel}>
+        <SpeedDialActionStaticTooltipLabel
+          style={transitionStyle}
+          id={`${id}-label`}
+          className={classes.staticTooltipLabel}
+          styleProps={styleProps}
+        >
           {tooltipTitle}
-        </span>
+        </SpeedDialActionStaticTooltipLabel>
         {fab}
-      </span>
+      </SpeedDialActionStaticTooltip>
     );
   }
 
@@ -196,6 +244,10 @@ SpeedDialAction.propTypes = {
    */
   open: PropTypes.bool,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
    * `classes` prop applied to the [`Tooltip`](/api/tooltip/) element.
    */
   TooltipClasses: PropTypes.object,
@@ -228,4 +280,4 @@ SpeedDialAction.propTypes = {
   tooltipTitle: PropTypes.node,
 };
 
-export default withStyles(styles, { name: 'MuiSpeedDialAction' })(SpeedDialAction);
+export default SpeedDialAction;

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -13,16 +13,21 @@ import Tooltip from '../Tooltip';
 import capitalize from '../utils/capitalize';
 import speedDialActionClasses, { getSpeedDialActionUtilityClass } from './speedDialActionClasses';
 
-const overridesResolver = (props, styles) => {
+const overridesResolverFab = (props, styles) => {
   const { styleProps } = props;
 
   return deepmerge(styles.fab || {}, {
     ...(!styleProps.open && styles.fabClosed),
-    [`& .${speedDialActionClasses.staticTooltip}`]: {
-      ...styles.staticTooltip,
-      ...(!styleProps.open && styles.staticTooltipClosed),
-      ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
-    },
+  });
+};
+
+const overridesResolverStatic = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(speedDialActionClasses.staticTooltip || {}, {
+    ...styles.staticTooltip,
+    ...(!styleProps.open && styles.staticTooltipClosed),
+    ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
     [`& .${speedDialActionClasses.staticTooltipLabel}`]: styles.staticTooltipLabel,
   });
 };
@@ -49,7 +54,7 @@ const SpeedDialActionFab = experimentalStyled(
   {
     name: 'MuiSpeedDialAction',
     slot: 'Fab',
-    overridesResolver,
+    overridesResolver: overridesResolverFab,
   },
 )(({ theme, styleProps }) => ({
   margin: 8,
@@ -74,6 +79,7 @@ const SpeedDialActionStaticTooltip = experimentalStyled(
   {
     name: 'MuiSpeedDialAction',
     slot: 'StaticTooltip',
+    overridesResolver: overridesResolverStatic,
   },
 )(({ theme, styleProps }) => ({
   position: 'relative',

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -16,20 +16,25 @@ import speedDialActionClasses, { getSpeedDialActionUtilityClass } from './speedD
 const overridesResolverFab = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(styles.fab || {}, {
-    ...(!styleProps.open && styles.fabClosed),
-  });
+  return deepmerge(
+    {
+      ...(!styleProps.open && styles.fabClosed),
+    },
+    styles.fab || {},
+  );
 };
 
 const overridesResolverStatic = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(speedDialActionClasses.staticTooltip || {}, {
-    ...styles.staticTooltip,
-    ...(!styleProps.open && styles.staticTooltipClosed),
-    ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
-    [`& .${speedDialActionClasses.staticTooltipLabel}`]: styles.staticTooltipLabel,
-  });
+  return deepmerge(
+    {
+      ...(!styleProps.open && styles.staticTooltipClosed),
+      ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
+      [`& .${speedDialActionClasses.staticTooltipLabel}`]: styles.staticTooltipLabel,
+    },
+    styles.staticTooltip || {},
+  );
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,18 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  getClasses,
-  createMount,
-  describeConformance,
-  act,
-  createClientRender,
-  fireEvent,
-} from 'test/utils';
+import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import { useFakeTimers } from 'sinon';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
 import { fabClasses } from '@material-ui/core/Fab';
-import SpeedDialAction from './SpeedDialAction';
+import SpeedDialAction, {
+  speedDialActionClasses as classes,
+} from '@material-ui/core/SpeedDialAction';
 
 describe('<SpeedDialAction />', () => {
   let clock;
@@ -26,20 +21,19 @@ describe('<SpeedDialAction />', () => {
 
   const mount = createMount({ strict: true });
   const render = createClientRender();
-  let classes;
 
-  before(() => {
-    classes = getClasses(<SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="placeholder" />);
-  });
-
-  describeConformance(
+  describeConformanceV5(
     <SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="placeholder" />,
     () => ({
       classes,
       inheritComponent: Tooltip,
       mount,
+      render,
       refInstanceof: window.HTMLButtonElement,
-      skip: ['componentProp', 'reactTestRenderer'],
+      muiName: 'MuiSpeedDialAction',
+      testRootOverrides: { slotName: 'fab' },
+      testVariantProps: { tooltipPlacement: 'right' },
+      skip: ['componentProp', 'reactTestRenderer', 'componentsProp'],
     }),
   );
 

--- a/packages/material-ui/src/SpeedDialAction/index.d.ts
+++ b/packages/material-ui/src/SpeedDialAction/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './SpeedDialAction';
 export * from './SpeedDialAction';
+
+export { default as speedDialActionClasses } from './speedDialActionClasses';
+export * from './speedDialActionClasses';

--- a/packages/material-ui/src/SpeedDialAction/index.js
+++ b/packages/material-ui/src/SpeedDialAction/index.js
@@ -1,1 +1,4 @@
 export { default } from './SpeedDialAction';
+
+export { default as speedDialActionClasses } from './speedDialActionClasses';
+export * from './speedDialActionClasses';

--- a/packages/material-ui/src/SpeedDialAction/speedDialActionClasses.d.ts
+++ b/packages/material-ui/src/SpeedDialAction/speedDialActionClasses.d.ts
@@ -1,0 +1,9 @@
+import { SpeedDialActionClassKey } from './SpeedDialAction';
+
+export type SpeedDialActionClasses = Record<SpeedDialActionClassKey, string>;
+
+declare const speedDialActionClasses: SpeedDialActionClasses;
+
+export function getSpeedDialActionUtilityClass(slot: string): string;
+
+export default speedDialActionClasses;

--- a/packages/material-ui/src/SpeedDialAction/speedDialActionClasses.js
+++ b/packages/material-ui/src/SpeedDialAction/speedDialActionClasses.js
@@ -1,0 +1,17 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getSpeedDialActionUtilityClass(slot) {
+  return generateUtilityClass('MuiSpeedDialAction', slot);
+}
+
+const speedDialActionClasses = generateUtilityClasses('MuiSpeedDialAction', [
+  'fab',
+  'fabClosed',
+  'staticTooltip',
+  'staticTooltipClosed',
+  'staticTooltipLabel',
+  'tooltipPlacementLeft',
+  'tooltipPlacementRight',
+]);
+
+export default speedDialActionClasses;

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '..';
 
 export interface SpeedDialIconProps
@@ -33,6 +35,10 @@ export interface SpeedDialIconProps
    * If `true`, the component is shown.
    */
   open?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export type SpeedDialIconClassKey = keyof NonNullable<SpeedDialIconProps['classes']>;

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
@@ -11,17 +11,20 @@ import speedDialIconClasses, { getSpeedDialIconUtilityClass } from './speedDialI
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge({
-    [`& .${speedDialIconClasses.icon}`]: {
-      ...styles.icon,
-      ...(styleProps.open && styles.iconOpen),
-      ...(styleProps.open && styleProps.openIcon && styles.iconWithOpenIconOpen),
+  return deepmerge(
+    {
+      [`& .${speedDialIconClasses.icon}`]: {
+        ...styles.icon,
+        ...(styleProps.open && styles.iconOpen),
+        ...(styleProps.open && styleProps.openIcon && styles.iconWithOpenIconOpen),
+      },
+      [`& .${speedDialIconClasses.openIcon}`]: {
+        ...styles.openIcon,
+        ...(styleProps.open && styles.openIconOpen),
+      },
     },
-    [`& .${speedDialIconClasses.openIcon}`]: {
-      ...styles.openIcon,
-      ...(styleProps.open && styles.openIconOpen),
-    },
-  }, styles.root || {});
+    styles.root || {},
+  );
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
@@ -1,53 +1,82 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
 import AddIcon from '../internal/svg-icons/Add';
+import speedDialIconClasses, { getSpeedDialIconUtilityClass } from './speedDialIconClasses';
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    height: 24,
+const overridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return deepmerge(styles.root || {}, {
+    [`& .${speedDialIconClasses.icon}`]: {
+      ...styles.icon,
+      ...(styleProps.open && styles.iconOpen),
+      ...(styleProps.open && styleProps.openIcon && styles.iconWithOpenIconOpen),
+    },
+    [`& .${speedDialIconClasses.openIcon}`]: {
+      ...styles.openIcon,
+      ...(styleProps.open && styles.openIconOpen),
+    },
+  });
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes, open, openIcon } = styleProps;
+
+  const slots = {
+    root: ['root'],
+    icon: ['icon', open && 'iconOpen', openIcon && open && 'iconWithOpenIconOpen'],
+    openIcon: ['openIcon', open && 'openIconOpen'],
+  };
+
+  return composeClasses(slots, getSpeedDialIconUtilityClass, classes);
+};
+
+const SpeedDialIconRoot = experimentalStyled(
+  'span',
+  {},
+  {
+    name: 'MuiSpeedDialIcon',
+    slot: 'Root',
+    overridesResolver,
   },
-  /* Styles applied to the icon component. */
-  icon: {
+)(({ theme, styleProps }) => ({
+  height: 24,
+  [`& .${speedDialIconClasses.icon}`]: {
     transition: theme.transitions.create(['transform', 'opacity'], {
       duration: theme.transitions.duration.short,
     }),
+    ...(styleProps.open && {
+      transform: 'rotate(45deg)',
+      ...(styleProps.openIcon && {
+        opacity: 0,
+      }),
+    }),
   },
-  /* Styles applied to the icon component if `open={true}`. */
-  iconOpen: {
-    transform: 'rotate(45deg)',
-  },
-  /* Styles applied to the icon when an `openIcon` is provided and if `open={true}`. */
-  iconWithOpenIconOpen: {
-    opacity: 0,
-  },
-  /* Styles applied to the `openIcon` if provided. */
-  openIcon: {
+  [`& .${speedDialIconClasses.openIcon}`]: {
     position: 'absolute',
     transition: theme.transitions.create(['transform', 'opacity'], {
       duration: theme.transitions.duration.short,
     }),
     opacity: 0,
     transform: 'rotate(-45deg)',
+    ...(styleProps.open && {
+      transform: 'rotate(0deg)',
+      opacity: 1,
+    }),
   },
-  /* Styles applied to the `openIcon` if provided and if `open={true}`. */
-  openIconOpen: {
-    transform: 'rotate(0deg)',
-    opacity: 1,
-  },
-});
+}));
 
-const SpeedDialIcon = React.forwardRef(function SpeedDialIcon(props, ref) {
-  const { className, classes, icon: iconProp, open, openIcon: openIconProp, ...other } = props;
+const SpeedDialIcon = React.forwardRef(function SpeedDialIcon(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSpeedDialIcon' });
+  const { className, icon: iconProp, open, openIcon: openIconProp, ...other } = props;
 
-  const iconClassName = clsx(classes.icon, {
-    [classes.iconOpen]: open,
-    [classes.iconWithOpenIconOpen]: openIconProp && open,
-  });
-
-  const openIconClassName = clsx(classes.openIcon, { [classes.openIconOpen]: open });
+  const styleProps = { ...props };
+  const classes = useUtilityClasses(styleProps);
 
   function formatIcon(icon, newClassName) {
     if (React.isValidElement(icon)) {
@@ -58,10 +87,15 @@ const SpeedDialIcon = React.forwardRef(function SpeedDialIcon(props, ref) {
   }
 
   return (
-    <span className={clsx(classes.root, className)} ref={ref} {...other}>
-      {openIconProp ? formatIcon(openIconProp, openIconClassName) : null}
-      {iconProp ? formatIcon(iconProp, iconClassName) : <AddIcon className={iconClassName} />}
-    </span>
+    <SpeedDialIconRoot
+      className={clsx(classes.root, className)}
+      ref={ref}
+      styleProps={styleProps}
+      {...other}
+    >
+      {openIconProp ? formatIcon(openIconProp, classes.openIcon) : null}
+      {iconProp ? formatIcon(iconProp, classes.icon) : <AddIcon className={classes.icon} />}
+    </SpeedDialIconRoot>
   );
 });
 
@@ -91,8 +125,12 @@ SpeedDialIcon.propTypes = {
    * The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open.
    */
   openIcon: PropTypes.node,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
 };
 
 SpeedDialIcon.muiName = 'SpeedDialIcon';
 
-export default withStyles(styles, { name: 'MuiSpeedDialIcon' })(SpeedDialIcon);
+export default SpeedDialIcon;

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
@@ -11,7 +11,7 @@ import speedDialIconClasses, { getSpeedDialIconUtilityClass } from './speedDialI
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(styles.root || {}, {
+  return deepmerge({
     [`& .${speedDialIconClasses.icon}`]: {
       ...styles.icon,
       ...(styleProps.open && styles.iconOpen),
@@ -21,7 +21,7 @@ const overridesResolver = (props, styles) => {
       ...styles.openIcon,
       ...(styleProps.open && styles.openIconOpen),
     },
-  });
+  }, styles.root || {});
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,25 +1,23 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import Icon from '@material-ui/core/Icon';
-import SpeedDialIcon from './SpeedDialIcon';
+import SpeedDialIcon, { speedDialIconClasses as classes } from '@material-ui/core/SpeedDialIcon';
 
 describe('<SpeedDialIcon />', () => {
   const mount = createMount();
   const render = createClientRender();
-  let classes;
   const icon = <Icon>font_icon</Icon>;
 
-  before(() => {
-    classes = getClasses(<SpeedDialIcon />);
-  });
-
-  describeConformance(<SpeedDialIcon />, () => ({
+  describeConformanceV5(<SpeedDialIcon />, () => ({
     classes,
     inheritComponent: 'span',
     mount,
+    render,
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp'],
+    muiName: 'MuiSpeedDialIcon',
+    testVariantProps: { icon },
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('should render the Add icon by default', () => {

--- a/packages/material-ui/src/SpeedDialIcon/index.d.ts
+++ b/packages/material-ui/src/SpeedDialIcon/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './SpeedDialIcon';
 export * from './SpeedDialIcon';
+
+export { default as speedDialIconClasses } from './speedDialIconClasses';
+export * from './speedDialIconClasses';

--- a/packages/material-ui/src/SpeedDialIcon/index.js
+++ b/packages/material-ui/src/SpeedDialIcon/index.js
@@ -1,1 +1,4 @@
 export { default } from './SpeedDialIcon';
+
+export { default as speedDialIconClasses } from './speedDialIconClasses';
+export * from './speedDialIconClasses';

--- a/packages/material-ui/src/SpeedDialIcon/speedDialIconClasses.d.ts
+++ b/packages/material-ui/src/SpeedDialIcon/speedDialIconClasses.d.ts
@@ -1,0 +1,9 @@
+import { SpeedDialIconClassKey } from './SpeedDialIcon';
+
+export type SpeedDialIconClasses = Record<SpeedDialIconClassKey, string>;
+
+declare const speedDialIconClasses: SpeedDialIconClasses;
+
+export function getSpeedDialIconUtilityClass(slot: string): string;
+
+export default speedDialIconClasses;

--- a/packages/material-ui/src/SpeedDialIcon/speedDialIconClasses.js
+++ b/packages/material-ui/src/SpeedDialIcon/speedDialIconClasses.js
@@ -1,0 +1,16 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getSpeedDialIconUtilityClass(slot) {
+  return generateUtilityClass('MuiSpeedDialIcon', slot);
+}
+
+const speedDialIconClasses = generateUtilityClasses('MuiSpeedDialIcon', [
+  'root',
+  'icon',
+  'iconOpen',
+  'iconWithOpenIconOpen',
+  'openIcon',
+  'openIconOpen',
+]);
+
+export default speedDialIconClasses;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR migrates `SpeedDial`, `SpeedDialIcon` and `SpeedDialAction` from #24405.