### PR TITLE
[pickers][internal] Use React.forwardRef instead of forwardedRef prop

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/KeyboardDateInput.tsx
@@ -9,11 +9,13 @@ import { useMaskedInput } from './hooks/useMaskedInput';
 import { DateInputProps, DateInputRefs } from './PureDateInput';
 import { getTextFieldAriaText } from './text-field-helper';
 
-export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
+export const KeyboardDateInput = React.forwardRef(function KeyboardDateInput(
+  props: DateInputProps & DateInputRefs,
+  ref: React.Ref<HTMLInputElement>,
+) {
   const {
     containerRef,
     disableOpenPicker,
-    forwardedRef = null,
     getOpenDialogAriaText = getTextFieldAriaText,
     InputAdornmentProps,
     InputProps,
@@ -25,7 +27,7 @@ export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
     ...other
   } = props;
   const utils = useUtils();
-  const inputRefHandle = useForkRef(inputRef, forwardedRef);
+  const inputRefHandle = useForkRef(inputRef, ref);
   const textFieldProps = useMaskedInput(other);
   const adornmentPosition = InputAdornmentProps?.position || 'end';
 
@@ -51,7 +53,7 @@ export function KeyboardDateInput(props: DateInputProps & DateInputRefs) {
       ),
     },
   });
-}
+});
 
 KeyboardDateInput.propTypes = {
   acceptRegex: PropTypes.instanceOf(RegExp),

--- a/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
@@ -90,8 +90,7 @@ export function makePickerWithState<
     );
   }
 
-  // tslint:disable-next-line
-  // @ts-ignore Simply ignore generic values in props, because it is impossible
+  // @ts-expect-error Simply ignore generic values in props, because it is impossible
   // to keep generics without additional cast when using forwardRef
   // @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35834
   return React.forwardRef<HTMLInputElement, React.ComponentProps<typeof PickerWithState>>(

--- a/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/makePickerWithState.tsx
@@ -46,7 +46,9 @@ export type SharedPickerProps<TDate, TWrapper extends SomeWrapper> = PublicWrapp
 type PickerComponent<
   TViewProps extends AllAvailableForOverrideProps,
   TWrapper extends SomeWrapper
-> = (props: TViewProps & SharedPickerProps<unknown, TWrapper>) => JSX.Element;
+> = (
+  props: TViewProps & SharedPickerProps<unknown, TWrapper> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element;
 
 export function makePickerWithState<
   T extends AllAvailableForOverrideProps,
@@ -60,11 +62,14 @@ export function makePickerWithState<
     PureDateInputComponent: PureDateInput,
   });
 
-  function PickerWithState<TDate>(
-    __props: T & AllSharedPickerProps<ParsableDate<TDate>, TDate> & PublicWrapperProps<TWrapper>,
+  const PickerWithState = React.forwardRef(function PickerWithState<TDate>(
+    __props: T & PublicWrapperProps<TWrapper> & AllSharedPickerProps<ParsableDate<TDate>, TDate>,
+    ref: React.Ref<HTMLInputElement>,
   ) {
     const allProps = useInterceptProps(__props) as AllPickerProps<T, TWrapper>;
-    const props = useThemeProps({ props: allProps, name });
+    // This is technically unsound if the type parameters appear in optional props.
+    // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
+    const props: AllPickerProps<T, TWrapper> = useThemeProps({ props: allProps, name });
 
     const validationError = useValidation(props.value, props) !== null;
     const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
@@ -75,7 +80,7 @@ export function makePickerWithState<
     // Note that we are passing down all the value without spread.
     // It saves us >1kb gzip and make any prop available automatically on any level down.
     const { value, onChange, ...other } = props;
-    const AllDateInputProps = { ...inputProps, ...other, validationError };
+    const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
     return (
       <WrapperComponent wrapperProps={wrapperProps} DateInputProps={AllDateInputProps} {...other}>
@@ -88,12 +93,10 @@ export function makePickerWithState<
         />
       </WrapperComponent>
     );
-  }
+  });
 
-  // @ts-expect-error Simply ignore generic values in props, because it is impossible
-  // to keep generics without additional cast when using forwardRef
-  // @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35834
-  return React.forwardRef<HTMLInputElement, React.ComponentProps<typeof PickerWithState>>(
-    (props, ref) => <PickerWithState {...(props as any)} forwardedRef={ref} />,
-  );
+  // @ts-expect-error Types are equal except `forwardRef` calls the returned types with `PropsWithoutRef`.
+  // The distributive nature of `PropsWithOutRef` causes the type error.
+  // TODO: Find out why we need a distributive `PropsWithOutRef`.
+  return PickerWithState as PickerComponent<T, TWrapper>;
 }

--- a/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
@@ -76,6 +76,7 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = unknown
    * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
    */
   getOpenDialogAriaText?: (value: ParsableDate, utils: MuiPickersAdapter) => string;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 export type ExportedDateInputProps<TInputValue, TDateValue> = Omit<
@@ -86,7 +87,6 @@ export type ExportedDateInputProps<TInputValue, TDateValue> = Omit<
   | 'inputFormat'
   | 'validationError'
   | 'rawValue'
-  | 'forwardedRef'
   | 'open'
   | 'TextFieldProps'
   | 'onBlur'
@@ -95,23 +95,27 @@ export type ExportedDateInputProps<TInputValue, TDateValue> = Omit<
 export interface DateInputRefs {
   inputRef?: React.Ref<HTMLInputElement>;
   containerRef?: React.Ref<HTMLDivElement>;
-  forwardedRef?: React.Ref<HTMLInputElement>;
 }
 
-export const PureDateInput: React.FC<DateInputProps & DateInputRefs> = ({
-  containerRef,
-  disabled,
-  forwardedRef,
-  getOpenDialogAriaText = getTextFieldAriaText,
-  inputFormat,
-  InputProps,
-  label,
-  openPicker: onOpen,
-  rawValue,
-  renderInput,
-  TextFieldProps = {},
-  validationError,
-}) => {
+// TODO: why is this called "Pure*" when it's not memoized? Does "Pure" mean "readonly"?
+export const PureDateInput = React.forwardRef(function PureDateInput(
+  props: DateInputProps & DateInputRefs,
+  ref: React.Ref<HTMLInputElement>,
+) {
+  const {
+    containerRef,
+    disabled,
+    getOpenDialogAriaText = getTextFieldAriaText,
+    inputFormat,
+    InputProps,
+    label,
+    openPicker: onOpen,
+    rawValue,
+    renderInput,
+    TextFieldProps = {},
+    validationError,
+  } = props;
+
   const utils = useUtils();
   const PureDateInputProps = React.useMemo(
     () => ({
@@ -127,7 +131,7 @@ export const PureDateInput: React.FC<DateInputProps & DateInputRefs> = ({
     label,
     disabled,
     ref: containerRef,
-    inputRef: forwardedRef,
+    inputRef: ref,
     error: validationError,
     InputProps: PureDateInputProps,
     inputProps: {
@@ -141,14 +145,9 @@ export const PureDateInput: React.FC<DateInputProps & DateInputRefs> = ({
     },
     ...TextFieldProps,
   });
-};
+});
 
 PureDateInput.propTypes = {
-  acceptRegex: PropTypes.instanceOf(RegExp),
   getOpenDialogAriaText: PropTypes.func,
-  mask: PropTypes.string,
-  OpenPickerButtonProps: PropTypes.object,
-  openPickerIcon: PropTypes.node,
   renderInput: PropTypes.func.isRequired,
-  rifmFormatter: PropTypes.func,
 };

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/WrapperProps.ts
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/WrapperProps.ts
@@ -4,11 +4,10 @@ import { ExportedPickerModalProps } from '../PickersModalDialog';
 
 export type DateInputPropsLike = Omit<
   DateInputProps<any, any>,
-  'renderInput' | 'validationError' | 'forwardedRef'
+  'renderInput' | 'validationError'
 > & {
   renderInput: (...args: any) => JSX.Element;
   validationError?: any;
-  forwardedRef?: any;
 };
 
 export interface StaticWrapperProps {


### PR DESCRIPTION
Internal change only. If this change affects your code, please open an issue.

Opened another can of worms in https://github.com/mui-org/material-ui/pull/25172: refs in pickers.