### PR TITLE
[examples] Fix jss-server-side output with nextjs

### DIFF
--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -11,7 +11,8 @@
     "clsx": "latest",
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "stylis": "latest"
   },
   "scripts": {
     "dev": "next",
@@ -20,9 +21,11 @@
     "post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest"
   },
   "devDependencies": {
+    "@babel/core": "latest",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",
+    "@types/stylis": "latest",
     "typescript": "latest"
   }
 }

--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { serialize, compile, middleware, prefixer, stringify } from 'stylis';
 import { ServerStyleSheets } from '@material-ui/core/styles';
 import createEmotionServer from '@emotion/server/create-instance';
 import theme from '../src/theme';
@@ -70,7 +71,14 @@ MyDocument.getInitialProps = async (ctx) => {
     // Styles fragment is rendered after the app and page rendering finish.
     styles: [
       ...React.Children.toArray(initialProps.styles),
-      sheets.getStyleElement(),
+      <style
+        key="jss-server-side"
+        id="jss-server-side"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: serialize(compile(sheets.toString()), middleware([prefixer, stringify])),
+        }}
+      />,
       <style
         key="emotion-style-tag"
         data-emotion={`css ${styles.ids.join(' ')}`}

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -12,7 +12,11 @@
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "stylis": "latest"
+  },
+  "devDependencies": {
+    "@babel/core": "latest"
   },
   "scripts": {
     "dev": "next",

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { serialize, compile, middleware, prefixer, stringify } from 'stylis';
 import { ServerStyleSheets } from '@material-ui/core/styles';
 import createEmotionServer from '@emotion/server/create-instance';
 import theme from '../src/theme';
@@ -70,7 +71,14 @@ MyDocument.getInitialProps = async (ctx) => {
     // Styles fragment is rendered after the app and page rendering finish.
     styles: [
       ...React.Children.toArray(initialProps.styles),
-      sheets.getStyleElement(),
+      <style
+        key="jss-server-side"
+        id="jss-server-side"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: serialize(compile(sheets.toString()), middleware([prefixer, stringify])),
+        }}
+      />,
       <style
         key="emotion-style-tag"
         data-emotion={`css ${styles.ids.join(' ')}`}


### PR DESCRIPTION
  ###
Fixes #1.add @babel/core as devDependencies for @emotion/styled.
2.add prefix and compressed jss-server-side output

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
#25178 