### PR TITLE
[docs] Migrate Pagination demos to emotion

### DIFF
--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -40,10 +40,8 @@ export default function MiddleDividers() {
         </Typography>
         <Box
           sx={{
-            // Replace with Stack
-            '& > :not(style) + :not(style)': {
-              ml: 1,
-            },
+            // TODO Replace with Stack
+            '& > :not(style) + :not(style)': { ml: 1 },
           }}
         >
           <Chip label="Extra Soft" />

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -40,10 +40,8 @@ export default function MiddleDividers() {
         </Typography>
         <Box
           sx={{
-            // Replace with Stack
-            '& > :not(style) + :not(style)': {
-              ml: 1,
-            },
+            // TODO Replace with Stack
+            '& > :not(style) + :not(style)': { ml: 1 },
           }}
         >
           <Chip label="Extra Soft" />

--- a/docs/src/pages/components/pagination/BasicPagination.js
+++ b/docs/src/pages/components/pagination/BasicPagination.js
@@ -1,23 +1,18 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function BasicPagination() {
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} />
       <Pagination count={10} color="primary" />
       <Pagination count={10} color="secondary" />
       <Pagination count={10} disabled />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/BasicPagination.js
+++ b/docs/src/pages/components/pagination/BasicPagination.js
@@ -6,7 +6,8 @@ export default function BasicPagination() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} />

--- a/docs/src/pages/components/pagination/BasicPagination.tsx
+++ b/docs/src/pages/components/pagination/BasicPagination.tsx
@@ -1,25 +1,18 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function BasicPagination() {
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} />
       <Pagination count={10} color="primary" />
       <Pagination count={10} color="secondary" />
       <Pagination count={10} disabled />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/BasicPagination.tsx
+++ b/docs/src/pages/components/pagination/BasicPagination.tsx
@@ -6,7 +6,8 @@ export default function BasicPagination() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} />

--- a/docs/src/pages/components/pagination/PaginationButtons.js
+++ b/docs/src/pages/components/pagination/PaginationButtons.js
@@ -6,7 +6,8 @@ export default function PaginationButtons() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} showFirstButton showLastButton />

--- a/docs/src/pages/components/pagination/PaginationButtons.js
+++ b/docs/src/pages/components/pagination/PaginationButtons.js
@@ -1,22 +1,16 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function PaginationButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} showFirstButton showLastButton />
       <Pagination count={10} hidePrevButton hideNextButton />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationButtons.tsx
+++ b/docs/src/pages/components/pagination/PaginationButtons.tsx
@@ -6,7 +6,8 @@ export default function PaginationButtons() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} showFirstButton showLastButton />

--- a/docs/src/pages/components/pagination/PaginationButtons.tsx
+++ b/docs/src/pages/components/pagination/PaginationButtons.tsx
@@ -1,24 +1,16 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function PaginationButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} showFirstButton showLastButton />
       <Pagination count={10} hidePrevButton hideNextButton />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationControlled.js
+++ b/docs/src/pages/components/pagination/PaginationControlled.js
@@ -12,7 +12,8 @@ export default function PaginationControlled() {
   return (
     <Box
       sx={{
-        '& > * + *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Typography>Page: {page}</Typography>

--- a/docs/src/pages/components/pagination/PaginationControlled.js
+++ b/docs/src/pages/components/pagination/PaginationControlled.js
@@ -1,27 +1,22 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > * + *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function PaginationControlled() {
-  const classes = useStyles();
   const [page, setPage] = React.useState(1);
   const handleChange = (event, value) => {
     setPage(value);
   };
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > * + *': { mt: 2 },
+      }}
+    >
       <Typography>Page: {page}</Typography>
       <Pagination count={10} page={page} onChange={handleChange} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationControlled.tsx
+++ b/docs/src/pages/components/pagination/PaginationControlled.tsx
@@ -12,7 +12,8 @@ export default function PaginationControlled() {
   return (
     <Box
       sx={{
-        '& > * + *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Typography>Page: {page}</Typography>

--- a/docs/src/pages/components/pagination/PaginationControlled.tsx
+++ b/docs/src/pages/components/pagination/PaginationControlled.tsx
@@ -1,29 +1,22 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > * + *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function PaginationControlled() {
-  const classes = useStyles();
   const [page, setPage] = React.useState(1);
   const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
   };
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > * + *': { mt: 2 },
+      }}
+    >
       <Typography>Page: {page}</Typography>
       <Pagination count={10} page={page} onChange={handleChange} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationOutlined.js
+++ b/docs/src/pages/components/pagination/PaginationOutlined.js
@@ -1,24 +1,18 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function PaginationOutlined() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} variant="outlined" />
       <Pagination count={10} variant="outlined" color="primary" />
       <Pagination count={10} variant="outlined" color="secondary" />
       <Pagination count={10} variant="outlined" disabled />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationOutlined.js
+++ b/docs/src/pages/components/pagination/PaginationOutlined.js
@@ -6,7 +6,8 @@ export default function PaginationOutlined() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} variant="outlined" />

--- a/docs/src/pages/components/pagination/PaginationOutlined.tsx
+++ b/docs/src/pages/components/pagination/PaginationOutlined.tsx
@@ -6,7 +6,8 @@ export default function PaginationOutlined() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} variant="outlined" />

--- a/docs/src/pages/components/pagination/PaginationOutlined.tsx
+++ b/docs/src/pages/components/pagination/PaginationOutlined.tsx
@@ -1,26 +1,18 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function PaginationOutlined() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} variant="outlined" />
       <Pagination count={10} variant="outlined" color="primary" />
       <Pagination count={10} variant="outlined" color="secondary" />
       <Pagination count={10} variant="outlined" disabled />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationRanges.js
+++ b/docs/src/pages/components/pagination/PaginationRanges.js
@@ -1,24 +1,18 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function PaginationRanges() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={11} defaultPage={6} siblingCount={0} />
       <Pagination count={11} defaultPage={6} /> {/* Default ranges */}
       <Pagination count={11} defaultPage={6} siblingCount={0} boundaryCount={2} />
       <Pagination count={11} defaultPage={6} boundaryCount={2} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationRanges.js
+++ b/docs/src/pages/components/pagination/PaginationRanges.js
@@ -6,7 +6,8 @@ export default function PaginationRanges() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={11} defaultPage={6} siblingCount={0} />

--- a/docs/src/pages/components/pagination/PaginationRanges.tsx
+++ b/docs/src/pages/components/pagination/PaginationRanges.tsx
@@ -6,7 +6,8 @@ export default function PaginationRanges() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={11} defaultPage={6} siblingCount={0} />

--- a/docs/src/pages/components/pagination/PaginationRanges.tsx
+++ b/docs/src/pages/components/pagination/PaginationRanges.tsx
@@ -1,26 +1,18 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function PaginationRanges() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={11} defaultPage={6} siblingCount={0} />
       <Pagination count={11} defaultPage={6} /> {/* Default ranges */}
       <Pagination count={11} defaultPage={6} siblingCount={0} boundaryCount={2} />
       <Pagination count={11} defaultPage={6} boundaryCount={2} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationRounded.js
+++ b/docs/src/pages/components/pagination/PaginationRounded.js
@@ -6,7 +6,8 @@ export default function PaginationRounded() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} shape="rounded" />

--- a/docs/src/pages/components/pagination/PaginationRounded.js
+++ b/docs/src/pages/components/pagination/PaginationRounded.js
@@ -1,22 +1,16 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function PaginationRounded() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} shape="rounded" />
       <Pagination count={10} variant="outlined" shape="rounded" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationRounded.tsx
+++ b/docs/src/pages/components/pagination/PaginationRounded.tsx
@@ -6,7 +6,8 @@ export default function PaginationRounded() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} shape="rounded" />

--- a/docs/src/pages/components/pagination/PaginationRounded.tsx
+++ b/docs/src/pages/components/pagination/PaginationRounded.tsx
@@ -1,24 +1,16 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function PaginationRounded() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} shape="rounded" />
       <Pagination count={10} variant="outlined" shape="rounded" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationSize.js
+++ b/docs/src/pages/components/pagination/PaginationSize.js
@@ -6,7 +6,8 @@ export default function PaginationSize() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} size="small" />

--- a/docs/src/pages/components/pagination/PaginationSize.js
+++ b/docs/src/pages/components/pagination/PaginationSize.js
@@ -1,23 +1,17 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(2),
-    },
-  },
-}));
-
 export default function PaginationSize() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} size="small" />
       <Pagination count={10} />
       <Pagination count={10} size="large" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationSize.tsx
+++ b/docs/src/pages/components/pagination/PaginationSize.tsx
@@ -1,25 +1,17 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Pagination from '@material-ui/core/Pagination';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function PaginationSize() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': { mt: 2 },
+      }}
+    >
       <Pagination count={10} size="small" />
       <Pagination count={10} />
       <Pagination count={10} size="large" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/pagination/PaginationSize.tsx
+++ b/docs/src/pages/components/pagination/PaginationSize.tsx
@@ -6,7 +6,8 @@ export default function PaginationSize() {
   return (
     <Box
       sx={{
-        '& > *': { mt: 2 },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { mt: 2 },
       }}
     >
       <Pagination count={10} size="small" />

--- a/docs/src/pages/components/pagination/UsePagination.js
+++ b/docs/src/pages/components/pagination/UsePagination.js
@@ -1,25 +1,22 @@
 import * as React from 'react';
 import usePagination from '@material-ui/core/usePagination';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 
-const useStyles = makeStyles({
-  ul: {
-    listStyle: 'none',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-  },
+const List = styled('ul')({
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+  display: 'flex',
 });
 
 export default function UsePagination() {
-  const classes = useStyles();
   const { items } = usePagination({
     count: 10,
   });
 
   return (
     <nav>
-      <ul className={classes.ul}>
+      <List>
         {items.map(({ page, type, selected, ...item }, index) => {
           let children = null;
 
@@ -47,7 +44,7 @@ export default function UsePagination() {
 
           return <li key={index}>{children}</li>;
         })}
-      </ul>
+      </List>
     </nav>
   );
 }

--- a/docs/src/pages/components/pagination/UsePagination.tsx
+++ b/docs/src/pages/components/pagination/UsePagination.tsx
@@ -1,25 +1,22 @@
 import * as React from 'react';
 import usePagination from '@material-ui/core/usePagination';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 
-const useStyles = makeStyles({
-  ul: {
-    listStyle: 'none',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-  },
+const List = styled('ul')({
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+  display: 'flex',
 });
 
 export default function UsePagination() {
-  const classes = useStyles();
   const { items } = usePagination({
     count: 10,
   });
 
   return (
     <nav>
-      <ul className={classes.ul}>
+      <List>
         {items.map(({ page, type, selected, ...item }, index) => {
           let children = null;
 
@@ -47,7 +44,7 @@ export default function UsePagination() {
 
           return <li key={index}>{children}</li>;
         })}
-      </ul>
+      </List>
     </nav>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Pagination component were migrated:

- [x] Basic pagination
- [x] Outlined pagination
- [x] Rounded pagination
- [x] Size pagination
- [x] Buttons pagination
- [x] Ranges pagination
- [x] Controlled pagination
- [x] usePagination    

Related to #16947