### PR TITLE
[docs] Remove dead generatePropTypeDescription method

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -23,7 +23,11 @@ import muiDefaultPropsHandler from 'docs/src/modules/utils/defaultPropsHandler';
 import muiFindAnnotatedComponentsResolver from 'docs/src/modules/utils/findAnnotatedComponentsResolver';
 import { LANGUAGES, LANGUAGES_IN_PROGRESS } from 'docs/src/modules/constants';
 import parseTest from 'docs/src/modules/utils/parseTest';
-import generatePropTypeDescription, { escapeCell, isElementTypeAcceptingRefProp, isElementAcceptingRefProp} from 'docs/src/modules/utils/generatePropTypeDescription';
+import generatePropTypeDescription, {
+  escapeCell,
+  isElementTypeAcceptingRefProp,
+  isElementAcceptingRefProp,
+} from 'docs/src/modules/utils/generatePropTypeDescription';
 import { findPages, findPagesMarkdown, findComponents } from 'docs/src/modules/utils/find';
 import {
   getHeaders,

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -23,6 +23,7 @@ import muiDefaultPropsHandler from 'docs/src/modules/utils/defaultPropsHandler';
 import muiFindAnnotatedComponentsResolver from 'docs/src/modules/utils/findAnnotatedComponentsResolver';
 import { LANGUAGES, LANGUAGES_IN_PROGRESS } from 'docs/src/modules/constants';
 import parseTest from 'docs/src/modules/utils/parseTest';
+import generatePropTypeDescription, { escapeCell, isElementTypeAcceptingRefProp, isElementAcceptingRefProp} from 'docs/src/modules/utils/generatePropTypeDescription';
 import { findPages, findPagesMarkdown, findComponents } from 'docs/src/modules/utils/find';
 import {
   getHeaders,
@@ -107,100 +108,6 @@ function getChained(type: PropTypeDescriptor): false | PropDescriptor {
   }
 
   return false;
-}
-
-function escapeCell(value: string): string {
-  // As the pipe is use for the table structure
-  return value.replace(/</g, '&lt;').replace(/`&lt;/g, '`<').replace(/\|/g, '\\|');
-}
-
-function isElementTypeAcceptingRefProp(type: PropTypeDescriptor): boolean {
-  return type.raw === 'elementTypeAcceptingRef';
-}
-
-function isRefType(type: PropTypeDescriptor): boolean {
-  return type.raw === 'refType';
-}
-
-function isElementAcceptingRefProp(type: PropTypeDescriptor): boolean {
-  return /^elementAcceptingRef/.test(type.raw);
-}
-
-function generatePropTypeDescription(type: PropTypeDescriptor): string | undefined {
-  switch (type.name) {
-    case 'custom': {
-      if (isElementTypeAcceptingRefProp(type)) {
-        return `element type`;
-      }
-      if (isElementAcceptingRefProp(type)) {
-        return `element`;
-      }
-      if (isRefType(type)) {
-        return `ref`;
-      }
-      if (type.raw === 'HTMLElementType') {
-        return `HTML element`;
-      }
-
-      const deprecatedInfo = getDeprecatedInfo(type);
-      if (deprecatedInfo !== false) {
-        return generatePropTypeDescription({
-          // eslint-disable-next-line react/forbid-foreign-prop-types
-          name: deprecatedInfo.propTypes,
-        } as any);
-      }
-
-      const chained = getChained(type);
-      if (chained !== false) {
-        return generatePropTypeDescription(chained.type);
-      }
-
-      return type.raw;
-    }
-
-    case 'shape':
-      return `{ ${Object.keys(type.value)
-        .map((subValue) => {
-          const subType = type.value[subValue];
-          return `${subValue}${subType.required ? '' : '?'}: ${generatePropTypeDescription(
-            subType,
-          )}`;
-        })
-        .join(', ')} }`;
-
-    case 'union':
-      return (
-        type.value
-          .map((type2) => {
-            return generatePropTypeDescription(type2);
-          })
-          // Display one value per line as it's better for visibility.
-          .join('<br>&#124;&nbsp;')
-      );
-    case 'enum':
-      return (
-        type.value
-          .map((type2) => {
-            return escapeCell(type2.value);
-          })
-          // Display one value per line as it's better for visibility.
-          .join('<br>&#124;&nbsp;')
-      );
-
-    case 'arrayOf': {
-      return `Array&lt;${generatePropTypeDescription(type.value)}&gt;`;
-    }
-
-    case 'instanceOf': {
-      if (type.value.startsWith('typeof')) {
-        return /typeof (.*) ===/.exec(type.value)![1];
-      }
-      return type.value;
-    }
-
-    default:
-      return type.name;
-  }
 }
 
 /**

--- a/docs/src/modules/utils/generatePropTypeDescription.ts
+++ b/docs/src/modules/utils/generatePropTypeDescription.ts
@@ -52,10 +52,6 @@ export function escapeCell(value: string): string {
   return value.replace(/</g, '&lt;').replace(/`&lt;/g, '`<').replace(/\|/g, '\\|');
 }
 
-function isIntegerPropType(type: PropTypeDescriptor): boolean {
-  return type.raw === 'integerPropType';
-}
-
 export function isElementTypeAcceptingRefProp(type: PropTypeDescriptor): boolean {
   return type.raw === 'elementTypeAcceptingRef';
 }
@@ -76,9 +72,6 @@ export default function generatePropTypeDescription(type: PropTypeDescriptor): s
       }
       if (isElementAcceptingRefProp(type)) {
         return `element`;
-      }
-      if (isIntegerPropType(type)) {
-        return `integer`;
       }
       if (isRefType(type)) {
         return `ref`;

--- a/docs/src/modules/utils/generatePropTypeDescription.ts
+++ b/docs/src/modules/utils/generatePropTypeDescription.ts
@@ -68,16 +68,16 @@ export default function generatePropTypeDescription(type: PropTypeDescriptor): s
   switch (type.name) {
     case 'custom': {
       if (isElementTypeAcceptingRefProp(type)) {
-        return `element type`;
+        return 'element type';
       }
       if (isElementAcceptingRefProp(type)) {
-        return `element`;
+        return 'element';
       }
       if (isRefType(type)) {
-        return `ref`;
+        return 'ref';
       }
       if (type.raw === 'HTMLElementType') {
-        return `HTML element`;
+        return 'HTML element';
       }
 
       const deprecatedInfo = getDeprecatedInfo(type);

--- a/docs/src/modules/utils/generatePropTypeDescription.ts
+++ b/docs/src/modules/utils/generatePropTypeDescription.ts
@@ -47,12 +47,16 @@ function getChained(type: PropTypeDescriptor) {
   return false;
 }
 
-function escapeCell(value: string): string {
+export function escapeCell(value: string): string {
   // As the pipe is use for the table structure
   return value.replace(/</g, '&lt;').replace(/`&lt;/g, '`<').replace(/\|/g, '\\|');
 }
 
-function isElementTypeAcceptingRefProp(type: PropTypeDescriptor): boolean {
+function isIntegerPropType(type: PropTypeDescriptor): boolean {
+  return type.raw === 'integerPropType';
+}
+
+export function isElementTypeAcceptingRefProp(type: PropTypeDescriptor): boolean {
   return type.raw === 'elementTypeAcceptingRef';
 }
 
@@ -60,7 +64,7 @@ function isRefType(type: PropTypeDescriptor): boolean {
   return type.raw === 'refType';
 }
 
-function isElementAcceptingRefProp(type: PropTypeDescriptor): boolean {
+export function isElementAcceptingRefProp(type: PropTypeDescriptor): boolean {
   return /^elementAcceptingRef/.test(type.raw);
 }
 
@@ -72,6 +76,9 @@ export default function generatePropTypeDescription(type: PropTypeDescriptor): s
       }
       if (isElementAcceptingRefProp(type)) {
         return `element`;
+      }
+      if (isIntegerPropType(type)) {
+        return `integer`;
       }
       if (isRefType(type)) {
         return `ref`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

By observing files, we have found that `generatePropTypeDescription` and several other functions have been duplicated at path `path1: docs/scripts/buildApi.ts` but at the path of `path2: docs/src/modules/utils/generatePropTypeDescription.ts`, we have a separate file with all of these functions. So I've decided to delete from `path1` all duplicate functions and import them from `path2`.

More: [discussion link](https://github.com/mui-org/material-ui/issues/25151#issuecomment-789075494)
