### PR TITLE
[docs] Improve accessibility of the basic menu demo

### DIFF
--- a/docs/src/modules/branding/BrandingPersona.tsx
+++ b/docs/src/modules/branding/BrandingPersona.tsx
@@ -81,8 +81,8 @@ export default function BrandingPersona(props: BrandingPersonaProps) {
       <Box
         sx={{
           display: 'flex',
-          // TODO use Stack
-          '&& > * + *': {
+          // TODO Replace with Stack
+          '& > :not(style) + :not(style)': {
             ml: 1,
           },
         }}

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -41,7 +41,9 @@ export default function MiddleDividers() {
         <Box
           sx={{
             // TODO Replace with Stack
-            '& > :not(style) + :not(style)': { ml: 1 },
+            '& > :not(style) + :not(style)': {
+              ml: 1,
+            },
           }}
         >
           <Chip label="Extra Soft" />

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -41,7 +41,9 @@ export default function MiddleDividers() {
         <Box
           sx={{
             // TODO Replace with Stack
-            '& > :not(style) + :not(style)': { ml: 1 },
+            '& > :not(style) + :not(style)': {
+              ml: 1,
+            },
           }}
         >
           <Chip label="Extra Soft" />

--- a/docs/src/pages/components/menus/BasicMenu.js
+++ b/docs/src/pages/components/menus/BasicMenu.js
@@ -16,6 +16,7 @@ export default function BasicMenu() {
   return (
     <div>
       <Button
+        id="basic-button"
         aria-controls="basic-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -23,7 +24,13 @@ export default function BasicMenu() {
       >
         Open Menu
       </Button>
-      <Menu id="basic-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="basic-button"
+      >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/menus/BasicMenu.js
+++ b/docs/src/pages/components/menus/BasicMenu.js
@@ -29,7 +29,9 @@ export default function BasicMenu() {
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        aria-labelledby="basic-button"
+        MenuListProps={{
+          'aria-labelledby': 'basic-button',
+        }}
       >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>

--- a/docs/src/pages/components/menus/BasicMenu.js
+++ b/docs/src/pages/components/menus/BasicMenu.js
@@ -3,29 +3,27 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 
-export default function SimpleMenu() {
+export default function BasicMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
-
+  const open = Boolean(anchorEl);
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
 
   return (
     <div>
-      <Button aria-controls="simple-menu" aria-haspopup="true" aria-expanded={!!anchorEl} onClick={handleClick}>
+      <Button
+        aria-controls="basic-menu"
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
         Open Menu
       </Button>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-      >
+      <Menu id="basic-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/menus/BasicMenu.js
+++ b/docs/src/pages/components/menus/BasicMenu.js
@@ -22,7 +22,7 @@ export default function BasicMenu() {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        Open Menu
+        Dashboard
       </Button>
       <Menu
         id="basic-menu"

--- a/docs/src/pages/components/menus/BasicMenu.tsx
+++ b/docs/src/pages/components/menus/BasicMenu.tsx
@@ -16,6 +16,7 @@ export default function BasicMenu() {
   return (
     <div>
       <Button
+        id="basic-button"
         aria-controls="basic-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -23,7 +24,13 @@ export default function BasicMenu() {
       >
         Open Menu
       </Button>
-      <Menu id="basic-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="basic-button"
+      >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/menus/BasicMenu.tsx
+++ b/docs/src/pages/components/menus/BasicMenu.tsx
@@ -3,29 +3,27 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 
-export default function SimpleMenu() {
+export default function BasicMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-
+  const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
 
   return (
     <div>
-      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
+      <Button
+        aria-controls="basic-menu"
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
         Open Menu
       </Button>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-      >
+      <Menu id="basic-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/menus/BasicMenu.tsx
+++ b/docs/src/pages/components/menus/BasicMenu.tsx
@@ -29,7 +29,9 @@ export default function BasicMenu() {
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        aria-labelledby="basic-button"
+        MenuListProps={{
+          'aria-labelledby': 'basic-button',
+        }}
       >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>

--- a/docs/src/pages/components/menus/BasicMenu.tsx
+++ b/docs/src/pages/components/menus/BasicMenu.tsx
@@ -22,7 +22,7 @@ export default function BasicMenu() {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        Open Menu
+        Dashboard
       </Button>
       <Menu
         id="basic-menu"

--- a/docs/src/pages/components/menus/ContextMenu.js
+++ b/docs/src/pages/components/menus/ContextMenu.js
@@ -38,7 +38,6 @@ export default function ContextMenu() {
         consequat. Suspendisse lacinia tellus a libero volutpat maximus.
       </Typography>
       <Menu
-        keepMounted
         open={contextMenu !== null}
         onClose={handleClose}
         anchorReference="anchorPosition"

--- a/docs/src/pages/components/menus/ContextMenu.tsx
+++ b/docs/src/pages/components/menus/ContextMenu.tsx
@@ -41,7 +41,6 @@ export default function ContextMenu() {
         consequat. Suspendisse lacinia tellus a libero volutpat maximus.
       </Typography>
       <Menu
-        keepMounted
         open={contextMenu !== null}
         onClose={handleClose}
         anchorReference="anchorPosition"

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -1,21 +1,39 @@
 import * as React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, alpha } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
-import InboxIcon from '@material-ui/icons/MoveToInbox';
-import DraftsIcon from '@material-ui/icons/Drafts';
-import SendIcon from '@material-ui/icons/Send';
+import EditIcon from '@material-ui/icons/Edit';
+import Divider from '@material-ui/core/Divider';
+import ArchiveIcon from '@material-ui/icons/Archive';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 
 const StyledMenu = withStyles((theme) => ({
   paper: {
-    border: '1px solid #d3d4d5',
-    '& .MuiListItem-root:focus': {
-      backgroundColor: theme.palette.primary.main,
-      '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
-        color: theme.palette.common.white,
+    borderRadius: 6,
+    marginTop: theme.spacing(1),
+    minWidth: 180,
+    color:
+      theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+    boxShadow:
+      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+    '& .MuiList-root': {
+      padding: '4px 0',
+    },
+    '& .MuiListItem-root': {
+      ...theme.typography.body1,
+      '& .MuiSvgIcon-root': {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+      '&:active': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity,
+        ),
       },
     },
   },
@@ -25,11 +43,11 @@ const StyledMenu = withStyles((theme) => ({
     getContentAnchorEl={null}
     anchorOrigin={{
       vertical: 'bottom',
-      horizontal: 'center',
+      horizontal: 'right',
     }}
     transformOrigin={{
       vertical: 'top',
-      horizontal: 'center',
+      horizontal: 'right',
     }}
     {...props}
   />
@@ -53,9 +71,11 @@ export default function CustomizedMenus() {
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         variant="contained"
+        disableElevation
         onClick={handleClick}
+        endIcon={<KeyboardArrowDownIcon />}
       >
-        My messages
+        Options
       </Button>
       <StyledMenu
         id="demo-customized-menu"
@@ -66,23 +86,22 @@ export default function CustomizedMenus() {
         open={open}
         onClose={handleClose}
       >
-        <MenuItem>
-          <ListItemIcon>
-            <SendIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Sent mail" />
+        <MenuItem onClick={handleClose} disableRipple>
+          <EditIcon />
+          Edit
         </MenuItem>
-        <MenuItem>
-          <ListItemIcon>
-            <DraftsIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Drafts" />
+        <MenuItem onClick={handleClose} disableRipple>
+          <FileCopyIcon />
+          Duplicate
         </MenuItem>
-        <MenuItem>
-          <ListItemIcon>
-            <InboxIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Inbox" />
+        <Divider sx={{ my: 0.5 }} />
+        <MenuItem onClick={handleClose} disableRipple>
+          <ArchiveIcon />
+          Archive
+        </MenuItem>
+        <MenuItem onClick={handleClose} disableRipple>
+          <MoreHorizIcon />
+          More
         </MenuItem>
       </StyledMenu>
     </div>

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -48,6 +48,7 @@ export default function CustomizedMenus() {
   return (
     <div>
       <Button
+        id="demo-customized-button"
         aria-controls="demo-customized-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -58,6 +59,7 @@ export default function CustomizedMenus() {
       </Button>
       <StyledMenu
         id="demo-customized-menu"
+        aria-labelledby="demo-customized-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -9,11 +9,17 @@ import InboxIcon from '@material-ui/icons/MoveToInbox';
 import DraftsIcon from '@material-ui/icons/Drafts';
 import SendIcon from '@material-ui/icons/Send';
 
-const StyledMenu = withStyles({
+const StyledMenu = withStyles((theme) => ({
   paper: {
     border: '1px solid #d3d4d5',
+    '& .MuiListItem-root:focus': {
+      backgroundColor: theme.palette.primary.main,
+      '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
+        color: theme.palette.common.white,
+      },
+    },
   },
-})((props) => (
+}))((props) => (
   <Menu
     elevation={0}
     getContentAnchorEl={null}
@@ -29,24 +35,12 @@ const StyledMenu = withStyles({
   />
 ));
 
-const StyledMenuItem = withStyles((theme) => ({
-  root: {
-    '&:focus': {
-      backgroundColor: theme.palette.primary.main,
-      '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
-        color: theme.palette.common.white,
-      },
-    },
-  },
-}))(MenuItem);
-
 export default function CustomizedMenus() {
   const [anchorEl, setAnchorEl] = React.useState(null);
-
+  const open = Boolean(anchorEl);
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -56,6 +50,7 @@ export default function CustomizedMenus() {
       <Button
         aria-controls="demo-customized-menu"
         aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
         variant="contained"
         onClick={handleClick}
       >
@@ -64,28 +59,27 @@ export default function CustomizedMenus() {
       <StyledMenu
         id="demo-customized-menu"
         anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
       >
-        <StyledMenuItem>
+        <MenuItem>
           <ListItemIcon>
             <SendIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText primary="Sent mail" />
-        </StyledMenuItem>
-        <StyledMenuItem>
+        </MenuItem>
+        <MenuItem>
           <ListItemIcon>
             <DraftsIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText primary="Drafts" />
-        </StyledMenuItem>
-        <StyledMenuItem>
+        </MenuItem>
+        <MenuItem>
           <ListItemIcon>
             <InboxIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText primary="Inbox" />
-        </StyledMenuItem>
+        </MenuItem>
       </StyledMenu>
     </div>
   );

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -59,7 +59,9 @@ export default function CustomizedMenus() {
       </Button>
       <StyledMenu
         id="demo-customized-menu"
-        aria-labelledby="demo-customized-button"
+        MenuListProps={{
+          'aria-labelledby': 'demo-customized-button',
+        }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -55,7 +55,7 @@ export default function CustomizedMenus() {
         variant="contained"
         onClick={handleClick}
       >
-        Open Menu
+        My messages
       </Button>
       <StyledMenu
         id="demo-customized-menu"

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -61,7 +61,9 @@ export default function CustomizedMenus() {
       </Button>
       <StyledMenu
         id="demo-customized-menu"
-        aria-labelledby="demo-customized-button"
+        MenuListProps={{
+          'aria-labelledby': 'demo-customized-button',
+        }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -50,6 +50,7 @@ export default function CustomizedMenus() {
   return (
     <div>
       <Button
+        id="demo-customized-button"
         aria-controls="demo-customized-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -60,6 +61,7 @@ export default function CustomizedMenus() {
       </Button>
       <StyledMenu
         id="demo-customized-menu"
+        aria-labelledby="demo-customized-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -1,22 +1,40 @@
 import * as React from 'react';
-import { withStyles, createStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles, alpha } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Menu, { MenuProps } from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
-import InboxIcon from '@material-ui/icons/MoveToInbox';
-import DraftsIcon from '@material-ui/icons/Drafts';
-import SendIcon from '@material-ui/icons/Send';
+import EditIcon from '@material-ui/icons/Edit';
+import Divider from '@material-ui/core/Divider';
+import ArchiveIcon from '@material-ui/icons/Archive';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 
 const StyledMenu = withStyles((theme) =>
   createStyles({
     paper: {
-      border: '1px solid #d3d4d5',
-      '& .MuiListItem-root:focus': {
-        backgroundColor: theme.palette.primary.main,
-        '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
-          color: theme.palette.common.white,
+      borderRadius: 6,
+      marginTop: theme.spacing(1),
+      minWidth: 180,
+      color:
+        theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+      boxShadow:
+        'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+      '& .MuiList-root': {
+        padding: '4px 0',
+      },
+      '& .MuiListItem-root': {
+        ...theme.typography.body1,
+        '& .MuiSvgIcon-root': {
+          fontSize: 18,
+          color: theme.palette.text.secondary,
+          marginRight: theme.spacing(1.5),
+        },
+        '&:active': {
+          backgroundColor: alpha(
+            theme.palette.primary.main,
+            theme.palette.action.selectedOpacity,
+          ),
         },
       },
     },
@@ -27,11 +45,11 @@ const StyledMenu = withStyles((theme) =>
     getContentAnchorEl={null}
     anchorOrigin={{
       vertical: 'bottom',
-      horizontal: 'center',
+      horizontal: 'right',
     }}
     transformOrigin={{
       vertical: 'top',
-      horizontal: 'center',
+      horizontal: 'right',
     }}
     {...props}
   />
@@ -55,9 +73,11 @@ export default function CustomizedMenus() {
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         variant="contained"
+        disableElevation
         onClick={handleClick}
+        endIcon={<KeyboardArrowDownIcon />}
       >
-        My messages
+        Options
       </Button>
       <StyledMenu
         id="demo-customized-menu"
@@ -68,23 +88,22 @@ export default function CustomizedMenus() {
         open={open}
         onClose={handleClose}
       >
-        <MenuItem>
-          <ListItemIcon>
-            <SendIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Sent mail" />
+        <MenuItem onClick={handleClose} disableRipple>
+          <EditIcon />
+          Edit
         </MenuItem>
-        <MenuItem>
-          <ListItemIcon>
-            <DraftsIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Drafts" />
+        <MenuItem onClick={handleClose} disableRipple>
+          <FileCopyIcon />
+          Duplicate
         </MenuItem>
-        <MenuItem>
-          <ListItemIcon>
-            <InboxIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Inbox" />
+        <Divider sx={{ my: 0.5 }} />
+        <MenuItem onClick={handleClose} disableRipple>
+          <ArchiveIcon />
+          Archive
+        </MenuItem>
+        <MenuItem onClick={handleClose} disableRipple>
+          <MoreHorizIcon />
+          More
         </MenuItem>
       </StyledMenu>
     </div>

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -57,7 +57,7 @@ export default function CustomizedMenus() {
         variant="contained"
         onClick={handleClick}
       >
-        Open Menu
+        My messages
       </Button>
       <StyledMenu
         id="demo-customized-menu"

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Menu, { MenuProps } from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -9,11 +9,19 @@ import InboxIcon from '@material-ui/icons/MoveToInbox';
 import DraftsIcon from '@material-ui/icons/Drafts';
 import SendIcon from '@material-ui/icons/Send';
 
-const StyledMenu = withStyles({
-  paper: {
-    border: '1px solid #d3d4d5',
-  },
-})((props: MenuProps) => (
+const StyledMenu = withStyles((theme) =>
+  createStyles({
+    paper: {
+      border: '1px solid #d3d4d5',
+      '& .MuiListItem-root:focus': {
+        backgroundColor: theme.palette.primary.main,
+        '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
+          color: theme.palette.common.white,
+        },
+      },
+    },
+  }),
+)((props: MenuProps) => (
   <Menu
     elevation={0}
     getContentAnchorEl={null}
@@ -29,24 +37,12 @@ const StyledMenu = withStyles({
   />
 ));
 
-const StyledMenuItem = withStyles((theme) => ({
-  root: {
-    '&:focus': {
-      backgroundColor: theme.palette.primary.main,
-      '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
-        color: theme.palette.common.white,
-      },
-    },
-  },
-}))(MenuItem);
-
 export default function CustomizedMenus() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-
+  const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -56,6 +52,7 @@ export default function CustomizedMenus() {
       <Button
         aria-controls="demo-customized-menu"
         aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
         variant="contained"
         onClick={handleClick}
       >
@@ -64,28 +61,27 @@ export default function CustomizedMenus() {
       <StyledMenu
         id="demo-customized-menu"
         anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
       >
-        <StyledMenuItem>
+        <MenuItem>
           <ListItemIcon>
             <SendIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText primary="Sent mail" />
-        </StyledMenuItem>
-        <StyledMenuItem>
+        </MenuItem>
+        <MenuItem>
           <ListItemIcon>
             <DraftsIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText primary="Drafts" />
-        </StyledMenuItem>
-        <StyledMenuItem>
+        </MenuItem>
+        <MenuItem>
           <ListItemIcon>
             <InboxIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText primary="Inbox" />
-        </StyledMenuItem>
+        </MenuItem>
       </StyledMenu>
     </div>
   );

--- a/docs/src/pages/components/menus/FadeMenu.js
+++ b/docs/src/pages/components/menus/FadeMenu.js
@@ -27,7 +27,9 @@ export default function FadeMenu() {
       </Button>
       <Menu
         id="fade-menu"
-        aria-labelledby="fade-button"
+        MenuListProps={{
+          'aria-labelledby': 'fade-button',
+        }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/FadeMenu.js
+++ b/docs/src/pages/components/menus/FadeMenu.js
@@ -23,7 +23,7 @@ export default function FadeMenu() {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        Open with fade transition
+        Dashboard
       </Button>
       <Menu
         id="fade-menu"

--- a/docs/src/pages/components/menus/FadeMenu.js
+++ b/docs/src/pages/components/menus/FadeMenu.js
@@ -17,6 +17,7 @@ export default function FadeMenu() {
   return (
     <div>
       <Button
+        id="fade-button"
         aria-controls="fade-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -26,6 +27,7 @@ export default function FadeMenu() {
       </Button>
       <Menu
         id="fade-menu"
+        aria-labelledby="fade-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/FadeMenu.js
+++ b/docs/src/pages/components/menus/FadeMenu.js
@@ -7,24 +7,26 @@ import Fade from '@material-ui/core/Fade';
 export default function FadeMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
-
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
 
   return (
     <div>
-      <Button aria-controls="fade-menu" aria-haspopup="true" onClick={handleClick}>
+      <Button
+        aria-controls="fade-menu"
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
         Open with fade transition
       </Button>
       <Menu
         id="fade-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={open}
         onClose={handleClose}
         TransitionComponent={Fade}

--- a/docs/src/pages/components/menus/FadeMenu.tsx
+++ b/docs/src/pages/components/menus/FadeMenu.tsx
@@ -27,7 +27,9 @@ export default function FadeMenu() {
       </Button>
       <Menu
         id="fade-menu"
-        aria-labelledby="fade-button"
+        MenuListProps={{
+          'aria-labelledby': 'fade-button',
+        }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/FadeMenu.tsx
+++ b/docs/src/pages/components/menus/FadeMenu.tsx
@@ -23,7 +23,7 @@ export default function FadeMenu() {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        Open with fade transition
+        Dashboard
       </Button>
       <Menu
         id="fade-menu"

--- a/docs/src/pages/components/menus/FadeMenu.tsx
+++ b/docs/src/pages/components/menus/FadeMenu.tsx
@@ -17,6 +17,7 @@ export default function FadeMenu() {
   return (
     <div>
       <Button
+        id="fade-button"
         aria-controls="fade-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -26,6 +27,7 @@ export default function FadeMenu() {
       </Button>
       <Menu
         id="fade-menu"
+        aria-labelledby="fade-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/FadeMenu.tsx
+++ b/docs/src/pages/components/menus/FadeMenu.tsx
@@ -7,24 +7,26 @@ import Fade from '@material-ui/core/Fade';
 export default function FadeMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
 
   return (
     <div>
-      <Button aria-controls="fade-menu" aria-haspopup="true" onClick={handleClick}>
+      <Button
+        aria-controls="fade-menu"
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
         Open with fade transition
       </Button>
       <Menu
         id="fade-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={open}
         onClose={handleClose}
         TransitionComponent={Fade}

--- a/docs/src/pages/components/menus/LongMenu.js
+++ b/docs/src/pages/components/menus/LongMenu.js
@@ -47,7 +47,9 @@ export default function LongMenu() {
       </IconButton>
       <Menu
         id="long-menu"
-        aria-labelledby="long-button"
+        MenuListProps={{
+          'aria-labelledby': 'long-button',
+        }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/LongMenu.js
+++ b/docs/src/pages/components/menus/LongMenu.js
@@ -26,11 +26,9 @@ const ITEM_HEIGHT = 48;
 export default function LongMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
-
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -40,6 +38,7 @@ export default function LongMenu() {
       <IconButton
         aria-label="more"
         aria-controls="long-menu"
+        aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
         onClick={handleClick}
       >
@@ -48,7 +47,6 @@ export default function LongMenu() {
       <Menu
         id="long-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={open}
         onClose={handleClose}
         PaperProps={{

--- a/docs/src/pages/components/menus/LongMenu.js
+++ b/docs/src/pages/components/menus/LongMenu.js
@@ -37,6 +37,7 @@ export default function LongMenu() {
     <div>
       <IconButton
         aria-label="more"
+        id="long-button"
         aria-controls="long-menu"
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
@@ -46,6 +47,7 @@ export default function LongMenu() {
       </IconButton>
       <Menu
         id="long-menu"
+        aria-labelledby="long-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/LongMenu.tsx
+++ b/docs/src/pages/components/menus/LongMenu.tsx
@@ -47,7 +47,9 @@ export default function LongMenu() {
       </IconButton>
       <Menu
         id="long-menu"
-        aria-labelledby="long-button"
+        MenuListProps={{
+          'aria-labelledby': 'long-button',
+        }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/LongMenu.tsx
+++ b/docs/src/pages/components/menus/LongMenu.tsx
@@ -26,11 +26,9 @@ const ITEM_HEIGHT = 48;
 export default function LongMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -40,6 +38,7 @@ export default function LongMenu() {
       <IconButton
         aria-label="more"
         aria-controls="long-menu"
+        aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
         onClick={handleClick}
       >
@@ -48,7 +47,6 @@ export default function LongMenu() {
       <Menu
         id="long-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={open}
         onClose={handleClose}
         PaperProps={{

--- a/docs/src/pages/components/menus/LongMenu.tsx
+++ b/docs/src/pages/components/menus/LongMenu.tsx
@@ -37,6 +37,7 @@ export default function LongMenu() {
     <div>
       <IconButton
         aria-label="more"
+        id="long-button"
         aria-controls="long-menu"
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
@@ -46,6 +47,7 @@ export default function LongMenu() {
       </IconButton>
       <Menu
         id="long-menu"
+        aria-labelledby="long-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -61,7 +61,8 @@ export default function MenuListComposition() {
       <div>
         <Button
           ref={anchorRef}
-          aria-controls={open ? 'menu-list-grow' : undefined}
+          id="composition-button"
+          aria-controls={open ? 'composition-menu' : undefined}
           aria-expanded={open ? 'true' : undefined}
           aria-haspopup="true"
           onClick={handleToggle}
@@ -87,7 +88,8 @@ export default function MenuListComposition() {
                 <ClickAwayListener onClickAway={handleClose}>
                   <MenuList
                     autoFocusItem={open}
-                    id="menu-list-grow"
+                    id="composition-menu"
+                    aria-labelledby="composition-button"
                     onKeyDown={handleListKeyDown}
                   >
                     <MenuItem onClick={handleClose}>Profile</MenuItem>

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -6,19 +6,9 @@ import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-  },
-  paper: {
-    marginRight: theme.spacing(2),
-  },
-}));
+import Box from '@material-ui/core/Box';
 
 export default function MenuListComposition() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef(null);
 
@@ -35,8 +25,10 @@ export default function MenuListComposition() {
   };
 
   function handleListKeyDown(event) {
-    if (event.key === 'Tab' || event.key === 'Escape') {
+    if (event.key === 'Tab') {
       event.preventDefault();
+      setOpen(false);
+    } else if (event.key === 'Escape') {
       setOpen(false);
     }
   }
@@ -52,8 +44,14 @@ export default function MenuListComposition() {
   }, [open]);
 
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
+    <Box
+      sx={{
+        display: 'flex',
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
+      }}
+    >
+      <Paper>
         <MenuList>
           <MenuItem>Profile</MenuItem>
           <MenuItem>My account</MenuItem>
@@ -64,6 +62,7 @@ export default function MenuListComposition() {
         <Button
           ref={anchorRef}
           aria-controls={open ? 'menu-list-grow' : undefined}
+          aria-expanded={open ? 'true' : undefined}
           aria-haspopup="true"
           onClick={handleToggle}
         >
@@ -101,6 +100,6 @@ export default function MenuListComposition() {
           )}
         </Popper>
       </div>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -67,12 +67,13 @@ export default function MenuListComposition() {
           aria-haspopup="true"
           onClick={handleToggle}
         >
-          Toggle Menu Grow
+          Dashboard
         </Button>
         <Popper
           open={open}
           anchorEl={anchorRef.current}
           role={undefined}
+          placement="bottom-start"
           transition
           disablePortal
         >
@@ -81,7 +82,7 @@ export default function MenuListComposition() {
               {...TransitionProps}
               style={{
                 transformOrigin:
-                  placement === 'bottom' ? 'center top' : 'center bottom',
+                  placement === 'bottom-start' ? 'left top' : 'left bottom',
               }}
             >
               <Paper>

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -70,12 +70,13 @@ export default function MenuListComposition() {
           aria-haspopup="true"
           onClick={handleToggle}
         >
-          Toggle Menu Grow
+          Dashboard
         </Button>
         <Popper
           open={open}
           anchorEl={anchorRef.current}
           role={undefined}
+          placement="bottom-start"
           transition
           disablePortal
         >
@@ -84,7 +85,7 @@ export default function MenuListComposition() {
               {...TransitionProps}
               style={{
                 transformOrigin:
-                  placement === 'bottom' ? 'center top' : 'center bottom',
+                  placement === 'bottom-start' ? 'left top' : 'left bottom',
               }}
             >
               <Paper>

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -64,7 +64,8 @@ export default function MenuListComposition() {
       <div>
         <Button
           ref={anchorRef}
-          aria-controls={open ? 'menu-list-grow' : undefined}
+          id="composition-button"
+          aria-controls={open ? 'composition-menu' : undefined}
           aria-expanded={open ? 'true' : undefined}
           aria-haspopup="true"
           onClick={handleToggle}
@@ -90,7 +91,8 @@ export default function MenuListComposition() {
                 <ClickAwayListener onClickAway={handleClose}>
                   <MenuList
                     autoFocusItem={open}
-                    id="menu-list-grow"
+                    id="composition-menu"
+                    aria-labelledby="composition-button"
                     onKeyDown={handleListKeyDown}
                   >
                     <MenuItem onClick={handleClose}>Profile</MenuItem>

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -6,21 +6,9 @@ import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-    },
-    paper: {
-      marginRight: theme.spacing(2),
-    },
-  }),
-);
+import Box from '@material-ui/core/Box';
 
 export default function MenuListComposition() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
 
@@ -40,8 +28,10 @@ export default function MenuListComposition() {
   };
 
   function handleListKeyDown(event: React.KeyboardEvent) {
-    if (event.key === 'Tab' || event.key === 'Escape') {
+    if (event.key === 'Tab') {
       event.preventDefault();
+      setOpen(false);
+    } else if (event.key === 'Escape') {
       setOpen(false);
     }
   }
@@ -57,8 +47,14 @@ export default function MenuListComposition() {
   }, [open]);
 
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
+    <Box
+      sx={{
+        display: 'flex',
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
+      }}
+    >
+      <Paper>
         <MenuList>
           <MenuItem>Profile</MenuItem>
           <MenuItem>My account</MenuItem>
@@ -69,6 +65,7 @@ export default function MenuListComposition() {
         <Button
           ref={anchorRef}
           aria-controls={open ? 'menu-list-grow' : undefined}
+          aria-expanded={open ? 'true' : undefined}
           aria-haspopup="true"
           onClick={handleToggle}
         >
@@ -106,6 +103,6 @@ export default function MenuListComposition() {
           )}
         </Popper>
       </div>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/menus/MenuPopupState.js
+++ b/docs/src/pages/components/menus/MenuPopupState.js
@@ -10,11 +10,12 @@ export default function MenuPopupState() {
       {(popupState) => (
         <React.Fragment>
           <Button variant="contained" {...bindTrigger(popupState)}>
-            Open Menu
+            Dashboard
           </Button>
           <Menu {...bindMenu(popupState)}>
-            <MenuItem onClick={popupState.close}>Cake</MenuItem>
-            <MenuItem onClick={popupState.close}>Death</MenuItem>
+            <MenuItem onClick={popupState.close}>Profile</MenuItem>
+            <MenuItem onClick={popupState.close}>My account</MenuItem>
+            <MenuItem onClick={popupState.close}>Logout</MenuItem>
           </Menu>
         </React.Fragment>
       )}

--- a/docs/src/pages/components/menus/MenuPopupState.tsx
+++ b/docs/src/pages/components/menus/MenuPopupState.tsx
@@ -10,11 +10,12 @@ export default function MenuPopupState() {
       {(popupState) => (
         <React.Fragment>
           <Button variant="contained" {...bindTrigger(popupState)}>
-            Open Menu
+            Dashboard
           </Button>
           <Menu {...bindMenu(popupState)}>
-            <MenuItem onClick={popupState.close}>Cake</MenuItem>
-            <MenuItem onClick={popupState.close}>Death</MenuItem>
+            <MenuItem onClick={popupState.close}>Profile</MenuItem>
+            <MenuItem onClick={popupState.close}>My account</MenuItem>
+            <MenuItem onClick={popupState.close}>Logout</MenuItem>
           </Menu>
         </React.Fragment>
       )}

--- a/docs/src/pages/components/menus/PositionedMenu.js
+++ b/docs/src/pages/components/menus/PositionedMenu.js
@@ -22,7 +22,7 @@ export default function PositionedMenu() {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        Open Menu
+        Dashboard
       </Button>
       <Menu
         id="demo-positioned-menu"

--- a/docs/src/pages/components/menus/PositionedMenu.js
+++ b/docs/src/pages/components/menus/PositionedMenu.js
@@ -5,11 +5,10 @@ import MenuItem from '@material-ui/core/MenuItem';
 
 export default function PositionedMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
-
+  const open = Boolean(anchorEl);
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -19,6 +18,7 @@ export default function PositionedMenu() {
       <Button
         aria-controls="demo-positioned-menu"
         aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
         Open Menu
@@ -26,8 +26,7 @@ export default function PositionedMenu() {
       <Menu
         id="demo-positioned-menu"
         anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
         getContentAnchorEl={null}
         anchorOrigin={{

--- a/docs/src/pages/components/menus/PositionedMenu.js
+++ b/docs/src/pages/components/menus/PositionedMenu.js
@@ -16,6 +16,7 @@ export default function PositionedMenu() {
   return (
     <div>
       <Button
+        id="demo-positioned-button"
         aria-controls="demo-positioned-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -25,6 +26,7 @@ export default function PositionedMenu() {
       </Button>
       <Menu
         id="demo-positioned-menu"
+        aria-labelledby="demo-positioned-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/PositionedMenu.tsx
+++ b/docs/src/pages/components/menus/PositionedMenu.tsx
@@ -22,7 +22,7 @@ export default function PositionedMenu() {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        Open Menu
+        Dashboard
       </Button>
       <Menu
         id="demo-positioned-menu"

--- a/docs/src/pages/components/menus/PositionedMenu.tsx
+++ b/docs/src/pages/components/menus/PositionedMenu.tsx
@@ -16,6 +16,7 @@ export default function PositionedMenu() {
   return (
     <div>
       <Button
+        id="demo-positioned-button"
         aria-controls="demo-positioned-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -25,6 +26,7 @@ export default function PositionedMenu() {
       </Button>
       <Menu
         id="demo-positioned-menu"
+        aria-labelledby="demo-positioned-button"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/PositionedMenu.tsx
+++ b/docs/src/pages/components/menus/PositionedMenu.tsx
@@ -5,11 +5,10 @@ import MenuItem from '@material-ui/core/MenuItem';
 
 export default function PositionedMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-
+  const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
-
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -19,6 +18,7 @@ export default function PositionedMenu() {
       <Button
         aria-controls="demo-positioned-menu"
         aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
         Open Menu
@@ -26,8 +26,7 @@ export default function PositionedMenu() {
       <Menu
         id="demo-positioned-menu"
         anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
         getContentAnchorEl={null}
         anchorOrigin={{

--- a/docs/src/pages/components/menus/SimpleListMenu.js
+++ b/docs/src/pages/components/menus/SimpleListMenu.js
@@ -16,7 +16,7 @@ const options = [
 export default function SimpleListMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [selectedIndex, setSelectedIndex] = React.useState(1);
-
+  const open = Boolean(anchorEl);
   const handleClickListItem = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -35,9 +35,11 @@ export default function SimpleListMenu() {
       <List component="nav" aria-label="Device settings">
         <ListItem
           button
-          aria-haspopup="true"
+          id="lock-button"
+          aria-haspopup="listbox"
           aria-controls="lock-menu"
           aria-label="when device is locked"
+          aria-expanded={open ? 'true' : undefined}
           onClick={handleClickListItem}
         >
           <ListItemText
@@ -49,8 +51,12 @@ export default function SimpleListMenu() {
       <Menu
         id="lock-menu"
         anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'lock-button',
+          role: 'listbox',
+        }}
       >
         {options.map((option, index) => (
           <MenuItem

--- a/docs/src/pages/components/menus/SimpleListMenu.js
+++ b/docs/src/pages/components/menus/SimpleListMenu.js
@@ -1,16 +1,10 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
 
 const options = [
   'Show some love to Material-UI',
@@ -20,7 +14,6 @@ const options = [
 ];
 
 export default function SimpleListMenu() {
-  const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [selectedIndex, setSelectedIndex] = React.useState(1);
 
@@ -38,7 +31,7 @@ export default function SimpleListMenu() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ bgcolor: 'background.paper' }}>
       <List component="nav" aria-label="Device settings">
         <ListItem
           button
@@ -56,7 +49,6 @@ export default function SimpleListMenu() {
       <Menu
         id="lock-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
@@ -71,6 +63,6 @@ export default function SimpleListMenu() {
           </MenuItem>
         ))}
       </Menu>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/menus/SimpleListMenu.tsx
+++ b/docs/src/pages/components/menus/SimpleListMenu.tsx
@@ -1,18 +1,10 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      backgroundColor: theme.palette.background.paper,
-    },
-  }),
-);
 
 const options = [
   'Show some love to Material-UI',
@@ -22,7 +14,6 @@ const options = [
 ];
 
 export default function SimpleListMenu() {
-  const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState(1);
 
@@ -43,7 +34,7 @@ export default function SimpleListMenu() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ bgcolor: 'background.paper' }}>
       <List component="nav" aria-label="Device settings">
         <ListItem
           button
@@ -61,7 +52,6 @@ export default function SimpleListMenu() {
       <Menu
         id="lock-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
@@ -76,6 +66,6 @@ export default function SimpleListMenu() {
           </MenuItem>
         ))}
       </Menu>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/menus/SimpleListMenu.tsx
+++ b/docs/src/pages/components/menus/SimpleListMenu.tsx
@@ -16,7 +16,7 @@ const options = [
 export default function SimpleListMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState(1);
-
+  const open = Boolean(anchorEl);
   const handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -38,9 +38,11 @@ export default function SimpleListMenu() {
       <List component="nav" aria-label="Device settings">
         <ListItem
           button
-          aria-haspopup="true"
+          id="lock-button"
+          aria-haspopup="listbox"
           aria-controls="lock-menu"
           aria-label="when device is locked"
+          aria-expanded={open ? 'true' : undefined}
           onClick={handleClickListItem}
         >
           <ListItemText
@@ -52,8 +54,12 @@ export default function SimpleListMenu() {
       <Menu
         id="lock-menu"
         anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'lock-button',
+          role: 'listbox',
+        }}
       >
         {options.map((option, index) => (
           <MenuItem

--- a/docs/src/pages/components/menus/SimpleMenu.js
+++ b/docs/src/pages/components/menus/SimpleMenu.js
@@ -16,7 +16,7 @@ export default function SimpleMenu() {
 
   return (
     <div>
-      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
+      <Button aria-controls="simple-menu" aria-haspopup="true" aria-expanded={!!anchorEl} onClick={handleClick}>
         Open Menu
       </Button>
       <Menu

--- a/docs/src/pages/components/menus/TypographyMenu.js
+++ b/docs/src/pages/components/menus/TypographyMenu.js
@@ -2,24 +2,15 @@ import * as React from 'react';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles } from '@material-ui/core/styles';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Typography from '@material-ui/core/Typography';
 import DraftsIcon from '@material-ui/icons/Drafts';
 import SendIcon from '@material-ui/icons/Send';
 import PriorityHighIcon from '@material-ui/icons/PriorityHigh';
 
-const useStyles = makeStyles({
-  root: {
-    width: 230,
-  },
-});
-
 export default function TypographyMenu() {
-  const classes = useStyles();
-
   return (
-    <Paper className={classes.root}>
+    <Paper sx={{ width: 230 }}>
       <MenuList>
         <MenuItem>
           <ListItemIcon>

--- a/docs/src/pages/components/menus/TypographyMenu.tsx
+++ b/docs/src/pages/components/menus/TypographyMenu.tsx
@@ -2,24 +2,15 @@ import * as React from 'react';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles } from '@material-ui/core/styles';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Typography from '@material-ui/core/Typography';
 import DraftsIcon from '@material-ui/icons/Drafts';
 import SendIcon from '@material-ui/icons/Send';
 import PriorityHighIcon from '@material-ui/icons/PriorityHigh';
 
-const useStyles = makeStyles({
-  root: {
-    width: 230,
-  },
-});
-
 export default function TypographyMenu() {
-  const classes = useStyles();
-
   return (
-    <Paper className={classes.root}>
+    <Paper sx={{ width: 230 }}>
       <MenuList>
         <MenuItem>
           <ListItemIcon>

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -22,7 +22,7 @@ Choosing an option should immediately ideally commit the option and close the me
 
 **Disambiguation**: In contrast to simple menus, simple dialogs can present additional detail related to the options available for a list item or provide navigational or orthogonal actions related to the primary task. Although they can display the same content, simple menus are preferred over simple dialogs because simple menus are less disruptive to the user's current context.
 
-{{"demo": "pages/components/menus/SimpleMenu.js"}}
+{{"demo": "pages/components/menus/BasicMenu.js"}}
 
 ## Selected menu
 


### PR DESCRIPTION
Menu buttons require an aria-expanded attribute that signals to screenreader whether the menu is currently open or not

This PR adds the missing attribute to the SimpleMenu example code

(see docs: https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
