### PR TITLE
[docs] Migrate Skeleton demos to emotion

### DIFF
--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -6,9 +6,7 @@ export default function ContainedButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button variant="contained">Primary</Button>

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -6,9 +6,7 @@ export default function ContainedButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button variant="contained">Primary</Button>

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -8,9 +8,7 @@ export default function IconLabelButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button variant="outlined" startIcon={<DeleteIcon />}>

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -8,9 +8,7 @@ export default function IconLabelButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button variant="outlined" startIcon={<DeleteIcon />}>

--- a/docs/src/pages/components/buttons/LoadingButtons.js
+++ b/docs/src/pages/components/buttons/LoadingButtons.js
@@ -7,9 +7,7 @@ export default function LoadingButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <LoadingButton pending variant="outlined">

--- a/docs/src/pages/components/buttons/LoadingButtons.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtons.tsx
@@ -7,9 +7,7 @@ export default function LoadingButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <LoadingButton pending variant="outlined">

--- a/docs/src/pages/components/buttons/OutlinedButtons.js
+++ b/docs/src/pages/components/buttons/OutlinedButtons.js
@@ -6,9 +6,7 @@ export default function OutlinedButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button variant="outlined">Primary</Button>

--- a/docs/src/pages/components/buttons/OutlinedButtons.tsx
+++ b/docs/src/pages/components/buttons/OutlinedButtons.tsx
@@ -6,9 +6,7 @@ export default function OutlinedButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button variant="outlined">Primary</Button>

--- a/docs/src/pages/components/buttons/TextButtons.js
+++ b/docs/src/pages/components/buttons/TextButtons.js
@@ -6,9 +6,7 @@ export default function TextButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button>Primary</Button>

--- a/docs/src/pages/components/buttons/TextButtons.tsx
+++ b/docs/src/pages/components/buttons/TextButtons.tsx
@@ -6,9 +6,7 @@ export default function TextButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Button>Primary</Button>

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -13,9 +13,7 @@ export default function UploadButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Input accept="image/*" id="contained-button-file" multiple type="file" />

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -13,9 +13,7 @@ export default function UploadButtons() {
   return (
     <Box
       sx={{
-        '& > :not(style)': {
-          m: 1,
-        },
+        '& > :not(style)': { m: 1 },
       }}
     >
       <Input accept="image/*" id="contained-button-file" multiple type="file" />

--- a/docs/src/pages/components/skeleton/Animations.js
+++ b/docs/src/pages/components/skeleton/Animations.js
@@ -1,20 +1,13 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Skeleton from '@material-ui/core/Skeleton';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles({
-  root: {
-    width: 300,
-  },
-});
 
 export default function Animations() {
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 300 }}>
       <Skeleton />
       <Skeleton animation="wave" />
       <Skeleton animation={false} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/skeleton/Animations.tsx
+++ b/docs/src/pages/components/skeleton/Animations.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Skeleton from '@material-ui/core/Skeleton';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles({
-  root: {
-    width: 300,
-  },
-});
 
 export default function Animations() {
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 300 }}>
       <Skeleton />
       <Skeleton animation="wave" />
       <Skeleton animation={false} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/skeleton/Facebook.js
+++ b/docs/src/pages/components/skeleton/Facebook.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
@@ -11,22 +10,11 @@ import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import Skeleton from '@material-ui/core/Skeleton';
 
-const useStyles = makeStyles((theme) => ({
-  card: {
-    maxWidth: 345,
-    margin: theme.spacing(2),
-  },
-  media: {
-    height: 190,
-  },
-}));
-
 function Media(props) {
   const { loading = false } = props;
-  const classes = useStyles();
 
   return (
-    <Card className={classes.card}>
+    <Card sx={{ maxWidth: 345, m: 2 }}>
       <CardHeader
         avatar={
           loading ? (
@@ -66,10 +54,10 @@ function Media(props) {
         }
       />
       {loading ? (
-        <Skeleton animation="wave" variant="rectangular" className={classes.media} />
+        <Skeleton sx={{ height: 190 }} animation="wave" variant="rectangular" />
       ) : (
         <CardMedia
-          className={classes.media}
+          sx={{ height: 190 }}
           image="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
           title="Ted talk"
         />

--- a/docs/src/pages/components/skeleton/Facebook.tsx
+++ b/docs/src/pages/components/skeleton/Facebook.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
@@ -10,28 +9,15 @@ import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import Skeleton from '@material-ui/core/Skeleton';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    card: {
-      maxWidth: 345,
-      margin: theme.spacing(2),
-    },
-    media: {
-      height: 190,
-    },
-  }),
-);
-
 interface MediaProps {
   loading?: boolean;
 }
 
 function Media(props: MediaProps) {
   const { loading = false } = props;
-  const classes = useStyles();
 
   return (
-    <Card className={classes.card}>
+    <Card sx={{ maxWidth: 345, m: 2 }}>
       <CardHeader
         avatar={
           loading ? (
@@ -71,10 +57,10 @@ function Media(props: MediaProps) {
         }
       />
       {loading ? (
-        <Skeleton animation="wave" variant="rectangular" className={classes.media} />
+        <Skeleton sx={{ height: 190 }} animation="wave" variant="rectangular" />
       ) : (
         <CardMedia
-          className={classes.media}
+          sx={{ height: 190 }}
           image="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
           title="Ted talk"
         />

--- a/docs/src/pages/components/skeleton/SkeletonChildren.js
+++ b/docs/src/pages/components/skeleton/SkeletonChildren.js
@@ -1,21 +1,18 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Avatar from '@material-ui/core/Avatar';
 import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';
 import Skeleton from '@material-ui/core/Skeleton';
 
-const useStyles = makeStyles(() => ({
-  image: {
-    width: '100%',
-  },
-}));
+const Image = styled('img')({
+  width: '100%',
+});
 
 function SkeletonChildrenDemo(props) {
   const { loading = false } = props;
-  const classes = useStyles();
 
   return (
     <div>
@@ -44,8 +41,7 @@ function SkeletonChildrenDemo(props) {
           <div style={{ paddingTop: '57%' }} />
         </Skeleton>
       ) : (
-        <img
-          className={classes.image}
+        <Image
           src="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
           alt=""
         />

--- a/docs/src/pages/components/skeleton/SkeletonChildren.tsx
+++ b/docs/src/pages/components/skeleton/SkeletonChildren.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Avatar from '@material-ui/core/Avatar';
 import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';
 import Skeleton from '@material-ui/core/Skeleton';
 
-const useStyles = makeStyles(() => ({
-  image: {
-    width: '100%',
-  },
-}));
+const Image = styled('img')({
+  width: '100%',
+});
 
 function SkeletonChildrenDemo(props: { loading?: boolean }) {
   const { loading = false } = props;
-  const classes = useStyles();
 
   return (
     <div>
@@ -43,8 +40,7 @@ function SkeletonChildrenDemo(props: { loading?: boolean }) {
           <div style={{ paddingTop: '57%' }} />
         </Skeleton>
       ) : (
-        <img
-          className={classes.image}
+        <Image
           src="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
           alt=""
         />

--- a/docs/src/pages/components/skeleton/Variants.js
+++ b/docs/src/pages/components/skeleton/Variants.js
@@ -1,23 +1,18 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Skeleton from '@material-ui/core/Skeleton';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      marginTop: theme.spacing(1),
-    },
-  },
-}));
-
 export default function Variants() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        // TODO Replace with Stack
+        '& > :not(style)': { mt: 1 },
+      }}
+    >
       <Skeleton variant="text" />
       <Skeleton variant="circular" width={40} height={40} />
       <Skeleton variant="rectangular" width={210} height={118} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/skeleton/Variants.js
+++ b/docs/src/pages/components/skeleton/Variants.js
@@ -7,7 +7,7 @@ export default function Variants() {
     <Box
       sx={{
         // TODO Replace with Stack
-        '& > :not(style)': { mt: 1 },
+        '& > :not(style) + :not(style)': { mt: 1 },
       }}
     >
       <Skeleton variant="text" />

--- a/docs/src/pages/components/skeleton/Variants.tsx
+++ b/docs/src/pages/components/skeleton/Variants.tsx
@@ -1,25 +1,18 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Skeleton from '@material-ui/core/Skeleton';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        marginTop: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function Variants() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        // TODO Replace with Stack
+        '& > :not(style)': { mt: 1 },
+      }}
+    >
       <Skeleton variant="text" />
       <Skeleton variant="circular" width={40} height={40} />
       <Skeleton variant="rectangular" width={210} height={118} />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/skeleton/Variants.tsx
+++ b/docs/src/pages/components/skeleton/Variants.tsx
@@ -7,7 +7,7 @@ export default function Variants() {
     <Box
       sx={{
         // TODO Replace with Stack
-        '& > :not(style)': { mt: 1 },
+        '& > :not(style) + :not(style)': { mt: 1 },
       }}
     >
       <Skeleton variant="text" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Skeleton component were migrated:

- [x] Variant skeleton
- [x] Animations skeleton
- [x] Wave skeleton
- [x] Children skeleton

Related to #16947