### PR TITLE
[Transition] Add easing prop to override default timing function

### DIFF
--- a/docs/pages/api-docs/collapse.json
+++ b/docs/pages/api-docs/collapse.json
@@ -7,6 +7,13 @@
       "default": "'0px'"
     },
     "component": { "type": { "name": "custom", "description": "element type" } },
+    "easing": {
+      "type": {
+        "name": "union",
+        "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
+      },
+      "default": "easingProps.sharp"
+    },
     "in": { "type": { "name": "bool" } },
     "orientation": {
       "type": { "name": "enum", "description": "'horizontal'<br>&#124;&nbsp;'vertical'" },

--- a/docs/pages/api-docs/collapse.json
+++ b/docs/pages/api-docs/collapse.json
@@ -11,8 +11,7 @@
       "type": {
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
-      },
-      "default": "easingProps.sharp"
+      }
     },
     "in": { "type": { "name": "bool" } },
     "orientation": {

--- a/docs/pages/api-docs/fade.json
+++ b/docs/pages/api-docs/fade.json
@@ -6,8 +6,7 @@
       "type": {
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
-      },
-      "default": "{\n  enter: easingProps.easeIn,\n  exit: easingProps.easeOut,\n}"
+      }
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {

--- a/docs/pages/api-docs/fade.json
+++ b/docs/pages/api-docs/fade.json
@@ -2,6 +2,13 @@
   "props": {
     "appear": { "type": { "name": "bool" }, "default": "true" },
     "children": { "type": { "name": "custom", "description": "element" } },
+    "easing": {
+      "type": {
+        "name": "union",
+        "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
+      },
+      "default": "{\n  enter: easingProps.easeIn,\n  exit: easingProps.easeOut,\n}"
+    },
     "in": { "type": { "name": "bool" } },
     "timeout": {
       "type": {

--- a/docs/pages/api-docs/grow.json
+++ b/docs/pages/api-docs/grow.json
@@ -6,8 +6,7 @@
       "type": {
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
-      },
-      "default": "'ease'"
+      }
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {

--- a/docs/pages/api-docs/grow.json
+++ b/docs/pages/api-docs/grow.json
@@ -2,6 +2,13 @@
   "props": {
     "appear": { "type": { "name": "bool" }, "default": "true" },
     "children": { "type": { "name": "custom", "description": "element" } },
+    "easing": {
+      "type": {
+        "name": "union",
+        "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
+      },
+      "default": "'ease'"
+    },
     "in": { "type": { "name": "bool" } },
     "timeout": {
       "type": {

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -13,8 +13,7 @@
       "type": {
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
-      },
-      "default": "{\n  enter: easingProps.easeOut,\n  exit: easingProps.sharp,\n}"
+      }
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -9,6 +9,13 @@
       },
       "default": "'down'"
     },
+    "easing": {
+      "type": {
+        "name": "union",
+        "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
+      },
+      "default": "{\n  enter: easingProps.easeOut,\n  exit: easingProps.sharp,\n}"
+    },
     "in": { "type": { "name": "bool" } },
     "timeout": {
       "type": {

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -13,7 +13,8 @@
       "type": {
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
-      }
+      },
+      "default": "{\n  enter: easing.easeOut,\n  exit: easing.sharp,\n}"
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {

--- a/docs/pages/api-docs/zoom.json
+++ b/docs/pages/api-docs/zoom.json
@@ -6,8 +6,7 @@
       "type": {
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
-      },
-      "default": "{\n  enter: easingProps.easeIn,\n  exit: easingProps.easeOut,\n}"
+      }
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {

--- a/docs/pages/api-docs/zoom.json
+++ b/docs/pages/api-docs/zoom.json
@@ -2,6 +2,13 @@
   "props": {
     "appear": { "type": { "name": "bool" }, "default": "true" },
     "children": { "type": { "name": "custom", "description": "element" } },
+    "easing": {
+      "type": {
+        "name": "union",
+        "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
+      },
+      "default": "{\n  enter: easingProps.easeIn,\n  exit: easingProps.easeOut,\n}"
+    },
     "in": { "type": { "name": "bool" } },
     "timeout": {
       "type": {

--- a/docs/translations/api-docs/collapse/collapse.json
+++ b/docs/translations/api-docs/collapse/collapse.json
@@ -5,6 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "collapsedSize": "The width (horizontal) or height (vertical) of the container when collapsed.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
+    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
     "in": "If <code>true</code>, the component will transition in.",
     "orientation": "The transition orientation.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",

--- a/docs/translations/api-docs/collapse/collapse.json
+++ b/docs/translations/api-docs/collapse/collapse.json
@@ -5,7 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "collapsedSize": "The width (horizontal) or height (vertical) of the container when collapsed.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
-    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
+    "easing": "The transition timing function. You may specify a single easing or a object containing enter and exit values.",
     "in": "If <code>true</code>, the component will transition in.",
     "orientation": "The transition orientation.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",

--- a/docs/translations/api-docs/fade/fade.json
+++ b/docs/translations/api-docs/fade/fade.json
@@ -3,7 +3,7 @@
   "propDescriptions": {
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
-    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
+    "easing": "The transition timing function. You may specify a single easing or a object containing enter and exit values.",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },

--- a/docs/translations/api-docs/fade/fade.json
+++ b/docs/translations/api-docs/fade/fade.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
+    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },

--- a/docs/translations/api-docs/grow/grow.json
+++ b/docs/translations/api-docs/grow/grow.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
+    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to &#39;auto&#39; to automatically calculate transition time based on height."
   },

--- a/docs/translations/api-docs/grow/grow.json
+++ b/docs/translations/api-docs/grow/grow.json
@@ -3,7 +3,7 @@
   "propDescriptions": {
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
-    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
+    "easing": "The transition timing function. You may specify a single easing or a object containing enter and exit values.",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to &#39;auto&#39; to automatically calculate transition time based on height."
   },

--- a/docs/translations/api-docs/slide/slide.json
+++ b/docs/translations/api-docs/slide/slide.json
@@ -4,6 +4,7 @@
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "direction": "Direction the child node will enter from.",
+    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },

--- a/docs/translations/api-docs/slide/slide.json
+++ b/docs/translations/api-docs/slide/slide.json
@@ -4,7 +4,7 @@
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "direction": "Direction the child node will enter from.",
-    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
+    "easing": "The transition timing function. You may specify a single easing or a object containing enter and exit values.",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },

--- a/docs/translations/api-docs/zoom/zoom.json
+++ b/docs/translations/api-docs/zoom/zoom.json
@@ -3,7 +3,7 @@
   "propDescriptions": {
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
-    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
+    "easing": "The transition timing function. You may specify a single easing or a object containing enter and exit values.",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },

--- a/docs/translations/api-docs/zoom/zoom.json
+++ b/docs/translations/api-docs/zoom/zoom.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "appear": "Perform the enter transition when it first mounts if <code>in</code> is also <code>true</code>. Set this to <code>false</code> to disable this behavior.",
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
+    "easing": "The transition timing function You may specify a single easing or a object containing enter and exit values",
     "in": "If <code>true</code>, the component will transition in.",
     "timeout": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -54,8 +54,8 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
    */
   timeout?: TransitionProps['timeout'] | 'auto';
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default easingProps.sharp
    */
   easing?: TransitionProps['easing'];

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -37,6 +37,11 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
    */
   component?: React.ElementType<TransitionProps>;
   /**
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
+   */
+  easing?: TransitionProps['easing'];
+  /**
    * If `true`, the component will transition in.
    */
   in?: boolean;
@@ -53,12 +58,6 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
    * @default duration.standard
    */
   timeout?: TransitionProps['timeout'] | 'auto';
-  /**
-   * The transition timing function.
-   * You may specify a single easing or a object containing enter and exit values.
-   * @default easingProps.sharp
-   */
-  easing?: TransitionProps['easing'];
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -54,6 +54,12 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
    */
   timeout?: TransitionProps['timeout'] | 'auto';
   /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default easingProps.sharp
+   */
+  easing?: TransitionProps['easing'];
+  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx?: SxProps<Theme>;

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -6,7 +6,7 @@ import { deepmerge, elementTypeAcceptingRef } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
-import { duration, easing as easingProps } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 import { getTransitionProps } from '../transitions/utils';
 import useTheme from '../styles/useTheme';
 import { useForkRef } from '../utils';
@@ -124,6 +124,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     className,
     collapsedSize: collapsedSizeProp = '0px',
     component,
+    easing,
     in: inProp,
     onEnter,
     onEntered,
@@ -134,7 +135,6 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     orientation = 'vertical',
     style,
     timeout = duration.standard,
-    easing = easingProps.sharp,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -359,7 +359,6 @@ Collapse.propTypes = {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
-   * @default easingProps.sharp
    */
   easing: PropTypes.oneOfType([
     PropTypes.shape({

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -6,7 +6,7 @@ import { deepmerge, elementTypeAcceptingRef } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
-import { duration } from '../styles/transitions';
+import { duration, easing as easingProps } from '../styles/transitions';
 import { getTransitionProps } from '../transitions/utils';
 import useTheme from '../styles/useTheme';
 import { useForkRef } from '../utils';
@@ -134,6 +134,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     orientation = 'vertical',
     style,
     timeout = duration.standard,
+    easing = easingProps.sharp,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -201,8 +202,8 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
       wrapperRef.current.style.position = '';
     }
 
-    const { duration: transitionDuration } = getTransitionProps(
-      { style, timeout },
+    const { duration: transitionDuration, easing: transitionTimingFunction } = getTransitionProps(
+      { style, timeout, easing },
       {
         mode: 'enter',
       },
@@ -218,6 +219,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     }
 
     node.style[size] = `${wrapperSize}px`;
+    node.style.transitionTimingFunction = transitionTimingFunction;
 
     if (onEntering) {
       onEntering(node, isAppearing);
@@ -244,8 +246,8 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
 
   const handleExiting = normalizedTransitionCallback((node) => {
     const wrapperSize = getWrapperSize();
-    const { duration: transitionDuration } = getTransitionProps(
-      { style, timeout },
+    const { duration: transitionDuration, easing: transitionTimingFunction } = getTransitionProps(
+      { style, timeout, easing },
       {
         mode: 'exit',
       },
@@ -263,6 +265,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
     }
 
     node.style[size] = collapsedSize;
+    node.style.transitionTimingFunction = transitionTimingFunction;
 
     if (onExiting) {
       onExiting(node);
@@ -353,6 +356,18 @@ Collapse.propTypes = {
    * Either a string to use a HTML element or a component.
    */
   component: elementTypeAcceptingRef,
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default easingProps.sharp
+   */
+  easing: PropTypes.oneOfType([
+    PropTypes.shape({
+      enter: PropTypes.string,
+      exit: PropTypes.string,
+    }),
+    PropTypes.string,
+  ]),
   /**
    * If `true`, the component will transition in.
    */

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -357,8 +357,8 @@ Collapse.propTypes = {
    */
   component: elementTypeAcceptingRef,
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default easingProps.sharp
    */
   easing: PropTypes.oneOfType([

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -27,8 +27,8 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    */
   timeout?: TransitionProps['timeout'];
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default {
    *   enter: easingProps.easeIn,
    *   exit: easingProps.easeOut,

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -26,6 +26,15 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    * }
    */
   timeout?: TransitionProps['timeout'];
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default {
+   *   enter: easingProps.easeIn,
+   *   exit: easingProps.easeOut,
+   * }
+   */
+  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -13,6 +13,11 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    */
   children?: React.ReactElement<any, any>;
   /**
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
+   */
+  easing?: TransitionProps['easing'];
+  /**
    * If `true`, the component will transition in.
    */
   in?: boolean;
@@ -26,15 +31,6 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    * }
    */
   timeout?: TransitionProps['timeout'];
-  /**
-   * The transition timing function.
-   * You may specify a single easing or a object containing enter and exit values.
-   * @default {
-   *   enter: easingProps.easeIn,
-   *   exit: easingProps.easeOut,
-   * }
-   */
-  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@material-ui/utils';
-import { duration, easing as easingProps } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
@@ -21,11 +21,6 @@ const defaultTimeout = {
   exit: duration.leavingScreen,
 };
 
-const defaultEasing = {
-  enter: easingProps.easeIn,
-  exit: easingProps.easeOut,
-};
-
 /**
  * The Fade transition is used by the [Modal](/components/modal/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
@@ -34,6 +29,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
   const {
     appear = true,
     children,
+    easing,
     in: inProp,
     onEnter,
     onEntered,
@@ -42,10 +38,9 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     onExited,
     onExiting,
     style,
+    timeout = defaultTimeout,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
-    timeout = defaultTimeout,
-    easing = defaultEasing,
     ...other
   } = props;
   const theme = useTheme();
@@ -159,10 +154,6 @@ Fade.propTypes = {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
-   * @default {
-   *   enter: easingProps.easeIn,
-   *   exit: easingProps.easeOut,
-   * }
    */
   easing: PropTypes.oneOfType([
     PropTypes.shape({

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@material-ui/utils';
-import { duration } from '../styles/transitions';
+import { duration, easing as easingProps } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
@@ -19,6 +19,11 @@ const styles = {
 const defaultTimeout = {
   enter: duration.enteringScreen,
   exit: duration.leavingScreen,
+};
+
+const defaultEasing = {
+  enter: easingProps.easeIn,
+  exit: easingProps.easeOut,
 };
 
 /**
@@ -40,6 +45,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     timeout = defaultTimeout,
+    easing = defaultEasing,
     ...other
   } = props;
   const theme = useTheme();
@@ -68,7 +74,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     reflow(node); // So the animation always start from the start.
 
     const transitionProps = getTransitionProps(
-      { style, timeout },
+      { style, timeout, easing },
       {
         mode: 'enter',
       },
@@ -88,7 +94,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
 
   const handleExit = normalizedTransitionCallback((node) => {
     const transitionProps = getTransitionProps(
-      { style, timeout },
+      { style, timeout, easing },
       {
         mode: 'exit',
       },
@@ -150,6 +156,21 @@ Fade.propTypes = {
    * A single child content element.
    */
   children: elementAcceptingRef,
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default {
+   *   enter: easingProps.easeIn,
+   *   exit: easingProps.easeOut,
+   * }
+   */
+  easing: PropTypes.oneOfType([
+    PropTypes.shape({
+      enter: PropTypes.string,
+      exit: PropTypes.string,
+    }),
+    PropTypes.string,
+  ]),
   /**
    * If `true`, the component will transition in.
    */

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -157,8 +157,8 @@ Fade.propTypes = {
    */
   children: elementAcceptingRef,
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default {
    *   enter: easingProps.easeIn,
    *   exit: easingProps.easeOut,

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -13,6 +13,11 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
    */
   children?: React.ReactElement<any, any>;
   /**
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
+   */
+  easing?: TransitionProps['easing'];
+  /**
    * If `true`, the component will transition in.
    */
   in?: boolean;
@@ -25,12 +30,6 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
    * @default 'auto'
    */
   timeout?: TransitionProps['timeout'] | 'auto';
-  /**
-   * The transition timing function.
-   * You may specify a single easing or a object containing enter and exit values.
-   * @default 'ease'
-   */
-  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -26,8 +26,8 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
    */
   timeout?: TransitionProps['timeout'] | 'auto';
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default 'ease'
    */
   easing?: TransitionProps['easing'];

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -25,6 +25,12 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
    * @default 'auto'
    */
   timeout?: TransitionProps['timeout'] | 'auto';
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default 'ease'
+   */
+  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -30,6 +30,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   const {
     appear = true,
     children,
+    easing,
     in: inProp,
     onEnter,
     onEntered,
@@ -39,7 +40,6 @@ const Grow = React.forwardRef(function Grow(props, ref) {
     onExiting,
     style,
     timeout = 'auto',
-    easing = 'ease',
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -215,7 +215,6 @@ Grow.propTypes = {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
-   * @default 'ease'
    */
   easing: PropTypes.oneOfType([
     PropTypes.shape({

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -39,6 +39,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
     onExiting,
     style,
     timeout = 'auto',
+    easing = 'ease',
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -69,8 +70,12 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   const handleEnter = normalizedTransitionCallback((node, isAppearing) => {
     reflow(node); // So the animation always start from the start.
 
-    const { duration: transitionDuration, delay } = getTransitionProps(
-      { style, timeout },
+    const {
+      duration: transitionDuration,
+      delay,
+      easing: transitionTimingFunction,
+    } = getTransitionProps(
+      { style, timeout, easing },
       {
         mode: 'enter',
       },
@@ -92,6 +97,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
       theme.transitions.create('transform', {
         duration: duration * 0.666,
         delay,
+        easing: transitionTimingFunction,
       }),
     ].join(',');
 
@@ -105,8 +111,12 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   const handleExiting = normalizedTransitionCallback(onExiting);
 
   const handleExit = normalizedTransitionCallback((node) => {
-    const { duration: transitionDuration, delay } = getTransitionProps(
-      { style, timeout },
+    const {
+      duration: transitionDuration,
+      delay,
+      easing: transitionTimingFunction,
+    } = getTransitionProps(
+      { style, timeout, easing },
       {
         mode: 'exit',
       },
@@ -128,6 +138,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
       theme.transitions.create('transform', {
         duration: duration * 0.666,
         delay: delay || duration * 0.333,
+        easing: transitionTimingFunction,
       }),
     ].join(',');
 
@@ -201,6 +212,18 @@ Grow.propTypes = {
    * A single child content element.
    */
   children: elementAcceptingRef,
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default 'ease'
+   */
+  easing: PropTypes.oneOfType([
+    PropTypes.shape({
+      enter: PropTypes.string,
+      exit: PropTypes.string,
+    }),
+    PropTypes.string,
+  ]),
   /**
    * If `true`, the component will transition in.
    */

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -213,8 +213,8 @@ Grow.propTypes = {
    */
   children: elementAcceptingRef,
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default 'ease'
    */
   easing: PropTypes.oneOfType([

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -18,6 +18,11 @@ export interface SlideProps extends TransitionProps {
    */
   direction?: 'left' | 'right' | 'up' | 'down';
   /**
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
+   */
+  easing?: TransitionProps['easing'];
+  /**
    * If `true`, the component will transition in.
    */
   in?: TransitionProps['in'];
@@ -31,15 +36,6 @@ export interface SlideProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
-  /**
-   * The transition timing function.
-   * You may specify a single easing or a object containing enter and exit values.
-   * @default {
-   *   enter: easingProps.easeOut,
-   *   exit: easingProps.sharp,
-   * }
-   */
-  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -32,8 +32,8 @@ export interface SlideProps extends TransitionProps {
    */
   timeout?: TransitionProps['timeout'];
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default {
    *   enter: easingProps.easeOut,
    *   exit: easingProps.sharp,

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -31,6 +31,15 @@ export interface SlideProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default {
+   *   enter: easingProps.easeOut,
+   *   exit: easingProps.sharp,
+   * }
+   */
+  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Slide/Slide.d.ts
+++ b/packages/material-ui/src/Slide/Slide.d.ts
@@ -20,6 +20,10 @@ export interface SlideProps extends TransitionProps {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
+   * @default {
+   *   enter: easing.easeOut,
+   *   exit: easing.sharp,
+   * }
    */
   easing?: TransitionProps['easing'];
   /**

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -5,7 +5,7 @@ import { elementAcceptingRef } from '@material-ui/utils';
 import debounce from '../utils/debounce';
 import useForkRef from '../utils/useForkRef';
 import useTheme from '../styles/useTheme';
-import { duration } from '../styles/transitions';
+import { duration, easing as easingProps } from '../styles/transitions';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import { ownerWindow } from '../utils';
 
@@ -64,6 +64,11 @@ const defaultTimeout = {
   exit: duration.leavingScreen,
 };
 
+const defaultEasing = {
+  enter: easingProps.easeOut,
+  exit: easingProps.sharp,
+};
+
 /**
  * The Slide transition is used by the [Drawer](/components/drawers/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
@@ -82,6 +87,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     onExiting,
     style,
     timeout = defaultTimeout,
+    easing = defaultEasing,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -114,7 +120,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
   const handleEntering = normalizedTransitionCallback((node, isAppearing) => {
     const transitionProps = getTransitionProps(
-      { timeout, style },
+      { timeout, style, easing },
       {
         mode: 'enter',
       },
@@ -122,12 +128,10 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
       ...transitionProps,
-      easing: theme.transitions.easing.easeOut,
     });
 
     node.style.transition = theme.transitions.create('transform', {
       ...transitionProps,
-      easing: theme.transitions.easing.easeOut,
     });
 
     node.style.webkitTransform = 'none';
@@ -142,7 +146,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
   const handleExit = normalizedTransitionCallback((node) => {
     const transitionProps = getTransitionProps(
-      { timeout, style },
+      { timeout, style, easing },
       {
         mode: 'exit',
       },
@@ -150,12 +154,10 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
       ...transitionProps,
-      easing: theme.transitions.easing.sharp,
     });
 
     node.style.transition = theme.transitions.create('transform', {
       ...transitionProps,
-      easing: theme.transitions.easing.sharp,
     });
 
     setTranslateValue(direction, node);
@@ -258,6 +260,21 @@ Slide.propTypes = {
    * @default 'down'
    */
   direction: PropTypes.oneOf(['down', 'left', 'right', 'up']),
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default {
+   *   enter: easingProps.easeOut,
+   *   exit: easingProps.sharp,
+   * }
+   */
+  easing: PropTypes.oneOfType([
+    PropTypes.shape({
+      enter: PropTypes.string,
+      exit: PropTypes.string,
+    }),
+    PropTypes.string,
+  ]),
   /**
    * If `true`, the component will transition in.
    */

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -5,7 +5,7 @@ import { elementAcceptingRef } from '@material-ui/utils';
 import debounce from '../utils/debounce';
 import useForkRef from '../utils/useForkRef';
 import useTheme from '../styles/useTheme';
-import { duration, easing as easingProps } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import { ownerWindow } from '../utils';
 
@@ -64,11 +64,6 @@ const defaultTimeout = {
   exit: duration.leavingScreen,
 };
 
-const defaultEasing = {
-  enter: easingProps.easeOut,
-  exit: easingProps.sharp,
-};
-
 /**
  * The Slide transition is used by the [Drawer](/components/drawers/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
@@ -78,6 +73,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     appear = true,
     children,
     direction = 'down',
+    easing,
     in: inProp,
     onEnter,
     onEntered,
@@ -87,7 +83,6 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     onExiting,
     style,
     timeout = defaultTimeout,
-    easing = defaultEasing,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -263,10 +258,6 @@ Slide.propTypes = {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
-   * @default {
-   *   enter: easingProps.easeOut,
-   *   exit: easingProps.sharp,
-   * }
    */
   easing: PropTypes.oneOfType([
     PropTypes.shape({

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -261,8 +261,8 @@ Slide.propTypes = {
    */
   direction: PropTypes.oneOf(['down', 'left', 'right', 'up']),
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default {
    *   enter: easingProps.easeOut,
    *   exit: easingProps.sharp,

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -5,7 +5,7 @@ import { elementAcceptingRef } from '@material-ui/utils';
 import debounce from '../utils/debounce';
 import useForkRef from '../utils/useForkRef';
 import useTheme from '../styles/useTheme';
-import { duration } from '../styles/transitions';
+import { duration, easing } from '../styles/transitions';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import { ownerWindow } from '../utils';
 
@@ -59,6 +59,11 @@ export function setTranslateValue(direction, node) {
   }
 }
 
+const defaultEasing = {
+  enter: easing.easeOut,
+  exit: easing.sharp,
+};
+
 const defaultTimeout = {
   enter: duration.enteringScreen,
   exit: duration.leavingScreen,
@@ -73,7 +78,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     appear = true,
     children,
     direction = 'down',
-    easing,
+    easing: easingProp = defaultEasing,
     in: inProp,
     onEnter,
     onEntered,
@@ -115,7 +120,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
   const handleEntering = normalizedTransitionCallback((node, isAppearing) => {
     const transitionProps = getTransitionProps(
-      { timeout, style, easing },
+      { timeout, style, easing: easingProp },
       {
         mode: 'enter',
       },
@@ -141,7 +146,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
 
   const handleExit = normalizedTransitionCallback((node) => {
     const transitionProps = getTransitionProps(
-      { timeout, style, easing },
+      { timeout, style, easing: easingProp },
       {
         mode: 'exit',
       },
@@ -258,6 +263,10 @@ Slide.propTypes = {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
+   * @default {
+   *   enter: easing.easeOut,
+   *   exit: easing.sharp,
+   * }
    */
   easing: PropTypes.oneOfType([
     PropTypes.shape({

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -116,7 +116,7 @@ describe('<Slide />', () => {
   });
 
   describe('prop: timeout', () => {
-    it('should create proper easeOut animation onEntering', () => {
+    it('should create proper enter animation onEntering', () => {
       const handleEntering = spy();
 
       render(
@@ -134,7 +134,7 @@ describe('<Slide />', () => {
       );
     });
 
-    it('should create proper sharp animation onExit', () => {
+    it('should create proper exit animation', () => {
       const handleExit = spy();
       const { setProps } = render(
         <Slide
@@ -150,6 +150,45 @@ describe('<Slide />', () => {
 
       expect(handleExit.args[0][0].style.transition).to.match(
         /transform 446ms cubic-bezier\(0.4, 0, 0.6, 1\)( 0ms)?/,
+      );
+    });
+  });
+
+  describe('prop: easing', () => {
+    it('should create proper enter animation', () => {
+      const handleEntering = spy();
+
+      render(
+        <Slide
+          {...defaultProps}
+          easing={{
+            enter: 'cubic-bezier(1, 1, 0, 0)',
+          }}
+          onEntering={handleEntering}
+        />,
+      );
+
+      expect(handleEntering.args[0][0].style.transition).to.match(
+        /transform 225ms cubic-bezier\(1, 1, 0, 0\)( 0ms)?/,
+      );
+    });
+
+    it('should create proper exit animation', () => {
+      const handleExit = spy();
+      const { setProps } = render(
+        <Slide
+          {...defaultProps}
+          easing={{
+            exit: 'cubic-bezier(0, 0, 1, 1)',
+          }}
+          onExit={handleExit}
+        />,
+      );
+
+      setProps({ in: false });
+
+      expect(handleExit.args[0][0].style.transition).to.match(
+        /transform 195ms cubic-bezier\(0, 0, 1, 1\)( 0ms)?/,
       );
     });
   });

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -26,6 +26,15 @@ export interface ZoomProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default {
+   *   enter: easingProps.easeIn,
+   *   exit: easingProps.easeOut,
+   * }
+   */
+  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -13,6 +13,11 @@ export interface ZoomProps extends TransitionProps {
    */
   children?: React.ReactElement<any, any>;
   /**
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
+   */
+  easing?: TransitionProps['easing'];
+  /**
    * If `true`, the component will transition in.
    */
   in?: boolean;
@@ -26,15 +31,6 @@ export interface ZoomProps extends TransitionProps {
    * }
    */
   timeout?: TransitionProps['timeout'];
-  /**
-   * The transition timing function.
-   * You may specify a single easing or a object containing enter and exit values.
-   * @default {
-   *   enter: easingProps.easeIn,
-   *   exit: easingProps.easeOut,
-   * }
-   */
-  easing?: TransitionProps['easing'];
 }
 
 /**

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -27,8 +27,8 @@ export interface ZoomProps extends TransitionProps {
    */
   timeout?: TransitionProps['timeout'];
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default {
    *   enter: easingProps.easeIn,
    *   exit: easingProps.easeOut,

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -158,8 +158,8 @@ Zoom.propTypes = {
    */
   children: elementAcceptingRef,
   /**
-   * The transition timing function
-   * You may specify a single easing or a object containing enter and exit values
+   * The transition timing function.
+   * You may specify a single easing or a object containing enter and exit values.
    * @default {
    *   enter: easingProps.easeIn,
    *   exit: easingProps.easeOut,

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@material-ui/utils';
-import { duration, easing as easingProps } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
@@ -21,11 +21,6 @@ const defaultTimeout = {
   exit: duration.leavingScreen,
 };
 
-const defaultEasing = {
-  enter: easingProps.easeIn,
-  exit: easingProps.easeOut,
-};
-
 /**
  * The Zoom transition can be used for the floating variant of the
  * [Button](/components/buttons/#floating-action-buttons) component.
@@ -35,6 +30,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
   const {
     appear = true,
     children,
+    easing,
     in: inProp,
     onEnter,
     onEntered,
@@ -44,7 +40,6 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     onExiting,
     style,
     timeout = defaultTimeout,
-    easing = defaultEasing,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -160,10 +155,6 @@ Zoom.propTypes = {
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
-   * @default {
-   *   enter: easingProps.easeIn,
-   *   exit: easingProps.easeOut,
-   * }
    */
   easing: PropTypes.oneOfType([
     PropTypes.shape({

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@material-ui/utils';
-import { duration } from '../styles/transitions';
+import { duration, easing as easingProps } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
@@ -19,6 +19,11 @@ const styles = {
 const defaultTimeout = {
   enter: duration.enteringScreen,
   exit: duration.leavingScreen,
+};
+
+const defaultEasing = {
+  enter: easingProps.easeIn,
+  exit: easingProps.easeOut,
 };
 
 /**
@@ -39,6 +44,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     onExiting,
     style,
     timeout = defaultTimeout,
+    easing = defaultEasing,
     // eslint-disable-next-line react/prop-types
     TransitionComponent = Transition,
     ...other
@@ -69,7 +75,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     reflow(node); // So the animation always start from the start.
 
     const transitionProps = getTransitionProps(
-      { style, timeout },
+      { style, timeout, easing },
       {
         mode: 'enter',
       },
@@ -89,7 +95,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
 
   const handleExit = normalizedTransitionCallback((node) => {
     const transitionProps = getTransitionProps(
-      { style, timeout },
+      { style, timeout, easing },
       {
         mode: 'exit',
       },
@@ -151,6 +157,21 @@ Zoom.propTypes = {
    * A single child content element.
    */
   children: elementAcceptingRef,
+  /**
+   * The transition timing function
+   * You may specify a single easing or a object containing enter and exit values
+   * @default {
+   *   enter: easingProps.easeIn,
+   *   exit: easingProps.easeOut,
+   * }
+   */
+  easing: PropTypes.oneOfType([
+    PropTypes.shape({
+      enter: PropTypes.string,
+      exit: PropTypes.string,
+    }),
+    PropTypes.string,
+  ]),
   /**
    * If `true`, the component will transition in.
    */

--- a/packages/material-ui/src/transitions/transition.d.ts
+++ b/packages/material-ui/src/transitions/transition.d.ts
@@ -13,9 +13,9 @@ export type TransitionHandlerKeys =
   | 'onExited';
 export type TransitionHandlerProps = Pick<_TransitionProps, TransitionHandlerKeys>;
 
-export type EasingProps = {
+export interface EasingProps {
   easing: string | { enter?: string; exit?: string };
-};
+}
 
 export type TransitionKeys =
   | 'in'

--- a/packages/material-ui/src/transitions/transition.d.ts
+++ b/packages/material-ui/src/transitions/transition.d.ts
@@ -13,15 +13,20 @@ export type TransitionHandlerKeys =
   | 'onExited';
 export type TransitionHandlerProps = Pick<_TransitionProps, TransitionHandlerKeys>;
 
+export type EasingProps = {
+  easing: string | { enter?: string; exit?: string };
+};
+
 export type TransitionKeys =
   | 'in'
   | 'mountOnEnter'
   | 'unmountOnExit'
   | 'timeout'
+  | 'easing'
   | 'addEndListener'
   | TransitionHandlerKeys;
 export interface TransitionProps
   extends TransitionActions,
-    Partial<Pick<_TransitionProps, TransitionKeys>> {
+    Partial<Pick<_TransitionProps & EasingProps, TransitionKeys>> {
   style?: React.CSSProperties;
 }

--- a/packages/material-ui/src/transitions/utils.js
+++ b/packages/material-ui/src/transitions/utils.js
@@ -9,9 +9,7 @@ export function getTransitionProps(props, options) {
         ? timeout
         : timeout[options.mode] || 0,
     easing:
-      style.transitionTimingFunction || typeof easing === 'string'
-        ? easing
-        : easing[options.mode],
+      style.transitionTimingFunction || typeof easing === 'object' ? easing[options.mode] : easing,
     delay: style.transitionDelay,
   };
 }

--- a/packages/material-ui/src/transitions/utils.js
+++ b/packages/material-ui/src/transitions/utils.js
@@ -11,7 +11,7 @@ export function getTransitionProps(props, options) {
     easing:
       style.transitionTimingFunction || typeof easing === 'string'
         ? easing
-        : easing[options.mode] || 'ease',
+        : easing[options.mode],
     delay: style.transitionDelay,
   };
 }

--- a/packages/material-ui/src/transitions/utils.js
+++ b/packages/material-ui/src/transitions/utils.js
@@ -1,13 +1,17 @@
 export const reflow = (node) => node.scrollTop;
 
 export function getTransitionProps(props, options) {
-  const { timeout, style = {} } = props;
+  const { timeout, easing, style = {} } = props;
 
   return {
     duration:
       style.transitionDuration || typeof timeout === 'number'
         ? timeout
         : timeout[options.mode] || 0,
+    easing:
+      style.transitionTimingFunction || typeof easing === 'string'
+        ? easing
+        : easing[options.mode] || 'ease',
     delay: style.transitionDelay,
   };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- Add easing (transition timing function) property to transition components to be able override the default style on enter and leave animations, similar to how timeout is set up.
```js
<Zoom 
  easing={{
    enter: 'cubic-bezier(0.71, 0.11, 0.35, 1.28)',
    exit: 'cubic-bezier(1,.18,.74,1.03)',
   }}
>
```
- Update type definitions and related API docs

Fix #24980 