### PR TITLE
[test] Convert createClientRender to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@types/lodash": "^4.14.138",
     "@types/mocha": "^8.0.0",
     "@types/prettier": "^2.0.0",
-    "@types/react": "^17.0.0",
+    "@types/react": "^17.0.3",
     "@types/scheduler": "^0.16.1",
     "@types/sinon": "^9.0.0",
     "@types/webpack": "^4.41.22",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/mocha": "^8.0.0",
     "@types/prettier": "^2.0.0",
     "@types/react": "^17.0.0",
+    "@types/scheduler": "^0.16.1",
     "@types/sinon": "^9.0.0",
     "@types/webpack": "^4.41.22",
     "@types/yargs": "^16.0.0",

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -313,9 +313,9 @@ export function createClientRender(
           return fileMatch[1];
         })
         .find((file) => {
-          return file?.endsWith('createClientRender.js');
+          return file?.endsWith('createClientRender.tsx');
         });
-      workspaceRoot = filename!.replace('test/utils/createClientRender.js', '');
+      workspaceRoot = filename!.replace('test/utils/createClientRender.tsx', '');
     }
   });
 

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -222,11 +222,11 @@ interface RenderConfiguration {
 export type RenderOptions = Omit<RenderConfiguration, 'emotionCache' | 'profiler'>;
 
 interface MuiRenderResult extends RenderResult<typeof queries & typeof customQueries> {
-  forceUpdate(): this;
+  forceUpdate(): void;
   /**
    * convenience helper. Better than repeating all props.
    */
-  setProps(props: object): this;
+  setProps(props: object): void;
 }
 
 function clientRender(
@@ -275,11 +275,9 @@ function clientRender(
           }),
         ),
       );
-      return this;
     },
     setProps(props) {
       trace('setProps', () => this.rerender(React.cloneElement(element, props)));
-      return this;
     },
   };
 

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -12,13 +12,14 @@ import {
   render as testingLibraryRender,
   prettyDOM,
   within,
+  RenderResult,
 } from '@testing-library/react/pure';
-import { unstable_trace } from 'scheduler/tracing';
+import { unstable_trace, Interaction } from 'scheduler/tracing';
 import userEvent from './user-event';
 
 const enableDispatchingProfiler = process.env.TEST_GATE === 'enable-dispatching-profiler';
 
-function noTrace(interaction, callback) {
+function noTrace<T>(interactionName: string, callback: () => T): T {
   return callback();
 }
 
@@ -26,18 +27,16 @@ function noTrace(interaction, callback) {
  * Path used in Error.prototype.stack.
  *
  * Computed in `before` hook.
- * @type {string}
  */
-let workspaceRoot;
+let workspaceRoot: string;
 
 /**
- * @param {string} interactionName - Human readable label for this particular interaction.
- * @param {() => T} callback
- * @returns {T}
+ * interactionName - Human readable label for this particular interaction.
+ * callback
  */
-function traceByStack(interactionName, callback) {
+function traceByStack<T>(interactionName: string, callback: () => T): T {
   const { stack } = new Error();
-  const testLines = stack
+  const testLines = stack!
     .split(/\r?\n/)
     .map((line) => {
       // anonymous functions create a "weird" stackframe like
@@ -50,7 +49,7 @@ function traceByStack(interactionName, callback) {
       }
       return { name: fileMatch[1], line: +fileMatch[3], column: +fileMatch[4] };
     })
-    .filter((maybeTestFile) => {
+    .filter((maybeTestFile): maybeTestFile is NonNullable<typeof maybeTestFile> => {
       return maybeTestFile !== null;
     })
     .map((file) => {
@@ -61,7 +60,13 @@ function traceByStack(interactionName, callback) {
   return unstable_trace(`${originLine} (${interactionName})`, performance.now(), callback);
 }
 
-class NoopProfiler {
+interface Profiler {
+  id: string;
+  onRender: import('react').ProfilerOnRenderCallback;
+  report(): void;
+}
+
+class NoopProfiler implements Profiler {
   id = 'noop';
 
   // eslint-disable-next-line class-methods-use-this
@@ -71,25 +76,34 @@ class NoopProfiler {
   report() {}
 }
 
-class DispatchingProfiler {
-  renders = [];
+type RenderMark = [
+  id: string,
+  phase: 'mount' | 'update',
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+  interactions: Set<Interaction>,
+];
 
-  /**
-   *
-   * @param {import('mocha').Test} test
-   */
-  constructor(test) {
-    /**
-     * @readonly
-     */
-    this.test = test;
+class DispatchingProfiler implements Profiler {
+  id: string;
+
+  private renders: RenderMark[] = [];
+
+  constructor(test: import('mocha').Test) {
     this.id = test.fullTitle();
   }
 
-  /**
-   * @type {import('react').ProfilerOnRenderCallback}
-   */
-  onRender = (id, phase, actualDuration, baseDuration, startTime, commitTime, interactions) => {
+  onRender: import('react').ProfilerOnRenderCallback = (
+    id,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+    interactions,
+  ) => {
     // Do minimal work here to keep the render fast.
     // Though it's unclear whether work here affects the profiler results.
     // But even if it doesn't we'll keep the test feedback snappy.
@@ -123,13 +137,13 @@ class DispatchingProfiler {
   }
 }
 
-const Profiler = enableDispatchingProfiler ? DispatchingProfiler : NoopProfiler;
+const UsedProfiler = enableDispatchingProfiler ? DispatchingProfiler : NoopProfiler;
 const trace = enableDispatchingProfiler ? traceByStack : noTrace;
 
 // holes are *All* selectors which aren't necessary for id selectors
 const [queryDescriptionOf, , getDescriptionOf, , findDescriptionOf] = buildQueries(
   function queryAllDescriptionsOf(container, element) {
-    return container.querySelectorAll(`#${element.getAttribute('aria-describedby')}`);
+    return Array.from(container.querySelectorAll(`#${element.getAttribute('aria-describedby')}`));
   },
   function getMultipleError() {
     return `Found multiple descriptions. An element should be described by a unique element.`;
@@ -143,7 +157,7 @@ const [queryDescriptionOf, , getDescriptionOf, , findDescriptionOf] = buildQueri
 // hide ByLabelText queries since they only support firefox >= 56, not IE 1:
 // - HTMLInputElement.prototype.labels https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/labels
 
-function queryAllByLabelText(container, label) {
+function queryAllByLabelText(element: any, label: string): HTMLElement[] {
   throw new Error(
     `*ByLabelText() relies on features that are not available in older browsers. Prefer \`*ByRole(someRole, { name: '${label}' })\` `,
   );
@@ -176,28 +190,49 @@ const customQueries = {
   findByLabelText,
 };
 
-/**
- * @typedef {object} RenderConfiguration
- * @property {HTMLElement} [baseElement] - https://testing-library.com/docs/react-testing-library/api#baseelement-1
- * @property {HTMLElement} [container] - https://testing-library.com/docs/react-testing-library/api#container
- * @property {boolean} [disableUnnmount] - if true does not cleanup before mount
- * @property {import('@emotion/cache').EmotionCache} emotionCache - Value for the CacheProvider of emotion
- * @property {boolean} [hydrate] - https://testing-library.com/docs/react-testing-library/api#hydrate
- * @property {typeof Profiler} profiler
- * @property {boolean} [strict] - wrap in React.StrictMode?
- */
+interface RenderConfiguration {
+  /**
+   * https://testing-library.com/docs/react-testing-library/api#baseelement-1
+   */
+  baseElement?: HTMLElement;
+  /**
+   * https://testing-library.com/docs/react-testing-library/api#container
+   */
+  container?: HTMLElement;
+  /**
+   * if true does not cleanup before mount
+   */
+  disableUnmount?: boolean;
+  /**
+   * Value for the CacheProvider of emotion
+   */
+  emotionCache: import('@emotion/cache').EmotionCache;
+  /**
+   * https://testing-library.com/docs/react-testing-library/api#hydrate
+   */
+  hydrate?: boolean;
+  profiler: Profiler;
+  /**
+   * wrap in React.StrictMode?
+   */
+  strict?: boolean;
+  wrapper?: React.JSXElementConstructor<{}>;
+}
 
-/**
- * @typedef {Omit<RenderConfiguration, 'emotionCache' | 'profiler'>} RenderOptions
- */
+export type RenderOptions = Omit<RenderConfiguration, 'emotionCache' | 'profiler'>;
 
-/**
- * @param {React.ReactElement} element
- * @param {RenderConfiguration} configuration
- * @returns {import('@testing-library/react').RenderResult<typeof queries & typeof customQueries> & { setProps(props: object): void}}
- * TODO: type return RenderResult in setProps
- */
-function clientRender(element, configuration) {
+interface MuiRenderResult extends RenderResult<typeof queries & typeof customQueries> {
+  forceUpdate(): this;
+  /**
+   * convenience helper. Better than repeating all props.
+   */
+  setProps(props: object): this;
+}
+
+function clientRender(
+  element: React.ReactElement,
+  configuration: RenderConfiguration,
+): MuiRenderResult {
   const {
     baseElement,
     container,
@@ -209,7 +244,7 @@ function clientRender(element, configuration) {
   } = configuration;
 
   const Mode = strict ? React.StrictMode : React.Fragment;
-  function Wrapper({ children }) {
+  function Wrapper({ children }: { children?: React.ReactNode }) {
     return (
       <Mode>
         <EmotionCacheProvider value={emotionCache}>
@@ -222,43 +257,43 @@ function clientRender(element, configuration) {
   }
   Wrapper.propTypes = { children: PropTypes.node };
 
-  const result = trace('render', () =>
-    testingLibraryRender(element, {
-      baseElement,
-      container,
-      hydrate,
-      queries: { ...queries, ...customQueries },
-      wrapper: Wrapper,
-    }),
-  );
-
-  /**
-   * convenience helper. Better than repeating all props.
-   */
-  result.setProps = function setProps(props) {
-    trace('setProps', () => result.rerender(React.cloneElement(element, props)));
-    return result;
-  };
-
-  result.forceUpdate = function forceUpdate() {
-    trace('forceUpdate', () =>
-      result.rerender(
-        React.cloneElement(element, {
-          'data-force-update': String(Math.random()),
-        }),
-      ),
-    );
-    return result;
+  const result: MuiRenderResult = {
+    ...trace('render', () =>
+      testingLibraryRender(element, {
+        baseElement,
+        container,
+        hydrate,
+        queries: { ...queries, ...customQueries },
+        wrapper: Wrapper,
+      }),
+    ),
+    forceUpdate() {
+      trace('forceUpdate', () =>
+        this.rerender(
+          React.cloneElement(element, {
+            'data-force-update': String(Math.random()),
+          }),
+        ),
+      );
+      return this;
+    },
+    setProps(props) {
+      trace('setProps', () => this.rerender(React.cloneElement(element, props)));
+      return this;
+    },
   };
 
   return result;
 }
 
-/**
- * @param {RenderOptions} [globalOptions]
- * @returns {(element: React.ReactElement, options?: RenderOptions) => import('@testing-library/react').RenderResult<typeof queries & typeof customQueries> & { setProps(props: object): void}}
- */
-export function createClientRender(globalOptions = {}) {
+export function createClientRender(
+  globalOptions: RenderOptions = {},
+): (
+  element: React.ReactElement,
+  options?: RenderOptions,
+) => import('@testing-library/react').RenderResult<typeof queries & typeof customQueries> & {
+  setProps(props: object): void;
+} {
   const { strict: globalStrict } = globalOptions;
   // save stack to re-use in test-hooks
   const { stack: createClientRenderStack } = new Error();
@@ -273,8 +308,8 @@ export function createClientRender(globalOptions = {}) {
 
     if (enableDispatchingProfiler) {
       // TODO windows?
-      const filename = new Error().stack
-        ?.split(/\r?\n/)
+      const filename = new Error()
+        .stack!.split(/\r?\n/)
         .map((line) => {
           const fileMatch = line.match(/\(([^)]+):\d+:\d+\)/);
           if (fileMatch === null) {
@@ -285,20 +320,17 @@ export function createClientRender(globalOptions = {}) {
         .find((file) => {
           return file?.endsWith('createClientRender.js');
         });
-      workspaceRoot = filename?.replace('test/utils/createClientRender.js', '');
+      workspaceRoot = filename!.replace('test/utils/createClientRender.js', '');
     }
   });
 
-  /**
-   * @type {import('@emotion/cache').EmotionCache}
-   */
-  let emotionCache = null;
+  let emotionCache: import('@emotion/cache').EmotionCache = null!;
   /**
    * Flag whether all setup for `configuredClientRender` was completed.
    * For legacy reasons `configuredClientRender` might accidentally be called in a before(Each) hook.
    */
   let prepared = false;
-  let profiler = null;
+  let profiler: Profiler = null!;
   beforeEach(function beforeEachHook() {
     if (!wasCalledInSuite) {
       const error = new Error(
@@ -314,7 +346,7 @@ export function createClientRender(globalOptions = {}) {
         'Unable to find the currently running test. This is a bug with the client-renderer. Please report this issue to a maintainer.',
       );
     }
-    profiler = new Profiler(this.currentTest);
+    profiler = new UsedProfiler(test);
 
     emotionCache = createEmotionCache({ key: 'emotion-client-render' });
 
@@ -336,12 +368,12 @@ export function createClientRender(globalOptions = {}) {
 
     cleanup();
     profiler.report();
-    profiler = null;
+    profiler = null!;
 
     emotionCache.sheet.tags.forEach((styleTag) => {
       styleTag.remove();
     });
-    emotionCache = null;
+    emotionCache = null!;
   });
 
   return function configuredClientRender(element, options = {}) {
@@ -359,20 +391,21 @@ export function createClientRender(globalOptions = {}) {
   };
 }
 
-/**
- * @type {typeof rtlFireEvent}
- */
-const fireEvent = (target, event, ...args) => {
+const fireEvent = ((target, event, ...args) => {
   return trace(`firEvent.${event.type}`, () => rtlFireEvent(target, event, ...args));
-};
+}) as typeof rtlFireEvent;
 
-Object.keys(rtlFireEvent).forEach((eventType) => {
-  fireEvent[eventType] = (...args) =>
-    trace(`firEvent.${eventType}`, () => rtlFireEvent[eventType](...args));
-});
+Object.keys(rtlFireEvent).forEach(
+  // @ts-expect-error
+  (eventType: keyof typeof rtlFireEvent) => {
+    fireEvent[eventType] = (...args) =>
+      trace(`firEvent.${eventType}`, () => rtlFireEvent[eventType](...args));
+  },
+);
 
 const originalFireEventKeyDown = rtlFireEvent.keyDown;
-fireEvent.keyDown = (element, options = {}) => {
+fireEvent.keyDown = (desiredTarget, options = {}) => {
+  const element = desiredTarget as Element | Document;
   // `element` shouldn't be `document` but we catch this later anyway
   const document = element.ownerDocument || element;
   const target = document.activeElement || document.body || document.documentElement;
@@ -386,18 +419,19 @@ fireEvent.keyDown = (element, options = {}) => {
       )}`,
     );
     // We're only interested in the callsite of fireEvent.keyDown
-    error.stack = error.stack
-      .split('\n')
+    error.stack = error
+      .stack!.split('\n')
       .filter((line) => !/at Function.key/.test(line))
       .join('\n');
     throw error;
   }
 
-  trace('fireEvent.keyDown', () => originalFireEventKeyDown(element, options));
+  return trace('fireEvent.keyDown', () => originalFireEventKeyDown(element, options));
 };
 
 const originalFireEventKeyUp = rtlFireEvent.keyUp;
-fireEvent.keyUp = (element, options = {}) => {
+fireEvent.keyUp = (desiredTarget, options = {}) => {
+  const element = desiredTarget as Element | Document;
   // `element` shouldn't be `document` but we catch this later anyway
   const document = element.ownerDocument || element;
   const target = document.activeElement || document.body || document.documentElement;
@@ -411,25 +445,21 @@ fireEvent.keyUp = (element, options = {}) => {
       )}`,
     );
     // We're only interested in the callsite of fireEvent.keyUp
-    error.stack = error.stack
-      .split('\n')
+    error.stack = error
+      .stack!.split('\n')
       .filter((line) => !/at Function.key/.test(line))
       .join('\n');
     throw error;
   }
 
-  trace('fireEvent.keyUp', () => originalFireEventKeyUp(element, options));
+  return trace('fireEvent.keyUp', () => originalFireEventKeyUp(element, options));
 };
 
-/**
- *
- * @param {Element} target
- * @param {'touchmove' | 'touchend'} type
- * @param {object} options
- * @param {Array<Pick<TouchInit, 'clientX' | 'clientY'>} options.changedTouches
- * @returns void
- */
-export function fireTouchChangedEvent(target, type, options) {
+export function fireTouchChangedEvent(
+  target: Element,
+  type: 'touchmove' | 'touchend',
+  options: { changedTouches: Array<Pick<TouchInit, 'clientX' | 'clientY'>> },
+): void {
   const { changedTouches } = options;
   const originalGetBoundingClientRect = target.getBoundingClientRect;
   target.getBoundingClientRect = () => ({
@@ -441,6 +471,18 @@ export function fireTouchChangedEvent(target, type, options) {
     right: 0,
     top: 0,
     width: 0,
+    toJSON() {
+      return {
+        x: 0,
+        y: 0,
+        bottom: 0,
+        height: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        width: 0,
+      };
+    },
   });
 
   const event = new window.TouchEvent(type, {
@@ -461,7 +503,7 @@ export function fireTouchChangedEvent(target, type, options) {
   target.getBoundingClientRect = originalGetBoundingClientRect;
 }
 
-export function act(callback) {
+export function act(callback: () => void) {
   return trace('act', () => rtlAct(callback));
 }
 

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -95,7 +95,7 @@ class DispatchingProfiler implements Profiler {
     this.id = test.fullTitle();
   }
 
-  onRender: import('react').ProfilerOnRenderCallback = (
+  onRender: Profiler['onRender'] = (
     id,
     phase,
     actualDuration,

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -32,7 +32,6 @@ let workspaceRoot: string;
 
 /**
  * interactionName - Human readable label for this particular interaction.
- * callback
  */
 function traceByStack<T>(interactionName: string, callback: () => T): T {
   const { stack } = new Error();

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -257,19 +257,20 @@ function clientRender(
   }
   Wrapper.propTypes = { children: PropTypes.node };
 
+  const testingLibraryRenderResult = trace('render', () =>
+    testingLibraryRender(element, {
+      baseElement,
+      container,
+      hydrate,
+      queries: { ...queries, ...customQueries },
+      wrapper: Wrapper,
+    }),
+  );
   const result: MuiRenderResult = {
-    ...trace('render', () =>
-      testingLibraryRender(element, {
-        baseElement,
-        container,
-        hydrate,
-        queries: { ...queries, ...customQueries },
-        wrapper: Wrapper,
-      }),
-    ),
+    ...testingLibraryRenderResult,
     forceUpdate() {
       trace('forceUpdate', () =>
-        this.rerender(
+        testingLibraryRenderResult.rerender(
           React.cloneElement(element, {
             'data-force-update': String(Math.random()),
           }),
@@ -277,7 +278,9 @@ function clientRender(
       );
     },
     setProps(props) {
-      trace('setProps', () => this.rerender(React.cloneElement(element, props)));
+      trace('setProps', () =>
+        testingLibraryRenderResult.rerender(React.cloneElement(element, props)),
+      );
     },
   };
 
@@ -286,12 +289,7 @@ function clientRender(
 
 export function createClientRender(
   globalOptions: RenderOptions = {},
-): (
-  element: React.ReactElement,
-  options?: RenderOptions,
-) => import('@testing-library/react').RenderResult<typeof queries & typeof customQueries> & {
-  setProps(props: object): void;
-} {
+): (element: React.ReactElement, options?: RenderOptions) => MuiRenderResult {
   const { strict: globalStrict } = globalOptions;
   // save stack to re-use in test-hooks
   const { stack: createClientRenderStack } = new Error();

--- a/tslint.json
+++ b/tslint.json
@@ -17,6 +17,8 @@
     "no-unnecessary-callback-wrapper": false,
     "no-unnecessary-generics": false,
     "no-redundant-jsdoc": false,
-    "semicolon": [true, "always", "ignore-bound-class-methods"]
+    "semicolon": [true, "always", "ignore-bound-class-methods"],
+    // rules conflicting with eslint
+    "prefer-template": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,12 +3185,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.0":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
-  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.0", "@types/react@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
   dependencies:
     "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/recharts@^1.8.14":
@@ -3213,7 +3214,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/scheduler@^0.16.1":
+"@types/scheduler@*", "@types/scheduler@^0.16.1":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,6 +3213,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/scheduler@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
 "@types/sinon@^9.0.0":
   version "9.0.10"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.10.tgz#7fb9bcb6794262482859cab66d59132fca18fcf7"


### PR DESCRIPTION
The file had a couple of mistakes and incomplete typings. These cannot be all fixed with `@ts-check`.

TODO:
- [x] `test_profile` still works (see hardcoded filename)
   - https://app.circleci.com/pipelines/github/mui-org/material-ui/38971/workflows/b0a64ca2-3a67-4195-9397-6f2bf7604747/jobs/230223
   - https://mui-dashboard.netlify.app/test-profile/230223