### PR TITLE
[docs] Migrate Fab demos to emotion

### DIFF
--- a/docs/src/pages/components/container/FixedContainer.js
+++ b/docs/src/pages/components/container/FixedContainer.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 
 export default function FixedContainer() {
@@ -8,13 +8,7 @@ export default function FixedContainer() {
     <React.Fragment>
       <CssBaseline />
       <Container fixed>
-        <Typography
-          component="div"
-          style={{
-            backgroundColor: '#cfe8fc',
-            height: '100vh',
-          }}
-        />
+        <Box sx={{ bgcolor: '#cfe8fc', height: '100vh' }} />
       </Container>
     </React.Fragment>
   );

--- a/docs/src/pages/components/container/FixedContainer.tsx
+++ b/docs/src/pages/components/container/FixedContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 
 export default function FixedContainer() {
@@ -8,13 +8,7 @@ export default function FixedContainer() {
     <React.Fragment>
       <CssBaseline />
       <Container fixed>
-        <Typography
-          component="div"
-          style={{
-            backgroundColor: '#cfe8fc',
-            height: '100vh',
-          }}
-        />
+        <Box sx={{ bgcolor: '#cfe8fc', height: '100vh' }} />
       </Container>
     </React.Fragment>
   );

--- a/docs/src/pages/components/container/SimpleContainer.js
+++ b/docs/src/pages/components/container/SimpleContainer.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 
 export default function SimpleContainer() {
@@ -8,13 +8,7 @@ export default function SimpleContainer() {
     <React.Fragment>
       <CssBaseline />
       <Container maxWidth="sm">
-        <Typography
-          component="div"
-          style={{
-            backgroundColor: '#cfe8fc',
-            height: '100vh',
-          }}
-        />
+        <Box sx={{ bgcolor: '#cfe8fc', height: '100vh' }} />
       </Container>
     </React.Fragment>
   );

--- a/docs/src/pages/components/container/SimpleContainer.tsx
+++ b/docs/src/pages/components/container/SimpleContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 
 export default function SimpleContainer() {
@@ -8,13 +8,7 @@ export default function SimpleContainer() {
     <React.Fragment>
       <CssBaseline />
       <Container maxWidth="sm">
-        <Typography
-          component="div"
-          style={{
-            backgroundColor: '#cfe8fc',
-            height: '100vh',
-          }}
-        />
+        <Box sx={{ bgcolor: '#cfe8fc', height: '100vh' }} />
       </Container>
     </React.Fragment>
   );

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.js
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.js
@@ -9,6 +9,7 @@ export default function FloatingActionButtonSize() {
     <Box
       sx={{
         '& button': { m: 1 },
+        '& svg': { mr: 1 },
       }}
     >
       <div>
@@ -22,11 +23,7 @@ export default function FloatingActionButtonSize() {
           <AddIcon />
         </Fab>
       </div>
-      <Box
-        sx={{
-          '& svg': { mr: 1 },
-        }}
-      >
+      <div>
         <Fab variant="extended" size="small" color="primary" aria-label="add">
           <NavigationIcon />
           Extended
@@ -39,7 +36,7 @@ export default function FloatingActionButtonSize() {
           <NavigationIcon />
           Extended
         </Fab>
-      </Box>
+      </div>
     </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.js
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.js
@@ -1,75 +1,45 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import NavigationIcon from '@material-ui/icons/Navigation';
 
-const useStyles = makeStyles((theme) => ({
-  margin: {
-    margin: theme.spacing(1),
-  },
-  extendedIcon: {
-    marginRight: theme.spacing(1),
-  },
-}));
-
 export default function FloatingActionButtonSize() {
-  const classes = useStyles();
-
   return (
-    <div>
+    <Box
+      sx={{
+        '& button': { m: 1 },
+      }}
+    >
       <div>
-        <Fab
-          size="small"
-          color="secondary"
-          aria-label="add"
-          className={classes.margin}
-        >
+        <Fab size="small" color="secondary" aria-label="add">
           <AddIcon />
         </Fab>
-        <Fab
-          size="medium"
-          color="secondary"
-          aria-label="add"
-          className={classes.margin}
-        >
+        <Fab size="medium" color="secondary" aria-label="add">
           <AddIcon />
         </Fab>
-        <Fab color="secondary" aria-label="add" className={classes.margin}>
+        <Fab color="secondary" aria-label="add">
           <AddIcon />
         </Fab>
       </div>
-      <div>
-        <Fab
-          variant="extended"
-          size="small"
-          color="primary"
-          aria-label="add"
-          className={classes.margin}
-        >
-          <NavigationIcon className={classes.extendedIcon} />
+      <Box
+        sx={{
+          '& svg': { mr: 1 },
+        }}
+      >
+        <Fab variant="extended" size="small" color="primary" aria-label="add">
+          <NavigationIcon />
           Extended
         </Fab>
-        <Fab
-          variant="extended"
-          size="medium"
-          color="primary"
-          aria-label="add"
-          className={classes.margin}
-        >
-          <NavigationIcon className={classes.extendedIcon} />
+        <Fab variant="extended" size="medium" color="primary" aria-label="add">
+          <NavigationIcon />
           Extended
         </Fab>
-        <Fab
-          variant="extended"
-          color="primary"
-          aria-label="add"
-          className={classes.margin}
-        >
-          <NavigationIcon className={classes.extendedIcon} />
+        <Fab variant="extended" color="primary" aria-label="add">
+          <NavigationIcon />
           Extended
         </Fab>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.tsx
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.tsx
@@ -9,6 +9,7 @@ export default function FloatingActionButtonSize() {
     <Box
       sx={{
         '& button': { m: 1 },
+        '& svg': { mr: 1 },
       }}
     >
       <div>
@@ -22,7 +23,7 @@ export default function FloatingActionButtonSize() {
           <AddIcon />
         </Fab>
       </div>
-      <Box>
+      <div>
         <Fab variant="extended" size="small" color="primary" aria-label="add">
           <NavigationIcon />
           Extended
@@ -35,7 +36,7 @@ export default function FloatingActionButtonSize() {
           <NavigationIcon />
           Extended
         </Fab>
-      </Box>
+      </div>
     </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.tsx
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonSize.tsx
@@ -1,77 +1,41 @@
 import * as React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import NavigationIcon from '@material-ui/icons/Navigation';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    margin: {
-      margin: theme.spacing(1),
-    },
-    extendedIcon: {
-      marginRight: theme.spacing(1),
-    },
-  }),
-);
-
 export default function FloatingActionButtonSize() {
-  const classes = useStyles();
-
   return (
-    <div>
+    <Box
+      sx={{
+        '& button': { m: 1 },
+      }}
+    >
       <div>
-        <Fab
-          size="small"
-          color="secondary"
-          aria-label="add"
-          className={classes.margin}
-        >
+        <Fab size="small" color="secondary" aria-label="add">
           <AddIcon />
         </Fab>
-        <Fab
-          size="medium"
-          color="secondary"
-          aria-label="add"
-          className={classes.margin}
-        >
+        <Fab size="medium" color="secondary" aria-label="add">
           <AddIcon />
         </Fab>
-        <Fab color="secondary" aria-label="add" className={classes.margin}>
+        <Fab color="secondary" aria-label="add">
           <AddIcon />
         </Fab>
       </div>
-      <div>
-        <Fab
-          variant="extended"
-          size="small"
-          color="primary"
-          aria-label="add"
-          className={classes.margin}
-        >
-          <NavigationIcon className={classes.extendedIcon} />
+      <Box>
+        <Fab variant="extended" size="small" color="primary" aria-label="add">
+          <NavigationIcon />
           Extended
         </Fab>
-        <Fab
-          variant="extended"
-          size="medium"
-          color="primary"
-          aria-label="add"
-          className={classes.margin}
-        >
-          <NavigationIcon className={classes.extendedIcon} />
+        <Fab variant="extended" size="medium" color="primary" aria-label="add">
+          <NavigationIcon />
           Extended
         </Fab>
-        <Fab
-          variant="extended"
-          color="primary"
-          aria-label="add"
-          className={classes.margin}
-        >
-          <NavigationIcon className={classes.extendedIcon} />
+        <Fab variant="extended" color="primary" aria-label="add">
+          <NavigationIcon />
           Extended
         </Fab>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.js
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import SwipeableViews from 'react-swipeable-views';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { useTheme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -45,29 +44,21 @@ function a11yProps(index) {
   };
 }
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.paper,
-    width: 500,
-    position: 'relative',
-    minHeight: 200,
+const fabStyle = {
+  position: 'absolute',
+  bottom: 16,
+  right: 16,
+};
+
+const fabGreenStyle = {
+  color: 'common.white',
+  bgcolor: green[500],
+  '&:hover': {
+    bgcolor: green[600],
   },
-  fab: {
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-  fabGreen: {
-    color: theme.palette.common.white,
-    backgroundColor: green[500],
-    '&:hover': {
-      backgroundColor: green[600],
-    },
-  },
-}));
+};
 
 export default function FloatingActionButtonZoom() {
-  const classes = useStyles();
   const theme = useTheme();
   const [value, setValue] = React.useState(0);
 
@@ -87,26 +78,33 @@ export default function FloatingActionButtonZoom() {
   const fabs = [
     {
       color: 'primary',
-      className: classes.fab,
+      className: fabStyle,
       icon: <AddIcon />,
       label: 'Add',
     },
     {
       color: 'secondary',
-      className: classes.fab,
+      className: fabStyle,
       icon: <EditIcon />,
       label: 'Edit',
     },
     {
       color: 'inherit',
-      className: clsx(classes.fab, classes.fabGreen),
+      className: { ...fabStyle, ...fabGreenStyle },
       icon: <UpIcon />,
       label: 'Expand',
     },
   ];
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        width: 500,
+        position: 'relative',
+        minHeight: 200,
+      }}
+    >
       <AppBar position="static" color="default">
         <Tabs
           value={value}
@@ -146,11 +144,11 @@ export default function FloatingActionButtonZoom() {
           }}
           unmountOnExit
         >
-          <Fab aria-label={fab.label} className={fab.className} color={fab.color}>
+          <Fab sx={fab.className} aria-label={fab.label} color={fab.color}>
             {fab.icon}
           </Fab>
         </Zoom>
       ))}
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.tsx
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import SwipeableViews from 'react-swipeable-views';
 import { useTheme } from '@material-ui/core/styles';
+import { SxProps } from '@material-ui/system';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -78,19 +79,19 @@ export default function FloatingActionButtonZoom() {
   const fabs = [
     {
       color: 'primary' as 'primary',
-      className: fabStyle,
+      className: fabStyle as SxProps,
       icon: <AddIcon />,
       label: 'Add',
     },
     {
       color: 'secondary' as 'secondary',
-      className: fabStyle,
+      className: fabStyle as SxProps,
       icon: <EditIcon />,
       label: 'Edit',
     },
     {
       color: 'inherit' as 'inherit',
-      className: { ...fabStyle, ...fabGreenStyle },
+      className: { ...fabStyle, ...fabGreenStyle } as SxProps,
       icon: <UpIcon />,
       label: 'Expand',
     },

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.tsx
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtonZoom.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import clsx from 'clsx';
 import SwipeableViews from 'react-swipeable-views';
-import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/core/styles';
+import { useTheme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -45,31 +44,21 @@ function a11yProps(index: any) {
   };
 }
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      backgroundColor: theme.palette.background.paper,
-      width: 500,
-      position: 'relative',
-      minHeight: 200,
-    },
-    fab: {
-      position: 'absolute',
-      bottom: theme.spacing(2),
-      right: theme.spacing(2),
-    },
-    fabGreen: {
-      color: theme.palette.common.white,
-      backgroundColor: green[500],
-      '&:hover': {
-        backgroundColor: green[600],
-      },
-    },
-  }),
-);
+const fabStyle = {
+  position: 'absolute',
+  bottom: 16,
+  right: 16,
+};
+
+const fabGreenStyle = {
+  color: 'common.white',
+  bgcolor: green[500],
+  '&:hover': {
+    bgcolor: green[600],
+  },
+};
 
 export default function FloatingActionButtonZoom() {
-  const classes = useStyles();
   const theme = useTheme();
   const [value, setValue] = React.useState(0);
 
@@ -89,26 +78,33 @@ export default function FloatingActionButtonZoom() {
   const fabs = [
     {
       color: 'primary' as 'primary',
-      className: classes.fab,
+      className: fabStyle,
       icon: <AddIcon />,
       label: 'Add',
     },
     {
       color: 'secondary' as 'secondary',
-      className: classes.fab,
+      className: fabStyle,
       icon: <EditIcon />,
       label: 'Edit',
     },
     {
       color: 'inherit' as 'inherit',
-      className: clsx(classes.fab, classes.fabGreen),
+      className: { ...fabStyle, ...fabGreenStyle },
       icon: <UpIcon />,
       label: 'Expand',
     },
   ];
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        width: 500,
+        position: 'relative',
+        minHeight: 200,
+      }}
+    >
       <AppBar position="static" color="default">
         <Tabs
           value={value}
@@ -148,11 +144,11 @@ export default function FloatingActionButtonZoom() {
           }}
           unmountOnExit
         >
-          <Fab aria-label={fab.label} className={fab.className} color={fab.color}>
+          <Fab sx={fab.className} aria-label={fab.label} color={fab.color}>
             {fab.icon}
           </Fab>
         </Zoom>
       ))}
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtons.js
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtons.js
@@ -1,27 +1,19 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import EditIcon from '@material-ui/icons/Edit';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import NavigationIcon from '@material-ui/icons/Navigation';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  extendedIcon: {
-    marginRight: theme.spacing(1),
-  },
-}));
-
 export default function FloatingActionButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        // TODO Replace with Stack
+        '& > :not(style)': { m: 1 },
+      }}
+    >
       <Fab color="primary" aria-label="add">
         <AddIcon />
       </Fab>
@@ -29,12 +21,12 @@ export default function FloatingActionButtons() {
         <EditIcon />
       </Fab>
       <Fab variant="extended">
-        <NavigationIcon className={classes.extendedIcon} />
+        <NavigationIcon sx={{ mr: 1 }} />
         Navigate
       </Fab>
       <Fab disabled aria-label="like">
         <FavoriteIcon />
       </Fab>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/floating-action-button/FloatingActionButtons.tsx
+++ b/docs/src/pages/components/floating-action-button/FloatingActionButtons.tsx
@@ -1,29 +1,19 @@
 import * as React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import EditIcon from '@material-ui/icons/Edit';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import NavigationIcon from '@material-ui/icons/Navigation';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    extendedIcon: {
-      marginRight: theme.spacing(1),
-    },
-  }),
-);
-
 export default function FloatingActionButtons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        // TODO Replace with Stack
+        '& > :not(style)': { m: 1 },
+      }}
+    >
       <Fab color="primary" aria-label="add">
         <AddIcon />
       </Fab>
@@ -31,12 +21,12 @@ export default function FloatingActionButtons() {
         <EditIcon />
       </Fab>
       <Fab variant="extended">
-        <NavigationIcon className={classes.extendedIcon} />
+        <NavigationIcon sx={{ mr: 1 }} />
         Navigate
       </Fab>
       <Fab disabled aria-label="like">
         <FavoriteIcon />
       </Fab>
-    </div>
+    </Box>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Fab component were migrated:

- [x] Basic fab
- [x] Sizes fab
- [x] Animation fab

Related to #16947 