### PR TITLE
[docs] Migrate Transfer List demos to emotion

### DIFF
--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.js
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
@@ -8,12 +7,8 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Checkbox from '@material-ui/core/Checkbox';
-import MuiButton from '@material-ui/core/Button';
+import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
-
-const Button = styled(MuiButton)(({ theme }) => ({
-  margin: theme.spacing(0.5, 0),
-}));
 
 function not(a, b) {
   return a.filter((value) => b.indexOf(value) === -1);
@@ -137,6 +132,7 @@ export default function TransferList() {
       <Grid item>
         <Grid container direction="column" alignItems="center">
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedRight}
@@ -146,6 +142,7 @@ export default function TransferList() {
             &gt;
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedLeft}

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.js
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
@@ -8,22 +8,11 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Checkbox from '@material-ui/core/Checkbox';
-import Button from '@material-ui/core/Button';
+import MuiButton from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme) => ({
-  cardHeader: {
-    padding: theme.spacing(1, 2),
-  },
-  list: {
-    width: 200,
-    height: 230,
-    backgroundColor: theme.palette.background.paper,
-    overflow: 'auto',
-  },
-  button: {
-    margin: theme.spacing(0.5, 0),
-  },
+const Button = styled(MuiButton)(({ theme }) => ({
+  margin: theme.spacing(0.5, 0),
 }));
 
 function not(a, b) {
@@ -39,7 +28,6 @@ function union(a, b) {
 }
 
 export default function TransferList() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState([]);
   const [left, setLeft] = React.useState([0, 1, 2, 3]);
   const [right, setRight] = React.useState([4, 5, 6, 7]);
@@ -85,7 +73,7 @@ export default function TransferList() {
   const customList = (title, items) => (
     <Card>
       <CardHeader
-        className={classes.cardHeader}
+        sx={{ px: 2, py: 1 }}
         avatar={
           <Checkbox
             onClick={handleToggleAll(items)}
@@ -103,7 +91,17 @@ export default function TransferList() {
         subheader={`${numberOfChecked(items)}/${items.length} selected`}
       />
       <Divider />
-      <List className={classes.list} dense component="div" role="list">
+      <List
+        sx={{
+          width: 200,
+          height: 230,
+          bgcolor: 'background.paper',
+          overflow: 'auto',
+        }}
+        dense
+        component="div"
+        role="list"
+      >
         {items.map((value) => {
           const labelId = `transfer-list-all-item-${value}-label`;
 
@@ -141,7 +139,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedRight}
             disabled={leftChecked.length === 0}
             aria-label="move selected right"
@@ -151,7 +148,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedLeft}
             disabled={rightChecked.length === 0}
             aria-label="move selected left"

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
@@ -8,12 +7,8 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Checkbox from '@material-ui/core/Checkbox';
-import MuiButton from '@material-ui/core/Button';
+import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
-
-const Button = styled(MuiButton)(({ theme }) => ({
-  margin: theme.spacing(0.5, 0),
-}));
 
 function not(a: number[], b: number[]) {
   return a.filter((value) => b.indexOf(value) === -1);
@@ -137,6 +132,7 @@ export default function TransferList() {
       <Grid item>
         <Grid container direction="column" alignItems="center">
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedRight}
@@ -146,6 +142,7 @@ export default function TransferList() {
             &gt;
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedLeft}

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
@@ -8,25 +8,12 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Checkbox from '@material-ui/core/Checkbox';
-import Button from '@material-ui/core/Button';
+import MuiButton from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    cardHeader: {
-      padding: theme.spacing(1, 2),
-    },
-    list: {
-      width: 200,
-      height: 230,
-      backgroundColor: theme.palette.background.paper,
-      overflow: 'auto',
-    },
-    button: {
-      margin: theme.spacing(0.5, 0),
-    },
-  }),
-);
+const Button = styled(MuiButton)(({ theme }) => ({
+  margin: theme.spacing(0.5, 0),
+}));
 
 function not(a: number[], b: number[]) {
   return a.filter((value) => b.indexOf(value) === -1);
@@ -41,7 +28,6 @@ function union(a: number[], b: number[]) {
 }
 
 export default function TransferList() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState<number[]>([]);
   const [left, setLeft] = React.useState<number[]>([0, 1, 2, 3]);
   const [right, setRight] = React.useState<number[]>([4, 5, 6, 7]);
@@ -87,7 +73,7 @@ export default function TransferList() {
   const customList = (title: React.ReactNode, items: number[]) => (
     <Card>
       <CardHeader
-        className={classes.cardHeader}
+        sx={{ px: 2, py: 1 }}
         avatar={
           <Checkbox
             onClick={handleToggleAll(items)}
@@ -105,7 +91,17 @@ export default function TransferList() {
         subheader={`${numberOfChecked(items)}/${items.length} selected`}
       />
       <Divider />
-      <List className={classes.list} dense component="div" role="list">
+      <List
+        sx={{
+          width: 200,
+          height: 230,
+          bgcolor: 'background.paper',
+          overflow: 'auto',
+        }}
+        dense
+        component="div"
+        role="list"
+      >
         {items.map((value: number) => {
           const labelId = `transfer-list-all-item-${value}-label`;
 
@@ -143,7 +139,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedRight}
             disabled={leftChecked.length === 0}
             aria-label="move selected right"
@@ -153,7 +148,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedLeft}
             disabled={rightChecked.length === 0}
             aria-label="move selected left"

--- a/docs/src/pages/components/transfer-list/TransferList.js
+++ b/docs/src/pages/components/transfer-list/TransferList.js
@@ -1,23 +1,16 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Checkbox from '@material-ui/core/Checkbox';
-import Button from '@material-ui/core/Button';
+import MuiButton from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 
-const useStyles = makeStyles((theme) => ({
-  paper: {
-    width: 200,
-    height: 230,
-    overflow: 'auto',
-  },
-  button: {
-    margin: theme.spacing(0.5, 0),
-  },
+const Button = styled(MuiButton)(({ theme }) => ({
+  margin: theme.spacing(0.5, 0),
 }));
 
 function not(a, b) {
@@ -29,7 +22,6 @@ function intersection(a, b) {
 }
 
 export default function TransferList() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState([]);
   const [left, setLeft] = React.useState([0, 1, 2, 3]);
   const [right, setRight] = React.useState([4, 5, 6, 7]);
@@ -73,7 +65,7 @@ export default function TransferList() {
   };
 
   const customList = (items) => (
-    <Paper className={classes.paper}>
+    <Paper sx={{ width: 200, height: 230, overflow: 'auto' }}>
       <List dense component="div" role="list">
         {items.map((value) => {
           const labelId = `transfer-list-item-${value}-label`;
@@ -112,7 +104,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleAllRight}
             disabled={left.length === 0}
             aria-label="move all right"
@@ -122,7 +113,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedRight}
             disabled={leftChecked.length === 0}
             aria-label="move selected right"
@@ -132,7 +122,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedLeft}
             disabled={rightChecked.length === 0}
             aria-label="move selected left"
@@ -142,7 +131,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleAllLeft}
             disabled={right.length === 0}
             aria-label="move all left"

--- a/docs/src/pages/components/transfer-list/TransferList.js
+++ b/docs/src/pages/components/transfer-list/TransferList.js
@@ -1,17 +1,12 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Checkbox from '@material-ui/core/Checkbox';
-import MuiButton from '@material-ui/core/Button';
+import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
-
-const Button = styled(MuiButton)(({ theme }) => ({
-  margin: theme.spacing(0.5, 0),
-}));
 
 function not(a, b) {
   return a.filter((value) => b.indexOf(value) === -1);
@@ -102,6 +97,7 @@ export default function TransferList() {
       <Grid item>
         <Grid container direction="column" alignItems="center">
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleAllRight}
@@ -111,6 +107,7 @@ export default function TransferList() {
             ≫
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedRight}
@@ -120,6 +117,7 @@ export default function TransferList() {
             &gt;
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedLeft}
@@ -129,6 +127,7 @@ export default function TransferList() {
             &lt;
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleAllLeft}

--- a/docs/src/pages/components/transfer-list/TransferList.tsx
+++ b/docs/src/pages/components/transfer-list/TransferList.tsx
@@ -1,17 +1,12 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Checkbox from '@material-ui/core/Checkbox';
-import MuiButton from '@material-ui/core/Button';
+import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
-
-const Button = styled(MuiButton)(({ theme }) => ({
-  margin: theme.spacing(0.5, 0),
-}));
 
 function not(a: number[], b: number[]) {
   return a.filter((value) => b.indexOf(value) === -1);
@@ -102,6 +97,7 @@ export default function TransferList() {
       <Grid item>
         <Grid container direction="column" alignItems="center">
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleAllRight}
@@ -111,6 +107,7 @@ export default function TransferList() {
             ≫
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedRight}
@@ -120,6 +117,7 @@ export default function TransferList() {
             &gt;
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleCheckedLeft}
@@ -129,6 +127,7 @@ export default function TransferList() {
             &lt;
           </Button>
           <Button
+            sx={{ my: 0.5 }}
             variant="outlined"
             size="small"
             onClick={handleAllLeft}

--- a/docs/src/pages/components/transfer-list/TransferList.tsx
+++ b/docs/src/pages/components/transfer-list/TransferList.tsx
@@ -1,26 +1,17 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Checkbox from '@material-ui/core/Checkbox';
-import Button from '@material-ui/core/Button';
+import MuiButton from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paper: {
-      width: 200,
-      height: 230,
-      overflow: 'auto',
-    },
-    button: {
-      margin: theme.spacing(0.5, 0),
-    },
-  }),
-);
+const Button = styled(MuiButton)(({ theme }) => ({
+  margin: theme.spacing(0.5, 0),
+}));
 
 function not(a: number[], b: number[]) {
   return a.filter((value) => b.indexOf(value) === -1);
@@ -31,7 +22,6 @@ function intersection(a: number[], b: number[]) {
 }
 
 export default function TransferList() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState<number[]>([]);
   const [left, setLeft] = React.useState<number[]>([0, 1, 2, 3]);
   const [right, setRight] = React.useState<number[]>([4, 5, 6, 7]);
@@ -75,7 +65,7 @@ export default function TransferList() {
   };
 
   const customList = (items: number[]) => (
-    <Paper className={classes.paper}>
+    <Paper sx={{ width: 200, height: 230, overflow: 'auto' }}>
       <List dense component="div" role="list">
         {items.map((value: number) => {
           const labelId = `transfer-list-item-${value}-label`;
@@ -114,7 +104,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleAllRight}
             disabled={left.length === 0}
             aria-label="move all right"
@@ -124,7 +113,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedRight}
             disabled={leftChecked.length === 0}
             aria-label="move selected right"
@@ -134,7 +122,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleCheckedLeft}
             disabled={rightChecked.length === 0}
             aria-label="move selected left"
@@ -144,7 +131,6 @@ export default function TransferList() {
           <Button
             variant="outlined"
             size="small"
-            className={classes.button}
             onClick={handleAllLeft}
             disabled={right.length === 0}
             aria-label="move all left"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Transfer List component were migrated:

- [x] Basic transfer list
- [x] Enhanced transfer list

Related to #16947