### PR TITLE
[Tooltip] Fix placement regression

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -143,37 +143,37 @@ const TooltipTooltip = experimentalStyled(
     fontWeight: theme.typography.fontWeightRegular,
   }),
   /* Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
-  ...(styleProps.placement.split('-')[0] === 'left' && {
+  [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
     marginRight: '24px',
     [theme.breakpoints.up('sm')]: {
       marginRight: '14px',
     },
-  }),
+  },
   /* Styles applied to the tooltip (label wrapper) element if `placement` contains "right". */
-  ...(styleProps.placement.split('-')[0] === 'right' && {
+  [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
     marginLeft: '24px',
     [theme.breakpoints.up('sm')]: {
       marginLeft: '14px',
     },
-  }),
+  },
   /* Styles applied to the tooltip (label wrapper) element if `placement` contains "top". */
-  ...(styleProps.placement.split('-')[0] === 'top' && {
+  [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',
     marginBottom: '24px',
     [theme.breakpoints.up('sm')]: {
       marginBottom: '14px',
     },
-  }),
+  },
   /* Styles applied to the tooltip (label wrapper) element if `placement` contains "bottom". */
-  ...(styleProps.placement.split('-')[0] === 'bottom' && {
+  [`.${tooltipClasses.popper}[data-popper-placement*="bottom"] &`]: {
     transformOrigin: 'center top',
     marginTop: '24px',
     [theme.breakpoints.up('sm')]: {
       marginTop: '14px',
     },
-  }),
+  },
 }));
 
 const TooltipArrow = experimentalStyled(


### PR DESCRIPTION
I have found this regression having a quick look at #25215.

To reproduce, you can:

- open https://next.material-ui.com/components/tooltips/#positioned-tooltips
- keyboard focus the bottom-start case, the tooltip should open
- scroll the page up until the tooltip swap its placement

**Before**
<img width="134" alt="Screenshot 2021-03-07 at 19 19 58" src="https://user-images.githubusercontent.com/3165635/110250176-424cd000-7f7a-11eb-82c9-a4a85088481f.png">

**After**
<img width="142" alt="Screenshot 2021-03-07 at 19 20 10 1" src="https://user-images.githubusercontent.com/3165635/110250177-437dfd00-7f7a-11eb-9081-f2d19b17a745.png">
