### PR TITLE
[Popover] Add pointer-events CSS property to enable interactions with the rest of the page

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -67,7 +67,9 @@ function getAnchorEl(anchorEl) {
 
 export const styles = {
   /* Styles applied to the root element. */
-  root: {},
+  root: {
+    pointerEvents: 'none',
+  },
   /* Styles applied to the Paper component. */
   paper: {
     position: 'absolute',


### PR DESCRIPTION
Hi! I'm excited to be contributing to this project for the first time. Please let me know if there is anything else that needs to be addressed.

This issue has been addressed several times, and the use case for such change would be to use `Popover` on hover.
- #7680 [Popover] event handlers issue (mouseEnter and mouseLeave)
- #7212 [Popover] Not working well with `onMouseLeave`

The change introduced is to add `pointer-events` CSS property to enable interactions with the rest of the page.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).