### PR TITLE
[SpeedDial] Reset tooltip state when the speed dial is closed

### DIFF
--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -360,7 +360,13 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
   });
 
   const children = allItems.map((child, index) => {
-    const { FabProps: { ref: origButtonRef, ...ChildFabProps } = {} } = child.props;
+    const {
+      FabProps: { ref: origButtonRef, ...ChildFabProps } = {},
+      tooltipPlacement: tooltipPlacementProp,
+    } = child.props;
+
+    const tooltipPlacement =
+      tooltipPlacementProp || getOrientation(direction) === 'vertical' ? 'left' : 'top';
 
     return React.cloneElement(child, {
       FabProps: {
@@ -369,6 +375,7 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
       },
       delay: 30 * (open ? index : allItems.length - index),
       open,
+      tooltipPlacement,
       id: `${id}-action-${index}`,
     });
   });

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -366,7 +366,7 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
     } = child.props;
 
     const tooltipPlacement =
-      tooltipPlacementProp || getOrientation(direction) === 'vertical' ? 'left' : 'top';
+      tooltipPlacementProp || (getOrientation(direction) === 'vertical' ? 'left' : 'top');
 
     return React.cloneElement(child, {
       FabProps: {

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -239,6 +239,8 @@ describe('<SpeedDial />', () => {
       });
       expect(queryByRole('tooltip')).not.to.equal(null);
 
+      // Manually fire an event to avoid calling act with:
+      // fireEvent.keyDown(actions[0], { key: 'Escape' });
       const escapeEvent = new window.Event('KeyboardEvent');
       escapeEvent.initEvent('keydown', true);
       escapeEvent.key = 'Escape';

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -229,6 +229,7 @@ describe('<SpeedDial />', () => {
       act(() => {
         clock.runAll();
       });
+
       expect(fab).to.have.attribute('aria-expanded', 'true');
 
       fireEvent.keyDown(fab, { key: 'ArrowUp' });
@@ -246,6 +247,7 @@ describe('<SpeedDial />', () => {
       act(() => {
         clock.runAll();
       });
+
       expect(queryByRole('tooltip')).to.equal(null);
       expect(fab).to.have.attribute('aria-expanded', 'false');
 

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -96,7 +96,7 @@ describe('<SpeedDial />', () => {
     expect(actions.map((element) => element.className)).not.to.contain('is-closed');
   });
 
-  it('should reset the state of the tooltip when the speed dial is closed while it is open', () => {
+  it.skip('should reset the state of the tooltip when the speed dial is closed while it is open', () => {
     const { queryByRole, getByRole, getAllByRole } = render(
       <SpeedDial icon={icon} ariaLabel="mySpeedDial">
         <SpeedDialAction icon={icon} tooltipTitle="SpeedDialAction1" />
@@ -239,11 +239,11 @@ describe('<SpeedDial />', () => {
       expect(queryByRole('tooltip')).not.to.equal(null);
 
       // Manually fire an event to avoid calling act with:
-      // fireEvent.keyDown(actions[0], { key: 'Escape' });
-      const escapeEvent = new window.Event('KeyboardEvent');
-      escapeEvent.initEvent('keydown', true);
-      escapeEvent.key = 'Escape';
-      actions[0].dispatchEvent(escapeEvent);
+      fireEvent.keyDown(actions[0], { key: 'Escape' });
+      // const escapeEvent = new window.Event('KeyboardEvent');
+      // escapeEvent.initEvent('keydown', true);
+      // escapeEvent.key = 'Escape';
+      // actions[0].dispatchEvent(escapeEvent);
       act(() => {
         clock.runAll();
       });

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -96,7 +96,7 @@ describe('<SpeedDial />', () => {
     expect(actions.map((element) => element.className)).not.to.contain('is-closed');
   });
 
-  it.skip('should reset the state of the tooltip when the speed dial is closed while it is open', () => {
+  it('should reset the state of the tooltip when the speed dial is closed while it is open', () => {
     const { queryByRole, getByRole, getAllByRole } = render(
       <SpeedDial icon={icon} ariaLabel="mySpeedDial">
         <SpeedDialAction icon={icon} tooltipTitle="SpeedDialAction1" />
@@ -239,11 +239,11 @@ describe('<SpeedDial />', () => {
       expect(queryByRole('tooltip')).not.to.equal(null);
 
       // Manually fire an event to avoid calling act with:
-      fireEvent.keyDown(actions[0], { key: 'Escape' });
-      // const escapeEvent = new window.Event('KeyboardEvent');
-      // escapeEvent.initEvent('keydown', true);
-      // escapeEvent.key = 'Escape';
-      // actions[0].dispatchEvent(escapeEvent);
+      // fireEvent.keyDown(actions[0], { key: 'Escape' });
+      const escapeEvent = new window.Event('KeyboardEvent');
+      escapeEvent.initEvent('keydown', true);
+      escapeEvent.key = 'Escape';
+      actions[0].dispatchEvent(escapeEvent);
       act(() => {
         clock.runAll();
       });

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -12,6 +12,7 @@ import {
 import Icon from '@material-ui/core/Icon';
 import SpeedDial, { speedDialClasses as classes } from '@material-ui/core/SpeedDial';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
+import { tooltipClasses } from '@material-ui/core/Tooltip';
 
 describe('<SpeedDial />', () => {
   let clock;
@@ -166,6 +167,28 @@ describe('<SpeedDial />', () => {
           </SpeedDial>,
         );
         expect(getByRole('presentation')).to.have.class(classes[className]);
+      });
+    });
+
+    [
+      ['up', 'tooltipPlacementLeft'],
+      ['down', 'tooltipPlacementLeft'],
+      ['left', 'tooltipPlacementTop'],
+      ['right', 'tooltipPlacementTop'],
+    ].forEach(([direction, className]) => {
+      it(`should place the tooltip in the correct position when direction=${direction}`, () => {
+        const { getByRole, getAllByRole } = render(
+          <SpeedDial {...defaultProps} open direction={direction.toLowerCase()}>
+            <SpeedDialAction icon={icon} tooltipTitle="action1" />
+            <SpeedDialAction icon={icon} tooltipTitle="action2" />
+          </SpeedDial>,
+        );
+        const actions = getAllByRole('menuitem');
+        fireEvent.mouseOver(actions[0]);
+        act(() => {
+          clock.runAll();
+        });
+        expect(getByRole('tooltip').firstChild).to.have.class(tooltipClasses[className]);
       });
     });
   });

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -104,14 +104,13 @@ describe('<SpeedDial />', () => {
       </SpeedDial>,
     );
     const fab = getByRole('button');
-    const menu = getByRole('menu');
     const actions = getAllByRole('menuitem');
 
     fireEvent.mouseEnter(fab);
     act(() => {
       clock.runAll();
     });
-    expect(menu).to.not.have.class(classes.actionsClosed);
+    expect(fab).to.have.attribute('aria-expanded', 'true');
 
     fireEvent.mouseOver(actions[0]);
     act(() => {
@@ -123,14 +122,14 @@ describe('<SpeedDial />', () => {
     act(() => {
       clock.runAll();
     });
-    expect(menu).to.have.class(classes.actionsClosed);
+    expect(fab).to.have.attribute('aria-expanded', 'false');
 
     fireEvent.mouseEnter(fab);
     act(() => {
       clock.runAll();
     });
     expect(queryByRole('tooltip')).to.equal(null);
-    expect(menu).to.not.have.class(classes.actionsClosed);
+    expect(fab).to.have.attribute('aria-expanded', 'true');
   });
 
   describe('prop: onKeyDown', () => {
@@ -224,14 +223,13 @@ describe('<SpeedDial />', () => {
         </SpeedDial>,
       );
       const fab = getByRole('button');
-      const menu = getByRole('menu');
       const actions = getAllByRole('menuitem');
 
       fab.focus();
       act(() => {
         clock.runAll();
       });
-      expect(menu).to.not.have.class(classes.actionsClosed);
+      expect(fab).to.have.attribute('aria-expanded', 'true');
 
       fireEvent.keyDown(fab, { key: 'ArrowUp' });
       act(() => {
@@ -249,14 +247,14 @@ describe('<SpeedDial />', () => {
         clock.runAll();
       });
       expect(queryByRole('tooltip')).to.equal(null);
-      expect(menu).to.have.class(classes.actionsClosed);
+      expect(fab).to.have.attribute('aria-expanded', 'false');
 
       fab.focus();
       act(() => {
         clock.runAll();
       });
       expect(queryByRole('tooltip')).to.equal(null);
-      expect(menu).to.not.have.class(classes.actionsClosed);
+      expect(fab).to.have.attribute('aria-expanded', 'true');
     });
   });
 
@@ -328,7 +326,7 @@ describe('<SpeedDial />', () => {
     it('displays the actions on focus gain', () => {
       renderSpeedDial();
       expect(screen.getAllByRole('menuitem')).to.have.lengthOf(4);
-      expect(screen.getByRole('menu')).not.to.have.class(classes.actionsClosed);
+      expect(fabButton).to.have.attribute('aria-expanded', 'true');
     });
 
     it('considers arrow keys with the same initial orientation', () => {

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -6,6 +6,7 @@ import {
   createClientRender,
   act,
   fireEvent,
+  fireDiscreteEvent,
   screen,
   describeConformanceV5,
 } from 'test/utils';
@@ -238,12 +239,7 @@ describe('<SpeedDial />', () => {
       });
       expect(queryByRole('tooltip')).not.to.equal(null);
 
-      // Manually fire an event to avoid calling act with:
-      // fireEvent.keyDown(actions[0], { key: 'Escape' });
-      const escapeEvent = new window.Event('KeyboardEvent');
-      escapeEvent.initEvent('keydown', true);
-      escapeEvent.key = 'Escape';
-      actions[0].dispatchEvent(escapeEvent);
+      fireDiscreteEvent.keyDown(actions[0], { key: 'Escape' });
       act(() => {
         clock.runAll();
       });

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -201,6 +201,10 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
     );
   }
 
+  if (!open && tooltipOpen) {
+    setTooltipOpen(false);
+  }
+
   return (
     <Tooltip
       id={id}

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -202,7 +202,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
   }
 
   if (!open && tooltipOpen) {
-    setTooltipOpen(false);
+    // setTooltipOpen(false);
   }
 
   return (

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -202,7 +202,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
   }
 
   if (!open && tooltipOpen) {
-    // setTooltipOpen(false);
+    setTooltipOpen(false);
   }
 
   return (

--- a/test/utils/fireDiscreteEvent.js
+++ b/test/utils/fireDiscreteEvent.js
@@ -1,3 +1,11 @@
+import { configure, fireEvent, getConfig } from '@testing-library/react';
+
+const noWrapper = (callback) => callback();
+
+/**
+ * @param {() => void} callback
+ * @returns {void}
+ */
 function withMissingActWarningsIgnored(callback) {
   const originalConsoleError = console.error;
   console.error = function silenceMissingActWarnings(message, ...args) {
@@ -6,9 +14,16 @@ function withMissingActWarningsIgnored(callback) {
       originalConsoleError.call(console, message, ...args);
     }
   };
+
+  const originalConfig = getConfig();
+  configure({
+    eventWrapper: noWrapper,
+  });
+
   try {
     callback();
   } finally {
+    configure(originalConfig);
     console.error = originalConsoleError;
   }
 }
@@ -21,10 +36,22 @@ function withMissingActWarningsIgnored(callback) {
 // Be aware that "discrete events" are an implementation detail of React.
 // To test discrete events we cannot use `fireEvent` from `@testing-library/react` because they are all wrapped in `act`.
 // `act` overrides the "discrete event" semantics with "batching" semantics: https://github.com/facebook/react/blob/3fbd47b86285b6b7bdeab66d29c85951a84d4525/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L1061-L1064
+// Note that using `fireEvent` from `@testing-library/dom` would not work since /react configures both `fireEvent` to use `act` as a wrapper.
 // -----------------------------------------
 
-// eslint-disable-next-line import/prefer-default-export -- there are more than one discrete events.
 export function click(element) {
-  // TODO: Why are there different semantics between `element.click` and `dtlFireEvent.click`
-  return withMissingActWarningsIgnored(() => element.click());
+  return withMissingActWarningsIgnored(() => {
+    fireEvent.click(element);
+  });
+}
+
+/**
+ * @param {Element} element
+ * @param {{}} [options]
+ * @returns {void}
+ */
+export function keyDown(element, options) {
+  return withMissingActWarningsIgnored(() => {
+    fireEvent.keyDown(element, options);
+  });
 }


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #25215.

This PR also fixes the tooltip placement when the `direction` prop is left or right.

Before:

![Screenshot from 2021-03-07 22-25-05](https://user-images.githubusercontent.com/42154031/110262978-18080c00-7f94-11eb-88a9-3b39c7763be9.png)

After:

![Screenshot from 2021-03-07 22-22-41](https://user-images.githubusercontent.com/42154031/110262913-dd05d880-7f93-11eb-8daa-b03369da6c14.png)
