### PR TITLE
[lab] Remove propTypes in production for exotic components

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -342,7 +342,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
   );
 }
 
-ClockPicker.propTypes = {
+ClockPicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -86,7 +86,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DatePicker as any).displayName = 'DatePicker';
 }
 
-DatePicker.propTypes = {
+DatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DateRangePicker as any).displayName = 'DateRangePicker';
 }
 
-DateRangePicker.propTypes = {
+DateRangePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -192,7 +192,7 @@ const DateRangePickerDay = React.forwardRef(function DateRangePickerDay<TDate>(
   );
 });
 
-DateRangePickerDay.propTypes = {
+DateRangePickerDay.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -149,7 +149,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DateTimePicker as any).displayName = 'DateTimePicker';
 }
 
-DateTimePicker.propTypes = {
+DateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -278,7 +278,7 @@ const DayPicker = React.forwardRef(function DayPicker<
   );
 });
 
-DayPicker.propTypes = {
+DayPicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DesktopDatePicker as any).displayName = 'DesktopDatePicker';
 }
 
-DesktopDatePicker.propTypes = {
+DesktopDatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -22,7 +22,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DesktopDateRangePicker as any).displayName = 'DesktopDateRangePicker';
 }
 
-DesktopDateRangePicker.propTypes = {
+DesktopDateRangePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DesktopDateTimePicker as any).displayName = 'DesktopDateTimePicker';
 }
 
-DesktopDateTimePicker.propTypes = {
+DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (DesktopTimePicker as any).displayName = 'DesktopTimePicker';
 }
 
-DesktopTimePicker.propTypes = {
+DesktopTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/material-ui-lab/src/LoadingButton/LoadingButton.js
@@ -93,7 +93,7 @@ const LoadingButton = React.forwardRef(function LoadingButton(props, ref) {
   );
 });
 
-LoadingButton.propTypes = {
+LoadingButton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/material-ui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -38,7 +38,7 @@ const LocalizationProvider: React.FC<LocalizationProviderProps> = (props) => {
   );
 };
 
-LocalizationProvider.propTypes = {
+LocalizationProvider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (MobileDatePicker as any).displayName = 'MobileDatePicker';
 }
 
-MobileDatePicker.propTypes = {
+MobileDatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
   (MobileDateRangePicker as any).displayName = 'MobileDateRangePicker';
 }
 
-MobileDateRangePicker.propTypes = {
+MobileDateRangePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -27,7 +27,7 @@ if (process.env.NODE_ENV !== 'production') {
   (MobileDateTimePicker as any).displayName = 'MobileDateTimePicker';
 }
 
-MobileDateTimePicker.propTypes = {
+MobileDateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (MobileTimePicker as any).displayName = 'MobileTimePicker';
 }
 
-MobileTimePicker.propTypes = {
+MobileTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.tsx
@@ -100,7 +100,7 @@ const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
   );
 });
 
-MonthPicker.propTypes = {
+MonthPicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/PickersCalendarSkeleton/PickersCalendarSkeleton.tsx
+++ b/packages/material-ui-lab/src/PickersCalendarSkeleton/PickersCalendarSkeleton.tsx
@@ -62,7 +62,7 @@ const PickersCalendarSkeleton: React.FC<
   );
 };
 
-PickersCalendarSkeleton.propTypes = {
+PickersCalendarSkeleton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -303,7 +303,7 @@ export const areDayPropsEqual = (
   );
 };
 
-PickersDay.propTypes = {
+PickersDay.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (StaticDatePicker as any).displayName = 'StaticDatePicker';
 }
 
-StaticDatePicker.propTypes = {
+StaticDatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
   (StaticDateRangePicker as any).displayName = 'StaticDateRangePicker';
 }
 
-StaticDateRangePicker.propTypes = {
+StaticDateRangePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -27,7 +27,7 @@ if (process.env.NODE_ENV !== 'production') {
   (StaticDateTimePicker as any).displayName = 'StaticDateTimePicker';
 }
 
-StaticDateTimePicker.propTypes = {
+StaticDateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
   (StaticTimePicker as any).displayName = 'StaticTimePicker';
 }
 
-StaticTimePicker.propTypes = {
+StaticTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/TabContext/TabContext.js
+++ b/packages/material-ui-lab/src/TabContext/TabContext.js
@@ -28,7 +28,7 @@ export default function TabContext(props) {
   return <Context.Provider value={context}>{children}</Context.Provider>;
 }
 
-TabContext.propTypes = {
+TabContext.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TabList/TabList.js
+++ b/packages/material-ui-lab/src/TabList/TabList.js
@@ -24,7 +24,7 @@ const TabList = React.forwardRef(function TabList(props, ref) {
   );
 });
 
-TabList.propTypes = {
+TabList.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.js
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.js
@@ -37,7 +37,7 @@ const TabPanel = React.forwardRef(function TabPanel(props, ref) {
   );
 });
 
-TabPanel.propTypes = {
+TabPanel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -94,7 +94,7 @@ const TimePicker = makePickerWithState<BaseTimePickerProps>(ResponsiveWrapper, {
   ...timePickerConfig,
 }) as TimePickerGenericComponent<typeof ResponsiveWrapper>;
 
-TimePicker.propTypes = {
+TimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/Timeline/Timeline.tsx
+++ b/packages/material-ui-lab/src/Timeline/Timeline.tsx
@@ -70,7 +70,7 @@ const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(function Time
   );
 });
 
-Timeline.propTypes = {
+Timeline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js
@@ -18,7 +18,7 @@ const TimelineConnector = React.forwardRef(function TimelineConnector(props, ref
   return <span className={clsx(classes.root, className)} ref={ref} {...other} />;
 });
 
-TimelineConnector.propTypes = {
+TimelineConnector.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
@@ -40,7 +40,7 @@ const TimelineContent = React.forwardRef(function TimelineContent(props, ref) {
   );
 });
 
-TimelineContent.propTypes = {
+TimelineContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
@@ -89,7 +89,7 @@ const TimelineDot = React.forwardRef(function TimelineDot(props, ref) {
   );
 });
 
-TimelineDot.propTypes = {
+TimelineDot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -78,7 +78,7 @@ const TimelineItem = React.forwardRef(function TimelineItem(props, ref) {
   );
 });
 
-TimelineItem.propTypes = {
+TimelineItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -42,7 +42,7 @@ const TimelineOppositeContent = React.forwardRef(function TimelineOppositeConten
   );
 });
 
-TimelineOppositeContent.propTypes = {
+TimelineOppositeContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.js
+++ b/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.js
@@ -19,7 +19,7 @@ const TimelineSeparator = React.forwardRef(function TimelineSeparator(props, ref
   return <div className={clsx(classes.root, className)} ref={ref} {...other} />;
 });
 
-TimelineSeparator.propTypes = {
+TimelineSeparator.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -283,7 +283,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   );
 });
 
-TreeItem.propTypes = {
+TreeItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -806,7 +806,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
   );
 });
 
-TreeView.propTypes = {
+TreeView.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
@@ -178,7 +178,7 @@ const YearPicker = React.forwardRef(function YearPicker<TDate>(
   );
 });
 
-YearPicker.propTypes = {
+YearPicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui-unstyled/src/BackdropUnstyled/BackdropUnstyled.js
+++ b/packages/material-ui-unstyled/src/BackdropUnstyled/BackdropUnstyled.js
@@ -55,7 +55,7 @@ const BackdropUnstyled = React.forwardRef(function BackdropUnstyled(props, ref) 
   );
 });
 
-BackdropUnstyled.propTypes = {
+BackdropUnstyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.js
@@ -124,7 +124,7 @@ const BadgeUnstyled = React.forwardRef(function BadgeUnstyled(props, ref) {
   );
 });
 
-BadgeUnstyled.propTypes = {
+BadgeUnstyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.js
@@ -284,7 +284,7 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
   );
 });
 
-ModalUnstyled.propTypes = {
+ModalUnstyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-unstyled/src/Portal/Portal.js
+++ b/packages/material-ui-unstyled/src/Portal/Portal.js
@@ -51,7 +51,7 @@ const Portal = React.forwardRef(function Portal(props, ref) {
   return mountNode ? ReactDOM.createPortal(children, mountNode) : mountNode;
 });
 
-Portal.propTypes = {
+Portal.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -772,7 +772,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
   );
 });
 
-SliderUnstyled.propTypes = {
+SliderUnstyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui-unstyled/src/Unstable_TrapFocus/Unstable_TrapFocus.js
+++ b/packages/material-ui-unstyled/src/Unstable_TrapFocus/Unstable_TrapFocus.js
@@ -350,7 +350,7 @@ function Unstable_TrapFocus(props) {
   );
 }
 
-Unstable_TrapFocus.propTypes = {
+Unstable_TrapFocus.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Accordion/Accordion.js
+++ b/packages/material-ui/src/Accordion/Accordion.js
@@ -200,7 +200,7 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
   );
 });
 
-Accordion.propTypes = {
+Accordion.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/AccordionActions/AccordionActions.js
+++ b/packages/material-ui/src/AccordionActions/AccordionActions.js
@@ -67,7 +67,7 @@ const AccordionActions = React.forwardRef(function AccordionActions(inProps, ref
   );
 });
 
-AccordionActions.propTypes = {
+AccordionActions.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.js
@@ -51,7 +51,7 @@ const AccordionDetails = React.forwardRef(function AccordionDetails(inProps, ref
   );
 });
 
-AccordionDetails.propTypes = {
+AccordionDetails.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -169,7 +169,7 @@ const AccordionSummary = React.forwardRef(function AccordionSummary(inProps, ref
   );
 });
 
-AccordionSummary.propTypes = {
+AccordionSummary.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -205,7 +205,7 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
   );
 });
 
-Alert.propTypes = {
+Alert.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/AlertTitle/AlertTitle.js
+++ b/packages/material-ui/src/AlertTitle/AlertTitle.js
@@ -60,7 +60,7 @@ const AlertTitle = React.forwardRef(function AlertTitle(inProps, ref) {
   );
 });
 
-AlertTitle.propTypes = {
+AlertTitle.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -147,7 +147,7 @@ const AppBar = React.forwardRef(function AppBar(inProps, ref) {
   );
 });
 
-AppBar.propTypes = {
+AppBar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -688,7 +688,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
   );
 });
 
-Autocomplete.propTypes = {
+Autocomplete.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -201,7 +201,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
   );
 });
 
-Avatar.propTypes = {
+Avatar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.js
@@ -152,7 +152,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
   );
 });
 
-AvatarGroup.propTypes = {
+AvatarGroup.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -100,7 +100,7 @@ const Backdrop = React.forwardRef(function Backdrop(inProps, ref) {
   );
 });
 
-Backdrop.propTypes = {
+Backdrop.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -259,7 +259,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
   );
 });
 
-Badge.propTypes = {
+Badge.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -92,7 +92,7 @@ const BottomNavigation = React.forwardRef(function BottomNavigation(inProps, ref
   );
 });
 
-BottomNavigation.propTypes = {
+BottomNavigation.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -202,7 +202,7 @@ const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(
   );
 });
 
-BottomNavigationAction.propTypes = {
+BottomNavigationAction.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Box/Box.js
+++ b/packages/material-ui/src/Box/Box.js
@@ -46,7 +46,7 @@ const Box = React.forwardRef(function Box(inProps, ref) {
   return <BoxRoot ref={ref} {...props} />;
 });
 
-Box.propTypes = {
+Box.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -205,7 +205,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(inProps, ref) {
   );
 });
 
-Breadcrumbs.propTypes = {
+Breadcrumbs.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -379,7 +379,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   );
 });
 
-Button.propTypes = {
+Button.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -373,7 +373,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
   );
 });
 
-ButtonBase.propTypes = {
+ButtonBase.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -260,7 +260,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
   );
 });
 
-ButtonGroup.propTypes = {
+ButtonGroup.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -58,7 +58,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
   );
 });
 
-Card.propTypes = {
+Card.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -99,7 +99,7 @@ const CardActionArea = React.forwardRef(function CardActionArea(inProps, ref) {
   );
 });
 
-CardActionArea.propTypes = {
+CardActionArea.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CardActions/CardActions.js
+++ b/packages/material-ui/src/CardActions/CardActions.js
@@ -71,7 +71,7 @@ const CardActions = React.forwardRef(function CardActions(inProps, ref) {
   );
 });
 
-CardActions.propTypes = {
+CardActions.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CardContent/CardContent.js
+++ b/packages/material-ui/src/CardContent/CardContent.js
@@ -59,7 +59,7 @@ const CardContent = React.forwardRef(function CardContent(inProps, ref) {
   );
 });
 
-CardContent.propTypes = {
+CardContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CardHeader/CardHeader.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.js
@@ -174,7 +174,7 @@ const CardHeader = React.forwardRef(function CardHeader(inProps, ref) {
   );
 });
 
-CardHeader.propTypes = {
+CardHeader.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -90,7 +90,7 @@ const CardMedia = React.forwardRef(function CardMedia(inProps, ref) {
   );
 });
 
-CardMedia.propTypes = {
+CardMedia.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -126,7 +126,7 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
   );
 });
 
-Checkbox.propTypes = {
+Checkbox.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -484,7 +484,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   );
 });
 
-Chip.propTypes = {
+Chip.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -218,7 +218,7 @@ const CircularProgress = React.forwardRef(function CircularProgress(inProps, ref
   );
 });
 
-CircularProgress.propTypes = {
+CircularProgress.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.tsx
@@ -207,7 +207,7 @@ function ClickAwayListener(props: ClickAwayListenerProps): JSX.Element {
   return <React.Fragment>{React.cloneElement(children, childrenProps)}</React.Fragment>;
 }
 
-ClickAwayListener.propTypes = {
+ClickAwayListener.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit TypeScript types and run "yarn proptypes"  |

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -326,7 +326,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
   );
 });
 
-Collapse.propTypes = {
+Collapse.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -118,7 +118,7 @@ const Container = React.forwardRef(function Container(inProps, ref) {
   );
 });
 
-Container.propTypes = {
+Container.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/CssBaseline/CssBaseline.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.js
@@ -66,7 +66,7 @@ function CssBaseline(inProps) {
   );
 }
 
-CssBaseline.propTypes = {
+CssBaseline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -309,7 +309,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
   );
 });
 
-Dialog.propTypes = {
+Dialog.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/DialogActions/DialogActions.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.js
@@ -71,7 +71,7 @@ const DialogActions = React.forwardRef(function DialogActions(inProps, ref) {
   );
 });
 
-DialogActions.propTypes = {
+DialogActions.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/DialogContent/DialogContent.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.js
@@ -74,7 +74,7 @@ const DialogContent = React.forwardRef(function DialogContent(inProps, ref) {
   );
 });
 
-DialogContent.propTypes = {
+DialogContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/DialogContentText/DialogContentText.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.js
@@ -14,7 +14,7 @@ const DialogContentText = React.forwardRef(function DialogContentText(props, ref
   return <Typography component="p" variant="body1" color="textSecondary" ref={ref} {...props} />;
 });
 
-DialogContentText.propTypes = {
+DialogContentText.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/DialogTitle/DialogTitle.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.js
@@ -64,7 +64,7 @@ const DialogTitle = React.forwardRef(function DialogTitle(inProps, ref) {
   );
 });
 
-DialogTitle.propTypes = {
+DialogTitle.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -238,7 +238,7 @@ const Divider = React.forwardRef(function Divider(inProps, ref) {
   );
 });
 
-Divider.propTypes = {
+Divider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -278,7 +278,7 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
   );
 });
 
-Drawer.propTypes = {
+Drawer.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -214,7 +214,7 @@ const Fab = React.forwardRef(function Fab(inProps, ref) {
   );
 });
 
-Fab.propTypes = {
+Fab.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -135,7 +135,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
   );
 });
 
-Fade.propTypes = {
+Fade.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -207,7 +207,7 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
   );
 });
 
-FilledInput.propTypes = {
+FilledInput.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -236,7 +236,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
   );
 });
 
-FormControl.propTypes = {
+FormControl.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -134,7 +134,7 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
   );
 });
 
-FormControlLabel.propTypes = {
+FormControlLabel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/FormGroup/FormGroup.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.js
@@ -72,7 +72,7 @@ const FormGroup = React.forwardRef(function FormGroup(inProps, ref) {
   );
 });
 
-FormGroup.propTypes = {
+FormGroup.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -125,7 +125,7 @@ const FormHelperText = React.forwardRef(function FormHelperText(inProps, ref) {
   );
 });
 
-FormHelperText.propTypes = {
+FormHelperText.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -124,7 +124,7 @@ const FormLabel = React.forwardRef(function FormLabel(inProps, ref) {
   );
 });
 
-FormLabel.propTypes = {
+FormLabel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/GlobalStyles/GlobalStyles.js
+++ b/packages/material-ui/src/GlobalStyles/GlobalStyles.js
@@ -7,7 +7,7 @@ function GlobalStyles(props) {
   return <StyledEngineGlobalStyles {...props} defaultTheme={defaultTheme} />;
 }
 
-GlobalStyles.propTypes = {
+GlobalStyles.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -274,7 +274,7 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
   );
 });
 
-Grid.propTypes = {
+Grid.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -186,7 +186,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   );
 });
 
-Grow.propTypes = {
+Grow.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Hidden/Hidden.js
+++ b/packages/material-ui/src/Hidden/Hidden.js
@@ -57,7 +57,7 @@ function Hidden(props) {
   );
 }
 
-Hidden.propTypes = {
+Hidden.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -110,7 +110,7 @@ const Icon = React.forwardRef(function Icon(inProps, ref) {
   );
 });
 
-Icon.propTypes = {
+Icon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -178,7 +178,7 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
   );
 });
 
-IconButton.propTypes = {
+IconButton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ImageList/ImageList.js
+++ b/packages/material-ui/src/ImageList/ImageList.js
@@ -113,7 +113,7 @@ const ImageList = React.forwardRef(function ImageList(inProps, ref) {
   );
 });
 
-ImageList.propTypes = {
+ImageList.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -143,7 +143,7 @@ const ImageListItem = React.forwardRef(function ImageListItem(inProps, ref) {
   );
 });
 
-ImageListItem.propTypes = {
+ImageListItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -214,7 +214,7 @@ const ImageListItemBar = React.forwardRef(function ImageListItemBar(inProps, ref
   );
 });
 
-ImageListItemBar.propTypes = {
+ImageListItemBar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -128,7 +128,7 @@ const Input = React.forwardRef(function Input(inProps, ref) {
   );
 });
 
-Input.propTypes = {
+Input.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -106,7 +106,7 @@ const InputAdornment = React.forwardRef(function InputAdornment(props, ref) {
   );
 });
 
-InputAdornment.propTypes = {
+InputAdornment.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -551,7 +551,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
   );
 });
 
-InputBase.propTypes = {
+InputBase.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -152,7 +152,7 @@ const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
   );
 });
 
-InputLabel.propTypes = {
+InputLabel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -335,7 +335,7 @@ const LinearProgress = React.forwardRef(function LinearProgress(inProps, ref) {
   );
 });
 
-LinearProgress.propTypes = {
+LinearProgress.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -162,7 +162,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
   );
 });
 
-Link.propTypes = {
+Link.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/List/List.js
+++ b/packages/material-ui/src/List/List.js
@@ -95,7 +95,7 @@ const List = React.forwardRef(function List(inProps, ref) {
   );
 });
 
-List.propTypes = {
+List.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -300,7 +300,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
   );
 });
 
-ListItem.propTypes = {
+ListItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
@@ -71,7 +71,7 @@ const ListItemAvatar = React.forwardRef(function ListItemAvatar(inProps, ref) {
   );
 });
 
-ListItemAvatar.propTypes = {
+ListItemAvatar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -73,7 +73,7 @@ const ListItemIcon = React.forwardRef(function ListItemIcon(inProps, ref) {
   );
 });
 
-ListItemIcon.propTypes = {
+ListItemIcon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -67,7 +67,7 @@ const ListItemSecondaryAction = React.forwardRef(function ListItemSecondaryActio
   );
 });
 
-ListItemSecondaryAction.propTypes = {
+ListItemSecondaryAction.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ListItemText/ListItemText.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.js
@@ -132,7 +132,7 @@ const ListItemText = React.forwardRef(function ListItemText(inProps, ref) {
   );
 });
 
-ListItemText.propTypes = {
+ListItemText.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ListSubheader/ListSubheader.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.js
@@ -115,7 +115,7 @@ const ListSubheader = React.forwardRef(function ListSubheader(inProps, ref) {
   );
 });
 
-ListSubheader.propTypes = {
+ListSubheader.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -163,7 +163,7 @@ const Menu = React.forwardRef(function Menu(props, ref) {
   );
 });
 
-Menu.propTypes = {
+Menu.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -91,7 +91,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
   );
 });
 
-MenuItem.propTypes = {
+MenuItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -264,7 +264,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
   );
 });
 
-MenuList.propTypes = {
+MenuList.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -116,7 +116,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
   );
 });
 
-MobileStepper.propTypes = {
+MobileStepper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -129,7 +129,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   );
 });
 
-Modal.propTypes = {
+Modal.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -144,7 +144,7 @@ const NativeSelect = React.forwardRef(function NativeSelect(props, ref) {
   });
 });
 
-NativeSelect.propTypes = {
+NativeSelect.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/NoSsr/NoSsr.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.js
@@ -32,7 +32,7 @@ function NoSsr(props) {
   return <React.Fragment>{mountedState ? children : fallback}</React.Fragment>;
 }
 
-NoSsr.propTypes = {
+NoSsr.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -159,7 +159,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
   );
 });
 
-OutlinedInput.propTypes = {
+OutlinedInput.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Pagination/Pagination.js
+++ b/packages/material-ui/src/Pagination/Pagination.js
@@ -140,7 +140,7 @@ const Pagination = React.forwardRef(function Pagination(inProps, ref) {
 
 // @default tags synced with default values from usePagination
 
-Pagination.propTypes = {
+Pagination.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -331,7 +331,7 @@ const PaginationItem = React.forwardRef(function PaginationItem(inProps, ref) {
   );
 });
 
-PaginationItem.propTypes = {
+PaginationItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -111,7 +111,7 @@ const Paper = React.forwardRef(function Paper(inProps, ref) {
   );
 });
 
-Paper.propTypes = {
+Paper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -456,7 +456,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
   );
 });
 
-Popover.propTypes = {
+Popover.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -240,7 +240,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   );
 });
 
-Popper.propTypes = {
+Popper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -117,7 +117,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   );
 });
 
-Radio.propTypes = {
+Radio.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -64,7 +64,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
   );
 });
 
-RadioGroup.propTypes = {
+RadioGroup.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -460,7 +460,7 @@ const Rating = React.forwardRef(function Rating(props, ref) {
   );
 });
 
-Rating.propTypes = {
+Rating.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -24,7 +24,7 @@ const ScopedCssBaseline = React.forwardRef(function ScopedCssBaseline(props, ref
   return <div className={clsx(classes.root, className)} ref={ref} {...other} />;
 });
 
-ScopedCssBaseline.propTypes = {
+ScopedCssBaseline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -96,7 +96,7 @@ const Select = React.forwardRef(function Select(props, ref) {
   });
 });
 
-Select.propTypes = {
+Select.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Skeleton/Skeleton.js
+++ b/packages/material-ui/src/Skeleton/Skeleton.js
@@ -193,7 +193,7 @@ const Skeleton = React.forwardRef(function Skeleton(inProps, ref) {
   );
 });
 
-Skeleton.propTypes = {
+Skeleton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -238,7 +238,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
   );
 });
 
-Slide.propTypes = {
+Slide.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -424,7 +424,7 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
   );
 });
 
-Slider.propTypes = {
+Slider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -239,7 +239,7 @@ const Snackbar = React.forwardRef(function Snackbar(inProps, ref) {
   );
 });
 
-Snackbar.propTypes = {
+Snackbar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -115,7 +115,7 @@ const SnackbarContent = React.forwardRef(function SnackbarContent(inProps, ref) 
   );
 });
 
-SnackbarContent.propTypes = {
+SnackbarContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -422,7 +422,7 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
   );
 });
 
-SpeedDial.propTypes = {
+SpeedDial.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -218,7 +218,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
   );
 });
 
-SpeedDialAction.propTypes = {
+SpeedDialAction.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
@@ -102,7 +102,7 @@ const SpeedDialIcon = React.forwardRef(function SpeedDialIcon(inProps, ref) {
   );
 });
 
-SpeedDialIcon.propTypes = {
+SpeedDialIcon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -128,7 +128,7 @@ const Step = React.forwardRef(function Step(inProps, ref) {
   );
 });
 
-Step.propTypes = {
+Step.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -61,7 +61,7 @@ const StepButton = React.forwardRef(function StepButton(props, ref) {
   );
 });
 
-StepButton.propTypes = {
+StepButton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -115,7 +115,7 @@ const StepConnector = React.forwardRef(function StepConnector(inProps, ref) {
   );
 });
 
-StepConnector.propTypes = {
+StepConnector.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -116,7 +116,7 @@ const StepContent = React.forwardRef(function StepContent(inProps, ref) {
   );
 });
 
-StepContent.propTypes = {
+StepContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -77,7 +77,7 @@ const StepIcon = React.forwardRef(function StepIcon(props, ref) {
   return icon;
 });
 
-StepIcon.propTypes = {
+StepIcon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -148,7 +148,7 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
   );
 });
 
-StepLabel.propTypes = {
+StepLabel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -73,7 +73,7 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
   );
 });
 
-Stepper.propTypes = {
+Stepper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -113,7 +113,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
   );
 });
 
-SvgIcon.propTypes = {
+SvgIcon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -580,7 +580,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
   );
 });
 
-SwipeableDrawer.propTypes = {
+SwipeableDrawer.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -236,7 +236,7 @@ const Switch = React.forwardRef(function Switch(inProps, ref) {
   );
 });
 
-Switch.propTypes = {
+Switch.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -220,7 +220,7 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
   );
 });
 
-Tab.propTypes = {
+Tab.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.js
@@ -87,7 +87,7 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(inProps, ref) 
   );
 });
 
-TabScrollButton.propTypes = {
+TabScrollButton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -100,7 +100,7 @@ const Table = React.forwardRef(function Table(inProps, ref) {
   );
 });
 
-Table.propTypes = {
+Table.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableBody/TableBody.js
+++ b/packages/material-ui/src/TableBody/TableBody.js
@@ -63,7 +63,7 @@ const TableBody = React.forwardRef(function TableBody(inProps, ref) {
   );
 });
 
-TableBody.propTypes = {
+TableBody.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -197,7 +197,7 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
   );
 });
 
-TableCell.propTypes = {
+TableCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableContainer/TableContainer.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.js
@@ -54,7 +54,7 @@ const TableContainer = React.forwardRef(function TableContainer(inProps, ref) {
   );
 });
 
-TableContainer.propTypes = {
+TableContainer.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableFooter/TableFooter.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.js
@@ -63,7 +63,7 @@ const TableFooter = React.forwardRef(function TableFooter(inProps, ref) {
   );
 });
 
-TableFooter.propTypes = {
+TableFooter.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableHead/TableHead.js
+++ b/packages/material-ui/src/TableHead/TableHead.js
@@ -63,7 +63,7 @@ const TableHead = React.forwardRef(function TableHead(inProps, ref) {
   );
 });
 
-TableHead.propTypes = {
+TableHead.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -180,7 +180,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
   );
 });
 
-TablePagination.propTypes = {
+TablePagination.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableRow/TableRow.js
+++ b/packages/material-ui/src/TableRow/TableRow.js
@@ -94,7 +94,7 @@ const TableRow = React.forwardRef(function TableRow(inProps, ref) {
   );
 });
 
-TableRow.propTypes = {
+TableRow.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -88,7 +88,7 @@ const TableSortLabel = React.forwardRef(function TableSortLabel(props, ref) {
   );
 });
 
-TableSortLabel.propTypes = {
+TableSortLabel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -549,7 +549,7 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
   );
 });
 
-Tabs.propTypes = {
+Tabs.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -195,7 +195,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
   );
 });
 
-TextField.propTypes = {
+TextField.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -179,7 +179,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
   );
 });
 
-TextareaAutosize.propTypes = {
+TextareaAutosize.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -151,7 +151,7 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
   );
 });
 
-ToggleButton.propTypes = {
+ToggleButton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -173,7 +173,7 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup(inProps, r
   );
 });
 
-ToggleButtonGroup.propTypes = {
+ToggleButtonGroup.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -91,7 +91,7 @@ const Toolbar = React.forwardRef(function Toolbar(inProps, ref) {
   );
 });
 
-Toolbar.propTypes = {
+Toolbar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -663,7 +663,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   );
 });
 
-Tooltip.propTypes = {
+Tooltip.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -138,7 +138,7 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
   );
 });
 
-Typography.propTypes = {
+Typography.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -136,7 +136,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
   );
 });
 
-Zoom.propTypes = {
+Zoom.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |

--- a/packages/typescript-to-proptypes/src/generator.ts
+++ b/packages/typescript-to-proptypes/src/generator.ts
@@ -11,6 +11,10 @@ export interface GenerateOptions {
    */
   disablePropTypesTypeChecking?: boolean;
   /**
+   * Set to true if you want to make sure `babel-plugin-transform-react-remove-prop-types` recognizes the generated .propTypes.
+   */
+  ensureBabelPluginTransformReactRemovePropTypesIntegration?: boolean;
+  /**
    * Enable/disable the default sorting (ascending) or provide your own sort function
    * @default true
    */
@@ -95,6 +99,7 @@ function defaultSortLiteralUnions(a: t.LiteralType, b: t.LiteralType) {
 export function generate(component: t.Component, options: GenerateOptions = {}): string {
   const {
     disablePropTypesTypeChecking = false,
+    ensureBabelPluginTransformReactRemovePropTypesIntegration = false,
     importedName = 'PropTypes',
     includeJSDoc = true,
     sortProptypes = true,
@@ -316,7 +321,11 @@ export function generate(component: t.Component, options: GenerateOptions = {}):
     options.comment &&
     `// ${options.comment.split(/\r?\n/gm).reduce((prev, curr) => `${prev}\n// ${curr}`)}\n`;
 
-  return `${component.name}.propTypes = {\n${comment !== undefined ? comment : ''}${generated}\n}${
-    disablePropTypesTypeChecking ? ' as any' : ''
-  }`;
+  const propTypesMemberTrailingComment = ensureBabelPluginTransformReactRemovePropTypesIntegration
+    ? '/* remove-proptypes */'
+    : '';
+  const propTypesCasting = disablePropTypesTypeChecking ? ' as any' : '';
+  const propTypesBanner = comment !== undefined ? comment : '';
+
+  return `${component.name}.propTypes ${propTypesMemberTrailingComment}= {\n${propTypesBanner}${generated}\n}${propTypesCasting}`;
 }

--- a/packages/typescript-to-proptypes/src/injector.ts
+++ b/packages/typescript-to-proptypes/src/injector.ts
@@ -12,6 +12,7 @@ export interface InjectOptions
     | 'comment'
     | 'disablePropTypesTypeChecking'
     | 'reconcilePropTypes'
+    | 'ensureBabelPluginTransformReactRemovePropTypesIntegration'
   > {
   /**
    * By default all unused props are omitted from the result.

--- a/packages/typescript-to-proptypes/src/parser.ts
+++ b/packages/typescript-to-proptypes/src/parser.ts
@@ -579,15 +579,13 @@ export function parseFromProgram(
             }
           }
           // handle component factories: x = createComponent()
-          if (variableNode.initializer) {
-            if (checkDeclarations && type.aliasSymbol && type.aliasTypeArguments) {
-              if (
-                type
-                  .getCallSignatures()
-                  .some((signature) => isTypeJSXElementLike(signature.getReturnType()))
-              ) {
-                parseFunctionComponent(variableNode);
-              }
+          if (checkDeclarations && variableNode.initializer) {
+            if (
+              type
+                .getCallSignatures()
+                .some((signature) => isTypeJSXElementLike(signature.getReturnType()))
+            ) {
+              parseFunctionComponent(variableNode);
             }
           }
         }

--- a/packages/typescript-to-proptypes/test/remove-proptypes/input.tsx
+++ b/packages/typescript-to-proptypes/test/remove-proptypes/input.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+interface Props {
+  /**
+   * UI to render
+   */
+  children?: React.ReactNode;
+}
+
+function makeComponent() {
+  return function Component(props: Props) {
+    return <div>{props.children}</div>;
+  };
+}
+
+// @typescript-to-proptypes-generate
+const MyComponent = makeComponent();
+
+export default MyComponent;

--- a/packages/typescript-to-proptypes/test/remove-proptypes/options.ts
+++ b/packages/typescript-to-proptypes/test/remove-proptypes/options.ts
@@ -1,0 +1,13 @@
+import { TestOptions } from '../types';
+
+const options: TestOptions = {
+  injector: {
+    ensureBabelPluginTransformReactRemovePropTypesIntegration: true,
+    includeUnusedProps: true,
+  },
+  parser: {
+    checkDeclarations: true,
+  },
+};
+
+export default options;

--- a/packages/typescript-to-proptypes/test/remove-proptypes/output.js
+++ b/packages/typescript-to-proptypes/test/remove-proptypes/output.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function makeComponent() {
+  return function Component(props) {
+    return <div>{props.children}</div>;
+  };
+}
+// @typescript-to-proptypes-generate
+const MyComponent = makeComponent();
+
+MyComponent.propTypes /* remove-proptypes */ = {
+  /**
+   * UI to render
+   */
+  children: PropTypes.node,
+};
+
+export default MyComponent;

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -210,7 +210,6 @@ async function generateProptypes(
   const generatedForTypeScriptFile = sourceFile === tsFile;
   const result = ttp.inject(proptypes, sourceContent, {
     disablePropTypesTypeChecking: generatedForTypeScriptFile,
-    removeExistingPropTypes: true,
     babelOptions: {
       filename: sourceFile,
     },
@@ -222,6 +221,7 @@ async function generateProptypes(
         : '|     To update them edit the d.ts file and run "yarn proptypes"     |',
       '----------------------------------------------------------------------',
     ].join('\n'),
+    ensureBabelPluginTransformReactRemovePropTypesIntegration: true,
     getSortLiteralUnions,
     reconcilePropTypes: (prop, previous, generated) => {
       const usedCustomValidator = previous !== undefined && !previous.startsWith('PropTypes');


### PR DESCRIPTION
Noticed the bundle size increase in https://github.com/mui-org/material-ui/pull/25254. Turns out we don't remove .propTypes for various dynamically created components. 

We can't make this the default behavior of `typescript-to-proptypes` since it would add the comment to our docs demos where it would just be noise.