### PR TITLE
[docs] Bring clarity about the IE 11 support policy: it's partial

### DIFF
--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -39,7 +39,7 @@ v6 will completely remove the support of IE 11.
 
 <!-- #stable-snapshot -->
 
-Material-UI support [Node.js](https://github.com/nodejs/node) starting with version 10 for server-side rendering.
+Material-UI supports [Node.js](https://github.com/nodejs/node) starting with version 10 for server-side rendering.
 Where possible, the [LTS versions that are in maintenance](https://github.com/nodejs/Release#release-schedule) are supported.
 
 ### CSS prefixing

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -9,24 +9,37 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 
 <!-- #stable-snapshot -->
 
-| Edge  | Firefox | Chrome | Safari (macOS) | Safari (iOS) |
-| :---- | :------ | :----- | :------------- | :----------- |
-| >= 85 | >= 78   | >= 84  | >= 13          | >= 12.1      |
+| Edge  | Firefox | Chrome | Safari (macOS) | Safari (iOS) | IE                   |
+| :---- | :------ | :----- | :------------- | :----------- | :------------------- |
+| >= 85 | >= 78   | >= 84  | >= 13          | >= 12.1      | 11 (partial support) |
 
 <!-- #default-branch-switch -->
 
 An extensive list can be found in our [.browserlistrc](https://github.com/mui-org/material-ui/blob/next/.browserslistrc#L12-L27) (check the `stable` entry).
-If you need to support IE 11, check out our [legacy bundle](/guides/minimizing-bundle-size/#legacy-bundle).
 
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that Material-UI supports it.
 [WRS regularly updates the rendering engine it uses](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).
 You can expect Material-UI's components to render without major issues.
 
+### IE 11
+
+Material-UI provides **partial** supports for IE 11. Be aware of the following:
+
+- Some of the components have no support. For instance, the new components, the data grid, the date picker.
+- Some of the components have degraded support. For instance, the outlined input border radius is missing, the combobox doesn't remove diacritics, the circular progress animation is wobbling.
+- The documentaton itself might crash.
+- You need install the [legacy bundle](/guides/minimizing-bundle-size/#legacy-bundle).
+- You might need to install polyfills. For instance for the [popper.js transitive dependency](https://popper.js.org/docs/v2/browser-support/#ie11).
+
+Overall, the library doesn't prioritize the support of IE 11 if it harms the most common use cases. For instance, we will close new issues opened about IE 11 and might not merge pull requests that improve IE 11 support.
+
+v6 will completely remove the support of IE 11.
+
 ## Server
 
 <!-- #stable-snapshot -->
 
-We support [Node.js](https://github.com/nodejs/node) starting with version 10 for server-side rendering.
+Material-UI support [Node.js](https://github.com/nodejs/node) starting with version 10 for server-side rendering.
 Where possible, the [LTS versions that are in maintenance](https://github.com/nodejs/Release#release-schedule) are supported.
 
 ### CSS prefixing


### PR DESCRIPTION
Preview: https://deploy-preview-25262--material-ui.netlify.app/getting-started/supported-platforms/#browser

This is a follow-up after #25222. Since the last time, we talk about the support policy of IE 11 in #14420, this happened: [Next.js issues with IE 11](https://github.com/vercel/next.js/issues?q=is%3Aissue+is%3Aopen+IE+11). Iterating on issues with IE 11 has become very painful. Our development environment crash when loaded in IE 11. While the cost of working on IE 11 has increased by a large amount, the value is also continually going down.

It seems that we have reached a point where the opportunity cost for improving the support of IE 11 will very rarely outweigh the value of the alternative problems we can spend time on. 

Hence, I'm taking the time to upgrade the documentation to be very transparent about what's the current status of IE 11. Basically, we don't plan to remove IE 11 fixes in v5. We don't really care about fixing new issues either. If the community is doing the legwork on a specific issue, **and** it only comes with a minor downside for the many, then, sure, we would be happy to accept the patch.