### PR TITLE
[docs] Migrate Image List to emotion

### DIFF
--- a/docs/src/pages/components/image-list/CustomImageList.js
+++ b/docs/src/pages/components/image-list/CustomImageList.js
@@ -29,7 +29,11 @@ export default function CustomImageList() {
 
         return (
           <ImageListItem key={item.img} cols={cols} rows={rows}>
-            <img srcSet={srcset(item.img, 250, 200, rows, cols)} alt={item.title} />
+            <img
+              srcSet={srcset(item.img, 250, 200, rows, cols)}
+              alt={item.title}
+              loading="lazy"
+            />
             <ImageListItemBar
               sx={{
                 background:

--- a/docs/src/pages/components/image-list/CustomImageList.js
+++ b/docs/src/pages/components/image-list/CustomImageList.js
@@ -1,28 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
 import IconButton from '@material-ui/core/IconButton';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
-
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-    // Promote the list into its own layer in Chrome. This costs memory, but helps keeping high FPS.
-    transform: 'translateZ(0)',
-  },
-  titleBar: {
-    background:
-      'linear-gradient(to bottom, rgba(0,0,0,0.7) 0%, ' +
-      'rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-  },
-  icon: {
-    color: 'white',
-  },
-});
 
 function srcset(image, width, height, rows = 1, cols = 1) {
   return `${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format 1x,
@@ -30,10 +12,17 @@ function srcset(image, width, height, rows = 1, cols = 1) {
 }
 
 export default function CustomImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList rowHeight={200} gap={1} className={classes.root}>
+    <ImageList
+      sx={{
+        width: 500,
+        height: 450,
+        // Promote the list into its own layer in Chrome. This costs memory, but helps keeping high FPS.
+        transform: 'translateZ(0)',
+      }}
+      rowHeight={200}
+      gap={1}
+    >
       {itemData.map((item) => {
         const cols = item.featured ? 2 : 1;
         const rows = item.featured ? 2 : 1;
@@ -42,18 +31,22 @@ export default function CustomImageList() {
           <ImageListItem key={item.img} cols={cols} rows={rows}>
             <img srcSet={srcset(item.img, 250, 200, rows, cols)} alt={item.title} />
             <ImageListItemBar
+              sx={{
+                background:
+                  'linear-gradient(to bottom, rgba(0,0,0,0.7) 0%, ' +
+                  'rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+              }}
               title={item.title}
               position="top"
               actionIcon={
                 <IconButton
+                  sx={{ color: 'white' }}
                   aria-label={`star ${item.title}`}
-                  className={classes.icon}
                 >
                   <StarBorderIcon />
                 </IconButton>
               }
               actionPosition="left"
-              className={classes.titleBar}
             />
           </ImageListItem>
         );

--- a/docs/src/pages/components/image-list/CustomImageList.tsx
+++ b/docs/src/pages/components/image-list/CustomImageList.tsx
@@ -1,28 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
 import IconButton from '@material-ui/core/IconButton';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
-
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-    // Promote the list into its own layer in Chrome. This costs memory, but helps keeping high FPS.
-    transform: 'translateZ(0)',
-  },
-  titleBar: {
-    background:
-      'linear-gradient(to bottom, rgba(0,0,0,0.7) 0%, ' +
-      'rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-  },
-  icon: {
-    color: 'white',
-  },
-});
 
 function srcset(image: string, width: number, height: number, rows = 1, cols = 1) {
   return `${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format 1x,
@@ -30,10 +12,17 @@ function srcset(image: string, width: number, height: number, rows = 1, cols = 1
 }
 
 export default function CustomImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList rowHeight={200} gap={1} className={classes.root}>
+    <ImageList
+      sx={{
+        width: 500,
+        height: 450,
+        // Promote the list into its own layer in Chrome. This costs memory, but helps keeping high FPS.
+        transform: 'translateZ(0)',
+      }}
+      rowHeight={200}
+      gap={1}
+    >
       {itemData.map((item) => {
         const cols = item.featured ? 2 : 1;
         const rows = item.featured ? 2 : 1;
@@ -42,18 +31,22 @@ export default function CustomImageList() {
           <ImageListItem key={item.img} cols={cols} rows={rows}>
             <img srcSet={srcset(item.img, 250, 200, rows, cols)} alt={item.title} />
             <ImageListItemBar
+              sx={{
+                background:
+                  'linear-gradient(to bottom, rgba(0,0,0,0.7) 0%, ' +
+                  'rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+              }}
               title={item.title}
               position="top"
               actionIcon={
                 <IconButton
+                  sx={{ color: 'white' }}
                   aria-label={`star ${item.title}`}
-                  className={classes.icon}
                 >
                   <StarBorderIcon />
                 </IconButton>
               }
               actionPosition="left"
-              className={classes.titleBar}
             />
           </ImageListItem>
         );

--- a/docs/src/pages/components/image-list/CustomImageList.tsx
+++ b/docs/src/pages/components/image-list/CustomImageList.tsx
@@ -29,7 +29,11 @@ export default function CustomImageList() {
 
         return (
           <ImageListItem key={item.img} cols={cols} rows={rows}>
-            <img srcSet={srcset(item.img, 250, 200, rows, cols)} alt={item.title} />
+            <img
+              srcSet={srcset(item.img, 250, 200, rows, cols)}
+              alt={item.title}
+              loading="lazy"
+            />
             <ImageListItemBar
               sx={{
                 background:

--- a/docs/src/pages/components/image-list/MasonryImageList.js
+++ b/docs/src/pages/components/image-list/MasonryImageList.js
@@ -1,22 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-    overflowY: 'scroll',
-  },
-});
-
 export default function MasonryImageList() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 500, height: 450, overflowY: 'scroll' }}>
       <ImageList variant="masonry" cols={3} gap={8}>
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
@@ -28,7 +18,7 @@ export default function MasonryImageList() {
           </ImageListItem>
         ))}
       </ImageList>
-    </div>
+    </Box>
   );
 }
 

--- a/docs/src/pages/components/image-list/MasonryImageList.js
+++ b/docs/src/pages/components/image-list/MasonryImageList.js
@@ -14,6 +14,7 @@ export default function MasonryImageList() {
               srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
                 ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
               alt={item.title}
+              loading="lazy"
             />
           </ImageListItem>
         ))}

--- a/docs/src/pages/components/image-list/MasonryImageList.tsx
+++ b/docs/src/pages/components/image-list/MasonryImageList.tsx
@@ -1,22 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-    overflowY: 'scroll',
-  },
-});
-
 export default function MasonryImageList() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 500, height: 450, overflowY: 'scroll' }}>
       <ImageList variant="masonry" cols={3} gap={8}>
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
@@ -28,7 +18,7 @@ export default function MasonryImageList() {
           </ImageListItem>
         ))}
       </ImageList>
-    </div>
+    </Box>
   );
 }
 

--- a/docs/src/pages/components/image-list/MasonryImageList.tsx
+++ b/docs/src/pages/components/image-list/MasonryImageList.tsx
@@ -14,6 +14,7 @@ export default function MasonryImageList() {
               srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
                 ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
               alt={item.title}
+              loading="lazy"
             />
           </ImageListItem>
         ))}

--- a/docs/src/pages/components/image-list/QuiltedImageList.js
+++ b/docs/src/pages/components/image-list/QuiltedImageList.js
@@ -21,6 +21,7 @@ export default function QuiltedImageList() {
           <img
             srcSet={srcset(item.img, 121, item.rows, item.cols)}
             alt={item.title}
+            loading="lazy"
           />
         </ImageListItem>
       ))}

--- a/docs/src/pages/components/image-list/QuiltedImageList.js
+++ b/docs/src/pages/components/image-list/QuiltedImageList.js
@@ -1,15 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
-
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-});
 
 function srcset(image, size, rows = 1, cols = 1) {
   return `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format 1x,
@@ -17,10 +9,13 @@ function srcset(image, size, rows = 1, cols = 1) {
 }
 
 export default function QuiltedImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList variant="quilted" cols={4} rowHeight={121} className={classes.root}>
+    <ImageList
+      sx={{ width: 500, height: 450 }}
+      variant="quilted"
+      cols={4}
+      rowHeight={121}
+    >
       {itemData.map((item) => (
         <ImageListItem key={item.img} cols={item.cols || 1} rows={item.rows || 1}>
           <img

--- a/docs/src/pages/components/image-list/QuiltedImageList.tsx
+++ b/docs/src/pages/components/image-list/QuiltedImageList.tsx
@@ -21,6 +21,7 @@ export default function QuiltedImageList() {
           <img
             srcSet={srcset(item.img, 121, item.rows, item.cols)}
             alt={item.title}
+            loading="lazy"
           />
         </ImageListItem>
       ))}

--- a/docs/src/pages/components/image-list/QuiltedImageList.tsx
+++ b/docs/src/pages/components/image-list/QuiltedImageList.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
-
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-});
 
 function srcset(image: string, size: number, rows = 1, cols = 1) {
   return `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format 1x,
@@ -17,10 +9,13 @@ function srcset(image: string, size: number, rows = 1, cols = 1) {
 }
 
 export default function QuiltedImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList variant="quilted" cols={4} rowHeight={121} className={classes.root}>
+    <ImageList
+      sx={{ width: 500, height: 450 }}
+      variant="quilted"
+      cols={4}
+      rowHeight={121}
+    >
       {itemData.map((item) => (
         <ImageListItem key={item.img} cols={item.cols || 1} rows={item.rows || 1}>
           <img

--- a/docs/src/pages/components/image-list/StandardImageList.js
+++ b/docs/src/pages/components/image-list/StandardImageList.js
@@ -1,21 +1,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-});
-
 export default function StandardImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList cols={3} rowHeight={164} className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }} cols={3} rowHeight={164}>
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img

--- a/docs/src/pages/components/image-list/StandardImageList.js
+++ b/docs/src/pages/components/image-list/StandardImageList.js
@@ -12,6 +12,7 @@ export default function StandardImageList() {
             srcSet={`${item.img}?w=164&h=164&fit=crop&auto=format 1x,
                 ${item.img}?w=164&h=164&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
         </ImageListItem>
       ))}

--- a/docs/src/pages/components/image-list/StandardImageList.tsx
+++ b/docs/src/pages/components/image-list/StandardImageList.tsx
@@ -1,21 +1,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-});
-
 export default function StandardImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList cols={3} rowHeight={164} className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }} cols={3} rowHeight={164}>
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img

--- a/docs/src/pages/components/image-list/StandardImageList.tsx
+++ b/docs/src/pages/components/image-list/StandardImageList.tsx
@@ -12,6 +12,7 @@ export default function StandardImageList() {
             srcSet={`${item.img}?w=164&h=164&fit=crop&auto=format 1x,
                 ${item.img}?w=164&h=164&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
         </ImageListItem>
       ))}

--- a/docs/src/pages/components/image-list/TitlebarBelowImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarBelowImageList.js
@@ -13,6 +13,7 @@ export default function TitlebarBelowImageList() {
             srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
                 ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
           <ImageListItemBar
             title={item.title}

--- a/docs/src/pages/components/image-list/TitlebarBelowImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarBelowImageList.js
@@ -1,25 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-  icon: {
-    color: 'rgba(255, 255, 255, 0.54)',
-  },
-});
-
 export default function TitlebarBelowImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }}>
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img

--- a/docs/src/pages/components/image-list/TitlebarBelowImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarBelowImageList.tsx
@@ -13,6 +13,7 @@ export default function TitlebarBelowImageList() {
             srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
                 ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
           <ImageListItemBar
             title={item.title}

--- a/docs/src/pages/components/image-list/TitlebarBelowImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarBelowImageList.tsx
@@ -1,25 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-  icon: {
-    color: 'rgba(255, 255, 255, 0.54)',
-  },
-});
-
 export default function TitlebarBelowImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }}>
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img

--- a/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.js
@@ -1,23 +1,13 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-    overflowY: 'scroll',
-  },
-});
-
 export default function TitlebarBelowMasonryImageList() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 500, height: 450, overflowY: 'scroll' }}>
       <ImageList variant="masonry" cols={3} gap={8}>
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
@@ -26,7 +16,7 @@ export default function TitlebarBelowMasonryImageList() {
           </ImageListItem>
         ))}
       </ImageList>
-    </div>
+    </Box>
   );
 }
 

--- a/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.js
@@ -11,7 +11,12 @@ export default function TitlebarBelowMasonryImageList() {
       <ImageList variant="masonry" cols={3} gap={8}>
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
-            <img src={item.img} alt={item.title} />
+            <img
+              srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
+                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+              alt={item.title}
+              loading="lazy"
+            />
             <ImageListItemBar position="below" title={item.author} />
           </ImageListItem>
         ))}

--- a/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.tsx
@@ -1,23 +1,13 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-    overflowY: 'scroll',
-  },
-});
-
 export default function TitlebarBelowMasonryImageList() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ width: 500, height: 450, overflowY: 'scroll' }}>
       <ImageList variant="masonry" cols={3} gap={8}>
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
@@ -26,7 +16,7 @@ export default function TitlebarBelowMasonryImageList() {
           </ImageListItem>
         ))}
       </ImageList>
-    </div>
+    </Box>
   );
 }
 

--- a/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.tsx
@@ -11,7 +11,12 @@ export default function TitlebarBelowMasonryImageList() {
       <ImageList variant="masonry" cols={3} gap={8}>
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
-            <img src={item.img} alt={item.title} />
+            <img
+              srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
+                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+              alt={item.title}
+              loading="lazy"
+            />
             <ImageListItemBar position="below" title={item.author} />
           </ImageListItem>
         ))}

--- a/docs/src/pages/components/image-list/TitlebarImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarImageList.js
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
@@ -8,21 +7,9 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 import IconButton from '@material-ui/core/IconButton';
 import InfoIcon from '@material-ui/icons/Info';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-  icon: {
-    color: 'rgba(255, 255, 255, 0.54)',
-  },
-});
-
 export default function TitlebarImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }}>
       <ImageListItem key="Subheader" cols={2}>
         <ListSubheader component="div">December</ListSubheader>
       </ImageListItem>
@@ -38,8 +25,8 @@ export default function TitlebarImageList() {
             subtitle={item.author}
             actionIcon={
               <IconButton
+                sx={{ color: 'rgba(255, 255, 255, 0.54)' }}
                 aria-label={`info about ${item.title}`}
-                className={classes.icon}
               >
                 <InfoIcon />
               </IconButton>

--- a/docs/src/pages/components/image-list/TitlebarImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarImageList.js
@@ -19,6 +19,7 @@ export default function TitlebarImageList() {
             srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
                 ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
           <ImageListItemBar
             title={item.title}

--- a/docs/src/pages/components/image-list/TitlebarImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarImageList.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 import ImageListItemBar from '@material-ui/core/ImageListItemBar';
@@ -8,21 +7,9 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 import IconButton from '@material-ui/core/IconButton';
 import InfoIcon from '@material-ui/icons/Info';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-  icon: {
-    color: 'rgba(255, 255, 255, 0.54)',
-  },
-});
-
 export default function TitlebarImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }}>
       <ImageListItem key="Subheader" cols={2}>
         <ListSubheader component="div">December</ListSubheader>
       </ImageListItem>
@@ -38,8 +25,8 @@ export default function TitlebarImageList() {
             subtitle={item.author}
             actionIcon={
               <IconButton
+                sx={{ color: 'rgba(255, 255, 255, 0.54)' }}
                 aria-label={`info about ${item.title}`}
-                className={classes.icon}
               >
                 <InfoIcon />
               </IconButton>

--- a/docs/src/pages/components/image-list/TitlebarImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarImageList.tsx
@@ -19,6 +19,7 @@ export default function TitlebarImageList() {
             srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
                 ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
           <ImageListItemBar
             title={item.title}

--- a/docs/src/pages/components/image-list/WovenImageList.js
+++ b/docs/src/pages/components/image-list/WovenImageList.js
@@ -12,6 +12,7 @@ export default function WovenImageList() {
             srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
                 ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
         </ImageListItem>
       ))}

--- a/docs/src/pages/components/image-list/WovenImageList.js
+++ b/docs/src/pages/components/image-list/WovenImageList.js
@@ -1,21 +1,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-});
-
 export default function WovenImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList variant="woven" cols={3} gap={8} className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }} variant="woven" cols={3} gap={8}>
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img

--- a/docs/src/pages/components/image-list/WovenImageList.tsx
+++ b/docs/src/pages/components/image-list/WovenImageList.tsx
@@ -12,6 +12,7 @@ export default function WovenImageList() {
             srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
                 ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
+            loading="lazy"
           />
         </ImageListItem>
       ))}

--- a/docs/src/pages/components/image-list/WovenImageList.tsx
+++ b/docs/src/pages/components/image-list/WovenImageList.tsx
@@ -1,21 +1,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
-const useStyles = makeStyles({
-  root: {
-    width: 500,
-    height: 450,
-  },
-});
-
 export default function WovenImageList() {
-  const classes = useStyles();
-
   return (
-    <ImageList variant="woven" cols={3} gap={8} className={classes.root}>
+    <ImageList sx={{ width: 500, height: 450 }} variant="woven" cols={3} gap={8}>
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Image List component were migrated:

- [x] Standard image list
- [x] Quilted image list
- [x] Woven image list
- [x] Masonry image list
- [x] Image list with title bars
- [x] Title bar below image (standard)
- [x] Title bar below image (masonry)
- [x] Custom image list

Related to #16947