### PR TITLE
[docs] Migrate Links to emotion

### DIFF
--- a/docs/src/pages/components/links/Links.js
+++ b/docs/src/pages/components/links/Links.js
@@ -1,20 +1,21 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
-
-const Box = styled('div')(({ theme }) => ({
-  ...theme.typography.body1,
-  '& > :not(style) + :not(style)': {
-    marginLeft: theme.spacing(2),
-  },
-}));
 
 export default function Links() {
   const preventDefault = (event) => event.preventDefault();
 
   return (
-    <Box onClick={preventDefault}>
+    <Box
+      sx={{
+        typography: 'body1',
+        '& > :not(style) + :not(style)': {
+          ml: 2,
+        },
+      }}
+      onClick={preventDefault}
+    >
       <Link href="#">Link</Link>
       <Link href="#" color="inherit">
         {'color="inherit"'}

--- a/docs/src/pages/components/links/Links.js
+++ b/docs/src/pages/components/links/Links.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';

--- a/docs/src/pages/components/links/Links.js
+++ b/docs/src/pages/components/links/Links.js
@@ -2,24 +2,21 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    ...theme.typography.body1,
-    '& > * + *': {
-      marginLeft: theme.spacing(2),
-    },
+const Box = styled('div')(({ theme }) => ({
+  ...theme.typography.body1,
+  '& > :not(style) + :not(style)': {
+    marginLeft: theme.spacing(2),
   },
 }));
 
 export default function Links() {
-  const classes = useStyles();
   const preventDefault = (event) => event.preventDefault();
 
   return (
-    <div className={classes.root} onClick={preventDefault}>
+    <Box onClick={preventDefault}>
       <Link href="#">Link</Link>
       <Link href="#" color="inherit">
         {'color="inherit"'}
@@ -27,6 +24,6 @@ export default function Links() {
       <Link href="#" variant="body2">
         {'variant="body2"'}
       </Link>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/links/Links.tsx
+++ b/docs/src/pages/components/links/Links.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';

--- a/docs/src/pages/components/links/Links.tsx
+++ b/docs/src/pages/components/links/Links.tsx
@@ -2,26 +2,22 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';
+import * as CSS from 'csstype';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      ...theme.typography.body1,
-      '& > * + *': {
-        marginLeft: theme.spacing(2),
-      },
-    },
-  }),
-);
+const Box = styled('div')(({ theme }) => ({
+  ...(theme.typography.body1 as CSS.Properties),
+  '& > :not(style) + :not(style)': {
+    marginLeft: theme.spacing(2),
+  },
+}));
 
 export default function Links() {
-  const classes = useStyles();
   const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
 
   return (
-    <div className={classes.root} onClick={preventDefault}>
+    <Box onClick={preventDefault}>
       <Link href="#">Link</Link>
       <Link href="#" color="inherit">
         {'color="inherit"'}
@@ -29,6 +25,6 @@ export default function Links() {
       <Link href="#" variant="body2">
         {'variant="body2"'}
       </Link>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/links/Links.tsx
+++ b/docs/src/pages/components/links/Links.tsx
@@ -1,21 +1,21 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
-import * as CSS from 'csstype';
-
-const Box = styled('div')(({ theme }) => ({
-  ...(theme.typography.body1 as CSS.Properties),
-  '& > :not(style) + :not(style)': {
-    marginLeft: theme.spacing(2),
-  },
-}));
 
 export default function Links() {
   const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
 
   return (
-    <Box onClick={preventDefault}>
+    <Box
+      sx={{
+        typography: 'body1',
+        '& > :not(style) + :not(style)': {
+          ml: 2,
+        },
+      }}
+      onClick={preventDefault}
+    >
       <Link href="#">Link</Link>
       <Link href="#" color="inherit">
         {'color="inherit"'}

--- a/docs/src/pages/components/links/UnderlineLink.js
+++ b/docs/src/pages/components/links/UnderlineLink.js
@@ -1,20 +1,21 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
-
-const Box = styled('div')(({ theme }) => ({
-  ...theme.typography.body1,
-  '& > :not(style) + :not(style)': {
-    marginLeft: theme.spacing(2),
-  },
-}));
 
 export default function UnderlineLink() {
   const preventDefault = (event) => event.preventDefault();
 
   return (
-    <Box onClick={preventDefault}>
+    <Box
+      sx={{
+        typography: 'body1',
+        '& > :not(style) + :not(style)': {
+          ml: 2,
+        },
+      }}
+      onClick={preventDefault}
+    >
       <Link href="#" underline="none">
         {'underline="none"'}
       </Link>

--- a/docs/src/pages/components/links/UnderlineLink.js
+++ b/docs/src/pages/components/links/UnderlineLink.js
@@ -2,24 +2,21 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    ...theme.typography.body1,
-    '& > * + *': {
-      marginLeft: theme.spacing(2),
-    },
+const Box = styled('div')(({ theme }) => ({
+  ...theme.typography.body1,
+  '& > :not(style) + :not(style)': {
+    marginLeft: theme.spacing(2),
   },
 }));
 
 export default function UnderlineLink() {
-  const classes = useStyles();
   const preventDefault = (event) => event.preventDefault();
 
   return (
-    <div className={classes.root} onClick={preventDefault}>
+    <Box onClick={preventDefault}>
       <Link href="#" underline="none">
         {'underline="none"'}
       </Link>
@@ -29,6 +26,6 @@ export default function UnderlineLink() {
       <Link href="#" underline="always">
         {'underline="always"'}
       </Link>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/links/UnderlineLink.js
+++ b/docs/src/pages/components/links/UnderlineLink.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';

--- a/docs/src/pages/components/links/UnderlineLink.js
+++ b/docs/src/pages/components/links/UnderlineLink.js
@@ -9,6 +9,9 @@ export default function UnderlineLink() {
   return (
     <Box
       sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
         typography: 'body1',
         '& > :not(style) + :not(style)': {
           ml: 2,

--- a/docs/src/pages/components/links/UnderlineLink.tsx
+++ b/docs/src/pages/components/links/UnderlineLink.tsx
@@ -1,21 +1,21 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
-import * as CSS from 'csstype';
-
-const Box = styled('div')(({ theme }) => ({
-  ...(theme.typography.body1 as CSS.Properties),
-  '& > :not(style) + :not(style)': {
-    marginLeft: theme.spacing(2),
-  },
-}));
 
 export default function UnderlineLink() {
   const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
 
   return (
-    <Box onClick={preventDefault}>
+    <Box
+      sx={{
+        typography: 'body1',
+        '& > :not(style) + :not(style)': {
+          ml: 2,
+        },
+      }}
+      onClick={preventDefault}
+    >
       <Link href="#" underline="none">
         {'underline="none"'}
       </Link>

--- a/docs/src/pages/components/links/UnderlineLink.tsx
+++ b/docs/src/pages/components/links/UnderlineLink.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';

--- a/docs/src/pages/components/links/UnderlineLink.tsx
+++ b/docs/src/pages/components/links/UnderlineLink.tsx
@@ -2,26 +2,22 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';
+import * as CSS from 'csstype';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      ...theme.typography.body1,
-      '& > * + *': {
-        marginLeft: theme.spacing(2),
-      },
-    },
-  }),
-);
+const Box = styled('div')(({ theme }) => ({
+  ...(theme.typography.body1 as CSS.Properties),
+  '& > :not(style) + :not(style)': {
+    marginLeft: theme.spacing(2),
+  },
+}));
 
 export default function UnderlineLink() {
-  const classes = useStyles();
   const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
 
   return (
-    <div className={classes.root} onClick={preventDefault}>
+    <Box onClick={preventDefault}>
       <Link href="#" underline="none">
         {'underline="none"'}
       </Link>
@@ -31,6 +27,6 @@ export default function UnderlineLink() {
       <Link href="#" underline="always">
         {'underline="always"'}
       </Link>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/links/UnderlineLink.tsx
+++ b/docs/src/pages/components/links/UnderlineLink.tsx
@@ -9,6 +9,9 @@ export default function UnderlineLink() {
   return (
     <Box
       sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
         typography: 'body1',
         '& > :not(style) + :not(style)': {
           ml: 2,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Links component were migrated:

- [x] Basic links
- [x] Underline

Related to #16947