### PR TITLE
[Table] Fix duplicated keys in TablePagination rows per page

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -146,11 +146,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
             {rowsPerPageOptions.map((rowsPerPageOption) => (
               <MenuItemComponent
                 className={classes.menuItem}
-                key={
-                  rowsPerPageOption.value
-                    ? `value-${rowsPerPageOption.value}`
-                    : `option-${rowsPerPageOption}`
-                }
+                key={rowsPerPageOption.label ? rowsPerPageOption.label : rowsPerPageOption}
                 value={rowsPerPageOption.value ? rowsPerPageOption.value : rowsPerPageOption}
               >
                 {rowsPerPageOption.label ? rowsPerPageOption.label : rowsPerPageOption}

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -143,10 +143,14 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
             labelId={labelId}
             {...SelectProps}
           >
-            {rowsPerPageOptions.map((rowsPerPageOption, index) => (
+            {rowsPerPageOptions.map((rowsPerPageOption) => (
               <MenuItemComponent
                 className={classes.menuItem}
-                key={index}
+                key={
+                  rowsPerPageOption.value
+                    ? `value-${rowsPerPageOption.value}`
+                    : `option-${rowsPerPageOption}`
+                }
                 value={rowsPerPageOption.value ? rowsPerPageOption.value : rowsPerPageOption}
               >
                 {rowsPerPageOption.label ? rowsPerPageOption.label : rowsPerPageOption}

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -146,7 +146,11 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
             {rowsPerPageOptions.map((rowsPerPageOption) => (
               <MenuItemComponent
                 className={classes.menuItem}
-                key={rowsPerPageOption.value ? rowsPerPageOption.value : rowsPerPageOption}
+                key={
+                  rowsPerPageOption.value
+                    ? `value-${rowsPerPageOption.value}`
+                    : `option-${rowsPerPageOption}`
+                }
                 value={rowsPerPageOption.value ? rowsPerPageOption.value : rowsPerPageOption}
               >
                 {rowsPerPageOption.label ? rowsPerPageOption.label : rowsPerPageOption}

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -143,14 +143,10 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
             labelId={labelId}
             {...SelectProps}
           >
-            {rowsPerPageOptions.map((rowsPerPageOption) => (
+            {rowsPerPageOptions.map((rowsPerPageOption, index) => (
               <MenuItemComponent
                 className={classes.menuItem}
-                key={
-                  rowsPerPageOption.value
-                    ? `value-${rowsPerPageOption.value}`
-                    : `option-${rowsPerPageOption}`
-                }
+                key={index}
                 value={rowsPerPageOption.value ? rowsPerPageOption.value : rowsPerPageOption}
               >
                 {rowsPerPageOption.label ? rowsPerPageOption.label : rowsPerPageOption}

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -425,4 +425,28 @@ describe('<TablePagination />', () => {
       expect(container).to.include.text('1-25 of 25');
     });
   });
+
+  describe('duplicated keys', () => {
+    it('should not raise a warning due to duplicated keys', () => {
+      render(
+        <table>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                rowsPerPageOptions={[5, 10, { label: 'All', value: 10 }]}
+                count={10}
+                rowsPerPage={10}
+                page={0}
+                onPageChange={noop}
+                SelectProps={{
+                  inputProps: { 'aria-label': 'rows per page' },
+                  native: true,
+                }}
+              />
+            </TableRow>
+          </TableFooter>
+        </table>,
+      );
+    });
+  });
 });


### PR DESCRIPTION
The `Select` control which appears after `Rows per page:` shows the current amount of rows per page (value, for example `10`).
When clicking on the value, a list with all of the possible options appears (option, for example `5`, `10`, `20`, etc.).
Previously, both the value and the options each had their text as the key.
This resulted in duplicated key usage, as the value `10` with key `10` has the same key as the option `10` with key `10`.
By prefixing the value with `value-` and the option with `option-`, the keys are guaranteed to be unique.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
