### PR TITLE
[Autocomplete] Warn when the input didn't resolve in time

### DIFF
--- a/docs/src/pages/components/autocomplete/CustomizedHook.js
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.js
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import useAutocomplete from '@material-ui/core/useAutocomplete';
-import NoSsr from '@material-ui/core/NoSsr';
-import { useTheme, createMuiTheme } from '@material-ui/core/styles';
 import CheckIcon from '@material-ui/icons/Check';
 import CloseIcon from '@material-ui/icons/Close';
-import styled, { ThemeProvider } from 'styled-components';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 
 const Label = styled('label')`
   padding: 0 0 4px;
@@ -13,8 +12,8 @@ const Label = styled('label')`
   display: block;
 `;
 
-const InputWrapper = styled('div')`
-  ${({ theme }) => `
+const InputWrapper = styled('div')(
+  ({ theme }) => `
   width: 300px;
   border: 1px solid ${theme.palette.mode === 'dark' ? '#434343' : '#d9d9d9'};
   background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
@@ -46,16 +45,26 @@ const InputWrapper = styled('div')`
     margin: 0;
     outline: 0;
   }
-`}
-`;
+`,
+);
 
-const Tag = styled(({ label, onDelete, ...props }) => (
-  <div {...props}>
-    <span>{label}</span>
-    <CloseIcon onClick={onDelete} />
-  </div>
-))`
-  ${({ theme }) => `
+function Tag(props) {
+  const { label, onDelete, ...other } = props;
+  return (
+    <div {...other}>
+      <span>{label}</span>
+      <CloseIcon onClick={onDelete} />
+    </div>
+  );
+}
+
+Tag.propTypes = {
+  label: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+const StyledTag = styled(Tag)(
+  ({ theme }) => `
   display: flex;
   align-items: center;
   height: 24px;
@@ -87,11 +96,11 @@ const Tag = styled(({ label, onDelete, ...props }) => (
     cursor: pointer;
     padding: 4px;
   }
-`}
-`;
+`,
+);
 
-const Listbox = styled('ul')`
-  ${({ theme }) => `
+const Listbox = styled('ul')(
+  ({ theme }) => `
   width: 300px;
   margin: 2px 0 0;
   padding: 0;
@@ -134,10 +143,8 @@ const Listbox = styled('ul')`
       color: currentColor;
     }
   }
-`}
-`;
-
-const defaultTheme = createMuiTheme();
+`,
+);
 
 export default function CustomizedHook() {
   const {
@@ -159,35 +166,29 @@ export default function CustomizedHook() {
     getOptionLabel: (option) => option.title,
   });
 
-  const theme = useTheme() || defaultTheme;
-
   return (
-    <NoSsr>
-      <ThemeProvider theme={theme}>
-        <div>
-          <div {...getRootProps()}>
-            <Label {...getInputLabelProps()}>Customized hook</Label>
-            <InputWrapper ref={setAnchorEl} className={focused ? 'focused' : ''}>
-              {value.map((option, index) => (
-                <Tag label={option.title} {...getTagProps({ index })} />
-              ))}
+    <div>
+      <div {...getRootProps()}>
+        <Label {...getInputLabelProps()}>Customized hook</Label>
+        <InputWrapper ref={setAnchorEl} className={focused ? 'focused' : ''}>
+          {value.map((option, index) => (
+            <StyledTag label={option.title} {...getTagProps({ index })} />
+          ))}
 
-              <input {...getInputProps()} />
-            </InputWrapper>
-          </div>
-          {groupedOptions.length > 0 ? (
-            <Listbox {...getListboxProps()}>
-              {groupedOptions.map((option, index) => (
-                <li {...getOptionProps({ option, index })}>
-                  <span>{option.title}</span>
-                  <CheckIcon fontSize="small" />
-                </li>
-              ))}
-            </Listbox>
-          ) : null}
-        </div>
-      </ThemeProvider>
-    </NoSsr>
+          <input {...getInputProps()} />
+        </InputWrapper>
+      </div>
+      {groupedOptions.length > 0 ? (
+        <Listbox {...getListboxProps()}>
+          {groupedOptions.map((option, index) => (
+            <li {...getOptionProps({ option, index })}>
+              <span>{option.title}</span>
+              <CheckIcon fontSize="small" />
+            </li>
+          ))}
+        </Listbox>
+      ) : null}
+    </div>
   );
 }
 

--- a/docs/src/pages/components/autocomplete/CustomizedHook.tsx
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import useAutocomplete from '@material-ui/core/useAutocomplete';
-import NoSsr from '@material-ui/core/NoSsr';
-import { useTheme, createMuiTheme } from '@material-ui/core/styles';
+import useAutocomplete, {
+  AutocompleteGetTagProps,
+} from '@material-ui/core/useAutocomplete';
 import CheckIcon from '@material-ui/icons/Check';
 import CloseIcon from '@material-ui/icons/Close';
-import styled, { ThemeProvider } from 'styled-components';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 
 const Label = styled('label')`
   padding: 0 0 4px;
@@ -13,8 +13,8 @@ const Label = styled('label')`
   display: block;
 `;
 
-const InputWrapper = styled('div')`
-  ${({ theme }) => `
+const InputWrapper = styled('div')(
+  ({ theme }) => `
   width: 300px;
   border: 1px solid ${theme.palette.mode === 'dark' ? '#434343' : '#d9d9d9'};
   background-color: ${theme.palette.mode === 'dark' ? '#141414' : '#fff'};
@@ -46,16 +46,25 @@ const InputWrapper = styled('div')`
     margin: 0;
     outline: 0;
   }
-`}
-`;
+`,
+);
 
-const Tag = styled(({ label, onDelete, ...props }) => (
-  <div {...props}>
-    <span>{label}</span>
-    <CloseIcon onClick={onDelete} />
-  </div>
-))`
-  ${({ theme }) => `
+interface TagProps extends ReturnType<AutocompleteGetTagProps> {
+  label: string;
+}
+
+function Tag(props: TagProps) {
+  const { label, onDelete, ...other } = props;
+  return (
+    <div {...other}>
+      <span>{label}</span>
+      <CloseIcon onClick={onDelete} />
+    </div>
+  );
+}
+
+const StyledTag = styled(Tag)<TagProps>(
+  ({ theme }) => `
   display: flex;
   align-items: center;
   height: 24px;
@@ -87,11 +96,11 @@ const Tag = styled(({ label, onDelete, ...props }) => (
     cursor: pointer;
     padding: 4px;
   }
-`}
-`;
+`,
+);
 
-const Listbox = styled('ul')`
-  ${({ theme }) => `
+const Listbox = styled('ul')(
+  ({ theme }) => `
   width: 300px;
   margin: 2px 0 0;
   padding: 0;
@@ -134,10 +143,8 @@ const Listbox = styled('ul')`
       color: currentColor;
     }
   }
-`}
-`;
-
-const defaultTheme = createMuiTheme();
+`,
+);
 
 export default function CustomizedHook() {
   const {
@@ -159,34 +166,28 @@ export default function CustomizedHook() {
     getOptionLabel: (option) => option.title,
   });
 
-  const theme = useTheme() || defaultTheme;
-
   return (
-    <NoSsr>
-      <ThemeProvider theme={theme}>
-        <div>
-          <div {...getRootProps()}>
-            <Label {...getInputLabelProps()}>Customized hook</Label>
-            <InputWrapper ref={setAnchorEl} className={focused ? 'focused' : ''}>
-              {value.map((option: FilmOptionType, index: number) => (
-                <Tag label={option.title} {...getTagProps({ index })} />
-              ))}
-              <input {...getInputProps()} />
-            </InputWrapper>
-          </div>
-          {groupedOptions.length > 0 ? (
-            <Listbox {...getListboxProps()}>
-              {(groupedOptions as typeof top100Films).map((option, index) => (
-                <li {...getOptionProps({ option, index })}>
-                  <span>{option.title}</span>
-                  <CheckIcon fontSize="small" />
-                </li>
-              ))}
-            </Listbox>
-          ) : null}
-        </div>
-      </ThemeProvider>
-    </NoSsr>
+    <div>
+      <div {...getRootProps()}>
+        <Label {...getInputLabelProps()}>Customized hook</Label>
+        <InputWrapper ref={setAnchorEl} className={focused ? 'focused' : ''}>
+          {value.map((option: FilmOptionType, index: number) => (
+            <StyledTag label={option.title} {...getTagProps({ index })} />
+          ))}
+          <input {...getInputProps()} />
+        </InputWrapper>
+      </div>
+      {groupedOptions.length > 0 ? (
+        <Listbox {...getListboxProps()}>
+          {(groupedOptions as typeof top100Films).map((option, index) => (
+            <li {...getOptionProps({ option, index })}>
+              <span>{option.title}</span>
+              <CheckIcon fontSize="small" />
+            </li>
+          ))}
+        </Listbox>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -499,7 +499,7 @@ export default function useAutocomplete(props) {
       if (!inputRef.current || inputRef.current.nodeName !== 'INPUT') {
         console.error(
           [
-            `Material-UI: The input ref is not binded correctly, it resolves to: ${inputRef.current}.`,
+            `Material-UI: Unable to find the input element. It was resolved to ${inputRef.current} while an HTMLInputElement was expected.`,
             `Instead, ${componentName} expects an input element.`,
             '',
             componentName === 'useAutocomplete'

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -283,9 +283,9 @@ export default function useAutocomplete(props) {
 
     // does the index exist?
     if (index === -1) {
-      inputRef.current.removeAttribute('aria-activedescendant');
+      inputRef.current?.removeAttribute('aria-activedescendant');
     } else {
-      inputRef.current.setAttribute('aria-activedescendant', `${id}-option-${index}`);
+      inputRef.current?.setAttribute('aria-activedescendant', `${id}-option-${index}`);
     }
 
     if (onHighlightChange) {

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.js
@@ -283,9 +283,9 @@ export default function useAutocomplete(props) {
 
     // does the index exist?
     if (index === -1) {
-      inputRef.current?.removeAttribute('aria-activedescendant');
+      inputRef.current.removeAttribute('aria-activedescendant');
     } else {
-      inputRef.current?.setAttribute('aria-activedescendant', `${id}-option-${index}`);
+      inputRef.current.setAttribute('aria-activedescendant', `${id}-option-${index}`);
     }
 
     if (onHighlightChange) {
@@ -492,6 +492,24 @@ export default function useAutocomplete(props) {
 
     syncHighlightedIndex();
   });
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      if (!inputRef.current || inputRef.current.nodeName !== 'INPUT') {
+        console.error(
+          [
+            `Material-UI: The input ref is not binded correctly, it resolves to: ${inputRef.current}.`,
+            `Instead, ${componentName} expects an input element.`,
+            '',
+            componentName === 'useAutocomplete'
+              ? 'Make sure you have binded getInputProps correctly and that the normal ref/effect resolutions order is guaranteed.'
+              : 'Make sure you have customized the input component correctly.',
+          ].join('\n'),
+        );
+      }
+    }, [componentName]);
+  }
 
   React.useEffect(() => {
     syncHighlightedIndex();

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, screen } from 'test/utils';
+import { createClientRender, screen, ErrorBoundary } from 'test/utils';
 import useAutocomplete, { createFilterOptions } from '@material-ui/core/useAutocomplete';
 
 describe('useAutocomplete', () => {
@@ -214,5 +214,53 @@ describe('useAutocomplete', () => {
         ]);
       });
     });
+  });
+
+  it('should warn if the input is not binded', () => {
+    const Test = (props) => {
+      const { options } = props;
+      const {
+        groupedOptions,
+        getRootProps,
+        getInputLabelProps,
+        // getInputProps,
+        getListboxProps,
+        getOptionProps,
+      } = useAutocomplete({
+        options,
+        open: true,
+      });
+
+      return (
+        <div>
+          <div {...getRootProps()}>
+            <label {...getInputLabelProps()}>useAutocomplete</label>
+          </div>
+          {groupedOptions.length > 0 ? (
+            <ul {...getListboxProps()}>
+              {groupedOptions.map((option, index) => {
+                return <li {...getOptionProps({ option, index })}>{option}</li>;
+              })}
+            </ul>
+          ) : null}
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(
+        <ErrorBoundary>
+          <Test options={['foo', 'bar']} />
+        </ErrorBoundary>,
+      );
+    }).toErrorDev([
+      "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
+      'Material-UI: The input ref is not binded correctly',
+      "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
+      'The above error occurred in the <ul> component',
+      'The above error occurred in the <ul> component',
+      'The above error occurred in the <Test> component',
+      'The above error occurred in the <Test> component',
+    ]);
   });
 });

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
@@ -216,7 +216,14 @@ describe('useAutocomplete', () => {
     });
   });
 
-  it('should warn if the input is not binded', () => {
+  it('should warn if the input is not binded', function test() {
+    // TODO is this fixed?
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      // can't catch render errors in the browser for unknown reason
+      // tried try-catch + error boundary + window onError preventDefault
+      this.skip();
+    }
+
     const Test = (props) => {
       const { options } = props;
       const {

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
@@ -262,7 +262,7 @@ describe('useAutocomplete', () => {
       );
     }).toErrorDev([
       "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
-      'Material-UI: The input ref is not binded correctly',
+      'Material-UI: Unable to find the input element.',
       "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
       'The above error occurred in the <ul> component',
       'The above error occurred in the <ul> component',

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.test.js
@@ -265,9 +265,11 @@ describe('useAutocomplete', () => {
       'Material-UI: Unable to find the input element.',
       "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
       'The above error occurred in the <ul> component',
-      'The above error occurred in the <ul> component',
+      // strict mode renders twice
+      React.version.startsWith('16') && 'The above error occurred in the <ul> component',
       'The above error occurred in the <Test> component',
-      'The above error occurred in the <Test> component',
+      // strict mode renders twice
+      React.version.startsWith('16') && 'The above error occurred in the <Test> component',
     ]);
   });
 });


### PR DESCRIPTION
This fixes a problem that seems to occur if a state change for a component causes React to re-render the component, removing an input ref for which the autocomplete attempts to alter focus. In that case, there is a null no-method error for one of these two lines.

JS is not my forte, but the solution in the linked issue works, and requires less wrestling with contingent order of operations. Perhaps there's a way to guarantee this hook has access to a current inputRef, but is anything truly lost by not highlighting something that no longer exists?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #25273

Verifies inputRef.current is non-null before modifying its attributes