### PR TITLE
[core] Use Promise.allSettled over .all where appropriate

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -1335,7 +1335,7 @@ async function run(argv: {
       });
   });
 
-  const builds = await Promise.all(componentBuilds);
+  const builds = await Promise.allSettled(componentBuilds);
 
   const fails = builds.filter(
     (promise): promise is { status: 'rejected'; reason: string } => promise.status === 'rejected',

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -342,7 +342,7 @@ async function run(argv: HandlerArgv) {
     return generateProptypes(program, sourceFile, tsFile);
   });
 
-  const results = await Promise.all(promises);
+  const results = await Promise.allSettled(promises);
 
   if (verbose) {
     files.forEach((file, index) => {

--- a/scripts/jsonlint.js
+++ b/scripts/jsonlint.js
@@ -33,7 +33,7 @@ async function run() {
     }
   });
 
-  await Promise.all(checks);
+  await Promise.allSettled(checks);
   if (passed === false) {
     throw new Error('At least one file did not pass. Check the console output');
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": ["es2020", "dom"],
     "jsx": "preserve",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Requires node 12

`Promise.all` resolves once any promise rejects. `Promise.allSettled` resolves after all promises have either resolved or rejected i.e. settled. `Promise.all` is like running the test suite with `--bail` which is not always desired. 

For `yarn proptypes` this will lead to only the failed Component creating an empty file (under certain circumstances). Before, it would leave the whole repo in an inconsistent state even though just one component failed.