### PR TITLE
[core] Batch small changes

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,8 +8,7 @@ module.exports = {
     'docs/.next/**',
   ],
   recursive: true,
-  // Circle CI has low-performance CPUs.
-  timeout: process.env.CIRCLECI === 'true' ? 5000 : 2000,
+  timeout: (process.env.CIRCLECI === 'true' ? 5 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
   require: [require.resolve('./test/utils/setupBabel'), require.resolve('./test/utils/setupJSDOM')],
   'watch-ignore': [

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,7 +8,8 @@ module.exports = {
     'docs/.next/**',
   ],
   recursive: true,
-  timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000, // Circle CI has low-performance CPUs.
+  // Circle CI has low-performance CPUs.
+  timeout: process.env.CIRCLECI === 'true' ? 5000 : 2000,
   reporter: 'dot',
   require: [require.resolve('./test/utils/setupBabel'), require.resolve('./test/utils/setupJSDOM')],
   'watch-ignore': [

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "author": "Material-UI Team",
   "license": "MIT",
   "scripts": {
-    "build": "cross-env NODE_ENV=production next build --profile",
+    "build": "cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 next build --profile",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev",

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -138,6 +138,7 @@ https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 /api/grid-list-tile-bar/ /api/image-list-item-bar/ 301
 /customization/components/ /customization/how-to-customize/ 301
 /customization/globals/ /customization/theme-components/ 301
+/components/slider-styled/ /components/slider/ 301
 
 # Proxies
 

--- a/docs/src/pages/components/material-icons/material-icons.md
+++ b/docs/src/pages/components/material-icons/material-icons.md
@@ -8,14 +8,14 @@ githubLabel: 'package: icons'
 
 # Material Icons
 
-<p class="description">1,300+ React Material icons ready to use from the official website.</p>
+<p class="description">1,700+ React Material icons ready to use from the official website.</p>
 
 The following npm package,
 [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons),
-includes the 1,300+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
+includes the 1,700+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 {{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
-ℹ️ The search supports synonyms. Try searching for "hamburger", or "logout".
+ℹ️ The search supports synonyms. Try searching for "hamburger" or "logout".

--- a/docs/src/pages/components/speed-dial/speed-dial.md
+++ b/docs/src/pages/components/speed-dial/speed-dial.md
@@ -2,7 +2,7 @@
 title: React Speed Dial component
 components: SpeedDial, SpeedDialAction, SpeedDialIcon
 githubLabel: 'component: SpeedDial'
-https://material.io/components/buttons-floating-action-button#types-of-transitions
+materialDesign: https://material.io/components/buttons-floating-action-button#types-of-transitions
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,6 @@
 
 [build.environment]
   NODE_VERSION = "12"
-  NODE_OPTIONS = "--max_old_space_size=4096"
   # Not using `playwright` when building docs.
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -17,7 +17,7 @@ import TreeView from '../TreeView';
 
 describe('<TreeItem />', () => {
   let classes;
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -17,7 +17,7 @@ import TreeItem from '../TreeItem';
 
 describe('<TreeView />', () => {
   let classes;
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {

--- a/packages/material-ui/src/Accordion/Accordion.test.js
+++ b/packages/material-ui/src/Accordion/Accordion.test.js
@@ -10,7 +10,7 @@ import classes from './accordionClasses';
 
 describe('<Accordion />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const minimalChildren = [<AccordionSummary key="header">Header</AccordionSummary>];
 
   describeConformanceV5(<Accordion>{minimalChildren}</Accordion>, () => ({

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -6,7 +6,7 @@ import Fade from '../Fade';
 
 describe('<Backdrop />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
 
   describeConformanceV5(<Backdrop open />, () => ({
     classes,

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -9,7 +9,7 @@ import classes from './collapseClasses';
 
 describe('<Collapse />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const defaultProps = {
     in: true,
     children: <div />,

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -7,7 +7,7 @@ import Fade from './Fade';
 
 describe('<Fade />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
 
   const defaultProps = {
     in: true,

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -11,7 +11,7 @@ import useForkRef from '../utils/useForkRef';
 
 describe('<Grow />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const defaultProps = {
     in: true,
     children: <div />,

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -21,7 +21,7 @@ const NoContent = React.forwardRef(() => {
 
 describe('<ListItem />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
 
   describeConformanceV5(<ListItem />, () => ({
     classes,

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -19,7 +19,7 @@ import Modal, { modalClasses as classes } from '@material-ui/core/Modal';
 
 describe('<Modal />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   let savedBodyStyle;
 
   before(() => {

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -15,7 +15,7 @@ import Grow from '../Grow';
 import Popper from './Popper';
 
 describe('<Popper />', () => {
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   let rtlTheme;
   const render = createClientRender();
   const defaultProps = {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -18,7 +18,7 @@ import Select from './Select';
 
 describe('<Select />', () => {
   let classes;
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   // StrictModeViolation: triggers "not wrapped in act()" warnings from timers.
   const render = createClientRender({ strict: false });
 

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -9,7 +9,7 @@ import { useForkRef } from '../utils';
 
 describe('<Slide />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const defaultProps = {
     in: true,
     children: <div id="testChild" />,

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -17,7 +17,7 @@ describe('<Snackbar />', () => {
     clock.restore();
   });
 
-  const mount = createMount({ strict: true });
+  const mount = createMount();
 
   const clientRender = createClientRender();
   /**

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.test.js
@@ -19,7 +19,7 @@ describe('<SpeedDialAction />', () => {
     clock.restore();
   });
 
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -8,7 +8,7 @@ import StepContent, { stepContentClasses as classes } from '@material-ui/core/St
 
 describe('<StepContent />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
 
   describeConformanceV5(<StepContent />, () => ({
     classes,

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -9,7 +9,7 @@ import StepLabel from './StepLabel';
 
 describe('<StepLabel />', () => {
   let classes;
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -9,7 +9,7 @@ import Stepper from '@material-ui/core/Stepper';
 
 describe('<Stepper />', () => {
   let classes;
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const render = createClientRender();
 
   before(() => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -45,7 +45,7 @@ describe('<Tooltip />', () => {
     });
   });
 
-  const mount = createMount({ strict: true });
+  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -7,7 +7,7 @@ import Zoom from './Zoom';
 
 describe('<Zoom />', () => {
   const render = createClientRender();
-  const mount = createMount({ strict: true });
+  const mount = createMount();
 
   describeConformance(
     <Zoom in>

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -40,7 +40,7 @@ module.exports = function setKarmaConfig(config) {
     client: {
       mocha: {
         // Some BrowserStack browsers can be slow.
-        timeout: process.env.CIRCLECI === 'true' ? 4000 : 2000,
+        timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000,
       },
     },
     frameworks: ['mocha'],

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -40,7 +40,7 @@ module.exports = function setKarmaConfig(config) {
     client: {
       mocha: {
         // Some BrowserStack browsers can be slow.
-        timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000,
+        timeout: process.env.CIRCLECI === 'true' ? 4000 : 2000,
       },
     },
     frameworks: ['mocha'],


### PR DESCRIPTION
- [SpeedDial] Fix Material Design reference b0c02b7: found this in #25320 with Sebastian.

<img width="174" alt="Screenshot 2021-03-13 at 16 14 56" src="https://user-images.githubusercontent.com/3165635/111034727-43b54700-8417-11eb-9409-aaf070894efc.png">

- [docs] We have a lot more icons now a97d13f: See https://next.material-ui.com/components/material-icons/

<img width="217" alt="Screenshot 2021-03-13 at 15 24 16" src="https://user-images.githubusercontent.com/3165635/111033173-36488e80-8410-11eb-90db-5b48b5b1eba4.png">

For reference, [FontAwesome](https://fontawesome.com/icons?d=gallery&p=2&s=solid) has 1,852 icons and 5 variants. We have 1,781 icons and 5 variants. I never thought Google would add so many icons 😆.

- [Slider] Fix 404 link to the lab slider 2220a19. The error was reported by our Moz.com crawler. We link the pages in the GitHub's issues, e.g. https://github.com/mui-org/material-ui/issues/17973#issuecomment-726237357. We don't really need to care about it, but it seems trivial to fix. 
- [test] Increase a bit the timeout 60cb89e. I have seen this timeout to reach a number of times [1.](https://app.circleci.com/pipelines/github/mui-org/material-ui/38989/workflows/f3fe1116-1a9e-49af-81fb-0c54738c4793/jobs/230352), [2.](https://app.circleci.com/pipelines/github/mui-org/material-ui/38992/workflows/5f75970f-c2a2-416a-9a01-50b951e4e1ff/jobs/230377), [3.](https://app.circleci.com/pipelines/github/mui-org/material-ui/39177/workflows/0fde6844-4297-4448-9a60-b8b1155a7c4e/jobs/231537). It's tiring.
- [docs] Netlify is no different to the local env 2933241. I have found this issue in https://github.com/mui-org/material-ui/pull/25190#issuecomment-790985741. I was working with Sebastian on finding the bottlenecks of the extra icons.
- [core] Strict is already the default option d791dee. A minor detail.