### PR TITLE
[docs] Migrate Grid to emotion

### DIFF
--- a/docs/src/pages/components/grid/AutoGrid.js
+++ b/docs/src/pages/components/grid/AutoGrid.js
@@ -1,44 +1,39 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 export default function AutoGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
       </Grid>
       <br />
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
         <Grid item xs={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6
-          </Paper>
+          <Item>xs=6</Item>
         </Grid>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
       </Grid>
     </Box>

--- a/docs/src/pages/components/grid/AutoGrid.js
+++ b/docs/src/pages/components/grid/AutoGrid.js
@@ -1,47 +1,46 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  paper: {
-    padding: theme.spacing(2),
-    textAlign: 'center',
-    color: theme.palette.text.secondary,
-  },
-}));
-
 export default function AutoGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
       </Grid>
       <br />
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
         <Grid item xs={6}>
-          <Paper className={classes.paper}>xs=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6
+          </Paper>
         </Grid>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/AutoGrid.tsx
+++ b/docs/src/pages/components/grid/AutoGrid.tsx
@@ -1,44 +1,39 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 export default function AutoGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
       </Grid>
       <br />
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
         <Grid item xs={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6
-          </Paper>
+          <Item>xs=6</Item>
         </Grid>
         <Grid item xs>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs
-          </Paper>
+          <Item>xs</Item>
         </Grid>
       </Grid>
     </Box>

--- a/docs/src/pages/components/grid/AutoGrid.tsx
+++ b/docs/src/pages/components/grid/AutoGrid.tsx
@@ -1,49 +1,46 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    paper: {
-      padding: theme.spacing(2),
-      textAlign: 'center',
-      color: theme.palette.text.secondary,
-    },
-  }),
-);
-
 export default function AutoGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
       </Grid>
       <br />
       <Grid container spacing={3}>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
         <Grid item xs={6}>
-          <Paper className={classes.paper}>xs=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6
+          </Paper>
         </Grid>
         <Grid item xs>
-          <Paper className={classes.paper}>xs</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs
+          </Paper>
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/AutoGridNoWrap.js
+++ b/docs/src/pages/components/grid/AutoGridNoWrap.js
@@ -1,32 +1,17 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Avatar from '@material-ui/core/Avatar';
 import Typography from '@material-ui/core/Typography';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-    overflow: 'hidden',
-    padding: theme.spacing(0, 3),
-  },
-  paper: {
-    maxWidth: 400,
-    margin: `${theme.spacing(1)} auto`,
-    padding: theme.spacing(2),
-  },
-}));
 
 const message = `Truncation should be conditionally applicable on this long line of text
  as this is a much longer line than what the container can support. `;
 
 export default function AutoGridNoWrap() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
+    <Box sx={{ flexGrow: 1, overflow: 'hidden', px: 3 }}>
+      <Paper sx={{ maxWidth: 400, my: 1, mx: 'auto', p: 2 }}>
         <Grid container wrap="nowrap" spacing={2}>
           <Grid item>
             <Avatar>W</Avatar>
@@ -36,7 +21,7 @@ export default function AutoGridNoWrap() {
           </Grid>
         </Grid>
       </Paper>
-      <Paper className={classes.paper}>
+      <Paper sx={{ maxWidth: 400, my: 1, mx: 'auto', p: 2 }}>
         <Grid container wrap="nowrap" spacing={2}>
           <Grid item>
             <Avatar>W</Avatar>
@@ -46,7 +31,7 @@ export default function AutoGridNoWrap() {
           </Grid>
         </Grid>
       </Paper>
-      <Paper className={classes.paper}>
+      <Paper sx={{ maxWidth: 400, my: 1, mx: 'auto', p: 2 }}>
         <Grid container wrap="nowrap" spacing={2}>
           <Grid item>
             <Avatar>W</Avatar>
@@ -56,6 +41,6 @@ export default function AutoGridNoWrap() {
           </Grid>
         </Grid>
       </Paper>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/AutoGridNoWrap.tsx
+++ b/docs/src/pages/components/grid/AutoGridNoWrap.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import Paper from '@material-ui/core/Paper';
 import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import Avatar from '@material-ui/core/Avatar';
 import Typography from '@material-ui/core/Typography';

--- a/docs/src/pages/components/grid/AutoGridNoWrap.tsx
+++ b/docs/src/pages/components/grid/AutoGridNoWrap.tsx
@@ -1,34 +1,17 @@
 import * as React from 'react';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import Avatar from '@material-ui/core/Avatar';
 import Typography from '@material-ui/core/Typography';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-      overflow: 'hidden',
-      padding: theme.spacing(0, 3),
-    },
-    paper: {
-      maxWidth: 400,
-      margin: `${theme.spacing(1)} auto`,
-      padding: theme.spacing(2),
-    },
-  }),
-);
 
 const message = `Truncation should be conditionally applicable on this long line of text
  as this is a much longer line than what the container can support. `;
 
 export default function AutoGridNoWrap() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
+    <Box sx={{ flexGrow: 1, overflow: 'hidden', px: 3 }}>
+      <Paper sx={{ maxWidth: 400, my: 1, mx: 'auto', p: 2 }}>
         <Grid container wrap="nowrap" spacing={2}>
           <Grid item>
             <Avatar>W</Avatar>
@@ -38,7 +21,7 @@ export default function AutoGridNoWrap() {
           </Grid>
         </Grid>
       </Paper>
-      <Paper className={classes.paper}>
+      <Paper sx={{ maxWidth: 400, my: 1, mx: 'auto', p: 2 }}>
         <Grid container wrap="nowrap" spacing={2}>
           <Grid item>
             <Avatar>W</Avatar>
@@ -48,7 +31,7 @@ export default function AutoGridNoWrap() {
           </Grid>
         </Grid>
       </Paper>
-      <Paper className={classes.paper}>
+      <Paper sx={{ maxWidth: 400, my: 1, mx: 'auto', p: 2 }}>
         <Grid container wrap="nowrap" spacing={2}>
           <Grid item>
             <Avatar>W</Avatar>
@@ -58,6 +41,6 @@ export default function AutoGridNoWrap() {
           </Grid>
         </Grid>
       </Paper>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/CSSGrid.js
+++ b/docs/src/pages/components/grid/CSSGrid.js
@@ -1,31 +1,11 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme) => ({
-  container: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(12, 1fr)',
-    gap: theme.spacing(3),
-  },
-  paper: {
-    padding: theme.spacing(1),
-    textAlign: 'center',
-    color: theme.palette.text.secondary,
-    whiteSpace: 'nowrap',
-    marginBottom: theme.spacing(1),
-  },
-  divider: {
-    margin: theme.spacing(2, 0),
-  },
-}));
-
 export default function CSSGrid() {
-  const classes = useStyles();
-
   return (
     <div>
       <Typography variant="subtitle1" gutterBottom component="div">
@@ -33,48 +13,168 @@ export default function CSSGrid() {
       </Typography>
       <Grid container spacing={3}>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={8}>
-          <Paper className={classes.paper}>xs=8</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=8
+          </Paper>
         </Grid>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>xs=4</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=4
+          </Paper>
         </Grid>
       </Grid>
-      <Divider className={classes.divider} />
+      <Divider sx={{ my: 2 }} />
       <Typography variant="subtitle1" gutterBottom component="div">
         CSS Grid Layout:
       </Typography>
-      <div className={classes.container}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 3 }}>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 8' }}>
-          <Paper className={classes.paper}>xs=8</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=8
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 4' }}>
-          <Paper className={classes.paper}>xs=4</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=4
+          </Paper>
         </div>
-      </div>
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/grid/CSSGrid.js
+++ b/docs/src/pages/components/grid/CSSGrid.js
@@ -1,9 +1,18 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  whiteSpace: 'nowrap',
+  marginBottom: theme.spacing(1),
+}));
 
 export default function CSSGrid() {
   return (
@@ -13,82 +22,22 @@ export default function CSSGrid() {
       </Typography>
       <Grid container spacing={3}>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={8}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=8
-          </Paper>
+          <Item>xs=8</Item>
         </Grid>
         <Grid item xs={4}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=4
-          </Paper>
+          <Item>xs=4</Item>
         </Grid>
       </Grid>
       <Divider sx={{ my: 2 }} />
@@ -96,84 +45,24 @@ export default function CSSGrid() {
         CSS Grid Layout:
       </Typography>
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 3 }}>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 8' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=8
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 4' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=4
-          </Paper>
-        </div>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 8' }}>
+          <Item>xs=8</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 4' }}>
+          <Item>xs=4</Item>
+        </Box>
       </Box>
     </div>
   );

--- a/docs/src/pages/components/grid/CSSGrid.tsx
+++ b/docs/src/pages/components/grid/CSSGrid.tsx
@@ -1,33 +1,11 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    container: {
-      display: 'grid',
-      gridTemplateColumns: 'repeat(12, 1fr)',
-      gap: theme.spacing(3),
-    },
-    paper: {
-      padding: theme.spacing(1),
-      textAlign: 'center',
-      color: theme.palette.text.secondary,
-      whiteSpace: 'nowrap',
-      marginBottom: theme.spacing(1),
-    },
-    divider: {
-      margin: theme.spacing(2, 0),
-    },
-  }),
-);
-
 export default function CSSGrid() {
-  const classes = useStyles();
-
   return (
     <div>
       <Typography variant="subtitle1" gutterBottom component="div">
@@ -35,48 +13,168 @@ export default function CSSGrid() {
       </Typography>
       <Grid container spacing={3}>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={8}>
-          <Paper className={classes.paper}>xs=8</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=8
+          </Paper>
         </Grid>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>xs=4</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=4
+          </Paper>
         </Grid>
       </Grid>
-      <Divider className={classes.divider} />
+      <Divider sx={{ my: 2 }} />
       <Typography variant="subtitle1" gutterBottom component="div">
         CSS Grid Layout:
       </Typography>
-      <div className={classes.container}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 3 }}>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=3
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 8' }}>
-          <Paper className={classes.paper}>xs=8</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=8
+          </Paper>
         </div>
         <div style={{ gridColumnEnd: 'span 4' }}>
-          <Paper className={classes.paper}>xs=4</Paper>
+          <Paper
+            sx={{
+              p: 1,
+              textAlign: 'center',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              mb: 1,
+            }}
+          >
+            xs=4
+          </Paper>
         </div>
-      </div>
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/grid/CSSGrid.tsx
+++ b/docs/src/pages/components/grid/CSSGrid.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  whiteSpace: 'nowrap',
+  marginBottom: theme.spacing(1),
+}));
 
 export default function CSSGrid() {
   return (
@@ -13,82 +22,22 @@ export default function CSSGrid() {
       </Typography>
       <Grid container spacing={3}>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={8}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=8
-          </Paper>
+          <Item>xs=8</Item>
         </Grid>
         <Grid item xs={4}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=4
-          </Paper>
+          <Item>xs=4</Item>
         </Grid>
       </Grid>
       <Divider sx={{ my: 2 }} />
@@ -96,84 +45,24 @@ export default function CSSGrid() {
         CSS Grid Layout:
       </Typography>
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 3 }}>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 3' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=3
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 8' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=8
-          </Paper>
-        </div>
-        <div style={{ gridColumnEnd: 'span 4' }}>
-          <Paper
-            sx={{
-              p: 1,
-              textAlign: 'center',
-              color: 'text.secondary',
-              whiteSpace: 'nowrap',
-              mb: 1,
-            }}
-          >
-            xs=4
-          </Paper>
-        </div>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 3' }}>
+          <Item>xs=3</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 8' }}>
+          <Item>xs=8</Item>
+        </Box>
+        <Box sx={{ gridColumnEnd: 'span 4' }}>
+          <Item>xs=4</Item>
+        </Box>
       </Box>
     </div>
   );

--- a/docs/src/pages/components/grid/CenteredGrid.js
+++ b/docs/src/pages/components/grid/CenteredGrid.js
@@ -1,47 +1,48 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  paper: {
-    padding: theme.spacing(2),
-    textAlign: 'center',
-    color: theme.palette.text.secondary,
-  },
-}));
-
 export default function CenteredGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper className={classes.paper}>xs=12</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12
+          </Paper>
         </Grid>
         <Grid item xs={6}>
-          <Paper className={classes.paper}>xs=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6
+          </Paper>
         </Grid>
         <Grid item xs={6}>
-          <Paper className={classes.paper}>xs=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/CenteredGrid.js
+++ b/docs/src/pages/components/grid/CenteredGrid.js
@@ -1,46 +1,39 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 export default function CenteredGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12
-          </Paper>
+          <Item>xs=12</Item>
         </Grid>
         <Grid item xs={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6
-          </Paper>
+          <Item>xs=6</Item>
         </Grid>
         <Grid item xs={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6
-          </Paper>
+          <Item>xs=6</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
       </Grid>
     </Box>

--- a/docs/src/pages/components/grid/CenteredGrid.tsx
+++ b/docs/src/pages/components/grid/CenteredGrid.tsx
@@ -1,49 +1,48 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    paper: {
-      padding: theme.spacing(2),
-      textAlign: 'center',
-      color: theme.palette.text.secondary,
-    },
-  }),
-);
-
 export default function CenteredGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper className={classes.paper}>xs=12</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12
+          </Paper>
         </Grid>
         <Grid item xs={6}>
-          <Paper className={classes.paper}>xs=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6
+          </Paper>
         </Grid>
         <Grid item xs={6}>
-          <Paper className={classes.paper}>xs=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper className={classes.paper}>xs=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=3
+          </Paper>
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/CenteredGrid.tsx
+++ b/docs/src/pages/components/grid/CenteredGrid.tsx
@@ -1,46 +1,39 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 export default function CenteredGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12
-          </Paper>
+          <Item>xs=12</Item>
         </Grid>
         <Grid item xs={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6
-          </Paper>
+          <Item>xs=6</Item>
         </Grid>
         <Grid item xs={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6
-          </Paper>
+          <Item>xs=6</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
         <Grid item xs={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=3
-          </Paper>
+          <Item>xs=3</Item>
         </Grid>
       </Grid>
     </Box>

--- a/docs/src/pages/components/grid/ComplexGrid.js
+++ b/docs/src/pages/components/grid/ComplexGrid.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
@@ -15,41 +14,39 @@ const Img = styled('img')(() => ({
 
 export default function ComplexGrid() {
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <Paper sx={{ p: 2, margin: 'auto', maxWidth: 500 }}>
-        <Grid container spacing={2}>
-          <Grid item>
-            <ButtonBase sx={{ width: 128, height: 128 }}>
-              <Img alt="complex" src="/static/images/grid/complex.jpg" />
-            </ButtonBase>
-          </Grid>
-          <Grid item xs={12} sm container>
-            <Grid item xs container direction="column" spacing={2}>
-              <Grid item xs>
-                <Typography gutterBottom variant="subtitle1" component="div">
-                  Standard license
-                </Typography>
-                <Typography variant="body2" gutterBottom>
-                  Full resolution 1920x1080 • JPEG
-                </Typography>
-                <Typography variant="body2" color="textSecondary">
-                  ID: 1030114
-                </Typography>
-              </Grid>
-              <Grid item>
-                <Typography sx={{ cursor: 'pointer' }} variant="body2">
-                  Remove
-                </Typography>
-              </Grid>
+    <Paper sx={{ p: 2, margin: 'auto', maxWidth: 500, flexGrow: 1 }}>
+      <Grid container spacing={2}>
+        <Grid item>
+          <ButtonBase sx={{ width: 128, height: 128 }}>
+            <Img alt="complex" src="/static/images/grid/complex.jpg" />
+          </ButtonBase>
+        </Grid>
+        <Grid item xs={12} sm container>
+          <Grid item xs container direction="column" spacing={2}>
+            <Grid item xs>
+              <Typography gutterBottom variant="subtitle1" component="div">
+                Standard license
+              </Typography>
+              <Typography variant="body2" gutterBottom>
+                Full resolution 1920x1080 • JPEG
+              </Typography>
+              <Typography variant="body2" color="textSecondary">
+                ID: 1030114
+              </Typography>
             </Grid>
             <Grid item>
-              <Typography variant="subtitle1" component="div">
-                $19.00
+              <Typography sx={{ cursor: 'pointer' }} variant="body2">
+                Remove
               </Typography>
             </Grid>
           </Grid>
+          <Grid item>
+            <Typography variant="subtitle1" component="div">
+              $19.00
+            </Typography>
+          </Grid>
         </Grid>
-      </Paper>
-    </Box>
+      </Grid>
+    </Paper>
   );
 }

--- a/docs/src/pages/components/grid/ComplexGrid.js
+++ b/docs/src/pages/components/grid/ComplexGrid.js
@@ -1,45 +1,26 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  paper: {
-    padding: theme.spacing(2),
-    margin: 'auto',
-    maxWidth: 500,
-  },
-  image: {
-    width: 128,
-    height: 128,
-  },
-  img: {
-    margin: 'auto',
-    display: 'block',
-    maxWidth: '100%',
-    maxHeight: '100%',
-  },
+const Img = styled('img')(() => ({
+  margin: 'auto',
+  display: 'block',
+  maxWidth: '100%',
+  maxHeight: '100%',
 }));
 
 export default function ComplexGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
+    <Box sx={{ flexGrow: 1 }}>
+      <Paper sx={{ p: 2, margin: 'auto', maxWidth: 500 }}>
         <Grid container spacing={2}>
           <Grid item>
-            <ButtonBase className={classes.image}>
-              <img
-                className={classes.img}
-                alt="complex"
-                src="/static/images/grid/complex.jpg"
-              />
+            <ButtonBase sx={{ width: 128, height: 128 }}>
+              <Img alt="complex" src="/static/images/grid/complex.jpg" />
             </ButtonBase>
           </Grid>
           <Grid item xs={12} sm container>
@@ -56,7 +37,7 @@ export default function ComplexGrid() {
                 </Typography>
               </Grid>
               <Grid item>
-                <Typography variant="body2" style={{ cursor: 'pointer' }}>
+                <Typography sx={{ cursor: 'pointer' }} variant="body2">
                   Remove
                 </Typography>
               </Grid>
@@ -69,6 +50,6 @@ export default function ComplexGrid() {
           </Grid>
         </Grid>
       </Paper>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/ComplexGrid.tsx
+++ b/docs/src/pages/components/grid/ComplexGrid.tsx
@@ -1,47 +1,26 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    paper: {
-      padding: theme.spacing(2),
-      margin: 'auto',
-      maxWidth: 500,
-    },
-    image: {
-      width: 128,
-      height: 128,
-    },
-    img: {
-      margin: 'auto',
-      display: 'block',
-      maxWidth: '100%',
-      maxHeight: '100%',
-    },
-  }),
-);
+const Img = styled('img')(() => ({
+  margin: 'auto',
+  display: 'block',
+  maxWidth: '100%',
+  maxHeight: '100%',
+}));
 
 export default function ComplexGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
+    <Box sx={{ flexGrow: 1 }}>
+      <Paper sx={{ p: 2, margin: 'auto', maxWidth: 500 }}>
         <Grid container spacing={2}>
           <Grid item>
-            <ButtonBase className={classes.image}>
-              <img
-                className={classes.img}
-                alt="complex"
-                src="/static/images/grid/complex.jpg"
-              />
+            <ButtonBase sx={{ width: 128, height: 128 }}>
+              <Img alt="complex" src="/static/images/grid/complex.jpg" />
             </ButtonBase>
           </Grid>
           <Grid item xs={12} sm container>
@@ -58,7 +37,7 @@ export default function ComplexGrid() {
                 </Typography>
               </Grid>
               <Grid item>
-                <Typography variant="body2" style={{ cursor: 'pointer' }}>
+                <Typography sx={{ cursor: 'pointer' }} variant="body2">
                   Remove
                 </Typography>
               </Grid>
@@ -71,6 +50,6 @@ export default function ComplexGrid() {
           </Grid>
         </Grid>
       </Paper>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/ComplexGrid.tsx
+++ b/docs/src/pages/components/grid/ComplexGrid.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
@@ -15,41 +14,39 @@ const Img = styled('img')(() => ({
 
 export default function ComplexGrid() {
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <Paper sx={{ p: 2, margin: 'auto', maxWidth: 500 }}>
-        <Grid container spacing={2}>
-          <Grid item>
-            <ButtonBase sx={{ width: 128, height: 128 }}>
-              <Img alt="complex" src="/static/images/grid/complex.jpg" />
-            </ButtonBase>
-          </Grid>
-          <Grid item xs={12} sm container>
-            <Grid item xs container direction="column" spacing={2}>
-              <Grid item xs>
-                <Typography gutterBottom variant="subtitle1" component="div">
-                  Standard license
-                </Typography>
-                <Typography variant="body2" gutterBottom>
-                  Full resolution 1920x1080 • JPEG
-                </Typography>
-                <Typography variant="body2" color="textSecondary">
-                  ID: 1030114
-                </Typography>
-              </Grid>
-              <Grid item>
-                <Typography sx={{ cursor: 'pointer' }} variant="body2">
-                  Remove
-                </Typography>
-              </Grid>
+    <Paper sx={{ p: 2, margin: 'auto', maxWidth: 500, flexGrow: 1 }}>
+      <Grid container spacing={2}>
+        <Grid item>
+          <ButtonBase sx={{ width: 128, height: 128 }}>
+            <Img alt="complex" src="/static/images/grid/complex.jpg" />
+          </ButtonBase>
+        </Grid>
+        <Grid item xs={12} sm container>
+          <Grid item xs container direction="column" spacing={2}>
+            <Grid item xs>
+              <Typography gutterBottom variant="subtitle1" component="div">
+                Standard license
+              </Typography>
+              <Typography variant="body2" gutterBottom>
+                Full resolution 1920x1080 • JPEG
+              </Typography>
+              <Typography variant="body2" color="textSecondary">
+                ID: 1030114
+              </Typography>
             </Grid>
             <Grid item>
-              <Typography variant="subtitle1" component="div">
-                $19.00
+              <Typography sx={{ cursor: 'pointer' }} variant="body2">
+                Remove
               </Typography>
             </Grid>
           </Grid>
+          <Grid item>
+            <Typography variant="subtitle1" component="div">
+              $19.00
+            </Typography>
+          </Grid>
         </Grid>
-      </Paper>
-    </Box>
+      </Grid>
+    </Paper>
   );
 }

--- a/docs/src/pages/components/grid/FullWidthGrid.js
+++ b/docs/src/pages/components/grid/FullWidthGrid.js
@@ -1,46 +1,39 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 export default function FullWidthGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12
-          </Paper>
+          <Item>xs=12</Item>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12 sm=6
-          </Paper>
+          <Item>xs=12 sm=6</Item>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12 sm=6
-          </Paper>
+          <Item>xs=12 sm=6</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
       </Grid>
     </Box>

--- a/docs/src/pages/components/grid/FullWidthGrid.js
+++ b/docs/src/pages/components/grid/FullWidthGrid.js
@@ -1,47 +1,48 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  paper: {
-    padding: theme.spacing(2),
-    textAlign: 'center',
-    color: theme.palette.text.secondary,
-  },
-}));
-
 export default function FullWidthGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper className={classes.paper}>xs=12</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12
+          </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper className={classes.paper}>xs=12 sm=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12 sm=6
+          </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper className={classes.paper}>xs=12 sm=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12 sm=6
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/FullWidthGrid.tsx
+++ b/docs/src/pages/components/grid/FullWidthGrid.tsx
@@ -1,46 +1,39 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 export default function FullWidthGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12
-          </Paper>
+          <Item>xs=12</Item>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12 sm=6
-          </Paper>
+          <Item>xs=12 sm=6</Item>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=12 sm=6
-          </Paper>
+          <Item>xs=12 sm=6</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
-            xs=6 sm=3
-          </Paper>
+          <Item>xs=6 sm=3</Item>
         </Grid>
       </Grid>
     </Box>

--- a/docs/src/pages/components/grid/FullWidthGrid.tsx
+++ b/docs/src/pages/components/grid/FullWidthGrid.tsx
@@ -1,49 +1,48 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    paper: {
-      padding: theme.spacing(2),
-      textAlign: 'center',
-      color: theme.palette.text.secondary,
-    },
-  }),
-);
-
 export default function FullWidthGrid() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Paper className={classes.paper}>xs=12</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12
+          </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper className={classes.paper}>xs=12 sm=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12 sm=6
+          </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Paper className={classes.paper}>xs=12 sm=6</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=12 sm=6
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
         <Grid item xs={6} sm={3}>
-          <Paper className={classes.paper}>xs=6 sm=3</Paper>
+          <Paper sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+            xs=6 sm=3
+          </Paper>
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/InteractiveGrid.js
+++ b/docs/src/pages/components/grid/InteractiveGrid.js
@@ -6,28 +6,9 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles } from '@material-ui/core/styles';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  demo: {
-    height: 240,
-  },
-  paper: {
-    padding: theme.spacing(2),
-    height: '100%',
-    color: theme.palette.text.secondary,
-  },
-  control: {
-    padding: theme.spacing(2),
-  },
-}));
-
 export default function InteractiveGrid() {
-  const classes = useStyles();
   const [direction, setDirection] = React.useState('row');
   const [justifyContent, setJustifyContent] = React.useState('center');
 
@@ -43,12 +24,12 @@ export default function InteractiveGrid() {
 `;
 
   return (
-    <Grid container className={classes.root}>
+    <Grid sx={{ flexGrow: 1 }} container>
       <Grid item xs={12}>
         <Grid
+          sx={{ height: 240 }}
           container
           spacing={2}
-          className={classes.demo}
           alignItems={alignItems}
           direction={direction}
           justifyContent={justifyContent}
@@ -56,10 +37,12 @@ export default function InteractiveGrid() {
           {[0, 1, 2].map((value) => (
             <Grid key={value} item>
               <Paper
-                className={classes.paper}
-                style={{
-                  paddingTop: (value + 1) * 10,
-                  paddingBottom: (value + 1) * 10,
+                sx={{
+                  p: 2,
+                  height: '100%',
+                  color: 'text.secondary',
+                  pt: `${(value + 1) * 10}px`,
+                  pb: `${(value + 1) * 10}px`,
                 }}
               >
                 {`Cell ${value + 1}`}
@@ -69,7 +52,7 @@ export default function InteractiveGrid() {
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Paper className={classes.control}>
+        <Paper sx={{ p: 2 }}>
           <Grid container spacing={3}>
             <Grid item xs={12}>
               <FormControl component="fieldset">

--- a/docs/src/pages/components/grid/InteractiveGrid.tsx
+++ b/docs/src/pages/components/grid/InteractiveGrid.tsx
@@ -6,7 +6,6 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 
 type GridItemsAlignment =
@@ -24,27 +23,7 @@ type GridJustification =
   | 'space-around'
   | 'space-evenly';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    demo: {
-      height: 240,
-    },
-    paper: {
-      padding: theme.spacing(2),
-      height: '100%',
-      color: theme.palette.text.secondary,
-    },
-    control: {
-      padding: theme.spacing(2),
-    },
-  }),
-);
-
 export default function InteractiveGrid() {
-  const classes = useStyles();
   const [direction, setDirection] = React.useState<GridDirection>('row');
   const [justifyContent, setJustifyContent] = React.useState<GridJustification>(
     'center',
@@ -61,12 +40,12 @@ export default function InteractiveGrid() {
 `;
 
   return (
-    <Grid container className={classes.root}>
+    <Grid sx={{ flexGrow: 1 }} container>
       <Grid item xs={12}>
         <Grid
+          sx={{ height: 240 }}
           container
           spacing={2}
-          className={classes.demo}
           alignItems={alignItems}
           direction={direction}
           justifyContent={justifyContent}
@@ -74,10 +53,12 @@ export default function InteractiveGrid() {
           {[0, 1, 2].map((value) => (
             <Grid key={value} item>
               <Paper
-                className={classes.paper}
-                style={{
-                  paddingTop: (value + 1) * 10,
-                  paddingBottom: (value + 1) * 10,
+                sx={{
+                  p: 2,
+                  height: '100%',
+                  color: 'text.secondary',
+                  pt: `${(value + 1) * 10}px`,
+                  pb: `${(value + 1) * 10}px`,
                 }}
               >
                 {`Cell ${value + 1}`}
@@ -87,7 +68,7 @@ export default function InteractiveGrid() {
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Paper className={classes.control}>
+        <Paper sx={{ p: 2 }}>
           <Grid container spacing={3}>
             <Grid item xs={12}>
               <FormControl component="fieldset">

--- a/docs/src/pages/components/grid/NestedGrid.js
+++ b/docs/src/pages/components/grid/NestedGrid.js
@@ -1,25 +1,26 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 function FormRow() {
   return (
     <React.Fragment>
       <Grid item xs={4}>
-        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-          item
-        </Paper>
+        <Item>item</Item>
       </Grid>
       <Grid item xs={4}>
-        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-          item
-        </Paper>
+        <Item>item</Item>
       </Grid>
       <Grid item xs={4}>
-        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-          item
-        </Paper>
+        <Item>item</Item>
       </Grid>
     </React.Fragment>
   );

--- a/docs/src/pages/components/grid/NestedGrid.js
+++ b/docs/src/pages/components/grid/NestedGrid.js
@@ -1,40 +1,33 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  paper: {
-    padding: theme.spacing(1),
-    textAlign: 'center',
-    color: theme.palette.text.secondary,
-  },
-}));
-
 export default function NestedGrid() {
-  const classes = useStyles();
-
   function FormRow() {
     return (
       <React.Fragment>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>item</Paper>
+          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+            item
+          </Paper>
         </Grid>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>item</Paper>
+          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+            item
+          </Paper>
         </Grid>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>item</Paper>
+          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+            item
+          </Paper>
         </Grid>
       </React.Fragment>
     );
   }
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={1}>
         <Grid container item spacing={3}>
           <FormRow />
@@ -46,6 +39,6 @@ export default function NestedGrid() {
           <FormRow />
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/NestedGrid.js
+++ b/docs/src/pages/components/grid/NestedGrid.js
@@ -3,29 +3,29 @@ import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-export default function NestedGrid() {
-  function FormRow() {
-    return (
-      <React.Fragment>
-        <Grid item xs={4}>
-          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-            item
-          </Paper>
-        </Grid>
-        <Grid item xs={4}>
-          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-            item
-          </Paper>
-        </Grid>
-        <Grid item xs={4}>
-          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-            item
-          </Paper>
-        </Grid>
-      </React.Fragment>
-    );
-  }
+function FormRow() {
+  return (
+    <React.Fragment>
+      <Grid item xs={4}>
+        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+          item
+        </Paper>
+      </Grid>
+      <Grid item xs={4}>
+        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+          item
+        </Paper>
+      </Grid>
+      <Grid item xs={4}>
+        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+          item
+        </Paper>
+      </Grid>
+    </React.Fragment>
+  );
+}
 
+export default function NestedGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={1}>

--- a/docs/src/pages/components/grid/NestedGrid.tsx
+++ b/docs/src/pages/components/grid/NestedGrid.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
 
 function FormRow() {
   return (
     <React.Fragment>
       <Grid item xs={4}>
-        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-          item
-        </Paper>
+        <Item>item</Item>
       </Grid>
       <Grid item xs={4}>
-        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-          item
-        </Paper>
+        <Item>item</Item>
       </Grid>
       <Grid item xs={4}>
-        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-          item
-        </Paper>
+        <Item>item</Item>
       </Grid>
     </React.Fragment>
   );

--- a/docs/src/pages/components/grid/NestedGrid.tsx
+++ b/docs/src/pages/components/grid/NestedGrid.tsx
@@ -1,42 +1,33 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    paper: {
-      padding: theme.spacing(1),
-      textAlign: 'center',
-      color: theme.palette.text.secondary,
-    },
-  }),
-);
-
 export default function NestedGrid() {
-  const classes = useStyles();
-
   function FormRow() {
     return (
       <React.Fragment>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>item</Paper>
+          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+            item
+          </Paper>
         </Grid>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>item</Paper>
+          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+            item
+          </Paper>
         </Grid>
         <Grid item xs={4}>
-          <Paper className={classes.paper}>item</Paper>
+          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+            item
+          </Paper>
         </Grid>
       </React.Fragment>
     );
   }
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={1}>
         <Grid container item spacing={3}>
           <FormRow />
@@ -48,6 +39,6 @@ export default function NestedGrid() {
           <FormRow />
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/grid/NestedGrid.tsx
+++ b/docs/src/pages/components/grid/NestedGrid.tsx
@@ -3,29 +3,29 @@ import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 
-export default function NestedGrid() {
-  function FormRow() {
-    return (
-      <React.Fragment>
-        <Grid item xs={4}>
-          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-            item
-          </Paper>
-        </Grid>
-        <Grid item xs={4}>
-          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-            item
-          </Paper>
-        </Grid>
-        <Grid item xs={4}>
-          <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
-            item
-          </Paper>
-        </Grid>
-      </React.Fragment>
-    );
-  }
+function FormRow() {
+  return (
+    <React.Fragment>
+      <Grid item xs={4}>
+        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+          item
+        </Paper>
+      </Grid>
+      <Grid item xs={4}>
+        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+          item
+        </Paper>
+      </Grid>
+      <Grid item xs={4}>
+        <Paper sx={{ p: 1, textAlign: 'center', color: 'text.secondary' }}>
+          item
+        </Paper>
+      </Grid>
+    </React.Fragment>
+  );
+}
 
+export default function NestedGrid() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container spacing={1}>

--- a/docs/src/pages/components/grid/SpacingGrid.js
+++ b/docs/src/pages/components/grid/SpacingGrid.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -7,40 +6,26 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  paper: {
-    height: 140,
-    width: 100,
-  },
-  control: {
-    padding: theme.spacing(2),
-  },
-}));
-
 export default function SpacingGrid() {
   const [spacing, setSpacing] = React.useState(2);
-  const classes = useStyles();
 
   const handleChange = (event) => {
     setSpacing(Number(event.target.value));
   };
 
   return (
-    <Grid container className={classes.root} spacing={2}>
+    <Grid sx={{ flexGrow: 1 }} container spacing={2}>
       <Grid item xs={12}>
         <Grid container justifyContent="center" spacing={spacing}>
           {[0, 1, 2].map((value) => (
             <Grid key={value} item>
-              <Paper className={classes.paper} />
+              <Paper sx={{ height: 140, width: 100 }} />
             </Grid>
           ))}
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Paper className={classes.control}>
+        <Paper sx={{ p: 2 }}>
           <Grid container>
             <Grid item>
               <FormLabel>spacing</FormLabel>

--- a/docs/src/pages/components/grid/SpacingGrid.tsx
+++ b/docs/src/pages/components/grid/SpacingGrid.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Grid, { GridSpacing } from '@material-ui/core/Grid';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -7,42 +6,26 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-    },
-    paper: {
-      height: 140,
-      width: 100,
-    },
-    control: {
-      padding: theme.spacing(2),
-    },
-  }),
-);
-
 export default function SpacingGrid() {
   const [spacing, setSpacing] = React.useState<GridSpacing>(2);
-  const classes = useStyles();
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSpacing(Number((event.target as HTMLInputElement).value) as GridSpacing);
   };
 
   return (
-    <Grid container className={classes.root} spacing={2}>
+    <Grid sx={{ flexGrow: 1 }} container spacing={2}>
       <Grid item xs={12}>
         <Grid container justifyContent="center" spacing={spacing}>
           {[0, 1, 2].map((value) => (
             <Grid key={value} item>
-              <Paper className={classes.paper} />
+              <Paper sx={{ height: 140, width: 100 }} />
             </Grid>
           ))}
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Paper className={classes.control}>
+        <Paper sx={{ p: 2 }}>
           <Grid container>
             <Grid item>
               <FormLabel>spacing</FormLabel>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Grid component were migrated:

- [x] Spacing
- [x] Basic grid
- [x] Grid whit multiple breakpoint
- [x] Auto Layout
- [x] Complex Grid
- [x] Nested Grid
- [x] Limitations: white-space: nowrap;
- [x] Interactive Grid
- [x] CSS Grid

Related to #16947