### PR TITLE
[docs] Refine the used prop-type to discriminate number from integer

### DIFF
--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -46,7 +46,7 @@
     "id": { "type": { "name": "string" } },
     "includeInputInList": { "type": { "name": "bool" } },
     "inputValue": { "type": { "name": "string" } },
-    "limitTags": { "type": { "name": "number" }, "default": "-1" },
+    "limitTags": { "type": { "name": "custom", "description": "integer" }, "default": "-1" },
     "ListboxComponent": { "type": { "name": "elementType" }, "default": "'ul'" },
     "ListboxProps": { "type": { "name": "object" } },
     "loading": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/breadcrumbs.json
+++ b/docs/pages/api-docs/breadcrumbs.json
@@ -4,9 +4,15 @@
     "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
     "expandText": { "type": { "name": "string" }, "default": "'Show path'" },
-    "itemsAfterCollapse": { "type": { "name": "number" }, "default": "1" },
-    "itemsBeforeCollapse": { "type": { "name": "number" }, "default": "1" },
-    "maxItems": { "type": { "name": "number" }, "default": "8" },
+    "itemsAfterCollapse": {
+      "type": { "name": "custom", "description": "integer" },
+      "default": "1"
+    },
+    "itemsBeforeCollapse": {
+      "type": { "name": "custom", "description": "integer" },
+      "default": "1"
+    },
+    "maxItems": { "type": { "name": "custom", "description": "integer" }, "default": "8" },
     "separator": { "type": { "name": "node" }, "default": "'/'" },
     "sx": { "type": { "name": "object" } }
   },

--- a/docs/pages/api-docs/drawer.json
+++ b/docs/pages/api-docs/drawer.json
@@ -9,7 +9,7 @@
     },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "elevation": { "type": { "name": "number" }, "default": "16" },
+    "elevation": { "type": { "name": "custom", "description": "integer" }, "default": "16" },
     "hideBackdrop": { "type": { "name": "bool" } },
     "ModalProps": { "type": { "name": "object" }, "default": "{}" },
     "onClose": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/image-list-item.json
+++ b/docs/pages/api-docs/image-list-item.json
@@ -2,9 +2,9 @@
   "props": {
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "cols": { "type": { "name": "number" }, "default": "1" },
+    "cols": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "component": { "type": { "name": "elementType" } },
-    "rows": { "type": { "name": "number" }, "default": "1" },
+    "rows": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "sx": { "type": { "name": "object" } }
   },
   "name": "ImageListItem",

--- a/docs/pages/api-docs/image-list.json
+++ b/docs/pages/api-docs/image-list.json
@@ -4,7 +4,7 @@
     "classes": { "type": { "name": "object" } },
     "cols": { "type": { "name": "custom", "description": "integer" }, "default": "2" },
     "component": { "type": { "name": "elementType" } },
-    "gap": { "type": { "name": "custom", "description": "integer" }, "default": "4" },
+    "gap": { "type": { "name": "number" }, "default": "4" },
     "rowHeight": {
       "type": { "name": "union", "description": "'auto'<br>&#124;&nbsp;number" },
       "default": "'auto'"

--- a/docs/pages/api-docs/image-list.json
+++ b/docs/pages/api-docs/image-list.json
@@ -2,9 +2,9 @@
   "props": {
     "children": { "type": { "name": "node" }, "required": true },
     "classes": { "type": { "name": "object" } },
-    "cols": { "type": { "name": "number" }, "default": "2" },
+    "cols": { "type": { "name": "custom", "description": "integer" }, "default": "2" },
     "component": { "type": { "name": "elementType" } },
-    "gap": { "type": { "name": "number" }, "default": "4" },
+    "gap": { "type": { "name": "custom", "description": "integer" }, "default": "4" },
     "rowHeight": {
       "type": { "name": "union", "description": "'auto'<br>&#124;&nbsp;number" },
       "default": "'auto'"

--- a/docs/pages/api-docs/mobile-stepper.json
+++ b/docs/pages/api-docs/mobile-stepper.json
@@ -1,7 +1,7 @@
 {
   "props": {
-    "steps": { "type": { "name": "number" }, "required": true },
-    "activeStep": { "type": { "name": "number" }, "default": "0" },
+    "steps": { "type": { "name": "custom", "description": "integer" }, "required": true },
+    "activeStep": { "type": { "name": "custom", "description": "integer" }, "default": "0" },
     "backButton": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "LinearProgressProps": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/pagination-item.json
+++ b/docs/pages/api-docs/pagination-item.json
@@ -10,7 +10,7 @@
     },
     "component": { "type": { "name": "elementType" } },
     "disabled": { "type": { "name": "bool" } },
-    "page": { "type": { "name": "number" } },
+    "page": { "type": { "name": "node" } },
     "selected": { "type": { "name": "bool" } },
     "shape": {
       "type": { "name": "enum", "description": "'circular'<br>&#124;&nbsp;'rounded'" },

--- a/docs/pages/api-docs/pagination.json
+++ b/docs/pages/api-docs/pagination.json
@@ -1,6 +1,6 @@
 {
   "props": {
-    "boundaryCount": { "type": { "name": "number" }, "default": "1" },
+    "boundaryCount": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
@@ -10,13 +10,13 @@
       "default": "'standard'"
     },
     "count": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
-    "defaultPage": { "type": { "name": "number" }, "default": "1" },
+    "defaultPage": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "disabled": { "type": { "name": "bool" } },
     "getItemAriaLabel": { "type": { "name": "func" } },
     "hideNextButton": { "type": { "name": "bool" } },
     "hidePrevButton": { "type": { "name": "bool" } },
     "onChange": { "type": { "name": "func" } },
-    "page": { "type": { "name": "number" } },
+    "page": { "type": { "name": "custom", "description": "integer" } },
     "renderItem": {
       "type": { "name": "func" },
       "default": "(item) => <PaginationItem {...item} />"
@@ -27,7 +27,7 @@
     },
     "showFirstButton": { "type": { "name": "bool" } },
     "showLastButton": { "type": { "name": "bool" } },
-    "siblingCount": { "type": { "name": "number" }, "default": "1" },
+    "siblingCount": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "size": {
       "type": {
         "name": "enum",

--- a/docs/pages/api-docs/paper.json
+++ b/docs/pages/api-docs/paper.json
@@ -3,7 +3,7 @@
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
-    "elevation": { "type": { "name": "custom", "description": "number" }, "default": "1" },
+    "elevation": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "square": { "type": { "name": "bool" } },
     "sx": { "type": { "name": "object" } },
     "variant": {

--- a/docs/pages/api-docs/popover.json
+++ b/docs/pages/api-docs/popover.json
@@ -23,7 +23,7 @@
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
-    "elevation": { "type": { "name": "number" }, "default": "8" },
+    "elevation": { "type": { "name": "custom", "description": "integer" }, "default": "8" },
     "getContentAnchorEl": { "type": { "name": "func" } },
     "marginThreshold": { "type": { "name": "number" }, "default": "16" },
     "onClose": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/step.json
+++ b/docs/pages/api-docs/step.json
@@ -6,7 +6,7 @@
     "completed": { "type": { "name": "bool" } },
     "disabled": { "type": { "name": "bool" } },
     "expanded": { "type": { "name": "bool" } },
-    "index": { "type": { "name": "number" } },
+    "index": { "type": { "name": "custom", "description": "integer" } },
     "last": { "type": { "name": "bool" } },
     "sx": { "type": { "name": "object" } }
   },

--- a/docs/pages/api-docs/stepper.json
+++ b/docs/pages/api-docs/stepper.json
@@ -1,6 +1,6 @@
 {
   "props": {
-    "activeStep": { "type": { "name": "number" }, "default": "0" },
+    "activeStep": { "type": { "name": "custom", "description": "integer" }, "default": "0" },
     "alternativeLabel": { "type": { "name": "bool" } },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/table-pagination.json
+++ b/docs/pages/api-docs/table-pagination.json
@@ -1,18 +1,9 @@
 {
   "props": {
-    "count": {
-      "type": { "name": "custom", "description": "integer" },
-      "required": true
-    },
+    "count": { "type": { "name": "custom", "description": "integer" }, "required": true },
     "onPageChange": { "type": { "name": "func" }, "required": true },
-    "page": {
-      "type": { "name": "custom", "description": "integer" },
-      "required": true
-    },
-    "rowsPerPage": {
-      "type": { "name": "custom", "description": "integer" },
-      "required": true
-    },
+    "page": { "type": { "name": "custom", "description": "integer" }, "required": true },
+    "rowsPerPage": { "type": { "name": "custom", "description": "integer" }, "required": true },
     "ActionsComponent": { "type": { "name": "elementType" }, "default": "TablePaginationActions" },
     "backIconButtonProps": { "type": { "name": "object" } },
     "classes": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/table-pagination.json
+++ b/docs/pages/api-docs/table-pagination.json
@@ -1,16 +1,16 @@
 {
   "props": {
     "count": {
-      "type": { "name": "custom", "description": "integerPropType.isRequired" },
+      "type": { "name": "custom", "description": "integer" },
       "required": true
     },
     "onPageChange": { "type": { "name": "func" }, "required": true },
     "page": {
-      "type": { "name": "custom", "description": "integerPropType.isRequired" },
+      "type": { "name": "custom", "description": "integer" },
       "required": true
     },
     "rowsPerPage": {
-      "type": { "name": "custom", "description": "integerPropType.isRequired" },
+      "type": { "name": "custom", "description": "integer" },
       "required": true
     },
     "ActionsComponent": { "type": { "name": "elementType" }, "default": "TablePaginationActions" },

--- a/docs/pages/api-docs/table-pagination.json
+++ b/docs/pages/api-docs/table-pagination.json
@@ -1,9 +1,18 @@
 {
   "props": {
-    "count": { "type": { "name": "number" }, "required": true },
+    "count": {
+      "type": { "name": "custom", "description": "integerPropType.isRequired" },
+      "required": true
+    },
     "onPageChange": { "type": { "name": "func" }, "required": true },
-    "page": { "type": { "name": "custom", "description": "number" }, "required": true },
-    "rowsPerPage": { "type": { "name": "number" }, "required": true },
+    "page": {
+      "type": { "name": "custom", "description": "integerPropType.isRequired" },
+      "required": true
+    },
+    "rowsPerPage": {
+      "type": { "name": "custom", "description": "integerPropType.isRequired" },
+      "required": true
+    },
     "ActionsComponent": { "type": { "name": "elementType" }, "default": "TablePaginationActions" },
     "backIconButtonProps": { "type": { "name": "object" } },
     "classes": { "type": { "name": "object" } },

--- a/docs/src/modules/utils/generatePropTypeDescription.ts
+++ b/docs/src/modules/utils/generatePropTypeDescription.ts
@@ -61,7 +61,7 @@ function isRefType(type: PropTypeDescriptor): boolean {
 }
 
 function isIntegerType(type: PropTypeDescriptor): boolean {
-  return type.raw === 'integerPropType';
+  return type.raw.startsWith('integerPropType');
 }
 
 export function isElementAcceptingRefProp(type: PropTypeDescriptor): boolean {

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes, integerPropType, deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { alpha } from '../styles/colorManipulator';
 import Popper from '../Popper';
@@ -896,7 +896,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Set `-1` to disable the limit.
    * @default -1
    */
-  limitTags: PropTypes.number,
+  limitTags: integerPropType,
   /**
    * The component used to render the listbox.
    * @default 'ul'

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
+import { deepmerge, integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -238,19 +238,19 @@ Breadcrumbs.propTypes /* remove-proptypes */ = {
    * If max items is exceeded, the number of items to show after the ellipsis.
    * @default 1
    */
-  itemsAfterCollapse: PropTypes.number,
+  itemsAfterCollapse: integerPropType,
   /**
    * If max items is exceeded, the number of items to show before the ellipsis.
    * @default 1
    */
-  itemsBeforeCollapse: PropTypes.number,
+  itemsBeforeCollapse: integerPropType,
   /**
    * Specifies the maximum number of breadcrumbs to display. When there are more
    * than the maximum number, only the first `itemsBeforeCollapse` and last `itemsAfterCollapse`
    * will be shown, with an ellipsis in between.
    * @default 8
    */
-  maxItems: PropTypes.number,
+  maxItems: integerPropType,
   /**
    * Custom separator node.
    * @default '/'

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
+import { deepmerge, integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Modal from '../Modal';
 import Slide from '../Slide';
@@ -310,7 +310,7 @@ Drawer.propTypes /* remove-proptypes */ = {
    * The elevation of the drawer.
    * @default 16
    */
-  elevation: PropTypes.number,
+  elevation: integerPropType,
   /**
    * If `true`, the backdrop is not rendered.
    * @default false

--- a/packages/material-ui/src/ImageList/ImageList.js
+++ b/packages/material-ui/src/ImageList/ImageList.js
@@ -1,5 +1,5 @@
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
+import { deepmerge, integerPropType } from '@material-ui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -134,7 +134,7 @@ ImageList.propTypes /* remove-proptypes */ = {
    * Number of columns.
    * @default 2
    */
-  cols: PropTypes.number,
+  cols: integerPropType,
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -144,7 +144,7 @@ ImageList.propTypes /* remove-proptypes */ = {
    * The gap between items in px.
    * @default 4
    */
-  gap: PropTypes.number,
+  gap: integerPropType,
   /**
    * The height of one row in px.
    * @default 'auto'

--- a/packages/material-ui/src/ImageList/ImageList.js
+++ b/packages/material-ui/src/ImageList/ImageList.js
@@ -144,7 +144,7 @@ ImageList.propTypes /* remove-proptypes */ = {
    * The gap between items in px.
    * @default 4
    */
-  gap: integerPropType,
+  gap: PropTypes.number,
   /**
    * The height of one row in px.
    * @default 'auto'

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -1,5 +1,5 @@
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
+import { deepmerge, integerPropType } from '@material-ui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -164,7 +164,7 @@ ImageListItem.propTypes /* remove-proptypes */ = {
    * Width of the item in number of grid columns.
    * @default 1
    */
-  cols: PropTypes.number,
+  cols: integerPropType,
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -174,7 +174,7 @@ ImageListItem.propTypes /* remove-proptypes */ = {
    * Height of the item in number of grid rows.
    * @default 1
    */
-  rows: PropTypes.number,
+  rows: integerPropType,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { integerPropType } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import Paper from '../Paper';
 import capitalize from '../utils/capitalize';
@@ -126,7 +127,7 @@ MobileStepper.propTypes /* remove-proptypes */ = {
    * Defines which dot is highlighted when the variant is 'dots'.
    * @default 0
    */
-  activeStep: PropTypes.number,
+  activeStep: integerPropType,
   /**
    * A back button element. For instance, it can be a `Button` or an `IconButton`.
    */
@@ -155,7 +156,7 @@ MobileStepper.propTypes /* remove-proptypes */ = {
   /**
    * The total steps.
    */
-  steps: PropTypes.number.isRequired,
+  steps: integerPropType.isRequired,
   /**
    * The variant to use.
    * @default 'dots'

--- a/packages/material-ui/src/Pagination/Pagination.js
+++ b/packages/material-ui/src/Pagination/Pagination.js
@@ -149,7 +149,7 @@ Pagination.propTypes /* remove-proptypes */ = {
    * Number of always visible pages at the beginning and end.
    * @default 1
    */
-  boundaryCount: PropTypes.number,
+  boundaryCount: integerPropType,
   /**
    * Override or extend the styles applied to the component.
    */
@@ -172,7 +172,7 @@ Pagination.propTypes /* remove-proptypes */ = {
    * The page selected by default when the component is uncontrolled.
    * @default 1
    */
-  defaultPage: PropTypes.number,
+  defaultPage: integerPropType,
   /**
    * If `true`, the component is disabled.
    * @default false
@@ -209,7 +209,7 @@ Pagination.propTypes /* remove-proptypes */ = {
   /**
    * The current page.
    */
-  page: PropTypes.number,
+  page: integerPropType,
   /**
    * Render the item.
    *
@@ -237,7 +237,7 @@ Pagination.propTypes /* remove-proptypes */ = {
    * Number of always visible pages before and after the current page.
    * @default 1
    */
-  siblingCount: PropTypes.number,
+  siblingCount: integerPropType,
   /**
    * The size of the component.
    * @default 'medium'

--- a/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
@@ -60,7 +60,7 @@ export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'di
     /**
      * The current page number.
      */
-    page?: number;
+    page?: React.ReactNode;
     /**
      * If `true` the pagination item is selected.
      * @default false

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import paginationItemClasses, { getPaginationItemUtilityClass } from './paginationItemClasses';

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
+import { deepmerge, integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import paginationItemClasses, { getPaginationItemUtilityClass } from './paginationItemClasses';
@@ -366,7 +366,7 @@ PaginationItem.propTypes /* remove-proptypes */ = {
   /**
    * The current page number.
    */
-  page: PropTypes.number,
+  page: PropTypes.node,
   /**
    * If `true` the pagination item is selected.
    * @default false

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes, integerPropType, deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -138,7 +138,7 @@ Paper.propTypes /* remove-proptypes */ = {
    * It accepts values between 0 and 24 inclusive.
    * @default 1
    */
-  elevation: chainPropTypes(PropTypes.number, (props) => {
+  elevation: chainPropTypes(integerPropType, (props) => {
     const { elevation, variant } = props;
     if (elevation > 0 && variant === 'outlined') {
       return new Error(

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import {
   chainPropTypes,
+  integerPropType,
   deepmerge,
   elementTypeAcceptingRef,
   refType,
@@ -566,7 +567,7 @@ Popover.propTypes /* remove-proptypes */ = {
    * The elevation of the popover.
    * @default 8
    */
-  elevation: PropTypes.number,
+  elevation: integerPropType,
   /**
    * This function is called in order to retrieve the content anchor element.
    * It's the opposite of the `anchorEl` prop.

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
+import { deepmerge, integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from './StepContext';
@@ -167,7 +167,7 @@ Step.propTypes /* remove-proptypes */ = {
    * The position of the step.
    * The prop defaults to the value inherited from the parent Stepper component.
    */
-  index: PropTypes.number,
+  index: integerPropType,
   /**
    * If `true`, the Step is displayed as rendered last.
    * The prop defaults to the value inherited from the parent Stepper component.

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { integerPropType } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import StepConnector from '../StepConnector';
 import StepperContext from './StepperContext';
@@ -83,7 +84,7 @@ Stepper.propTypes /* remove-proptypes */ = {
    * Set to -1 to disable all the steps.
    * @default 0
    */
-  activeStep: PropTypes.number,
+  activeStep: integerPropType,
   /**
    * If set to 'true' and orientation is horizontal,
    * then the step label will be positioned under the icon.

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { chainPropTypes } from '@material-ui/utils';
+import { chainPropTypes, integerPropType } from '@material-ui/utils';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import InputBase from '../InputBase';
@@ -217,7 +217,7 @@ TablePagination.propTypes /* remove-proptypes */ = {
    *
    * To enable server side pagination for an unknown number of items, provide -1.
    */
-  count: PropTypes.number.isRequired,
+  count: integerPropType.isRequired,
   /**
    * Accepts a function which returns a string value that provides a user-friendly name for the current page.
    *
@@ -267,7 +267,7 @@ TablePagination.propTypes /* remove-proptypes */ = {
   /**
    * The zero-based index of the current page.
    */
-  page: chainPropTypes(PropTypes.number.isRequired, (props) => {
+  page: chainPropTypes(integerPropType.isRequired, (props) => {
     const { count, page, rowsPerPage } = props;
 
     if (count === -1) {
@@ -288,7 +288,7 @@ TablePagination.propTypes /* remove-proptypes */ = {
    *
    * Set -1 to display all the rows.
    */
-  rowsPerPage: PropTypes.number.isRequired,
+  rowsPerPage: integerPropType.isRequired,
   /**
    * Customizes the options of the rows per page select field. If less than two options are
    * available, no select field will be displayed.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As we have successfully integrated our custom propType in Pagination component on ['count'](https://github.com/mui-org/material-ui/pull/25224) prop, so we have decided to move forward and change the ones, who have a strong preference to be an 'integer' type. So we have [discussed](https://github.com/mui-org/material-ui/pull/25224#issuecomment-794504745) changing, several components props' types for proper validating. 

CodeSandbox Link: https://codesandbox.io/s/create-react-app-bsix2?file=/src/App.js

Closes #25327