### PR TITLE
[docs] Migrate SpeedDial to emotion

### DIFF
--- a/docs/src/pages/components/speed-dial/BasicSpeedDial.js
+++ b/docs/src/pages/components/speed-dial/BasicSpeedDial.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormLabel from '@material-ui/core/FormLabel';
 import Radio from '@material-ui/core/Radio';
@@ -13,29 +14,15 @@ import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    transform: 'translateZ(0px)',
-    flexGrow: 1,
+const StyledSpeedDial = styled(SpeedDial)(({ theme }) => ({
+  position: 'absolute',
+  '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
   },
-  exampleWrapper: {
-    position: 'relative',
-    marginTop: theme.spacing(3),
-    height: 320,
-  },
-  radioGroup: {
-    margin: theme.spacing(1, 0),
-  },
-  speedDial: {
-    position: 'absolute',
-    '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
-      bottom: theme.spacing(2),
-      right: theme.spacing(2),
-    },
-    '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
-      top: theme.spacing(2),
-      left: theme.spacing(2),
-    },
+  '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
+    top: theme.spacing(2),
+    left: theme.spacing(2),
   },
 }));
 
@@ -47,7 +34,6 @@ const actions = [
 ];
 
 export default function SpeedDials() {
-  const classes = useStyles();
   const [direction, setDirection] = React.useState('up');
 
   const [hidden, setHidden] = React.useState(false);
@@ -61,14 +47,14 @@ export default function SpeedDials() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ transform: 'translateZ(0px)', flexGrow: 1 }}>
       <FormControlLabel
         control={
           <Switch checked={hidden} onChange={handleHiddenChange} color="primary" />
         }
         label="Hidden"
       />
-      <FormLabel className={classes.radioGroup} component="legend">
+      <FormLabel sx={{ my: 1 }} component="legend">
         Direction
       </FormLabel>
       <RadioGroup
@@ -83,10 +69,9 @@ export default function SpeedDials() {
         <FormControlLabel value="down" control={<Radio />} label="Down" />
         <FormControlLabel value="left" control={<Radio />} label="Left" />
       </RadioGroup>
-      <div className={classes.exampleWrapper}>
-        <SpeedDial
+      <Box sx={{ position: 'relative', mt: 3, height: 320 }}>
+        <StyledSpeedDial
           ariaLabel="SpeedDial example"
-          className={classes.speedDial}
           hidden={hidden}
           icon={<SpeedDialIcon />}
           direction={direction}
@@ -98,8 +83,8 @@ export default function SpeedDials() {
               tooltipTitle={action.name}
             />
           ))}
-        </SpeedDial>
-      </div>
-    </div>
+        </StyledSpeedDial>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/BasicSpeedDial.js
+++ b/docs/src/pages/components/speed-dial/BasicSpeedDial.js
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import FormLabel from '@material-ui/core/FormLabel';
-import Radio from '@material-ui/core/Radio';
-import RadioGroup from '@material-ui/core/RadioGroup';
-import Switch from '@material-ui/core/Switch';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
@@ -14,18 +8,6 @@ import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 
-const StyledSpeedDial = styled(SpeedDial)(({ theme }) => ({
-  position: 'absolute',
-  '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-  '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
-    top: theme.spacing(2),
-    left: theme.spacing(2),
-  },
-}));
-
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
   { icon: <SaveIcon />, name: 'Save' },
@@ -33,58 +15,22 @@ const actions = [
   { icon: <ShareIcon />, name: 'Share' },
 ];
 
-export default function SpeedDials() {
-  const [direction, setDirection] = React.useState('up');
-
-  const [hidden, setHidden] = React.useState(false);
-
-  const handleDirectionChange = (event) => {
-    setDirection(event.target.value);
-  };
-
-  const handleHiddenChange = (event) => {
-    setHidden(event.target.checked);
-  };
-
+export default function BasicSpeedDial() {
   return (
-    <Box sx={{ transform: 'translateZ(0px)', flexGrow: 1 }}>
-      <FormControlLabel
-        control={
-          <Switch checked={hidden} onChange={handleHiddenChange} color="primary" />
-        }
-        label="Hidden"
-      />
-      <FormLabel sx={{ my: 1 }} component="legend">
-        Direction
-      </FormLabel>
-      <RadioGroup
-        aria-label="direction"
-        name="direction"
-        value={direction}
-        onChange={handleDirectionChange}
-        row
+    <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
+      <SpeedDial
+        ariaLabel="SpeedDial basic example"
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
+        icon={<SpeedDialIcon />}
       >
-        <FormControlLabel value="up" control={<Radio />} label="Up" />
-        <FormControlLabel value="right" control={<Radio />} label="Right" />
-        <FormControlLabel value="down" control={<Radio />} label="Down" />
-        <FormControlLabel value="left" control={<Radio />} label="Left" />
-      </RadioGroup>
-      <Box sx={{ position: 'relative', mt: 3, height: 320 }}>
-        <StyledSpeedDial
-          ariaLabel="SpeedDial example"
-          hidden={hidden}
-          icon={<SpeedDialIcon />}
-          direction={direction}
-        >
-          {actions.map((action) => (
-            <SpeedDialAction
-              key={action.name}
-              icon={action.icon}
-              tooltipTitle={action.name}
-            />
-          ))}
-        </StyledSpeedDial>
-      </Box>
+        {actions.map((action) => (
+          <SpeedDialAction
+            key={action.name}
+            icon={action.icon}
+            tooltipTitle={action.name}
+          />
+        ))}
+      </SpeedDial>
     </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/BasicSpeedDial.tsx
+++ b/docs/src/pages/components/speed-dial/BasicSpeedDial.tsx
@@ -1,30 +1,12 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import FormLabel from '@material-ui/core/FormLabel';
-import Radio from '@material-ui/core/Radio';
-import RadioGroup from '@material-ui/core/RadioGroup';
-import Switch from '@material-ui/core/Switch';
-import SpeedDial, { SpeedDialProps } from '@material-ui/core/SpeedDial';
+import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
 import FileCopyIcon from '@material-ui/icons/FileCopyOutlined';
 import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
-
-const StyledSpeedDial = styled(SpeedDial)(({ theme }) => ({
-  position: 'absolute',
-  '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-  '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
-    top: theme.spacing(2),
-    left: theme.spacing(2),
-  },
-}));
 
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
@@ -33,61 +15,22 @@ const actions = [
   { icon: <ShareIcon />, name: 'Share' },
 ];
 
-export default function SpeedDials() {
-  const [direction, setDirection] = React.useState<SpeedDialProps['direction']>(
-    'up',
-  );
-  const [hidden, setHidden] = React.useState(false);
-
-  const handleDirectionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setDirection(
-      (event.target as HTMLInputElement).value as SpeedDialProps['direction'],
-    );
-  };
-
-  const handleHiddenChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setHidden(event.target.checked);
-  };
-
+export default function BasicSpeedDial() {
   return (
-    <Box sx={{ transform: 'translateZ(0px)', flexGrow: 1 }}>
-      <FormControlLabel
-        control={
-          <Switch checked={hidden} onChange={handleHiddenChange} color="primary" />
-        }
-        label="Hidden"
-      />
-      <FormLabel sx={{ my: 1 }} component="legend">
-        Direction
-      </FormLabel>
-      <RadioGroup
-        aria-label="direction"
-        name="direction"
-        value={direction}
-        onChange={handleDirectionChange}
-        row
+    <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
+      <SpeedDial
+        ariaLabel="SpeedDial basic example"
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
+        icon={<SpeedDialIcon />}
       >
-        <FormControlLabel value="up" control={<Radio />} label="Up" />
-        <FormControlLabel value="right" control={<Radio />} label="Right" />
-        <FormControlLabel value="down" control={<Radio />} label="Down" />
-        <FormControlLabel value="left" control={<Radio />} label="Left" />
-      </RadioGroup>
-      <Box sx={{ position: 'relative', mt: 3, height: 320 }}>
-        <StyledSpeedDial
-          ariaLabel="SpeedDial example"
-          hidden={hidden}
-          icon={<SpeedDialIcon />}
-          direction={direction}
-        >
-          {actions.map((action) => (
-            <SpeedDialAction
-              key={action.name}
-              icon={action.icon}
-              tooltipTitle={action.name}
-            />
-          ))}
-        </StyledSpeedDial>
-      </Box>
+        {actions.map((action) => (
+          <SpeedDialAction
+            key={action.name}
+            icon={action.icon}
+            tooltipTitle={action.name}
+          />
+        ))}
+      </SpeedDial>
     </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/BasicSpeedDial.tsx
+++ b/docs/src/pages/components/speed-dial/BasicSpeedDial.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormLabel from '@material-ui/core/FormLabel';
 import Radio from '@material-ui/core/Radio';
@@ -13,33 +14,17 @@ import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      transform: 'translateZ(0px)',
-      flexGrow: 1,
-    },
-    exampleWrapper: {
-      position: 'relative',
-      marginTop: theme.spacing(3),
-      height: 320,
-    },
-    radioGroup: {
-      margin: theme.spacing(1, 0),
-    },
-    speedDial: {
-      position: 'absolute',
-      '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
-        bottom: theme.spacing(2),
-        right: theme.spacing(2),
-      },
-      '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
-        top: theme.spacing(2),
-        left: theme.spacing(2),
-      },
-    },
-  }),
-);
+const StyledSpeedDial = styled(SpeedDial)(({ theme }) => ({
+  position: 'absolute',
+  '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
+  },
+  '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
+    top: theme.spacing(2),
+    left: theme.spacing(2),
+  },
+}));
 
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
@@ -49,7 +34,6 @@ const actions = [
 ];
 
 export default function SpeedDials() {
-  const classes = useStyles();
   const [direction, setDirection] = React.useState<SpeedDialProps['direction']>(
     'up',
   );
@@ -66,14 +50,14 @@ export default function SpeedDials() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ transform: 'translateZ(0px)', flexGrow: 1 }}>
       <FormControlLabel
         control={
           <Switch checked={hidden} onChange={handleHiddenChange} color="primary" />
         }
         label="Hidden"
       />
-      <FormLabel className={classes.radioGroup} component="legend">
+      <FormLabel sx={{ my: 1 }} component="legend">
         Direction
       </FormLabel>
       <RadioGroup
@@ -88,10 +72,9 @@ export default function SpeedDials() {
         <FormControlLabel value="down" control={<Radio />} label="Down" />
         <FormControlLabel value="left" control={<Radio />} label="Left" />
       </RadioGroup>
-      <div className={classes.exampleWrapper}>
-        <SpeedDial
+      <Box sx={{ position: 'relative', mt: 3, height: 320 }}>
+        <StyledSpeedDial
           ariaLabel="SpeedDial example"
-          className={classes.speedDial}
           hidden={hidden}
           icon={<SpeedDialIcon />}
           direction={direction}
@@ -103,8 +86,8 @@ export default function SpeedDials() {
               tooltipTitle={action.name}
             />
           ))}
-        </SpeedDial>
-      </div>
-    </div>
+        </StyledSpeedDial>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.js
+++ b/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
@@ -7,19 +7,6 @@ import FileCopyIcon from '@material-ui/icons/FileCopyOutlined';
 import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 320,
-    transform: 'translateZ(0px)',
-    flexGrow: 1,
-  },
-  speedDial: {
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-}));
 
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
@@ -29,16 +16,15 @@ const actions = [
 ];
 
 export default function ControlledOpenSpeedDial() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <SpeedDial
         ariaLabel="SpeedDial uncontrolled open example"
-        className={classes.speedDial}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
         onClose={handleClose}
         onOpen={handleOpen}
@@ -53,6 +39,6 @@ export default function ControlledOpenSpeedDial() {
           />
         ))}
       </SpeedDial>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.tsx
+++ b/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
@@ -7,19 +7,6 @@ import FileCopyIcon from '@material-ui/icons/FileCopyOutlined';
 import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    height: 320,
-    transform: 'translateZ(0px)',
-    flexGrow: 1,
-  },
-  speedDial: {
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-}));
 
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
@@ -29,16 +16,15 @@ const actions = [
 ];
 
 export default function ControlledOpenSpeedDial() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <SpeedDial
         ariaLabel="SpeedDial uncontrolled open example"
-        className={classes.speedDial}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
         onClose={handleClose}
         onOpen={handleOpen}
@@ -53,6 +39,6 @@ export default function ControlledOpenSpeedDial() {
           />
         ))}
       </SpeedDial>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/OpenIconSpeedDial.js
+++ b/docs/src/pages/components/speed-dial/OpenIconSpeedDial.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
@@ -9,19 +9,6 @@ import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 import EditIcon from '@material-ui/icons/Edit';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 320,
-    transform: 'translateZ(0px)',
-    flexGrow: 1,
-  },
-  speedDial: {
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-}));
-
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
   { icon: <SaveIcon />, name: 'Save' },
@@ -30,13 +17,11 @@ const actions = [
 ];
 
 export default function OpenIconSpeedDial() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <SpeedDial
         ariaLabel="SpeedDial openIcon example"
-        className={classes.speedDial}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon openIcon={<EditIcon />} />}
       >
         {actions.map((action) => (
@@ -47,6 +32,6 @@ export default function OpenIconSpeedDial() {
           />
         ))}
       </SpeedDial>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/OpenIconSpeedDial.tsx
+++ b/docs/src/pages/components/speed-dial/OpenIconSpeedDial.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/core/SpeedDialAction';
@@ -9,21 +9,6 @@ import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 import EditIcon from '@material-ui/icons/Edit';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 320,
-      transform: 'translateZ(0px)',
-      flexGrow: 1,
-    },
-    speedDial: {
-      position: 'absolute',
-      bottom: theme.spacing(2),
-      right: theme.spacing(2),
-    },
-  }),
-);
-
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
   { icon: <SaveIcon />, name: 'Save' },
@@ -32,13 +17,11 @@ const actions = [
 ];
 
 export default function OpenIconSpeedDial() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <SpeedDial
         ariaLabel="SpeedDial openIcon example"
-        className={classes.speedDial}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon openIcon={<EditIcon />} />}
       >
         {actions.map((action) => (
@@ -49,6 +32,6 @@ export default function OpenIconSpeedDial() {
           />
         ))}
       </SpeedDial>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/PlaygroundSpeedDial.js
+++ b/docs/src/pages/components/speed-dial/PlaygroundSpeedDial.js
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormLabel from '@material-ui/core/FormLabel';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Switch from '@material-ui/core/Switch';
+import SpeedDial from '@material-ui/core/SpeedDial';
+import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
+import SpeedDialAction from '@material-ui/core/SpeedDialAction';
+import FileCopyIcon from '@material-ui/icons/FileCopyOutlined';
+import SaveIcon from '@material-ui/icons/Save';
+import PrintIcon from '@material-ui/icons/Print';
+import ShareIcon from '@material-ui/icons/Share';
+
+const StyledSpeedDial = styled(SpeedDial)(({ theme }) => ({
+  position: 'absolute',
+  '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
+  },
+  '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
+    top: theme.spacing(2),
+    left: theme.spacing(2),
+  },
+}));
+
+const actions = [
+  { icon: <FileCopyIcon />, name: 'Copy' },
+  { icon: <SaveIcon />, name: 'Save' },
+  { icon: <PrintIcon />, name: 'Print' },
+  { icon: <ShareIcon />, name: 'Share' },
+];
+
+export default function PlaygroundSpeedDial() {
+  const [direction, setDirection] = React.useState('up');
+
+  const [hidden, setHidden] = React.useState(false);
+
+  const handleDirectionChange = (event) => {
+    setDirection(event.target.value);
+  };
+
+  const handleHiddenChange = (event) => {
+    setHidden(event.target.checked);
+  };
+
+  return (
+    <Box sx={{ transform: 'translateZ(0px)', flexGrow: 1 }}>
+      <FormControlLabel
+        control={
+          <Switch checked={hidden} onChange={handleHiddenChange} color="primary" />
+        }
+        label="Hidden"
+      />
+      <FormLabel sx={{ my: 1 }} component="legend">
+        Direction
+      </FormLabel>
+      <RadioGroup
+        aria-label="direction"
+        name="direction"
+        value={direction}
+        onChange={handleDirectionChange}
+        row
+      >
+        <FormControlLabel value="up" control={<Radio />} label="Up" />
+        <FormControlLabel value="right" control={<Radio />} label="Right" />
+        <FormControlLabel value="down" control={<Radio />} label="Down" />
+        <FormControlLabel value="left" control={<Radio />} label="Left" />
+      </RadioGroup>
+      <Box sx={{ position: 'relative', mt: 3, height: 320 }}>
+        <StyledSpeedDial
+          ariaLabel="SpeedDial playground example"
+          hidden={hidden}
+          icon={<SpeedDialIcon />}
+          direction={direction}
+        >
+          {actions.map((action) => (
+            <SpeedDialAction
+              key={action.name}
+              icon={action.icon}
+              tooltipTitle={action.name}
+            />
+          ))}
+        </StyledSpeedDial>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/speed-dial/PlaygroundSpeedDial.tsx
+++ b/docs/src/pages/components/speed-dial/PlaygroundSpeedDial.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormLabel from '@material-ui/core/FormLabel';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Switch from '@material-ui/core/Switch';
+import SpeedDial, { SpeedDialProps } from '@material-ui/core/SpeedDial';
+import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
+import SpeedDialAction from '@material-ui/core/SpeedDialAction';
+import FileCopyIcon from '@material-ui/icons/FileCopyOutlined';
+import SaveIcon from '@material-ui/icons/Save';
+import PrintIcon from '@material-ui/icons/Print';
+import ShareIcon from '@material-ui/icons/Share';
+
+const StyledSpeedDial = styled(SpeedDial)(({ theme }) => ({
+  position: 'absolute',
+  '&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft': {
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
+  },
+  '&.MuiSpeedDial-directionDown, &.MuiSpeedDial-directionRight': {
+    top: theme.spacing(2),
+    left: theme.spacing(2),
+  },
+}));
+
+const actions = [
+  { icon: <FileCopyIcon />, name: 'Copy' },
+  { icon: <SaveIcon />, name: 'Save' },
+  { icon: <PrintIcon />, name: 'Print' },
+  { icon: <ShareIcon />, name: 'Share' },
+];
+
+export default function PlaygroundSpeedDial() {
+  const [direction, setDirection] = React.useState<SpeedDialProps['direction']>(
+    'up',
+  );
+  const [hidden, setHidden] = React.useState(false);
+
+  const handleDirectionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDirection(
+      (event.target as HTMLInputElement).value as SpeedDialProps['direction'],
+    );
+  };
+
+  const handleHiddenChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setHidden(event.target.checked);
+  };
+
+  return (
+    <Box sx={{ transform: 'translateZ(0px)', flexGrow: 1 }}>
+      <FormControlLabel
+        control={
+          <Switch checked={hidden} onChange={handleHiddenChange} color="primary" />
+        }
+        label="Hidden"
+      />
+      <FormLabel sx={{ my: 1 }} component="legend">
+        Direction
+      </FormLabel>
+      <RadioGroup
+        aria-label="direction"
+        name="direction"
+        value={direction}
+        onChange={handleDirectionChange}
+        row
+      >
+        <FormControlLabel value="up" control={<Radio />} label="Up" />
+        <FormControlLabel value="right" control={<Radio />} label="Right" />
+        <FormControlLabel value="down" control={<Radio />} label="Down" />
+        <FormControlLabel value="left" control={<Radio />} label="Left" />
+      </RadioGroup>
+      <Box sx={{ position: 'relative', mt: 3, height: 320 }}>
+        <StyledSpeedDial
+          ariaLabel="SpeedDial playground example"
+          hidden={hidden}
+          icon={<SpeedDialIcon />}
+          direction={direction}
+        >
+          {actions.map((action) => (
+            <SpeedDialAction
+              key={action.name}
+              icon={action.icon}
+              tooltipTitle={action.name}
+            />
+          ))}
+        </StyledSpeedDial>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.js
+++ b/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Backdrop from '@material-ui/core/Backdrop';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
@@ -9,19 +9,6 @@ import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 330,
-    transform: 'translateZ(0px)',
-    flexGrow: 1,
-  },
-  speedDial: {
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-}));
-
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
   { icon: <SaveIcon />, name: 'Save' },
@@ -30,17 +17,16 @@ const actions = [
 ];
 
 export default function SpeedDialTooltipOpen() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 330, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <Backdrop open={open} />
       <SpeedDial
         ariaLabel="SpeedDial tooltip example"
-        className={classes.speedDial}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
         onClose={handleClose}
         onOpen={handleOpen}
@@ -56,6 +42,6 @@ export default function SpeedDialTooltipOpen() {
           />
         ))}
       </SpeedDial>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.tsx
+++ b/docs/src/pages/components/speed-dial/SpeedDialTooltipOpen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Backdrop from '@material-ui/core/Backdrop';
 import SpeedDial from '@material-ui/core/SpeedDial';
 import SpeedDialIcon from '@material-ui/core/SpeedDialIcon';
@@ -9,21 +9,6 @@ import SaveIcon from '@material-ui/icons/Save';
 import PrintIcon from '@material-ui/icons/Print';
 import ShareIcon from '@material-ui/icons/Share';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 330,
-      transform: 'translateZ(0px)',
-      flexGrow: 1,
-    },
-    speedDial: {
-      position: 'absolute',
-      bottom: theme.spacing(2),
-      right: theme.spacing(2),
-    },
-  }),
-);
-
 const actions = [
   { icon: <FileCopyIcon />, name: 'Copy' },
   { icon: <SaveIcon />, name: 'Save' },
@@ -32,17 +17,16 @@ const actions = [
 ];
 
 export default function SpeedDialTooltipOpen() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 330, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <Backdrop open={open} />
       <SpeedDial
         ariaLabel="SpeedDial tooltip example"
-        className={classes.speedDial}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
         onClose={handleClose}
         onOpen={handleOpen}
@@ -58,6 +42,6 @@ export default function SpeedDialTooltipOpen() {
           />
         ))}
       </SpeedDial>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/speed-dial/speed-dial.md
+++ b/docs/src/pages/components/speed-dial/speed-dial.md
@@ -20,6 +20,10 @@ The floating action button can display related actions.
 
 {{"demo": "pages/components/speed-dial/BasicSpeedDial.js"}}
 
+## Playground
+
+{{"demo": "pages/components/speed-dial/PlaygroundSpeedDial.js"}}
+
 ## Controlled speed dial
 
 The open state of the component can be controlled with the `open`/`onOpen`/`onClose` props.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Speed Dial component were migrated:

- [x] Basic speed dial
- [x] Controlled speed dial
- [x] Custom close speed dial
- [x] Persistent action tooltips

Related to #16947