### PR TITLE
[docs] Use `env` next config over DefinePlugin

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,4 +1,3 @@
-const webpack = require('webpack');
 const path = require('path');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const pkg = require('../package.json');
@@ -32,19 +31,7 @@ module.exports = {
     ignoreBuildErrors: true,
   },
   webpack: (config, options) => {
-    const plugins = config.plugins.concat([
-      new webpack.DefinePlugin({
-        'process.env': {
-          COMMIT_REF: JSON.stringify(process.env.COMMIT_REF),
-          ENABLE_AD: JSON.stringify(process.env.ENABLE_AD),
-          GITHUB_AUTH: JSON.stringify(process.env.GITHUB_AUTH),
-          LIB_VERSION: JSON.stringify(pkg.version),
-          PULL_REQUEST: JSON.stringify(process.env.PULL_REQUEST === 'true'),
-          REACT_MODE: JSON.stringify(reactMode),
-          FEEDBACK_URL: JSON.stringify(process.env.FEEDBACK_URL),
-        },
-      }),
-    ]);
+    const plugins = config.plugins;
 
     if (process.env.DOCS_STATS_ENABLED) {
       plugins.push(
@@ -154,6 +141,15 @@ module.exports = {
     };
   },
   trailingSlash: true,
+  env: {
+    COMMIT_REF: JSON.stringify(process.env.COMMIT_REF),
+    ENABLE_AD: JSON.stringify(process.env.ENABLE_AD),
+    GITHUB_AUTH: JSON.stringify(process.env.GITHUB_AUTH),
+    LIB_VERSION: JSON.stringify(pkg.version),
+    PULL_REQUEST: JSON.stringify(process.env.PULL_REQUEST === 'true'),
+    REACT_MODE: JSON.stringify(reactMode),
+    FEEDBACK_URL: JSON.stringify(process.env.FEEDBACK_URL),
+  },
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
   exportPathMap: () => {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -142,13 +142,13 @@ module.exports = {
   },
   trailingSlash: true,
   env: {
-    COMMIT_REF: JSON.stringify(process.env.COMMIT_REF),
-    ENABLE_AD: JSON.stringify(process.env.ENABLE_AD),
-    GITHUB_AUTH: JSON.stringify(process.env.GITHUB_AUTH),
-    LIB_VERSION: JSON.stringify(pkg.version),
-    PULL_REQUEST: JSON.stringify(process.env.PULL_REQUEST === 'true'),
-    REACT_MODE: JSON.stringify(reactMode),
-    FEEDBACK_URL: JSON.stringify(process.env.FEEDBACK_URL),
+    COMMIT_REF: process.env.COMMIT_REF,
+    ENABLE_AD: process.env.ENABLE_AD,
+    GITHUB_AUTH: process.env.GITHUB_AUTH,
+    LIB_VERSION: pkg.version,
+    PULL_REQUEST: process.env.PULL_REQUEST === 'true',
+    REACT_MODE: reactMode,
+    FEEDBACK_URL: process.env.FEEDBACK_URL,
   },
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -31,7 +31,7 @@ module.exports = {
     ignoreBuildErrors: true,
   },
   webpack: (config, options) => {
-    const plugins = config.plugins;
+    const plugins = config.plugins.slice();
 
     if (process.env.DOCS_STATS_ENABLED) {
       plugins.push(

--- a/docs/package.json
+++ b/docs/package.json
@@ -117,7 +117,6 @@
     "stylis": "^4.0.3",
     "stylis-plugin-rtl": "^2.0.1",
     "webfontloader": "^1.6.28",
-    "webpack": "^4.41.0",
     "webpack-bundle-analyzer": "^4.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -195,8 +195,7 @@
     "**/@types/react-dom": "^17.0.0",
     "**/cross-fetch": "^3.0.5",
     "**/dot-prop": "^5.2.0",
-    "**/react-is": "^16.13.1",
-    "**/webpack": "^4.44.1"
+    "**/react-is": "^16.13.1"
   },
   "nyc": {
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16664,7 +16664,7 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.41.0, webpack@^4.43.0, webpack@^4.44.1:
+webpack@^4.41.0, webpack@^4.43.0:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==


### PR DESCRIPTION
In next 10 webpack is bundled so `resolutions` does not have any effect. This can result in a mismatch between `webpack.DefinePlugin` and the webpack version used by next. We can use their 1st class API for environment variables instead.