### PR TITLE
[docs] Migrate Avatar demos to emotion

### DIFF
--- a/docs/src/pages/components/avatars/BadgeAvatars.js
+++ b/docs/src/pages/components/avatars/BadgeAvatars.js
@@ -5,7 +5,7 @@ import Badge from '@material-ui/core/Badge';
 import Avatar from '@material-ui/core/Avatar';
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
-  '.MuiBadge-badge': {
+  '& .MuiBadge-badge': {
     backgroundColor: '#44b700',
     color: '#44b700',
     boxShadow: `0 0 0 2px ${theme.palette.background.paper}`,
@@ -44,9 +44,8 @@ export default function BadgeAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <StyledBadge

--- a/docs/src/pages/components/avatars/BadgeAvatars.js
+++ b/docs/src/pages/components/avatars/BadgeAvatars.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Badge from '@material-ui/core/Badge';
 import Avatar from '@material-ui/core/Avatar';
-import { makeStyles, withStyles } from '@material-ui/core/styles';
 
-const StyledBadge = withStyles((theme) => ({
-  badge: {
+const StyledBadge = styled(Badge)(({ theme }) => ({
+  '.MuiBadge-badge': {
     backgroundColor: '#44b700',
     color: '#44b700',
     boxShadow: `0 0 0 2px ${theme.palette.background.paper}`,
@@ -30,52 +31,40 @@ const StyledBadge = withStyles((theme) => ({
       opacity: 0,
     },
   },
-}))(Badge);
+}));
 
-const SmallAvatar = withStyles((theme) => ({
-  root: {
-    width: 22,
-    height: 22,
-    border: `2px solid ${theme.palette.background.paper}`,
-  },
-}))(Avatar);
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
+const SmallAvatar = styled(Avatar)(({ theme }) => ({
+  width: 22,
+  height: 22,
+  border: `2px solid ${theme.palette.background.paper}`,
 }));
 
 export default function BadgeAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <StyledBadge
         overlap="circular"
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         variant="dot"
       >
         <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       </StyledBadge>
       <Badge
         overlap="circular"
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         badgeContent={
           <SmallAvatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
         }
       >
         <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
       </Badge>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/BadgeAvatars.js
+++ b/docs/src/pages/components/avatars/BadgeAvatars.js
@@ -16,7 +16,7 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
       width: '100%',
       height: '100%',
       borderRadius: '50%',
-      animation: '$ripple 1.2s infinite ease-in-out',
+      animation: 'ripple 1.2s infinite ease-in-out',
       border: '1px solid currentColor',
       content: '""',
     },

--- a/docs/src/pages/components/avatars/BadgeAvatars.tsx
+++ b/docs/src/pages/components/avatars/BadgeAvatars.tsx
@@ -5,7 +5,7 @@ import Badge from '@material-ui/core/Badge';
 import Avatar from '@material-ui/core/Avatar';
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
-  '.MuiBadge-badge': {
+  '& .MuiBadge-badge': {
     backgroundColor: '#44b700',
     color: '#44b700',
     boxShadow: `0 0 0 2px ${theme.palette.background.paper}`,
@@ -44,9 +44,8 @@ export default function BadgeAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <StyledBadge

--- a/docs/src/pages/components/avatars/BadgeAvatars.tsx
+++ b/docs/src/pages/components/avatars/BadgeAvatars.tsx
@@ -1,92 +1,70 @@
 import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Badge from '@material-ui/core/Badge';
 import Avatar from '@material-ui/core/Avatar';
-import {
-  Theme,
-  makeStyles,
-  withStyles,
-  createStyles,
-} from '@material-ui/core/styles';
 
-const StyledBadge = withStyles((theme: Theme) =>
-  createStyles({
-    badge: {
-      backgroundColor: '#44b700',
-      color: '#44b700',
-      boxShadow: `0 0 0 2px ${theme.palette.background.paper}`,
-      '&::after': {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        borderRadius: '50%',
-        animation: '$ripple 1.2s infinite ease-in-out',
-        border: '1px solid currentColor',
-        content: '""',
-      },
+const StyledBadge = styled(Badge)(({ theme }) => ({
+  '.MuiBadge-badge': {
+    backgroundColor: '#44b700',
+    color: '#44b700',
+    boxShadow: `0 0 0 2px ${theme.palette.background.paper}`,
+    '&::after': {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      borderRadius: '50%',
+      animation: '$ripple 1.2s infinite ease-in-out',
+      border: '1px solid currentColor',
+      content: '""',
     },
-    '@keyframes ripple': {
-      '0%': {
-        transform: 'scale(.8)',
-        opacity: 1,
-      },
-      '100%': {
-        transform: 'scale(2.4)',
-        opacity: 0,
-      },
+  },
+  '@keyframes ripple': {
+    '0%': {
+      transform: 'scale(.8)',
+      opacity: 1,
     },
-  }),
-)(Badge);
+    '100%': {
+      transform: 'scale(2.4)',
+      opacity: 0,
+    },
+  },
+}));
 
-const SmallAvatar = withStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: 22,
-      height: 22,
-      border: `2px solid ${theme.palette.background.paper}`,
-    },
-  }),
-)(Avatar);
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
+const SmallAvatar = styled(Avatar)(({ theme }) => ({
+  width: 22,
+  height: 22,
+  border: `2px solid ${theme.palette.background.paper}`,
+}));
 
 export default function BadgeAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <StyledBadge
         overlap="circular"
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         variant="dot"
       >
         <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       </StyledBadge>
       <Badge
         overlap="circular"
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         badgeContent={
           <SmallAvatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
         }
       >
         <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
       </Badge>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/BadgeAvatars.tsx
+++ b/docs/src/pages/components/avatars/BadgeAvatars.tsx
@@ -16,7 +16,7 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
       width: '100%',
       height: '100%',
       borderRadius: '50%',
-      animation: '$ripple 1.2s infinite ease-in-out',
+      animation: 'ripple 1.2s infinite ease-in-out',
       border: '1px solid currentColor',
       content: '""',
     },

--- a/docs/src/pages/components/avatars/FallbackAvatars.js
+++ b/docs/src/pages/components/avatars/FallbackAvatars.js
@@ -8,9 +8,8 @@ export default function FallbackAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar

--- a/docs/src/pages/components/avatars/FallbackAvatars.js
+++ b/docs/src/pages/components/avatars/FallbackAvatars.js
@@ -1,31 +1,31 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import { deepOrange } from '@material-ui/core/colors';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  orange: {
-    color: theme.palette.getContrastText(deepOrange[500]),
-    backgroundColor: deepOrange[500],
-  },
-}));
-
 export default function FallbackAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Avatar alt="Remy Sharp" src="/broken-image.jpg" className={classes.orange}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
+      <Avatar
+        sx={{ bgcolor: deepOrange[500] }}
+        alt="Remy Sharp"
+        src="/broken-image.jpg"
+      >
         B
       </Avatar>
-      <Avatar alt="Remy Sharp" src="/broken-image.jpg" className={classes.orange} />
+      <Avatar
+        sx={{ bgcolor: deepOrange[500] }}
+        alt="Remy Sharp"
+        src="/broken-image.jpg"
+      />
       <Avatar src="/broken-image.jpg" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/FallbackAvatars.tsx
+++ b/docs/src/pages/components/avatars/FallbackAvatars.tsx
@@ -8,9 +8,8 @@ export default function FallbackAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar

--- a/docs/src/pages/components/avatars/FallbackAvatars.tsx
+++ b/docs/src/pages/components/avatars/FallbackAvatars.tsx
@@ -1,33 +1,31 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import { deepOrange } from '@material-ui/core/colors';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    orange: {
-      color: theme.palette.getContrastText(deepOrange[500]),
-      backgroundColor: deepOrange[500],
-    },
-  }),
-);
-
 export default function FallbackAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Avatar alt="Remy Sharp" src="/broken-image.jpg" className={classes.orange}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
+      <Avatar
+        sx={{ bgcolor: deepOrange[500] }}
+        alt="Remy Sharp"
+        src="/broken-image.jpg"
+      >
         B
       </Avatar>
-      <Avatar alt="Remy Sharp" src="/broken-image.jpg" className={classes.orange} />
+      <Avatar
+        sx={{ bgcolor: deepOrange[500] }}
+        alt="Remy Sharp"
+        src="/broken-image.jpg"
+      />
       <Avatar src="/broken-image.jpg" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/IconAvatars.js
+++ b/docs/src/pages/components/avatars/IconAvatars.js
@@ -1,42 +1,30 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import { green, pink } from '@material-ui/core/colors';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import FolderIcon from '@material-ui/icons/Folder';
 import PageviewIcon from '@material-ui/icons/Pageview';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  pink: {
-    color: theme.palette.getContrastText(pink[500]),
-    backgroundColor: pink[500],
-  },
-  green: {
-    color: '#fff',
-    backgroundColor: green[500],
-  },
-}));
-
 export default function IconAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar>
         <FolderIcon />
       </Avatar>
-      <Avatar className={classes.pink}>
+      <Avatar sx={{ bgcolor: pink[500] }}>
         <PageviewIcon />
       </Avatar>
-      <Avatar className={classes.green}>
+      <Avatar sx={{ bgcolor: green[500] }}>
         <AssignmentIcon />
       </Avatar>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/IconAvatars.js
+++ b/docs/src/pages/components/avatars/IconAvatars.js
@@ -11,9 +11,8 @@ export default function IconAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar>

--- a/docs/src/pages/components/avatars/IconAvatars.tsx
+++ b/docs/src/pages/components/avatars/IconAvatars.tsx
@@ -1,44 +1,30 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import { green, pink } from '@material-ui/core/colors';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import FolderIcon from '@material-ui/icons/Folder';
 import PageviewIcon from '@material-ui/icons/Pageview';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    pink: {
-      color: theme.palette.getContrastText(pink[500]),
-      backgroundColor: pink[500],
-    },
-    green: {
-      color: '#fff',
-      backgroundColor: green[500],
-    },
-  }),
-);
-
 export default function IconAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar>
         <FolderIcon />
       </Avatar>
-      <Avatar className={classes.pink}>
+      <Avatar sx={{ bgcolor: pink[500] }}>
         <PageviewIcon />
       </Avatar>
-      <Avatar className={classes.green}>
+      <Avatar sx={{ bgcolor: green[500] }}>
         <AssignmentIcon />
       </Avatar>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/IconAvatars.tsx
+++ b/docs/src/pages/components/avatars/IconAvatars.tsx
@@ -11,9 +11,8 @@ export default function IconAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar>

--- a/docs/src/pages/components/avatars/ImageAvatars.js
+++ b/docs/src/pages/components/avatars/ImageAvatars.js
@@ -7,9 +7,8 @@ export default function ImageAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />

--- a/docs/src/pages/components/avatars/ImageAvatars.js
+++ b/docs/src/pages/components/avatars/ImageAvatars.js
@@ -1,24 +1,20 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function ImageAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
       <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/ImageAvatars.tsx
+++ b/docs/src/pages/components/avatars/ImageAvatars.tsx
@@ -1,26 +1,20 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function ImageAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
       <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/ImageAvatars.tsx
+++ b/docs/src/pages/components/avatars/ImageAvatars.tsx
@@ -7,9 +7,8 @@ export default function ImageAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />

--- a/docs/src/pages/components/avatars/LetterAvatars.js
+++ b/docs/src/pages/components/avatars/LetterAvatars.js
@@ -1,33 +1,21 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import { deepOrange, deepPurple } from '@material-ui/core/colors';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  orange: {
-    color: theme.palette.getContrastText(deepOrange[500]),
-    backgroundColor: deepOrange[500],
-  },
-  purple: {
-    color: theme.palette.getContrastText(deepPurple[500]),
-    backgroundColor: deepPurple[500],
-  },
-}));
-
 export default function LetterAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar>H</Avatar>
-      <Avatar className={classes.orange}>N</Avatar>
-      <Avatar className={classes.purple}>OP</Avatar>
-    </div>
+      <Avatar sx={{ bgcolor: deepOrange[500] }}>N</Avatar>
+      <Avatar sx={{ bgcolor: deepPurple[500] }}>OP</Avatar>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/LetterAvatars.js
+++ b/docs/src/pages/components/avatars/LetterAvatars.js
@@ -8,9 +8,8 @@ export default function LetterAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar>H</Avatar>

--- a/docs/src/pages/components/avatars/LetterAvatars.tsx
+++ b/docs/src/pages/components/avatars/LetterAvatars.tsx
@@ -1,35 +1,21 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import { deepOrange, deepPurple } from '@material-ui/core/colors';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    orange: {
-      color: theme.palette.getContrastText(deepOrange[500]),
-      backgroundColor: deepOrange[500],
-    },
-    purple: {
-      color: theme.palette.getContrastText(deepPurple[500]),
-      backgroundColor: deepPurple[500],
-    },
-  }),
-);
-
 export default function LetterAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar>H</Avatar>
-      <Avatar className={classes.orange}>N</Avatar>
-      <Avatar className={classes.purple}>OP</Avatar>
-    </div>
+      <Avatar sx={{ bgcolor: deepOrange[500] }}>N</Avatar>
+      <Avatar sx={{ bgcolor: deepPurple[500] }}>OP</Avatar>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/LetterAvatars.tsx
+++ b/docs/src/pages/components/avatars/LetterAvatars.tsx
@@ -8,9 +8,8 @@ export default function LetterAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar>H</Avatar>

--- a/docs/src/pages/components/avatars/SizeAvatars.js
+++ b/docs/src/pages/components/avatars/SizeAvatars.js
@@ -7,9 +7,8 @@ export default function ImageAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar

--- a/docs/src/pages/components/avatars/SizeAvatars.js
+++ b/docs/src/pages/components/avatars/SizeAvatars.js
@@ -1,40 +1,28 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  small: {
-    width: theme.spacing(3),
-    height: theme.spacing(3),
-  },
-  large: {
-    width: theme.spacing(7),
-    height: theme.spacing(7),
-  },
-}));
-
 export default function ImageAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar
         alt="Remy Sharp"
         src="/static/images/avatar/1.jpg"
-        className={classes.small}
+        sx={{ width: 24, height: 24 }}
       />
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar
         alt="Remy Sharp"
         src="/static/images/avatar/1.jpg"
-        className={classes.large}
+        sx={{ width: 56, height: 56 }}
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/SizeAvatars.tsx
+++ b/docs/src/pages/components/avatars/SizeAvatars.tsx
@@ -7,9 +7,8 @@ export default function ImageAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar

--- a/docs/src/pages/components/avatars/SizeAvatars.tsx
+++ b/docs/src/pages/components/avatars/SizeAvatars.tsx
@@ -1,42 +1,28 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    small: {
-      width: theme.spacing(3),
-      height: theme.spacing(3),
-    },
-    large: {
-      width: theme.spacing(7),
-      height: theme.spacing(7),
-    },
-  }),
-);
-
 export default function ImageAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <Avatar
         alt="Remy Sharp"
         src="/static/images/avatar/1.jpg"
-        className={classes.small}
+        sx={{ width: 24, height: 24 }}
       />
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar
         alt="Remy Sharp"
         src="/static/images/avatar/1.jpg"
-        className={classes.large}
+        sx={{ width: 56, height: 56 }}
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/VariantAvatars.js
+++ b/docs/src/pages/components/avatars/VariantAvatars.js
@@ -9,9 +9,8 @@ export default function VariantAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar sx={{ bgcolor: deepOrange[500] }} variant="square">

--- a/docs/src/pages/components/avatars/VariantAvatars.js
+++ b/docs/src/pages/components/avatars/VariantAvatars.js
@@ -1,37 +1,25 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import { deepOrange, green } from '@material-ui/core/colors';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-  square: {
-    color: theme.palette.getContrastText(deepOrange[500]),
-    backgroundColor: deepOrange[500],
-  },
-  rounded: {
-    color: '#fff',
-    backgroundColor: green[500],
-  },
-}));
-
 export default function VariantAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Avatar variant="square" className={classes.square}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
+      <Avatar sx={{ bgcolor: deepOrange[500] }} variant="square">
         N
       </Avatar>
-      <Avatar variant="rounded" className={classes.rounded}>
+      <Avatar sx={{ bgcolor: green[500] }} variant="rounded">
         <AssignmentIcon />
       </Avatar>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/avatars/VariantAvatars.tsx
+++ b/docs/src/pages/components/avatars/VariantAvatars.tsx
@@ -9,9 +9,8 @@ export default function VariantAvatars() {
     <Box
       sx={{
         display: 'flex',
-        '& > :not(style)': {
-          m: 1,
-        },
+        // TODO Replace with Stack
+        '& > :not(style) + :not(style)': { ml: 2 },
       }}
     >
       <Avatar sx={{ bgcolor: deepOrange[500] }} variant="square">

--- a/docs/src/pages/components/avatars/VariantAvatars.tsx
+++ b/docs/src/pages/components/avatars/VariantAvatars.tsx
@@ -1,39 +1,25 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Avatar from '@material-ui/core/Avatar';
 import { deepOrange, green } from '@material-ui/core/colors';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    square: {
-      color: theme.palette.getContrastText(deepOrange[500]),
-      backgroundColor: deepOrange[500],
-    },
-    rounded: {
-      color: '#fff',
-      backgroundColor: green[500],
-    },
-  }),
-);
-
 export default function VariantAvatars() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
-      <Avatar variant="square" className={classes.square}>
+    <Box
+      sx={{
+        display: 'flex',
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
+      <Avatar sx={{ bgcolor: deepOrange[500] }} variant="square">
         N
       </Avatar>
-      <Avatar variant="rounded" className={classes.rounded}>
+      <Avatar sx={{ bgcolor: green[500] }} variant="rounded">
         <AssignmentIcon />
       </Avatar>
-    </div>
+    </Box>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Avatar component were migrated:

- [x] Image avatar
- [x] Letter avatar
- [x] Size avatar
- [x] Icon avatar
- [x] Variant avatar
- [x] Fallbacks avatar
- [x] With badge + demo

Related to #16947