### PR TITLE
[utils] Allow functional updates in TypeScript declaration of useControlled

### DIFF
--- a/packages/material-ui-utils/src/useControlled.d.ts
+++ b/packages/material-ui-utils/src/useControlled.d.ts
@@ -19,4 +19,4 @@ export interface UseControlledProps<T = unknown> {
 
 export default function useControlled<T = unknown>(
   props: UseControlledProps<T>
-): [T, (newValue: T) => void];
+): [T, (newValue: T | ((prevValue: T) => T)) => void];


### PR DESCRIPTION
useControlled returns a pair: value and function to update value. And useControlled is using React.useState. The function from useControlled is a simple wrapper around the function from useState. Since useState hook allows to update state by passing a function as an argument (prevState: T => T) useControlled hook should allow to do so.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
