### PR TITLE
[styles] add 'minimize' option in createGenerateClassName

### DIFF
--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.d.ts
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.d.ts
@@ -4,6 +4,7 @@ export interface GenerateClassNameOptions {
   disableGlobal?: boolean;
   productionPrefix?: string;
   seed?: string;
+  minimize?: boolean;
 }
 
 export default function createGenerateClassName(options?: GenerateClassNameOptions): GenerateId;

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.js
@@ -27,7 +27,12 @@ const pseudoClasses = [
 // It's inspired by
 // https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
 export default function createGenerateClassName(options = {}) {
-  const { disableGlobal = false, productionPrefix = 'jss', seed = '' } = options;
+  const {
+    disableGlobal = false,
+    productionPrefix = 'jss',
+    seed = '',
+    minimize = process.env.NODE_ENV === 'production',
+  } = options;
   const seedPrefix = seed === '' ? '' : `${seed}-`;
   let ruleCounter = 0;
 
@@ -65,7 +70,7 @@ export default function createGenerateClassName(options = {}) {
       return `${prefix}-${getNextCounterId()}`;
     }
 
-    if (process.env.NODE_ENV === 'production') {
+    if (minimize) {
       return `${seedPrefix}${productionPrefix}${getNextCounterId()}`;
     }
 

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
@@ -154,5 +154,21 @@ describe('createGenerateClassName', () => {
         ),
       ).to.equal('dark-jss1');
     });
+
+    it('should keep the key and classNamePrefix if minimize === false', () => {
+      const generateClassName = createGenerateClassName({
+        minimize: false,
+      });
+      expect(
+        generateClassName(
+          { key: 'key' },
+          {
+            options: {
+              classNamePrefix: 'classNamePrefix',
+            },
+          },
+        ),
+      ).to.equal('classNamePrefix-key-1');
+    });
   });
 });


### PR DESCRIPTION
It can be useful to keep keys and classNamePrefixes even in production. For example to be able to refer to the class names in end-to-end tests, or easier debugging. I've added an option which defaults to the old behaviour (defaults to NODE_ENV === production), but is now overridable.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
