### PR TITLE
[material-design] Remove default grey bgcolor in light mode

### DIFF
--- a/packages/material-ui/src/styles/createPalette.js
+++ b/packages/material-ui/src/styles/createPalette.js
@@ -26,7 +26,7 @@ export const light = {
   // Consistency between these values is important.
   background: {
     paper: common.white,
-    default: grey[50],
+    default: common.white,
   },
   // The colors used to style the action elements.
   action: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Thought I'd try to help, followed the contributing guide and [this comment](https://github.com/mui-org/material-ui/issues/24440#issuecomment-761281899) to replace the grey with a white color.

I'm wondering though if the paper color should be grey then?

Thanks.