### PR TITLE
[core] Bump missed node versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '10.x'
+          versionSpec: '12.x'
         displayName: 'Install Node.js'
 
       # From https://github.com/GoogleChrome/puppeteer/blob/811415bc8c47f7882375629b57b3fe186ad61ed4/docs/troubleshooting.md#chrome-headless-doesnt-launch

--- a/test/utils/initMatchers.test.js
+++ b/test/utils/initMatchers.test.js
@@ -44,7 +44,7 @@ describe('custom matchers', () => {
         'Could not match the following console.error calls. ' +
           "Make sure previous actions didn't call console.error by wrapping them in expect(() => {}).not.toErrorDev(): \n\n" +
           '  - "expected message"\n' +
-          '    at Context.', // `Context.it` in node 10.x, `Context.<anonymous>` in later node version
+          '    at Context.', // `Context.it` in node 12.x, `Context.<anonymous>` in later node version
       );
       // check that the top stackframe points to this test
       // if this test is moved to another file the next assertion fails


### PR DESCRIPTION
Requires https://github.com/mui-org/material-ui/pull/25402

Missed some in https://github.com/mui-org/material-ui/pull/25306

## Test plan

- [x] performance monitoring passes: https://dev.azure.com/mui-org/Material-UI/_build/results?buildId=25158&view=logs&j=d85cee4e-0023-518e-ada4-a1472ffb2935