### PR TITLE
[slider] Add `tabIndex` prop

### DIFF
--- a/docs/pages/api-docs/slider-unstyled.json
+++ b/docs/pages/api-docs/slider-unstyled.json
@@ -38,6 +38,7 @@
     },
     "scale": { "type": { "name": "func" }, "default": "(x) => x" },
     "step": { "type": { "name": "number" }, "default": "1" },
+    "tabIndex": { "type": { "name": "number" } },
     "track": {
       "type": {
         "name": "enum",

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -43,6 +43,7 @@
     "scale": { "type": { "name": "func" }, "default": "(x) => x" },
     "step": { "type": { "name": "number" }, "default": "1" },
     "sx": { "type": { "name": "object" } },
+    "tabIndex": { "type": { "name": "number" } },
     "track": {
       "type": {
         "name": "enum",

--- a/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
+++ b/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
@@ -22,6 +22,7 @@
     "orientation": "The component orientation.",
     "scale": "A transformation function, to change the scale of the slider.",
     "step": "The granularity with which the slider can step through values. (A &quot;discrete&quot; slider.) The <code>min</code> prop serves as the origin for the valid values. We recommend (max - min) to be evenly divisible by the step.<br>When step is <code>null</code>, the thumb can only be slid onto marks provided with the <code>marks</code> prop.",
+    "tabIndex": "Tab index attribute of the hidden <code>input</code> element.",
     "track": "The track presentation:<br>- <code>normal</code> the track will render a bar representing the slider value. - <code>inverted</code> the track will render a bar representing the remaining slider value. - <code>false</code> the track will render without a bar.",
     "value": "The value of the slider. For ranged sliders, provide an array with two values.",
     "valueLabelDisplay": "Controls when the value label is displayed:<br>- <code>auto</code> the value label will display when the thumb is hovered or focused. - <code>on</code> will display persistently. - <code>off</code> will never display.",

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -23,6 +23,7 @@
     "scale": "A transformation function, to change the scale of the slider.",
     "step": "The granularity with which the slider can step through values. (A &quot;discrete&quot; slider.) The <code>min</code> prop serves as the origin for the valid values. We recommend (max - min) to be evenly divisible by the step.<br>When step is <code>null</code>, the thumb can only be slid onto marks provided with the <code>marks</code> prop.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "tabIndex": "Tab index attribute of the hidden <code>input</code> element.",
     "track": "The track presentation:<br>- <code>normal</code> the track will render a bar representing the slider value. - <code>inverted</code> the track will render a bar representing the remaining slider value. - <code>false</code> the track will render without a bar.",
     "value": "The value of the slider. For ranged sliders, provide an array with two values.",
     "valueLabelDisplay": "Controls when the value label is displayed:<br>- <code>auto</code> the value label will display when the thumb is hovered or focused. - <code>on</code> will display persistently. - <code>off</code> will never display.",

--- a/framer/Material-UI.framerfx/code/Slider.tsx
+++ b/framer/Material-UI.framerfx/code/Slider.tsx
@@ -9,6 +9,7 @@ interface Props {
   min?: number;
   orientation?: 'horizontal' | 'vertical';
   step?: number;
+  tabIndex?: number;
   track?: 'inverted' | 'normal' | false;
   valueLabelDisplay?: 'auto' | 'off' | 'on';
   width: number | string;
@@ -52,6 +53,10 @@ addPropertyControls(Slider, {
   step: {
     type: ControlType.Number,
     title: 'Step',
+  },
+  tabIndex: {
+    type: ControlType.Number,
+    title: 'Tab index',
   },
   track: {
     type: ControlType.Enum,

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.d.ts
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.d.ts
@@ -213,6 +213,10 @@ export interface SliderUnstyledTypeMap<P = {}, D extends React.ElementType = 'sp
      */
     step?: number | null;
     /**
+     * Tab index attribute of the hidden `input` element.
+     */
+    tabIndex?: number;
+    /**
      * The track presentation:
      *
      * - `normal` the track will render a bar representing the slider value.

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -205,6 +205,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
     orientation = 'horizontal',
     scale = Identity,
     step = 1,
+    tabIndex,
     track = 'normal',
     value: valueProp,
     valueLabelDisplay = 'off',
@@ -735,6 +736,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                 style={{ ...style, ...thumbProps.style }}
               >
                 <input
+                  tabIndex={tabIndex}
                   data-index={index}
                   aria-label={getAriaLabel ? getAriaLabel(index) : ariaLabel}
                   aria-labelledby={ariaLabelledby}
@@ -944,6 +946,10 @@ SliderUnstyled.propTypes /* remove-proptypes */ = {
    * @default 1
    */
   step: PropTypes.number,
+  /**
+   * Tab index attribute of the hidden `input` element.
+   */
+  tabIndex: PropTypes.number,
   /**
    * The track presentation:
    *

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -593,6 +593,10 @@ Slider.propTypes /* remove-proptypes */ = {
    */
   sx: PropTypes.object,
   /**
+   * Tab index attribute of the hidden `input` element.
+   */
+  tabIndex: PropTypes.number,
+  /**
    * The track presentation:
    *
    * - `normal` the track will render a bar representing the slider value.

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -1118,4 +1118,9 @@ describe('<Slider />', () => {
       expect(container.firstChild).not.to.have.class(classes.dragging);
     });
   });
+
+  it('should remove the slider from the tab sequence', () => {
+    render(<SliderUnstyled tabIndex={-1} value={30} />);
+    expect(screen.getByRole('slider')).to.have.property('tabIndex', -1);
+  });
 });


### PR DESCRIPTION
Add a tabIndex prop to the Slider component and pass it through to the hidden input element.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
