### PR TITLE
[docs] Migrate Checkbox demos to emotion

### DIFF
--- a/docs/src/pages/components/checkboxes/CheckboxLabels.js
+++ b/docs/src/pages/components/checkboxes/CheckboxLabels.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import { green } from '@material-ui/core/colors';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -9,15 +9,14 @@ import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import Favorite from '@material-ui/icons/Favorite';
 import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
 
-const GreenCheckbox = withStyles({
-  root: {
+const GreenCheckbox = styled((props) => <Checkbox color="default" {...props} />)(
+  () => ({
     color: green[400],
-    '&$checked': {
+    '&.Mui-checked': {
       color: green[600],
     },
-  },
-  checked: {},
-})((props) => <Checkbox color="default" {...props} />);
+  }),
+);
 
 export default function CheckboxLabels() {
   const [state, setState] = React.useState({

--- a/docs/src/pages/components/checkboxes/CheckboxLabels.js
+++ b/docs/src/pages/components/checkboxes/CheckboxLabels.js
@@ -1,115 +1,19 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import { green } from '@material-ui/core/colors';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
-import CheckBoxIcon from '@material-ui/icons/CheckBox';
-import Favorite from '@material-ui/icons/Favorite';
-import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
-
-const GreenCheckbox = styled((props) => <Checkbox color="default" {...props} />)(
-  () => ({
-    color: green[400],
-    '&.Mui-checked': {
-      color: green[600],
-    },
-  }),
-);
 
 export default function CheckboxLabels() {
-  const [state, setState] = React.useState({
-    checkedA: true,
-    checkedB: true,
-    checkedF: true,
-    checkedG: true,
-  });
-
-  const handleChange = (event) => {
-    setState({
-      ...state,
-      [event.target.name]: event.target.checked,
-    });
-  };
-
   return (
-    <FormGroup row>
+    <FormGroup>
       <FormControlLabel
-        control={
-          <Checkbox
-            checked={state.checkedA}
-            onChange={handleChange}
-            name="checkedA"
-          />
-        }
+        control={<Checkbox defaultChecked name="checkedA" />}
         label="Secondary"
       />
       <FormControlLabel
-        control={
-          <Checkbox
-            checked={state.checkedB}
-            onChange={handleChange}
-            name="checkedB"
-            color="primary"
-          />
-        }
-        label="Primary"
-      />
-      <FormControlLabel
-        control={<Checkbox name="checkedC" />}
-        label="Uncontrolled"
-      />
-      <FormControlLabel
         disabled
-        control={<Checkbox name="checkedD" />}
+        control={<Checkbox name="checkedB" />}
         label="Disabled"
-      />
-      <FormControlLabel
-        disabled
-        control={<Checkbox checked name="checkedE" />}
-        label="Disabled"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={state.checkedF}
-            onChange={handleChange}
-            name="checkedF"
-            indeterminate
-          />
-        }
-        label="Indeterminate"
-      />
-      <FormControlLabel
-        control={
-          <GreenCheckbox
-            checked={state.checkedG}
-            onChange={handleChange}
-            name="checkedG"
-          />
-        }
-        label="Custom color"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            icon={<FavoriteBorder />}
-            checkedIcon={<Favorite />}
-            name="checkedH"
-          />
-        }
-        label="Custom icon"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-            checkedIcon={<CheckBoxIcon fontSize="small" />}
-            name="checkedI"
-          />
-        }
-        label="Custom size"
       />
     </FormGroup>
   );

--- a/docs/src/pages/components/checkboxes/CheckboxLabels.tsx
+++ b/docs/src/pages/components/checkboxes/CheckboxLabels.tsx
@@ -1,115 +1,19 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import { green } from '@material-ui/core/colors';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
-import CheckBoxIcon from '@material-ui/icons/CheckBox';
-import Favorite from '@material-ui/icons/Favorite';
-import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
-
-const GreenCheckbox = styled((props: CheckboxProps) => (
-  <Checkbox color="default" {...props} />
-))(() => ({
-  color: green[400],
-  '&.Mui-checked': {
-    color: green[600],
-  },
-}));
+import Checkbox from '@material-ui/core/Checkbox';
 
 export default function CheckboxLabels() {
-  const [state, setState] = React.useState({
-    checkedA: true,
-    checkedB: true,
-    checkedF: true,
-    checkedG: true,
-  });
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      [event.target.name]: event.target.checked,
-    });
-  };
-
   return (
-    <FormGroup row>
+    <FormGroup>
       <FormControlLabel
-        control={
-          <Checkbox
-            checked={state.checkedA}
-            onChange={handleChange}
-            name="checkedA"
-          />
-        }
+        control={<Checkbox defaultChecked name="checkedA" />}
         label="Secondary"
       />
       <FormControlLabel
-        control={
-          <Checkbox
-            checked={state.checkedB}
-            onChange={handleChange}
-            name="checkedB"
-            color="primary"
-          />
-        }
-        label="Primary"
-      />
-      <FormControlLabel
-        control={<Checkbox name="checkedC" />}
-        label="Uncontrolled"
-      />
-      <FormControlLabel
         disabled
-        control={<Checkbox name="checkedD" />}
+        control={<Checkbox name="checkedB" />}
         label="Disabled"
-      />
-      <FormControlLabel
-        disabled
-        control={<Checkbox checked name="checkedE" />}
-        label="Disabled"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={state.checkedF}
-            onChange={handleChange}
-            name="checkedF"
-            indeterminate
-          />
-        }
-        label="Indeterminate"
-      />
-      <FormControlLabel
-        control={
-          <GreenCheckbox
-            checked={state.checkedG}
-            onChange={handleChange}
-            name="checkedG"
-          />
-        }
-        label="Custom color"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            icon={<FavoriteBorder />}
-            checkedIcon={<Favorite />}
-            name="checkedH"
-          />
-        }
-        label="Custom icon"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-            checkedIcon={<CheckBoxIcon fontSize="small" />}
-            name="checkedI"
-          />
-        }
-        label="Custom size"
       />
     </FormGroup>
   );

--- a/docs/src/pages/components/checkboxes/CheckboxLabels.tsx
+++ b/docs/src/pages/components/checkboxes/CheckboxLabels.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import { green } from '@material-ui/core/colors';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -9,15 +9,14 @@ import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import Favorite from '@material-ui/icons/Favorite';
 import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
 
-const GreenCheckbox = withStyles({
-  root: {
-    color: green[400],
-    '&$checked': {
-      color: green[600],
-    },
+const GreenCheckbox = styled((props: CheckboxProps) => (
+  <Checkbox color="default" {...props} />
+))(() => ({
+  color: green[400],
+  '&.Mui-checked': {
+    color: green[600],
   },
-  checked: {},
-})((props: CheckboxProps) => <Checkbox color="default" {...props} />);
+}));
 
 export default function CheckboxLabels() {
   const [state, setState] = React.useState({

--- a/docs/src/pages/components/checkboxes/Checkboxes.js
+++ b/docs/src/pages/components/checkboxes/Checkboxes.js
@@ -2,57 +2,15 @@ import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 
 export default function Checkboxes() {
-  const [checked, setChecked] = React.useState(true);
-
-  const handleChange = (event) => {
-    setChecked(event.target.checked);
-  };
-
   return (
     <div>
-      <Checkbox
-        checked={checked}
-        onChange={handleChange}
-        inputProps={{ 'aria-label': 'primary checkbox' }}
-      />
-      <Checkbox
-        defaultChecked
-        color="primary"
-        inputProps={{ 'aria-label': 'secondary checkbox' }}
-      />
-      <Checkbox
-        inputProps={{
-          'aria-label': 'uncontrolled-checkbox',
-        }}
-      />
+      <Checkbox defaultChecked inputProps={{ 'aria-label': 'checked checkbox' }} />
+      <Checkbox inputProps={{ 'aria-label': 'uncontrolled-checkbox' }} />
       <Checkbox disabled inputProps={{ 'aria-label': 'disabled checkbox' }} />
       <Checkbox
         disabled
         checked
-        inputProps={{
-          'aria-label': 'disabled checked checkbox',
-        }}
-      />
-      <Checkbox
-        defaultChecked
-        indeterminate
-        inputProps={{
-          'aria-label': 'indeterminate checkbox',
-        }}
-      />
-      <Checkbox
-        defaultChecked
-        color="default"
-        inputProps={{
-          'aria-label': 'checkbox with default color',
-        }}
-      />
-      <Checkbox
-        defaultChecked
-        size="small"
-        inputProps={{
-          'aria-label': 'checkbox with small size',
-        }}
+        inputProps={{ 'aria-label': 'disabled checked checkbox' }}
       />
     </div>
   );

--- a/docs/src/pages/components/checkboxes/Checkboxes.tsx
+++ b/docs/src/pages/components/checkboxes/Checkboxes.tsx
@@ -2,57 +2,15 @@ import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 
 export default function Checkboxes() {
-  const [checked, setChecked] = React.useState(true);
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setChecked(event.target.checked);
-  };
-
   return (
     <div>
-      <Checkbox
-        checked={checked}
-        onChange={handleChange}
-        inputProps={{ 'aria-label': 'primary checkbox' }}
-      />
-      <Checkbox
-        defaultChecked
-        color="primary"
-        inputProps={{ 'aria-label': 'secondary checkbox' }}
-      />
-      <Checkbox
-        inputProps={{
-          'aria-label': 'uncontrolled-checkbox',
-        }}
-      />
+      <Checkbox defaultChecked inputProps={{ 'aria-label': 'checked checkbox' }} />
+      <Checkbox inputProps={{ 'aria-label': 'uncontrolled-checkbox' }} />
       <Checkbox disabled inputProps={{ 'aria-label': 'disabled checkbox' }} />
       <Checkbox
         disabled
         checked
-        inputProps={{
-          'aria-label': 'disabled checked checkbox',
-        }}
-      />
-      <Checkbox
-        defaultChecked
-        indeterminate
-        inputProps={{
-          'aria-label': 'indeterminate checkbox',
-        }}
-      />
-      <Checkbox
-        defaultChecked
-        color="default"
-        inputProps={{
-          'aria-label': 'checkbox with default color',
-        }}
-      />
-      <Checkbox
-        defaultChecked
-        size="small"
-        inputProps={{
-          'aria-label': 'checkbox with small size',
-        }}
+        inputProps={{ 'aria-label': 'disabled checked checkbox' }}
       />
     </div>
   );

--- a/docs/src/pages/components/checkboxes/CheckboxesGroup.js
+++ b/docs/src/pages/components/checkboxes/CheckboxesGroup.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -7,17 +7,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Checkbox from '@material-ui/core/Checkbox';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-  },
-  formControl: {
-    margin: theme.spacing(3),
-  },
-}));
-
 export default function CheckboxesGroup() {
-  const classes = useStyles();
   const [state, setState] = React.useState({
     gilad: true,
     jason: false,
@@ -35,8 +25,8 @@ export default function CheckboxesGroup() {
   const error = [gilad, jason, antoine].filter((v) => v).length !== 2;
 
   return (
-    <div className={classes.root}>
-      <FormControl component="fieldset" className={classes.formControl}>
+    <Box sx={{ display: 'flex' }}>
+      <FormControl sx={{ m: 3 }} component="fieldset">
         <FormLabel component="legend">Assign responsibility</FormLabel>
         <FormGroup>
           <FormControlLabel
@@ -60,12 +50,7 @@ export default function CheckboxesGroup() {
         </FormGroup>
         <FormHelperText>Be careful</FormHelperText>
       </FormControl>
-      <FormControl
-        required
-        error={error}
-        component="fieldset"
-        className={classes.formControl}
-      >
+      <FormControl required error={error} component="fieldset" sx={{ m: 3 }}>
         <FormLabel component="legend">Pick two</FormLabel>
         <FormGroup>
           <FormControlLabel
@@ -89,6 +74,6 @@ export default function CheckboxesGroup() {
         </FormGroup>
         <FormHelperText>You can display an error</FormHelperText>
       </FormControl>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/checkboxes/CheckboxesGroup.tsx
+++ b/docs/src/pages/components/checkboxes/CheckboxesGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -7,19 +7,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Checkbox from '@material-ui/core/Checkbox';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-    },
-    formControl: {
-      margin: theme.spacing(3),
-    },
-  }),
-);
-
 export default function CheckboxesGroup() {
-  const classes = useStyles();
   const [state, setState] = React.useState({
     gilad: true,
     jason: false,
@@ -37,8 +25,8 @@ export default function CheckboxesGroup() {
   const error = [gilad, jason, antoine].filter((v) => v).length !== 2;
 
   return (
-    <div className={classes.root}>
-      <FormControl component="fieldset" className={classes.formControl}>
+    <Box sx={{ display: 'flex' }}>
+      <FormControl sx={{ m: 3 }} component="fieldset">
         <FormLabel component="legend">Assign responsibility</FormLabel>
         <FormGroup>
           <FormControlLabel
@@ -62,12 +50,7 @@ export default function CheckboxesGroup() {
         </FormGroup>
         <FormHelperText>Be careful</FormHelperText>
       </FormControl>
-      <FormControl
-        required
-        error={error}
-        component="fieldset"
-        className={classes.formControl}
-      >
+      <FormControl required error={error} component="fieldset" sx={{ m: 3 }}>
         <FormLabel component="legend">Pick two</FormLabel>
         <FormGroup>
           <FormControlLabel
@@ -91,6 +74,6 @@ export default function CheckboxesGroup() {
         </FormGroup>
         <FormHelperText>You can display an error</FormHelperText>
       </FormControl>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/checkboxes/ColorCheckboxes.js
+++ b/docs/src/pages/components/checkboxes/ColorCheckboxes.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { green } from '@material-ui/core/colors';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function ColorCheckboxes() {
+  return (
+    <div>
+      <Checkbox defaultChecked name="checkedA" />
+      <Checkbox defaultChecked name="checkedB" color="primary" />
+      <Checkbox defaultChecked name="checkedC" color="default" />
+      <Checkbox
+        defaultChecked
+        name="checkedD"
+        sx={{
+          color: green[800],
+          '&.Mui-checked': {
+            color: green[600],
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/checkboxes/ColorCheckboxes.tsx
+++ b/docs/src/pages/components/checkboxes/ColorCheckboxes.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { green } from '@material-ui/core/colors';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function ColorCheckboxes() {
+  return (
+    <div>
+      <Checkbox defaultChecked name="checkedA" />
+      <Checkbox defaultChecked name="checkedB" color="primary" />
+      <Checkbox defaultChecked name="checkedC" color="default" />
+      <Checkbox
+        defaultChecked
+        name="checkedD"
+        sx={{
+          color: green[800],
+          '&.Mui-checked': {
+            color: green[600],
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/checkboxes/ControlledCheckbox.js
+++ b/docs/src/pages/components/checkboxes/ControlledCheckbox.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function ControlledCheckbox() {
+  const [checked, setChecked] = React.useState(true);
+
+  const handleChange = (event) => {
+    setChecked(event.target.checked);
+  };
+
+  return (
+    <Checkbox
+      checked={checked}
+      onChange={handleChange}
+      inputProps={{ 'aria-label': 'controlled checkbox' }}
+    />
+  );
+}

--- a/docs/src/pages/components/checkboxes/ControlledCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/ControlledCheckbox.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function ControlledCheckbox() {
+  const [checked, setChecked] = React.useState(true);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+  };
+
+  return (
+    <Checkbox
+      checked={checked}
+      onChange={handleChange}
+      inputProps={{ 'aria-label': 'controlled checkbox' }}
+    />
+  );
+}

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
@@ -1,63 +1,56 @@
 import * as React from 'react';
-import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
 
-const useStyles = makeStyles({
-  root: {
-    '&:hover': {
-      backgroundColor: 'transparent',
-    },
+const Icon = styled('span')({
+  borderRadius: 3,
+  width: 16,
+  height: 16,
+  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: '#f5f8fa',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  '.root.Mui-focusVisible &': {
+    outline: '2px auto rgba(19,124,189,.6)',
+    outlineOffset: 2,
   },
-  icon: {
-    borderRadius: 3,
+  'input:hover ~ &': {
+    backgroundColor: '#ebf1f5',
+  },
+  'input:disabled ~ &': {
+    boxShadow: 'none',
+    background: 'rgba(206,217,224,.5)',
+  },
+});
+
+const CheckedIcon = styled(Icon)({
+  backgroundColor: '#137cbd',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
+  '&:before': {
+    display: 'block',
     width: 16,
     height: 16,
-    boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-    backgroundColor: '#f5f8fa',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-    '$root.Mui-focusVisible &': {
-      outline: '2px auto rgba(19,124,189,.6)',
-      outlineOffset: 2,
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#ebf1f5',
-    },
-    'input:disabled ~ &': {
-      boxShadow: 'none',
-      background: 'rgba(206,217,224,.5)',
-    },
+    backgroundImage:
+      "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath" +
+      " fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 " +
+      "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
+    content: '""',
   },
-  checkedIcon: {
-    backgroundColor: '#137cbd',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
-    '&:before': {
-      display: 'block',
-      width: 16,
-      height: 16,
-      backgroundImage:
-        "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath" +
-        " fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 " +
-        "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
-      content: '""',
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#106ba3',
-    },
+  'input:hover ~ &': {
+    backgroundColor: '#106ba3',
   },
 });
 
 // Inspired by blueprintjs
 function StyledCheckbox(props) {
-  const classes = useStyles();
-
   return (
     <Checkbox
-      className={classes.root}
+      sx={{
+        '&:hover': { bgcolor: 'transparent' },
+      }}
       disableRipple
       color="default"
-      checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
-      icon={<span className={classes.icon} />}
+      checkedIcon={<CheckedIcon />}
+      icon={<Icon />}
       inputProps={{ 'aria-label': 'decorative checkbox' }}
       {...props}
     />

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
@@ -13,10 +13,10 @@ const Icon = styled('span')({
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
-  '& input:hover ~ &': {
+  'input:hover ~ &': {
     backgroundColor: '#ebf1f5',
   },
-  '& input:disabled ~ &': {
+  'input:disabled ~ &': {
     boxShadow: 'none',
     background: 'rgba(206,217,224,.5)',
   },
@@ -35,7 +35,7 @@ const CheckedIcon = styled(Icon)({
       "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
     content: '""',
   },
-  '& input:hover ~ &': {
+  'input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
 });

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
@@ -9,14 +9,14 @@ const Icon = styled('span')({
   boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
   backgroundColor: '#f5f8fa',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-  '.root.Mui-focusVisible &': {
+  '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
-  'input:hover ~ &': {
+  '& input:hover ~ &': {
     backgroundColor: '#ebf1f5',
   },
-  'input:disabled ~ &': {
+  '& input:disabled ~ &': {
     boxShadow: 'none',
     background: 'rgba(206,217,224,.5)',
   },
@@ -35,7 +35,7 @@ const CheckedIcon = styled(Icon)({
       "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
     content: '""',
   },
-  'input:hover ~ &': {
+  '& input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
 });

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
@@ -13,10 +13,10 @@ const Icon = styled('span')({
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
-  '& input:hover ~ &': {
+  'input:hover ~ &': {
     backgroundColor: '#ebf1f5',
   },
-  '& input:disabled ~ &': {
+  'input:disabled ~ &': {
     boxShadow: 'none',
     background: 'rgba(206,217,224,.5)',
   },
@@ -35,7 +35,7 @@ const CheckedIcon = styled(Icon)({
       "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
     content: '""',
   },
-  '& input:hover ~ &': {
+  'input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
 });

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
@@ -9,14 +9,14 @@ const Icon = styled('span')({
   boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
   backgroundColor: '#f5f8fa',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-  '.root.Mui-focusVisible &': {
+  '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
-  'input:hover ~ &': {
+  '& input:hover ~ &': {
     backgroundColor: '#ebf1f5',
   },
-  'input:disabled ~ &': {
+  '& input:disabled ~ &': {
     boxShadow: 'none',
     background: 'rgba(206,217,224,.5)',
   },
@@ -35,7 +35,7 @@ const CheckedIcon = styled(Icon)({
       "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
     content: '""',
   },
-  'input:hover ~ &': {
+  '& input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
 });

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
@@ -1,63 +1,56 @@
 import * as React from 'react';
-import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 
-const useStyles = makeStyles({
-  root: {
-    '&:hover': {
-      backgroundColor: 'transparent',
-    },
+const Icon = styled('span')({
+  borderRadius: 3,
+  width: 16,
+  height: 16,
+  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: '#f5f8fa',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  '.root.Mui-focusVisible &': {
+    outline: '2px auto rgba(19,124,189,.6)',
+    outlineOffset: 2,
   },
-  icon: {
-    borderRadius: 3,
+  'input:hover ~ &': {
+    backgroundColor: '#ebf1f5',
+  },
+  'input:disabled ~ &': {
+    boxShadow: 'none',
+    background: 'rgba(206,217,224,.5)',
+  },
+});
+
+const CheckedIcon = styled(Icon)({
+  backgroundColor: '#137cbd',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
+  '&:before': {
+    display: 'block',
     width: 16,
     height: 16,
-    boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-    backgroundColor: '#f5f8fa',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-    '$root.Mui-focusVisible &': {
-      outline: '2px auto rgba(19,124,189,.6)',
-      outlineOffset: 2,
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#ebf1f5',
-    },
-    'input:disabled ~ &': {
-      boxShadow: 'none',
-      background: 'rgba(206,217,224,.5)',
-    },
+    backgroundImage:
+      "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath" +
+      " fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 " +
+      "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
+    content: '""',
   },
-  checkedIcon: {
-    backgroundColor: '#137cbd',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
-    '&:before': {
-      display: 'block',
-      width: 16,
-      height: 16,
-      backgroundImage:
-        "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath" +
-        " fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 " +
-        "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
-      content: '""',
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#106ba3',
-    },
+  'input:hover ~ &': {
+    backgroundColor: '#106ba3',
   },
 });
 
 // Inspired by blueprintjs
 function StyledCheckbox(props: CheckboxProps) {
-  const classes = useStyles();
-
   return (
     <Checkbox
-      className={classes.root}
+      sx={{
+        '&:hover': { bgcolor: 'transparent' },
+      }}
       disableRipple
       color="default"
-      checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
-      icon={<span className={classes.icon} />}
+      checkedIcon={<CheckedIcon />}
+      icon={<Icon />}
       inputProps={{ 'aria-label': 'decorative checkbox' }}
       {...props}
     />

--- a/docs/src/pages/components/checkboxes/FormControlLabelPosition.js
+++ b/docs/src/pages/components/checkboxes/FormControlLabelPosition.js
@@ -12,25 +12,25 @@ export default function FormControlLabelPosition() {
       <FormGroup aria-label="position" row>
         <FormControlLabel
           value="top"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="Top"
           labelPlacement="top"
         />
         <FormControlLabel
           value="start"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="Start"
           labelPlacement="start"
         />
         <FormControlLabel
           value="bottom"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="Bottom"
           labelPlacement="bottom"
         />
         <FormControlLabel
           value="end"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="End"
           labelPlacement="end"
         />

--- a/docs/src/pages/components/checkboxes/FormControlLabelPosition.tsx
+++ b/docs/src/pages/components/checkboxes/FormControlLabelPosition.tsx
@@ -12,25 +12,25 @@ export default function FormControlLabelPosition() {
       <FormGroup aria-label="position" row>
         <FormControlLabel
           value="top"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="Top"
           labelPlacement="top"
         />
         <FormControlLabel
           value="start"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="Start"
           labelPlacement="start"
         />
         <FormControlLabel
           value="bottom"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="Bottom"
           labelPlacement="bottom"
         />
         <FormControlLabel
           value="end"
-          control={<Checkbox color="primary" />}
+          control={<Checkbox />}
           label="End"
           labelPlacement="end"
         />

--- a/docs/src/pages/components/checkboxes/IconCheckboxes.js
+++ b/docs/src/pages/components/checkboxes/IconCheckboxes.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
+import Favorite from '@material-ui/icons/Favorite';
+import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
+import BookmarkIcon from '@material-ui/icons/Bookmark';
+
+export default function IconCheckboxes() {
+  return (
+    <div>
+      <Checkbox
+        icon={<FavoriteBorder />}
+        checkedIcon={<Favorite />}
+        name="checkedA"
+        inputProps={{ 'aria-label': 'favorite checkbox' }}
+      />
+      <Checkbox
+        icon={<BookmarkBorderIcon />}
+        checkedIcon={<BookmarkIcon />}
+        name="checkedB"
+        inputProps={{ 'aria-label': 'bookmarked checkbox' }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/checkboxes/IconCheckboxes.tsx
+++ b/docs/src/pages/components/checkboxes/IconCheckboxes.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
+import Favorite from '@material-ui/icons/Favorite';
+import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
+import BookmarkIcon from '@material-ui/icons/Bookmark';
+
+export default function IconCheckboxes() {
+  return (
+    <div>
+      <Checkbox
+        icon={<FavoriteBorder />}
+        checkedIcon={<Favorite />}
+        name="checkedA"
+        inputProps={{ 'aria-label': 'favorite checkbox' }}
+      />
+      <Checkbox
+        icon={<BookmarkBorderIcon />}
+        checkedIcon={<BookmarkIcon />}
+        name="checkedB"
+        inputProps={{ 'aria-label': 'bookmarked checkbox' }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/checkboxes/IndeterminateCheckbox.js
+++ b/docs/src/pages/components/checkboxes/IndeterminateCheckbox.js
@@ -22,15 +22,11 @@ export default function IndeterminateCheckbox() {
     <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
       <FormControlLabel
         label="Child 1"
-        control={
-          <Checkbox checked={checked[0]} color="primary" onChange={handleChange2} />
-        }
+        control={<Checkbox checked={checked[0]} onChange={handleChange2} />}
       />
       <FormControlLabel
         label="Child 2"
-        control={
-          <Checkbox checked={checked[1]} color="primary" onChange={handleChange3} />
-        }
+        control={<Checkbox checked={checked[1]} onChange={handleChange3} />}
       />
     </Box>
   );
@@ -38,15 +34,14 @@ export default function IndeterminateCheckbox() {
   return (
     <div>
       <FormControlLabel
-        label="Parent"
         control={
           <Checkbox
             checked={checked[0] && checked[1]}
             indeterminate={checked[0] !== checked[1]}
             onChange={handleChange1}
-            color="primary"
           />
         }
+        label="Parent"
       />
       {children}
     </div>

--- a/docs/src/pages/components/checkboxes/IndeterminateCheckbox.js
+++ b/docs/src/pages/components/checkboxes/IndeterminateCheckbox.js
@@ -1,18 +1,9 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme) => ({
-  children: {
-    display: 'flex',
-    flexDirection: 'column',
-    marginLeft: theme.spacing(3),
-  },
-}));
-
 export default function IndeterminateCheckbox() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState([true, false]);
 
   const handleChange1 = (event) => {
@@ -28,7 +19,7 @@ export default function IndeterminateCheckbox() {
   };
 
   const children = (
-    <div className={classes.children}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
       <FormControlLabel
         label="Child 1"
         control={
@@ -41,7 +32,7 @@ export default function IndeterminateCheckbox() {
           <Checkbox checked={checked[1]} color="primary" onChange={handleChange3} />
         }
       />
-    </div>
+    </Box>
   );
 
   return (

--- a/docs/src/pages/components/checkboxes/IndeterminateCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/IndeterminateCheckbox.tsx
@@ -1,18 +1,9 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme) => ({
-  children: {
-    display: 'flex',
-    flexDirection: 'column',
-    marginLeft: theme.spacing(3),
-  },
-}));
-
 export default function IndeterminateCheckbox() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState([true, false]);
 
   const handleChange1 = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -28,7 +19,7 @@ export default function IndeterminateCheckbox() {
   };
 
   const children = (
-    <div className={classes.children}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
       <FormControlLabel
         label="Child 1"
         control={
@@ -41,7 +32,7 @@ export default function IndeterminateCheckbox() {
           <Checkbox checked={checked[1]} color="primary" onChange={handleChange3} />
         }
       />
-    </div>
+    </Box>
   );
 
   return (

--- a/docs/src/pages/components/checkboxes/IndeterminateCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/IndeterminateCheckbox.tsx
@@ -22,15 +22,11 @@ export default function IndeterminateCheckbox() {
     <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
       <FormControlLabel
         label="Child 1"
-        control={
-          <Checkbox checked={checked[0]} color="primary" onChange={handleChange2} />
-        }
+        control={<Checkbox checked={checked[0]} onChange={handleChange2} />}
       />
       <FormControlLabel
         label="Child 2"
-        control={
-          <Checkbox checked={checked[1]} color="primary" onChange={handleChange3} />
-        }
+        control={<Checkbox checked={checked[1]} onChange={handleChange3} />}
       />
     </Box>
   );
@@ -38,15 +34,14 @@ export default function IndeterminateCheckbox() {
   return (
     <div>
       <FormControlLabel
-        label="Parent"
         control={
           <Checkbox
             checked={checked[0] && checked[1]}
             indeterminate={checked[0] !== checked[1]}
             onChange={handleChange1}
-            color="primary"
           />
         }
+        label="Parent"
       />
       {children}
     </div>

--- a/docs/src/pages/components/checkboxes/SizeCheckboxes.js
+++ b/docs/src/pages/components/checkboxes/SizeCheckboxes.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function SizeCheckboxes() {
+  return (
+    <div>
+      <Checkbox
+        defaultChecked
+        inputProps={{ 'aria-label': 'small checkbox' }}
+        size="small"
+      />
+      <Checkbox defaultChecked inputProps={{ 'aria-label': 'normal checkbox' }} />
+      <Checkbox
+        defaultChecked
+        inputProps={{ 'aria-label': 'large checkbox' }}
+        sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/checkboxes/SizeCheckboxes.tsx
+++ b/docs/src/pages/components/checkboxes/SizeCheckboxes.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function SizeCheckboxes() {
+  return (
+    <div>
+      <Checkbox
+        defaultChecked
+        inputProps={{ 'aria-label': 'small checkbox' }}
+        size="small"
+      />
+      <Checkbox defaultChecked inputProps={{ 'aria-label': 'normal checkbox' }} />
+      <Checkbox
+        defaultChecked
+        inputProps={{ 'aria-label': 'large checkbox' }}
+        sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -22,18 +22,18 @@ If you have a single option, avoid using a checkbox and use an on/off switch ins
 
 {{"demo": "pages/components/checkboxes/Checkboxes.js"}}
 
+## Label
+
+You can provide a label to the `Checkbox` thanks to the `FormControlLabel` component.
+
+{{"demo": "pages/components/checkboxes/CheckboxLabels.js"}}
+
 ## Indeterminate
 
 A checkbox input can only have two states in a form: checked or unchecked. It either submits its value or doesn't.
 Visually, there are actually three states a checkbox can be in: checked, unchecked, or indeterminate.
 
 {{"demo": "pages/components/checkboxes/IndeterminateCheckbox.js"}}
-
-## Label
-
-`Checkbox` can be provided with a label thanks to the `FormControlLabel` component.
-
-{{"demo": "pages/components/checkboxes/CheckboxLabels.js"}}
 
 ## FormGroup
 

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -43,7 +43,7 @@ Visually, there are **three** states a checkbox can be in: checked, unchecked, o
 
 ## FormGroup
 
-`FormGroup` is a helpful wrapper used to group selection controls components that provides an easier API.
+`FormGroup` is a helpful wrapper used to group selection control components.
 
 {{"demo": "pages/components/checkboxes/CheckboxesGroup.js"}}
 

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -38,6 +38,9 @@ Visually, there are **three** states a checkbox can be in: checked, unchecked, o
 
 {{"demo": "pages/components/checkboxes/IndeterminateCheckbox.js"}}
 
+> ⚠️ When indeterminate is set, the value of the `checked` prop only impacts the form submitted values.
+> It has no accessibility or UX implications.
+
 ## FormGroup
 
 `FormGroup` is a helpful wrapper used to group selection controls components that provides an easier API.

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -28,7 +28,25 @@ You can provide a label to the `Checkbox` thanks to the `FormControlLabel` compo
 
 {{"demo": "pages/components/checkboxes/CheckboxLabels.js"}}
 
+## Size
 
+Use the `size` prop or customize the font size of the svg icons to change the size of the checkboxes.
+
+{{"demo": "pages/components/checkboxes/SizeCheckboxes.js"}}
+
+## Color
+
+{{"demo": "pages/components/checkboxes/ColorCheckboxes.js"}}
+
+## Icon
+
+{{"demo": "pages/components/checkboxes/IconCheckboxes.js"}}
+
+## Controlled
+
+You can control the checkbox with the `value` and `onChange` props:
+
+{{"demo": "pages/components/checkboxes/ControlledCheckbox.js"}}
 
 ## Indeterminate
 

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -28,10 +28,13 @@ You can provide a label to the `Checkbox` thanks to the `FormControlLabel` compo
 
 {{"demo": "pages/components/checkboxes/CheckboxLabels.js"}}
 
+
+
 ## Indeterminate
 
-A checkbox input can only have two states in a form: checked or unchecked. It either submits its value or doesn't.
-Visually, there are actually three states a checkbox can be in: checked, unchecked, or indeterminate.
+A checkbox input can only have two states in a form: checked or unchecked.
+It either submits its value or doesn't.
+Visually, there are **three** states a checkbox can be in: checked, unchecked, or indeterminate.
 
 {{"demo": "pages/components/checkboxes/IndeterminateCheckbox.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Checkbox component were migrated:

- [x] Indeterminate
- [x] Label
- [x] FormGroup
- [x] Customized checkbox

Related to #16947