### PR TITLE
[docs] Migrate Radio demos to emotion

### DIFF
--- a/docs/src/pages/components/radio-buttons/ColorRadioButtons.js
+++ b/docs/src/pages/components/radio-buttons/ColorRadioButtons.js
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { green } from '@material-ui/core/colors';
+import Radio from '@material-ui/core/Radio';
+
+export default function ColorRadioButtons() {
+  const [selectedValue, setSelectedValue] = React.useState('a');
+
+  const handleChange = (event) => {
+    setSelectedValue(event.target.value);
+  };
+
+  const controlProps = (item) => ({
+    checked: selectedValue === item,
+    onChange: handleChange,
+    value: item,
+    name: 'color-radio-button-demo',
+    inputProps: { 'aria-label': item },
+  });
+
+  return (
+    <div>
+      <Radio {...controlProps('a')} />
+      <Radio {...controlProps('b')} color="primary" />
+      <Radio {...controlProps('c')} color="default" />
+      <Radio
+        {...controlProps('d')}
+        sx={{
+          color: green[800],
+          '&.Mui-checked': {
+            color: green[600],
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/radio-buttons/ColorRadioButtons.tsx
+++ b/docs/src/pages/components/radio-buttons/ColorRadioButtons.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { green } from '@material-ui/core/colors';
+import Radio from '@material-ui/core/Radio';
+
+export default function ColorRadioButtons() {
+  const [selectedValue, setSelectedValue] = React.useState('a');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedValue(event.target.value);
+  };
+
+  const controlProps = (item: string) => ({
+    checked: selectedValue === item,
+    onChange: handleChange,
+    value: item,
+    name: 'color-radio-button-demo',
+    inputProps: { 'aria-label': item },
+  });
+
+  return (
+    <div>
+      <Radio {...controlProps('a')} />
+      <Radio {...controlProps('b')} color="primary" />
+      <Radio {...controlProps('c')} color="default" />
+      <Radio
+        {...controlProps('d')}
+        sx={{
+          color: green[800],
+          '&.Mui-checked': {
+            color: green[600],
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/radio-buttons/ControlledRadioButtonsGroup.js
+++ b/docs/src/pages/components/radio-buttons/ControlledRadioButtonsGroup.js
@@ -5,18 +5,24 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-export default function RadioButtonsGroup() {
+export default function ControlledRadioButtonsGroup() {
+  const [value, setValue] = React.useState('female');
+
+  const handleChange = (event) => {
+    setValue(event.target.value);
+  };
+
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
       <RadioGroup
         aria-label="gender"
-        defaultValue="female"
-        name="radio-buttons-group"
+        name="controlled-radio-buttons-group"
+        value={value}
+        onChange={handleChange}
       >
         <FormControlLabel value="female" control={<Radio />} label="Female" />
         <FormControlLabel value="male" control={<Radio />} label="Male" />
-        <FormControlLabel value="other" control={<Radio />} label="Other" />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/ControlledRadioButtonsGroup.tsx
+++ b/docs/src/pages/components/radio-buttons/ControlledRadioButtonsGroup.tsx
@@ -5,18 +5,24 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-export default function RadioButtonsGroup() {
+export default function ControlledRadioButtonsGroup() {
+  const [value, setValue] = React.useState('female');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue((event.target as HTMLInputElement).value);
+  };
+
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
       <RadioGroup
         aria-label="gender"
-        defaultValue="female"
-        name="radio-buttons-group"
+        name="controlled-radio-buttons-group"
+        value={value}
+        onChange={handleChange}
       >
         <FormControlLabel value="female" control={<Radio />} label="Female" />
         <FormControlLabel value="male" control={<Radio />} label="Male" />
-        <FormControlLabel value="other" control={<Radio />} label="Other" />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/CustomizedRadios.js
+++ b/docs/src/pages/components/radio-buttons/CustomizedRadios.js
@@ -1,64 +1,59 @@
 import * as React from 'react';
-import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-const useStyles = makeStyles({
-  root: {
-    '&:hover': {
-      backgroundColor: 'transparent',
-    },
+const Icon = styled('span')({
+  borderRadius: '50%',
+  width: 16,
+  height: 16,
+  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: '#f5f8fa',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  '.root.Mui-focusVisible &': {
+    outline: '2px auto rgba(19,124,189,.6)',
+    outlineOffset: 2,
   },
-  icon: {
-    borderRadius: '50%',
+  'input:hover ~ &': {
+    backgroundColor: '#ebf1f5',
+  },
+  'input:disabled ~ &': {
+    boxShadow: 'none',
+    background: 'rgba(206,217,224,.5)',
+  },
+});
+
+const CheckedIcon = styled(Icon)({
+  backgroundColor: '#137cbd',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
+  '&:before': {
+    display: 'block',
     width: 16,
     height: 16,
-    boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-    backgroundColor: '#f5f8fa',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-    '$root.Mui-focusVisible &': {
-      outline: '2px auto rgba(19,124,189,.6)',
-      outlineOffset: 2,
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#ebf1f5',
-    },
-    'input:disabled ~ &': {
-      boxShadow: 'none',
-      background: 'rgba(206,217,224,.5)',
-    },
+    backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
+    content: '""',
   },
-  checkedIcon: {
-    backgroundColor: '#137cbd',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
-    '&:before': {
-      display: 'block',
-      width: 16,
-      height: 16,
-      backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
-      content: '""',
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#106ba3',
-    },
+  'input:hover ~ &': {
+    backgroundColor: '#106ba3',
   },
 });
 
 // Inspired by blueprintjs
 function StyledRadio(props) {
-  const classes = useStyles();
-
   return (
     <Radio
-      className={classes.root}
+      sx={{
+        '&:hover': {
+          bgcolor: 'transparent',
+        },
+      }}
       disableRipple
       color="default"
-      checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
-      icon={<span className={classes.icon} />}
+      checkedIcon={<CheckedIcon />}
+      icon={<Icon />}
       {...props}
     />
   );

--- a/docs/src/pages/components/radio-buttons/CustomizedRadios.js
+++ b/docs/src/pages/components/radio-buttons/CustomizedRadios.js
@@ -13,7 +13,7 @@ const Icon = styled('span')({
   boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
   backgroundColor: '#f5f8fa',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-  '.root.Mui-focusVisible &': {
+  '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },

--- a/docs/src/pages/components/radio-buttons/CustomizedRadios.tsx
+++ b/docs/src/pages/components/radio-buttons/CustomizedRadios.tsx
@@ -1,64 +1,59 @@
 import * as React from 'react';
-import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Radio, { RadioProps } from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-const useStyles = makeStyles({
-  root: {
-    '&:hover': {
-      backgroundColor: 'transparent',
-    },
+const Icon = styled('span')({
+  borderRadius: '50%',
+  width: 16,
+  height: 16,
+  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: '#f5f8fa',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  '.root.Mui-focusVisible &': {
+    outline: '2px auto rgba(19,124,189,.6)',
+    outlineOffset: 2,
   },
-  icon: {
-    borderRadius: '50%',
+  'input:hover ~ &': {
+    backgroundColor: '#ebf1f5',
+  },
+  'input:disabled ~ &': {
+    boxShadow: 'none',
+    background: 'rgba(206,217,224,.5)',
+  },
+});
+
+const CheckedIcon = styled(Icon)({
+  backgroundColor: '#137cbd',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
+  '&:before': {
+    display: 'block',
     width: 16,
     height: 16,
-    boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-    backgroundColor: '#f5f8fa',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-    '$root.Mui-focusVisible &': {
-      outline: '2px auto rgba(19,124,189,.6)',
-      outlineOffset: 2,
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#ebf1f5',
-    },
-    'input:disabled ~ &': {
-      boxShadow: 'none',
-      background: 'rgba(206,217,224,.5)',
-    },
+    backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
+    content: '""',
   },
-  checkedIcon: {
-    backgroundColor: '#137cbd',
-    backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
-    '&:before': {
-      display: 'block',
-      width: 16,
-      height: 16,
-      backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
-      content: '""',
-    },
-    'input:hover ~ &': {
-      backgroundColor: '#106ba3',
-    },
+  'input:hover ~ &': {
+    backgroundColor: '#106ba3',
   },
 });
 
 // Inspired by blueprintjs
 function StyledRadio(props: RadioProps) {
-  const classes = useStyles();
-
   return (
     <Radio
-      className={classes.root}
+      sx={{
+        '&:hover': {
+          bgcolor: 'transparent',
+        },
+      }}
       disableRipple
       color="default"
-      checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
-      icon={<span className={classes.icon} />}
+      checkedIcon={<CheckedIcon />}
+      icon={<Icon />}
       {...props}
     />
   );

--- a/docs/src/pages/components/radio-buttons/CustomizedRadios.tsx
+++ b/docs/src/pages/components/radio-buttons/CustomizedRadios.tsx
@@ -13,7 +13,7 @@ const Icon = styled('span')({
   boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
   backgroundColor: '#f5f8fa',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
-  '.root.Mui-focusVisible &': {
+  '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },

--- a/docs/src/pages/components/radio-buttons/ErrorRadios.js
+++ b/docs/src/pages/components/radio-buttons/ErrorRadios.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -8,17 +7,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import FormLabel from '@material-ui/core/FormLabel';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme) => ({
-  formControl: {
-    margin: theme.spacing(3),
-  },
-  button: {
-    margin: theme.spacing(1, 1, 0, 0),
-  },
-}));
-
 export default function ErrorRadios() {
-  const classes = useStyles();
   const [value, setValue] = React.useState('');
   const [error, setError] = React.useState(false);
   const [helperText, setHelperText] = React.useState('Choose wisely');
@@ -46,11 +35,7 @@ export default function ErrorRadios() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <FormControl
-        component="fieldset"
-        error={error}
-        className={classes.formControl}
-      >
+      <FormControl sx={{ m: 3 }} component="fieldset" error={error}>
         <FormLabel component="legend">Pop quiz: Material-UI is...</FormLabel>
         <RadioGroup
           aria-label="quiz"
@@ -62,7 +47,7 @@ export default function ErrorRadios() {
           <FormControlLabel value="worst" control={<Radio />} label="The worst." />
         </RadioGroup>
         <FormHelperText>{helperText}</FormHelperText>
-        <Button type="submit" variant="outlined" className={classes.button}>
+        <Button sx={{ mt: 1, ml: 1 }} type="submit" variant="outlined">
           Check Answer
         </Button>
       </FormControl>

--- a/docs/src/pages/components/radio-buttons/ErrorRadios.js
+++ b/docs/src/pages/components/radio-buttons/ErrorRadios.js
@@ -47,7 +47,7 @@ export default function ErrorRadios() {
           <FormControlLabel value="worst" control={<Radio />} label="The worst." />
         </RadioGroup>
         <FormHelperText>{helperText}</FormHelperText>
-        <Button sx={{ mt: 1, ml: 1 }} type="submit" variant="outlined">
+        <Button sx={{ mt: 1, mr: 1 }} type="submit" variant="outlined">
           Check Answer
         </Button>
       </FormControl>

--- a/docs/src/pages/components/radio-buttons/ErrorRadios.tsx
+++ b/docs/src/pages/components/radio-buttons/ErrorRadios.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -8,17 +7,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import FormLabel from '@material-ui/core/FormLabel';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme) => ({
-  formControl: {
-    margin: theme.spacing(3),
-  },
-  button: {
-    margin: theme.spacing(1, 1, 0, 0),
-  },
-}));
-
 export default function ErrorRadios() {
-  const classes = useStyles();
   const [value, setValue] = React.useState('');
   const [error, setError] = React.useState(false);
   const [helperText, setHelperText] = React.useState('Choose wisely');
@@ -46,11 +35,7 @@ export default function ErrorRadios() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <FormControl
-        component="fieldset"
-        error={error}
-        className={classes.formControl}
-      >
+      <FormControl sx={{ m: 3 }} component="fieldset" error={error}>
         <FormLabel component="legend">Pop quiz: Material-UI is...</FormLabel>
         <RadioGroup
           aria-label="quiz"
@@ -62,7 +47,7 @@ export default function ErrorRadios() {
           <FormControlLabel value="worst" control={<Radio />} label="The worst." />
         </RadioGroup>
         <FormHelperText>{helperText}</FormHelperText>
-        <Button type="submit" variant="outlined" className={classes.button}>
+        <Button sx={{ mt: 1, ml: 1 }} type="submit" variant="outlined">
           Check Answer
         </Button>
       </FormControl>

--- a/docs/src/pages/components/radio-buttons/ErrorRadios.tsx
+++ b/docs/src/pages/components/radio-buttons/ErrorRadios.tsx
@@ -47,7 +47,7 @@ export default function ErrorRadios() {
           <FormControlLabel value="worst" control={<Radio />} label="The worst." />
         </RadioGroup>
         <FormHelperText>{helperText}</FormHelperText>
-        <Button sx={{ mt: 1, ml: 1 }} type="submit" variant="outlined">
+        <Button sx={{ mt: 1, mr: 1 }} type="submit" variant="outlined">
           Check Answer
         </Button>
       </FormControl>

--- a/docs/src/pages/components/radio-buttons/FormControlLabelPlacement.js
+++ b/docs/src/pages/components/radio-buttons/FormControlLabelPlacement.js
@@ -12,27 +12,23 @@ export default function FormControlLabelPlacement() {
       <RadioGroup row aria-label="position" name="position" defaultValue="top">
         <FormControlLabel
           value="top"
-          control={<Radio color="primary" />}
+          control={<Radio />}
           label="Top"
           labelPlacement="top"
         />
         <FormControlLabel
           value="start"
-          control={<Radio color="primary" />}
+          control={<Radio />}
           label="Start"
           labelPlacement="start"
         />
         <FormControlLabel
           value="bottom"
-          control={<Radio color="primary" />}
+          control={<Radio />}
           label="Bottom"
           labelPlacement="bottom"
         />
-        <FormControlLabel
-          value="end"
-          control={<Radio color="primary" />}
-          label="End"
-        />
+        <FormControlLabel value="end" control={<Radio />} label="End" />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/FormControlLabelPlacement.tsx
+++ b/docs/src/pages/components/radio-buttons/FormControlLabelPlacement.tsx
@@ -12,27 +12,23 @@ export default function FormControlLabelPlacement() {
       <RadioGroup row aria-label="position" name="position" defaultValue="top">
         <FormControlLabel
           value="top"
-          control={<Radio color="primary" />}
+          control={<Radio />}
           label="Top"
           labelPlacement="top"
         />
         <FormControlLabel
           value="start"
-          control={<Radio color="primary" />}
+          control={<Radio />}
           label="Start"
           labelPlacement="start"
         />
         <FormControlLabel
           value="bottom"
-          control={<Radio color="primary" />}
+          control={<Radio />}
           label="Bottom"
           labelPlacement="bottom"
         />
-        <FormControlLabel
-          value="end"
-          control={<Radio color="primary" />}
-          label="End"
-        />
+        <FormControlLabel value="end" control={<Radio />} label="End" />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/RadioButtons.js
+++ b/docs/src/pages/components/radio-buttons/RadioButtons.js
@@ -23,39 +23,15 @@ export default function RadioButtons() {
         checked={selectedValue === 'a'}
         onChange={handleChange}
         value="a"
-        name="radio-button-demo"
+        name="radio-buttons"
         inputProps={{ 'aria-label': 'A' }}
       />
       <Radio
         checked={selectedValue === 'b'}
         onChange={handleChange}
         value="b"
-        name="radio-button-demo"
+        name="radio-buttons"
         inputProps={{ 'aria-label': 'B' }}
-      />
-      <GreenRadio
-        checked={selectedValue === 'c'}
-        onChange={handleChange}
-        value="c"
-        name="radio-button-demo"
-        inputProps={{ 'aria-label': 'C' }}
-      />
-      <Radio
-        checked={selectedValue === 'd'}
-        onChange={handleChange}
-        value="d"
-        color="default"
-        name="radio-button-demo"
-        inputProps={{ 'aria-label': 'D' }}
-      />
-      <Radio
-        checked={selectedValue === 'e'}
-        onChange={handleChange}
-        value="e"
-        color="default"
-        name="radio-button-demo"
-        inputProps={{ 'aria-label': 'E' }}
-        size="small"
       />
     </div>
   );

--- a/docs/src/pages/components/radio-buttons/RadioButtons.js
+++ b/docs/src/pages/components/radio-buttons/RadioButtons.js
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import { green } from '@material-ui/core/colors';
 import Radio from '@material-ui/core/Radio';
-
-const GreenRadio = styled(Radio)({
-  color: green[400],
-  '&.Mui-checked': {
-    color: green[600],
-  },
-});
 
 export default function RadioButtons() {
   const [selectedValue, setSelectedValue] = React.useState('a');

--- a/docs/src/pages/components/radio-buttons/RadioButtons.tsx
+++ b/docs/src/pages/components/radio-buttons/RadioButtons.tsx
@@ -23,39 +23,15 @@ export default function RadioButtons() {
         checked={selectedValue === 'a'}
         onChange={handleChange}
         value="a"
-        name="radio-button-demo"
+        name="radio-buttons"
         inputProps={{ 'aria-label': 'A' }}
       />
       <Radio
         checked={selectedValue === 'b'}
         onChange={handleChange}
         value="b"
-        name="radio-button-demo"
+        name="radio-buttons"
         inputProps={{ 'aria-label': 'B' }}
-      />
-      <GreenRadio
-        checked={selectedValue === 'c'}
-        onChange={handleChange}
-        value="c"
-        name="radio-button-demo"
-        inputProps={{ 'aria-label': 'C' }}
-      />
-      <Radio
-        checked={selectedValue === 'd'}
-        onChange={handleChange}
-        value="d"
-        color="default"
-        name="radio-button-demo"
-        inputProps={{ 'aria-label': 'D' }}
-      />
-      <Radio
-        checked={selectedValue === 'e'}
-        onChange={handleChange}
-        value="e"
-        color="default"
-        name="radio-button-demo"
-        inputProps={{ 'aria-label': 'E' }}
-        size="small"
       />
     </div>
   );

--- a/docs/src/pages/components/radio-buttons/RadioButtons.tsx
+++ b/docs/src/pages/components/radio-buttons/RadioButtons.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import { green } from '@material-ui/core/colors';
 import Radio from '@material-ui/core/Radio';
-
-const GreenRadio = styled(Radio)({
-  color: green[400],
-  '&.Mui-checked': {
-    color: green[600],
-  },
-});
 
 export default function RadioButtons() {
   const [selectedValue, setSelectedValue] = React.useState('a');

--- a/docs/src/pages/components/radio-buttons/RadioButtonsGroup.tsx
+++ b/docs/src/pages/components/radio-buttons/RadioButtonsGroup.tsx
@@ -6,30 +6,17 @@ import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
 export default function RadioButtonsGroup() {
-  const [value, setValue] = React.useState('female');
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue((event.target as HTMLInputElement).value);
-  };
-
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
       <RadioGroup
         aria-label="gender"
-        name="gender1"
-        value={value}
-        onChange={handleChange}
+        defaultValue="female"
+        name="radio-buttons-group"
       >
         <FormControlLabel value="female" control={<Radio />} label="Female" />
         <FormControlLabel value="male" control={<Radio />} label="Male" />
         <FormControlLabel value="other" control={<Radio />} label="Other" />
-        <FormControlLabel
-          value="disabled"
-          disabled
-          control={<Radio />}
-          label="(Disabled option)"
-        />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/RowRadioButtonsGroup.js
+++ b/docs/src/pages/components/radio-buttons/RowRadioButtonsGroup.js
@@ -5,18 +5,20 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-export default function RadioButtonsGroup() {
+export default function RowRadioButtonsGroup() {
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
-      <RadioGroup
-        aria-label="gender"
-        defaultValue="female"
-        name="radio-buttons-group"
-      >
+      <RadioGroup row aria-label="gender" name="row-radio-buttons-group">
         <FormControlLabel value="female" control={<Radio />} label="Female" />
         <FormControlLabel value="male" control={<Radio />} label="Male" />
         <FormControlLabel value="other" control={<Radio />} label="Other" />
+        <FormControlLabel
+          value="disabled"
+          disabled
+          control={<Radio />}
+          label="other"
+        />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/RowRadioButtonsGroup.tsx
+++ b/docs/src/pages/components/radio-buttons/RowRadioButtonsGroup.tsx
@@ -5,18 +5,20 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-export default function RadioButtonsGroup() {
+export default function RowRadioButtonsGroup() {
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
-      <RadioGroup
-        aria-label="gender"
-        defaultValue="female"
-        name="radio-buttons-group"
-      >
+      <RadioGroup row aria-label="gender" name="row-radio-buttons-group">
         <FormControlLabel value="female" control={<Radio />} label="Female" />
         <FormControlLabel value="male" control={<Radio />} label="Male" />
         <FormControlLabel value="other" control={<Radio />} label="Other" />
+        <FormControlLabel
+          value="disabled"
+          disabled
+          control={<Radio />}
+          label="other"
+        />
       </RadioGroup>
     </FormControl>
   );

--- a/docs/src/pages/components/radio-buttons/SizeRadioButtons.js
+++ b/docs/src/pages/components/radio-buttons/SizeRadioButtons.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import Radio from '@material-ui/core/Radio';
+
+export default function SizeRadioButtons() {
+  const [selectedValue, setSelectedValue] = React.useState('a');
+  const handleChange = (event) => {
+    setSelectedValue(event.target.value);
+  };
+
+  const controlProps = (item) => ({
+    checked: selectedValue === item,
+    onChange: handleChange,
+    value: item,
+    name: 'size-radio-button-demo',
+    inputProps: { 'aria-label': item },
+  });
+
+  return (
+    <div>
+      <Radio {...controlProps('a')} size="small" />
+      <Radio {...controlProps('b')} />
+      <Radio
+        {...controlProps('c')}
+        sx={{
+          '& .MuiSvgIcon-root': {
+            fontSize: 28,
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/radio-buttons/SizeRadioButtons.tsx
+++ b/docs/src/pages/components/radio-buttons/SizeRadioButtons.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import Radio from '@material-ui/core/Radio';
+
+export default function SizeRadioButtons() {
+  const [selectedValue, setSelectedValue] = React.useState('a');
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedValue(event.target.value);
+  };
+
+  const controlProps = (item: string) => ({
+    checked: selectedValue === item,
+    onChange: handleChange,
+    value: item,
+    name: 'size-radio-button-demo',
+    inputProps: { 'aria-label': item },
+  });
+
+  return (
+    <div>
+      <Radio {...controlProps('a')} size="small" />
+      <Radio {...controlProps('b')} />
+      <Radio
+        {...controlProps('c')}
+        sx={{
+          '& .MuiSvgIcon-root': {
+            fontSize: 28,
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/radio-buttons/UseRadioGroup.js
+++ b/docs/src/pages/components/radio-buttons/UseRadioGroup.js
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import RadioGroup, { useRadioGroup } from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Radio from '@material-ui/core/Radio';
 
-const useStyles = makeStyles((theme) => ({
-  labelChecked: {
-    color: theme.palette.secondary.main,
-  },
-}));
+const StyledFormControlLabel = styled((props) => <FormControlLabel {...props} />)(
+  ({ theme, checked }) => ({
+    '.MuiFormControlLabel-label': checked && {
+      color: theme.palette.secondary.main,
+    },
+  }),
+);
 
 function MyFormControlLabel(props) {
-  const classes = useStyles();
   const radioGroup = useRadioGroup();
 
   let checked = false;
@@ -21,14 +22,7 @@ function MyFormControlLabel(props) {
     checked = radioGroup.value === props.value;
   }
 
-  return (
-    <FormControlLabel
-      classes={{
-        label: checked ? classes.labelChecked : '',
-      }}
-      {...props}
-    />
-  );
+  return <StyledFormControlLabel checked={checked} {...props} />;
 }
 
 MyFormControlLabel.propTypes = {

--- a/docs/src/pages/components/radio-buttons/UseRadioGroup.tsx
+++ b/docs/src/pages/components/radio-buttons/UseRadioGroup.tsx
@@ -1,21 +1,24 @@
 import * as React from 'react';
-import { makeStyles, createStyles } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import RadioGroup, { useRadioGroup } from '@material-ui/core/RadioGroup';
 import FormControlLabel, {
   FormControlLabelProps,
 } from '@material-ui/core/FormControlLabel';
 import Radio from '@material-ui/core/Radio';
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    labelChecked: {
-      color: theme.palette.secondary.main,
-    },
-  }),
-);
+interface StyledFormControlLabelProps extends FormControlLabelProps {
+  checked: boolean;
+}
+
+const StyledFormControlLabel = styled((props: StyledFormControlLabelProps) => (
+  <FormControlLabel {...props} />
+))(({ theme, checked }) => ({
+  '.MuiFormControlLabel-label': checked && {
+    color: theme.palette.secondary.main,
+  },
+}));
 
 function MyFormControlLabel(props: FormControlLabelProps) {
-  const classes = useStyles();
   const radioGroup = useRadioGroup();
 
   let checked = false;
@@ -24,14 +27,7 @@ function MyFormControlLabel(props: FormControlLabelProps) {
     checked = radioGroup.value === props.value;
   }
 
-  return (
-    <FormControlLabel
-      classes={{
-        label: checked ? classes.labelChecked : '',
-      }}
-      {...props}
-    />
-  );
+  return <StyledFormControlLabel checked={checked} {...props} />;
 }
 
 export default function UseRadioGroup() {

--- a/docs/src/pages/components/radio-buttons/radio-buttons.md
+++ b/docs/src/pages/components/radio-buttons/radio-buttons.md
@@ -17,19 +17,39 @@ Radio buttons should have the most commonly used option selected by default.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-## RadioGroup
+## Radio group
 
 `RadioGroup` is a helpful wrapper used to group `Radio` components that provides an easier API, and proper keyboard accessibility to the group.
 
 {{"demo": "pages/components/radio-buttons/RadioButtonsGroup.js"}}
 
-To lay out the buttons horizontally, set the `row` prop: `<RadioGroup row />`.
+### Direction
+
+To lay out the buttons horizontally, set the `row` prop:
+
+{{"demo": "pages/components/radio-buttons/RowRadioButtonsGroup.js"}}
+
+### Controllable
+
+You can control the radio with the `value` and `onChange` props:
+
+{{"demo": "pages/components/radio-buttons/ControlledRadioButtonsGroup.js"}}
 
 ## Standalone radio buttons
 
 `Radio` can also be used standalone, without the RadioGroup wrapper.
 
 {{"demo": "pages/components/radio-buttons/RadioButtons.js"}}
+
+## Size
+
+Use the `size` prop or customize the font size of the svg icons to change the size of the radios.
+
+{{"demo": "pages/components/radio-buttons/SizeRadioButtons.js"}}
+
+## Color
+
+{{"demo": "pages/components/radio-buttons/ColorRadioButtons.js"}}
 
 ## Label placement
 
@@ -87,7 +107,7 @@ import { useRadioGroup } from '@material-ui/core/RadioGroup';
   In this case, you can apply the additional attribute (e.g. `aria-label`, `aria-labelledby`, `title`) via the `inputProps` property.
 
 ```jsx
-<RadioButton
+<Radio
   value="radioA"
   inputProps={{
     'aria-label': 'Radio A',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Radio component were migrated:

- [x] Error radio
- [x] Customized radio
- [x] useRadioGroup

Related to #16947