### PR TITLE
[benchmark] Set intended environment

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,17 +4,22 @@ const React = require('react');
 const errorCodesPath = path.resolve(__dirname, './docs/public/static/error-codes.json');
 const missingError = process.env.MUI_EXTRACT_ERROR_CODES === 'true' ? 'write' : 'annotate';
 
+function resolveAliasPath(relativeToBabelConf) {
+  const resolvedPath = path.relative(process.cwd(), path.resolve(__dirname, relativeToBabelConf));
+  return `./${resolvedPath.replace('\\', '/')}`;
+}
+
 const defaultAlias = {
-  '@material-ui/core': './packages/material-ui/src',
-  '@material-ui/docs': './packages/material-ui-docs/src',
-  '@material-ui/icons': './packages/material-ui-icons/src',
-  '@material-ui/lab': './packages/material-ui-lab/src',
-  '@material-ui/styled-engine': './packages/material-ui-styled-engine/src',
-  '@material-ui/styled-engine-sc': './packages/material-ui-styled-engine-sc/src',
-  '@material-ui/styles': './packages/material-ui-styles/src',
-  '@material-ui/system': './packages/material-ui-system/src',
-  '@material-ui/unstyled': './packages/material-ui-unstyled/src',
-  '@material-ui/utils': './packages/material-ui-utils/src',
+  '@material-ui/core': resolveAliasPath('./packages/material-ui/src'),
+  '@material-ui/docs': resolveAliasPath('./packages/material-ui-docs/src'),
+  '@material-ui/icons': resolveAliasPath('./packages/material-ui-icons/src'),
+  '@material-ui/lab': resolveAliasPath('./packages/material-ui-lab/src'),
+  '@material-ui/styled-engine': resolveAliasPath('./packages/material-ui-styled-engine/src'),
+  '@material-ui/styled-engine-sc': resolveAliasPath('./packages/material-ui-styled-engine-sc/src'),
+  '@material-ui/styles': resolveAliasPath('./packages/material-ui-styles/src'),
+  '@material-ui/system': resolveAliasPath('./packages/material-ui-system/src'),
+  '@material-ui/unstyled': resolveAliasPath('./packages/material-ui-unstyled/src'),
+  '@material-ui/utils': resolveAliasPath('./packages/material-ui-utils/src'),
 };
 
 const productionPlugins = [

--- a/benchmark/browser/README.md
+++ b/benchmark/browser/README.md
@@ -16,29 +16,31 @@ For compareable results ask a maintainer to approve the CircleCI job `benchmark`
 
 ```
 noop (baseline):
-  06.13 ±00.83ms
+  06.57 ±00.66ms
+Table:
+  133.29 ±09.16ms
 React primitives:
-  61.38 ±51.51ms
+  35 ±6%
 React components:
-  100 ±6%
+  45 ±2%
 Styled Material-UI:
-  160 ±11%
+  76 ±3%
 Styled emotion:
-  144 ±7%
+  67 ±2%
 Styled SC:
-  170 ±9%
+  84 ±2%
 makeStyles:
-  149 ±5%
+  71 ±3%
 Box Baseline:
-  170 ±12%
+  80 ±2%
 Box Material-UI:
-  402 ±14%
+  194 ±4%
 Box Theme-UI:
-  354 ±16%
+  163 ±5%
 Box Chakra-UI:
-  268 ±14%
+  114 ±2%
 styled-components Box + @material-ui/system:
-  373 ±13%
+  186 ±4%
 styled-components Box + styled-system:
-  298 ±13%
+  153 ±6%
 ```

--- a/benchmark/browser/README.md
+++ b/benchmark/browser/README.md
@@ -16,31 +16,31 @@ For compareable results ask a maintainer to approve the CircleCI job `benchmark`
 
 ```
 noop (baseline):
-  06.57 ±00.66ms
+  06.29 ±00.44ms
 Table:
-  133.29 ±09.16ms
+  127.33 ±10.08ms
 React primitives:
-  35 ±6%
+  34 ±6%
 React components:
-  45 ±2%
+  45 ±3%
 Styled Material-UI:
-  76 ±3%
+  73 ±4%
 Styled emotion:
-  67 ±2%
+  67 ±3%
 Styled SC:
-  84 ±2%
+  80 ±2%
 makeStyles:
   71 ±3%
 Box Baseline:
-  80 ±2%
+  81 ±3%
 Box Material-UI:
-  194 ±4%
+  209 ±15%
 Box Theme-UI:
-  163 ±5%
+  172 ±8%
 Box Chakra-UI:
-  114 ±2%
+  115 ±8%
 styled-components Box + @material-ui/system:
-  186 ±4%
+  194 ±9%
 styled-components Box + styled-system:
-  153 ±6%
+  162 ±10%
 ```

--- a/benchmark/browser/webpack.config.js
+++ b/benchmark/browser/webpack.config.js
@@ -2,6 +2,11 @@ const path = require('path');
 
 const workspaceRoot = path.resolve(__dirname, '../..');
 
+// for babel.config.js
+// webpack `mode: 'production'` does not affect NODE_ENV nor BABEL_ENV in babel-loader
+// FIXME: This is the previous behavior. We want `'production'`. Running benchmarks with old behavior first.
+process.env.NODE_ENV = undefined;
+
 module.exports = {
   context: workspaceRoot,
   entry: 'benchmark/browser/index.js',
@@ -16,7 +21,11 @@ module.exports = {
         test: /\.(js|ts|tsx)$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
-        options: { cacheDirectory: true, cwd: workspaceRoot },
+        options: {
+          cacheDirectory: true,
+          configFile: path.join(workspaceRoot, 'babel.config.js'),
+          envName: 'benchmark',
+        },
       },
       {
         test: /\.(jpg|gif|png)$/,
@@ -26,9 +35,6 @@ module.exports = {
   },
   resolve: {
     alias: {
-      '@material-ui/core': path.join(workspaceRoot, './packages/material-ui/src'),
-      '@material-ui/styles': path.join(workspaceRoot, './packages/material-ui-styles/src'),
-      '@material-ui/system': path.join(workspaceRoot, './packages/material-ui-system/src'),
       'react-dom$': 'react-dom/profiling',
       'scheduler/tracing': 'scheduler/tracing-profiling',
     },

--- a/benchmark/browser/webpack.config.js
+++ b/benchmark/browser/webpack.config.js
@@ -4,8 +4,7 @@ const workspaceRoot = path.resolve(__dirname, '../..');
 
 // for babel.config.js
 // webpack `mode: 'production'` does not affect NODE_ENV nor BABEL_ENV in babel-loader
-// FIXME: This is the previous behavior. We want `'production'`. Running benchmarks with old behavior first.
-process.env.NODE_ENV = undefined;
+process.env.NODE_ENV = 'production';
 
 module.exports = {
   context: workspaceRoot,


### PR DESCRIPTION
My assumption that `mode: 'production'` sets `NODE_ENV` to `'production'` in `babel-loader` was wrong. We didn't actually use the babel aliases at all an instead reliead on webpack `resolve.alias`.

But we do want to run in production.

Test Plan:

- [x] benchmark job passes: 
   - run: https://dev.azure.com/mui-org/Material-UI/_build/results?buildId=25140&view=logs&j=9ef21fd1-5d60-5fa4-f8b2-6dc79e173863&t=9ef21fd1-5d60-5fa4-f8b2-6dc79e173863
   - changed results: [`26e85fa` (#25402)](https://github.com/mui-org/material-ui/pull/25402/commits/26e85fa314850f22bd0a4df95d07919c61264f70)
- [x] update benchmark results with files transpiled using production plugins: 
   - run: https://dev.azure.com/mui-org/Material-UI/_build/results?buildId=25142&view=logs&j=9ef21fd1-5d60-5fa4-f8b2-6dc79e173863
   - changed results: [`b874ba8` (#25402)](https://github.com/mui-org/material-ui/pull/25402/commits/b874ba8dfcf7487f8ced28f362d2c81856019602)

/cc @mnajdova, @oliviertassinari 
Just as a notice in case you made the same assumption as I did.