### PR TITLE
[test] Transpile more similar to prod bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,14 +18,7 @@ const defaultAlias = {
 };
 
 const productionPlugins = [
-  '@babel/plugin-transform-react-constant-elements',
   ['babel-plugin-react-remove-properties', { properties: ['data-mui-test'] }],
-  [
-    'babel-plugin-transform-react-remove-prop-types',
-    {
-      mode: 'unsafe-wrap',
-    },
-  ],
 ];
 
 module.exports = function getBabelConfig(api) {
@@ -76,6 +69,13 @@ module.exports = function getBabelConfig(api) {
         useESModules,
         // any package needs to declare 7.4.4 as a runtime dependency. default is ^7.0.0
         version: '^7.4.4',
+      },
+    ],
+    '@babel/plugin-transform-react-constant-elements',
+    [
+      'babel-plugin-transform-react-remove-prop-types',
+      {
+        mode: 'unsafe-wrap',
       },
     ],
   ];

--- a/test/utils/mochaHooks.test.js
+++ b/test/utils/mochaHooks.test.js
@@ -64,19 +64,21 @@ describe('mochaHooks', () => {
           return null;
         });
 
-        let setState;
+        let unsafeSetState;
         function Parent() {
-          setState = React.useState(0)[1];
+          const [state, setState] = React.useState(0);
+          unsafeSetState = setState;
+
           React.useEffect(() => {});
           React.useEffect(() => {});
 
-          return <Child />;
+          return <Child rerender={state} />;
         }
 
         render(<Parent />);
 
         // not wrapped in act()
-        setState(1);
+        unsafeSetState(1);
       });
 
       afterEach(function afterEachHook() {


### PR DESCRIPTION
Generally we want to test as similar as possible to production environments to make debugging easier. I moved some babel plugins into the default plugins to make testing more similar to prod. I don't think we've ever had a problem but let's be safe.

`date-mui-test` will ultimately be removed as well. Though it's used fairly often in pickers so I want to take a gradual approach or rather do it while refactoring the pickers.