### PR TITLE
[docs] Migrate Icons demos to emotion

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -153,6 +153,8 @@ MyDocument.getInitialProps = async (ctx) => {
       userLanguage: ctx.query.userLanguage || 'en',
       // Styles fragment is rendered after the app and page rendering finish.
       styles: [
+        <style id="material-icon-font" key="material-icon-font" />,
+        <style id="font-awesome-css" key="font-awesome-css" />,
         styledComponentsSheet.getStyleElement(),
         <style
           id="emotion-server-side"
@@ -167,8 +169,6 @@ MyDocument.getInitialProps = async (ctx) => {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: css }}
         />,
-        <style id="material-icon-font" key="material-icon-font" />,
-        <style id="font-awesome-css" key="font-awesome-css" />,
         <style id="app-search" key="app-search" />,
         <style id="prismjs" key="prismjs" />,
         <style id="insertion-point-jss" key="insertion-point-jss" />,

--- a/docs/src/pages/components/icons/CreateSvgIcon.js
+++ b/docs/src/pages/components/icons/CreateSvgIcon.js
@@ -1,14 +1,6 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { createSvgIcon } from '@material-ui/core/utils';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > svg': {
-      margin: theme.spacing(2),
-    },
-  },
-}));
 
 const HomeIcon = createSvgIcon(
   <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />,
@@ -16,12 +8,16 @@ const HomeIcon = createSvgIcon(
 );
 
 export default function CreateSvgIcon() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > svg': {
+          m: 2,
+        },
+      }}
+    >
       <HomeIcon />
       <HomeIcon color="primary" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/CreateSvgIcon.js
+++ b/docs/src/pages/components/icons/CreateSvgIcon.js
@@ -11,7 +11,7 @@ export default function CreateSvgIcon() {
   return (
     <Box
       sx={{
-        '& > svg': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/CreateSvgIcon.tsx
+++ b/docs/src/pages/components/icons/CreateSvgIcon.tsx
@@ -11,7 +11,7 @@ export default function CreateSvgIcon() {
   return (
     <Box
       sx={{
-        '& > svg': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/CreateSvgIcon.tsx
+++ b/docs/src/pages/components/icons/CreateSvgIcon.tsx
@@ -1,16 +1,6 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { createSvgIcon } from '@material-ui/core/utils';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > svg': {
-        margin: theme.spacing(2),
-      },
-    },
-  }),
-);
 
 const HomeIcon = createSvgIcon(
   <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />,
@@ -18,12 +8,16 @@ const HomeIcon = createSvgIcon(
 );
 
 export default function CreateSvgIcon() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > svg': {
+          m: 2,
+        },
+      }}
+    >
       <HomeIcon />
       <HomeIcon color="primary" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.js
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.js
@@ -20,7 +20,7 @@ export default function FontAwesomeIcon() {
   return (
     <Box
       sx={{
-        '& > *': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/FontAwesomeIcon.js
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.js
@@ -1,20 +1,10 @@
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { green } from '@material-ui/core/colors';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(2),
-    },
-  },
-}));
-
 export default function FontAwesomeIcon() {
-  const classes = useStyles();
-
   React.useEffect(() => {
     const node = loadCSS(
       'https://use.fontawesome.com/releases/v5.14.0/css/all.css',
@@ -28,7 +18,13 @@ export default function FontAwesomeIcon() {
   }, []);
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': {
+          m: 2,
+        },
+      }}
+    >
       <Icon baseClassName="fas" className="fa-plus-circle" />
       <Icon baseClassName="fas" className="fa-plus-circle" color="primary" />
       <Icon
@@ -42,6 +38,6 @@ export default function FontAwesomeIcon() {
         className="fa-plus-circle"
         style={{ fontSize: 30 }}
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.js
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.js
@@ -30,14 +30,10 @@ export default function FontAwesomeIcon() {
       <Icon
         baseClassName="fas"
         className="fa-plus-circle"
-        style={{ color: green[500] }}
+        sx={{ color: green[500] }}
       />
       <Icon baseClassName="fas" className="fa-plus-circle" fontSize="small" />
-      <Icon
-        baseClassName="fas"
-        className="fa-plus-circle"
-        style={{ fontSize: 30 }}
-      />
+      <Icon baseClassName="fas" className="fa-plus-circle" sx={{ fontSize: 30 }} />
     </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.tsx
@@ -20,7 +20,7 @@ export default function FontAwesomeIcon() {
   return (
     <Box
       sx={{
-        '& > *': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/FontAwesomeIcon.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.tsx
@@ -30,14 +30,10 @@ export default function FontAwesomeIcon() {
       <Icon
         baseClassName="fas"
         className="fa-plus-circle"
-        style={{ color: green[500] }}
+        sx={{ color: green[500] }}
       />
       <Icon baseClassName="fas" className="fa-plus-circle" fontSize="small" />
-      <Icon
-        baseClassName="fas"
-        className="fa-plus-circle"
-        style={{ fontSize: 30 }}
-      />
+      <Icon baseClassName="fas" className="fa-plus-circle" sx={{ fontSize: 30 }} />
     </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIcon.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIcon.tsx
@@ -1,22 +1,10 @@
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { green } from '@material-ui/core/colors';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function FontAwesomeIcon() {
-  const classes = useStyles();
-
   React.useEffect(() => {
     const node = loadCSS(
       'https://use.fontawesome.com/releases/v5.14.0/css/all.css',
@@ -30,7 +18,13 @@ export default function FontAwesomeIcon() {
   }, []);
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': {
+          m: 2,
+        },
+      }}
+    >
       <Icon baseClassName="fas" className="fa-plus-circle" />
       <Icon baseClassName="fas" className="fa-plus-circle" color="primary" />
       <Icon
@@ -44,6 +38,6 @@ export default function FontAwesomeIcon() {
         className="fa-plus-circle"
         style={{ fontSize: 30 }}
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIconSize.js
+++ b/docs/src/pages/components/icons/FontAwesomeIconSize.js
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
-import { ThemeProvider, createMuiTheme, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Icon from '@material-ui/core/Icon';
 import MdPhone from '@material-ui/icons/Phone';
 import Chip from '@material-ui/core/Chip';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
 
 const theme = createMuiTheme({
   components: {
@@ -29,8 +22,6 @@ const theme = createMuiTheme({
 });
 
 export default function FontAwesomeIconSize() {
-  const classes = useStyles();
-
   React.useEffect(() => {
     const node = loadCSS(
       'https://use.fontawesome.com/releases/v5.14.0/css/all.css',
@@ -44,11 +35,17 @@ export default function FontAwesomeIconSize() {
   }, []);
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': {
+          m: 1,
+        },
+      }}
+    >
       <ThemeProvider theme={theme}>
         <Chip icon={<MdPhone />} label="Call me" />
         <Chip icon={<Icon className="fas fa-phone-alt" />} label="Call me" />
       </ThemeProvider>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIconSize.js
+++ b/docs/src/pages/components/icons/FontAwesomeIconSize.js
@@ -37,7 +37,7 @@ export default function FontAwesomeIconSize() {
   return (
     <Box
       sx={{
-        '& > *': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/icons/FontAwesomeIconSize.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIconSize.tsx
@@ -1,25 +1,10 @@
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
-import {
-  ThemeProvider,
-  createMuiTheme,
-  makeStyles,
-  createStyles,
-  Theme,
-} from '@material-ui/core/styles';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Icon from '@material-ui/core/Icon';
 import MdPhone from '@material-ui/icons/Phone';
 import Chip from '@material-ui/core/Chip';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
 
 const theme = createMuiTheme({
   components: {
@@ -37,8 +22,6 @@ const theme = createMuiTheme({
 });
 
 export default function FontAwesomeIconSize() {
-  const classes = useStyles();
-
   React.useEffect(() => {
     const node = loadCSS(
       'https://use.fontawesome.com/releases/v5.14.0/css/all.css',
@@ -52,11 +35,17 @@ export default function FontAwesomeIconSize() {
   }, []);
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > *': {
+          m: 1,
+        },
+      }}
+    >
       <ThemeProvider theme={theme}>
         <Chip icon={<MdPhone />} label="Call me" />
         <Chip icon={<Icon className="fas fa-phone-alt" />} label="Call me" />
       </ThemeProvider>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeIconSize.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIconSize.tsx
@@ -37,7 +37,7 @@ export default function FontAwesomeIconSize() {
   return (
     <Box
       sx={{
-        '& > *': {
+        '& > :not(style)': {
           m: 1,
         },
       }}

--- a/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.js
+++ b/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons/faEllipsisV';
 import { faInfo } from '@fortawesome/free-solid-svg-icons/faInfo';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import SvgIcon from '@material-ui/core/SvgIcon';
@@ -39,19 +39,15 @@ FontAwesomeSvgIcon.propTypes = {
   icon: PropTypes.any.isRequired,
 };
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > *': {
-      margin: theme.spacing(1),
-    },
-  },
-}));
-
 export default function FontAwesomeSvgIconDemo() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <IconButton aria-label="Example">
         <FontAwesomeIcon icon={faEllipsisV} />
       </IconButton>
@@ -64,6 +60,6 @@ export default function FontAwesomeSvgIconDemo() {
       <Button variant="contained" startIcon={<FontAwesomeSvgIcon icon={faInfo} />}>
         Example
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeSvgIconDemo.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons/faEllipsisV';
 import { faInfo } from '@fortawesome/free-solid-svg-icons/faInfo';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import SvgIcon from '@material-ui/core/SvgIcon';
@@ -40,21 +40,15 @@ const FontAwesomeSvgIcon = React.forwardRef<SVGSVGElement, FontAwesomeSvgIconPro
   },
 );
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-  }),
-);
-
 export default function FontAwesomeSvgIconDemo() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > :not(style)': {
+          m: 1,
+        },
+      }}
+    >
       <IconButton aria-label="Example">
         <FontAwesomeIcon icon={faEllipsisV} />
       </IconButton>
@@ -67,6 +61,6 @@ export default function FontAwesomeSvgIconDemo() {
       <Button variant="contained" startIcon={<FontAwesomeSvgIcon icon={faInfo} />}>
         Example
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -14,9 +14,9 @@ export default function Icons() {
     >
       <Icon>add_circle</Icon>
       <Icon color="primary">add_circle</Icon>
-      <Icon style={{ color: green[500] }}>add_circle</Icon>
+      <Icon sx={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
-      <Icon style={{ fontSize: 30 }}>add_circle</Icon>
+      <Icon sx={{ fontSize: 30 }}>add_circle</Icon>
     </Box>
   );
 }

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -7,7 +7,7 @@ export default function Icons() {
   return (
     <Box
       sx={{
-        '& > span': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -1,26 +1,22 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { green } from '@material-ui/core/colors';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > span': {
-      margin: theme.spacing(2),
-    },
-  },
-}));
-
 export default function Icons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > span': {
+          m: 2,
+        },
+      }}
+    >
       <Icon>add_circle</Icon>
       <Icon color="primary">add_circle</Icon>
       <Icon style={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -14,9 +14,9 @@ export default function Icons() {
     >
       <Icon>add_circle</Icon>
       <Icon color="primary">add_circle</Icon>
-      <Icon style={{ color: green[500] }}>add_circle</Icon>
+      <Icon sx={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
-      <Icon style={{ fontSize: 30 }}>add_circle</Icon>
+      <Icon sx={{ fontSize: 30 }}>add_circle</Icon>
     </Box>
   );
 }

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -7,7 +7,7 @@ export default function Icons() {
   return (
     <Box
       sx={{
-        '& > span': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -1,28 +1,22 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { green } from '@material-ui/core/colors';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > span': {
-        margin: theme.spacing(2),
-      },
-    },
-  }),
-);
-
 export default function Icons() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > span': {
+          m: 2,
+        },
+      }}
+    >
       <Icon>add_circle</Icon>
       <Icon color="primary">add_circle</Icon>
       <Icon style={{ color: green[500] }}>add_circle</Icon>
       <Icon fontSize="small">add_circle</Icon>
       <Icon style={{ fontSize: 30 }}>add_circle</Icon>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/SvgIconsColor.js
+++ b/docs/src/pages/components/icons/SvgIconsColor.js
@@ -15,7 +15,7 @@ export default function SvgIconsColor() {
   return (
     <Box
       sx={{
-        '& > svg': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/SvgIconsColor.js
+++ b/docs/src/pages/components/icons/SvgIconsColor.js
@@ -1,15 +1,7 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { green } from '@material-ui/core/colors';
 import SvgIcon from '@material-ui/core/SvgIcon';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > svg': {
-      margin: theme.spacing(2),
-    },
-  },
-}));
 
 function HomeIcon(props) {
   return (
@@ -20,16 +12,20 @@ function HomeIcon(props) {
 }
 
 export default function SvgIconsColor() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > svg': {
+          m: 2,
+        },
+      }}
+    >
       <HomeIcon />
       <HomeIcon color="primary" />
       <HomeIcon color="secondary" />
       <HomeIcon color="action" />
       <HomeIcon color="disabled" />
-      <HomeIcon style={{ color: green[500] }} />
-    </div>
+      <HomeIcon sx={{ color: green[500] }} />
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/SvgIconsColor.tsx
+++ b/docs/src/pages/components/icons/SvgIconsColor.tsx
@@ -1,17 +1,7 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import { green } from '@material-ui/core/colors';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > svg': {
-        margin: theme.spacing(2),
-      },
-    },
-  }),
-);
 
 function HomeIcon(props: SvgIconProps) {
   return (
@@ -22,16 +12,20 @@ function HomeIcon(props: SvgIconProps) {
 }
 
 export default function SvgIconsColor() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > svg': {
+          m: 2,
+        },
+      }}
+    >
       <HomeIcon />
       <HomeIcon color="primary" />
       <HomeIcon color="secondary" />
       <HomeIcon color="action" />
       <HomeIcon color="disabled" />
-      <HomeIcon style={{ color: green[500] }} />
-    </div>
+      <HomeIcon sx={{ color: green[500] }} />
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/SvgIconsColor.tsx
+++ b/docs/src/pages/components/icons/SvgIconsColor.tsx
@@ -15,7 +15,7 @@ export default function SvgIconsColor() {
   return (
     <Box
       sx={{
-        '& > svg': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/SvgIconsSize.js
+++ b/docs/src/pages/components/icons/SvgIconsSize.js
@@ -1,14 +1,6 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import SvgIcon from '@material-ui/core/SvgIcon';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& > svg': {
-      margin: theme.spacing(2),
-    },
-  },
-}));
 
 function HomeIcon(props) {
   return (
@@ -19,14 +11,18 @@ function HomeIcon(props) {
 }
 
 export default function SvgIconsSize() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > svg': {
+          m: 2,
+        },
+      }}
+    >
       <HomeIcon fontSize="small" />
       <HomeIcon />
       <HomeIcon fontSize="large" />
-      <HomeIcon style={{ fontSize: 40 }} />
-    </div>
+      <HomeIcon sx={{ fontSize: 40 }} />
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/SvgIconsSize.js
+++ b/docs/src/pages/components/icons/SvgIconsSize.js
@@ -14,7 +14,7 @@ export default function SvgIconsSize() {
   return (
     <Box
       sx={{
-        '& > svg': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/SvgIconsSize.tsx
+++ b/docs/src/pages/components/icons/SvgIconsSize.tsx
@@ -1,16 +1,6 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > svg': {
-        margin: theme.spacing(2),
-      },
-    },
-  }),
-);
 
 function HomeIcon(props: SvgIconProps) {
   return (
@@ -21,14 +11,18 @@ function HomeIcon(props: SvgIconProps) {
 }
 
 export default function SvgIconsSize() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        '& > svg': {
+          m: 2,
+        },
+      }}
+    >
       <HomeIcon fontSize="small" />
       <HomeIcon />
       <HomeIcon fontSize="large" />
-      <HomeIcon style={{ fontSize: 40 }} />
-    </div>
+      <HomeIcon sx={{ fontSize: 40 }} />
+    </Box>
   );
 }

--- a/docs/src/pages/components/icons/SvgIconsSize.tsx
+++ b/docs/src/pages/components/icons/SvgIconsSize.tsx
@@ -14,7 +14,7 @@ export default function SvgIconsSize() {
   return (
     <Box
       sx={{
-        '& > svg': {
+        '& > :not(style)': {
           m: 2,
         },
       }}

--- a/docs/src/pages/components/icons/SvgMaterialIcons.js
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.js
@@ -14,19 +14,10 @@ import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
 import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
 import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    color: theme.palette.text.primary,
-  },
-}));
 
 export default function SvgMaterialIcons() {
-  const classes = useStyles();
-
   return (
-    <Grid container className={classes.root}>
+    <Grid container sx={{ color: 'text.primary' }}>
       <Grid item xs={4}>
         <Typography>Filled</Typography>
       </Grid>

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -14,21 +14,10 @@ import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
 import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
 import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      color: theme.palette.text.primary,
-    },
-  }),
-);
 
 export default function SvgMaterialIcons() {
-  const classes = useStyles();
-
   return (
-    <Grid container className={classes.root}>
+    <Grid container sx={{ color: 'text.primary' }}>
       <Grid item xs={4}>
         <Typography>Filled</Typography>
       </Grid>

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -339,7 +339,7 @@ import { visuallyHidden } from '@material-ui/utils';
 // ...
 
 <Icon>add_circle</Icon>
-<Box component='span' sx={visuallyHidden}>Create a user</Box>
+<Box component="span" sx={visuallyHidden}>Create a user</Box>
 ```
 
 #### Reference

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -332,16 +332,14 @@ import SvgIcon from '@material-ui/core/SvgIcon';
 You need to provide a text alternative that is only visible to assistive technologies.
 
 ```jsx
+import Box from '@material-ui/core/Box';
 import Icon from '@material-ui/core/Icon';
 import { visuallyHidden } from '@material-ui/utils';
-import { makeStyles } from '@material-ui/core/styles';
-
-const classes = makeStyles({ visuallyHidden })();
 
 // ...
 
 <Icon>add_circle</Icon>
-<span className={classes.visuallyHidden}>Create a user</span>
+<Box component='span' sx={visuallyHidden}>Create a user</Box>
 ```
 
 #### Reference


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Icons component were migrated:

- [x] SvgMaterialIcons
- [x] SvgIconsColor
- [x] SvgIconsSize
- [x] CreateSvgIcon
- [x] FontAwesomeSvgIconDemo
- [x] Icons
- [x] FontAwesomeIcon
- [x] FontAwesomeIconSize
- [x] visuallyHidden 

Related to #16947