### PR TITLE
[Table] Consistency with DataTable

### DIFF
--- a/packages/material-ui/src/TableRow/TableRow.js
+++ b/packages/material-ui/src/TableRow/TableRow.js
@@ -5,7 +5,6 @@ import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 import { alpha } from '../styles/colorManipulator';
-
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import tableRowClasses, { getTableRowUtilityClass } from './tableRowClasses';
@@ -50,8 +49,14 @@ const TableRowRoot = experimentalStyled(
   [`&.${tableRowClasses.hover}:hover`]: {
     backgroundColor: theme.palette.action.hover,
   },
-  '&.Mui-selected, &.Mui-selected:hover': {
+  '&.Mui-selected': {
     backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+    '&:hover': {
+      backgroundColor: alpha(
+        theme.palette.primary.main,
+        theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+      ),
+    },
   },
 }));
 


### PR DESCRIPTION
Use the same hover UI implementation between Table and DataTable. The latter seems to do it better https://material.io/design/interaction/states.html#selected.