### PR TITLE
[internal][pickers] Follow "private by default" in makeDateRangePicker

### DIFF
--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { ResponsiveTooltipWrapper } from '../internal/pickers/wrappers/ResponsiveWrapper';
-import { makeDateRangePicker } from './makeDateRangePicker';
+import makeDateRangePicker from './makeDateRangePicker';
 
 /**
  *

--- a/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
@@ -19,7 +19,7 @@ import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 import { ResponsiveWrapperProps } from '../internal/pickers/wrappers/ResponsiveWrapper';
 import { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 
-export interface BaseDateRangePickerProps<TDate>
+interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
@@ -35,14 +35,14 @@ export interface BaseDateRangePickerProps<TDate>
   endText?: React.ReactNode;
 }
 
-export type DateRangePickerComponent<PublicWrapperProps> = (<TDate>(
+type DateRangePickerComponent<PublicWrapperProps> = (<TDate>(
   props: BaseDateRangePickerProps<TDate> &
     PublicWrapperProps &
     AllSharedDateRangePickerProps<TDate> &
     React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes: unknown };
 
-export const useDateRangeValidation = makeValidationHook<
+const useDateRangeValidation = makeValidationHook<
   DateRangeValidationError,
   RangeInput<unknown>,
   BaseDateRangePickerProps<any>
@@ -59,7 +59,7 @@ interface WithWrapperProps {
   >;
 }
 
-export function makeDateRangePicker<PublicWrapperProps>(
+export default function makeDateRangePicker<PublicWrapperProps>(
   name: string,
   Wrapper: React.JSXElementConstructor<PublicWrapperProps & PrivateWrapperProps>,
 ): DateRangePickerComponent<PublicWrapperProps> {

--- a/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/makeDateRangePicker.tsx
@@ -19,7 +19,7 @@ import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 import { ResponsiveWrapperProps } from '../internal/pickers/wrappers/ResponsiveWrapper';
 import { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 
-interface BaseDateRangePickerProps<TDate>
+export interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makeDateRangePicker } from '../DateRangePicker/makeDateRangePicker';
+import makeDateRangePicker from '../DateRangePicker/makeDateRangePicker';
 import DesktopTooltipWrapper from '../internal/pickers/wrappers/DesktopTooltipWrapper';
 
 /**

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makeDateRangePicker } from '../DateRangePicker/makeDateRangePicker';
+import makeDateRangePicker from '../DateRangePicker/makeDateRangePicker';
 import MobileWrapper from '../internal/pickers/wrappers/MobileWrapper';
 
 /**

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { makeDateRangePicker } from '../DateRangePicker/makeDateRangePicker';
+import makeDateRangePicker from '../DateRangePicker/makeDateRangePicker';
 import StaticWrapper from '../internal/pickers/wrappers/StaticWrapper';
 
 /**


### PR DESCRIPTION
When we create a module we want to be able to move the implementation as much around as possible. Making a piece of code part of the public API goes against that. So if nobody needs a piece of code, keep it internally. **We** don't know if an abstraction is "correct" when writing a piece of code.