### PR TITLE
[Paper] Fix component prop type error

### DIFF
--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -42,6 +42,10 @@ export interface AppBarProps extends StandardProps<PaperProps> {
     AppBarPropsColorOverrides
   >;
   /**
+   * @ignore
+   */
+  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
+  /**
    * The positioning type. The behavior of the different options is described
    * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
    * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -173,6 +173,10 @@ AppBar.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
+   * @ignore
+   */
+  component: PropTypes.elementType,
+  /**
    * The positioning type. The behavior of the different options is described
    * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
    * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -54,11 +54,6 @@ export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
         elevation24?: string;
       };
       /**
-       * The component used for the root node.
-       * Either a string to use a HTML element or a component.
-       */
-      component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
-      /**
        * Shadow depth, corresponds to `dp` in the spec.
        * It accepts values between 0 and 24 inclusive.
        * @default 1

--- a/packages/material-ui/src/Paper/Paper.spec.tsx
+++ b/packages/material-ui/src/Paper/Paper.spec.tsx
@@ -8,8 +8,8 @@ const PaperTest = () => (
     <Paper elevation={4} />
     <Paper component="a" href="test" />
 
-    <Paper component={CustomComponent} stringProp='test' numberProp={0}/>
-     {/* @ts-expect-error */}
-    <Paper component={CustomComponent}/>
+    <Paper component={CustomComponent} stringProp="test" numberProp={0} />
+    {/* @ts-expect-error */}
+    <Paper component={CustomComponent} />
   </div>
 );

--- a/packages/material-ui/src/Paper/Paper.spec.tsx
+++ b/packages/material-ui/src/Paper/Paper.spec.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import Paper from '@material-ui/core/Paper';
 
+const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> = () => <div />;
+
 const PaperTest = () => (
   <div>
     <Paper elevation={4} />
     <Paper component="a" href="test" />
+
+    <Paper component={CustomComponent} stringProp='test' numberProp={0}/>
+     {/* @ts-expect-error */}
+    <Paper component={CustomComponent}/>
   </div>
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Looks like we don't need to use `component` prop directly anymore, since `OverridableComponent` is used in this pull request: https://github.com/mui-org/material-ui/pull/25059.
Otherwise, typescript `No overload matches this call` error occurs. Here's [codesandbox](https://codesandbox.io/s/thirsty-yonath-wdpox?file=/src/App.tsx:68-160) live example.
