### PR TITLE
[AppBar] Fix type support of overridable component

### DIFF
--- a/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
+++ b/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
@@ -4,7 +4,10 @@ import Snackbar from '@material-ui/core/Snackbar';
 import MuiAlert, { AlertProps } from '@material-ui/core/Alert';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(props, ref) {
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  props,
+  ref,
+) {
   return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
 });
 

--- a/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
+++ b/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
@@ -4,7 +4,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import MuiAlert, { AlertProps } from '@material-ui/core/Alert';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
-const Alert = React.forwardRef(function Alert(props: AlertProps, ref) {
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(props, ref) {
   return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
 });
 

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppAppBar.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppAppBar.js
@@ -82,8 +82,6 @@ function AppAppBar(props) {
 AppAppBar.propTypes = {
   /**
    * Override or extend the styles applied to the component.
-   * Override or extend the styles applied to the component.
-   * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object.isRequired,
 };

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppAppBar.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppAppBar.js
@@ -82,6 +82,8 @@ function AppAppBar(props) {
 AppAppBar.propTypes = {
   /**
    * Override or extend the styles applied to the component.
+   * Override or extend the styles applied to the component.
+   * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object.isRequired,
 };

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -220,9 +220,9 @@ const PickersPopper: React.FC<PickerPopperProps & WithStyles<typeof styles>> = (
   }, [open, role]);
 
   const [clickAwayRef, onPaperClick, onPaperTouchStart] = useClickAwayListener(open, onClose);
-  const paperRef = React.useRef<HTMLElement>(null);
+  const paperRef = React.useRef<HTMLDivElement>(null);
   const handleRef = useForkRef(paperRef, containerRef);
-  const handlePaperRef = useForkRef(handleRef, clickAwayRef);
+  const handlePaperRef = useForkRef(handleRef, clickAwayRef as React.Ref<HTMLDivElement>);
 
   return (
     <Popper

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
-import { OverridableStringUnion } from '@material-ui/types';
+import { DistributiveOmit, OverridableStringUnion } from '@material-ui/types';
 import { OverridableComponent, OverrideProps } from '@material-ui/core/OverridableComponent';
-import { InternalStandardProps as StandardProps, PaperTypeMap, PropTypes, Theme } from '..';
+import { PropTypes, Theme } from '..';
 import { PaperProps } from '../Paper';
 
 export interface AppBarPropsColorOverrides {}
 
 export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
   props: P &
-    StandardProps<PaperProps> & {
+    DistributiveOmit<PaperProps, 'position' | 'color'> & {
       /**
        * Override or extend the styles applied to the component.
        */
@@ -57,7 +57,6 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
        */
       sx?: SxProps<Theme>;
     };
-
   defaultComponent: D;
 }
 
@@ -78,7 +77,7 @@ declare const AppBar: OverridableComponent<AppBarTypeMap>;
 export type AppBarProps<
   D extends React.ElementType = AppBarTypeMap['defaultComponent'],
   P = {}
-> = OverrideProps<PaperTypeMap<P, D>, D>;
+> = OverrideProps<AppBarTypeMap<P, D>, D>;
 
 export type AppBarClassKey = keyof NonNullable<AppBarProps['classes']>;
 

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -1,64 +1,65 @@
+import * as React from 'react';
 import { SxProps } from '@material-ui/system';
 import { OverridableStringUnion } from '@material-ui/types';
-import { PropTypes, InternalStandardProps as StandardProps, Theme } from '..';
+import { OverridableComponent, OverrideProps } from '@material-ui/core/OverridableComponent';
+import { InternalStandardProps as StandardProps, PaperTypeMap, PropTypes, Theme } from '..';
 import { PaperProps } from '../Paper';
 
 export interface AppBarPropsColorOverrides {}
 
-export interface AppBarProps extends StandardProps<PaperProps> {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: {
-    /** Styles applied to the root element. */
-    root?: string;
-    /** Styles applied to the root element if `position="fixed"`. */
-    positionFixed?: string;
-    /** Styles applied to the root element if `position="absolute"`. */
-    positionAbsolute?: string;
-    /** Styles applied to the root element if `position="sticky"`. */
-    positionSticky?: string;
-    /** Styles applied to the root element if `position="static"`. */
-    positionStatic?: string;
-    /** Styles applied to the root element if `position="relative"`. */
-    positionRelative?: string;
-    /** Styles applied to the root element if `color="default"`. */
-    colorDefault?: string;
-    /** Styles applied to the root element if `color="primary"`. */
-    colorPrimary?: string;
-    /** Styles applied to the root element if `color="secondary"`. */
-    colorSecondary?: string;
-    /** Styles applied to the root element if `color="inherit"`. */
-    colorInherit?: string;
-    /** Styles applied to the root element if `color="transparent"`. */
-    colorTransparent?: string;
-  };
-  /**
-   * The color of the component. It supports those theme colors that make sense for this component.
-   * @default 'primary'
-   */
-  color?: OverridableStringUnion<
-    Record<PropTypes.Color | 'transparent', true>,
-    AppBarPropsColorOverrides
-  >;
-  /**
-   * @ignore
-   */
-  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
-  /**
-   * The positioning type. The behavior of the different options is described
-   * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
-   * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.
-   * @default 'fixed'
-   */
-  position?: 'fixed' | 'absolute' | 'sticky' | 'static' | 'relative';
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx?: SxProps<Theme>;
-}
+export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
+  props: P &
+    StandardProps<PaperProps> & {
+      /**
+       * Override or extend the styles applied to the component.
+       */
+      classes?: {
+        /** Styles applied to the root element. */
+        root?: string;
+        /** Styles applied to the root element if `position="fixed"`. */
+        positionFixed?: string;
+        /** Styles applied to the root element if `position="absolute"`. */
+        positionAbsolute?: string;
+        /** Styles applied to the root element if `position="sticky"`. */
+        positionSticky?: string;
+        /** Styles applied to the root element if `position="static"`. */
+        positionStatic?: string;
+        /** Styles applied to the root element if `position="relative"`. */
+        positionRelative?: string;
+        /** Styles applied to the root element if `color="default"`. */
+        colorDefault?: string;
+        /** Styles applied to the root element if `color="primary"`. */
+        colorPrimary?: string;
+        /** Styles applied to the root element if `color="secondary"`. */
+        colorSecondary?: string;
+        /** Styles applied to the root element if `color="inherit"`. */
+        colorInherit?: string;
+        /** Styles applied to the root element if `color="transparent"`. */
+        colorTransparent?: string;
+      };
+      /**
+       * The color of the component. It supports those theme colors that make sense for this component.
+       * @default 'primary'
+       */
+      color?: OverridableStringUnion<
+        Record<PropTypes.Color | 'transparent', true>,
+        AppBarPropsColorOverrides
+      >;
+      /**
+       * The positioning type. The behavior of the different options is described
+       * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
+       * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.
+       * @default 'fixed'
+       */
+      position?: 'fixed' | 'absolute' | 'sticky' | 'static' | 'relative';
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps<Theme>;
+    };
 
-export type AppBarClassKey = keyof NonNullable<AppBarProps['classes']>;
+  defaultComponent: D;
+}
 
 /**
  *
@@ -71,4 +72,14 @@ export type AppBarClassKey = keyof NonNullable<AppBarProps['classes']>;
  * - [AppBar API](https://material-ui.com/api/app-bar/)
  * - inherits [Paper API](https://material-ui.com/api/paper/)
  */
-export default function AppBar(props: AppBarProps): JSX.Element;
+
+declare const AppBar: OverridableComponent<AppBarTypeMap>;
+
+export type AppBarProps<
+  D extends React.ElementType = AppBarTypeMap['defaultComponent'],
+  P = {}
+> = OverrideProps<PaperTypeMap<P, D>, D>;
+
+export type AppBarClassKey = keyof NonNullable<AppBarProps['classes']>;
+
+export default AppBar;

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -113,11 +113,7 @@ const AppBarRoot = experimentalStyled(
 });
 
 const AppBar = React.forwardRef(function AppBar(inProps, ref) {
-  const props = useThemeProps({
-    props: inProps,
-    name: 'MuiAppBar',
-  });
-
+  const props = useThemeProps({ props: inProps, name: 'MuiAppBar' });
   const { className, color = 'primary', position = 'fixed', ...other } = props;
 
   const styleProps = {
@@ -166,6 +162,7 @@ AppBar.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'primary'
    */
   color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary', 'transparent']),

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -166,16 +166,11 @@ AppBar.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
-   * @default 'primary'
    */
   color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary', 'transparent']),
     PropTypes.string,
   ]),
-  /**
-   * @ignore
-   */
-  component: PropTypes.elementType,
   /**
    * The positioning type. The behavior of the different options is described
    * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).

--- a/packages/material-ui/src/AppBar/AppBar.spec.tsx
+++ b/packages/material-ui/src/AppBar/AppBar.spec.tsx
@@ -10,7 +10,7 @@ const AppBarTest = () => (
 
     <AppBar component="a" href="test" />
     <AppBar component={CustomComponent} stringProp="test" numberProp={0} />
-    {/* @ts-expect-error */}
+    {/* @ts-expect-error missing stringProp and numberProp */}
     <AppBar component={CustomComponent} />
   </div>
 );

--- a/packages/material-ui/src/AppBar/AppBar.spec.tsx
+++ b/packages/material-ui/src/AppBar/AppBar.spec.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import AppBar from '@material-ui/core/AppBar';
+
+const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> = () => <div />;
+
+const AppBarTest = () => (
+  <div>
+    <AppBar />
+    <AppBar elevation={4} />
+
+    <AppBar component="a" href="test" />
+    <AppBar component={CustomComponent} stringProp="test" numberProp={0} />
+    {/* @ts-expect-error */}
+    <AppBar component={CustomComponent} />
+  </div>
+);

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -2,78 +2,78 @@ import * as React from 'react';
 import { SxProps } from '@material-ui/system';
 import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '../styles';
-import { InternalStandardProps as StandardProps } from '..';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 
 export interface PaperPropsVariantOverrides {}
-export type PaperVariantDefaults = Record<'elevation' | 'outlined', true>;
 
 export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
-    StandardProps<React.HTMLAttributes<HTMLElement>> & {
-      /**
-       * The content of the component.
-       */
-      children?: React.ReactNode;
-      /**
-       * Override or extend the styles applied to the component.
-       */
-      classes?: {
-        /** Styles applied to the root element. */
-        root?: string;
-        /** Styles applied to the root element unless `square={true}`. */
-        rounded?: string;
-        /** Styles applied to the root element if `variant="outlined"`. */
-        outlined?: string;
-        /** Styles applied to the root element if `variant="elevation"`. */
-        elevation?: string;
-        elevation0?: string;
-        elevation1?: string;
-        elevation2?: string;
-        elevation3?: string;
-        elevation4?: string;
-        elevation5?: string;
-        elevation6?: string;
-        elevation7?: string;
-        elevation8?: string;
-        elevation9?: string;
-        elevation10?: string;
-        elevation11?: string;
-        elevation12?: string;
-        elevation13?: string;
-        elevation14?: string;
-        elevation15?: string;
-        elevation16?: string;
-        elevation17?: string;
-        elevation18?: string;
-        elevation19?: string;
-        elevation20?: string;
-        elevation21?: string;
-        elevation22?: string;
-        elevation23?: string;
-        elevation24?: string;
-      };
-      /**
-       * Shadow depth, corresponds to `dp` in the spec.
-       * It accepts values between 0 and 24 inclusive.
-       * @default 1
-       */
-      elevation?: number;
-      /**
-       * If `true`, rounded corners are disabled.
-       * @default false
-       */
-      square?: boolean;
-      /**
-       * The system prop that allows defining system overrides as well as additional CSS styles.
-       */
-      sx?: SxProps<Theme>;
-      /**
-       * The variant to use.
-       * @default 'elevation'
-       */
-      variant?: OverridableStringUnion<PaperVariantDefaults, PaperPropsVariantOverrides>;
+  props: P & {
+    /**
+     * The content of the component.
+     */
+    children?: React.ReactNode;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: {
+      /** Styles applied to the root element. */
+      root?: string;
+      /** Styles applied to the root element unless `square={true}`. */
+      rounded?: string;
+      /** Styles applied to the root element if `variant="outlined"`. */
+      outlined?: string;
+      /** Styles applied to the root element if `variant="elevation"`. */
+      elevation?: string;
+      elevation0?: string;
+      elevation1?: string;
+      elevation2?: string;
+      elevation3?: string;
+      elevation4?: string;
+      elevation5?: string;
+      elevation6?: string;
+      elevation7?: string;
+      elevation8?: string;
+      elevation9?: string;
+      elevation10?: string;
+      elevation11?: string;
+      elevation12?: string;
+      elevation13?: string;
+      elevation14?: string;
+      elevation15?: string;
+      elevation16?: string;
+      elevation17?: string;
+      elevation18?: string;
+      elevation19?: string;
+      elevation20?: string;
+      elevation21?: string;
+      elevation22?: string;
+      elevation23?: string;
+      elevation24?: string;
     };
+    /**
+     * Shadow depth, corresponds to `dp` in the spec.
+     * It accepts values between 0 and 24 inclusive.
+     * @default 1
+     */
+    elevation?: number;
+    /**
+     * If `true`, rounded corners are disabled.
+     * @default false
+     */
+    square?: boolean;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+    /**
+     * The variant to use.
+     * @default 'elevation'
+     */
+    variant?: OverridableStringUnion<
+      Record<'elevation' | 'outlined', true>,
+      PaperPropsVariantOverrides
+    >;
+  };
   defaultComponent: D;
 }
 

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -1058,6 +1058,7 @@ const refTest = () => {
   const divRef = React.createRef<HTMLDivElement>();
   const inputRef = React.createRef<HTMLInputElement>();
 
+  // @ts-expect-error too generic
   <Paper ref={genericRef} />;
   <Paper ref={divRef} />;
   // undesired: throws when assuming inputRef.current.value !== undefined


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Added the OverridableComponent to AppBar.

Can somebody help me to understand why proptypes generator insistently removes `component` prop and `@default` annotation from js file? It's not easy to understand how `typescript-to-proptypes` and `generateProptypes.ts` works, so I gave up.