### PR TITLE
[core] Drop support for React 16

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const React = require('react');
 
 const errorCodesPath = path.resolve(__dirname, './docs/public/static/error-codes.json');
 const missingError = process.env.MUI_EXTRACT_ERROR_CODES === 'true' ? 'write' : 'annotate';
@@ -29,8 +28,6 @@ const productionPlugins = [
 module.exports = function getBabelConfig(api) {
   const useESModules = api.env(['legacy', 'modern', 'stable', 'rollup']);
 
-  const isReactPreRelease = /\d+\.\d+\.\d+-\w+/.test(React.version);
-
   const presets = [
     [
       '@babel/preset-env',
@@ -45,11 +42,7 @@ module.exports = function getBabelConfig(api) {
     [
       '@babel/preset-react',
       {
-        runtime: isReactPreRelease
-          ? // default in Babel 8
-            // TODO: Always use automatic once we drop React 16
-            'automatic'
-          : 'classic',
+        runtime: 'automatic',
       },
     ],
     '@babel/preset-typescript',

--- a/framer/Material-UI.framerfx/package.json
+++ b/framer/Material-UI.framerfx/package.json
@@ -22,8 +22,8 @@
   "peerDependencies": {
     "@types/react": "^16.8.6",
     "framer": "^1.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -36,8 +36,8 @@
   "peerDependencies": {
     "@material-ui/core": "^5.0.0-alpha.1",
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@material-ui/core": "^5.0.0-alpha.15",
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -42,7 +42,7 @@
     "dayjs": "^1.8.17",
     "luxon": "^1.21.3",
     "moment": "^2.24.0",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -71,7 +71,7 @@
     "@material-ui/utils": "5.0.0-alpha.27",
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
-    "react-is": "^16.8.0 || ^17.0.0",
+    "react-is": "^17.0.0",
     "react-transition-group": "^4.4.1",
     "rifm": "^0.12.0"
   },

--- a/packages/material-ui-styled-engine/package.json
+++ b/packages/material-ui-styled-engine/package.json
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@emotion/react": {

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -39,8 +39,8 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-unstyled/package.json
+++ b/packages/material-ui-unstyled/package.json
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -50,7 +50,7 @@
     "@material-ui/utils": "5.0.0-alpha.27",
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
-    "react-is": "^16.8.0 || ^17.0.0"
+    "react-is": "^17.0.0"
   },
   "devDependencies": {
     "@material-ui/types": "5.1.7"

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -35,14 +35,14 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@types/prop-types": "^15.7.3",
     "@types/react-is": "^16.7.1 || ^17.0.0",
     "prop-types": "^15.7.2",
-    "react-is": "^16.8.0 || ^17.0.0"
+    "react-is": "^17.0.0"
   },
   "devDependencies": {
     "@babel/helper-module-imports": "^7.8.3",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -44,8 +44,8 @@
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -72,7 +72,7 @@
     "csstype": "^3.0.2",
     "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.7.2",
-    "react-is": "^16.8.0 || ^17.0.0",
+    "react-is": "^17.0.0",
     "react-transition-group": "^4.4.0"
   },
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13374,7 +13374,7 @@ react-final-form@^6.3.0:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-react-is@16.10.2, react-is@16.13.1, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, "react-is@^16.8.0 || ^17.0.0", react-is@^16.8.1, react-is@^17.0.0, react-is@^17.0.1:
+react-is@16.10.2, react-is@16.13.1, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^17.0.0, react-is@^17.0.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
**BREAKING CHANGE**

Official support for React 16 is discontinued.

Note that for now you can still use the library with React ^16.14.0.
This changes simplifies development for us a lot since we no longer have to consider certain behavior for two versions. This became especially problematic for event behavior when using the DOM.

Bundle size changes are expected since we're using the new jsx runtime.

Follow-up to https://github.com/mui-org/material-ui/pull/25416