### PR TITLE
[utils] Fix useForkRef typings rejecting nullish

### DIFF
--- a/packages/material-ui-utils/src/useForkRef.d.ts
+++ b/packages/material-ui-utils/src/useForkRef.d.ts
@@ -1,3 +1,0 @@
-import * as React from 'react';
-
-export default function useForkRef<T>(refA: React.Ref<T>, refB: React.Ref<T>): React.Ref<T>;

--- a/packages/material-ui-utils/src/useForkRef.ts
+++ b/packages/material-ui-utils/src/useForkRef.ts
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import setRef from './setRef';
 
-export default function useForkRef(refA, refB) {
+export default function useForkRef<Instance>(
+  refA: React.Ref<Instance> | null | undefined,
+  refB: React.Ref<Instance> | null | undefined,
+): React.Ref<Instance> | null {
   /**
    * This will create a new function if the ref props change and are defined.
    * This means react will call the old forkRef with `null` and the new forkRef


### PR DESCRIPTION
We handle `useForkRef(null, null)` at runtime but rejected it in the types.