### PR TITLE
[pickers][internal] Sort properties

### DIFF
--- a/packages/material-ui-lab/src/DayPicker/PickersCalendar.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersCalendar.tsx
@@ -15,6 +15,17 @@ export interface ExportedCalendarProps<TDate>
     'disableHighlightToday' | 'showDaysOutsideCurrentMonth' | 'allowSameDateSelection'
   > {
   /**
+   * Enables keyboard listener for moving between days in calendar.
+   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
+   */
+  allowKeyboardControl?: boolean;
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading?: boolean;
+  /**
    * Calendar onChange.
    */
   onChange: PickerOnChangeFn<TDate>;
@@ -27,17 +38,6 @@ export interface ExportedCalendarProps<TDate>
     DayComponentProps: PickersDayProps<TDate>,
   ) => JSX.Element;
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl?: boolean;
-  /**
-   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
-   * Can be used to preload information and show it in calendar.
-   * @default false
-   */
-  loading?: boolean;
-  /**
    * Component displaying when passed `loading` true.
    * @default () => "..."
    */
@@ -45,17 +45,17 @@ export interface ExportedCalendarProps<TDate>
 }
 
 export interface PickersCalendarProps<TDate> extends ExportedCalendarProps<TDate> {
-  date: TDate | [TDate | null, TDate | null] | null;
-  isDateDisabled: (day: TDate) => boolean;
-  slideDirection: SlideDirection;
-  currentMonth: TDate;
-  reduceAnimations: boolean;
-  focusedDay: TDate | null;
-  onFocusedDayChange: (newFocusedDay: TDate) => void;
-  isMonthSwitchingAnimating: boolean;
-  onMonthSwitchingAnimationEnd: () => void;
-  TransitionProps?: Partial<SlideTransitionProps>;
   className?: string;
+  currentMonth: TDate;
+  date: TDate | [TDate | null, TDate | null] | null;
+  focusedDay: TDate | null;
+  isDateDisabled: (day: TDate) => boolean;
+  isMonthSwitchingAnimating: boolean;
+  onFocusedDayChange: (newFocusedDay: TDate) => void;
+  onMonthSwitchingAnimationEnd: () => void;
+  reduceAnimations: boolean;
+  slideDirection: SlideDirection;
+  TransitionProps?: Partial<SlideTransitionProps>;
 }
 
 export type PickersCalendarClassKey =

--- a/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
@@ -23,9 +23,9 @@ export type ExportedCalendarHeaderProps<TDate> = Pick<
   PickersCalendarHeaderProps<TDate>,
   | 'components'
   | 'componentsProps'
+  | 'getViewSwitchingButtonText'
   | 'leftArrowButtonText'
   | 'rightArrowButtonText'
-  | 'getViewSwitchingButtonText'
 >;
 
 export interface PickersCalendarHeaderProps<TDate>
@@ -47,16 +47,16 @@ export interface PickersCalendarHeaderProps<TDate>
   componentsProps?: ExportedArrowSwitcherProps['componentsProps'] & {
     switchViewButton?: any;
   };
-  openView: DatePickerView;
-  views: DatePickerView[];
   currentMonth: TDate;
+  views: DatePickerView[];
   /**
    * Get aria-label text for switching between views button.
    */
   getViewSwitchingButtonText?: (currentView: DatePickerView) => string;
+  onMonthChange: (date: TDate, slideDirection: SlideDirection) => void;
+  openView: DatePickerView;
   reduceAnimations: boolean;
   onViewChange?: (view: DatePickerView) => void;
-  onMonthChange: (date: TDate, slideDirection: SlideDirection) => void;
 }
 
 export type PickersCalendarHeaderClassKey =

--- a/packages/material-ui-lab/src/DayPicker/PickersFadeTransitionGroup.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersFadeTransitionGroup.tsx
@@ -4,10 +4,10 @@ import { MuiStyles, WithStyles, withStyles, StyleRules } from '@material-ui/core
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 interface FadeTransitionProps {
-  transKey: React.Key;
+  children: React.ReactElement;
   className?: string;
   reduceAnimations: boolean;
-  children: React.ReactElement;
+  transKey: React.Key;
 }
 
 export type PickersFadeTransitionGroupClassKey =

--- a/packages/material-ui-lab/src/DayPicker/PickersSlideTransition.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersSlideTransition.tsx
@@ -6,11 +6,11 @@ import { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 
 export type SlideDirection = 'right' | 'left';
 export interface SlideTransitionProps extends Omit<CSSTransitionProps, 'timeout'> {
-  transKey: React.Key;
+  children: React.ReactElement;
   className?: string;
   reduceAnimations: boolean;
   slideDirection: SlideDirection;
-  children: React.ReactElement;
+  transKey: React.Key;
 }
 
 export type PickersSlideTransitionClassKey =

--- a/packages/material-ui-lab/src/DayPicker/useCalendarState.tsx
+++ b/packages/material-ui-lab/src/DayPicker/useCalendarState.tsx
@@ -4,9 +4,9 @@ import { validateDate } from '../internal/pickers/date-utils';
 import { MuiPickersAdapter, useUtils, useNow } from '../internal/pickers/hooks/useUtils';
 
 interface CalendarState<TDate> {
-  isMonthSwitchingAnimating: boolean;
   currentMonth: TDate;
   focusedDay: TDate | null;
+  isMonthSwitchingAnimating: boolean;
   slideDirection: SlideDirection;
 }
 
@@ -69,15 +69,15 @@ export const createCalendarStateReducer = <TDate extends unknown>(
 
 type CalendarStateInput<TDate> = Pick<
   import('./DayPicker').DayPickerProps<TDate>,
+  | 'date'
+  | 'defaultCalendarMonth'
   | 'disableFuture'
   | 'disablePast'
-  | 'shouldDisableDate'
-  | 'date'
-  | 'reduceAnimations'
-  | 'onMonthChange'
-  | 'defaultCalendarMonth'
   | 'minDate'
   | 'maxDate'
+  | 'onMonthChange'
+  | 'reduceAnimations'
+  | 'shouldDisableDate'
 > & {
   disableSwitchToMonthOnDayFocus?: boolean;
 };

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.tsx
@@ -7,19 +7,19 @@ import { useUtils, useNow } from '../internal/pickers/hooks/useUtils';
 import { PickerOnChangeFn } from '../internal/pickers/hooks/useViews';
 
 export interface MonthPickerProps<TDate> {
+  className?: string;
   /** Date value for the MonthPicker */
   date: TDate | null;
+  /** If `true` past days are disabled. */
+  disablePast?: boolean | null;
+  /** If `true` future days are disabled. */
+  disableFuture?: boolean | null;
   /** Minimal selectable date. */
   minDate: TDate;
   /** Maximal selectable date. */
   maxDate: TDate;
   /** Callback fired on date change. */
   onChange: PickerOnChangeFn<TDate>;
-  /** If `true` past days are disabled. */
-  disablePast?: boolean | null;
-  /** If `true` future days are disabled. */
-  disableFuture?: boolean | null;
-  className?: string;
   onMonthChange?: (date: TDate) => void | Promise<void>;
 }
 

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -81,55 +81,55 @@ export const styles: MuiStyles<PickersDayClassKey> = (theme): StyleRules<Pickers
 
 export interface PickersDayProps<TDate> extends ExtendMui<ButtonBaseProps> {
   /**
+   * If `true`, keyboard control and focus management is enabled.
+   */
+  allowKeyboardControl?: boolean;
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection?: boolean;
+  /**
    * The date to show.
    */
   day: TDate;
-  /**
-   * If `true`, day is outside of month and will be hidden.
-   */
-  outsideCurrentMonth: boolean;
-  /**
-   * If `true`, renders as today date.
-   * @default false
-   */
-  today?: boolean;
   /**
    * If `true`, renders as disabled.
    * @default false
    */
   disabled?: boolean;
   /**
-   * If `true`, renders as selected.
+   * If `true`, todays date is rendering without highlighting with circle.
    * @default false
    */
-  selected?: boolean;
-  /**
-   * If `true`, keyboard control and focus management is enabled.
-   */
-  allowKeyboardControl?: boolean;
+  disableHighlightToday?: boolean;
   /**
    * If `true`, days are rendering without margin. Useful for displaying linked range of days.
    * @default false
    */
   disableMargin?: boolean;
+  isAnimating?: boolean;
+  onDayFocus?: (day: TDate) => void;
+  onDaySelect: (day: TDate, isFinish: PickerSelectionState) => void;
+  /**
+   * If `true`, day is outside of month and will be hidden.
+   */
+  outsideCurrentMonth: boolean;
+  /**
+   * If `true`, renders as selected.
+   * @default false
+   */
+  selected?: boolean;
   /**
    * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
    * @default false
    */
   showDaysOutsideCurrentMonth?: boolean;
   /**
-   * If `true`, todays date is rendering without highlighting with circle.
+   * If `true`, renders as today date.
    * @default false
    */
-  disableHighlightToday?: boolean;
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection?: boolean;
-  isAnimating?: boolean;
-  onDayFocus?: (day: TDate) => void;
-  onDaySelect: (day: TDate, isFinish: PickerSelectionState) => void;
+  today?: boolean;
 }
 
 const useEnhancedEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;

--- a/packages/material-ui-lab/src/YearPicker/PickersYear.tsx
+++ b/packages/material-ui-lab/src/YearPicker/PickersYear.tsx
@@ -8,11 +8,11 @@ export interface YearProps {
   autoFocus?: boolean;
   children: React.ReactNode;
   disabled?: boolean;
+  forwardedRef?: React.Ref<HTMLButtonElement>;
   onClick: (event: React.MouseEvent, value: number) => void;
   onKeyDown: (event: React.KeyboardEvent, value: number) => void;
   selected: boolean;
   value: number;
-  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
 export type PickersYearClassKey = 'root' | 'modeDesktop' | 'yearButton' | 'disabled' | 'selected';

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.tsx
@@ -23,15 +23,15 @@ export interface ExportedYearPickerProps<TDate> {
 
 export interface YearPickerProps<TDate> extends ExportedYearPickerProps<TDate> {
   allowKeyboardControl?: boolean;
-  onFocusedDayChange?: (day: TDate) => void;
+  className?: string;
   date: TDate | null;
   disableFuture?: boolean | null;
   disablePast?: boolean | null;
   isDateDisabled: (day: TDate) => boolean;
-  maxDate: TDate;
   minDate: TDate;
+  maxDate: TDate;
   onChange: PickerOnChangeFn<TDate>;
-  className?: string;
+  onFocusedDayChange?: (day: TDate) => void;
 }
 
 export type YearPickerClassKey = 'root';

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -26,15 +26,15 @@ export interface ExportedPickerProps<TView extends AllAvailableViews>
 
 export interface PickerProps<TView extends AllAvailableViews, TDateValue = any>
   extends ExportedPickerProps<TView> {
-  isMobileKeyboardViewOpen: boolean;
-  toggleMobileKeyboardView: () => void;
-  DateInputProps: DateInputPropsLike;
   date: TDateValue;
+  DateInputProps: DateInputPropsLike;
+  isMobileKeyboardViewOpen: boolean;
   onDateChange: (
     date: TDateValue,
     currentWrapperVariant: WrapperVariant,
     isFinish?: PickerSelectionState,
   ) => void;
+  toggleMobileKeyboardView: () => void;
 }
 
 export const MobileKeyboardInputView = styled('div')(

--- a/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
@@ -8,11 +8,11 @@ export interface AllSharedPickerProps<TInputValue = any, TDateValue = any>
 
 export interface WithViewsProps<T extends AllAvailableViews> {
   /**
-   * Array of views to show.
-   */
-  views?: T[];
-  /**
    * First view to show.
    */
   openTo?: T;
+  /**
+   * Array of views to show.
+   */
+  views?: T[];
 }

--- a/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
@@ -12,21 +12,59 @@ import { getDisplayDate, getTextFieldAriaText } from './text-field-helper';
 export type MuiTextFieldProps = MuiTextFieldPropsType | Omit<MuiTextFieldPropsType, 'variant'>;
 
 export interface DateInputProps<TInputValue = ParsableDate, TDateValue = unknown> {
-  open: boolean;
-  rawValue: TInputValue;
-  inputFormat: string;
-  onChange: (date: TDateValue, keyboardInputValue?: string) => void;
-  openPicker: () => void;
-  readOnly?: boolean;
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex?: RegExp;
   disabled?: boolean;
-  validationError?: boolean;
-  label?: MuiTextFieldProps['label'];
-  InputProps?: MuiTextFieldProps['InputProps'];
-  TextFieldProps?: Partial<MuiTextFieldProps>;
-  // lib/src/wrappers/DesktopPopperWrapper.tsx:87
-  onBlur?: () => void;
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput?: boolean;
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker?: boolean;
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText?: (value: ParsableDate, utils: MuiPickersAdapter) => string;
   // ?? TODO when it will be possible to display "empty" date in datepicker use it instead of ignoring invalid inputs.
   ignoreInvalidInputs?: boolean;
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps?: Partial<InputAdornmentProps>;
+  inputFormat: string;
+  InputProps?: MuiTextFieldProps['InputProps'];
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef?: React.Ref<HTMLInputElement>;
+  label?: MuiTextFieldProps['label'];
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask?: string;
+  // lib/src/wrappers/DesktopPopperWrapper.tsx:87
+  onBlur?: () => void;
+  onChange: (date: TDateValue, keyboardInputValue?: string) => void;
+  open: boolean;
+  openPicker: () => void;
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps?: Partial<IconButtonProps>;
+  /**
+   * Icon displaying for open picker button.
+   */
+  openPickerIcon?: React.ReactNode;
+  rawValue: TInputValue;
+  readOnly?: boolean;
   /**
    * The `renderInput` prop allows you to customize the rendered input.
    * The `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.
@@ -37,62 +75,24 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = unknown
    */
   renderInput: (props: MuiTextFieldPropsType) => React.ReactElement;
   /**
-   * Icon displaying for open picker button.
-   */
-  openPickerIcon?: React.ReactNode;
-  /**
-   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
-   */
-  mask?: string;
-  /**
-   * Regular expression to detect "accepted" symbols.
-   * @default /\dap/gi
-   */
-  acceptRegex?: RegExp;
-  /**
-   * Props to pass to keyboard input adornment.
-   */
-  InputAdornmentProps?: Partial<InputAdornmentProps>;
-  /**
-   * Props to pass to keyboard adornment button.
-   */
-  OpenPickerButtonProps?: Partial<IconButtonProps>;
-  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter?: (str: string) => string;
-  /**
-   * Do not render open picker button (renders only text field with validation).
-   * @default false
-   */
-  disableOpenPicker?: boolean;
-  /**
-   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
-   * @default false
-   */
-  disableMaskedInput?: boolean;
-  /**
-   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
-   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
-   */
-  getOpenDialogAriaText?: (value: ParsableDate, utils: MuiPickersAdapter) => string;
-  /**
-   * Pass a ref to the `input` element.
-   */
-  inputRef?: React.Ref<HTMLInputElement>;
+  TextFieldProps?: Partial<MuiTextFieldProps>;
+  validationError?: boolean;
 }
 
 export type ExportedDateInputProps<TInputValue, TDateValue> = Omit<
   DateInputProps<TInputValue, TDateValue>,
-  | 'openPicker'
-  | 'inputValue'
-  | 'onChange'
   | 'inputFormat'
-  | 'validationError'
-  | 'rawValue'
-  | 'open'
-  | 'TextFieldProps'
+  | 'inputValue'
   | 'onBlur'
+  | 'onChange'
+  | 'open'
+  | 'openPicker'
+  | 'rawValue'
+  | 'TextFieldProps'
+  | 'validationError'
 >;
 
 // TODO: why is this called "Pure*" when it's not memoized? Does "Pure" mean "readonly"?

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.ts
@@ -6,22 +6,22 @@ import { MuiPickersAdapter } from './hooks/useUtils';
 
 interface FindClosestDateParams<TDate> {
   date: TDate;
-  utils: MuiPickersAdapter<TDate>;
-  minDate: TDate;
-  maxDate: TDate;
   disableFuture: boolean;
   disablePast: boolean;
+  maxDate: TDate;
+  minDate: TDate;
   shouldDisableDate: (date: TDate) => boolean;
+  utils: MuiPickersAdapter<TDate>;
 }
 
 export const findClosestEnabledDate = <TDate>({
   date,
-  utils,
-  minDate,
-  maxDate,
   disableFuture,
   disablePast,
+  maxDate,
+  minDate,
   shouldDisableDate,
+  utils,
 }: FindClosestDateParams<TDate>) => {
   const today = utils.startOfDay(utils.date()!);
 
@@ -153,6 +153,16 @@ export const isEndOfRange = <TDate>(
 
 export interface DateValidationProps<TDate> {
   /**
+   * Disable past dates.
+   * @default false
+   */
+  disablePast?: boolean;
+  /**
+   * Disable future dates.
+   * @default false
+   */
+  disableFuture?: boolean;
+  /**
    * Min selectable date. @DateIOType
    * @default Date(1900-01-01)
    */
@@ -166,22 +176,12 @@ export interface DateValidationProps<TDate> {
    * Disable specific date. @DateIOType
    */
   shouldDisableDate?: (day: TDate) => boolean;
-  /**
-   * Disable past dates.
-   * @default false
-   */
-  disablePast?: boolean;
-  /**
-   * Disable future dates.
-   * @default false
-   */
-  disableFuture?: boolean;
 }
 
 export const validateDate = <TDate>(
   utils: MuiPickersAdapter<TDate>,
   value: TDate | ParsableDate,
-  { minDate, maxDate, disableFuture, shouldDisableDate, disablePast }: DateValidationProps<TDate>,
+  { disablePast, disableFuture, minDate, maxDate, shouldDisableDate }: DateValidationProps<TDate>,
 ) => {
   const now = utils.date()!;
   const date = utils.date(value);

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -11,16 +11,16 @@ import {
 
 type MaskedInputProps = Omit<
   DateInputProps,
-  | 'open'
   | 'adornmentPosition'
-  | 'renderInput'
-  | 'openPicker'
-  | 'InputProps'
-  | 'InputAdornmentProps'
-  | 'openPickerIcon'
   | 'disableOpenPicker'
   | 'getOpenDialogAriaText'
+  | 'InputAdornmentProps'
+  | 'InputProps'
+  | 'open'
+  | 'openPicker'
   | 'OpenPickerButtonProps'
+  | 'openPickerIcon'
+  | 'renderInput'
 > & { inputProps?: Partial<React.HTMLProps<HTMLInputElement>> };
 
 export function useMaskedInput({

--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -5,13 +5,13 @@ import { BasePickerProps } from '../typings/BasePicker';
 import { useUtils, MuiPickersAdapter } from './useUtils';
 
 export interface PickerStateValueManager<TInputValue, TDateValue> {
-  parseInput: (utils: MuiPickersAdapter, value: TInputValue) => TDateValue;
-  emptyValue: TDateValue;
   areValuesEqual: (
     utils: MuiPickersAdapter,
     valueLeft: TDateValue,
     valueRight: TDateValue,
   ) => boolean;
+  emptyValue: TDateValue;
+  parseInput: (utils: MuiPickersAdapter, value: TInputValue) => TDateValue;
 }
 
 export type PickerSelectionState = 'partial' | 'shallow' | 'finish';
@@ -31,12 +31,12 @@ export function usePickerState<TInput, TDateValue>(
   valueManager: PickerStateValueManager<TInput, TDateValue>,
 ) {
   const {
-    inputFormat,
+    disableCloseOnSelect,
     disabled,
-    readOnly,
+    inputFormat,
     onAccept,
     onChange,
-    disableCloseOnSelect,
+    readOnly,
     value,
   } = props;
 

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useViews.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useViews.tsx
@@ -11,18 +11,18 @@ export type PickerOnChangeFn<TDate> = (
 
 interface UseViewsOptions<TDate, TView extends AllAvailableViews> {
   onChange: PickerOnChangeFn<TDate>;
-  views: TView[];
-  view: TView | undefined;
-  openTo?: TView;
   onViewChange?: (newView: TView) => void;
+  openTo?: TView;
+  view: TView | undefined;
+  views: TView[];
 }
 
 export function useViews<TDate, TView extends AllAvailableViews>({
-  view,
-  views,
-  openTo,
   onChange,
   onViewChange,
+  openTo,
+  view,
+  views,
 }: UseViewsOptions<TDate, TView>) {
   const [openView, setOpenView] = useControlled<TView>({
     name: 'Picker',
@@ -68,10 +68,10 @@ export function useViews<TDate, TView extends AllAvailableViews>({
   );
 
   return {
+    handleChangeAndOpenNext,
     nextView,
     previousView,
     openNext,
-    handleChangeAndOpenNext,
     openView,
     setOpenView: changeView,
   };

--- a/packages/material-ui-lab/src/internal/pickers/typings/BasePicker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/typings/BasePicker.tsx
@@ -30,76 +30,76 @@ export type ToolbarComponentProps<
 
 export interface BasePickerProps<TInputValue = ParsableDate, TDateValue = unknown> {
   /**
-   * The value of the picker.
+   * className applied to the root component.
    */
-  value: TInputValue;
-  /**
-   * Callback fired when the value (the selected date) changes @DateIOType.
-   */
-  onChange: (date: TDateValue, keyboardInputValue?: string) => void;
+  className?: string;
   /**
    * If `true` the popup or dialog will immediately close after submitting full date.
    * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
    */
   disableCloseOnSelect?: boolean;
   /**
-   * Format string.
-   */
-  inputFormat?: string;
-  /**
    * If `true`, the picker and text field are disabled.
    */
   disabled?: boolean;
   /**
-   * Make picker read only.
+   * Format string.
    */
-  readOnly?: boolean;
+  inputFormat?: string;
   /**
    * Callback fired when date is accepted @DateIOType.
    */
   onAccept?: (date: TDateValue | null) => void;
   /**
-   * Callback fired when the popup requests to be opened.
-   * Use in controlled mode (see open).
+   * Callback fired when the value (the selected date) changes @DateIOType.
    */
-  onOpen?: () => void;
+  onChange: (date: TDateValue, keyboardInputValue?: string) => void;
   /**
    * Callback fired when the popup requests to be closed.
    * Use in controlled mode (see open).
    */
   onClose?: () => void;
   /**
-   * Control the popup or dialog open state.
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
    */
-  open?: boolean;
-  /**
-   * If `true`, show the toolbar even in desktop mode.
-   */
-  showToolbar?: boolean;
+  onOpen?: () => void;
   /**
    * Force rendering in particular orientation.
    */
   orientation?: 'portrait' | 'landscape';
   /**
+   * Control the popup or dialog open state.
+   */
+  open?: boolean;
+  /**
+   * Make picker read only.
+   */
+  readOnly?: boolean;
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar?: boolean;
+  /**
    * Component that will replace default toolbar renderer.
    */
   ToolbarComponent?: React.ComponentType<ToolbarComponentProps>;
   /**
-   * Mobile picker title, displaying in the toolbar.
-   * @default "SELECT DATE"
+   * Date format, that is displaying in toolbar.
    */
-  toolbarTitle?: React.ReactNode;
+  toolbarFormat?: string;
   /**
    * Mobile picker date value placeholder, displaying if `value` === `null`.
    * @default "–"
    */
   toolbarPlaceholder?: React.ReactNode;
   /**
-   * Date format, that is displaying in toolbar.
+   * Mobile picker title, displaying in the toolbar.
+   * @default "SELECT DATE"
    */
-  toolbarFormat?: string;
+  toolbarTitle?: React.ReactNode;
   /**
-   * className applied to the root component.
+   * The value of the picker.
    */
-  className?: string;
+  value: TInputValue;
 }

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopTooltipWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopTooltipWrapper.tsx
@@ -9,13 +9,13 @@ import { DesktopWrapperProps } from './DesktopWrapper';
 
 const DesktopTooltipWrapper: React.FC<PrivateWrapperProps & DesktopWrapperProps> = (props) => {
   const {
-    open,
     children,
-    PopperProps,
-    onDismiss,
     DateInputProps,
-    TransitionComponent,
     KeyboardDateInputComponent = KeyboardDateInput,
+    onDismiss,
+    open,
+    PopperProps,
+    TransitionComponent,
   } = props;
   const inputContainerRef = React.useRef<HTMLDivElement>(null);
   const popperRef = React.useRef<HTMLDivElement>(null);

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/Wrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/Wrapper.tsx
@@ -5,11 +5,11 @@ import { ResponsiveWrapper } from './ResponsiveWrapper';
 import DesktopTooltipWrapper from './DesktopTooltipWrapper';
 
 export type SomeWrapper =
-  | typeof ResponsiveWrapper
-  | typeof StaticWrapper
-  | typeof MobileWrapper
+  | typeof DesktopTooltipWrapper
   | typeof DesktopWrapper
-  | typeof DesktopTooltipWrapper;
+  | typeof MobileWrapper
+  | typeof ResponsiveWrapper
+  | typeof StaticWrapper;
 
 // Required for babel https://github.com/vercel/next.js/issues/7882. Replace with `export type` in future
 export type WrapperVariant = import('./WrapperVariantContext').WrapperVariant;

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/WrapperProps.ts
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/WrapperProps.ts
@@ -10,13 +10,14 @@ export type DateInputPropsLike = Omit<
 };
 
 export interface PrivateWrapperProps {
-  open: boolean;
-  onAccept: () => void;
-  onDismiss: () => void;
-  onClear: () => void;
-  onSetToday: () => void;
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
-  // TODO: these are not optional
+  // TODO: Mark as required
   KeyboardDateInputComponent?: React.ComponentType<DateInputPropsLike>;
+  onAccept: () => void;
+  onClear: () => void;
+  onDismiss: () => void;
+  onSetToday: () => void;
+  open: boolean;
+  // TODO: Mark as required
   PureDateInputComponent?: React.ComponentType<DateInputPropsLike>;
 }


### PR DESCRIPTION
Properties are sorted ascending, case insensitive unless they "obviously" belong together. Then we sort them in the order that makes "sense" e.g. `minDate < maxDate` (sorting numerically) or `disablePast < disableFuture` (sorting temporally).

This should help find a specific property in an interface.