### PR TITLE
[test] Wait on e2e server to start before starting runner

### DIFF
--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,6 +1,38 @@
 import { expect } from 'chai';
 import * as playwright from 'playwright';
 
+function sleep(timeoutMS: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(), timeoutMS);
+  });
+}
+
+/**
+ * Attempts page.goto with retries
+ *
+ * @remarks The server and runner can be started up simultaneously
+ * @param page
+ * @param url
+ */
+async function attemptGoto(page: playwright.Page, url: string): Promise<boolean> {
+  const maxAttempts = 10;
+  const retryTimeoutMS = 250;
+
+  let didNavigate = false;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await page.goto(url);
+      didNavigate = true;
+    } catch (error) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(retryTimeoutMS);
+    }
+  }
+
+  return didNavigate;
+}
+
 describe('e2e', () => {
   const baseUrl = 'http://localhost:5000';
   let browser: playwright.Browser;
@@ -10,12 +42,19 @@ describe('e2e', () => {
     await page.goto(`${baseUrl}/e2e/${fixturePath}#no-dev`);
   }
 
-  before(async () => {
+  before(async function beforeHook() {
+    this.timeout(20000);
+
     browser = await playwright.chromium.launch({
       headless: true,
     });
     page = await browser.newPage();
-    await page.goto(`${baseUrl}#no-dev`);
+    const isServerRunning = await attemptGoto(page, `${baseUrl}#no-dev`);
+    if (!isServerRunning) {
+      throw new Error(
+        `Unable to navigate to ${baseUrl} after multiple attempts. Did you forget to run \`yarn test:e2e:server\` and \`yarn test:e2e:build\`?`,
+      );
+    }
   });
 
   after(async () => {


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/mui-org/material-ui/39638/workflows/d07cf743-eb36-4a71-b6a3-74400199ac2c/jobs/234518

We start server and runner concurrently but we didn't actually wait on the server. The regression suite did not have problems with this. Probably because starting the headful browser was enough time for the server to start.