### PR TITLE
[docs] Cover change of React support

### DIFF
--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -16,6 +16,8 @@ npm install @material-ui/core@next @emotion/react @emotion/styled
 yarn add @material-ui/core@next @emotion/react @emotion/styled
 ```
 
+<!-- #react-peer-version -->
+
 Please note that [react](https://www.npmjs.com/package/react) >= 17.0.0 and [react-dom](https://www.npmjs.com/package/react-dom) >= 17.0.0 are peer dependencies.
 
 ## Roboto Font

--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -16,7 +16,7 @@ npm install @material-ui/core@next @emotion/react @emotion/styled
 yarn add @material-ui/core@next @emotion/react @emotion/styled
 ```
 
-Please note that [react](https://www.npmjs.com/package/react) >= 16.8.0 and [react-dom](https://www.npmjs.com/package/react-dom) >= 16.8.0 are peer dependencies.
+Please note that [react](https://www.npmjs.com/package/react) >= 17.0.0 and [react-dom](https://www.npmjs.com/package/react-dom) >= 17.0.0 are peer dependencies.
 
 ## Roboto Font
 

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -55,6 +55,8 @@ It's a must-do for static pages, but it needs to be put in balance with not doin
 
 ## React
 
+<!-- #react-peer-version -->
+
 Material-UI supports the most recent versions of React, starting with ^17.0.0 (the one with event delegation at the React root).
 Have a look at the older [versions](https://material-ui.com/versions/) for backward compatibility.
 

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -55,7 +55,7 @@ It's a must-do for static pages, but it needs to be put in balance with not doin
 
 ## React
 
-Material-UI supports the most recent versions of React, starting with ^16.8.0 (the one with the hooks).
+Material-UI supports the most recent versions of React, starting with ^17.0.0 (the one with event delegation at the React root).
 Have a look at the older [versions](https://material-ui.com/versions/) for backward compatibility.
 
 ## TypeScript

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -72,6 +72,10 @@ Support for non-ref-forwarding class components in the `component` prop or as im
 Otherwise check out the ["Caveat with refs" section in our composition guide](/guides/composition/#caveat-with-refs) to find out how to migrate.
 This change affects almost all components where you're using the `component` prop or passing `children` to components that require `children` to be elements (e.g. `<MenuList><CustomMenuItem /></MenuList>`)
 
+### Supported React version
+
+The minimum supported version of React was increased from v16.8.0 to v17.0.0.
+
 ### Supported TypeScript version
 
 The minimum supported version of TypeScript was increased from v3.2 to v3.5.


### PR DESCRIPTION
I forgot about it during the review of #25464. It went back to me this afternoon, for some reasons, in the 🏊‍♂️ 🤷‍♂️.