### PR TITLE
[docs] Migrate Transitions demos to emotion

### DIFF
--- a/docs/src/pages/components/transitions/SimpleCollapse.js
+++ b/docs/src/pages/components/transitions/SimpleCollapse.js
@@ -1,39 +1,27 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Collapse from '@material-ui/core/Collapse';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 300,
-  },
-  container: {
-    display: 'flex',
-    justifyContent: 'space-around',
-    height: 120,
-    width: 250,
-  },
-  halfWidth: {
-    width: '50%',
-  },
-  paper: {
-    margin: theme.spacing(1),
-  },
-  svg: {
-    width: 100,
-    height: 100,
-  },
-  polygon: {
-    fill: theme.palette.common.white,
-    stroke: theme.palette.divider,
-    strokeWidth: 1,
-  },
-}));
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
+);
 
 export default function SimpleCollapse() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -41,47 +29,40 @@ export default function SimpleCollapse() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 300 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Collapse in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Collapse>
-        <Collapse in={checked} collapsedSize={40}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Collapse>
-      </div>
-      <div className={classes.container}>
-        <div className={classes.halfWidth}>
-          <Collapse orientation="horizontal" in={checked}>
-            <Paper elevation={4} className={classes.paper}>
-              <svg className={classes.svg}>
-                <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-              </svg>
-            </Paper>
+      <Box
+        sx={{
+          '& > :not(style)': {
+            display: 'flex',
+            justifyContent: 'space-around',
+            height: 120,
+            width: 250,
+          },
+        }}
+      >
+        <div>
+          <Collapse in={checked}>{icon}</Collapse>
+          <Collapse in={checked} collapsedSize={40}>
+            {icon}
           </Collapse>
         </div>
-        <div className={classes.halfWidth}>
-          <Collapse orientation="horizontal" in={checked} collapsedSize={40}>
-            <Paper elevation={4} className={classes.paper}>
-              <svg className={classes.svg}>
-                <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-              </svg>
-            </Paper>
-          </Collapse>
+        <div>
+          <Box sx={{ width: '50%' }}>
+            <Collapse orientation="horizontal" in={checked}>
+              {icon}
+            </Collapse>
+          </Box>
+          <Box sx={{ width: '50%' }}>
+            <Collapse orientation="horizontal" in={checked} collapsedSize={40}>
+              {icon}
+            </Collapse>
+          </Box>
         </div>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleCollapse.tsx
+++ b/docs/src/pages/components/transitions/SimpleCollapse.tsx
@@ -1,41 +1,27 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Collapse from '@material-ui/core/Collapse';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 300,
-    },
-    container: {
-      display: 'flex',
-      justifyContent: 'space-around',
-      height: 120,
-      width: 250,
-    },
-    halfWidth: {
-      width: '50%',
-    },
-    paper: {
-      margin: theme.spacing(1),
-    },
-    svg: {
-      width: 100,
-      height: 100,
-    },
-    polygon: {
-      fill: theme.palette.common.white,
-      stroke: theme.palette.divider,
-      strokeWidth: 1,
-    },
-  }),
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
 );
 
 export default function SimpleCollapse() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -43,47 +29,40 @@ export default function SimpleCollapse() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 300 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Collapse in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Collapse>
-        <Collapse in={checked} collapsedSize={40}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Collapse>
-      </div>
-      <div className={classes.container}>
-        <div className={classes.halfWidth}>
-          <Collapse orientation="horizontal" in={checked}>
-            <Paper elevation={4} className={classes.paper}>
-              <svg className={classes.svg}>
-                <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-              </svg>
-            </Paper>
+      <Box
+        sx={{
+          '& > :not(style)': {
+            display: 'flex',
+            justifyContent: 'space-around',
+            height: 120,
+            width: 250,
+          },
+        }}
+      >
+        <div>
+          <Collapse in={checked}>{icon}</Collapse>
+          <Collapse in={checked} collapsedSize={40}>
+            {icon}
           </Collapse>
         </div>
-        <div className={classes.halfWidth}>
-          <Collapse orientation="horizontal" in={checked} collapsedSize={40}>
-            <Paper elevation={4} className={classes.paper}>
-              <svg className={classes.svg}>
-                <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-              </svg>
-            </Paper>
-          </Collapse>
+        <div>
+          <Box sx={{ width: '50%' }}>
+            <Collapse orientation="horizontal" in={checked}>
+              {icon}
+            </Collapse>
+          </Box>
+          <Box sx={{ width: '50%' }}>
+            <Collapse orientation="horizontal" in={checked} collapsedSize={40}>
+              {icon}
+            </Collapse>
+          </Box>
         </div>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleFade.js
+++ b/docs/src/pages/components/transitions/SimpleFade.js
@@ -1,33 +1,27 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Fade from '@material-ui/core/Fade';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 180,
-  },
-  container: {
-    display: 'flex',
-  },
-  paper: {
-    margin: theme.spacing(1),
-  },
-  svg: {
-    width: 100,
-    height: 100,
-  },
-  polygon: {
-    fill: theme.palette.common.white,
-    stroke: theme.palette.divider,
-    strokeWidth: 1,
-  },
-}));
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
+);
 
 export default function SimpleFade() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -35,20 +29,14 @@ export default function SimpleFade() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 180 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Fade in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Fade>
-      </div>
-    </div>
+      <Box sx={{ display: 'flex' }}>
+        <Fade in={checked}>{icon}</Fade>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleFade.tsx
+++ b/docs/src/pages/components/transitions/SimpleFade.tsx
@@ -1,35 +1,27 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Fade from '@material-ui/core/Fade';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 180,
-    },
-    container: {
-      display: 'flex',
-    },
-    paper: {
-      margin: theme.spacing(1),
-    },
-    svg: {
-      width: 100,
-      height: 100,
-    },
-    polygon: {
-      fill: theme.palette.common.white,
-      stroke: theme.palette.divider,
-      strokeWidth: 1,
-    },
-  }),
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
 );
 
 export default function SimpleFade() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -37,20 +29,14 @@ export default function SimpleFade() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 180 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Fade in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Fade>
-      </div>
-    </div>
+      <Box sx={{ display: 'flex' }}>
+        <Fade in={checked}>{icon}</Fade>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleGrow.js
+++ b/docs/src/pages/components/transitions/SimpleGrow.js
@@ -1,33 +1,27 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Grow from '@material-ui/core/Grow';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 180,
-  },
-  container: {
-    display: 'flex',
-  },
-  paper: {
-    margin: theme.spacing(1),
-  },
-  svg: {
-    width: 100,
-    height: 100,
-  },
-  polygon: {
-    fill: theme.palette.common.white,
-    stroke: theme.palette.divider,
-    strokeWidth: 1,
-  },
-}));
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
+);
 
 export default function SimpleGrow() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -35,32 +29,22 @@ export default function SimpleGrow() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 180 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Grow in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Grow>
+      <Box sx={{ display: 'flex' }}>
+        <Grow in={checked}>{icon}</Grow>
         {/* Conditionally applies the timeout prop to change the entry speed. */}
         <Grow
           in={checked}
           style={{ transformOrigin: '0 0 0' }}
           {...(checked ? { timeout: 1000 } : {})}
         >
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
+          {icon}
         </Grow>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleGrow.tsx
+++ b/docs/src/pages/components/transitions/SimpleGrow.tsx
@@ -1,35 +1,27 @@
 import * as React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Grow from '@material-ui/core/Grow';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 180,
-    },
-    container: {
-      display: 'flex',
-    },
-    paper: {
-      margin: theme.spacing(1),
-    },
-    svg: {
-      width: 100,
-      height: 100,
-    },
-    polygon: {
-      fill: theme.palette.common.white,
-      stroke: theme.palette.divider,
-      strokeWidth: 1,
-    },
-  }),
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
 );
 
 export default function SimpleGrow() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -37,32 +29,22 @@ export default function SimpleGrow() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 180 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Grow in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Grow>
+      <Box sx={{ display: 'flex' }}>
+        <Grow in={checked}>{icon}</Grow>
         {/* Conditionally applies the timeout prop to change the entry speed. */}
         <Grow
           in={checked}
           style={{ transformOrigin: '0 0 0' }}
           {...(checked ? { timeout: 1000 } : {})}
         >
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
+          {icon}
         </Grow>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleSlide.js
+++ b/docs/src/pages/components/transitions/SimpleSlide.js
@@ -1,35 +1,27 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Slide from '@material-ui/core/Slide';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 180,
-  },
-  wrapper: {
-    width: `calc(100px + ${theme.spacing(2)})`,
-  },
-  paper: {
-    zIndex: 1,
-    position: 'relative',
-    margin: theme.spacing(1),
-  },
-  svg: {
-    width: 100,
-    height: 100,
-  },
-  polygon: {
-    fill: theme.palette.common.white,
-    stroke: theme.palette.divider,
-    strokeWidth: 1,
-  },
-}));
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
+);
 
 export default function SimpleSlide() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -37,20 +29,16 @@ export default function SimpleSlide() {
   };
 
   return (
-    <div className={classes.root}>
-      <div className={classes.wrapper}>
+    <Box sx={{ height: 180 }}>
+      <Box sx={{ width: `calc(100px + 16px)` }}>
         <FormControlLabel
           control={<Switch checked={checked} onChange={handleChange} />}
           label="Show"
         />
         <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
+          {icon}
         </Slide>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleSlide.tsx
+++ b/docs/src/pages/components/transitions/SimpleSlide.tsx
@@ -1,37 +1,27 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Slide from '@material-ui/core/Slide';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 180,
-    },
-    wrapper: {
-      width: `calc(100px + ${theme.spacing(2)})`,
-    },
-    paper: {
-      zIndex: 1,
-      position: 'relative',
-      margin: theme.spacing(1),
-    },
-    svg: {
-      width: 100,
-      height: 100,
-    },
-    polygon: {
-      fill: theme.palette.common.white,
-      stroke: theme.palette.divider,
-      strokeWidth: 1,
-    },
-  }),
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
 );
 
 export default function SimpleSlide() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -39,20 +29,16 @@ export default function SimpleSlide() {
   };
 
   return (
-    <div className={classes.root}>
-      <div className={classes.wrapper}>
+    <Box sx={{ height: 180 }}>
+      <Box sx={{ width: `calc(100px + 16px)` }}>
         <FormControlLabel
           control={<Switch checked={checked} onChange={handleChange} />}
           label="Show"
         />
         <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
+          {icon}
         </Slide>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleZoom.js
+++ b/docs/src/pages/components/transitions/SimpleZoom.js
@@ -1,33 +1,27 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Zoom from '@material-ui/core/Zoom';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: 180,
-  },
-  container: {
-    display: 'flex',
-  },
-  paper: {
-    margin: theme.spacing(1),
-  },
-  svg: {
-    width: 100,
-    height: 100,
-  },
-  polygon: {
-    fill: theme.palette.common.white,
-    stroke: theme.palette.divider,
-    strokeWidth: 1,
-  },
-}));
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
+);
 
 export default function SimpleZoom() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -35,32 +29,17 @@ export default function SimpleZoom() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 180 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Zoom in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
+      <Box sx={{ display: 'flex' }}>
+        <Zoom in={checked}>{icon}</Zoom>
+        <Zoom in={checked} style={{ transitionDelay: checked ? '500ms' : '0ms' }}>
+          {icon}
         </Zoom>
-        <Zoom
-          in={checked}
-          style={{
-            transitionDelay: checked ? '500ms' : '0ms',
-          }}
-        >
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Zoom>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/pages/components/transitions/SimpleZoom.tsx
+++ b/docs/src/pages/components/transitions/SimpleZoom.tsx
@@ -1,35 +1,27 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Zoom from '@material-ui/core/Zoom';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      height: 180,
-    },
-    container: {
-      display: 'flex',
-    },
-    paper: {
-      margin: theme.spacing(1),
-    },
-    svg: {
-      width: 100,
-      height: 100,
-    },
-    polygon: {
-      fill: theme.palette.common.white,
-      stroke: theme.palette.divider,
-      strokeWidth: 1,
-    },
-  }),
+const icon = (
+  <Paper sx={{ m: 1 }} elevation={4}>
+    <Box component="svg" sx={{ width: 100, height: 100 }}>
+      <Box
+        component="polygon"
+        sx={{
+          fill: (theme) => theme.palette.common.white,
+          stroke: (theme) => theme.palette.divider,
+          strokeWidth: 1,
+        }}
+        points="0,100 50,00, 100,100"
+      />
+    </Box>
+  </Paper>
 );
 
 export default function SimpleZoom() {
-  const classes = useStyles();
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = () => {
@@ -37,32 +29,17 @@ export default function SimpleZoom() {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ height: 180 }}>
       <FormControlLabel
         control={<Switch checked={checked} onChange={handleChange} />}
         label="Show"
       />
-      <div className={classes.container}>
-        <Zoom in={checked}>
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
+      <Box sx={{ display: 'flex' }}>
+        <Zoom in={checked}>{icon}</Zoom>
+        <Zoom in={checked} style={{ transitionDelay: checked ? '500ms' : '0ms' }}>
+          {icon}
         </Zoom>
-        <Zoom
-          in={checked}
-          style={{
-            transitionDelay: checked ? '500ms' : '0ms',
-          }}
-        >
-          <Paper elevation={4} className={classes.paper}>
-            <svg className={classes.svg}>
-              <polygon points="0,100 50,00, 100,100" className={classes.polygon} />
-            </svg>
-          </Paper>
-        </Zoom>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following demos of the Transitions components were migrated:

- [x] Collapse
- [x] Fade
- [x] Grow
- [x] Slide
- [x] Zoom

Related to #16947