### PR TITLE
[docs] Improve coverage of TypeScript theme augmentation

### DIFF
--- a/docs/src/modules/branding/BrandingRoot.tsx
+++ b/docs/src/modules/branding/BrandingRoot.tsx
@@ -32,7 +32,7 @@ interface CustomPaletteOptions {
   greyF3?: string;
 }
 
-declare module '@material-ui/core/styles/createPalette' {
+declare module '@material-ui/core/styles' {
   interface Palette extends CustomPalette {}
   interface PaletteOptions extends CustomPaletteOptions {}
 }

--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -29,12 +29,12 @@ and the un-prefixed shades for the other palette colors.
 You may override the default palette values by including a palette object as part of your theme.
 If any of the:
 
-- [`palette.primary`](/customization/default-theme/?expand-path=$.palette.primary)
-- [`palette.secondary`](/customization/default-theme/?expand-path=$.palette.secondary)
-- [`palette.error`](/customization/default-theme/?expand-path=$.palette.error)
-- [`palette.warning`](/customization/default-theme/?expand-path=$.palette.warning)
-- [`palette.info`](/customization/default-theme/?expand-path=$.palette.info)
-- [`palette.success`](/customization/default-theme/?expand-path=$.palette.success)
+- [`.palette.primary`](/customization/default-theme/?expand-path=$.palette.primary)
+- [`.palette.secondary`](/customization/default-theme/?expand-path=$.palette.secondary)
+- [`.palette.error`](/customization/default-theme/?expand-path=$.palette.error)
+- [`.palette.warning`](/customization/default-theme/?expand-path=$.palette.warning)
+- [`.palette.info`](/customization/default-theme/?expand-path=$.palette.info)
+- [`.palette.success`](/customization/default-theme/?expand-path=$.palette.success)
 
 palette color objects are provided, they will replace the default ones.
 

--- a/docs/src/pages/customization/theming/CustomStyles.js
+++ b/docs/src/pages/customization/theming/CustomStyles.js
@@ -1,31 +1,18 @@
 import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
-import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles';
+import {
+  createMuiTheme,
+  ThemeProvider,
+  experimentalStyled as styled,
+} from '@material-ui/core/styles';
 import { orange } from '@material-ui/core/colors';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
+const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
+  color: theme.status.danger,
+  '&.Mui-checked': {
     color: theme.status.danger,
-    '&$checked': {
-      color: theme.status.danger,
-    },
   },
-  checked: {},
 }));
-
-function CustomCheckbox() {
-  const classes = useStyles();
-
-  return (
-    <Checkbox
-      defaultChecked
-      classes={{
-        root: classes.root,
-        checked: classes.checked,
-      }}
-    />
-  );
-}
 
 const theme = createMuiTheme({
   status: {
@@ -36,7 +23,7 @@ const theme = createMuiTheme({
 export default function CustomStyles() {
   return (
     <ThemeProvider theme={theme}>
-      <CustomCheckbox />
+      <CustomCheckbox defaultChecked />
     </ThemeProvider>
   );
 }

--- a/docs/src/pages/customization/theming/CustomStyles.tsx
+++ b/docs/src/pages/customization/theming/CustomStyles.tsx
@@ -2,10 +2,8 @@ import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import {
   createMuiTheme,
-  makeStyles,
-  createStyles,
-  Theme as AugmentedTheme,
   ThemeProvider,
+  experimentalStyled as styled,
 } from '@material-ui/core/styles';
 import { orange } from '@material-ui/core/colors';
 
@@ -23,31 +21,12 @@ declare module '@material-ui/core/styles' {
   }
 }
 
-const useStyles = makeStyles((theme: AugmentedTheme) =>
-  createStyles({
-    root: {
-      color: theme.status.danger,
-      '&$checked': {
-        color: theme.status.danger,
-      },
-    },
-    checked: {},
-  }),
-);
-
-function CustomCheckbox() {
-  const classes = useStyles();
-
-  return (
-    <Checkbox
-      defaultChecked
-      classes={{
-        root: classes.root,
-        checked: classes.checked,
-      }}
-    />
-  );
-}
+const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
+  color: theme.status.danger,
+  '&.Mui-checked': {
+    color: theme.status.danger,
+  },
+}));
 
 const theme = createMuiTheme({
   status: {
@@ -58,7 +37,7 @@ const theme = createMuiTheme({
 export default function CustomStyles() {
   return (
     <ThemeProvider theme={theme}>
-      <CustomCheckbox />
+      <CustomCheckbox defaultChecked />
     </ThemeProvider>
   );
 }

--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -21,13 +21,13 @@ You can learn more about this in [the API section](/styles/api/#themeprovider).
 Changing the theme configuration variables is the most effective way to match Material-UI to your needs.
 The following sections cover the most important theme variables:
 
-- [Palette](/customization/palette/)
-- [Typography](/customization/typography/)
-- [Spacing](/customization/spacing/)
-- [Breakpoints](/customization/breakpoints/)
-- [z-index](/customization/z-index/)
-- [Components](/customization/theme-components/)
-- [Transitions](/customization/transitions/)
+- [`.palette`](/customization/palette/)
+- [`.typography`](/customization/typography/)
+- [`.spacing`](/customization/spacing/)
+- [`.breakpoints`](/customization/breakpoints/)
+- [`.zIndex`](/customization/z-index/)
+- [`.transitions`](/customization/transitions/)
+- [`.components`](/customization/theme-components/)
 
 You can check out the [default theme section](/customization/default-theme/) to view the default theme in full.
 
@@ -35,6 +35,32 @@ You can check out the [default theme section](/customization/default-theme/) to 
 
 When using Material-UI's theme with the [styling solution](/styles/basics/) or [any others](/guides/interoperability/#themeprovider), it can be convenient to add additional variables to the theme so you can use them everywhere.
 For instance:
+
+```jsx
+const theme = createMuiTheme({
+  status: {
+    danger: orange[500],
+  },
+});
+```
+
+If you are using TypeScript, you would also need to use [module augmentation](/guides/typescript/#customization-of-theme) for the theme to accept the above values.
+
+```tsx
+declare module '@material-ui/core/styles' {
+  interface Theme {
+    status: {
+      danger: string;
+    };
+  }
+  // allow configuration using `createMuiTheme`
+  interface ThemeOptions {
+    status?: {
+      danger?: string;
+    };
+  }
+}
+```
 
 {{"demo": "pages/customization/theming/CustomStyles.js"}}
 

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -232,42 +232,54 @@ Unfortunately due to a [current limitation of TypeScript decorators](https://git
 When adding custom properties to the `Theme`, you may continue to use it in a strongly typed way by exploiting
 [TypeScript's module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
-The following example adds an `appDrawer` prop that is merged into the one exported by `material-ui`:
-
+The following example adds an `appDrawer` prop to theme and `customColors` to palette, that is merged into the one exported by `material-ui`:
+In file:
+**./styles/createMyTheme**:
 ```ts
-import { Breakpoint, Theme } from '@material-ui/core/styles';
+import { ThemeOptions } from "@material-ui/core/styles/createMuiTheme";
+import { createMuiTheme } from "@material-ui/core/styles";
+import React from "react";
 
-declare module '@material-ui/core/styles' {
+//Extending Palette
+declare module "@material-ui/core/styles/createPalette" {
+  interface PaletteOptions {
+    customColors?: {
+      backgroundColor?: string;
+    };
+  }
+  interface Palette {
+    customColors: {
+      backgroundColor: string;
+    };
+  }
+}
+//Extending Theme
+declare module "@material-ui/core/styles/createMuiTheme" {
   interface Theme {
     appDrawer: {
-      width: React.CSSProperties['width'];
-      breakpoint: Breakpoint;
+      width: React.CSSProperties["width"];
     };
   }
   // allow configuration using `createMuiTheme`
   interface ThemeOptions {
     appDrawer?: {
-      width?: React.CSSProperties['width'];
-      breakpoint?: Breakpoint;
+      width?: React.CSSProperties["width"];
     };
   }
 }
-```
-
-And a custom theme factory with additional defaulted options:
-
-**./styles/createMyTheme**:
-
-```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
+  console.log(options);
   return createMuiTheme({
     appDrawer: {
-      width: 225,
-      breakpoint: 'lg',
+      width: 225
     },
-    ...options,
+    palette: {
+      customColors: {
+        backgroundColor: "pink"
+      }
+    },
+    ...options
   });
 }
 ```
@@ -275,11 +287,32 @@ export default function createMyTheme(options: ThemeOptions) {
 This could be used like:
 
 ```ts
-import createMyTheme from './styles/createMyTheme';
+import { red } from "@material-ui/core/colors";
+import createMyTheme from "./createMyTheme";
 
 const theme = createMyTheme({
-  appDrawer: { breakpoint: 'md' },
+  appDrawer: {
+    width: 100
+  },
+  palette: {
+    primary: {
+      main: "#556cd6"
+    },
+    secondary: {
+      main: "#19857b"
+    },
+    error: {
+      main: red.A400
+    },
+    background: {
+      default: "#fff"
+    },
+    customColors:{
+      backgroundColor:"black"
+    }
+  }
 });
+export default theme;
 ```
 
 ## Usage of `component` prop

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -232,54 +232,42 @@ Unfortunately due to a [current limitation of TypeScript decorators](https://git
 When adding custom properties to the `Theme`, you may continue to use it in a strongly typed way by exploiting
 [TypeScript's module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
-The following example adds an `appDrawer` prop to theme and `customColors` to palette, that is merged into the one exported by `material-ui`:
-In file:
-**./styles/createMyTheme**:
-```ts
-import { ThemeOptions } from "@material-ui/core/styles/createMuiTheme";
-import { createMuiTheme } from "@material-ui/core/styles";
-import React from "react";
+The following example adds an `appDrawer` prop that is merged into the one exported by `material-ui`:
 
-//Extending Palette
-declare module "@material-ui/core/styles/createPalette" {
-  interface PaletteOptions {
-    customColors?: {
-      backgroundColor?: string;
-    };
-  }
-  interface Palette {
-    customColors: {
-      backgroundColor: string;
-    };
-  }
-}
-//Extending Theme
-declare module "@material-ui/core/styles/createMuiTheme" {
+```ts
+import { Breakpoint, Theme } from '@material-ui/core/styles';
+
+declare module '@material-ui/core/styles' {
   interface Theme {
     appDrawer: {
-      width: React.CSSProperties["width"];
+      width: React.CSSProperties['width'];
+      breakpoint: Breakpoint;
     };
   }
   // allow configuration using `createMuiTheme`
   interface ThemeOptions {
     appDrawer?: {
-      width?: React.CSSProperties["width"];
+      width?: React.CSSProperties['width'];
+      breakpoint?: Breakpoint;
     };
   }
 }
+```
+
+And a custom theme factory with additional defaulted options:
+
+**./styles/createMyTheme**:
+
+```ts
+import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  console.log(options);
   return createMuiTheme({
     appDrawer: {
-      width: 225
+      width: 225,
+      breakpoint: 'lg',
     },
-    palette: {
-      customColors: {
-        backgroundColor: "pink"
-      }
-    },
-    ...options
+    ...options,
   });
 }
 ```
@@ -287,32 +275,11 @@ export default function createMyTheme(options: ThemeOptions) {
 This could be used like:
 
 ```ts
-import { red } from "@material-ui/core/colors";
-import createMyTheme from "./createMyTheme";
+import createMyTheme from './styles/createMyTheme';
 
 const theme = createMyTheme({
-  appDrawer: {
-    width: 100
-  },
-  palette: {
-    primary: {
-      main: "#556cd6"
-    },
-    secondary: {
-      main: "#19857b"
-    },
-    error: {
-      main: red.A400
-    },
-    background: {
-      default: "#fff"
-    },
-    customColors:{
-      backgroundColor:"black"
-    }
-  }
+  appDrawer: { breakpoint: 'md' },
 });
-export default theme;
 ```
 
 ## Usage of `component` prop


### PR DESCRIPTION
The current theme customization documentation seems incomplete and does not give enough information to users on properly customizing the theme and other props within it. Especially the module augmentation piece doesn't specify specific module names and caused a lot of frustration for me personally (and there might be others who might be feeling the same pain). I have provided a more complete example, with specific extension points as sample for users to theme customization.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
