### PR TITLE
[website] Fix layout shift and improve purpose

### DIFF
--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -59,8 +59,10 @@ function Image(props: ImageProps) {
 function BrandingHero() {
   return (
     <Container>
-      <Typography variant="h1" align="center" sx={{ mt: 9, maxWidth: '19ch', mx: 'auto' }}>
-        We&apos;re are making building UIs more <UnderlinedText>accessible</UnderlinedText>
+      <Typography variant="h1" align="center" sx={{ mt: 9, mx: 'auto' }}>
+        {"We're are making building "}
+        <Box component="span" sx={{ display: { xs: 'none', md: 'block' } }} />
+        UIs more <UnderlinedText>accessible</UnderlinedText>
       </Typography>
       <Typography sx={{ mt: 4, maxWidth: '60ch', mx: 'auto', textAlign: 'center', mb: 15 }}>
         Material-UI started back in 2014 to unify <Link href="https://reactjs.org/">React</Link> and{' '}

--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -59,9 +59,8 @@ function Image(props: ImageProps) {
 function BrandingHero() {
   return (
     <Container>
-      <Typography variant="h1" align="center" sx={{ mt: 9 }}>
-        We&apos;re on a mission to make building UIs with <UnderlinedText>React</UnderlinedText>{' '}
-        fun.
+      <Typography variant="h1" align="center" sx={{ mt: 9, maxWidth: 870, mx: 'auto' }}>
+        We&apos;re are making building UIs more <UnderlinedText>accessible</UnderlinedText>
       </Typography>
       <Typography sx={{ mt: 4, maxWidth: 670, mx: 'auto', textAlign: 'center', mb: 15 }}>
         Material-UI started back in 2014 to unify <Link href="https://reactjs.org/">React</Link> and{' '}

--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -59,10 +59,10 @@ function Image(props: ImageProps) {
 function BrandingHero() {
   return (
     <Container>
-      <Typography variant="h1" align="center" sx={{ mt: 9, maxWidth: 870, mx: 'auto' }}>
+      <Typography variant="h1" align="center" sx={{ mt: 9, maxWidth: '19ch', mx: 'auto' }}>
         We&apos;re are making building UIs more <UnderlinedText>accessible</UnderlinedText>
       </Typography>
-      <Typography sx={{ mt: 4, maxWidth: 670, mx: 'auto', textAlign: 'center', mb: 15 }}>
+      <Typography sx={{ mt: 4, maxWidth: '60ch', mx: 'auto', textAlign: 'center', mb: 15 }}>
         Material-UI started back in 2014 to unify <Link href="https://reactjs.org/">React</Link> and{' '}
         <Link href="https://material.io/design">Material Design</Link>.
         <br />
@@ -364,7 +364,7 @@ function BrandingTeam() {
           }}
         />
         <Typography variant="h2">Team</Typography>
-        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: 700 }}>
+        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: '60ch' }}>
           Material-UI is maintained by a group of invaluable core contributors, with the massive
           support and involvement of the community.
         </Typography>
@@ -444,7 +444,7 @@ function BrandingCompany() {
         <Typography variant="h3">
           <UnderlinedText>Company</UnderlinedText>
         </Typography>
-        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: 700 }}>
+        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: '60ch' }}>
           The development of the project and its ecosystem is guided by an international team.
         </Typography>
         <Grid container spacing={4}>
@@ -503,7 +503,7 @@ function BrandingContributors() {
         <Typography variant="h3">
           Community <UnderlinedText>Contributors</UnderlinedText>
         </Typography>
-        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: 700 }}>
+        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: '60ch' }}>
           Some members of the community have so enriched it, that they deserve special mention.
         </Typography>
         <Grid container spacing={4}>
@@ -611,7 +611,7 @@ function BrandingEmeriti() {
         <Typography variant="h3">
           Community <UnderlinedText>Emeriti</UnderlinedText>
         </Typography>
-        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: 700 }}>
+        <Typography sx={{ mt: 1.5, mb: 7, maxWidth: '60ch' }}>
           We honor some no-longer-active core team members who have made valuable contributons in
           the past. They advise us from time-to-time.
         </Typography>

--- a/docs/pages/branding/pricing.tsx
+++ b/docs/pages/branding/pricing.tsx
@@ -95,7 +95,7 @@ function StartMaterialUi() {
       <Typography component="h1" variant="h2" align="center" sx={{ mt: 8 }}>
         Start using Material-UI <UnderlinedText>for free!</UnderlinedText>
       </Typography>
-      <Typography sx={{ mt: 4, maxWidth: 670, mx: 'auto', textAlign: 'center', mb: 12 }}>
+      <Typography sx={{ mt: 4, maxWidth: '60ch', mx: 'auto', textAlign: 'center', mb: 12 }}>
         The community edition lets you get going right away. Switch to a commercial plan for more
         components & premium support.
       </Typography>
@@ -144,7 +144,7 @@ function Benefits() {
       <Typography
         variant="h3"
         component="div"
-        sx={{ textAlign: 'center', mt: 8, mb: 6, maxWidth: 380, mx: 'auto' }}
+        sx={{ textAlign: 'center', mt: 8, mb: 6, maxWidth: '16ch', mx: 'auto' }}
       >
         Benefits included with all the plans
       </Typography>
@@ -192,7 +192,7 @@ function ComparePlans() {
       <Typography
         sx={{
           mt: 3,
-          maxWidth: 670,
+          maxWidth: '60ch',
           mx: 'auto',
           textAlign: 'center',
           p: { xs: '0 15px', md: 0 },
@@ -243,7 +243,7 @@ function WhatToExpect() {
         }}
       />
       <Container>
-        <Typography variant="h2" sx={{ mb: { xs: 5, md: 10 }, maxWidth: 550 }}>
+        <Typography variant="h2" sx={{ mb: { xs: 5, md: 10 }, maxWidth: '16ch' }}>
           Here&apos;s <UnderlinedText>what to expect</UnderlinedText> from Material-UI
         </Typography>
         <Grid container spacing={5}>

--- a/docs/src/modules/branding/BrandingRoot.tsx
+++ b/docs/src/modules/branding/BrandingRoot.tsx
@@ -119,81 +119,81 @@ theme = createMuiTheme(theme, {
       fontWeight: 700,
       letterSpacing: `${round(-2 / 72)}em`,
       lineHeight: 1.111,
-      fontSize: 44,
+      fontSize: theme.typography.pxToRem(44),
       [theme.breakpoints.up('sm')]: {
-        fontSize: 68,
+        fontSize: theme.typography.pxToRem(68),
       },
       [theme.breakpoints.up('md')]: {
-        fontSize: 72,
+        fontSize: theme.typography.pxToRem(72),
       },
     },
     h2: {
       fontWeight: 700,
       letterSpacing: `${round(-1.5 / 52)}em`,
       lineHeight: 1.154,
-      fontSize: 40,
+      fontSize: theme.typography.pxToRem(40),
       [theme.breakpoints.up('sm')]: {
-        fontSize: 48,
+        fontSize: theme.typography.pxToRem(48),
       },
       [theme.breakpoints.up('md')]: {
-        fontSize: 52,
+        fontSize: theme.typography.pxToRem(52),
       },
     },
     h3: {
       fontWeight: 700,
       letterSpacing: `${round(-1 / 36)}em`,
       lineHeight: 1.222,
-      fontSize: 28,
+      fontSize: theme.typography.pxToRem(28),
       [theme.breakpoints.up('sm')]: {
-        fontSize: 32,
+        fontSize: theme.typography.pxToRem(32),
       },
       [theme.breakpoints.up('md')]: {
-        fontSize: 36,
+        fontSize: theme.typography.pxToRem(36),
       },
     },
     h4: {
       fontWeight: 700,
       letterSpacing: `${round(-0.5 / 24)}em`,
       lineHeight: 1.25,
-      fontSize: 24,
+      fontSize: theme.typography.pxToRem(24),
     },
     h5: {
       fontWeight: 600,
       letterSpacing: `${round(-0.25 / 20)}em`,
       lineHeight: 1.3,
-      fontSize: 20,
+      fontSize: theme.typography.pxToRem(20),
     },
     h6: undefined,
     subtitle1: undefined,
     subtitle2: undefined,
     button: {
       fontWeight: 600,
-      fontSize: 16,
+      fontSize: theme.typography.pxToRem(16),
       lineHeight: 1.25,
     },
     body1: {
-      fontSize: 16,
+      fontSize: theme.typography.pxToRem(16),
       [theme.breakpoints.up('sm')]: {
-        fontSize: 18,
+        fontSize: theme.typography.pxToRem(18),
       },
     },
     body2: {
-      fontSize: 14,
+      fontSize: theme.typography.pxToRem(14),
       [theme.breakpoints.up('sm')]: {
-        fontSize: 16,
+        fontSize: theme.typography.pxToRem(16),
       },
     },
     body3: {
-      fontSize: 14,
+      fontSize: theme.typography.pxToRem(14),
     },
   },
   components: {
     MuiInputBase: {
       styleOverrides: {
         root: {
-          fontSize: 16,
+          fontSize: theme.typography.pxToRem(16),
           [theme.breakpoints.up('sm')]: {
-            fontSize: 16,
+            fontSize: theme.typography.pxToRem(16),
           },
         },
       },
@@ -269,7 +269,7 @@ theme = createMuiTheme(theme, {
           props: { size: 'small' },
           style: {
             padding: '8px 16px',
-            fontSize: 14,
+            fontSize: theme.typography.pxToRem(14),
             fontWeight: 700,
           },
         },
@@ -278,7 +278,7 @@ theme = createMuiTheme(theme, {
           style: {
             padding: '14px 22px',
             boxShadow: '0 2px 3px rgba(0, 30, 60, 0.08)',
-            fontSize: 18,
+            fontSize: theme.typography.pxToRem(18),
             fontWeight: 700,
           },
         },
@@ -309,7 +309,7 @@ theme = createMuiTheme(theme, {
         tooltip: {
           padding: '12px',
           fontWeight: 'normal',
-          fontSize: 14,
+          fontSize: theme.typography.pxToRem(14),
           lineHeight: '20px',
           color: theme.palette.secondary.contrastText,
           backgroundColor: theme.palette.secondary.main,

--- a/docs/src/modules/branding/UnderlinedText.tsx
+++ b/docs/src/modules/branding/UnderlinedText.tsx
@@ -7,7 +7,7 @@ const UnderlinedText = styled('span')(({ theme }) => ({
   )} 75%)`,
   backgroundPosition: '0 0.9em',
   backgroundRepeat: 'repeat-x',
-  backgroundSize: '2px 10px',
+  backgroundSize: '1px 0.147em',
 }));
 
 export default UnderlinedText;

--- a/docs/src/modules/branding/UnderlinedText.tsx
+++ b/docs/src/modules/branding/UnderlinedText.tsx
@@ -1,6 +1,6 @@
 import { experimentalStyled as styled, alpha } from '@material-ui/core/styles';
 
-const UnderlinedText = styled('span')<{}>(({ theme }) => ({
+const UnderlinedText = styled('span')(({ theme }) => ({
   backgroundImage: `linear-gradient(to right, ${alpha(theme.palette.vividBlue, 0.4)} 75%, ${alpha(
     theme.palette.vividBlue,
     0.4,


### PR DESCRIPTION
The bug I went after:

![layout shift](https://user-images.githubusercontent.com/3165635/112396658-d64fc300-8d00-11eb-8b5c-c715996a3a49.gif)

Adding a max-width creates more constraints and reduces the intensity of the layout change once the font loads.