### PR TITLE
[pickers][internal] Move own internals from lab internals to dedicated file

### DIFF
--- a/docs/pages/api-docs/clock-picker.json
+++ b/docs/pages/api-docs/clock-picker.json
@@ -15,7 +15,7 @@
     "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getHoursClockNumberText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -40,7 +40,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -32,7 +32,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/desktop-time-picker.json
+++ b/docs/pages/api-docs/desktop-time-picker.json
@@ -20,7 +20,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -36,7 +36,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/mobile-time-picker.json
+++ b/docs/pages/api-docs/mobile-time-picker.json
@@ -24,7 +24,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -36,7 +36,7 @@
     },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/static-time-picker.json
+++ b/docs/pages/api-docs/static-time-picker.json
@@ -24,7 +24,7 @@
     },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/time-picker.json
+++ b/docs/pages/api-docs/time-picker.json
@@ -28,7 +28,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: 'hours' | 'minutes' | 'seconds',\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -6,7 +6,6 @@ import Typography from '@material-ui/core/Typography';
 import { MuiStyles, StyleRules, WithStyles, withStyles } from '@material-ui/core/styles';
 import ClockPointer from './ClockPointer';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
-import { ClockViewType } from '../internal/pickers/constants/ClockType';
 import { getHours, getMinutes } from '../internal/pickers/time-utils';
 import { useGlobalKeyDown, keycode } from '../internal/pickers/hooks/useKeyDown';
 import {
@@ -15,23 +14,20 @@ import {
 } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { PickerSelectionState } from '../internal/pickers/hooks/usePickerState';
 import { useMeridiemMode } from '../internal/pickers/hooks/date-helpers-hooks';
+import { ClockView } from './shared';
 
 export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
   date: TDate | null;
-  type: ClockViewType;
+  type: ClockView;
   value: number;
-  isTimeDisabled: (timeValue: number, type: ClockViewType) => boolean;
+  isTimeDisabled: (timeValue: number, type: ClockView) => boolean;
   children: React.ReactNode[];
   onChange: (value: number, isFinish?: PickerSelectionState) => void;
   ampm: boolean;
   minutesStep?: number;
   ampmInClock: boolean;
   allowKeyboardControl?: boolean;
-  getClockLabelText: (
-    view: 'hours' | 'minutes' | 'seconds',
-    time: TDate,
-    adapter: MuiPickersAdapter<TDate>,
-  ) => string;
+  getClockLabelText: (view: ClockView, time: TDate, adapter: MuiPickersAdapter<TDate>) => string;
 }
 
 export type ClockClassKey =

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -16,17 +16,17 @@ import { useMeridiemMode } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ClockView, getHours, getMinutes } from './shared';
 
 export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
+  allowKeyboardControl?: boolean;
+  ampm: boolean;
+  ampmInClock: boolean;
+  children: React.ReactNode[];
   date: TDate | null;
+  getClockLabelText: (view: ClockView, time: TDate, adapter: MuiPickersAdapter<TDate>) => string;
+  isTimeDisabled: (timeValue: number, type: ClockView) => boolean;
+  minutesStep?: number;
+  onChange: (value: number, isFinish?: PickerSelectionState) => void;
   type: ClockView;
   value: number;
-  isTimeDisabled: (timeValue: number, type: ClockView) => boolean;
-  children: React.ReactNode[];
-  onChange: (value: number, isFinish?: PickerSelectionState) => void;
-  ampm: boolean;
-  minutesStep?: number;
-  ampmInClock: boolean;
-  allowKeyboardControl?: boolean;
-  getClockLabelText: (view: ClockView, time: TDate, adapter: MuiPickersAdapter<TDate>) => string;
 }
 
 export type ClockClassKey =

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -6,7 +6,6 @@ import Typography from '@material-ui/core/Typography';
 import { MuiStyles, StyleRules, WithStyles, withStyles } from '@material-ui/core/styles';
 import ClockPointer from './ClockPointer';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
-import { getHours, getMinutes } from '../internal/pickers/time-utils';
 import { useGlobalKeyDown, keycode } from '../internal/pickers/hooks/useKeyDown';
 import {
   WrapperVariantContext,
@@ -14,7 +13,7 @@ import {
 } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { PickerSelectionState } from '../internal/pickers/hooks/usePickerState';
 import { useMeridiemMode } from '../internal/pickers/hooks/date-helpers-hooks';
-import { ClockView } from './shared';
+import { ClockView, getHours, getMinutes } from './shared';
 
 export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
   date: TDate | null;

--- a/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { MuiStyles, StyleRules, WithStyles, withStyles } from '@material-ui/core/styles';
-import { CLOCK_WIDTH, CLOCK_HOUR_WIDTH } from '../internal/pickers/constants/dimensions';
+import { CLOCK_WIDTH, CLOCK_HOUR_WIDTH } from './shared';
 
 export interface ClockNumberProps {
   disabled: boolean;

--- a/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
@@ -9,6 +9,7 @@ export interface ClockNumberProps {
   inner: boolean;
   label: string;
   selected: boolean;
+  // TODO: spread to a `span`. What are the implications (generic role etc.)
   'aria-label': string;
 }
 

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -40,7 +40,7 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
@@ -388,7 +388,7 @@ ClockPicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -14,6 +14,7 @@ import {
 import { PickerOnChangeFn } from '../internal/pickers/hooks/useViews';
 import { PickerSelectionState } from '../internal/pickers/hooks/usePickerState';
 import { useMeridiemMode } from '../internal/pickers/hooks/date-helpers-hooks';
+import { ClockView } from './shared';
 
 export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDate> {
   /**
@@ -44,11 +45,7 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
-  getClockLabelText?: (
-    view: 'hours' | 'minutes' | 'seconds',
-    time: TDate,
-    adapter: MuiPickersAdapter<TDate>,
-  ) => string;
+  getClockLabelText?: (view: ClockView, time: TDate, adapter: MuiPickersAdapter<TDate>) => string;
 }
 
 export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate> {
@@ -109,7 +106,7 @@ export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate>
    */
   rightArrowButtonText?: string;
   showViewSwitcher?: boolean;
-  view: 'hours' | 'minutes' | 'seconds';
+  view: ClockView;
 }
 
 export const styles: MuiStyles<'arrowSwitcher'> = {
@@ -121,7 +118,7 @@ export const styles: MuiStyles<'arrowSwitcher'> = {
 };
 
 const defaultGetClockLabelText = <TDate extends any>(
-  view: 'hours' | 'minutes' | 'seconds',
+  view: ClockView,
   time: TDate,
   adapter: MuiPickersAdapter<TDate>,
 ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`;
@@ -174,7 +171,7 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode<TDate>(dateOrNow, ampm, onChange);
 
   const isTimeDisabled = React.useCallback(
-    (rawValue: number, viewType: 'hours' | 'minutes' | 'seconds') => {
+    (rawValue: number, viewType: ClockView) => {
       if (date === null) {
         return false;
       }

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -76,10 +76,6 @@ export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate>
    */
   date: TDate | null;
   /**
-   * On change callback @DateIOType.
-   */
-  onChange: PickerOnChangeFn<TDate>;
-  /**
    * Get clock number aria-text for hours.
    * @default (hours: string) => `${hours} hours`
    */
@@ -99,18 +95,21 @@ export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate>
    * @default 'open previous view'
    */
   leftArrowButtonText?: string;
+  previousViewAvailable: boolean;
+  nextViewAvailable: boolean;
+  /**
+   * On change callback @DateIOType.
+   */
+  onChange: PickerOnChangeFn<TDate>;
   openNextView: () => void;
   openPreviousView: () => void;
-
   /**
    * Right arrow icon aria-label text.
    * @default 'open next view'
    */
   rightArrowButtonText?: string;
-  view: 'hours' | 'minutes' | 'seconds';
-  nextViewAvailable: boolean;
-  previousViewAvailable: boolean;
   showViewSwitcher?: boolean;
+  view: 'hours' | 'minutes' | 'seconds';
 }
 
 export const styles: MuiStyles<'arrowSwitcher'> = {

--- a/packages/material-ui-lab/src/ClockPicker/ClockPickerStandalone.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPickerStandalone.tsx
@@ -9,15 +9,23 @@ export interface ClockPickerStandaloneProps<TDate>
     ClockPickerProps<TDate>,
     'view' | 'openNextView' | 'openPreviousView' | 'nextViewAvailable' | 'previousViewAvailable'
   > {
-  /** Controlled clock view. */
-  view?: TimePickerView;
-  /** Available views for clock. */
-  views?: TimePickerView[];
-  /** Callback fired on view change. */
-  onViewChange?: (view: TimePickerView) => void;
-  /** Initially opened view. */
-  openTo?: TimePickerView;
   className?: string;
+  /**
+   * Callback fired on view change.
+   */
+  onViewChange?: (view: TimePickerView) => void;
+  /**
+   * Initially opened view.
+   */
+  openTo?: TimePickerView;
+  /**
+   * Controlled clock view.
+   */
+  view?: TimePickerView;
+  /**
+   * Available views for clock.
+   */
+  views?: TimePickerView[];
 }
 
 /**

--- a/packages/material-ui-lab/src/ClockPicker/ClockPickerStandalone.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPickerStandalone.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ClockPicker, { ClockPickerProps } from './ClockPicker';
-import { TimePickerView } from '../internal/pickers/typings/Views';
+import { ClockView } from './shared';
 import PickerView from '../internal/pickers/Picker/PickerView';
 import { useViews } from '../internal/pickers/hooks/useViews';
 
@@ -13,19 +13,19 @@ export interface ClockPickerStandaloneProps<TDate>
   /**
    * Callback fired on view change.
    */
-  onViewChange?: (view: TimePickerView) => void;
+  onViewChange?: (view: ClockView) => void;
   /**
    * Initially opened view.
    */
-  openTo?: TimePickerView;
+  openTo?: ClockView;
   /**
    * Controlled clock view.
    */
-  view?: TimePickerView;
+  view?: ClockView;
   /**
    * Available views for clock.
    */
-  views?: TimePickerView[];
+  views?: ClockView[];
 }
 
 /**
@@ -41,7 +41,7 @@ export default React.forwardRef(function ClockPickerStandalone<TDate>(
     openTo,
     className,
     onViewChange,
-    views = ['hours', 'minutes'] as TimePickerView[],
+    views = ['hours', 'minutes'] as ClockView[],
     ...other
   } = props;
 

--- a/packages/material-ui-lab/src/ClockPicker/ClockPointer.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPointer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { StyleRules, MuiStyles, withStyles, WithStyles } from '@material-ui/core/styles';
 import { CLOCK_WIDTH, CLOCK_HOUR_WIDTH } from '../internal/pickers/constants/dimensions';
-import { ClockViewType } from '../internal/pickers/constants/ClockType';
+import { ClockView } from './shared';
 
 export type ClockPointerClassKey = 'root' | 'animateTransform' | 'thumb' | 'noPoint';
 
@@ -41,7 +41,7 @@ export interface ClockPointerProps
     WithStyles<typeof styles> {
   hasSelected: boolean;
   isInner: boolean;
-  type: ClockViewType;
+  type: ClockView;
   value: number;
 }
 

--- a/packages/material-ui-lab/src/ClockPicker/ClockPointer.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPointer.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { StyleRules, MuiStyles, withStyles, WithStyles } from '@material-ui/core/styles';
-import { CLOCK_WIDTH, CLOCK_HOUR_WIDTH } from '../internal/pickers/constants/dimensions';
-import { ClockView } from './shared';
+import { ClockView, CLOCK_WIDTH, CLOCK_HOUR_WIDTH } from './shared';
 
 export type ClockPointerClassKey = 'root' | 'animateTransform' | 'thumb' | 'noPoint';
 

--- a/packages/material-ui-lab/src/ClockPicker/index.ts
+++ b/packages/material-ui-lab/src/ClockPicker/index.ts
@@ -3,3 +3,4 @@ export { default } from './ClockPickerStandalone';
 export type ClockPickerProps<
   TDate
 > = import('./ClockPickerStandalone').ClockPickerStandaloneProps<TDate>;
+export type ClockPickerView = NonNullable<ClockPickerProps<unknown>['view']>;

--- a/packages/material-ui-lab/src/ClockPicker/shared.ts
+++ b/packages/material-ui-lab/src/ClockPicker/shared.ts
@@ -1,0 +1,1 @@
+export type ClockView = 'hours' | 'minutes' | 'seconds';

--- a/packages/material-ui-lab/src/ClockPicker/shared.ts
+++ b/packages/material-ui-lab/src/ClockPicker/shared.ts
@@ -1,1 +1,59 @@
+import { CLOCK_WIDTH } from '../internal/pickers/constants/dimensions';
+
 export type ClockView = 'hours' | 'minutes' | 'seconds';
+
+const clockCenter = {
+  x: CLOCK_WIDTH / 2,
+  y: CLOCK_WIDTH / 2,
+};
+
+const baseClockPoint = {
+  x: clockCenter.x,
+  y: 0,
+};
+
+const cx = baseClockPoint.x - clockCenter.x;
+const cy = baseClockPoint.y - clockCenter.y;
+
+const rad2deg = (rad: number) => rad * 57.29577951308232;
+
+const getAngleValue = (step: number, offsetX: number, offsetY: number) => {
+  const x = offsetX - clockCenter.x;
+  const y = offsetY - clockCenter.y;
+
+  const atan = Math.atan2(cx, cy) - Math.atan2(x, y);
+
+  let deg = rad2deg(atan);
+  deg = Math.round(deg / step) * step;
+  deg %= 360;
+
+  const value = Math.floor(deg / step) || 0;
+  const delta = x ** 2 + y ** 2;
+  const distance = Math.sqrt(delta);
+
+  return { value, distance };
+};
+
+export const getMinutes = (offsetX: number, offsetY: number, step = 1) => {
+  const angleStep = step * 6;
+  let { value } = getAngleValue(angleStep, offsetX, offsetY);
+  value = (value * step) % 60;
+
+  return value;
+};
+
+export const getHours = (offsetX: number, offsetY: number, ampm: boolean) => {
+  const { value, distance } = getAngleValue(30, offsetX, offsetY);
+  let hour = value || 12;
+
+  if (!ampm) {
+    if (distance < 90) {
+      hour += 12;
+      hour %= 24;
+    }
+  } else {
+    hour %= 12;
+  }
+
+  return hour;
+};

--- a/packages/material-ui-lab/src/ClockPicker/shared.ts
+++ b/packages/material-ui-lab/src/ClockPicker/shared.ts
@@ -16,7 +16,7 @@ const baseClockPoint = {
 const cx = baseClockPoint.x - clockCenter.x;
 const cy = baseClockPoint.y - clockCenter.y;
 
-const rad2deg = (rad: number) => rad * 57.29577951308232;
+const rad2deg = (rad: number) => rad * (180 / Math.PI);
 
 const getAngleValue = (step: number, offsetX: number, offsetY: number) => {
   const x = offsetX - clockCenter.x;

--- a/packages/material-ui-lab/src/ClockPicker/shared.ts
+++ b/packages/material-ui-lab/src/ClockPicker/shared.ts
@@ -1,4 +1,5 @@
-import { CLOCK_WIDTH } from '../internal/pickers/constants/dimensions';
+export const CLOCK_WIDTH = 220;
+export const CLOCK_HOUR_WIDTH = 36;
 
 export type ClockView = 'hours' | 'minutes' | 'seconds';
 

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -20,7 +20,6 @@ import {
   defaultMaxDate,
 } from '../internal/pickers/constants/prop-types';
 import {
-  getFormatAndMaskByViews,
   DateValidationError,
   validateDate,
   parsePickerInputValue,
@@ -29,6 +28,7 @@ import Picker from '../internal/pickers/Picker/Picker';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
+import { getFormatAndMaskByViews } from './shared';
 
 type AllResponsiveDatePickerProps = BaseDatePickerProps<unknown> &
   AllSharedPickerProps &

--- a/packages/material-ui-lab/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePickerToolbar.tsx
@@ -4,9 +4,9 @@ import Typography from '@material-ui/core/Typography';
 import { MuiStyles, WithStyles, withStyles } from '@material-ui/core/styles';
 import PickersToolbar from '../internal/pickers/PickersToolbar';
 import { useUtils } from '../internal/pickers/hooks/useUtils';
-import { isYearAndMonthViews, isYearOnlyView } from '../internal/pickers/date-utils';
-import { DatePickerView } from '../internal/pickers/typings/Views';
 import { ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
+import { isYearAndMonthViews, isYearOnlyView } from './shared';
+import { DayPickerView } from '../DayPicker';
 
 export type DatePickerToolbarClassKey = 'root' | 'dateTitleLandscape' | 'penIcon';
 
@@ -48,11 +48,11 @@ const DatePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
       return utils.formatByString(date, toolbarFormat);
     }
 
-    if (isYearOnlyView(views as DatePickerView[])) {
+    if (isYearOnlyView(views as DayPickerView[])) {
       return utils.format(date, 'year');
     }
 
-    if (isYearAndMonthViews(views as DatePickerView[])) {
+    if (isYearAndMonthViews(views as DayPickerView[])) {
       return utils.format(date, 'month');
     }
 

--- a/packages/material-ui-lab/src/DatePicker/shared.ts
+++ b/packages/material-ui-lab/src/DatePicker/shared.ts
@@ -1,0 +1,34 @@
+import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
+import { DayPickerView } from '../DayPicker';
+
+export const isYearOnlyView = (views: readonly DayPickerView[]): views is ReadonlyArray<'year'> =>
+  views.length === 1 && views[0] === 'year';
+
+export const isYearAndMonthViews = (
+  views: readonly DayPickerView[],
+): views is ReadonlyArray<'month' | 'year'> =>
+  views.length === 2 && views.indexOf('month') !== -1 && views.indexOf('year') !== -1;
+
+export const getFormatAndMaskByViews = (
+  views: readonly DayPickerView[],
+  utils: MuiPickersAdapter,
+) => {
+  if (isYearOnlyView(views)) {
+    return {
+      mask: '____',
+      inputFormat: utils.formats.year,
+    };
+  }
+
+  if (isYearAndMonthViews(views)) {
+    return {
+      disableMaskedInput: true,
+      inputFormat: utils.formats.monthAndYear,
+    };
+  }
+
+  return {
+    mask: '__/__/____',
+    inputFormat: utils.formats.keyboardDate,
+  };
+};

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -336,7 +336,7 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -7,7 +7,7 @@ import { MuiStyles, WithStyles, withStyles, useTheme, StyleRules } from '@materi
 import TimeIcon from '../internal/svg-icons/Time';
 import DateRangeIcon from '../internal/svg-icons/DateRange';
 import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
-import { DateTimePickerView } from '../internal/pickers/typings/Views';
+import { DateTimePickerView } from './shared';
 
 const viewToTabIndex = (openView: DateTimePickerView) => {
   if (openView === 'date' || openView === 'year') {

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -7,7 +7,7 @@ import DateTimePickerTabs from './DateTimePickerTabs';
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
-import { DateTimePickerView } from '../internal/pickers/typings/Views';
+import { DateTimePickerView } from './shared';
 
 export const styles: MuiStyles<
   'root' | 'separator' | 'timeContainer' | 'dateContainer' | 'timeTypography' | 'penIcon'

--- a/packages/material-ui-lab/src/DateTimePicker/shared.ts
+++ b/packages/material-ui-lab/src/DateTimePicker/shared.ts
@@ -1,0 +1,1 @@
+export type DateTimePickerView = 'year' | 'date' | 'month' | 'hours' | 'minutes';

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -14,10 +14,10 @@ import YearPicker, { ExportedYearPickerProps } from '../YearPicker/YearPicker';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
 import { IsStaticVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { findClosestEnabledDate } from '../internal/pickers/date-utils';
-import { DatePickerView } from '../internal/pickers/typings/Views';
+import { DayPickerView } from './shared';
 import PickerView from '../internal/pickers/Picker/PickerView';
 
-export interface DayPickerProps<TDate, TView extends DatePickerView = DatePickerView>
+export interface DayPickerProps<TDate, TView extends DayPickerView = DayPickerView>
   extends ExportedCalendarProps<TDate>,
     ExportedYearPickerProps<TDate>,
     ExportedCalendarHeaderProps<TDate> {
@@ -123,7 +123,7 @@ export const defaultReduceAnimations =
 
 const DayPicker = React.forwardRef(function DayPicker<
   TDate extends any,
-  TView extends DatePickerView = DatePickerView
+  TView extends DayPickerView = DayPickerView
 >(props: DayPickerProps<TDate, TView> & WithStyles<typeof styles>, ref: React.Ref<HTMLDivElement>) {
   const {
     allowKeyboardControl: allowKeyboardControlProp,
@@ -216,7 +216,7 @@ const DayPicker = React.forwardRef(function DayPicker<
         views={views}
         openView={openView}
         currentMonth={calendarState.currentMonth}
-        onViewChange={setOpenView as (view: DatePickerView) => void}
+        onViewChange={setOpenView as (view: DayPickerView) => void}
         onMonthChange={(newMonth, direction) => handleChangeMonth({ newMonth, direction })}
         minDate={minDate}
         maxDate={maxDate}

--- a/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
@@ -17,7 +17,7 @@ import {
   usePreviousMonthDisabled,
   useNextMonthDisabled,
 } from '../internal/pickers/hooks/date-helpers-hooks';
-import { DatePickerView } from '../internal/pickers/typings/Views';
+import { DayPickerView } from './shared';
 
 export type ExportedCalendarHeaderProps<TDate> = Pick<
   PickersCalendarHeaderProps<TDate>,
@@ -48,15 +48,15 @@ export interface PickersCalendarHeaderProps<TDate>
     switchViewButton?: any;
   };
   currentMonth: TDate;
-  views: DatePickerView[];
+  views: DayPickerView[];
   /**
    * Get aria-label text for switching between views button.
    */
-  getViewSwitchingButtonText?: (currentView: DatePickerView) => string;
+  getViewSwitchingButtonText?: (currentView: DayPickerView) => string;
   onMonthChange: (date: TDate, slideDirection: SlideDirection) => void;
-  openView: DatePickerView;
+  openView: DayPickerView;
   reduceAnimations: boolean;
-  onViewChange?: (view: DatePickerView) => void;
+  onViewChange?: (view: DayPickerView) => void;
 }
 
 export type PickersCalendarHeaderClassKey =
@@ -107,7 +107,7 @@ export const styles: MuiStyles<PickersCalendarHeaderClassKey> = (
   },
 });
 
-function getSwitchingViewAriaText(view: DatePickerView) {
+function getSwitchingViewAriaText(view: DayPickerView) {
   return view === 'year'
     ? 'year view is open, switch to calendar view'
     : 'calendar view is open, switch to year view';

--- a/packages/material-ui-lab/src/DayPicker/index.ts
+++ b/packages/material-ui-lab/src/DayPicker/index.ts
@@ -2,3 +2,4 @@ export { default } from './DayPicker';
 
 export type DayPickerClassKey = import('./DayPicker').DayPickerClassKey;
 export type DayPickerProps<TDate> = import('./DayPicker').DayPickerProps<TDate>;
+export type DayPickerView = NonNullable<DayPickerProps<unknown>['view']>;

--- a/packages/material-ui-lab/src/DayPicker/shared.ts
+++ b/packages/material-ui-lab/src/DayPicker/shared.ts
@@ -1,0 +1,1 @@
+export type DayPickerView = 'year' | 'date' | 'month';

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -190,7 +190,7 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -142,7 +142,7 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -209,7 +209,7 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -161,7 +161,7 @@ MobileTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -195,7 +195,7 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -147,7 +147,7 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -241,7 +241,7 @@ TimePicker.propTypes /* remove-proptypes */ = {
   /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
-   *   view: 'hours' | 'minutes' | 'seconds',
+   *   view: ClockView,
    *   time: TDate,
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { MuiStyles, styled, WithStyles, withStyles } from '@material-ui/core/styles';
 import { useViews } from '../hooks/useViews';
-import ClockPicker, { ClockPickerProps } from '../../../ClockPicker/ClockPicker';
-import DayPicker from '../../../DayPicker/DayPicker';
+import ClockPicker from '../../../ClockPicker/ClockPicker';
+import { ClockPickerView } from '../../../ClockPicker';
+import DayPicker, { DayPickerView } from '../../../DayPicker';
 import { KeyboardDateInput } from '../KeyboardDateInput';
 import { useIsLandscape } from '../hooks/useIsLandscape';
 import { DIALOG_WIDTH, VIEW_HEIGHT } from '../constants/dimensions';
@@ -12,7 +13,7 @@ import { DateInputPropsLike } from '../wrappers/WrapperProps';
 import { PickerSelectionState } from '../hooks/usePickerState';
 import { BasePickerProps, CalendarAndClockProps } from '../typings/BasePicker';
 import { WithViewsProps } from './SharedPickerProps';
-import { AllAvailableViews, DatePickerView } from '../typings/Views';
+import { AllAvailableViews } from '../typings/Views';
 import PickerView from './PickerView';
 
 export interface ExportedPickerProps<TView extends AllAvailableViews>
@@ -65,10 +66,10 @@ export const styles: MuiStyles<PickerClassKey> = {
 
 const MobileKeyboardTextFieldProps = { fullWidth: true };
 
-const isDatePickerView = (view: AllAvailableViews): view is DatePickerView =>
+const isDatePickerView = (view: AllAvailableViews): view is DayPickerView =>
   view === 'year' || view === 'month' || view === 'date';
 
-const isTimePickerView = (view: AllAvailableViews): view is ClockPickerProps<unknown>['view'] =>
+const isTimePickerView = (view: AllAvailableViews): view is ClockPickerView =>
   view === 'hours' || view === 'minutes' || view === 'seconds';
 
 function Picker({

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { MuiStyles, styled, WithStyles, withStyles } from '@material-ui/core/styles';
 import { useViews } from '../hooks/useViews';
-import ClockPicker from '../../../ClockPicker/ClockPicker';
+import ClockPicker, { ClockPickerProps } from '../../../ClockPicker/ClockPicker';
 import DayPicker from '../../../DayPicker/DayPicker';
 import { KeyboardDateInput } from '../KeyboardDateInput';
 import { useIsLandscape } from '../hooks/useIsLandscape';
@@ -12,7 +12,7 @@ import { DateInputPropsLike } from '../wrappers/WrapperProps';
 import { PickerSelectionState } from '../hooks/usePickerState';
 import { BasePickerProps, CalendarAndClockProps } from '../typings/BasePicker';
 import { WithViewsProps } from './SharedPickerProps';
-import { AllAvailableViews, TimePickerView, DatePickerView } from '../typings/Views';
+import { AllAvailableViews, DatePickerView } from '../typings/Views';
 import PickerView from './PickerView';
 
 export interface ExportedPickerProps<TView extends AllAvailableViews>
@@ -68,7 +68,7 @@ const MobileKeyboardTextFieldProps = { fullWidth: true };
 const isDatePickerView = (view: AllAvailableViews): view is DatePickerView =>
   view === 'year' || view === 'month' || view === 'date';
 
-const isTimePickerView = (view: AllAvailableViews): view is TimePickerView =>
+const isTimePickerView = (view: AllAvailableViews): view is ClockPickerProps<unknown>['view'] =>
   view === 'hours' || view === 'minutes' || view === 'seconds';
 
 function Picker({

--- a/packages/material-ui-lab/src/internal/pickers/constants/ClockType.ts
+++ b/packages/material-ui-lab/src/internal/pickers/constants/ClockType.ts
@@ -1,1 +1,0 @@
-export type ClockViewType = 'hours' | 'minutes' | 'seconds';

--- a/packages/material-ui-lab/src/internal/pickers/constants/dimensions.ts
+++ b/packages/material-ui-lab/src/internal/pickers/constants/dimensions.ts
@@ -1,5 +1,3 @@
-export const CLOCK_WIDTH = 220;
-export const CLOCK_HOUR_WIDTH = 36;
 export const DAY_SIZE = 36;
 export const DAY_MARGIN = 2;
 export const DIALOG_WIDTH = 320;

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.ts
@@ -1,7 +1,5 @@
 import { RangeInput, NonEmptyDateRange, DateRange } from '../../DateRangePicker/RangeTypes';
-import { arrayIncludes } from './utils';
 import { ParsableDate } from './constants/prop-types';
-import { DatePickerView } from './typings/Views';
 import { MuiPickersAdapter } from './hooks/useUtils';
 
 interface FindClosestDateParams<TDate> {
@@ -73,36 +71,6 @@ export const findClosestEnabledDate = <TDate>({
 
   // fallback to today if no enabled days
   return utils.date();
-};
-
-export const isYearOnlyView = (views: readonly DatePickerView[]) =>
-  views.length === 1 && views[0] === 'year';
-
-export const isYearAndMonthViews = (views: readonly DatePickerView[]) =>
-  views.length === 2 && arrayIncludes(views, 'month') && arrayIncludes(views, 'year');
-
-export const getFormatAndMaskByViews = (
-  views: readonly DatePickerView[],
-  utils: MuiPickersAdapter,
-) => {
-  if (isYearOnlyView(views)) {
-    return {
-      mask: '____',
-      inputFormat: utils.formats.year,
-    };
-  }
-
-  if (isYearAndMonthViews(views)) {
-    return {
-      disableMaskedInput: true,
-      inputFormat: utils.formats.monthAndYear,
-    };
-  }
-
-  return {
-    mask: '__/__/____',
-    inputFormat: utils.formats.keyboardDate,
-  };
 };
 
 export function parsePickerInputValue(utils: MuiPickersAdapter, value: unknown): unknown {

--- a/packages/material-ui-lab/src/internal/pickers/time-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/time-utils.ts
@@ -1,5 +1,4 @@
 import { ParsableDate } from './constants/prop-types';
-import { CLOCK_WIDTH } from './constants/dimensions';
 import { MuiPickersAdapter } from './hooks/useUtils';
 
 type Meridiem = 'am' | 'pm' | null;
@@ -31,62 +30,6 @@ export const convertToMeridiem = <TDate>(
 ) => {
   const newHoursAmount = convertValueToMeridiem(utils.getHours(time), meridiem, ampm);
   return utils.setHours(time, newHoursAmount);
-};
-
-const clockCenter = {
-  x: CLOCK_WIDTH / 2,
-  y: CLOCK_WIDTH / 2,
-};
-
-const baseClockPoint = {
-  x: clockCenter.x,
-  y: 0,
-};
-
-const cx = baseClockPoint.x - clockCenter.x;
-const cy = baseClockPoint.y - clockCenter.y;
-
-const rad2deg = (rad: number) => rad * 57.29577951308232;
-
-const getAngleValue = (step: number, offsetX: number, offsetY: number) => {
-  const x = offsetX - clockCenter.x;
-  const y = offsetY - clockCenter.y;
-
-  const atan = Math.atan2(cx, cy) - Math.atan2(x, y);
-
-  let deg = rad2deg(atan);
-  deg = Math.round(deg / step) * step;
-  deg %= 360;
-
-  const value = Math.floor(deg / step) || 0;
-  const delta = x ** 2 + y ** 2;
-  const distance = Math.sqrt(delta);
-
-  return { value, distance };
-};
-
-export const getMinutes = (offsetX: number, offsetY: number, step = 1) => {
-  const angleStep = step * 6;
-  let { value } = getAngleValue(angleStep, offsetX, offsetY);
-  value = (value * step) % 60;
-
-  return value;
-};
-
-export const getHours = (offsetX: number, offsetY: number, ampm: boolean) => {
-  const { value, distance } = getAngleValue(30, offsetX, offsetY);
-  let hour = value || 12;
-
-  if (!ampm) {
-    if (distance < 90) {
-      hour += 12;
-      hour %= 24;
-    }
-  } else {
-    hour %= 12;
-  }
-
-  return hour;
 };
 
 export function getSecondsInDay(date: unknown, utils: MuiPickersAdapter) {

--- a/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
+++ b/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
@@ -1,3 +1,1 @@
 export type AllAvailableViews = 'year' | 'date' | 'month' | 'hours' | 'minutes' | 'seconds';
-
-export type DatePickerView = 'year' | 'date' | 'month';

--- a/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
+++ b/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
@@ -1,5 +1,3 @@
 export type AllAvailableViews = 'year' | 'date' | 'month' | 'hours' | 'minutes' | 'seconds';
 
 export type DatePickerView = 'year' | 'date' | 'month';
-
-export type TimePickerView = 'hours' | 'minutes' | 'seconds';

--- a/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
+++ b/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
@@ -1,7 +1,5 @@
 export type AllAvailableViews = 'year' | 'date' | 'month' | 'hours' | 'minutes' | 'seconds';
 
-export type DateTimePickerView = 'year' | 'date' | 'month' | 'hours' | 'minutes';
-
 export type DatePickerView = 'year' | 'date' | 'month';
 
 export type TimePickerView = 'hours' | 'minutes' | 'seconds';

--- a/packages/material-ui-lab/src/internal/pickers/typings/helpers.ts
+++ b/packages/material-ui-lab/src/internal/pickers/typings/helpers.ts
@@ -1,5 +1,3 @@
-import { WithStyles } from '@material-ui/core/styles';
-
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with
  * certain `classes`, on which one can also set a top-level `className` and inline
@@ -14,12 +12,3 @@ export type MakeOptional<T, K extends keyof T> = {
   [P in K]?: T[P] | undefined;
 } &
   Omit<T, K>;
-
-export type MakeRequired<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X];
-} &
-  {
-    [P in K]-?: T[P];
-  };
-
-export type WithoutClasses<TProps extends WithStyles<any>> = Omit<TProps, keyof WithStyles<any>>;


### PR DESCRIPTION
`internal/pickers` implies they're concerned with all pickers. But some of them are more generic and some less. Especially specific utils just make it harder to grok the implementation of a specific component because you encounter all these unrelated utilities. It also goes against the "as private as possible by default" approach because e.g. the DatePicker could import some clock related utils without making the accidental coupling obvious.

