### PR TITLE
[Grid] Support decimal spacing

### DIFF
--- a/docs/pages/api-docs/grid.json
+++ b/docs/pages/api-docs/grid.json
@@ -34,10 +34,7 @@
       "default": "false"
     },
     "spacing": {
-      "type": {
-        "name": "enum",
-        "description": "0<br>&#124;&nbsp;1<br>&#124;&nbsp;2<br>&#124;&nbsp;3<br>&#124;&nbsp;4<br>&#124;&nbsp;5<br>&#124;&nbsp;6<br>&#124;&nbsp;7<br>&#124;&nbsp;8<br>&#124;&nbsp;9<br>&#124;&nbsp;10"
-      },
+      "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" },
       "default": "0"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/stack.json
+++ b/docs/pages/api-docs/stack.json
@@ -12,8 +12,9 @@
     "spacing": {
       "type": {
         "name": "union",
-        "description": "Array&lt;number&gt;<br>&#124;&nbsp;number<br>&#124;&nbsp;object"
-      }
+        "description": "Array&lt;number<br>&#124;&nbsp;string&gt;<br>&#124;&nbsp;number<br>&#124;&nbsp;object<br>&#124;&nbsp;string"
+      },
+      "default": "0"
     },
     "sx": { "type": { "name": "object" } }
   },

--- a/docs/src/pages/components/grid/SpacingGrid.js
+++ b/docs/src/pages/components/grid/SpacingGrid.js
@@ -38,7 +38,7 @@ export default function SpacingGrid() {
                   onChange={handleChange}
                   row
                 >
-                  {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
+                  {[0, 1, 2, 3.5, 4, 8, 12].map((value) => (
                     <FormControlLabel
                       key={value}
                       value={value.toString()}

--- a/docs/src/pages/components/grid/SpacingGrid.js
+++ b/docs/src/pages/components/grid/SpacingGrid.js
@@ -3,6 +3,7 @@ import Grid from '@material-ui/core/Grid';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
@@ -13,6 +14,10 @@ export default function SpacingGrid() {
   const handleChange = (event) => {
     setSpacing(Number(event.target.value));
   };
+
+  const jsx = `
+<Grid container spacing={${spacing}}>
+`;
 
   return (
     <Grid sx={{ flexGrow: 1 }} container spacing={2}>
@@ -38,7 +43,7 @@ export default function SpacingGrid() {
                   onChange={handleChange}
                   row
                 >
-                  {[0, 1, 2, 3.5, 4, 8, 12].map((value) => (
+                  {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
                     <FormControlLabel
                       key={value}
                       value={value.toString()}
@@ -51,6 +56,7 @@ export default function SpacingGrid() {
             </Grid>
           </Grid>
         </Paper>
+        <HighlightedCode code={jsx} language="jsx" />
       </Grid>
     </Grid>
   );

--- a/docs/src/pages/components/grid/SpacingGrid.tsx
+++ b/docs/src/pages/components/grid/SpacingGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Grid, { GridSpacing } from '@material-ui/core/Grid';
+import Grid from '@material-ui/core/Grid';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -9,10 +9,10 @@ import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
 
 export default function SpacingGrid() {
-  const [spacing, setSpacing] = React.useState<GridSpacing>(2);
+  const [spacing, setSpacing] = React.useState(2);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSpacing(Number((event.target as HTMLInputElement).value) as GridSpacing);
+    setSpacing(Number((event.target as HTMLInputElement).value));
   };
 
   const jsx = `

--- a/docs/src/pages/components/grid/SpacingGrid.tsx
+++ b/docs/src/pages/components/grid/SpacingGrid.tsx
@@ -38,7 +38,7 @@ export default function SpacingGrid() {
                   onChange={handleChange}
                   row
                 >
-                  {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
+                  {[0, 1, 2, 3.5, 4, 8, 12].map((value) => (
                     <FormControlLabel
                       key={value}
                       value={value.toString()}

--- a/docs/src/pages/components/grid/SpacingGrid.tsx
+++ b/docs/src/pages/components/grid/SpacingGrid.tsx
@@ -3,6 +3,7 @@ import Grid, { GridSpacing } from '@material-ui/core/Grid';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
@@ -13,6 +14,10 @@ export default function SpacingGrid() {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSpacing(Number((event.target as HTMLInputElement).value) as GridSpacing);
   };
+
+  const jsx = `
+<Grid container spacing={${spacing}}>
+`;
 
   return (
     <Grid sx={{ flexGrow: 1 }} container spacing={2}>
@@ -38,7 +43,7 @@ export default function SpacingGrid() {
                   onChange={handleChange}
                   row
                 >
-                  {[0, 1, 2, 3.5, 4, 8, 12].map((value) => (
+                  {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
                     <FormControlLabel
                       key={value}
                       value={value.toString()}
@@ -51,6 +56,7 @@ export default function SpacingGrid() {
             </Grid>
           </Grid>
         </Paper>
+        <HighlightedCode code={jsx} language="jsx" />
       </Grid>
     </Grid>
   );

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -52,11 +52,12 @@ For example, `xs={12} sm={6}` sizes a component to occupy half of the viewport w
 ## Spacing
 
 The responsive grid focuses on consistent spacing widths, rather than column width.
-Material Design margins and columns follow an **8px** square baseline grid.
-The `spacing` prop value is an integer between 0 and 10 inclusive.
-By default, the spacing between two grid items follows a linear function: `output(spacing) = spacing * 8px`, e.g. `spacing={2}` creates a 16px wide gap.
 
-This output transformation function can be customized [using the theme](/customization/spacing/).
+By default, the spacing between two grid items follows a linear function: `output(spacing) = spacing * 8px`, so `spacing={2}` creates a 16px wide gap.
+
+The spacing value can be any positive number, including decimals. For example, `spacing={3.5}` creates a 28px gap.
+
+For further customization, the output transformation function can be changed [using the theme](/customization/spacing/).
 
 {{"demo": "pages/components/grid/SpacingGrid.js", "bg": true}}
 

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -51,13 +51,9 @@ For example, `xs={12} sm={6}` sizes a component to occupy half of the viewport w
 
 ## Spacing
 
-The responsive grid focuses on consistent spacing widths, rather than column width.
-
-By default, the spacing between two grid items follows a linear function: `output(spacing) = spacing * 8px`, so `spacing={2}` creates a 16px wide gap.
-
-The spacing value can be any positive number, including decimals. For example, `spacing={3.5}` creates a 28px gap.
-
-For further customization, the output transformation function can be changed [using the theme](/customization/spacing/).
+To control space between children, use the `spacing` prop.
+The spacing value can be any positive number, including decimals and any string.
+The prop is converted into a CSS property using the [`theme.spacing()`](/customization/spacing/) helper.
 
 {{"demo": "pages/components/grid/SpacingGrid.js", "bg": true}}
 

--- a/docs/src/pages/components/stack/InteractiveStack.js
+++ b/docs/src/pages/components/stack/InteractiveStack.js
@@ -173,17 +173,17 @@ export default function InteractiveStack() {
                 row
                 name="spacing"
                 aria-label="spacing"
-                value={spacing}
+                value={spacing.toString()}
                 onChange={(event) => {
-                  setSpacing(parseInt(event.target.value, 10));
+                  setSpacing(Number(event.target.value));
                 }}
               >
-                {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
+                {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
                   <FormControlLabel
                     key={value}
-                    value={value}
+                    value={value.toString()}
                     control={<Radio />}
-                    label={value}
+                    label={value.toString()}
                   />
                 ))}
               </RadioGroup>

--- a/docs/src/pages/components/stack/InteractiveStack.js
+++ b/docs/src/pages/components/stack/InteractiveStack.js
@@ -13,7 +13,7 @@ export default function InteractiveStack() {
   const [direction, setDirection] = React.useState('row');
   const [justifyContent, setJustifyContent] = React.useState('center');
   const [alignItems, setAlignItems] = React.useState('center');
-  const [spacing, setSpacing] = React.useState(1);
+  const [spacing, setSpacing] = React.useState(2);
 
   const jsx = `
 <Stack
@@ -183,7 +183,7 @@ export default function InteractiveStack() {
                     key={value}
                     value={value.toString()}
                     control={<Radio />}
-                    label={value.toString()}
+                    label={value}
                   />
                 ))}
               </RadioGroup>

--- a/docs/src/pages/components/stack/InteractiveStack.tsx
+++ b/docs/src/pages/components/stack/InteractiveStack.tsx
@@ -13,7 +13,7 @@ export default function InteractiveStack() {
   const [direction, setDirection] = React.useState<StackProps['direction']>('row');
   const [justifyContent, setJustifyContent] = React.useState('center');
   const [alignItems, setAlignItems] = React.useState('center');
-  const [spacing, setSpacing] = React.useState(1);
+  const [spacing, setSpacing] = React.useState(2);
 
   const jsx = `
 <Stack
@@ -175,9 +175,7 @@ export default function InteractiveStack() {
                 aria-label="spacing"
                 value={spacing.toString()}
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setSpacing(
-                    Number((event.target as HTMLInputElement).value) as GridSpacing,
-                  );
+                  setSpacing(Number((event.target as HTMLInputElement).value));
                 }}
               >
                 {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
@@ -185,7 +183,7 @@ export default function InteractiveStack() {
                     key={value}
                     value={value.toString()}
                     control={<Radio />}
-                    label={value.toString()}
+                    label={value}
                   />
                 ))}
               </RadioGroup>

--- a/docs/src/pages/components/stack/InteractiveStack.tsx
+++ b/docs/src/pages/components/stack/InteractiveStack.tsx
@@ -173,17 +173,19 @@ export default function InteractiveStack() {
                 row
                 name="spacing"
                 aria-label="spacing"
-                value={spacing}
-                onChange={(event) => {
-                  setSpacing(parseInt(event.target.value, 10));
+                value={spacing.toString()}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setSpacing(
+                    Number((event.target as HTMLInputElement).value) as GridSpacing,
+                  );
                 }}
               >
-                {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
+                {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
                   <FormControlLabel
                     key={value}
-                    value={value}
+                    value={value.toString()}
                     control={<Radio />}
-                    label={value}
+                    label={value.toString()}
                   />
                 ))}
               </RadioGroup>

--- a/docs/src/pages/components/stack/stack.md
+++ b/docs/src/pages/components/stack/stack.md
@@ -12,9 +12,13 @@ githubLabel: 'component: Stack'
 
 ## Usage
 
-`Stack` is concerned with one-dimensional layouts, while [Grid](/components/grid/) that handles two-dimensional layouts. The default direction is `column` which stacks children vertically. To control space between children, use the `spacing` prop.
+`Stack` is concerned with one-dimensional layouts, while [Grid](/components/grid/) that handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
 
 {{"demo": "pages/components/stack/BasicStack.js", "bg": true}}
+
+To control space between children, use the `spacing` prop.
+The spacing value can be any number, including decimals and any string.
+The prop is converted into a CSS property using the [`theme.spacing()`](/customization/spacing/) helper.
 
 ## Direction
 

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -5,7 +5,7 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
-export type GridSpacing = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+export type GridSpacing = number | string;
 
 export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -346,7 +346,7 @@ Grid.propTypes /* remove-proptypes */ = {
    * It can only be used on a type `container` component.
    * @default 0
    */
-  spacing: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+  spacing: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -63,6 +63,21 @@ describe('<Grid />', () => {
 
       expect(container.firstChild).to.have.class(classes['spacing-xs-1']);
     });
+
+    it('should support decimal values', () => {
+      const { container } = render(
+        <Grid container spacing={1.5}>
+          <Grid item data-testid="child" />
+        </Grid>,
+      );
+
+      expect(container.firstChild).to.have.class('MuiGrid-spacing-xs-1.5');
+
+      expect(screen.getByTestId('child')).toHaveComputedStyle({
+        paddingTop: '12px',
+        paddingLeft: '12px',
+      });
+    });
   });
 
   describe('gutter', () => {

--- a/packages/material-ui/src/Stack/Stack.d.ts
+++ b/packages/material-ui/src/Stack/Stack.d.ts
@@ -19,8 +19,9 @@ export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
       direction?: ResponsiveStyleValue<'row' | 'row-reverse' | 'column' | 'column-reverse'>;
       /**
        * Defines the space between immediate children.
+       * @default 0
        */
-      spacing?: ResponsiveStyleValue<number>;
+      spacing?: ResponsiveStyleValue<number | string>;
       /**
        * Add an element between each child.
        */

--- a/packages/material-ui/src/Stack/Stack.js
+++ b/packages/material-ui/src/Stack/Stack.js
@@ -102,7 +102,7 @@ const StackRoot = experimentalStyled('div', {}, { name: 'Stack' })(style);
 const Stack = React.forwardRef(function Stack(inProps, ref) {
   const themeProps = useThemeProps({ props: inProps, name: 'MuiStack' });
   const props = extendSxProp(themeProps);
-  const { direction = 'column', spacing, divider, children, ...other } = props;
+  const { direction = 'column', spacing = 0, divider, children, ...other } = props;
   const styleProps = {
     direction,
     spacing,
@@ -140,11 +140,13 @@ Stack.propTypes /* remove-proptypes */ = {
   divider: PropTypes.node,
   /**
    * Defines the space between immediate children.
+   * @default 0
    */
   spacing: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.number),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
     PropTypes.number,
     PropTypes.object,
+    PropTypes.string,
   ]),
   /**
    * The system prop, which allows defining system overrides as well as additional CSS styles.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Resolves #16481.

* I was originally planning on using something like:

``` javascript
      expect(() => {
        render(<Grid container spacing={1.5} />);
      }).not.toWarnDev();
```

as a regression test, but I couldn't get it to fail with the original code. When running the test I would see `Warning: Failed prop type: Invalid prop spacing of value 1.5 supplied to ForwardRef(Grid), expected one of [0,1,2,3,4,5,6,7,8,9,10].` printed to the console, but the test would pass. I don't understand why and would be curious for others' thoughts.

* I wasn't sure how much to test. I tested that the class was added and that the child has 1.5 * 8px padding in the appropriate places. I could see myself basically cloning the gutter test for 1.5 or not adding this test at all. Up to you. The test would have passed before my change.
* That test uses a hardcoded class `MuiGrid-spacing-xs-1.5` rather than looking up the class from GridClasses e.g. `classes['grid-xs-auto']` like the other tests. This is because we only generate utility classes for integers 1-10 and we're using those to look up the full class names. Should I be doing something else?
* Because we now support any number for spacing I replaced the 1-10 range in the docs with some random choices. My choices are fairly abritrary and I'm happy to change them if you have a better suggestion.
* I had to change the language a bit in the docs. Do you have any kind of phrasing guidelines for contributors? I'm not sure if it adequately matches the style.


