### PR TITLE
[Paper] Support dark mode brightening based on elevation

### DIFF
--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -5,6 +5,7 @@ import { chainPropTypes, integerPropType, deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
+import { alpha } from '../styles/colorManipulator';
 import useTheme from '../styles/useTheme';
 import { getPaperUtilityClass } from './paperClasses';
 
@@ -45,6 +46,18 @@ const PaperRoot = experimentalStyled(
     overridesResolver,
   },
 )(({ theme, styleProps }) => {
+  // Inspired by https://github.com/material-components/material-components-ios/blob/bca36107405594d5b7b16265a5b0ed698f85a5ee/components/Elevation/src/UIColor%2BMaterialElevation.m#L61
+  const getOverlayAlpha = (elevation) => {
+    let alphaValue;
+    if (elevation < 1) {
+      alphaValue = 5.11916 * elevation ** 2;
+    } else {
+      alphaValue = 4.5 * Math.log(elevation + 1) + 2;
+    }
+    return (alphaValue / 100).toFixed(2);
+  };
+  const overlayColor = alpha(theme.palette.common.white, getOverlayAlpha(styleProps.elevation));
+
   return {
     /* Styles applied to the root element. */
     backgroundColor: theme.palette.background.paper,
@@ -61,6 +74,9 @@ const PaperRoot = experimentalStyled(
     /* Styles applied to the root element if `variant="elevation"`. */
     ...(styleProps.variant === 'elevation' && {
       boxShadow: theme.shadows[styleProps.elevation],
+    }),
+    ...(theme.palette.mode === 'dark' && {
+      backgroundImage: `linear-gradient(${overlayColor}, ${overlayColor})`,
     }),
   };
 });

--- a/packages/material-ui/src/styles/createPalette.js
+++ b/packages/material-ui/src/styles/createPalette.js
@@ -58,8 +58,8 @@ export const dark = {
   },
   divider: 'rgba(255, 255, 255, 0.12)',
   background: {
-    paper: grey[800],
-    default: '#303030',
+    paper: '#121212',
+    default: '#121212',
   },
   action: {
     active: common.white,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #18309

Based on #21748

TODO: Add section to the Paper docs page explaining the influence of the elevation in the background color