### PR TITLE
[docs] Update minimizing-bundle-size.md

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -117,7 +117,7 @@ Pick one of the following plugins:
       'babel-plugin-import',
       {
         libraryName: '@material-ui/core',
-        libraryDirectory: "",
+        libraryDirectory: '',
         camel2DashComponentName: false,
       },
       'core',
@@ -126,7 +126,7 @@ Pick one of the following plugins:
       'babel-plugin-import',
       {
         libraryName: '@material-ui/icons',
-        libraryDirectory: "",
+        libraryDirectory: '',
         camel2DashComponentName: false,
       },
       'icons',

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -117,6 +117,7 @@ Pick one of the following plugins:
       'babel-plugin-import',
       {
         libraryName: '@material-ui/core',
+        libraryDirectory: "",
         camel2DashComponentName: false,
       },
       'core',
@@ -125,6 +126,7 @@ Pick one of the following plugins:
       'babel-plugin-import',
       {
         libraryName: '@material-ui/icons',
+        libraryDirectory: "",
         camel2DashComponentName: false,
       },
       'icons',


### PR DESCRIPTION
We need to add this line `libraryDirectory: ""` to the config, otherwise, the final result will be something like:

```js
@material-ui/core/lib/Button
```

The default **libraryDirectory** is `lib`.

Ref: https://github.com/ant-design/babel-plugin-import#options