### PR TITLE
[Avatar] Remove circle variant deprecation

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import Person from '../internal/svg-icons/Person';
 
@@ -173,24 +172,7 @@ Avatar.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: chainPropTypes(PropTypes.object, (props) => {
-    const { classes } = props;
-    if (classes == null) {
-      return null;
-    }
-
-    if (
-      classes.circle != null &&
-      // 2 classnames? one from withStyles the other must be custom
-      classes.circle.split(' ').length > 1
-    ) {
-      throw new Error(
-        `Material-UI: The \`circle\` class was deprecated. Use \`circular\` instead.`,
-      );
-    }
-
-    return null;
-  }),
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -221,17 +203,7 @@ Avatar.propTypes = {
   /**
    * The shape of the avatar.
    */
-  variant: chainPropTypes(PropTypes.oneOf(['circle', 'circular', 'rounded', 'square']), (props) => {
-    const { variant } = props;
-
-    if (variant === 'circle') {
-      throw new Error(
-        'Material-UI: `variant="circle"` was deprecated. Use `variant="circular"` instead.',
-      );
-    }
-
-    return null;
-  }),
+  variant: PropTypes.oneOf(['circle', 'circular', 'rounded', 'square']),
 };
 
 export default withStyles(styles, { name: 'MuiAvatar' })(Avatar);

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import * as PropTypes from 'prop-types';
 import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import { getClasses } from '@material-ui/core/test-utils';
 import createMount from 'test/utils/createMount';
-import { spy, stub } from 'sinon';
+import { spy } from 'sinon';
 import CancelIcon from '../internal/svg-icons/Cancel';
 import describeConformance from '../test-utils/describeConformance';
 import Avatar from './Avatar';
@@ -194,49 +193,6 @@ describe('<Avatar />', () => {
 
     it('should apply the colorDefault class', () => {
       expect(avatar).to.have.class(classes.colorDefault);
-    });
-  });
-
-  describe('v5 deprecations', () => {
-    beforeEach(() => {
-      PropTypes.resetWarningCache();
-      stub(console, 'error');
-    });
-
-    afterEach(() => {
-      console.error.restore();
-    });
-
-    it('issues a warning for variant="circle"', () => {
-      PropTypes.checkPropTypes(
-        Avatar.Naked.propTypes,
-        {
-          variant: 'circle',
-        },
-        'props',
-        'Avatar',
-      );
-
-      expect(console.error.callCount).to.equal(1);
-      expect(console.error.firstCall.args[0]).to.equal(
-        'Warning: Failed props type: Material-UI: `variant="circle"` was deprecated. Use `variant="circular"` instead.',
-      );
-    });
-
-    it('issues a warning for the `circle` class', () => {
-      PropTypes.checkPropTypes(
-        Avatar.Naked.propTypes,
-        {
-          classes: { circle: 'mui-class my-class' },
-        },
-        'props',
-        'Badge',
-      );
-
-      expect(console.error.callCount).to.equal(1);
-      expect(console.error.firstCall.args[0]).to.equal(
-        'Warning: Failed props type: Material-UI: The `circle` class was deprecated. Use `circular` instead.',
-      );
     });
   });
 });


### PR DESCRIPTION
This PR removes the circle variant deprecation warning, as suggested by @oliviertassinari in https://github.com/mui-org/material-ui/issues/24864.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).