### PR TITLE
[docs] Fully customizeable palette

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -80,6 +80,7 @@
     "jss": "^10.0.3",
     "jss-plugin-template": "^10.0.3",
     "jss-rtl": "^0.3.0",
+    "leva": "^0.8.3",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",
     "markdown-to-jsx": "^7.0.0",

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -15,6 +15,33 @@ import { getCookie } from 'docs/src/modules/utils/helpers';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
 
+const ThemePicker = React.lazy(() => import('./ThemePicker'));
+function CustomizeableTheme(props) {
+  const { children, theme } = props;
+
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    <React.Fragment>
+      {/* Suspense isn't supported for SSR yet */}
+      {mounted ? (
+        <React.Suspense fallback={null}>
+          <ThemePicker theme={theme}>{children}</ThemePicker>
+        </React.Suspense>
+      ) : (
+        <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+      )}
+    </React.Fragment>
+  );
+}
+CustomizeableTheme.propTypes = {
+  children: PropTypes.node,
+  theme: PropTypes.object,
+};
+
 const languageMap = {
   en: enUS,
   zh: zhCN,
@@ -255,9 +282,9 @@ export function ThemeProvider(props) {
   }, [theme]);
 
   return (
-    <MuiThemeProvider theme={theme}>
+    <CustomizeableTheme theme={theme}>
       <DispatchContext.Provider value={dispatch}>{children}</DispatchContext.Provider>
-    </MuiThemeProvider>
+    </CustomizeableTheme>
   );
 }
 

--- a/docs/src/modules/components/ThemePicker.tsx
+++ b/docs/src/modules/components/ThemePicker.tsx
@@ -1,7 +1,36 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
-import { ThemeProvider as MuiThemeProvider, createMuiTheme, Theme } from '@material-ui/core/styles';
-import { folder, useControls } from 'leva';
+import {
+  ThemeProvider as MuiThemeProvider,
+  createMuiTheme,
+  experimentalStyled as styled,
+  Theme,
+} from '@material-ui/core/styles';
+import {
+  folder,
+  LevaPanel,
+  LevaStoreProvider,
+  useCreateStore,
+  useStoreContext,
+  useControls,
+} from 'leva';
+
+const LevaPanelWrapper = styled('div')`
+  & > div {
+    z-index: ${({ theme }) => theme.zIndex.drawer};
+  }
+`;
+
+function ThemeCustomization() {
+  const store = useStoreContext();
+  return ReactDOM.createPortal(
+    <LevaPanelWrapper>
+      <LevaPanel hidden={false} store={store} />
+    </LevaPanelWrapper>,
+    document.body,
+  );
+}
 
 interface ThemePickerProps {
   children: React.ReactNode;
@@ -10,6 +39,7 @@ interface ThemePickerProps {
 
 export default function ThemePicker(props: ThemePickerProps) {
   const { children, theme } = props;
+  const store = useCreateStore();
 
   const {
     primaryMain,
@@ -52,196 +82,200 @@ export default function ThemePicker(props: ThemePickerProps) {
     actionSelectedOpacity,
     backgroundDefault,
     backgroundPaper,
-  } = useControls('palette', {
-    primaryMain: {
-      value: theme.palette.primary.main,
-      label: 'primary',
-    },
-    secondaryMain: {
-      value: theme.palette.secondary.main,
-      label: 'seconary',
-    },
-    error: folder({
-      errorContrastText: {
-        value: theme.palette.error.contrastText,
-        label: 'contrastText',
-      },
-      errorDark: {
-        value: theme.palette.error.dark,
-        label: 'dark',
-      },
-      errorLight: {
-        value: theme.palette.error.light,
-        label: 'light',
-      },
-      errorMain: {
-        value: theme.palette.error.main,
-        label: 'main',
-      },
-    }),
-    warning: folder({
-      warningContrastText: {
-        value: theme.palette.warning.contrastText,
-        label: 'contrastText',
-      },
-      warningDark: {
-        value: theme.palette.warning.dark,
-        label: 'dark',
-      },
-      warningLight: {
-        value: theme.palette.warning.light,
-        label: 'light',
-      },
-      warningMain: {
-        value: theme.palette.warning.main,
-        label: 'main',
-      },
-    }),
-    info: folder({
-      infoContrastText: {
-        value: theme.palette.info.contrastText,
-        label: 'contrastText',
-      },
-      infoDark: {
-        value: theme.palette.info.dark,
-        label: 'dark',
-      },
-      infoLight: {
-        value: theme.palette.info.light,
-        label: 'light',
-      },
-      infoMain: {
-        value: theme.palette.info.main,
-        label: 'main',
-      },
-    }),
-    success: folder({
-      successContrastText: {
-        value: theme.palette.success.contrastText,
-        label: 'contrastText',
-      },
-      successDark: {
-        value: theme.palette.success.dark,
-        label: 'dark',
-      },
-      successLight: {
-        value: theme.palette.success.light,
-        label: 'light',
-      },
-      successMain: {
-        value: theme.palette.success.main,
-        label: 'main',
-      },
-    }),
-    mode: {
-      value: theme.palette.mode,
-      options: ['dark', 'light'],
-    },
-    tonalOffset: {
-      // TODO: validate at runtime
-      value: theme.palette.tonalOffset as number,
-      // TODO: good range for `tonalOffset`
-      min: 0,
-      max: 10,
-    },
-    contrastThreshold: {
-      value: theme.palette.contrastThreshold,
-      // TODO: good range for `contrastThreshold`
-      min: 0,
-      max: 10,
-    },
-    common: folder({
-      commonBlack: {
-        value: theme.palette.common.black,
-        label: 'black',
-      },
-      commonWhite: {
-        value: theme.palette.common.white,
-        label: 'white',
-      },
-    }),
-    text: folder({
-      textDisabled: {
-        value: theme.palette.text.disabled,
-        label: 'disabled',
-      },
-      textPrimary: {
-        value: theme.palette.text.primary,
+  } = useControls(
+    'palette',
+    {
+      primaryMain: {
+        value: theme.palette.primary.main,
         label: 'primary',
       },
-      textSecondary: {
-        value: theme.palette.text.secondary,
-        label: 'secondary',
+      secondaryMain: {
+        value: theme.palette.secondary.main,
+        label: 'seconary',
       },
-    }),
-    divider: theme.palette.divider,
-    action: folder({
-      actionActivatedOpacity: {
-        value: theme.palette.action.activatedOpacity,
-        label: 'activatedOpacity',
+      error: folder({
+        errorContrastText: {
+          value: theme.palette.error.contrastText,
+          label: 'contrastText',
+        },
+        errorDark: {
+          value: theme.palette.error.dark,
+          label: 'dark',
+        },
+        errorLight: {
+          value: theme.palette.error.light,
+          label: 'light',
+        },
+        errorMain: {
+          value: theme.palette.error.main,
+          label: 'main',
+        },
+      }),
+      warning: folder({
+        warningContrastText: {
+          value: theme.palette.warning.contrastText,
+          label: 'contrastText',
+        },
+        warningDark: {
+          value: theme.palette.warning.dark,
+          label: 'dark',
+        },
+        warningLight: {
+          value: theme.palette.warning.light,
+          label: 'light',
+        },
+        warningMain: {
+          value: theme.palette.warning.main,
+          label: 'main',
+        },
+      }),
+      info: folder({
+        infoContrastText: {
+          value: theme.palette.info.contrastText,
+          label: 'contrastText',
+        },
+        infoDark: {
+          value: theme.palette.info.dark,
+          label: 'dark',
+        },
+        infoLight: {
+          value: theme.palette.info.light,
+          label: 'light',
+        },
+        infoMain: {
+          value: theme.palette.info.main,
+          label: 'main',
+        },
+      }),
+      success: folder({
+        successContrastText: {
+          value: theme.palette.success.contrastText,
+          label: 'contrastText',
+        },
+        successDark: {
+          value: theme.palette.success.dark,
+          label: 'dark',
+        },
+        successLight: {
+          value: theme.palette.success.light,
+          label: 'light',
+        },
+        successMain: {
+          value: theme.palette.success.main,
+          label: 'main',
+        },
+      }),
+      mode: {
+        value: theme.palette.mode,
+        options: ['dark', 'light'],
+      },
+      tonalOffset: {
+        // TODO: validate at runtime
+        value: theme.palette.tonalOffset as number,
+        // TODO: good range for `tonalOffset`
         min: 0,
-        max: 1,
+        max: 10,
       },
-      actionActive: {
-        value: theme.palette.action.active,
-        label: 'active',
-      },
-      actionDisabled: {
-        value: theme.palette.action.disabled,
-        label: 'disabled',
-      },
-      actionDisabledBackground: {
-        value: theme.palette.action.disabledBackground,
-        label: 'disabledBackground',
-      },
-      actionDisabledOpacity: {
-        value: theme.palette.action.disabledOpacity,
-        label: 'disabledOpacity',
+      contrastThreshold: {
+        value: theme.palette.contrastThreshold,
+        // TODO: good range for `contrastThreshold`
         min: 0,
-        max: 1,
+        max: 10,
       },
-      actionFocus: {
-        value: theme.palette.action.focus,
-        label: 'focus',
-      },
-      actionFocusOpacity: {
-        value: theme.palette.action.focusOpacity,
-        label: 'focusOpacity',
-        min: 0,
-        max: 1,
-      },
-      actionHover: {
-        value: theme.palette.action.hover,
-        label: 'hover',
-      },
-      actionHoverOpacity: {
-        value: theme.palette.action.hoverOpacity,
-        label: 'hoverOpacity',
-        min: 0,
-        max: 1,
-      },
-      actionSelected: {
-        value: theme.palette.action.selected,
-        label: 'selected',
-      },
-      actionSelectedOpacity: {
-        value: theme.palette.action.selectedOpacity,
-        label: 'selectedOpacity',
-        min: 0,
-        max: 1,
-      },
-    }),
-    background: folder({
-      backgroundDefault: {
-        value: theme.palette.background.default,
-        label: 'default',
-      },
-      backgroundPaper: {
-        value: theme.palette.background.paper,
-        label: 'paper',
-      },
-    }),
-  });
+      common: folder({
+        commonBlack: {
+          value: theme.palette.common.black,
+          label: 'black',
+        },
+        commonWhite: {
+          value: theme.palette.common.white,
+          label: 'white',
+        },
+      }),
+      text: folder({
+        textDisabled: {
+          value: theme.palette.text.disabled,
+          label: 'disabled',
+        },
+        textPrimary: {
+          value: theme.palette.text.primary,
+          label: 'primary',
+        },
+        textSecondary: {
+          value: theme.palette.text.secondary,
+          label: 'secondary',
+        },
+      }),
+      divider: theme.palette.divider,
+      action: folder({
+        actionActivatedOpacity: {
+          value: theme.palette.action.activatedOpacity,
+          label: 'activatedOpacity',
+          min: 0,
+          max: 1,
+        },
+        actionActive: {
+          value: theme.palette.action.active,
+          label: 'active',
+        },
+        actionDisabled: {
+          value: theme.palette.action.disabled,
+          label: 'disabled',
+        },
+        actionDisabledBackground: {
+          value: theme.palette.action.disabledBackground,
+          label: 'disabledBackground',
+        },
+        actionDisabledOpacity: {
+          value: theme.palette.action.disabledOpacity,
+          label: 'disabledOpacity',
+          min: 0,
+          max: 1,
+        },
+        actionFocus: {
+          value: theme.palette.action.focus,
+          label: 'focus',
+        },
+        actionFocusOpacity: {
+          value: theme.palette.action.focusOpacity,
+          label: 'focusOpacity',
+          min: 0,
+          max: 1,
+        },
+        actionHover: {
+          value: theme.palette.action.hover,
+          label: 'hover',
+        },
+        actionHoverOpacity: {
+          value: theme.palette.action.hoverOpacity,
+          label: 'hoverOpacity',
+          min: 0,
+          max: 1,
+        },
+        actionSelected: {
+          value: theme.palette.action.selected,
+          label: 'selected',
+        },
+        actionSelectedOpacity: {
+          value: theme.palette.action.selectedOpacity,
+          label: 'selectedOpacity',
+          min: 0,
+          max: 1,
+        },
+      }),
+      background: folder({
+        backgroundDefault: {
+          value: theme.palette.background.default,
+          label: 'default',
+        },
+        backgroundPaper: {
+          value: theme.palette.background.paper,
+          label: 'paper',
+        },
+      }),
+    },
+    { store },
+  );
 
   const customizedTheme = createMuiTheme({
     ...theme,
@@ -311,7 +345,14 @@ export default function ThemePicker(props: ThemePickerProps) {
     },
   });
 
-  return <MuiThemeProvider theme={customizedTheme}>{children}</MuiThemeProvider>;
+  return (
+    <LevaStoreProvider store={store}>
+      <MuiThemeProvider theme={customizedTheme}>
+        <ThemeCustomization />
+        {children}
+      </MuiThemeProvider>
+    </LevaStoreProvider>
+  );
 }
 
 ThemePicker.propTypes = {

--- a/docs/src/modules/components/ThemePicker.tsx
+++ b/docs/src/modules/components/ThemePicker.tsx
@@ -1,0 +1,320 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { ThemeProvider as MuiThemeProvider, createMuiTheme, Theme } from '@material-ui/core/styles';
+import { folder, useControls } from 'leva';
+
+interface ThemePickerProps {
+  children: React.ReactNode;
+  theme: Theme;
+}
+
+export default function ThemePicker(props: ThemePickerProps) {
+  const { children, theme } = props;
+
+  const {
+    primaryMain,
+    secondaryMain,
+    errorContrastText,
+    errorDark,
+    errorLight,
+    errorMain,
+    warningContrastText,
+    warningDark,
+    warningLight,
+    warningMain,
+    infoContrastText,
+    infoDark,
+    infoLight,
+    infoMain,
+    successContrastText,
+    successDark,
+    successLight,
+    successMain,
+    mode,
+    tonalOffset,
+    contrastThreshold,
+    commonBlack,
+    commonWhite,
+    textDisabled,
+    textPrimary,
+    textSecondary,
+    divider,
+    actionActivatedOpacity,
+    actionActive,
+    actionDisabled,
+    actionDisabledBackground,
+    actionDisabledOpacity,
+    actionFocus,
+    actionFocusOpacity,
+    actionHover,
+    actionHoverOpacity,
+    actionSelected,
+    actionSelectedOpacity,
+    backgroundDefault,
+    backgroundPaper,
+  } = useControls('palette', {
+    primaryMain: {
+      value: theme.palette.primary.main,
+      label: 'primary',
+    },
+    secondaryMain: {
+      value: theme.palette.secondary.main,
+      label: 'seconary',
+    },
+    error: folder({
+      errorContrastText: {
+        value: theme.palette.error.contrastText,
+        label: 'contrastText',
+      },
+      errorDark: {
+        value: theme.palette.error.dark,
+        label: 'dark',
+      },
+      errorLight: {
+        value: theme.palette.error.light,
+        label: 'light',
+      },
+      errorMain: {
+        value: theme.palette.error.main,
+        label: 'main',
+      },
+    }),
+    warning: folder({
+      warningContrastText: {
+        value: theme.palette.warning.contrastText,
+        label: 'contrastText',
+      },
+      warningDark: {
+        value: theme.palette.warning.dark,
+        label: 'dark',
+      },
+      warningLight: {
+        value: theme.palette.warning.light,
+        label: 'light',
+      },
+      warningMain: {
+        value: theme.palette.warning.main,
+        label: 'main',
+      },
+    }),
+    info: folder({
+      infoContrastText: {
+        value: theme.palette.info.contrastText,
+        label: 'contrastText',
+      },
+      infoDark: {
+        value: theme.palette.info.dark,
+        label: 'dark',
+      },
+      infoLight: {
+        value: theme.palette.info.light,
+        label: 'light',
+      },
+      infoMain: {
+        value: theme.palette.info.main,
+        label: 'main',
+      },
+    }),
+    success: folder({
+      successContrastText: {
+        value: theme.palette.success.contrastText,
+        label: 'contrastText',
+      },
+      successDark: {
+        value: theme.palette.success.dark,
+        label: 'dark',
+      },
+      successLight: {
+        value: theme.palette.success.light,
+        label: 'light',
+      },
+      successMain: {
+        value: theme.palette.success.main,
+        label: 'main',
+      },
+    }),
+    mode: {
+      value: theme.palette.mode,
+      options: ['dark', 'light'],
+    },
+    tonalOffset: {
+      // TODO: validate at runtime
+      value: theme.palette.tonalOffset as number,
+      // TODO: good range for `tonalOffset`
+      min: 0,
+      max: 10,
+    },
+    contrastThreshold: {
+      value: theme.palette.contrastThreshold,
+      // TODO: good range for `contrastThreshold`
+      min: 0,
+      max: 10,
+    },
+    common: folder({
+      commonBlack: {
+        value: theme.palette.common.black,
+        label: 'black',
+      },
+      commonWhite: {
+        value: theme.palette.common.white,
+        label: 'white',
+      },
+    }),
+    text: folder({
+      textDisabled: {
+        value: theme.palette.text.disabled,
+        label: 'disabled',
+      },
+      textPrimary: {
+        value: theme.palette.text.primary,
+        label: 'primary',
+      },
+      textSecondary: {
+        value: theme.palette.text.secondary,
+        label: 'secondary',
+      },
+    }),
+    divider: theme.palette.divider,
+    action: folder({
+      actionActivatedOpacity: {
+        value: theme.palette.action.activatedOpacity,
+        label: 'activatedOpacity',
+        min: 0,
+        max: 1,
+      },
+      actionActive: {
+        value: theme.palette.action.active,
+        label: 'active',
+      },
+      actionDisabled: {
+        value: theme.palette.action.disabled,
+        label: 'disabled',
+      },
+      actionDisabledBackground: {
+        value: theme.palette.action.disabledBackground,
+        label: 'disabledBackground',
+      },
+      actionDisabledOpacity: {
+        value: theme.palette.action.disabledOpacity,
+        label: 'disabledOpacity',
+        min: 0,
+        max: 1,
+      },
+      actionFocus: {
+        value: theme.palette.action.focus,
+        label: 'focus',
+      },
+      actionFocusOpacity: {
+        value: theme.palette.action.focusOpacity,
+        label: 'focusOpacity',
+        min: 0,
+        max: 1,
+      },
+      actionHover: {
+        value: theme.palette.action.hover,
+        label: 'hover',
+      },
+      actionHoverOpacity: {
+        value: theme.palette.action.hoverOpacity,
+        label: 'hoverOpacity',
+        min: 0,
+        max: 1,
+      },
+      actionSelected: {
+        value: theme.palette.action.selected,
+        label: 'selected',
+      },
+      actionSelectedOpacity: {
+        value: theme.palette.action.selectedOpacity,
+        label: 'selectedOpacity',
+        min: 0,
+        max: 1,
+      },
+    }),
+    background: folder({
+      backgroundDefault: {
+        value: theme.palette.background.default,
+        label: 'default',
+      },
+      backgroundPaper: {
+        value: theme.palette.background.paper,
+        label: 'paper',
+      },
+    }),
+  });
+
+  const customizedTheme = createMuiTheme({
+    ...theme,
+    palette: {
+      ...theme.palette,
+      primary: {
+        main: primaryMain,
+      },
+      secondary: {
+        main: secondaryMain,
+      },
+      error: {
+        contrastText: errorContrastText,
+        dark: errorDark,
+        light: errorLight,
+        main: errorMain,
+      },
+      warning: {
+        contrastText: warningContrastText,
+        dark: warningDark,
+        light: warningLight,
+        main: warningMain,
+      },
+      info: {
+        contrastText: infoContrastText,
+        dark: infoDark,
+        light: infoLight,
+        main: infoMain,
+      },
+      success: {
+        contrastText: successContrastText,
+        dark: successDark,
+        light: successLight,
+        main: successMain,
+      },
+      mode: mode as NonNullable<Theme['palette']['mode']>,
+      tonalOffset,
+      contrastThreshold,
+      common: {
+        black: commonBlack,
+        white: commonWhite,
+      },
+      // TODO: `grey` accepts a ColorPartial. Does this even make sense?
+      text: {
+        disabled: textDisabled,
+        primary: textPrimary,
+        secondary: textSecondary,
+      },
+      divider,
+      action: {
+        activatedOpacity: actionActivatedOpacity,
+        active: actionActive,
+        disabled: actionDisabled,
+        disabledBackground: actionDisabledBackground,
+        disabledOpacity: actionDisabledOpacity,
+        focus: actionFocus,
+        focusOpacity: actionFocusOpacity,
+        hover: actionHover,
+        hoverOpacity: actionHoverOpacity,
+        selected: actionSelected,
+        selectedOpacity: actionSelectedOpacity,
+      },
+      background: {
+        default: backgroundDefault,
+        paper: backgroundPaper,
+      },
+    },
+  });
+
+  return <MuiThemeProvider theme={customizedTheme}>{children}</MuiThemeProvider>;
+}
+
+ThemePicker.propTypes = {
+  children: PropTypes.node,
+  theme: PropTypes.object,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,6 +2472,160 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.3.tgz#8b4eae3d9dd470c022cb9238128db8b1906e7fca"
   integrity sha512-olsVs3lo8qKycPoWAUv4bMyoTGVXsEpLR9XxGk3LJR5Qa92a1Eg/Fj1ATdhwtC/6VMaKtsz1nSAeheD2B2Ru9A==
 
+"@radix-ui/popper@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/popper/-/popper-0.0.5.tgz#23db61910fecd64c2c388c7eee185374a0f5bb2f"
+  integrity sha512-TQZflpkjAvPWMl8w89RiIYrGBkc+VpkaHisW3Sy5U2/vrYBrx4EsOt/4tz73+1qKLH4EOjjOem7FtP8PHpliOQ==
+  dependencies:
+    csstype "^3.0.4"
+
+"@radix-ui/primitive@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-0.0.1.tgz#402fe0e690d5ff970737689dbb5f24705d423889"
+  integrity sha512-Z8R0kdAZui8eYTuGY5oQUA0SU4jYq43m4bZW6Dw0B35fUp+U3r+pCrkj0EADJAPv1UaKNskSv/lrfRdC7719Rg==
+
+"@radix-ui/react-arrow@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-0.0.6.tgz#acaddcf5fb2e3387c445ceeb76cc16d1d3ea21c8"
+  integrity sha512-O8RcgasVaoVN65mIhcx30yWM1MDvpKHyVdIi2/joVm3xfJ0nprjcwEAnALw2lh03nXUNnOAEbpV9P2jsiXRUgw==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.5"
+
+"@radix-ui/react-compose-refs@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-0.0.1.tgz#b615382fe6c838b6e8dc6d6ae0b504d141e46d8b"
+  integrity sha512-Am9lwUHns7zx9bYwDWQcXoLQu5mCp/uIourc15LDVNJHFT3fBhXsbTCSJrt2JQv2AfYtVM+4gR2OfdIBjlkE8w==
+
+"@radix-ui/react-context@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-0.0.1.tgz#23524f0d605fe12ee806f6e1e3834d41988c7d3d"
+  integrity sha512-oNm8xrhzbCKu/Y6E80x+mbzNlF4v34avfTqj9ZvHQzRhTKAhlgGT7JRXT3aeV7vZj4M1ofsaj/b57pYPx+GKXw==
+
+"@radix-ui/react-id@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.0.1.tgz#f04627366a64c3ceab321258731dcb9515a31451"
+  integrity sha512-b6ihKYxBV/4B6A49NBRMYdHVpyvavk8QakFMm+6JFwQqad4iSPbJt8aN4wOeLyEfG97rDf6hVR1YdOuA/x85dg==
+
+"@radix-ui/react-polymorphic@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.6.tgz#7cbadb346925d459984f540bab32403913f60ef0"
+  integrity sha512-M6VVxOLII8bdnKIYK9qDH8kO8/sYJXunA0VcNKlGJvD95GuolwypXGi3gLIHCqlAozHMFJ5hzy/Vsy/rCU8Glw==
+
+"@radix-ui/react-popper@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-0.0.8.tgz#8e3912de8b2473f032822b26850f3e5ffffe94f5"
+  integrity sha512-LAryuSo8yRVKV4fXKGauoafnam7RRZxJP7iNwEA2U2T1m84zav6ccXZSQPscrcvYCxTsJIsXns6XOeY34PG51g==
+  dependencies:
+    "@radix-ui/popper" "0.0.5"
+    "@radix-ui/react-arrow" "0.0.6"
+    "@radix-ui/react-compose-refs" "0.0.1"
+    "@radix-ui/react-context" "0.0.1"
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.6"
+    "@radix-ui/react-use-rect" "0.0.1"
+    "@radix-ui/react-use-size" "0.0.1"
+    "@radix-ui/rect" "0.0.1"
+
+"@radix-ui/react-portal@0.0.6", "@radix-ui/react-portal@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-0.0.6.tgz#fc69aa73446af17fb4fb3353a611dcc13805933e"
+  integrity sha512-+OthyHBAr5WCXmXgiZX2cFFTs1+4iy81NiEwz5Te9ABEs/fNYU0fDVOIFtUYlhTPxpbHDmgq3YDXoWCEDCyTCQ==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.5"
+    "@radix-ui/react-use-layout-effect" "0.0.1"
+
+"@radix-ui/react-primitive@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.5.tgz#2e56cf75ada56258458957ae930771e502f151b9"
+  integrity sha512-zZacpav02cmljSaBfuc/jTqJdsZmVSQsp9Eh03v6ksS/6sGmLga46cwztDzb2by/x2izodke5NdHrVOUNAMbeA==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.6"
+
+"@radix-ui/react-primitive@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.6.tgz#fa26d8fe60e7a0a66b35f8c485c603d3d948be83"
+  integrity sha512-Z3NuzZvTXF36y/HnUTuWUqbLstH41LD/kDGtn5Cz6lwzvy9Mc3rMHwnIXGjXZe8MqvZ9+FxGO4p0+2cpdc+oXg==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.6"
+
+"@radix-ui/react-slot@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-0.0.4.tgz#b39cca285ac326b7011e743577f6b85d2f5aa6cf"
+  integrity sha512-FPN/LREC+1kDguujiaum16fyPrj2HsIqgFLEvj116P4e3usErmJaWXgJYMmmDpAmZZw9Y9fvCZpHwp/+g0SUYg==
+  dependencies:
+    "@radix-ui/primitive" "0.0.1"
+    "@radix-ui/react-compose-refs" "0.0.1"
+
+"@radix-ui/react-tooltip@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-0.0.9.tgz#618f4f95c294d3edcc081345e81c56c381fd9be4"
+  integrity sha512-4wUKvbsl1i7YZ8TI8ijVxEdGQI9NmXmMyggWkp+DPaXn/XiiOBTdZFxKXmDcP9gfgLDQmRP4QJJPaetP44oiGQ==
+  dependencies:
+    "@radix-ui/primitive" "0.0.1"
+    "@radix-ui/react-compose-refs" "0.0.1"
+    "@radix-ui/react-context" "0.0.1"
+    "@radix-ui/react-id" "0.0.1"
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-popper" "0.0.8"
+    "@radix-ui/react-portal" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.6"
+    "@radix-ui/react-slot" "0.0.4"
+    "@radix-ui/react-use-controllable-state" "0.0.1"
+    "@radix-ui/react-use-layout-effect" "0.0.1"
+    "@radix-ui/react-use-previous" "0.0.1"
+    "@radix-ui/react-use-rect" "0.0.1"
+    "@radix-ui/react-visually-hidden" "0.0.6"
+
+"@radix-ui/react-use-callback-ref@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.0.1.tgz#70c8fd7d6a146bf65860ae7d4915985aacc53acc"
+  integrity sha512-WNqLyGlHuxfghIPuKH1/1q/NNc+W2ve2S823syefD78btShmR6LJqpUXinn9X7uK7ih/pB3UySMmbTv9CWrb9A==
+
+"@radix-ui/react-use-controllable-state@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.0.1.tgz#e31ae3d52ce7db5bdae215008fe81f7eda701440"
+  integrity sha512-xWirTCesup7uyt7jDRkQDQbjKzlNq7B4y+FhHFjRF5ZThSVICdR30O4IXhfAs3gH0Of/6yLR+RnGPOwEui1bqQ==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "0.0.1"
+
+"@radix-ui/react-use-layout-effect@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.0.1.tgz#6003a55174f002b415ad615fec6ddcb11b7cb29a"
+  integrity sha512-6SRJijFUZQvFOzQ2ZkMTN2gR/B8zn6sv0CwR8gVLIS34fl+yrElXUpKm6DGMtZU+fSFgLm6Ua6qCzNjsGV0rbA==
+
+"@radix-ui/react-use-previous@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-0.0.1.tgz#1b538983ed5637d6f66e66061bc21c9035eb6d47"
+  integrity sha512-r1UPtyRXCVKrqIacv9R+yJwn6PKReTpOrI3FzN0iDQ0COaDdzeZV2zohrz0CCw5RZHu0V0zbCPMnwNgyETWmeg==
+
+"@radix-ui/react-use-rect@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-0.0.1.tgz#faf1aa84416b06b41fd4b26208cd52c2ff4a7f36"
+  integrity sha512-kqFDh+aSLXNk58j1XrZJJTnR6127Iq6d3N1LtuVPLcluFrsbmXjU0otBctj60vBrvkxHKS/A7M5LTyuOQ5jdqg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "0.0.1"
+    "@radix-ui/rect" "0.0.1"
+
+"@radix-ui/react-use-size@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-0.0.1.tgz#63762495c5eac92fcf944f3c15237b333b53de44"
+  integrity sha512-WTY9SQbXOWGHGK4qcMtBy2Ty2+gYdJ6d+lk+wL0/fFTjqgWZaokItLPRstB6vrhVFV8bQBUN7W8l1sc41UWoWw==
+
+"@radix-ui/react-visually-hidden@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.0.6.tgz#a22a8ecf7df8c353c0470d1c9168aac762a98ca0"
+  integrity sha512-2nsYMHBDot50fCSH1pi/Cu27Z/D3HQigqqcXrbCeCzVb2nmI5BWi6hxScNzDr+4KBB1qZ9OfUqGttLJrPwkM5A==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.5"
+
+"@radix-ui/rect@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-0.0.1.tgz#fb79542e837336c60a81f480f0252dc52611749d"
+  integrity sha512-8MswNYU/AVxLZxfy2eOqna5piTR+DJoS+miRPCKTJe4MHkp4ZT7nGW/zdyS9LCXwQB8HW2htdP5vKAJYMBVD9Q==
+
 "@rollup/plugin-replace@^2.3.1", "@rollup/plugin-replace@^2.3.2":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.4.1.tgz#c411b5ab72809fb1bfc8b487d8d02eef661460d3"
@@ -2521,6 +2675,18 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
+"@stitches/core@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-0.1.4.tgz#1b33c3ef55c044f006049d8310b784720d669798"
+  integrity sha512-jFZMpw6uD7BRvkPp3n0JsUlLO6d7oRwBgInEHDB1xlsRLqB4yaepyEyJ1CqMx8HidyW5QeLXH6IYPzERxCUM/Q==
+
+"@stitches/react@^0.1.0":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.1.4.tgz#f1a37911683cfc192906b0710c9685bddb316abc"
+  integrity sha512-/YI/cuyd8tCGaq5ewDF2goGVa/LuIQZbb4SKQM/DroluOrZ4W1Pwczk/vkijhP3pH11ssEHtD9/v8VzXb01nvw==
+  dependencies:
+    "@stitches/core" "^0.1.4"
 
 "@styled-system/background@^5.1.2":
   version "5.1.2"
@@ -3543,6 +3709,13 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.3.0.tgz#2730c770f5f1f132767c63dcaaa4ec28f8c56a6c"
   integrity sha512-k2p2VrONcYVX1wRRrf0f3X2VGltLWcv+JzXRBDmvCxGlCeESx4OXw91TsWeKOkp784uNoVQo313vxJFHXPPwfw==
 
+"@welldone-software/why-did-you-render@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-6.1.1.tgz#3dcf66620fcafbf79e5260bd6ace5e51254055ac"
+  integrity sha512-BMFp33T4MC27qvCWsI1SqwZCxIlxoQXsPQFdGLDsPSg7sgoWX4Gzj0+hlKVrWrCBiIxi7gP2JcS9IK6CZzk8mg==
+  dependencies:
+    lodash "^4"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4206,6 +4379,11 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+attr-accept@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
 autocomplete.js@0.36.0:
   version "0.36.0"
@@ -5336,6 +5514,11 @@ clipboard-copy@^3.0.0:
   resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-3.2.0.tgz#3c5b8651d3512dcfad295d77a9eb09e7fac8d5fb"
   integrity sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==
 
+clipboard-polyfill@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/clipboard-polyfill/-/clipboard-polyfill-3.0.2.tgz#6d45719421395257460e09febb5dffa495a2878b"
+  integrity sha512-1DTdwGicGBAhK4/VjOwFYG3fAu1aj1n/jC/00qkRyDobKSB/PF8mhJkbAlDGbNEc8hIrPElv5j96OE5PwHMUfA==
+
 clipboard@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
@@ -6204,7 +6387,7 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
-csstype@^3.0.2, csstype@^3.0.6:
+csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.6:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
   integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
@@ -6570,6 +6753,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+dequal@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -7844,6 +8032,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-selector@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
+  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
+  dependencies:
+    tslib "^2.0.3"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -9357,7 +9552,7 @@ is-extendable@^0.1.0, is-extendable@^0.1.1:
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
   integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
-is-extendable@^1.0.1:
+is-extendable@^1.0.0, is-extendable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
   integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
@@ -10334,6 +10529,25 @@ lerna@^4.0.0:
     import-local "^3.0.2"
     npmlog "^4.1.2"
 
+leva@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/leva/-/leva-0.8.3.tgz#be064b2172dce246d58c6fdcc999c65f22b85974"
+  integrity sha512-3gSP3ISGYdbYEF/FCpmRpXjtzftfVGyi3Rmn2rS2F53tgQtGHbMPlv1OQW1OyZvsRK7vnIC7+7i5Yp8S2uEM/Q==
+  dependencies:
+    "@radix-ui/react-portal" "^0.0.6"
+    "@radix-ui/react-tooltip" "0.0.9"
+    "@stitches/react" "^0.1.0"
+    "@welldone-software/why-did-you-render" "^6.1.1"
+    clipboard-polyfill "^3.0.2"
+    dequal "^2.0.2"
+    merge-value "^1.0.0"
+    react-colorful "^5.0.1"
+    react-dropzone "^11.3.1"
+    react-use-gesture "^9.1.3"
+    tinycolor2 "^1.4.2"
+    v8n "^1.3.3"
+    zustand "^3.3.3"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -10667,7 +10881,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.4:
+lodash@^4, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11024,6 +11238,16 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+merge-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/merge-value/-/merge-value-1.0.0.tgz#d28f8d41c0b37426e032d1059a0d0343302de502"
+  integrity sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==
+  dependencies:
+    get-value "^2.0.6"
+    is-extendable "^1.0.0"
+    mixin-deep "^1.2.0"
+    set-value "^2.0.0"
 
 merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
@@ -13317,6 +13541,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-colorful@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.0.1.tgz#50dcd10cd94bc0b2257492ca8785c53b07805faf"
+  integrity sha512-I/ctDkUZVCIKvIqBwqQWphPxDUJv8q1omKzQ3XJ6H3PhrxF/1t9olNVcTKBJSTKDACZJbyJ0cEAUi3rvAZWdSA==
+
 react-display-name@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
@@ -13352,6 +13581,15 @@ react-draggable@^4.0.3:
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
+
+react-dropzone@^11.3.1:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.3.2.tgz#2efb6af800a4779a9daa1e7ba1f8d51d0ab862d7"
+  integrity sha512-Z0l/YHcrNK1r85o6RT77Z5XgTARmlZZGfEKBl3tqTXL9fZNQDuIdRx/J0QjvR60X+yYu26dnHeaG2pWU+1HHvw==
+  dependencies:
+    attr-accept "^2.2.1"
+    file-selector "^0.2.2"
+    prop-types "^15.7.2"
 
 react-event-listener@^0.6.0:
   version "0.6.6"
@@ -13565,6 +13803,11 @@ react-transition-group@^4.4.0, react-transition-group@^4.4.1:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-use-gesture@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-9.1.3.tgz#92bd143e4f58e69bd424514a5bfccba2a1d62ec0"
+  integrity sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg==
 
 react-virtualized@^9.21.1:
   version "9.22.3"
@@ -15809,6 +16052,11 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+tinycolor2@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
+  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
+
 tmp@0.2.1, tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -15981,7 +16229,7 @@ tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.1.0:
+tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
@@ -16475,6 +16723,11 @@ v8flags@^3.1.1:
   integrity sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==
   dependencies:
     homedir-polyfill "^1.0.1"
+
+v8n@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/v8n/-/v8n-1.3.3.tgz#4e03782173f1ac6108370859319050470d72a1c9"
+  integrity sha512-5w0/blXdz5idt+TJj72Vs69HcRYDARRWFami3bj7TLx8qvOVpyL3D3wdnXVrPLWvSApfVe2vBV54V16QYVlJnA==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
@@ -17068,6 +17321,11 @@ zip-stream@^2.1.2:
     archiver-utils "^2.1.0"
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
+
+zustand@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.3.3.tgz#88b930a873d0f13e406f96958c1409645ea8b370"
+  integrity sha512-KTN/O76rVc9muDoprsCDe/LQjbuq+GHYt5JdYahuXaGZ+8Gyk44SepzTFeQTF5J+b8+/Q+o90BaSEQ3WImKPog==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Current status: proof-of-concept i.e. not mergable
Preview: https://deploy-preview-25548--material-ui.netlify.app/

Help welcome. I can't dedicate much time to it so feel free to propose pull requests targetting this branch that fix one of the items below.

## Goal

Closes #20275
Allow fully customizing the theme of the docs to explore customization options.

## TODOs for minimal viable product

In order to be mergable we need to fix the following bugs:

- [ ] panel disapears in dev when React Refresh kicks in
 
In order to be mergable we need to add the following features:

- [ ] hide customization by default (displaying the customization requires remount of the visible UI)
- [ ] add affordance to show/hide the panel
- [ ] reset values
- [ ] persist values (between full page reload)

## follow-ups

- [ ] shareable themes

