### PR TITLE
[docs] Fix <kbd> style in dark mode

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -200,9 +200,9 @@ const styles = (theme) => ({
       color: theme.palette.text.primary,
       verticalAlign: 'middle',
       backgroundColor: theme.palette.mode === 'dark' ? 'transparent' : '#fafbfc',
-      border: `1px solid ${theme.palette.mode === 'dark' ? '#d1d5da' : '#6e7681'}`,
+      border: `1px solid ${theme.palette.mode === 'dark' ? '#6e7681' : '#d1d5da'}`,
       borderRadius: 6,
-      boxShadow: `inset 0 -1px 0 ${theme.palette.mode === 'dark' ? '#d1d5da' : '#6e7681'}`,
+      boxShadow: `inset 0 -1px 0 ${theme.palette.mode === 'dark' ? '#6e7681' : '#d1d5da'}`,
     },
   },
 });

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -199,10 +199,10 @@ const styles = (theme) => ({
       lineHeight: '10px',
       color: theme.palette.text.primary,
       verticalAlign: 'middle',
-      backgroundColor: '#fafbfc',
-      border: '1px solid #d1d5da',
+      backgroundColor: theme.palette.mode === 'dark' ? 'transparent' : '#fafbfc',
+      border: `1px solid ${theme.palette.mode === 'dark' ? '#d1d5da' : '#6e7681'}`,
       borderRadius: 6,
-      boxShadow: 'inset 0 -1px 0 #d1d5da',
+      boxShadow: `inset 0 -1px 0 ${theme.palette.mode === 'dark' ? '#d1d5da' : '#6e7681'}`,
     },
   },
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #25550.

Styles taken from GitHub "Default Dark" theme.

Preview: https://deploy-preview-25551--material-ui.netlify.app/components/trap-focus/