### PR TITLE
[Select] Fix selection of non-options

### DIFF
--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -11,10 +11,11 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-import MenuItem from '../MenuItem';
-import Input from '../Input';
-import InputLabel from '../InputLabel';
-import Select from './Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
+import Select from '@material-ui/core/Select';
+import Divider from '@material-ui/core/Divider';
 
 describe('<Select />', () => {
   let classes;
@@ -1130,5 +1131,20 @@ describe('<Select />', () => {
 
     expect(handleChange.callCount).to.equal(1);
     expect(handleEvent.returnValues).to.have.members([options[0]]);
+  });
+
+  it('should only select options', () => {
+    const handleChange = spy();
+    render(
+      <Select open onChange={handleChange} value="second">
+        <MenuItem value="first" />
+        <Divider />
+        <MenuItem value="second" />
+      </Select>
+    );
+
+    const divider = document.querySelector('hr');
+    divider.click();
+    expect(handleChange.callCount).to.equal(0);
   });
 });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1140,7 +1140,7 @@ describe('<Select />', () => {
         <MenuItem value="first" />
         <Divider />
         <MenuItem value="second" />
-      </Select>
+      </Select>,
     );
 
     const divider = document.querySelector('hr');

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -169,6 +169,11 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const handleItemClick = (child) => (event) => {
     let newValue;
 
+    // Ignore items without a tab index
+    if (!event.currentTarget.hasAttribute('tabindex')) {
+      return;
+    }
+
     if (multiple) {
       newValue = Array.isArray(value) ? value.slice() : [];
       const itemIndex = value.indexOf(child.props.value);

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -169,7 +169,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const handleItemClick = (child) => (event) => {
     let newValue;
 
-    // Ignore items without a tab index
+    // We use the tabindex attribute to signal the available options.
     if (!event.currentTarget.hasAttribute('tabindex')) {
       return;
     }


### PR DESCRIPTION
A follow-up on #25532. How the solution work is explained in https://github.com/mui-org/material-ui/pull/25532#issuecomment-808922387.

Closes #18200 (duplicates: #18390, #22274)

A simplified reproduction:

1. Open https://codesandbox.io/s/basicselect-material-demo-forked-h08b1
2. Open the select
3. Click the divider
4. 💥 warning in the console

cc @tanmoyopenroot