### PR TITLE
[TimePicker] Use clock icon when editing in mobile mode

### DIFF
--- a/packages/material-ui-lab/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePickerToolbar.tsx
@@ -95,6 +95,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof styl
 
   return (
     <PickersToolbar
+      viewType="clock"
       landscapeDirection="row"
       toolbarTitle={toolbarTitle}
       isLandscape={isLandscape}

--- a/packages/material-ui-lab/src/internal/pickers/PickersToolbar.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersToolbar.tsx
@@ -6,6 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import { MuiStyles, StyleRules, WithStyles, withStyles } from '@material-ui/core/styles';
 import PenIcon from '../svg-icons/Pen';
 import CalendarIcon from '../svg-icons/Calendar';
+import ClockIcon from '../svg-icons/Clock';
 import { ToolbarComponentProps } from './typings/BasePicker';
 
 export type PickersToolbarClassKey = 'root' | 'toolbarLandscape' | 'dateTitleContainer';
@@ -32,22 +33,29 @@ export const styles: MuiStyles<PickersToolbarClassKey> = (
   },
 });
 
+const getViewTypeIcon = (viewType: 'calendar' | 'clock') =>
+  viewType === 'clock' ? <ClockIcon color="inherit" /> : <CalendarIcon color="inherit" />;
+
 export interface PickersToolbarProps
   extends Pick<
     ToolbarComponentProps,
     'getMobileKeyboardInputViewButtonText' | 'isMobileKeyboardViewOpen' | 'toggleMobileKeyboardView'
   > {
   className?: string;
+  viewType?: 'calendar' | 'clock';
   isLandscape: boolean;
   landscapeDirection?: 'row' | 'column';
   penIconClassName?: string;
   toolbarTitle: React.ReactNode;
 }
 
-function defaultGetKeyboardInputSwitchingButtonText(isKeyboardInputOpen: boolean) {
+function defaultGetKeyboardInputSwitchingButtonText(
+  isKeyboardInputOpen: boolean,
+  viewType: 'calendar' | 'clock',
+) {
   return isKeyboardInputOpen
-    ? 'text input view is open, go to calendar view'
-    : 'calendar view is open, go to text input view';
+    ? `text input view is open, go to ${viewType} view`
+    : `${viewType} view is open, go to text input view`;
 }
 
 const PickerToolbar: React.FC<PickersToolbarProps & WithStyles<typeof styles>> = (props) => {
@@ -62,6 +70,7 @@ const PickerToolbar: React.FC<PickersToolbarProps & WithStyles<typeof styles>> =
     penIconClassName,
     toggleMobileKeyboardView,
     toolbarTitle,
+    viewType = 'calendar',
   } = props;
 
   return (
@@ -85,13 +94,9 @@ const PickerToolbar: React.FC<PickersToolbarProps & WithStyles<typeof styles>> =
           className={penIconClassName}
           color="inherit"
           data-mui-test="toggle-mobile-keyboard-view"
-          aria-label={getMobileKeyboardInputViewButtonText(isMobileKeyboardViewOpen)}
+          aria-label={getMobileKeyboardInputViewButtonText(isMobileKeyboardViewOpen, viewType)}
         >
-          {isMobileKeyboardViewOpen ? (
-            <CalendarIcon color="inherit" />
-          ) : (
-            <PenIcon color="inherit" />
-          )}
+          {isMobileKeyboardViewOpen ? getViewTypeIcon(viewType) : <PenIcon color="inherit" />}
         </IconButton>
       </Grid>
     </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


The time picker toolbar used the calendar icon instead of the clock icon for the button to switch away from the text input view, which was confusing. This replaces the icon on the time picker as well as the aria label to match the actual use of the component.

Steps to reproduce:
Insert a TimePicker
Open TimePicker in mobile mode
Click the pen icon to go to the keyboard edit view
The icon to return to the clock view is a calendar. This is confusing.