### PR TITLE
[docs] Add note for typescript on the styled() customization guide

### DIFF
--- a/docs/src/pages/customization/how-to-customize/DynamicCSS.tsx
+++ b/docs/src/pages/customization/how-to-customize/DynamicCSS.tsx
@@ -6,7 +6,7 @@ import Switch from '@material-ui/core/Switch';
 
 interface StyledSliderProps extends SliderProps {
   success?: boolean;
-};
+}
 
 const StyledSlider = experimentalStyled(Slider, {
   shouldForwardProp: (prop) => prop !== 'success',

--- a/docs/src/pages/customization/how-to-customize/DynamicCSS.tsx
+++ b/docs/src/pages/customization/how-to-customize/DynamicCSS.tsx
@@ -4,7 +4,7 @@ import Slider, { SliderProps } from '@material-ui/core/Slider';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 
-type StyledSliderProps = SliderProps & {
+interface StyledSliderProps extends SliderProps {
   success?: boolean;
 };
 

--- a/docs/src/pages/customization/how-to-customize/how-to-customize.md
+++ b/docs/src/pages/customization/how-to-customize/how-to-customize.md
@@ -156,7 +156,7 @@ import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Slider, { SliderProps } from '@material-ui/core/Slider';
 
-type StyledSliderProps = SliderProps & {
+interface StyledSliderProps extends SliderProps {
   success?: boolean;
 };
 

--- a/docs/src/pages/customization/how-to-customize/how-to-customize.md
+++ b/docs/src/pages/customization/how-to-customize/how-to-customize.md
@@ -149,7 +149,7 @@ Using the `styled()` utility offers a simple way for adding dynamic styles based
 
 {{"demo": "pages/customization/how-to-customize/DynamicCSS.js", "defaultCodeOpen": false}}
 
-> ⚠️ Note that if you are using `typescript` you will need to update the prop's types of the new component.
+> ⚠️ Note that if you are using TypeScript you will need to update the prop's types of the new component.
 
 ```tsx
 import * as React from 'react';

--- a/docs/src/pages/customization/how-to-customize/how-to-customize.md
+++ b/docs/src/pages/customization/how-to-customize/how-to-customize.md
@@ -158,7 +158,7 @@ import Slider, { SliderProps } from '@material-ui/core/Slider';
 
 interface StyledSliderProps extends SliderProps {
   success?: boolean;
-};
+}
 
 const StyledSlider = styled(Slider, {
   shouldForwardProp: (prop) => prop !== 'success',

--- a/docs/src/pages/customization/how-to-customize/how-to-customize.md
+++ b/docs/src/pages/customization/how-to-customize/how-to-customize.md
@@ -145,7 +145,30 @@ Here are four alternatives; each has its pros and cons.
 
 ### Dynamic CSS
 
+Using the `styled()` utility offers a simple way for adding dynamic styles based on props.
+
 {{"demo": "pages/customization/how-to-customize/DynamicCSS.js", "defaultCodeOpen": false}}
+
+> ⚠️ Note that if you are using `typescript` you will need to update the prop's types of the new component.
+
+```tsx
+import * as React from 'react';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
+import Slider, { SliderProps } from '@material-ui/core/Slider';
+
+type StyledSliderProps = SliderProps & {
+  success?: boolean;
+};
+
+const StyledSlider = styled(Slider, {
+  shouldForwardProp: (prop) => prop !== 'success',
+})<StyledSliderProps>(({ success, theme }) => ({
+  ...(success &&
+    {
+      // the overrides added when the new prop is used
+    }),
+}));
+```
 
 ### Class name branch
 


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/24862

Adds a section on how the props of the styled component created with `experimentalStyled()` can be typed.