### PR TITLE
[docs] Provide an alternative to right-to-left

### DIFF
--- a/docs/src/pages/guides/right-to-left/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left.md
@@ -12,6 +12,20 @@ Make sure the `dir` attribute is set on the body, otherwise native components wi
 <body dir="rtl"></body>
 ```
 
+As an alternative to the above, you can also wrap your application in an element with the `dir` attribute:
+
+```jsx
+function App() {
+  return (
+    <div dir="rtl">
+      <MyComponent />
+    </div>
+  );
+}
+```
+
+This can be helpful for creating components to toggle language settings in the live application.
+
 ### 2. Theme
 
 Set the direction in your custom theme:


### PR DESCRIPTION
Updating the right-to-left language guide to reflect that adding `dir="rtl"` to the `<body>` element is only one solution for configuring RTL for native components. You can also wrap them in a lower-level div, as long as it is the parent of all your UI components. This is helpful because `<body>` is often defined as a template outside the scope of a React app, whereas a `<div>` that wraps the entire application can be easily controlled from an application component like a language switching toggle.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
