### PR TITLE
[Select] Dispatch click event with same target of the mousedown event

### DIFF
--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1142,38 +1142,6 @@ describe('<Select />', () => {
     expect(handleEvent.returnValues).to.have.members([options[0]]);
   });
 
-  it('should call onClick with the same event.target of the mousedown event', () => {
-    const handleDocumentClick = spy();
-    const handleEvent = spy((event) => event.target);
-
-    function Test() {
-      React.useEffect(() => {
-        document.addEventListener('click', handleDocumentClick);
-        return () => {
-          document.removeEventListener('click', handleDocumentClick);
-        };
-      }, []);
-
-      return (
-        <div onClick={handleEvent}>
-          <Select value="first">
-            <MenuItem value="first" />
-            <MenuItem value="second" />
-          </Select>
-        </div>
-      );
-    }
-
-    render(<Test />);
-    const button = screen.getByRole('button');
-    fireEvent.mouseDown(button);
-    fireEvent.click(document.body);
-
-    // Ensure only one `click` event during the bubbling phase.
-    expect(handleDocumentClick.callCount).to.equal(1);
-    expect(handleEvent.returnValues).to.have.members([button]);
-  });
-
   it('should only select options', () => {
     const handleChange = spy();
     render(

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -247,8 +247,9 @@ describe('<Select />', () => {
           <MenuItem value="2" />
         </Select>,
       );
-      fireEvent.mouseDown(getByRole('button'));
-      fireEvent.click(getByRole('button'));
+      const button = getByRole('button');
+      fireEvent.mouseDown(button);
+      fireEvent.click(button);
       getAllByRole('option')[1].click();
 
       expect(onChangeHandler.calledOnce).to.equal(true);
@@ -267,8 +268,9 @@ describe('<Select />', () => {
         </Select>,
       );
 
-      fireEvent.mouseDown(getByRole('button'));
-      fireEvent.click(getByRole('button'));
+      const button = getByRole('button');
+      fireEvent.mouseDown(button);
+      fireEvent.click(button);
       getAllByRole('option')[1].click();
 
       expect(eventLog).to.deep.equal(['CHANGE_EVENT', 'CLOSE_EVENT']);
@@ -727,8 +729,9 @@ describe('<Select />', () => {
       }
       const { getByRole, queryByRole } = render(<ControlledWrapper />);
 
-      fireEvent.mouseDown(getByRole('button'));
-      fireEvent.click(getByRole('button'));
+      const button = getByRole('button');
+      fireEvent.mouseDown(button);
+      fireEvent.click(button);
       expect(getByRole('listbox')).not.to.equal(null);
 
       act(() => {
@@ -925,8 +928,9 @@ describe('<Select />', () => {
         });
         const { getByRole, getAllByRole } = render(<ControlledSelectInput onChange={onChange} />);
 
-        fireEvent.mouseDown(getByRole('button'));
-        fireEvent.click(getByRole('button'));
+        const button = getByRole('button');
+        fireEvent.mouseDown(button);
+        fireEvent.click(button);
         const options = getAllByRole('option');
         fireEvent.click(options[2]);
 

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -116,6 +116,7 @@ describe('<Select />', () => {
     const trigger = getByRole('button');
 
     fireEvent.mouseDown(trigger);
+    fireEvent.click(trigger);
 
     expect(handleBlur.callCount).to.equal(0);
     expect(getByRole('listbox')).not.to.equal(null);
@@ -247,6 +248,7 @@ describe('<Select />', () => {
         </Select>,
       );
       fireEvent.mouseDown(getByRole('button'));
+      fireEvent.click(getByRole('button'));
       getAllByRole('option')[1].click();
 
       expect(onChangeHandler.calledOnce).to.equal(true);
@@ -266,6 +268,7 @@ describe('<Select />', () => {
       );
 
       fireEvent.mouseDown(getByRole('button'));
+      fireEvent.click(getByRole('button'));
       getAllByRole('option')[1].click();
 
       expect(eventLog).to.deep.equal(['CHANGE_EVENT', 'CLOSE_EVENT']);
@@ -725,6 +728,7 @@ describe('<Select />', () => {
       const { getByRole, queryByRole } = render(<ControlledWrapper />);
 
       fireEvent.mouseDown(getByRole('button'));
+      fireEvent.click(getByRole('button'));
       expect(getByRole('listbox')).not.to.equal(null);
 
       act(() => {
@@ -922,6 +926,7 @@ describe('<Select />', () => {
         const { getByRole, getAllByRole } = render(<ControlledSelectInput onChange={onChange} />);
 
         fireEvent.mouseDown(getByRole('button'));
+        fireEvent.click(getByRole('button'));
         const options = getAllByRole('option');
         fireEvent.click(options[2]);
 
@@ -1131,6 +1136,38 @@ describe('<Select />', () => {
 
     expect(handleChange.callCount).to.equal(1);
     expect(handleEvent.returnValues).to.have.members([options[0]]);
+  });
+
+  it('should call onClick with the same event.target of the mousedown event', () => {
+    const handleDocumentClick = spy();
+    const handleEvent = spy((event) => event.target);
+
+    function Test() {
+      React.useEffect(() => {
+        document.addEventListener('click', handleDocumentClick);
+        return () => {
+          document.removeEventListener('click', handleDocumentClick);
+        };
+      }, []);
+
+      return (
+        <div onClick={handleEvent}>
+          <Select value="first">
+            <MenuItem value="first" />
+            <MenuItem value="second" />
+          </Select>
+        </div>
+      );
+    }
+
+    render(<Test />);
+    const button = screen.getByRole('button');
+    fireEvent.mouseDown(button);
+    fireEvent.click(document.body);
+
+    // Ensure only one `click` event during the bubbling phase.
+    expect(handleDocumentClick.callCount).to.equal(1);
+    expect(handleEvent.returnValues).to.have.members([button]);
   });
 
   it('should only select options', () => {

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -97,9 +97,10 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   );
 
   React.useEffect(() => {
+    const doc = ownerDocument(inputRef.current);
     return () => {
       if (handleClick.current) {
-        document.removeEventListener('click', handleClick.current, true);
+        doc.removeEventListener('click', handleClick.current, true);
       }
     };
   }, []);
@@ -150,18 +151,20 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     event.preventDefault();
     displayRef.current.focus();
 
-    const doc = ownerDocument(event.target);
+    const doc = ownerDocument(inputRef.current);
     if (handleClick.current) {
       doc.removeEventListener('click', handleClick.current, true);
     }
 
     // Since the targets of the `mousedown` and `mouseup` events are different,
     // the browser will dispatch the `click` to a common ancestor.
-    // This stops the next `click` and re-dispatch it with the right target.
+    // This stops the next `click` and re-dispatch it with the same target of the `mousedown`.
     handleClick.current = (clickEvent) => {
       clickEvent.stopPropagation();
       doc.removeEventListener('click', handleClick.current, true);
-      event.target.dispatchEvent(new window.Event('click', { bubbles: true }));
+      event.target.dispatchEvent(
+        new doc.defaultView.MouseEvent('click', { bubbles: true, cancelable: true }),
+      );
       handleClick.current = null;
     };
     doc.addEventListener('click', handleClick.current, true);

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -150,10 +150,14 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     event.preventDefault();
     displayRef.current.focus();
 
+    const doc = ownerDocument(event.target);
+    if (handleClick.current) {
+      doc.removeEventListener('click', handleClick.current, true);
+    }
+
     // Since the targets of the `mousedown` and `mouseup` events are different,
     // the browser will dispatch the `click` to a common ancestor.
     // This stops the next `click` and re-dispatch it with the right target.
-    const doc = ownerDocument(event.target);
     handleClick.current = (clickEvent) => {
       clickEvent.stopPropagation();
       doc.removeEventListener('click', handleClick.current, true);

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -58,6 +58,7 @@ describe('<Select> integration', () => {
       // Let's open the select component
       // in the browser user click also focuses
       fireEvent.mouseDown(trigger);
+      fireEvent.click(trigger);
 
       const options = getAllByRole('option');
       expect(options[1]).toHaveFocus();
@@ -82,6 +83,7 @@ describe('<Select> integration', () => {
       // Let's open the select component
       // in the browser user click also focuses
       fireEvent.mouseDown(trigger);
+      fireEvent.click(trigger);
 
       const options = getAllByRole('option');
       expect(options[1]).toHaveFocus();

--- a/test/e2e/fixtures/ClickAwayListener/WithSelect.tsx
+++ b/test/e2e/fixtures/ClickAwayListener/WithSelect.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+
+export default function WithSelect() {
+  const [clickedAway, setClickedAway] = React.useState(false);
+
+  return (
+    <React.Fragment>
+      <div>{clickedAway ? 'onClickAway called' : null}</div>
+      <ClickAwayListener onClickAway={() => setClickedAway(true)}>
+        <Select value="">
+          <MenuItem value={10}>One</MenuItem>
+          <MenuItem value={20}>Two</MenuItem>
+          <MenuItem value={30}>Three</MenuItem>
+        </Select>
+      </ClickAwayListener>
+    </React.Fragment>
+  );
+}

--- a/test/e2e/fixtures/ClickAwayListener/WithSelect.tsx
+++ b/test/e2e/fixtures/ClickAwayListener/WithSelect.tsx
@@ -4,12 +4,12 @@ import MenuItem from '@material-ui/core/MenuItem';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 
 export default function WithSelect() {
-  const [clickedAway, setClickedAway] = React.useState(false);
+  const [counter, setCounter] = React.useState(0);
 
   return (
     <React.Fragment>
-      <div>{clickedAway ? 'onClickAway called' : null}</div>
-      <ClickAwayListener onClickAway={() => setClickedAway(true)}>
+      <div>{`onClickAway=${counter}`}</div>
+      <ClickAwayListener onClickAway={() => setCounter(counter + 1)}>
         <Select value="">
           <MenuItem value={10}>One</MenuItem>
           <MenuItem value={20}>Two</MenuItem>

--- a/test/e2e/fixtures/ClickAwayListener/WithSelect.tsx
+++ b/test/e2e/fixtures/ClickAwayListener/WithSelect.tsx
@@ -8,7 +8,7 @@ export default function WithSelect() {
 
   return (
     <React.Fragment>
-      <div>{`onClickAway=${counter}`}</div>
+      <div id="onClickAway">{counter}</div>
       <ClickAwayListener onClickAway={() => setCounter(counter + 1)}>
         <Select value="">
           <MenuItem value={10}>One</MenuItem>

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -102,11 +102,12 @@ describe('e2e', () => {
   describe('<ClickAwayListener />', () => {
     it('should not call onClickAway when opening a select', async () => {
       await renderFixture('ClickAwayListener/WithSelect');
+      expect(await page.textContent('#onClickAway')).to.equal('0');
       await page.click('body');
-      expect(await page.$('"onClickAway=1"')).not.to.equal(null);
+      expect(await page.textContent('#onClickAway')).to.equal('1');
       await page.click('[role="button"]');
       await page.click('"One"');
-      expect(await page.$('"onClickAway=1"')).not.to.equal(null);
+      expect(await page.textContent('#onClickAway')).to.equal('1');
     });
   });
 });

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -98,4 +98,13 @@ describe('e2e', () => {
       expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('ok');
     });
   });
+
+  describe('<ClickAwayListener />', () => {
+    it('should not call onClickAway when opening a select', async () => {
+      await renderFixture('ClickAwayListener/WithSelect');
+      await page.click('[role="button"]');
+      await page.click('text=One');
+      expect(await page.$('text=onClickAway called')).to.equal(null);
+    });
+  });
 });

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -102,9 +102,12 @@ describe('e2e', () => {
   describe('<ClickAwayListener />', () => {
     it('should not call onClickAway when opening a select', async () => {
       await renderFixture('ClickAwayListener/WithSelect');
+      await page.click('body');
+      expect(await page.$('"onClickAway=1"')).not.to.equal(null);
       await page.click('[role="button"]');
-      await page.click('text=One');
-      expect(await page.$('text=onClickAway called')).to.equal(null);
+      await page.click('"One"');
+      expect(await page.$('"onClickAway=1"')).not.to.equal(null);
+      await page.pause();
     });
   });
 });

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -107,7 +107,6 @@ describe('e2e', () => {
       await page.click('[role="button"]');
       await page.click('"One"');
       expect(await page.$('"onClickAway=1"')).not.to.equal(null);
-      await page.pause();
     });
   });
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #25578

Trade-offs:
- Two `click` events in the capture phase
- Test cases that call `fireEvent.mouseDown` must also call `fireEvent.click` to clear the added listener. Related to #18655

A codesandbox with the upstream issue and the fix in this PR: https://codesandbox.io/s/datagrid-bug-demo-forked-ntsb3?file=/package.json