### PR TITLE
[docs] Fix typo in switches.md doc

### DIFF
--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -44,7 +44,7 @@ Use the `size` prop or customize the font size of the svg icons to change the si
 
 ## Controlled
 
-You can control the checkbox with the `value` and `onChange` props:
+You can control the checkbox with the `checked` and `onChange` props:
 
 {{"demo": "pages/components/checkboxes/ControlledCheckbox.js"}}
 

--- a/docs/src/pages/components/switches/switches.md
+++ b/docs/src/pages/components/switches/switches.md
@@ -37,7 +37,7 @@ Use the `size` prop to change the size of the switch.
 
 ## Controlled
 
-You can control the switch with the `value` and `onChange` props:
+You can control the switch with the `checked` and `onChange` props:
 
 {{"demo": "pages/components/switches/ControlledSwitches.js"}}
 


### PR DESCRIPTION
the text said `value` but the actual prop is `checked` and the example uses `checked`.  if this is incorrect, then we should update the example code instead to use `value` instead of what it uses now, `checked`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
