### PR TITLE
[core] Ensure react-is uses v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "**/@types/react-dom": "^17.0.0",
     "**/cross-fetch": "^3.0.5",
     "**/dot-prop": "^5.2.0",
-    "**/react-is": "^16.13.1"
+    "**/react-is": "^17.0.1"
   },
   "nyc": {
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13336,9 +13336,9 @@ react-final-form@^6.3.0:
     "@babel/runtime" "^7.12.1"
 
 react-is@16.10.2, react-is@16.13.1, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-jss@^10.3.0:
   version "10.6.0"


### PR DESCRIPTION
Forgot to update in https://github.com/mui-org/material-ui/pull/25416