### PR TITLE
[docs] Remove inline-style

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { makeStyles, alpha } from '@material-ui/core/styles';
+import { useTheme, makeStyles, alpha } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
@@ -92,6 +92,7 @@ export default function AppNavDrawerItem(props) {
     ...other
   } = props;
   const classes = useStyles();
+  const theme = useTheme();
   const [open, setOpen] = React.useState(openImmediately);
 
   const handleClick = () => {
@@ -99,7 +100,7 @@ export default function AppNavDrawerItem(props) {
   };
 
   const style = {
-    paddingInlineStart: 8 * (3 + 1.5 * depth),
+    [theme.direction === 'rtl' ? 'paddingRight' : 'paddingLeft']: 8 * (3 + 1.5 * depth),
   };
 
   if (href) {

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { useTheme, makeStyles, alpha } from '@material-ui/core/styles';
+import { makeStyles, alpha } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
@@ -21,7 +21,8 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: theme.shape.borderRadius,
     outline: 0,
     width: '100%',
-    padding: '8px 0',
+    paddingTop: 8,
+    paddingBottom: 8,
     justifyContent: 'flex-start',
     fontWeight: theme.typography.fontWeightMedium,
     transition: theme.transitions.create(['color', 'background-color'], {
@@ -35,7 +36,8 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.action.focus,
     },
     [theme.breakpoints.up('md')]: {
-      padding: '6px 0',
+      paddingTop: 6,
+      paddingBottom: 6,
     },
   },
   button: {
@@ -92,15 +94,14 @@ export default function AppNavDrawerItem(props) {
     ...other
   } = props;
   const classes = useStyles();
-  const theme = useTheme();
   const [open, setOpen] = React.useState(openImmediately);
 
   const handleClick = () => {
     setOpen((oldOpen) => !oldOpen);
   };
 
-  const style = {
-    [theme.direction === 'rtl' ? 'paddingRight' : 'paddingLeft']: 8 * (3 + 1.5 * depth),
+  const sx = {
+    pl: `${8 * (3 + 1.5 * depth)}px`,
   };
 
   if (href) {
@@ -117,7 +118,7 @@ export default function AppNavDrawerItem(props) {
           underline="none"
           className={clsx(classes.item, classes.link)}
           onClick={onClick}
-          style={style}
+          sx={sx}
           {...linkProps}
         >
           {title}
@@ -139,7 +140,7 @@ export default function AppNavDrawerItem(props) {
           'algolia-lvl0': topLevel,
         })}
         onClick={handleClick}
-        style={style}
+        sx={sx}
       >
         <ArrowRightIcon className={open ? classes.open : ''} />
         {title}


### PR DESCRIPTION
The usage of the `paddingInlineStart` CSS property is [flooding](https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext.material-ui.com%2Fcomponents%2Faccordion%2F) all the other errors, #25669 was hard to spot. This the only occurrence of a direction-aware CSS property we have in the codebase. The change didn't seem to cost much, it's unclear when validator will solve the root issue. My hope is that it will help us catch other issues on the pages.

I have opened https://github.com/validator/validator/issues/1134 upstream, which is probably the most important part.

---

Edit, this PR now focuses on remove usages of inline-style: https://github.com/mui-org/material-ui/issues/19938#issuecomment-645893048.