### PR TITLE
[core] Fix build step for unstyled package

### DIFF
--- a/packages/material-ui-unstyled/package.json
+++ b/packages/material-ui-unstyled/package.json
@@ -30,7 +30,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
-    "prebuild": "rimraf build",
+    "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build --tag next",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-unstyled/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"


### PR DESCRIPTION
This is a continuation of #23805 (same solution). I had to remove this file in order to make [v5.0.0-alpha.29](https://github.com/mui-org/material-ui/releases/tag/) happen. In HEAD `yarn release:build` is failing for me with:

```
@material-ui/unstyled: buildTypes
@material-ui/unstyled: Builds a project with a fix for
@material-ui/unstyled: https://github.com/microsoft/TypeScript/issues/39117
@material-ui/unstyled: Options:
@material-ui/unstyled:   --help  Show help                                                    [boolean]
@material-ui/unstyled: Error: Unable to find declaration files in '/Users/oliviertassinari/material-ui/packages/material-ui-unstyled/build'
@material-ui/unstyled:     at Object.main [as handler] (/Users/oliviertassinari/material-ui/scripts/buildTypes.js:49:11)
@material-ui/unstyled:     at processTicksAndRejections (internal/process/task_queues.js:97:5)
@material-ui/unstyled: error Command failed with exit code 1.
@material-ui/unstyled: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@material-ui/unstyled: error Command failed with exit code 1.
@material-ui/unstyled: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run build exited 1 in '@material-ui/unstyled'
lerna ERR! yarn run build stdout:
$ rimraf build
$ yarn build:legacy && yarn build:modern && yarn build:node && yarn build:stable && yarn build:types && yarn build:copy-files
$ node ../../scripts/build legacy
$ node ../../scripts/build modern
$ node ../../scripts/build node
$ node ../../scripts/build stable
$ node ../../scripts/buildTypes
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run build stderr:
buildTypes

Builds a project with a fix for
https://github.com/microsoft/TypeScript/issues/39117

Options:
  --help  Show help                                                    [boolean]

Error: Unable to find declaration files in '/Users/oliviertassinari/material-ui/packages/material-ui-unstyled/build'
    at Object.main [as handler] (/Users/oliviertassinari/material-ui/scripts/buildTypes.js:49:11)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```