### PR TITLE
[Autocomplete] Fix text field standard visual regression

### DIFF
--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -153,7 +153,7 @@ const AutocompleteRoot = experimentalStyled(
     '&.MuiInput-root': {
       paddingBottom: 1,
       '& .MuiInput-input': {
-        padding: '6px 4px 6px 0px',
+        padding: '4px 4px 4px 0px',
       },
     },
     '&.MuiInput-root.MuiInputBase-sizeSmall': {

--- a/test/regressions/fixtures/Autocomplete/StandardAutocomplete.js
+++ b/test/regressions/fixtures/Autocomplete/StandardAutocomplete.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import Autocomplete from '@material-ui/core/Autocomplete';
+
+export default function StandardAutocomplete() {
+  return (
+    <div style={{ width: 300 }}>
+      <Autocomplete
+        options={[]}
+        renderInput={(params) => (
+          <TextField {...params} label="Standard autocomplete" variant="standard" />
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
I have noticed the issue looking into #25657.

v4 (OK):
<img width="351" alt="Screenshot 2021-04-09 at 00 15 03" src="https://user-images.githubusercontent.com/3165635/114103018-ab509c00-98c8-11eb-9b77-177eaa4010a7.png">

https://material-ui.com/components/autocomplete/#playground

HEAD (KO):
<img width="372" alt="Screenshot 2021-04-09 at 00 15 41" src="https://user-images.githubusercontent.com/3165635/114103083-c1f6f300-98c8-11eb-9d6e-19d0256495d8.png">

https://next.material-ui.com/components/autocomplete/#playground

The visual regression should confirm the fix work (bring us back to v4). Regarding why the regression has happened. It's related to a recent change of the `<input>` `line-height` in the InputBase component to account for fonts with long descended and ascender characters. It's not related to emotion.