### PR TITLE
[docs] Ensure old api-docs translations are cleaned

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import * as fse from 'fs-extra';
 import path from 'path';
 import * as babel from '@babel/core';
 import traverse from '@babel/traverse';
@@ -40,6 +41,22 @@ import { createMuiTheme } from '@material-ui/core/styles';
 import { getLineFeed, getUnstyledFilename } from './helpers';
 
 const DEMO_IGNORE = LANGUAGES_IN_PROGRESS.map((language) => `-${language}.md`);
+
+const apiDocsTranslationsDirectory = path.resolve('docs', 'translations', 'api-docs');
+function resolveApiDocsTranslationsComponentDirectory(component: ReactApi): string {
+  return path.resolve(apiDocsTranslationsDirectory, kebabCase(component.name));
+}
+function resolveApiDocsTranslationsComponentLanguagePath(
+  component: ReactApi,
+  language: typeof LANGUAGES[0],
+): string {
+  const languageSuffix = language === 'en' ? '' : `-${language}`;
+
+  return path.join(
+    resolveApiDocsTranslationsComponentDirectory(component),
+    `${kebabCase(component.name)}${languageSuffix}.json`,
+  );
+}
 
 interface ReactApi extends ReactDocgenApi {
   EOL: string;
@@ -846,7 +863,7 @@ async function buildDocs(options: {
   outputDirectory: string;
   theme: object;
   workspaceRoot: string;
-}): Promise<void> {
+}): Promise<ReactApi | null> {
   const {
     component: componentObject,
     outputDirectory,
@@ -857,13 +874,13 @@ async function buildDocs(options: {
   } = options;
 
   if (componentObject.filename.indexOf('internal') !== -1) {
-    return;
+    return null;
   }
 
   const src = readFileSync(componentObject.filename, 'utf8');
 
   if (src.match(/@ignore - internal component\./) || src.match(/@ignore - do not document\./)) {
-    return;
+    return null;
   }
 
   const spread = !src.match(/ = exactProp\(/);
@@ -1112,36 +1129,22 @@ async function buildDocs(options: {
    */
   componentApi.classDescriptions = extractClassConditions(reactApi.styles.descriptions);
 
-  mkdirSync(path.resolve('docs', 'translations', 'api-docs', kebabCase(reactApi.name)), {
+  mkdirSync(resolveApiDocsTranslationsComponentDirectory(reactApi), {
     mode: 0o777,
     recursive: true,
   });
 
-  // docs/translations/api-docs/component-name/component-name.json
   writePrettifiedFile(
-    path.resolve(
-      'docs',
-      'translations',
-      'api-docs',
-      kebabCase(reactApi.name),
-      `${kebabCase(reactApi.name)}.json`,
-    ),
+    resolveApiDocsTranslationsComponentLanguagePath(reactApi, 'en'),
     JSON.stringify(componentApi),
     prettierConfigPath,
   );
 
-  // docs/translations/api-docs/component-name/component-name-xx.json
   LANGUAGES.forEach((language) => {
     if (language !== 'en') {
       try {
         writePrettifiedFile(
-          path.resolve(
-            'docs',
-            'translations',
-            'api-docs',
-            kebabCase(reactApi.name),
-            `${kebabCase(reactApi.name)}-${language}.json`,
-          ),
+          resolveApiDocsTranslationsComponentLanguagePath(reactApi, language),
           JSON.stringify(componentApi),
           prettierConfigPath,
           { flag: 'wx' },
@@ -1237,6 +1240,8 @@ Page.getInitialProps = () => {
       prettierConfigPath,
     });
   }
+
+  return reactApi;
 }
 
 /**
@@ -1250,6 +1255,38 @@ function generateApiPagesManifest(outputPath: string, prettierConfigPath: string
 
   const source = `module.exports = ${JSON.stringify(apiPages)}`;
   writePrettifiedFile(outputPath, source, prettierConfigPath);
+}
+
+async function removeOutdatedApiDocsTranslations(components: ReactApi[]): Promise<void> {
+  const componentDirectories = new Set<string>();
+  const files = await fse.readdir(apiDocsTranslationsDirectory);
+  await Promise.all(
+    files.map(async (filename) => {
+      const filepath = path.join(apiDocsTranslationsDirectory, filename);
+      const stats = await fse.stat(filepath);
+      if (stats.isDirectory()) {
+        componentDirectories.add(filepath);
+      }
+    }),
+  );
+
+  const currentComponentDirectories = new Set(
+    components.map((component) => {
+      return resolveApiDocsTranslationsComponentDirectory(component);
+    }),
+  );
+
+  // outdatedComponentDirectories = currentComponentDirectories.differene(componentDirectories)
+  const outdatedComponentDirectories = new Set(componentDirectories);
+  currentComponentDirectories.forEach((componentDirectory) => {
+    outdatedComponentDirectories.delete(componentDirectory);
+  });
+
+  await Promise.all(
+    Array.from(outdatedComponentDirectories, (outdatedComponentDirectory) => {
+      return fse.remove(outdatedComponentDirectory);
+    }),
+  );
 }
 
 async function run(argv: {
@@ -1305,6 +1342,9 @@ async function run(argv: {
       return directories.concat(findComponents(componentDirectory));
     }, [] as Array<{ filename: string }>)
     .filter((component) => {
+      if (component.filename.includes('ThemeProvider')) {
+        return false;
+      }
       if (grep === null) {
         return true;
       }
@@ -1312,13 +1352,8 @@ async function run(argv: {
     });
 
   const componentBuilds = components.map(async (component) => {
-    // Don't document ThmeProvider API
-    if (component.filename.includes('ThemeProvider')) {
-      return;
-    }
-
     try {
-      await buildDocs({
+      return await buildDocs({
         component,
         outputDirectory,
         pagesMarkdown,
@@ -1346,6 +1381,16 @@ async function run(argv: {
   }
 
   generateApiPagesManifest(apiPagesManifestPath, prettierConfigPath);
+  if (grep === null) {
+    const componentApis = builds
+      .filter((build): build is PromiseFulfilledResult<ReactApi> => {
+        return build.status === 'fulfilled' && build.value !== null;
+      })
+      .map((build) => {
+        return build.value;
+      });
+    await removeOutdatedApiDocsTranslations(componentApis);
+  }
 }
 
 yargs

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -1276,7 +1276,7 @@ async function removeOutdatedApiDocsTranslations(components: ReactApi[]): Promis
     }),
   );
 
-  // outdatedComponentDirectories = currentComponentDirectories.differene(componentDirectories)
+  // outdatedComponentDirectories = currentComponentDirectories.difference(componentDirectories)
   const outdatedComponentDirectories = new Set(componentDirectories);
   currentComponentDirectories.forEach((componentDirectory) => {
     outdatedComponentDirectories.delete(componentDirectory);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release:publish": "lerna publish from-package --dist-tag next --contents build",
     "release:publish:dry-run": "lerna publish from-package --dist-tag next --contents build --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag",
-    "docs:api": "rimraf ./docs/pages/api-docs && yarn docs:api:build",
+    "docs:api": "rimraf ./docs/pages/api-docs ./docs/translations/api-docs && yarn docs:api:build",
     "docs:api:build": "cross-env BABEL_ENV=development __NEXT_EXPORT_TRAILING_SLASH=true babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/buildApi.ts  ./docs/pages/api-docs ./packages/material-ui-unstyled/src ./packages/material-ui/src ./packages/material-ui-lab/src --apiPagesManifestPath ./docs/src/pagesApi.js",
     "docs:build": "yarn workspace docs build",
     "docs:build-sw": "yarn workspace docs build-sw",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release:publish": "lerna publish from-package --dist-tag next --contents build",
     "release:publish:dry-run": "lerna publish from-package --dist-tag next --contents build --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag",
-    "docs:api": "rimraf ./docs/pages/api-docs ./docs/translations/api-docs && yarn docs:api:build",
+    "docs:api": "rimraf ./docs/pages/api-docs && yarn docs:api:build",
     "docs:api:build": "cross-env BABEL_ENV=development __NEXT_EXPORT_TRAILING_SLASH=true babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/buildApi.ts  ./docs/pages/api-docs ./packages/material-ui-unstyled/src ./packages/material-ui/src ./packages/material-ui-lab/src --apiPagesManifestPath ./docs/src/pagesApi.js",
     "docs:build": "yarn workspace docs build",
     "docs:build-sw": "yarn workspace docs build-sw",


### PR DESCRIPTION
Required for https://github.com/mui-org/material-ui/pull/25679

Initial version just removed `docs/translations/api-docs` in `docs:api`. However, `docs:api` relies on the existence of directories in `docs/translations/api-docs` to determine the merging strategy. We can't just clean `docs/translations/api-docs` for that reason but have to use the difference between the components for which we currently create api-docs and the directories that are existing during that process.