### PR TITLE
[Pickers] Rename `date` `view` to `day` 

### DIFF
--- a/docs/pages/api-docs/date-picker.json
+++ b/docs/pages/api-docs/date-picker.json
@@ -61,7 +61,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -100,7 +100,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -83,7 +83,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -124,7 +124,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/day-picker.json
+++ b/docs/pages/api-docs/day-picker.json
@@ -11,7 +11,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       },
       "default": "'date'"
     },
@@ -28,13 +28,13 @@
     "view": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       },
       "default": "['year', 'date']"
     }

--- a/docs/pages/api-docs/day-picker.json
+++ b/docs/pages/api-docs/day-picker.json
@@ -13,7 +13,7 @@
         "name": "enum",
         "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       },
-      "default": "'date'"
+      "default": "'day'"
     },
     "reduceAnimations": {
       "type": { "name": "bool" },
@@ -36,7 +36,7 @@
         "name": "arrayOf",
         "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       },
-      "default": "['year', 'date']"
+      "default": "['year', 'day']"
     }
   },
   "name": "DayPicker",

--- a/docs/pages/api-docs/desktop-date-picker.json
+++ b/docs/pages/api-docs/desktop-date-picker.json
@@ -52,7 +52,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -89,7 +89,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -74,7 +74,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -113,7 +113,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/desktop-time-picker.json
+++ b/docs/pages/api-docs/desktop-time-picker.json
@@ -43,7 +43,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/mobile-date-picker.json
+++ b/docs/pages/api-docs/mobile-date-picker.json
@@ -57,7 +57,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -94,7 +94,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -79,7 +79,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -118,7 +118,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/mobile-time-picker.json
+++ b/docs/pages/api-docs/mobile-time-picker.json
@@ -48,7 +48,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/static-date-picker.json
+++ b/docs/pages/api-docs/static-date-picker.json
@@ -56,7 +56,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -91,7 +91,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -78,7 +78,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {
@@ -115,7 +115,7 @@
     "views": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
       }
     }
   },

--- a/docs/pages/api-docs/static-time-picker.json
+++ b/docs/pages/api-docs/static-time-picker.json
@@ -47,7 +47,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/time-picker.json
+++ b/docs/pages/api-docs/time-picker.json
@@ -52,7 +52,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'date'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
@@ -33,7 +33,7 @@ export default function ResponsiveDatePickers() {
           disableFuture
           label="Responsive"
           openTo="year"
-          views={['year', 'month', 'date']}
+          views={['year', 'month', 'day']}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
@@ -33,7 +33,7 @@ export default function ResponsiveDatePickers() {
           disableFuture
           label="Responsive"
           openTo="year"
-          views={['year', 'month', 'date']}
+          views={['year', 'month', 'day']}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);

--- a/docs/src/pages/components/date-picker/StaticDatePickerLandscape.js
+++ b/docs/src/pages/components/date-picker/StaticDatePickerLandscape.js
@@ -12,7 +12,7 @@ export default function StaticDatePickerLandscape() {
     <LocalizaitonProvider dateAdapter={AdapterDateFns}>
       <StaticDatePicker
         orientation="landscape"
-        openTo="date"
+        openTo="day"
         value={value}
         shouldDisableDate={isWeekend}
         onChange={(newValue) => {

--- a/docs/src/pages/components/date-picker/StaticDatePickerLandscape.tsx
+++ b/docs/src/pages/components/date-picker/StaticDatePickerLandscape.tsx
@@ -12,7 +12,7 @@ export default function StaticDatePickerLandscape() {
     <LocalizaitonProvider dateAdapter={AdapterDateFns}>
       <StaticDatePicker<Date>
         orientation="landscape"
-        openTo="date"
+        openTo="day"
         value={value}
         shouldDisableDate={isWeekend}
         onChange={(newValue) => {

--- a/docs/src/pages/components/date-picker/ViewsDatePicker.js
+++ b/docs/src/pages/components/date-picker/ViewsDatePicker.js
@@ -46,7 +46,7 @@ export default function ViewsDatePicker() {
         />
         <DatePicker
           openTo="year"
-          views={['year', 'month', 'date']}
+          views={['year', 'month', 'day']}
           label="Year, month and date"
           value={value}
           onChange={(newValue) => {
@@ -62,7 +62,7 @@ export default function ViewsDatePicker() {
           )}
         />
         <DatePicker
-          views={['date', 'month', 'year']}
+          views={['day', 'month', 'year']}
           label="Invert the order of views"
           value={value}
           onChange={(newValue) => {
@@ -78,7 +78,7 @@ export default function ViewsDatePicker() {
           )}
         />
         <DatePicker
-          views={['date']}
+          views={['day']}
           label="Just date"
           value={value}
           onChange={(newValue) => {

--- a/docs/src/pages/components/date-picker/ViewsDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/ViewsDatePicker.tsx
@@ -46,7 +46,7 @@ export default function ViewsDatePicker() {
         />
         <DatePicker
           openTo="year"
-          views={['year', 'month', 'date']}
+          views={['year', 'month', 'day']}
           label="Year, month and date"
           value={value}
           onChange={(newValue) => {
@@ -62,7 +62,7 @@ export default function ViewsDatePicker() {
           )}
         />
         <DatePicker
-          views={['date', 'month', 'year']}
+          views={['day', 'month', 'year']}
           label="Invert the order of views"
           value={value}
           onChange={(newValue) => {
@@ -78,7 +78,7 @@ export default function ViewsDatePicker() {
           )}
         />
         <DatePicker
-          views={['date']}
+          views={['day']}
           label="Just date"
           value={value}
           onChange={(newValue) => {

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -384,7 +384,7 @@ DatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -490,7 +490,7 @@ DatePicker.propTypes /* remove-proptypes */ = {
   /**
    * Array of views to show.
    */
-  views: PropTypes.arrayOf(PropTypes.oneOf(['date', 'month', 'year']).isRequired),
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
 } as any;
 
 export default DatePicker;

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -44,10 +44,10 @@ type SharedPickerProps<TDate, PublicWrapperProps> = PublicWrapperProps &
   AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
   React.RefAttributes<HTMLInputElement>;
 
-export type DatePickerView = 'year' | 'date' | 'month';
+export type DatePickerView = 'year' | 'day' | 'month';
 
 export interface BaseDatePickerProps<TDate>
-  extends WithViewsProps<'year' | 'date' | 'month'>,
+  extends WithViewsProps<DatePickerView>,
     ValidationProps<DateValidationError, ParsableDate>,
     OverrideParsableDateProps<TDate, ExportedDayPickerProps<TDate>, 'minDate' | 'maxDate'> {}
 
@@ -59,8 +59,8 @@ export const datePickerConfig = {
   >(validateDate),
   DefaultToolbarComponent: DatePickerToolbar,
   useInterceptProps: ({
-    openTo = 'date',
-    views = ['year', 'date'],
+    openTo = 'day',
+    views = ['year', 'day'],
     minDate: __minDate = defaultMinDate,
     maxDate: __maxDate = defaultMaxDate,
     ...other

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewMobile.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerViewMobile.tsx
@@ -28,7 +28,7 @@ interface DesktopDateRangeCalendarProps<TDate>
   changeMonth: (date: TDate) => void;
 }
 
-const onlyDateView = ['date'] as ['date'];
+const onlyDayView = ['day'] as ['day'];
 
 /**
  * @ignore - internal component.
@@ -61,9 +61,9 @@ export function DateRangePickerViewMobile<TDate>(props: DesktopDateRangeCalendar
         maxDate={maxDate}
         minDate={minDate}
         onMonthChange={changeMonth as any}
-        openView="date"
+        openView="day"
         rightArrowButtonText={rightArrowButtonText}
-        views={onlyDateView}
+        views={onlyDayView}
         {...other}
       />
       <PickersCalendar<TDate>

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -27,6 +27,7 @@ import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
+import { DateTimePickerView } from './shared';
 
 type AllResponsiveDateTimePickerProps = BaseDateTimePickerProps<unknown> &
   AllSharedPickerProps &
@@ -49,7 +50,7 @@ type DateTimePickerViewsProps<TDate> = OverrideParsableDateProps<
 >;
 
 export interface BaseDateTimePickerProps<TDate>
-  extends WithViewsProps<'year' | 'date' | 'month' | 'hours' | 'minutes'>,
+  extends WithViewsProps<DateTimePickerView>,
     ValidationProps<DateAndTimeValidationError, ParsableDate>,
     DateTimePickerViewsProps<TDate> {
   /**
@@ -87,9 +88,9 @@ function useInterceptProps({
   minDate: __minDate = defaultMinDate,
   minDateTime: __minDateTime,
   minTime: __minTime,
-  openTo = 'date',
+  openTo = 'day',
   orientation = 'portrait',
-  views = ['year', 'date', 'hours', 'minutes'],
+  views = ['year', 'day', 'hours', 'minutes'],
   ...other
 }: BaseDateTimePickerProps<unknown> & AllSharedPickerProps) {
   const utils = useUtils();

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -521,7 +521,7 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -637,7 +637,7 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(
-    PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
 } as any;
 

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -9,16 +9,19 @@ import DateRangeIcon from '../internal/svg-icons/DateRange';
 import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { DateTimePickerView } from './shared';
 
-const viewToTabIndex = (openView: DateTimePickerView) => {
+type TabValue = 'date' | 'time';
+
+const viewToTab = (openView: DateTimePickerView): TabValue => {
+  // TODO: what happens if `openView` is `month`?
   if (openView === 'day' || openView === 'year') {
-    return 'day';
+    return 'date';
   }
 
   return 'time';
 };
 
-const tabIndexToView = (tab: DateTimePickerView) => {
-  if (tab === 'day') {
+const tabToView = (tab: TabValue): DateTimePickerView => {
+  if (tab === 'date') {
     return 'day';
   }
 
@@ -70,17 +73,15 @@ const DateTimePickerTabs: React.FC<DateTimePickerTabsProps & WithStyles<typeof s
   const wrapperVariant = React.useContext(WrapperVariantContext);
   const indicatorColor = theme.palette.mode === 'light' ? 'secondary' : 'primary';
 
-  const handleChange = (event: React.ChangeEvent<{}>, value: DateTimePickerView) => {
-    if (value !== viewToTabIndex(view)) {
-      onChange(tabIndexToView(value));
-    }
+  const handleChange = (event: React.SyntheticEvent, value: TabValue) => {
+    onChange(tabToView(value));
   };
 
   return (
     <Paper className={clsx(classes.root, { [classes.modeDesktop]: wrapperVariant === 'desktop' })}>
       <Tabs
         variant="fullWidth"
-        value={viewToTabIndex(view)}
+        value={viewToTab(view)}
         onChange={handleChange}
         className={classes.tabs}
         indicatorColor={indicatorColor}

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -10,16 +10,16 @@ import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVaria
 import { DateTimePickerView } from './shared';
 
 const viewToTabIndex = (openView: DateTimePickerView) => {
-  if (openView === 'date' || openView === 'year') {
-    return 'date';
+  if (openView === 'day' || openView === 'year') {
+    return 'day';
   }
 
   return 'time';
 };
 
 const tabIndexToView = (tab: DateTimePickerView) => {
-  if (tab === 'date') {
-    return 'date';
+  if (tab === 'day') {
+    return 'day';
   }
 
   return 'hours';

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -108,9 +108,9 @@ const DateTimePickerToolbar: React.FC<ToolbarComponentProps & WithStyles<typeof 
             <PickersToolbarButton
               tabIndex={-1}
               variant="h4"
-              data-mui-test="datetimepicker-toolbar-date"
-              onClick={() => setOpenView('date')}
-              selected={openView === 'date'}
+              data-mui-test="datetimepicker-toolbar-day"
+              onClick={() => setOpenView('day')}
+              selected={openView === 'day'}
               value={dateText}
             />
           </div>

--- a/packages/material-ui-lab/src/DateTimePicker/shared.ts
+++ b/packages/material-ui-lab/src/DateTimePicker/shared.ts
@@ -1,1 +1,1 @@
-export type DateTimePickerView = 'year' | 'date' | 'month' | 'hours' | 'minutes';
+export type DateTimePickerView = 'year' | 'day' | 'month' | 'hours' | 'minutes';

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.spec.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.spec.tsx
@@ -4,8 +4,8 @@ import DayPicker from '@material-ui/lab/DayPicker';
 
 // External components are generic as well
 <DayPicker<Moment>
-  view="date"
-  views={['date']}
+  view="day"
+  views={['day']}
   date={moment()}
   minDate={moment()}
   maxDate={moment()}

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -257,7 +257,7 @@ const DayPicker = React.forwardRef(function DayPicker<
             />
           )}
 
-          {openView === 'date' && (
+          {openView === 'day' && (
             <PickersCalendar
               {...other}
               {...calendarState}

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -57,7 +57,7 @@ export interface DayPickerProps<TDate, TView extends DayPickerView = DayPickerVi
   onMonthChange?: (date: TDate) => void;
   /**
    * Initially open view.
-   * @default 'date'
+   * @default 'day'
    */
   openTo?: TView;
   /**
@@ -80,7 +80,7 @@ export interface DayPickerProps<TDate, TView extends DayPickerView = DayPickerVi
   view?: TView;
   /**
    * Views for day picker.
-   * @default ['year', 'date']
+   * @default ['year', 'day']
    */
   views?: TView[];
 }
@@ -143,10 +143,10 @@ const DayPicker = React.forwardRef(function DayPicker<
     shouldDisableDate,
     shouldDisableYear,
     view,
-    // TODO: unsound. `TView` could be `'date'`. `T extends Literal` does not mean there are more constituents but less.
+    // TODO: unsound. `TView` could be `'day'`. `T extends Literal` does not mean there are more constituents but less.
     // Probably easiest to remove `TView`. How would one even pass this type parameter?
-    views = ['year', 'date'] as TView[],
-    openTo = 'date' as TView,
+    views = ['year', 'day'] as TView[],
+    openTo = 'day' as TView,
     className,
     ...other
   } = props;
@@ -340,7 +340,7 @@ DayPicker.propTypes /* remove-proptypes */ = {
   onViewChange: PropTypes.func,
   /**
    * Initially open view.
-   * @default 'date'
+   * @default 'day'
    */
   openTo: PropTypes.oneOf(['day', 'month', 'year']),
   /**
@@ -368,7 +368,7 @@ DayPicker.propTypes /* remove-proptypes */ = {
   view: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Views for day picker.
-   * @default ['year', 'date']
+   * @default ['year', 'day']
    */
   views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
 } as any;

--- a/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
+++ b/packages/material-ui-lab/src/DayPicker/DayPicker.tsx
@@ -342,7 +342,7 @@ DayPicker.propTypes /* remove-proptypes */ = {
    * Initially open view.
    * @default 'date'
    */
-  openTo: PropTypes.oneOf(['date', 'month', 'year']),
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Disable heavy animations.
    * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
@@ -365,12 +365,12 @@ DayPicker.propTypes /* remove-proptypes */ = {
   /**
    * Controlled open view.
    */
-  view: PropTypes.oneOf(['date', 'month', 'year']),
+  view: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Views for day picker.
    * @default ['year', 'date']
    */
-  views: PropTypes.arrayOf(PropTypes.oneOf(['date', 'month', 'year']).isRequired),
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
 } as any;
 
 /**

--- a/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
+++ b/packages/material-ui-lab/src/DayPicker/PickersCalendarHeader.tsx
@@ -203,7 +203,7 @@ function PickersCalendarHeader<TDate>(
           </SwitchViewButton>
         )}
       </div>
-      <Fade in={currentView === 'date'}>
+      <Fade in={currentView === 'day'}>
         <PickersArrowSwitcher
           leftArrowButtonText={leftArrowButtonText}
           rightArrowButtonText={rightArrowButtonText}

--- a/packages/material-ui-lab/src/DayPicker/shared.ts
+++ b/packages/material-ui-lab/src/DayPicker/shared.ts
@@ -1,1 +1,1 @@
-export type DayPickerView = 'year' | 'date' | 'month';
+export type DayPickerView = 'year' | 'day' | 'month';

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -292,7 +292,7 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -388,7 +388,7 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * Array of views to show.
    */
-  views: PropTypes.arrayOf(PropTypes.oneOf(['date', 'month', 'year']).isRequired),
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
 } as any;
 
 export default DesktopDatePicker;

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -369,7 +369,7 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -475,7 +475,7 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(
-    PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
 } as any;
 

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -255,7 +255,7 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -316,7 +316,7 @@ MobileDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -414,7 +414,7 @@ MobileDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * Array of views to show.
    */
-  views: PropTypes.arrayOf(PropTypes.oneOf(['date', 'month', 'year']).isRequired),
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
 } as any;
 
 export default MobileDatePicker;

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePickerLocalization.test.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePickerLocalization.test.tsx
@@ -42,13 +42,13 @@ describe('<MobileDatePicker /> localization', () => {
     expect(getByMuiTest('datepicker-toolbar-date').textContent).to.equal('janvier');
   });
 
-  it('format for year+month+date view', () => {
+  it('format for year+month+day view', () => {
     render(
       <MobileDatePicker
         onChange={() => {}}
         renderInput={(params) => <TextField {...params} />}
         value={adapterToUse.date('2018-01-01T00:00:00.000')}
-        views={['year', 'month', 'date']}
+        views={['year', 'month', 'day']}
       />,
     );
 

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -66,7 +66,7 @@ describe('<MobileDateTimePicker />', () => {
     render(<DateTimePickerWithState />);
     fireEvent.click(screen.getByLabelText(/choose date/i));
 
-    expect(getByMuiTest('datetimepicker-toolbar-date')).to.have.text('Enter Date');
+    expect(getByMuiTest('datetimepicker-toolbar-day')).to.have.text('Enter Date');
     expect(getByMuiTest('hours')).to.have.text('--');
     expect(getByMuiTest('minutes')).to.have.text('--');
 
@@ -79,7 +79,7 @@ describe('<MobileDateTimePicker />', () => {
     // 2. Date
     fireEvent.click(screen.getByLabelText('Jan 15, 2010'));
 
-    expect(getByMuiTest('datetimepicker-toolbar-date')).to.have.text('Jan 15');
+    expect(getByMuiTest('datetimepicker-toolbar-day')).to.have.text('Jan 15');
 
     // 3. Hours
     fireTouchChangedEvent(getByMuiTest('clock'), 'touchmove', clockTouchEvent);

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -393,7 +393,7 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -501,7 +501,7 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(
-    PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
 } as any;
 

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -279,7 +279,7 @@ MobileTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -297,7 +297,7 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -385,7 +385,7 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * Array of views to show.
    */
-  views: PropTypes.arrayOf(PropTypes.oneOf(['date', 'month', 'year']).isRequired),
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
 } as any;
 
 export default StaticDatePicker;

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -374,7 +374,7 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */
@@ -472,7 +472,7 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
    * Array of views to show.
    */
   views: PropTypes.arrayOf(
-    PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'year']).isRequired,
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']).isRequired,
   ),
 } as any;
 

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -260,7 +260,7 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -38,9 +38,11 @@ type SharedPickerProps<TDate, PublicWrapperProps> = PublicWrapperProps &
   AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
   React.RefAttributes<HTMLInputElement>;
 
+export type TimePickerView = 'hours' | 'minutes' | 'seconds';
+
 export interface BaseTimePickerProps<TDate = unknown>
   extends ValidationProps<TimeValidationError, ParsableDate<TDate>>,
-    WithViewsProps<'hours' | 'minutes' | 'seconds'>,
+    WithViewsProps<TimePickerView>,
     OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'> {}
 
 export function getTextFieldAriaText(value: ParsableDate, utils: MuiPickersAdapter) {

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -361,7 +361,7 @@ TimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['date', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -67,7 +67,7 @@ export const styles: MuiStyles<PickerClassKey> = {
 const MobileKeyboardTextFieldProps = { fullWidth: true };
 
 const isDatePickerView = (view: AllAvailableViews): view is DayPickerView =>
-  view === 'year' || view === 'month' || view === 'date';
+  view === 'year' || view === 'month' || view === 'day';
 
 const isTimePickerView = (view: AllAvailableViews): view is ClockPickerView =>
   view === 'hours' || view === 'minutes' || view === 'seconds';
@@ -79,7 +79,7 @@ function Picker({
   DateInputProps,
   isMobileKeyboardViewOpen,
   onDateChange,
-  openTo = 'date',
+  openTo = 'day',
   orientation,
   showToolbar,
   toggleMobileKeyboardView,
@@ -87,7 +87,7 @@ function Picker({
   toolbarFormat,
   toolbarPlaceholder,
   toolbarTitle,
-  views = ['year', 'month', 'date', 'hours', 'minutes', 'seconds'],
+  views = ['year', 'month', 'day', 'hours', 'minutes', 'seconds'],
   ...other
 }: PickerProps<AllAvailableViews> & WithStyles<typeof styles>) {
   const isLandscape = useIsLandscape(views, orientation);

--- a/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
+++ b/packages/material-ui-lab/src/internal/pickers/typings/Views.ts
@@ -1,1 +1,1 @@
-export type AllAvailableViews = 'year' | 'date' | 'month' | 'hours' | 'minutes' | 'seconds';
+export type AllAvailableViews = 'year' | 'day' | 'month' | 'hours' | 'minutes' | 'seconds';


### PR DESCRIPTION
**BREAKING CHANGE**

```diff
-<DatePicker openTo="date" views={['date', 'month']} />
+<DatePicker openTo="day" views={['day', 'month']} />
```

Part of https://github.com/mui-org/material-ui/issues/25481

Based on https://github.com/mui-org/material-ui/pull/25679 ([diff](https://github.com/eps1lon/material-ui/compare/feat/rename-calendars-picker-skeleton...feat/rename-date-view)).

Right now we have the `DatePicker` which has the `year`, `month` and `date` `view`. That's a bit confusing since `date` is already part of the component name when `date` refers to a particular **day**. 

This PR creates another conflict with the `DayPicker` component which doesn't actually pick a **day** but a **date**. So we're going to rename `DayPicker` to `CalendarPicker` to completely entangle this confusion. Will add this in another PR though for proper changelog attention.