### PR TITLE
[Popover] Remove getContentAnchorEl prop

### DIFF
--- a/docs/pages/api-docs/popover.json
+++ b/docs/pages/api-docs/popover.json
@@ -24,7 +24,6 @@
     "classes": { "type": { "name": "object" } },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
     "elevation": { "type": { "name": "custom", "description": "integer" }, "default": "8" },
-    "getContentAnchorEl": { "type": { "name": "func" } },
     "marginThreshold": { "type": { "name": "number" }, "default": "16" },
     "onClose": { "type": { "name": "func" } },
     "PaperProps": {

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -484,7 +484,6 @@ export default function DemoToolbar(props) {
             anchorEl={anchorEl}
             open={Boolean(anchorEl)}
             onClose={handleMoreClose}
-            getContentAnchorEl={null}
             anchorOrigin={{
               vertical: 'top',
               horizontal: 'right',

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -13,7 +13,6 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 const StyledMenu = styled((props) => (
   <Menu
     elevation={0}
-    getContentAnchorEl={null}
     anchorOrigin={{
       vertical: 'bottom',
       horizontal: 'right',

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -14,7 +14,6 @@ import * as CSS from 'csstype';
 const StyledMenu = styled((props: MenuProps) => (
   <Menu
     elevation={0}
-    getContentAnchorEl={null}
     anchorOrigin={{
       vertical: 'bottom',
       horizontal: 'right',

--- a/docs/src/pages/components/menus/PositionedMenu.js
+++ b/docs/src/pages/components/menus/PositionedMenu.js
@@ -30,7 +30,6 @@ export default function PositionedMenu() {
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        getContentAnchorEl={null}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/docs/src/pages/components/menus/PositionedMenu.tsx
+++ b/docs/src/pages/components/menus/PositionedMenu.tsx
@@ -30,7 +30,6 @@ export default function PositionedMenu() {
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        getContentAnchorEl={null}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -26,10 +26,9 @@ Choosing an option should immediately ideally commit the option and close the me
 
 ## Selected menu
 
-If used for item selection, when opened, simple menus attempt to vertically align the currently selected menu item with the anchor element,
-and the initial focus will be placed on the selected menu item.
+If used for item selection, when opened, simple menus places the initial focus on the selected menu item.
 The currently selected menu item is set using the `selected` prop (from [ListItem](/api/list-item/)).
-To use a selected menu item without impacting the initial focus or the vertical positioning of the menu, set the `variant` prop to "menu".
+To use a selected menu item without impacting the initial focus, set the `variant` prop to "menu".
 
 {{"demo": "pages/components/menus/SimpleListMenu.js"}}
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -793,6 +793,8 @@ As the core components use emotion as a styled engine, the props used by emotion
   >
   ```
 
+- The `selectedMenu` variant will not vertically align the selected item with the anchor anymore.
+
 ### Modal
 
 - Remove the `disableBackdropClick` prop because redundant.
@@ -873,6 +875,8 @@ As the core components use emotion as a styled engine, the props used by emotion
   +  }}
   />
   ```
+
+- The `getContentAnchorEl` prop was removed to simplify the positioning logic.
 
 ### Popper
 

--- a/docs/translations/api-docs/menu/menu.json
+++ b/docs/translations/api-docs/menu/menu.json
@@ -13,7 +13,7 @@
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
     "transitionDuration": "The length of the transition in <code>ms</code>, or &#39;auto&#39;",
     "TransitionProps": "Props applied to the transition element. By default, the element is based on this <a href=\"http://reactcommunity.org/react-transition-group/transition\"><code>Transition</code></a> component.",
-    "variant": "The variant to use. Use <code>menu</code> to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element."
+    "variant": "The variant to use. Use <code>menu</code> to prevent selected items from impacting the initial focus."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/popover/popover.json
+++ b/docs/translations/api-docs/popover/popover.json
@@ -10,7 +10,6 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "container": "An HTML element, component instance, or function that returns either. The <code>container</code> will passed to the Modal component.<br>By default, it uses the body of the anchorEl&#39;s top-level document object, so it&#39;s simply <code>document.body</code> most of the time.",
     "elevation": "The elevation of the popover.",
-    "getContentAnchorEl": "This function is called in order to retrieve the content anchor element. It&#39;s the opposite of the <code>anchorEl</code> prop. The content anchor element should be an element inside the popover. It&#39;s used to correctly scroll and set the position of the popover. The positioning strategy tries to make the content anchor element just above the anchor element.",
     "marginThreshold": "Specifies how close to the edge of the window the popover can appear.",
     "onClose": "Callback fired when the component requests to be closed. The <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>.",
     "open": "If <code>true</code>, the component is shown.",

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -79,8 +79,7 @@ export interface MenuProps extends StandardProps<PopoverProps & Partial<Transiti
    */
   TransitionProps?: TransitionProps;
   /**
-   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus
-   * and the vertical alignment relative to the anchor element.
+   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus.
    * @default 'selectedMenu'
    */
   variant?: 'menu' | 'selectedMenu';

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -290,8 +290,7 @@ Menu.propTypes /* remove-proptypes */ = {
    */
   TransitionProps: PropTypes.object,
   /**
-   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus
-   * and the vertical alignment relative to the anchor element.
+   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus.
    * @default 'selectedMenu'
    */
   variant: PropTypes.oneOf(['menu', 'selectedMenu']),

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -9,7 +9,6 @@ import Paper from '../Paper';
 import Popover from '../Popover';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
-import setRef from '../utils/setRef';
 import menuClasses, { getMenuUtilityClass } from './menuClasses';
 
 const RTL_ORIGIN = {
@@ -118,7 +117,6 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
   const autoFocusItem = autoFocus && !disableAutoFocusItem && open;
 
   const menuListActionsRef = React.useRef(null);
-  const contentAnchorRef = React.useRef(null);
 
   const handleEntering = (element, isAppearing) => {
     if (menuListActionsRef.current) {
@@ -174,22 +172,8 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
     }
   });
 
-  const items = React.Children.map(children, (child, index) => {
-    if (index === activeItemIndex) {
-      return React.cloneElement(child, {
-        ref: (instance) => {
-          contentAnchorRef.current = instance;
-          setRef(child.ref, instance);
-        },
-      });
-    }
-
-    return child;
-  });
-
   return (
     <MenuRoot
-      getContentAnchorEl={() => contentAnchorRef.current}
       classes={PopoverClasses}
       onClose={onClose}
       anchorOrigin={isRtl ? RTL_ORIGIN : LTR_ORIGIN}
@@ -219,7 +203,7 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
         {...MenuListProps}
         className={clsx(classes.list, MenuListProps.className)}
       >
-        {items}
+        {children}
       </MenuMenuList>
     </MenuRoot>
   );

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -107,12 +107,6 @@ describe('<Menu />', () => {
     });
   });
 
-  it('should pass the instance function `getContentAnchorEl` to Popover', () => {
-    const menuRef = React.createRef();
-    const wrapper = mount(<Menu ref={menuRef} {...defaultProps} />);
-    expect(wrapper.find(Popover).props().getContentAnchorEl != null).to.equal(true);
-  });
-
   it('should pass onClose prop to Popover', () => {
     const fn = () => {};
     const wrapper = mount(<Menu {...defaultProps} onClose={fn} />);

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -82,15 +82,6 @@ export interface PopoverProps
    */
   elevation?: number;
   /**
-   * This function is called in order to retrieve the content anchor element.
-   * It's the opposite of the `anchorEl` prop.
-   * The content anchor element should be an element inside the popover.
-   * It's used to correctly scroll and set the position of the popover.
-   * The positioning strategy tries to make the content anchor element just above the
-   * anchor element.
-   */
-  getContentAnchorEl?: null | ((element: Element) => Element);
-  /**
    * Specifies how close to the edge of the window the popover can appear.
    * @default 16
    */

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -15,20 +15,6 @@ import Popover, { popoverClasses as classes } from '@material-ui/core/Popover';
 import { getOffsetLeft, getOffsetTop } from './Popover';
 import useForkRef from '../utils/useForkRef';
 
-const mockedAnchorEl = () => {
-  const div = document.createElement('div');
-
-  stub(div, 'getBoundingClientRect').callsFake(() => ({
-    width: 100,
-    height: 58,
-    left: 160,
-    top: 160,
-    bottom: 218,
-    right: 260,
-  }));
-  return div;
-};
-
 const FakePaper = React.forwardRef(function FakeWidthPaper(props, ref) {
   const handleMocks = React.useCallback((paperInstance) => {
     if (paperInstance) {
@@ -772,37 +758,6 @@ describe('<Popover />', () => {
           expect(positioningStyle.transformOrigin).to.match(/1px 0px( 0px)?/);
         });
       });
-    });
-  });
-
-  describe('prop: getContentAnchorEl', () => {
-    it('should position accordingly', () => {
-      const handleEntering = spy();
-      const divRef = React.createRef();
-      const getContentAnchorEl = () => {
-        Object.defineProperties(divRef.current, {
-          offsetTop: { get: () => 8 },
-          clientHeight: { get: () => 48 },
-          clientWidth: { get: () => 116 },
-        });
-        return divRef.current;
-      };
-
-      mount(
-        <Popover
-          anchorEl={mockedAnchorEl}
-          TransitionProps={{ onEntering: handleEntering }}
-          getContentAnchorEl={getContentAnchorEl}
-          open
-        >
-          <div ref={divRef} />
-        </Popover>,
-      );
-
-      const elementStyle = handleEntering.args[0][0].style;
-      expect(elementStyle.transformOrigin).to.match(/0px 32px( 0px)?/);
-      expect(elementStyle.top).to.equal('157px');
-      expect(elementStyle.left).to.equal('160px');
     });
   });
 


### PR DESCRIPTION
### Breaking changes

- [Popover] Remove the `getContentAnchorEl` prop to simplify the positioning logic.
- [Menu] The `selectedMenu` variant will not vertically align the selected item with the anchor anymore.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012.
