### PR TITLE
[Rating] Fix focus visible regression

### DIFF
--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -109,7 +109,7 @@ const RatingRoot = experimentalStyled(
     opacity: theme.palette.action.disabledOpacity,
     pointerEvents: 'none',
   },
-  [`&.Mui-focusVisible ${ratingClasses.iconActive}`]: {
+  [`&.Mui-focusVisible .${ratingClasses.iconActive}`]: {
     outline: '1px solid #999',
   },
   [`& .${ratingClasses.visuallyHidden}`]: visuallyHidden,

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -74,7 +74,7 @@ const useUtilityClasses = (styleProps) => {
       readOnly && 'readyOnly',
     ],
     label: ['label', 'pristine'],
-    emptyValueFocused: [emptyValueFocused && 'labelEmptyValueActive'],
+    labelEmptyValue: [emptyValueFocused && 'labelEmptyValueActive'],
     icon: ['icon'],
     iconEmpty: ['iconEmpty'],
     iconFilled: ['iconFilled'],
@@ -534,7 +534,7 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
       })}
       {!readOnly && !disabled && valueRounded == null && (
         <RatingLabel
-          className={clsx(classes.label, classes.emptyValueFocused)}
+          className={clsx(classes.label, classes.labelEmptyValue)}
           styleProps={styleProps}
         >
           <input

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -74,7 +74,7 @@ const useUtilityClasses = (styleProps) => {
       readOnly && 'readyOnly',
     ],
     label: ['label', 'pristine'],
-    emptyValueFocused: [emptyValueFocused && 'labelEmptyValueActive'],
+    emptyValueFocused: ['labelEmptyValueActive'],
     icon: ['icon'],
     iconEmpty: ['iconEmpty'],
     iconFilled: ['iconFilled'],

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -388,7 +388,6 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
     disabled,
     emptyIcon,
     emptyLabelText,
-    emptyValueFocused,
     focusVisible,
     getLabelText,
     icon,
@@ -528,7 +527,7 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
         });
       })}
       {!readOnly && !disabled && valueRounded == null && (
-        <RatingLabel className={classes.label} styleProps={styleProps}>
+        <RatingLabel className={classes.label} styleProps={{ emptyValueFocused, ...styleProps }}>
           <input
             className={classes.visuallyHidden}
             value=""

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -73,7 +73,8 @@ const useUtilityClasses = (styleProps) => {
       focusVisible && 'focusVisible',
       readOnly && 'readyOnly',
     ],
-    label: ['label', emptyValueFocused && 'labelEmptyValueActive', 'pristine'],
+    label: ['label', 'pristine'],
+    emptyValueFocused: [emptyValueFocused && 'labelEmptyValueActive'],
     icon: ['icon'],
     iconEmpty: ['iconEmpty'],
     iconFilled: ['iconFilled'],
@@ -388,6 +389,7 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
     disabled,
     emptyIcon,
     emptyLabelText,
+    emptyValueFocused,
     focusVisible,
     getLabelText,
     icon,
@@ -436,7 +438,11 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
 
     return (
       <React.Fragment key={state.value}>
-        <RatingLabel styleProps={styleProps} htmlFor={id} {...labelProps}>
+        <RatingLabel
+          styleProps={{ ...styleProps, emptyValueFocused: undefined }}
+          htmlFor={id}
+          {...labelProps}
+        >
           {container}
           <span className={classes.visuallyHidden}>{getLabelText(state.value)}</span>
         </RatingLabel>
@@ -527,7 +533,10 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
         });
       })}
       {!readOnly && !disabled && valueRounded == null && (
-        <RatingLabel className={classes.label} styleProps={{ emptyValueFocused, ...styleProps }}>
+        <RatingLabel
+          className={clsx(classes.label, classes.emptyValueFocused)}
+          styleProps={styleProps}
+        >
           <input
             className={classes.visuallyHidden}
             value=""

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -74,7 +74,7 @@ const useUtilityClasses = (styleProps) => {
       readOnly && 'readyOnly',
     ],
     label: ['label', 'pristine'],
-    emptyValueFocused: ['labelEmptyValueActive'],
+    emptyValueFocused: [emptyValueFocused && 'labelEmptyValueActive'],
     icon: ['icon'],
     iconEmpty: ['iconEmpty'],
     iconFilled: ['iconFilled'],

--- a/test/regressions/fixtures/Rating/FocusVisibleRating.js
+++ b/test/regressions/fixtures/Rating/FocusVisibleRating.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Rating from '@material-ui/core/Rating';
+
+export default function FocusVisibleRating() {
+  return <Rating name="no-value" value={null} />;
+}

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -78,7 +78,7 @@ const blacklist = [
   'docs-components-popover/AnchorPlayground.png', // Redux isolation
   'docs-components-popover/MouseOverPopover.png', // Needs interaction
   'docs-components-popover/PopoverPopupState.png', // Needs interaction
-  'docs-components-popover/SimplePopover.png', // Needs interaction
+  'docs-components-popover/BasicPopover.png', // Needs interaction
   'docs-components-popper/PopperPopupState.png', // Needs interaction
   'docs-components-popper/PositionedPopper.png', // Needs interaction
   'docs-components-popper/ScrollPlayground.png', // Redux isolation

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -42,11 +42,32 @@ async function main() {
     });
   });
 
-  const routes = await page.$$eval('#tests a', (links) => {
-    return links.map((link) => {
-      return link.href;
-    });
+  let routes = await page.$$eval('#tests a', (links) => {
+    return links.map((link) => link.href);
   });
+  routes = routes.map((route) => route.replace(baseUrl, ''));
+
+  async function renderFixture(index) {
+    // Use client-side routing which is much faster than full page navigation via page.goto().
+    // Could become an issue with test isolation.
+    // If tests are flaky due to global pollution switch to page.goto(route);
+    // puppeteers built-in click() times out
+    await page.$eval(`#tests li:nth-of-type(${index + 1}) a`, (link) => {
+      link.click();
+    });
+    // Move cursor offscreen to not trigger unwanted hover effects.
+    page.mouse.move(0, 0);
+
+    const testcase = await page.waitForSelector('[data-testid="testcase"]:not([aria-busy="true"])');
+
+    return testcase;
+  }
+
+  async function takeScreenshot({ testcase, route }) {
+    const screenshotPath = path.resolve(screenshotDir, `.${route}.png`);
+    await fse.ensureDir(path.dirname(screenshotPath));
+    await testcase.screenshot({ path: screenshotPath, type: 'png' });
+  }
 
   // prepare screenshots
   await fse.emptyDir(screenshotDir);
@@ -57,29 +78,27 @@ async function main() {
     });
 
     routes.forEach((route, index) => {
-      it(`creates screenshots of ${route.replace(baseUrl, '')}`, async function test() {
+      it(`creates screenshots of ${route}`, async function test() {
         // With the playwright inspector we might want to call `page.pause` which would lead to a timeout.
         if (process.env.PWDEBUG) {
           this.timeout(0);
         }
 
-        // Use client-side routing which is much faster than full page navigation via page.goto().
-        // Could become an issue with test isolation.
-        // If tests are flaky due to global pollution switch to page.goto(route);
-        // puppeteers built-in click() times out
-        await page.$eval(`#tests li:nth-of-type(${index + 1}) a`, (link) => {
-          link.click();
-        });
-        // Move cursor offscreen to not trigger unwanted hover effects.
-        page.mouse.move(0, 0);
+        const testcase = await renderFixture(index);
+        await takeScreenshot({ testcase, route });
+      });
+    });
 
-        const testcase = await page.waitForSelector(
-          '[data-testid="testcase"]:not([aria-busy="true"])',
+    describe('Rating', () => {
+      it('should handle focus-visible correctly', async () => {
+        const index = routes.findIndex(
+          (route) => route === '/regression-Rating/FocusVisibleRating',
         );
-
-        const screenshotPath = path.resolve(screenshotDir, `${route.replace(baseUrl, '.')}.png`);
-        await fse.ensureDir(path.dirname(screenshotPath));
-        await testcase.screenshot({ path: screenshotPath, type: 'png' });
+        const testcase = await renderFixture(index);
+        await page.keyboard.press('Tab');
+        await takeScreenshot({ testcase, route: '/regression-Rating/FocusVisibleRating2' });
+        await page.keyboard.press('ArrowLeft');
+        await takeScreenshot({ testcase, route: '/regression-Rating/FocusVisibleRating3' });
       });
     });
   });


### PR DESCRIPTION
Two recent regressions in https://github.com/mui-org/material-ui/pull/25588/files. The outline is working again:

1. 
<img width="255" alt="Screenshot 2021-04-10 at 16 22 09" src="https://user-images.githubusercontent.com/3165635/114273059-ec57c600-9a18-11eb-82ae-b7e628dcde51.png">

2. 
<img width="179" alt="Screenshot 2021-04-10 at 16 38 42" src="https://user-images.githubusercontent.com/3165635/114273696-68530d80-9a1b-11eb-92bb-f371846cf39f.png">
