### PR TITLE
[theme] Change default bgColor to white in light mode

### DIFF
--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -217,9 +217,6 @@ export function ThemeProvider(props) {
             main: paletteMode === 'light' ? darken(pink.A400, 0.1) : pink[200],
           },
           mode: paletteMode,
-          background: {
-            default: paletteMode === 'light' ? '#fff' : '#121212',
-          },
           ...paletteColors,
         },
         spacing,

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -125,6 +125,8 @@ export default function PlainCssPriority() {
 
 ### Theme
 
+- The default background color is now `#fff` in light mode and `#121212` in dark mode.
+  This matches the material design guidelines.
 - Breakpoints are now treated as values instead of ranges. The behavior of `down(key)` was changed to define media query less than the value defined with the corresponding breakpoint (exclusive).
   The `between(start, end)` was also updated to define media query for the values between the actual values of start (inclusive) and end (exclusive).
   When using the `down()` breakpoints utility you need to update the breakpoint key by one step up. When using the `between(start, end)` the end breakpoint should also be updated by one step up. The same should be done when using the `Hidden` component. Find examples of the changes required defined below:

--- a/packages/material-ui/src/styles/createPalette.js
+++ b/packages/material-ui/src/styles/createPalette.js
@@ -26,7 +26,7 @@ export const light = {
   // Consistency between these values is important.
   background: {
     paper: common.white,
-    default: grey[50],
+    default: common.white,
   },
   // The colors used to style the action elements.
   action: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #24440

Hello, forgive me but I am trying to find the best way to solve this issue. Seems simple enough (just changed the default background to white. But would it also make sense to change the default paper background too? I ended up just following the comment [https://github.com/mui-org/material-ui/issues/24440#issuecomment-761281899](here) to do my part. Please let me know if I can be of more assistance. Thank you.

From looking through the docs, I found this and used it as a reference to assume this would be all that would be needed.

![color palette](https://user-images.githubusercontent.com/34875122/114322408-10d1a200-9aee-11eb-853d-1802aa8d0b6c.png)
