### PR TITLE
[docs] Document circular progress inherit

### DIFF
--- a/docs/src/pages/components/progress/CircularColor.js
+++ b/docs/src/pages/components/progress/CircularColor.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Stack from '@material-ui/core/Stack';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+export default function CircularColor() {
+  return (
+    <Stack sx={{ color: 'success.main' }} spacing={2} direction="row">
+      <CircularProgress color="secondary" />
+      <CircularProgress color="inherit" />
+    </Stack>
+  );
+}

--- a/docs/src/pages/components/progress/CircularColor.js
+++ b/docs/src/pages/components/progress/CircularColor.js
@@ -4,7 +4,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 
 export default function CircularColor() {
   return (
-    <Stack sx={{ color: 'success.main' }} spacing={2} direction="row">
+    <Stack sx={{ color: 'warning.main' }} spacing={2} direction="row">
       <CircularProgress color="secondary" />
       <CircularProgress color="inherit" />
     </Stack>

--- a/docs/src/pages/components/progress/CircularColor.tsx
+++ b/docs/src/pages/components/progress/CircularColor.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Stack from '@material-ui/core/Stack';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+export default function CircularColor() {
+  return (
+    <Stack sx={{ color: 'success.main' }} spacing={2} direction="row">
+      <CircularProgress color="secondary" />
+      <CircularProgress color="inherit" />
+    </Stack>
+  );
+}

--- a/docs/src/pages/components/progress/CircularColor.tsx
+++ b/docs/src/pages/components/progress/CircularColor.tsx
@@ -4,7 +4,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 
 export default function CircularColor() {
   return (
-    <Stack sx={{ color: 'success.main' }} spacing={2} direction="row">
+    <Stack sx={{ color: 'warning.main' }} spacing={2} direction="row">
       <CircularProgress color="secondary" />
       <CircularProgress color="inherit" />
     </Stack>

--- a/docs/src/pages/components/progress/CircularIndeterminate.js
+++ b/docs/src/pages/components/progress/CircularIndeterminate.js
@@ -1,23 +1,11 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    '& > * + *': {
-      marginLeft: theme.spacing(2),
-    },
-  },
-}));
+import Box from '@material-ui/core/Box';
 
 export default function CircularIndeterminate() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ display: 'flex' }}>
       <CircularProgress />
-      <CircularProgress color="secondary" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/progress/CircularIndeterminate.tsx
+++ b/docs/src/pages/components/progress/CircularIndeterminate.tsx
@@ -1,25 +1,11 @@
 import * as React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      '& > * + *': {
-        marginLeft: theme.spacing(2),
-      },
-    },
-  }),
-);
+import Box from '@material-ui/core/Box';
 
 export default function CircularIndeterminate() {
-  const classes = useStyles();
-
   return (
-    <div className={classes.root}>
+    <Box sx={{ display: 'flex' }}>
       <CircularProgress />
-      <CircularProgress color="secondary" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/components/progress/LinearColor.js
+++ b/docs/src/pages/components/progress/LinearColor.js
@@ -4,7 +4,7 @@ import LinearProgress from '@material-ui/core/LinearProgress';
 
 export default function LinearColor() {
   return (
-    <Stack sx={{ width: '100%', color: 'success.main' }} spacing={2}>
+    <Stack sx={{ width: '100%', color: 'warning.main' }} spacing={2}>
       <LinearProgress color="secondary" />
       <LinearProgress color="inherit" />
     </Stack>

--- a/docs/src/pages/components/progress/LinearColor.tsx
+++ b/docs/src/pages/components/progress/LinearColor.tsx
@@ -4,7 +4,7 @@ import LinearProgress from '@material-ui/core/LinearProgress';
 
 export default function LinearColor() {
   return (
-    <Stack sx={{ width: '100%', color: 'success.main' }} spacing={2}>
+    <Stack sx={{ width: '100%', color: 'warning.main' }} spacing={2}>
       <LinearProgress color="secondary" />
       <LinearProgress color="inherit" />
     </Stack>

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -24,6 +24,10 @@ The animations of the components rely on CSS as much as possible to work even be
 
 {{"demo": "pages/components/progress/CircularIndeterminate.js"}}
 
+### Circular color
+
+{{"demo": "pages/components/progress/CircularColor.js"}}
+
 ### Circular determinate
 
 {{"demo": "pages/components/progress/CircularDeterminate.js"}}


### PR DESCRIPTION
A follow-up on #25641 to bring parity in the documentation between circular and linear progress.

Preview: https://deploy-preview-25736--material-ui.netlify.app/components/progress/#circular-color