### PR TITLE
[TextField] Fix InputAdornment classes

### DIFF
--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -24,15 +24,15 @@ const overridesResolver = (props, styles) => {
 };
 
 const useUtilityClasses = (styleProps) => {
-  const { classes, disablePointerEvents, position, variant } = styleProps;
+  const { classes, disablePointerEvents, hiddenLabel, position, size, variant } = styleProps;
   const slots = {
     root: [
       'root',
       disablePointerEvents && 'disablePointerEvents',
       position && `position${capitalize(position)}`,
       variant,
-      'hiddenLabel',
-      'sizeSmall',
+      hiddenLabel && 'hiddenLabel',
+      size && `size${capitalize(size)}`,
     ],
   };
 
@@ -56,7 +56,7 @@ const InputAdornmentRoot = experimentalStyled(
   color: theme.palette.action.active,
   ...(styleProps.variant === 'filled' && {
     // Styles applied to the root element if `variant="filled"`.
-    [`&.${inputAdornmentClasses.positionStart}&:not(.Mui-hiddenLabel)`]: {
+    [`&.${inputAdornmentClasses.positionStart}&:not(.${inputAdornmentClasses.hiddenLabel})`]: {
       marginTop: 16,
     },
   }),
@@ -87,13 +87,6 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
     ...other
   } = props;
 
-  const styleProps = {
-    ...props,
-    disablePointerEvents,
-    position,
-    variant: variantProp,
-  };
-
   const muiFormControl = useFormControl() || {};
 
   let variant = variantProp;
@@ -113,6 +106,16 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
     variant = muiFormControl.variant;
     styleProps.variant = variant;
   }
+  
+  const styleProps = {
+    ...props,
+    hiddenLabel: muiFormControl.hiddenLabel,
+    size: muiFormControl.size,
+    disablePointerEvents,
+    position,
+    variant,
+  };
+   
   const classes = useUtilityClasses(styleProps);
 
   return (

--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -104,7 +104,6 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
 
   if (muiFormControl && !variant) {
     variant = muiFormControl.variant;
-    styleProps.variant = variant;
   }
 
   const styleProps = {

--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -106,7 +106,7 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
     variant = muiFormControl.variant;
     styleProps.variant = variant;
   }
-  
+
   const styleProps = {
     ...props,
     hiddenLabel: muiFormControl.hiddenLabel,
@@ -115,7 +115,7 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
     position,
     variant,
   };
-   
+
   const classes = useUtilityClasses(styleProps);
 
   return (

--- a/test/regressions/fixtures/TextField/FilledHiddenLabelInputAdornment.js
+++ b/test/regressions/fixtures/TextField/FilledHiddenLabelInputAdornment.js
@@ -1,31 +1,17 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
 
 export default function FilledHiddenLabelInputAdornment() {
   return (
-    <Box
-      component="form"
-      sx={{
-        '& .MuiTextField-root': { m: 1, width: '25ch' },
+    <TextField
+      hiddenLabel
+      id="filled-hidden-label"
+      defaultValue="Value"
+      variant="filled"
+      InputProps={{
+        startAdornment: <InputAdornment position="start">Kg</InputAdornment>,
       }}
-      noValidate
-      autoComplete="off"
-    >
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        <label htmlFor="filled-hidden-label-small">Hidden label</label>
-        <TextField
-          hiddenLabel
-          id="filled-hidden-label-small"
-          defaultValue="Small"
-          variant="filled"
-          size="small"
-          InputProps={{
-            startAdornment: <InputAdornment position="start">Kg</InputAdornment>,
-          }}
-        />
-      </Box>
-    </Box>
+    />
   );
 }

--- a/test/regressions/fixtures/TextField/FilledHiddenLabelInputAdornment.js
+++ b/test/regressions/fixtures/TextField/FilledHiddenLabelInputAdornment.js
@@ -1,0 +1,31 @@
+import * as React from "react";
+import Box from "@material-ui/core/Box";
+import TextField from "@material-ui/core/TextField";
+import InputAdornment from "@material-ui/core/InputAdornment";
+
+export default function FilledHiddenLabelInputAdornment() {
+  return (
+    <Box
+      component="form"
+      sx={{
+        "& .MuiTextField-root": { m: 1, width: "25ch" }
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <Box sx={{ display: "flex", alignItems: "center" }}>
+        <label htmlFor="filled-hidden-label-small">Hidden label</label>
+        <TextField
+          hiddenLabel
+          id="filled-hidden-label-small"
+          defaultValue="Small"
+          variant="filled"
+          size="small"
+          InputProps={{
+            startAdornment: <InputAdornment position="start">Kg</InputAdornment>
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/test/regressions/fixtures/TextField/FilledHiddenLabelInputAdornment.js
+++ b/test/regressions/fixtures/TextField/FilledHiddenLabelInputAdornment.js
@@ -1,19 +1,19 @@
-import * as React from "react";
-import Box from "@material-ui/core/Box";
-import TextField from "@material-ui/core/TextField";
-import InputAdornment from "@material-ui/core/InputAdornment";
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import TextField from '@material-ui/core/TextField';
+import InputAdornment from '@material-ui/core/InputAdornment';
 
 export default function FilledHiddenLabelInputAdornment() {
   return (
     <Box
       component="form"
       sx={{
-        "& .MuiTextField-root": { m: 1, width: "25ch" }
+        '& .MuiTextField-root': { m: 1, width: '25ch' },
       }}
       noValidate
       autoComplete="off"
     >
-      <Box sx={{ display: "flex", alignItems: "center" }}>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <label htmlFor="filled-hidden-label-small">Hidden label</label>
         <TextField
           hiddenLabel
@@ -22,7 +22,7 @@ export default function FilledHiddenLabelInputAdornment() {
           variant="filled"
           size="small"
           InputProps={{
-            startAdornment: <InputAdornment position="start">Kg</InputAdornment>
+            startAdornment: <InputAdornment position="start">Kg</InputAdornment>,
           }}
         />
       </Box>


### PR DESCRIPTION
Fixes regression from https://github.com/mui-org/material-ui/pull/25279

Previously:

https://codesandbox.io/s/textfieldhiddenlabel-material-demo-forked-hc7mt?file=/demo.js

![image](https://user-images.githubusercontent.com/4512430/114568246-41dbdf00-9c74-11eb-82bb-0b612a773a89.png)

Now:

https://codesandbox.io/s/textfieldhiddenlabel-material-demo-forked-83oyo?file=/demo.js

![image](https://user-images.githubusercontent.com/4512430/114568577-8798a780-9c74-11eb-9558-66030b3f96fc.png)
