### PR TITLE
[docs] Fix autocommplete disable event value

### DIFF
--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -283,7 +283,7 @@ If you would like to prevent the default key handler behavior, you can set the e
   onKeyDown={(event) => {
     if (event.key === 'Enter') {
       // Prevent's default 'Enter' behavior.
-      event.defaultMuiPrevented = false;
+      event.defaultMuiPrevented = true;
       // your handler code
     }
   }}


### PR DESCRIPTION
I have found this working on https://github.com/mui-org/material-ui-x/issues/1403. The docs doesn't match the tests:

https://github.com/mui-org/material-ui/blob/7c3d3bb204e26c8f016f99bf50b070d054123f79/packages/material-ui/src/Autocomplete/Autocomplete.test.js#L2199