### PR TITLE
[DateRangePicker] Add DateRangePickerDay to theme augmentation list

### DIFF
--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -43,7 +43,7 @@ const startBorderStyle = {
   borderBottomLeftRadius: '50%',
 };
 
-type DateRangePickerDayClassKey =
+export type DateRangePickerDayClassKey =
   | 'root'
   | 'rangeIntervalDayHighlight'
   | 'rangeIntervalDayHighlightStart'

--- a/packages/material-ui-lab/src/themeAugmentation/components.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/components.d.ts
@@ -123,6 +123,10 @@ export interface LabComponents {
     defaultProps?: ComponentsProps['MuiPickersDay'];
     styleOverrides?: ComponentsOverrides['MuiPickersDay'];
   };
+  MuiDateRangePickerDay?: {
+    defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
+    styleOverrides?: ComponentsOverrides['MuiDateRangePickerDay'];
+  };
   MuiStaticDatePicker?: {
     defaultProps?: ComponentsProps['MuiStaticDatePicker'];
   };

--- a/packages/material-ui-lab/src/themeAugmentation/components.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/components.d.ts
@@ -7,6 +7,10 @@ export interface LabComponents {
   MuiDatePicker?: {
     defaultProps?: ComponentsProps['MuiDatePicker'];
   };
+  MuiDateRangePickerDay?: {
+    defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
+    styleOverrides?: ComponentsOverrides['MuiDateRangePickerDay'];
+  };
   MuiDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiDateTimePicker'];
   };
@@ -122,10 +126,6 @@ export interface LabComponents {
   MuiPickersDay?: {
     defaultProps?: ComponentsProps['MuiPickersDay'];
     styleOverrides?: ComponentsOverrides['MuiPickersDay'];
-  };
-  MuiDateRangePickerDay?: {
-    defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
-    styleOverrides?: ComponentsOverrides['MuiDateRangePickerDay'];
   };
   MuiStaticDatePicker?: {
     defaultProps?: ComponentsProps['MuiStaticDatePicker'];

--- a/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
@@ -1,3 +1,4 @@
+import { DateRangePickerDayClassKey } from '../DateRangePickerDay/DateRangePickerDay';
 import { CalendarPickerSkeletonClassKey } from '../CalendarPickerSkeleton';
 import { ClockClassKey } from '../ClockPicker/Clock';
 import { ClockNumberClassKey } from '../ClockPicker/ClockNumber';
@@ -53,6 +54,7 @@ export interface LabComponentNameToClassKey {
   MuiPickersCalendar: PickersCalendarClassKey;
   MuiPickersCalendarHeader: PickersCalendarHeaderClassKey;
   MuiPickersDay: PickersDayClassKey;
+  MuiDateRangePickerDay: DateRangePickerDayClassKey;
   MuiPickersFadeTransition: PickersFadeTransitionGroupClassKey;
   MuiPickersModalDialog: PickersModalDialogClassKey;
   MuiPickersMonth: PickersMonthClassKey;

--- a/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
@@ -1,9 +1,9 @@
-import { DateRangePickerDayClassKey } from '../DateRangePickerDay/DateRangePickerDay';
 import { CalendarPickerSkeletonClassKey } from '../CalendarPickerSkeleton';
 import { ClockClassKey } from '../ClockPicker/Clock';
 import { ClockNumberClassKey } from '../ClockPicker/ClockNumber';
 import { ClockPointerClassKey } from '../ClockPicker/ClockPointer';
 import { DatePickerToolbarClassKey } from '../DatePicker/DatePickerToolbar';
+import { DateRangePickerDayClassKey } from '../DateRangePickerDay/DateRangePickerDay';
 import { DateTimePickerTabsClassKey } from '../DateTimePicker/DateTimePickerTabs';
 import { DateTimePickerToolbarClassKey } from '../DateTimePicker/DateTimePickerToolbar';
 import { DayPickerClassKey } from '../DayPicker';
@@ -44,6 +44,7 @@ export interface LabComponentNameToClassKey {
   MuiClockNumber: ClockNumberClassKey;
   MuiClockPointer: ClockPointerClassKey;
   MuiDatePickerToolbar: DatePickerToolbarClassKey;
+  MuiDateRangePickerDay: DateRangePickerDayClassKey;
   MuiDateTimePickerTabs: DateTimePickerTabsClassKey;
   MuiDateTimePickerToolbar: DateTimePickerToolbarClassKey;
   MuiDayPicker: DayPickerClassKey;
@@ -54,7 +55,6 @@ export interface LabComponentNameToClassKey {
   MuiPickersCalendar: PickersCalendarClassKey;
   MuiPickersCalendarHeader: PickersCalendarHeaderClassKey;
   MuiPickersDay: PickersDayClassKey;
-  MuiDateRangePickerDay: DateRangePickerDayClassKey;
   MuiPickersFadeTransition: PickersFadeTransitionGroupClassKey;
   MuiPickersModalDialog: PickersModalDialogClassKey;
   MuiPickersMonth: PickersMonthClassKey;

--- a/packages/material-ui-lab/src/themeAugmentation/props.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/props.d.ts
@@ -28,6 +28,7 @@ import { TimePickerProps } from '../TimePicker';
 import { TreeItemProps } from '../TreeItem';
 import { TreeViewProps } from '../TreeView';
 import { YearPickerProps } from '../YearPicker';
+import { DateRangePickerDayProps } from '../DateRangePickerDay/DateRangePickerDay';
 
 export interface LabComponentsPropsList {
   MuiAvatarGroup: AvatarGroupProps;
@@ -44,6 +45,7 @@ export interface LabComponentsPropsList {
   MuiMobileTimePicker: MobileTimePickerProps;
   MuiMonthPicker: MonthPickerProps<unknown>;
   MuiPickersDay: PickersDayProps<unknown>;
+  MuiDateRangePickerDay: DateRangePickerDayProps;
   MuiStaticDatePicker: StaticDatePickerProps;
   MuiStaticDateTimePicker: StaticDateTimePickerProps;
   MuiStaticTimePicker: StaticTimePickerProps;

--- a/packages/material-ui-lab/src/themeAugmentation/props.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/props.d.ts
@@ -2,6 +2,7 @@ import { AvatarGroupProps } from '../AvatarGroup';
 import { CalendarPickerSkeletonProps } from '../CalendarPickerSkeleton';
 import { ClockPickerProps } from '../ClockPicker';
 import { DatePickerProps } from '../DatePicker';
+import { DateRangePickerDayProps } from '../DateRangePickerDay/DateRangePickerDay';
 import { DateTimePickerProps } from '../DateTimePicker';
 import { DayPickerProps } from '../DayPicker';
 import { DesktopDateTimePickerProps } from '../DesktopDateTimePicker';
@@ -28,13 +29,13 @@ import { TimePickerProps } from '../TimePicker';
 import { TreeItemProps } from '../TreeItem';
 import { TreeViewProps } from '../TreeView';
 import { YearPickerProps } from '../YearPicker';
-import { DateRangePickerDayProps } from '../DateRangePickerDay/DateRangePickerDay';
 
 export interface LabComponentsPropsList {
   MuiAvatarGroup: AvatarGroupProps;
   MuiCalendarPickerSkeleton: CalendarPickerSkeletonProps;
   MuiClockPicker: ClockPickerProps<unknown>;
   MuiDatePicker: DatePickerProps;
+  MuiDateRangePickerDay: DateRangePickerDayProps;
   MuiDateTimePicker: DateTimePickerProps;
   MuiDayPicker: DayPickerProps<unknown>;
   MuiDesktopDateTimePicker: DesktopDateTimePickerProps;
@@ -45,7 +46,6 @@ export interface LabComponentsPropsList {
   MuiMobileTimePicker: MobileTimePickerProps;
   MuiMonthPicker: MonthPickerProps<unknown>;
   MuiPickersDay: PickersDayProps<unknown>;
-  MuiDateRangePickerDay: DateRangePickerDayProps;
   MuiStaticDatePicker: StaticDatePickerProps;
   MuiStaticDateTimePicker: StaticDateTimePickerProps;
   MuiStaticTimePicker: StaticTimePickerProps;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

'MuiDateRangePickerDay' key is missing in `overrides.d.ts`, so added one.
Please let me know if this PR need further work. Thanks!