### PR TITLE
[core] Remove incorrect overridesResolver usages

### DIFF
--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -59,7 +59,6 @@ const StepContentTransition = experimentalStyled(
   {
     name: 'MuiStepContent',
     slot: 'Transition',
-    overridesResolver,
   },
 )();
 

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -62,7 +62,6 @@ const StepIconText = experimentalStyled(
   {
     name: 'MuiStepIcon',
     slot: 'Text',
-    overridesResolver,
   },
 )(({ theme }) => ({
   /* Styles applied to the SVG text element. */

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -111,7 +111,6 @@ const StepLabelIconContainer = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'IconContainer',
-    overridesResolver,
   },
 )(() => ({
   /* Styles applied to the `icon` container element. */

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -82,7 +82,6 @@ const StepLabelLabel = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'Label',
-    overridesResolver,
   },
 )(({ theme }) => ({
   /* Styles applied to the Typography component that wraps `children`. */
@@ -130,7 +129,6 @@ const StepLabelLabelContainer = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'LabelContainer',
-    overridesResolver,
   },
 )(({ theme }) => ({
   /* Styles applied to the container element which wraps `Typography` and `optional`. */


### PR DESCRIPTION
Non `Root` & `Container` slots should not have `overrideResolver` defined, their overrides can be defined under the root component's style overrides definition.