### PR TITLE
[core] Don't call noop event.persist()

### DIFF
--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -2195,7 +2195,6 @@ describe('<Autocomplete />', () => {
           onChange={handleChange}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
-              event.persist();
               event.defaultMuiPrevented = true;
             }
           }}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -226,7 +226,6 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
       event.key === ' '
     ) {
       keydownRef.current = true;
-      event.persist();
       rippleRef.current.stop(event, () => {
         rippleRef.current.start(event);
       });
@@ -265,7 +264,6 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
       !event.defaultPrevented
     ) {
       keydownRef.current = false;
-      event.persist();
       rippleRef.current.stop(event, () => {
         rippleRef.current.pulsate(event);
       });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -896,8 +896,8 @@ describe('<ButtonBase />', () => {
 
     describe('keyboard accessibility for non interactive elements', () => {
       it('does not call onClick when a spacebar is pressed on the element but prevents the default', () => {
-        const onKeyDown = spy((event) => event.defaultPrevented);
-        const onClickSpy = spy((event) => event.defaultPrevented);
+        const onKeyDown = spy();
+        const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase onClick={onClickSpy} onKeyDown={onKeyDown} component="div">
             Hello
@@ -913,12 +913,12 @@ describe('<ButtonBase />', () => {
         });
 
         expect(onClickSpy.callCount).to.equal(0);
-        // defaultPrevented?
-        expect(onKeyDown.returnValues[0]).to.equal(true);
+        expect(onKeyDown.callCount).to.equal(1);
+        expect(onKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
 
       it('does call onClick when a spacebar is released on the element', () => {
-        const onClickSpy = spy((event) => event.defaultPrevented);
+        const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase onClick={onClickSpy} component="div">
             Hello
@@ -934,12 +934,11 @@ describe('<ButtonBase />', () => {
         });
 
         expect(onClickSpy.callCount).to.equal(1);
-        // defaultPrevented?
-        expect(onClickSpy.returnValues[0]).to.equal(false);
+        expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', false);
       });
 
       it('does not call onClick when a spacebar is released and the default is prevented', () => {
-        const onClickSpy = spy((event) => event.defaultPrevented);
+        const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase
             onClick={onClickSpy}
@@ -967,7 +966,7 @@ describe('<ButtonBase />', () => {
       });
 
       it('calls onClick when Enter is pressed on the element', () => {
-        const onClickSpy = spy((event) => event.defaultPrevented);
+        const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase onClick={onClickSpy} component="div">
             Hello
@@ -983,12 +982,11 @@ describe('<ButtonBase />', () => {
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
-        // defaultPrevented?
-        expect(onClickSpy.returnValues[0]).to.equal(true);
+        expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
 
       it('does not call onClick if Enter was pressed on a child', () => {
-        const onClickSpy = spy((event) => event.defaultPrevented);
+        const onClickSpy = spy();
         const onKeyDownSpy = spy();
         render(
           <ButtonBase onClick={onClickSpy} onKeyDown={onKeyDownSpy} component="div">
@@ -1022,7 +1020,7 @@ describe('<ButtonBase />', () => {
       });
 
       it('prevents default with an anchor and empty href', () => {
-        const onClickSpy = spy((event) => event.defaultPrevented);
+        const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase component="a" onClick={onClickSpy}>
             Hello
@@ -1036,13 +1034,12 @@ describe('<ButtonBase />', () => {
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
-        // defaultPrevented?
-        expect(onClickSpy.returnValues[0]).to.equal(true);
+        expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
 
       it('should ignore anchors with href', () => {
         const onClick = spy();
-        const onKeyDown = spy((event) => event.defaultPrevented);
+        const onKeyDown = spy();
         const { getByText } = render(
           <ButtonBase component="a" href="href" onClick={onClick} onKeyDown={onKeyDown}>
             Hello
@@ -1057,9 +1054,9 @@ describe('<ButtonBase />', () => {
           });
         });
 
-        expect(onClick.calledOnce).to.equal(false);
-        // defaultPrevented
-        expect(onKeyDown.returnValues[0]).to.equal(false);
+        expect(onClick.callCount).to.equal(0);
+        expect(onKeyDown.callCount).to.equal(1);
+        expect(onKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', false);
       });
     });
   });

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -273,7 +273,6 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
     // The touch interaction occurs too quickly.
     // We still want to show ripple effect.
     if (event.type === 'touchend' && startTimerCommit.current) {
-      event.persist();
       startTimerCommit.current();
       startTimerCommit.current = null;
       startTimer.current = setTimeout(() => {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -245,7 +245,7 @@ describe('<TouchRipple />', () => {
       expect(queryAllStoppingRipples()).to.have.lengthOf(0);
 
       act(() => {
-        instance.stop({ type: 'touchend', persist: () => {} }, cb);
+        instance.stop({ type: 'touchend' }, cb);
       });
 
       expect(queryAllActiveRipples()).to.have.lengthOf(1);

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -41,7 +41,7 @@ describe('<Checkbox />', () => {
   });
 
   it('flips the checked property when clicked and calls onchange with the checked state', () => {
-    const handleChange = spy((event) => event.persist());
+    const handleChange = spy();
     const { getByRole } = render(<Checkbox onChange={handleChange} />);
 
     act(() => {

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -381,7 +381,7 @@ describe('<Chip />', () => {
       ['Backspace', 'Delete'].forEach((key) => {
         it(`should call onDelete '${key}' is released`, () => {
           const handleDelete = spy();
-          const handleKeyDown = spy((event) => event.defaultPrevented);
+          const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Chip onClick={() => {}} onKeyDown={handleKeyDown} onDelete={handleDelete} />,
           );
@@ -393,7 +393,8 @@ describe('<Chip />', () => {
           fireEvent.keyDown(chip, { key });
 
           // defaultPrevented?
-          expect(handleKeyDown.returnValues[0]).to.equal(true);
+          expect(handleKeyDown.callCount).to.equal(1);
+          expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           expect(handleDelete.callCount).to.equal(0);
 
           fireEvent.keyUp(chip, { key });
@@ -403,14 +404,14 @@ describe('<Chip />', () => {
       });
 
       it('should not prevent default on input', () => {
-        const handleKeyDown = spy((event) => event.defaultPrevented);
+        const handleKeyDown = spy();
         const { container } = render(<Chip label={<input />} onKeyDown={handleKeyDown} />);
         const input = container.querySelector('input');
         input.focus();
         fireEvent.keyDown(input, { key: 'Backspace' });
 
-        // defaultPrevented?
-        expect(handleKeyDown.returnValues[0]).to.equal(false);
+        expect(handleKeyDown.callCount).to.equal(1);
+        expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', false);
       });
     });
 

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1010,7 +1010,7 @@ describe('<Select />', () => {
   });
 
   it('prevents the default when releasing Space on the children', () => {
-    const keyUpSpy = spy((event) => event.defaultPrevented);
+    const keyUpSpy = spy();
     render(
       <Select value="one" open>
         <MenuItem onKeyUp={keyUpSpy} value="one">
@@ -1022,7 +1022,7 @@ describe('<Select />', () => {
     fireEvent.keyUp(screen.getAllByRole('option')[0], { key: ' ' });
 
     expect(keyUpSpy.callCount).to.equal(1);
-    expect(keyUpSpy.returnValues[0]).to.equal(true);
+    expect(keyUpSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
   });
 
   it('should pass onClick prop to MenuItem', () => {
@@ -1112,9 +1112,9 @@ describe('<Select />', () => {
 
   it('should not override the event.target on mouse events', () => {
     const handleChange = spy();
-    const handleEvent = spy((event) => event.target);
+    const handleClick = spy();
     render(
-      <div onClick={handleEvent}>
+      <div onClick={handleClick}>
         <Select open onChange={handleChange} value="second">
           <MenuItem value="first" />
           <MenuItem value="second" />
@@ -1126,7 +1126,8 @@ describe('<Select />', () => {
     options[0].click();
 
     expect(handleChange.callCount).to.equal(1);
-    expect(handleEvent.returnValues).to.have.members([options[0]]);
+    expect(handleClick.callCount).to.equal(1);
+    expect(handleClick.firstCall.args[0]).to.have.property('target', options[0]);
   });
 
   it('should only select options', () => {

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -302,7 +302,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const handleBlur = (event) => {
     // if open event.stopImmediatePropagation
     if (!open && onBlur) {
-      event.persist();
       // Preact support, target is read only property on a native event.
       Object.defineProperty(event, 'target', { writable: true, value: { value, name } });
       onBlur(event);

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -1006,8 +1006,8 @@ describe('<Slider />', () => {
 
   it('should not override the event.target on touch events', () => {
     const handleChange = spy();
-    const handleNativeEvent = spy((event) => event.target);
-    const handleEvent = spy((event) => event.target);
+    const handleNativeEvent = spy();
+    const handleEvent = spy();
     function Test() {
       React.useEffect(() => {
         document.addEventListener('touchstart', handleNativeEvent);
@@ -1028,14 +1028,16 @@ describe('<Slider />', () => {
     fireEvent.touchStart(slider, createTouches([{ identifier: 1 }]));
 
     expect(handleChange.callCount).to.equal(1);
-    expect(handleNativeEvent.returnValues).to.have.members([slider]);
-    expect(handleEvent.returnValues).to.have.members([slider]);
+    expect(handleNativeEvent.callCount).to.equal(1);
+    expect(handleNativeEvent.firstCall.args[0]).to.have.property('target', slider);
+    expect(handleEvent.callCount).to.equal(1);
+    expect(handleEvent.firstCall.args[0]).to.have.property('target', slider);
   });
 
   it('should not override the event.target on mouse events', () => {
     const handleChange = spy();
-    const handleNativeEvent = spy((event) => event.target);
-    const handleEvent = spy((event) => event.target);
+    const handleNativeEvent = spy();
+    const handleEvent = spy();
     function Test() {
       React.useEffect(() => {
         document.addEventListener('mousedown', handleNativeEvent);
@@ -1056,8 +1058,10 @@ describe('<Slider />', () => {
     fireEvent.mouseDown(slider);
 
     expect(handleChange.callCount).to.equal(1);
-    expect(handleNativeEvent.returnValues).to.have.members([slider]);
-    expect(handleEvent.returnValues).to.have.members([slider]);
+    expect(handleNativeEvent.callCount).to.equal(1);
+    expect(handleNativeEvent.firstCall.args[0]).to.have.property('target', slider);
+    expect(handleEvent.callCount).to.equal(1);
+    expect(handleEvent.firstCall.args[0]).to.have.property('target', slider);
   });
 
   describe('dragging state', () => {

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -276,7 +276,6 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
 
     clearTimeout(eventTimer.current);
     if (event.type === 'blur') {
-      event.persist();
       eventTimer.current = setTimeout(() => {
         setOpenState(false);
         if (onClose) {
@@ -326,7 +325,6 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
     clearTimeout(eventTimer.current);
 
     if (!open) {
-      event.persist();
       // Wait for a future focus or click event
       eventTimer.current = setTimeout(() => {
         setOpenState(true);

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -693,7 +693,7 @@ describe('<SwipeableDrawer />', () => {
       this.skip();
     }
 
-    const handleTouchMove = spy((event) => event.defaultPrevented);
+    const handleTouchMove = spy();
 
     function Test() {
       React.useEffect(() => {
@@ -719,7 +719,8 @@ describe('<SwipeableDrawer />', () => {
     fireEvent.touchMove(target, {
       touches: [new Touch({ identifier: 0, target, pageX: 50, clientY: 0 })],
     });
-    expect(handleTouchMove.returnValues).to.deep.equal([false]);
+    expect(handleTouchMove.callCount).to.equal(1);
+    expect(handleTouchMove.firstCall.args[0]).to.have.property('defaultPrevented', false);
   });
 
   it('should not ignore scroll container if parent is overflow hidden', function test() {
@@ -728,7 +729,7 @@ describe('<SwipeableDrawer />', () => {
       this.skip();
     }
 
-    const handleTouchMove = spy((event) => event.defaultPrevented);
+    const handleTouchMove = spy();
 
     function Test() {
       React.useEffect(() => {
@@ -758,6 +759,8 @@ describe('<SwipeableDrawer />', () => {
     fireEvent.touchMove(target, {
       touches: [new Touch({ identifier: 0, target, pageX: 50, clientY: 0 })],
     });
-    expect(handleTouchMove.returnValues).to.deep.equal([false]);
+
+    expect(handleTouchMove.callCount).to.equal(1);
+    expect(handleTouchMove.firstCall.args[0]).to.have.property('defaultPrevented', false);
   });
 });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -313,7 +313,7 @@ describe('<Tabs />', () => {
     });
 
     it('when `selectionFollowsFocus` should call if an unselected tab gets focused', () => {
-      const handleChange = spy((event, value) => value);
+      const handleChange = spy();
       const { getAllByRole } = render(
         <Tabs value={0} onChange={handleChange} selectionFollowsFocus>
           <Tab />
@@ -327,7 +327,7 @@ describe('<Tabs />', () => {
       });
 
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.firstCall.returnValue).to.equal(1);
+      expect(handleChange.firstCall.args[1]).to.equal(1);
     });
 
     it('when `selectionFollowsFocus` should not call if an selected tab gets focused', () => {
@@ -766,7 +766,7 @@ describe('<Tabs />', () => {
         describe(previousItemKey, () => {
           it('moves focus to the last tab without activating it if focus is on the first tab', () => {
             const handleChange = spy();
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -789,12 +789,13 @@ describe('<Tabs />', () => {
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
 
           it('when `selectionFollowsFocus` moves focus to the last tab while activating it if focus is on the first tab', () => {
-            const handleChange = spy((event, value) => value);
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleChange = spy();
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -818,13 +819,14 @@ describe('<Tabs />', () => {
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
-            expect(handleChange.firstCall.returnValue).to.equal(2);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleChange.firstCall.args[1]).to.equal(2);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
 
           it('moves focus to the previous tab without activating it', () => {
             const handleChange = spy();
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -847,12 +849,13 @@ describe('<Tabs />', () => {
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
 
           it('when `selectionFollowsFocus` moves focus to the previous tab while activating it', () => {
-            const handleChange = spy((event, value) => value);
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleChange = spy();
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -876,15 +879,16 @@ describe('<Tabs />', () => {
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
-            expect(handleChange.firstCall.returnValue).to.equal(0);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleChange.firstCall.args[1]).to.equal(0);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
         });
 
         describe(nextItemKey, () => {
           it('moves focus to the first tab without activating it if focus is on the last tab', () => {
             const handleChange = spy();
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -907,12 +911,13 @@ describe('<Tabs />', () => {
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
 
           it('when `selectionFollowsFocus` moves focus to the first tab while activating it if focus is on the last tab', () => {
-            const handleChange = spy((event, value) => value);
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleChange = spy();
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -936,13 +941,14 @@ describe('<Tabs />', () => {
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
-            expect(handleChange.firstCall.returnValue).to.equal(0);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleChange.firstCall.args[1]).to.equal(0);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
 
           it('moves focus to the next tab without activating it it', () => {
             const handleChange = spy();
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -965,12 +971,13 @@ describe('<Tabs />', () => {
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
 
           it('when `selectionFollowsFocus` moves focus to the next tab while activating it it', () => {
-            const handleChange = spy((event, value) => value);
-            const handleKeyDown = spy((event) => event.defaultPrevented);
+            const handleChange = spy();
+            const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs
                 onChange={handleChange}
@@ -994,8 +1001,9 @@ describe('<Tabs />', () => {
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
-            expect(handleChange.firstCall.returnValue).to.equal(2);
-            expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+            expect(handleChange.firstCall.args[1]).to.equal(2);
+            expect(handleKeyDown.callCount).to.equal(1);
+            expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
           });
         });
       });
@@ -1005,7 +1013,7 @@ describe('<Tabs />', () => {
       describe('Home', () => {
         it('moves focus to the first tab without activating it', () => {
           const handleChange = spy();
-          const handleKeyDown = spy((event) => event.defaultPrevented);
+          const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Tabs onChange={handleChange} onKeyDown={handleKeyDown} value={1}>
               <Tab />
@@ -1022,12 +1030,13 @@ describe('<Tabs />', () => {
 
           expect(firstTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(0);
-          expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+          expect(handleKeyDown.callCount).to.equal(1);
+          expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
 
         it('when `selectionFollowsFocus` moves focus to the first tab without activating it', () => {
-          const handleChange = spy((event, value) => value);
-          const handleKeyDown = spy((event) => event.defaultPrevented);
+          const handleChange = spy();
+          const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Tabs onChange={handleChange} onKeyDown={handleKeyDown} selectionFollowsFocus value={2}>
               <Tab />
@@ -1044,15 +1053,16 @@ describe('<Tabs />', () => {
 
           expect(firstTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(1);
-          expect(handleChange.firstCall.returnValue).to.equal(0);
-          expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+          expect(handleChange.firstCall.args[1]).to.equal(0);
+          expect(handleKeyDown.callCount).to.equal(1);
+          expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
       });
 
       describe('End', () => {
         it('moves focus to the last tab without activating it', () => {
           const handleChange = spy();
-          const handleKeyDown = spy((event) => event.defaultPrevented);
+          const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Tabs onChange={handleChange} onKeyDown={handleKeyDown} value={1}>
               <Tab />
@@ -1069,12 +1079,13 @@ describe('<Tabs />', () => {
 
           expect(lastTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(0);
-          expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+          expect(handleKeyDown.callCount).to.equal(1);
+          expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
 
         it('when `selectionFollowsFocus` moves focus to the last tab without activating it', () => {
-          const handleChange = spy((event, value) => value);
-          const handleKeyDown = spy((event) => event.defaultPrevented);
+          const handleChange = spy();
+          const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Tabs onChange={handleChange} onKeyDown={handleKeyDown} selectionFollowsFocus value={0}>
               <Tab />
@@ -1091,8 +1102,9 @@ describe('<Tabs />', () => {
 
           expect(lastTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(1);
-          expect(handleChange.firstCall.returnValue).to.equal(2);
-          expect(handleKeyDown.firstCall.returnValue).to.equal(true);
+          expect(handleChange.firstCall.args[1]).to.equal(2);
+          expect(handleKeyDown.callCount).to.equal(1);
+          expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
       });
     });

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -366,7 +366,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     clearTimeout(enterTimer.current);
     clearTimeout(leaveTimer.current);
     if (enterDelay || (hystersisOpen && enterNextDelay)) {
-      event.persist();
       enterTimer.current = setTimeout(
         () => {
           handleOpen(event);
@@ -381,7 +380,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   const handleLeave = (event) => {
     clearTimeout(enterTimer.current);
     clearTimeout(leaveTimer.current);
-    event.persist();
     leaveTimer.current = setTimeout(() => {
       handleClose(event);
     }, leaveDelay);
@@ -436,7 +434,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     clearTimeout(leaveTimer.current);
     clearTimeout(closeTimer.current);
     stopTouchInteraction();
-    event.persist();
 
     prevUserSelect.current = document.body.style.WebkitUserSelect;
     // Prevent iOS text selection on long-tap.
@@ -455,7 +452,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
 
     clearTimeout(touchTimer.current);
     clearTimeout(leaveTimer.current);
-    event.persist();
     leaveTimer.current = setTimeout(() => {
       handleClose(event);
     }, leaveTouchDelay);

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -175,7 +175,7 @@ describe('<SwitchBase />', () => {
 
   describe('handleInputChange()', () => {
     it('should call onChange when uncontrolled', () => {
-      const handleChange = spy((event) => event.target.checked);
+      const handleChange = spy();
       const { getByRole } = render(
         <SwitchBase
           icon="unchecked"
@@ -190,13 +190,12 @@ describe('<SwitchBase />', () => {
       });
 
       expect(handleChange.callCount).to.equal(1);
-      // event.target.check is true
-      expect(handleChange.firstCall.returnValue).to.equal(true);
+      expect(handleChange.firstCall.args[0].target).to.have.property('checked', true);
     });
 
     it('should call onChange when controlled', () => {
       const checked = true;
-      const handleChange = spy((event, newChecked) => newChecked);
+      const handleChange = spy();
       const { getByRole } = render(
         <SwitchBase
           icon="unchecked"
@@ -210,11 +209,11 @@ describe('<SwitchBase />', () => {
       getByRole('checkbox').click();
 
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.firstCall.returnValue).to.equal(!checked);
+      expect(handleChange.firstCall.args[1]).to.equal(!checked);
     });
 
     it('should not change checkbox state when event is default prevented', () => {
-      const handleChange = spy((event) => event.target.checked);
+      const handleChange = spy();
       const handleClick = spy((event) => event.preventDefault());
       const { container, getByRole } = render(
         <SwitchBase

--- a/packages/material-ui/test/integration/PopperChildrenLayout.test.js
+++ b/packages/material-ui/test/integration/PopperChildrenLayout.test.js
@@ -72,7 +72,7 @@ describe('<Popper />', () => {
     });
 
     it('focus during layout effect does not scroll', () => {
-      const handleFocus = spy((event) => event.target.getBoundingClientRect().top);
+      const handleFocus = spy();
       function LayoutEffectFocusButton(props) {
         const buttonRef = React.useRef(null);
         React.useLayoutEffect(() => {
@@ -97,7 +97,7 @@ describe('<Popper />', () => {
     });
 
     it('focus during passive effects do not scroll', () => {
-      const handleFocus = spy((event) => event.target.getBoundingClientRect().top);
+      const handleFocus = spy();
       function EffectFocusButton(props) {
         const buttonRef = React.useRef(null);
         React.useEffect(() => {
@@ -161,7 +161,7 @@ describe('<Popper />', () => {
         });
 
         it('focus during layout effect does not scroll', () => {
-          const handleFocus = spy((event) => event.target.getBoundingClientRect().top);
+          const handleFocus = spy();
           function LayoutEffectFocusButton(props) {
             const buttonRef = React.useRef(null);
             React.useLayoutEffect(() => {
@@ -194,7 +194,7 @@ describe('<Popper />', () => {
         });
 
         it('focus during passive effects do not scroll', () => {
-          const handleFocus = spy((event) => event.target.getBoundingClientRect().top);
+          const handleFocus = spy();
           function EffectFocusButton(props) {
             const buttonRef = React.useRef(null);
             React.useEffect(() => {


### PR DESCRIPTION
[`event.persist()` is a noop in React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#no-event-pooling) so we might as well get rid of it to simplify code.

PR consists of two parts:
1. Removal of event.persist
2. Removal of implicitly persisting event properties in tests
   This reduces indirection for which we sometimes added comments, sometimes we didn't. We can skip the comments and use actual code now.

Note that preact doesn't pool events to begin with so this won't break compat.