### PR TITLE
[l10n] zhTW refinement

### DIFF
--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -2657,9 +2657,9 @@ export const zhTW: Localization = {
       defaultProps: {
         clearText: '清空',
         closeText: '關閉',
-        loadingText: '加載中……',
+        loadingText: '載入中……',
         noOptionsText: '没有可用選項',
-        openText: '打开',
+        openText: '打開',
       },
     },
     MuiAlert: {


### PR DESCRIPTION
We use 開 rather than 开 as 'open' in Traditional Chinese.
In Taiwan we usually use 載入中/讀取中 rather than 加載中. Even though languages do affect each other.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
