### PR TITLE
[Avatar] Fix onload event not firing when img cached

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -112,10 +112,6 @@ function useLoaded({ src, srcSet }) {
 
     let active = true;
     const image = new Image();
-    image.src = src;
-    if (srcSet) {
-      image.srcset = srcSet;
-    }
     image.onload = () => {
       if (!active) {
         return;
@@ -128,6 +124,10 @@ function useLoaded({ src, srcSet }) {
       }
       setLoaded('error');
     };
+    image.src = src;
+    if (srcSet) {
+      image.srcset = srcSet;
+    }
 
     return () => {
       active = false;


### PR DESCRIPTION
onerror and onload may fire before attaching to the events, so it makes sense to attach to them before settings the `image.src`.

this issue can appear specifically with cached images.