### PR TITLE
[Select] Fix overrides for slots

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import NativeSelect, { nativeSelectClasses as classes } from '@material-ui/core/NativeSelect';
 import Input, { inputClasses } from '@material-ui/core/Input';
@@ -62,5 +63,33 @@ describe('<NativeSelect />', () => {
   it('should provide the classes to the select component', () => {
     const { getByRole } = render(<NativeSelect {...defaultProps} />);
     expect(getByRole('combobox')).to.have.class(classes.root);
+  });
+
+  it('slots overrides should work', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const iconStyle = {
+      marginTop: '13px',
+    };
+
+    const theme = createMuiTheme({
+      components: {
+        MuiNativeSelect: {
+          styleOverrides: {
+            icon: iconStyle,
+          },
+        },
+      },
+    });
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <NativeSelect {...defaultProps} />
+      </ThemeProvider>,
+    );
+
+    expect(container.getElementsByClassName(classes.icon)[0]).to.toHaveComputedStyle(iconStyle);
   });
 });

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -7,18 +7,13 @@ import capitalize from '../utils/capitalize';
 import nativeSelectClasses, { getNativeSelectUtilitiyClasses } from './nativeSelectClasses';
 import experimentalStyled from '../styles/experimentalStyled';
 
-export const overridesResolver = (props, styles) => {
+const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
   return deepmerge(
     {
       ...styles.select,
       ...styles[styleProps.variant],
-      [`& .${nativeSelectClasses.icon}`]: {
-        ...styles.icon,
-        ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
-        ...(styleProps.open && styles.iconOpen),
-      },
     },
     styles.root || {},
   );
@@ -89,6 +84,17 @@ const NativeSelectRoot = experimentalStyled(
   { name: 'MuiNativeSelect', slot: 'Root', overridesResolver },
 )(nativeSelectRootStyles);
 
+const iconOverridesResolver = (props, styles) => {
+  const { styleProps } = props;
+  return deepmerge(
+    {
+      ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
+      ...(styleProps.open && styles.iconOpen),
+    },
+    styles.icon || {},
+  );
+};
+
 export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
   // We use a position absolute over a flexbox in order to forward the pointer events
   // to the input and to support wrapping tags..
@@ -114,7 +120,7 @@ export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
 const NativeSelectIcon = experimentalStyled(
   'svg',
   {},
-  { name: 'MuiNativeSelect', slot: 'Icon' },
+  { name: 'MuiNativeSelect', slot: 'Icon', overridesResolver: iconOverridesResolver },
 )(nativeSelectIconStyles);
 
 /**

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -10,6 +10,7 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import MenuItem from '@material-ui/core/MenuItem';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -1143,5 +1144,42 @@ describe('<Select />', () => {
     const divider = document.querySelector('hr');
     divider.click();
     expect(handleChange.callCount).to.equal(0);
+  });
+
+  it('slots overrides should work', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const iconStyle = {
+      marginTop: '13px',
+    };
+
+    const nativeInputStyle = {
+      marginTop: '10px',
+    };
+
+    const theme = createMuiTheme({
+      components: {
+        MuiSelect: {
+          styleOverrides: {
+            icon: iconStyle,
+            nativeInput: nativeInputStyle,
+          },
+        },
+      },
+    });
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Select open value="first">
+          <MenuItem value="first" />
+          <MenuItem value="second" />
+        </Select>
+      </ThemeProvider>,
+    );
+
+    expect(container.getElementsByClassName(classes.icon)[0]).to.toHaveComputedStyle(iconStyle);
+    expect(container.getElementsByClassName(classes.nativeInput)[0]).to.toHaveComputedStyle(nativeInputStyle);
   });
 });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1180,6 +1180,8 @@ describe('<Select />', () => {
     );
 
     expect(container.getElementsByClassName(classes.icon)[0]).to.toHaveComputedStyle(iconStyle);
-    expect(container.getElementsByClassName(classes.nativeInput)[0]).to.toHaveComputedStyle(nativeInputStyle);
+    expect(container.getElementsByClassName(classes.nativeInput)[0]).to.toHaveComputedStyle(
+      nativeInputStyle,
+    );
   });
 });

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -15,17 +15,12 @@ import useForkRef from '../utils/useForkRef';
 import useControlled from '../utils/useControlled';
 import selectClasses, { getSelectUtilitiyClasses } from './selectClasses';
 
-export const overridesResolver = (props, styles) => {
+const overridesResolver = (props, styles) => {
   const { styleProps } = props;
   return deepmerge(
     {
       ...styles.select,
       ...styles[styleProps.variant],
-      [`& .${selectClasses.icon}`]: {
-        ...styles.icon,
-        ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
-        ...(styleProps.open && styles.iconOpen),
-      },
     },
     styles.root || {},
   );
@@ -45,16 +40,31 @@ const SelectRoot = experimentalStyled(
   },
 });
 
+const iconOverridesResolver = (props, styles) => {
+  const { styleProps } = props;
+  return deepmerge(
+    {
+      ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
+      ...(styleProps.open && styles.iconOpen),
+    },
+    styles.icon || {},
+  );
+};
+
 const SelectIcon = experimentalStyled(
   'svg',
   {},
-  { name: 'MuiSelect', slot: 'Icon' },
+  { name: 'MuiSelect', slot: 'Icon', overridesResolver: iconOverridesResolver },
 )(nativeSelectIconStyles);
 
 const SelectNativeInput = experimentalStyled(
   'input',
   {},
-  { name: 'MuiSelect', slot: 'NativeInput' },
+  {
+    name: 'MuiSelect',
+    slot: 'NativeInput',
+    overridesResolver: (props, styles) => styles.nativeInput,
+  },
 )({
   bottom: 0,
   left: 0,


### PR DESCRIPTION
Follow up after https://github.com/mui-org/material-ui/pull/25777 for the `Select` components