### PR TITLE
[Box] Add utility mui class

### DIFF
--- a/packages/material-ui/src/Box/Box.js
+++ b/packages/material-ui/src/Box/Box.js
@@ -9,17 +9,17 @@ const BoxInner = React.forwardRef((props, ref) => {
 
   if (clone) {
     return React.cloneElement(children, {
-      className: clsx(children.props.className, className),
+      className: clsx(children.props.className, className, 'MuiBox-root'),
       ...other,
     });
   }
 
   if (typeof children === 'function') {
-    return children({ className, ...other });
+    return children({ className: clsx(className, 'MuiBox-root'), ...other });
   }
 
   return (
-    <Component ref={ref} className={className} {...other}>
+    <Component ref={ref} className={clsx(className, 'MuiBox-root')} {...other}>
       {children}
     </Component>
   );

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -163,7 +163,7 @@ describe('<Box />', () => {
     );
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
-    expect(getByTestId('children-as-fn')).to.have.class('MuiBox-root'));
-    expect(getByTestId('cloned-children')).to.have.class('MuiBox-root'));
+    expect(getByTestId('children-as-fn')).to.have.class('MuiBox-root');
+    expect(getByTestId('cloned-children')).to.have.class('MuiBox-root');
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -150,4 +150,20 @@ describe('<Box />', () => {
       marginBottom: '16px',
     });
   });
+
+  it('adds the utility mui class', () => {
+    const { getByTestId } = render(
+      <React.Fragment>
+        <Box data-testid="regular-box" />
+        <Box>{(props) => <div data-testid="children-as-fn" {...props} />}</Box>
+        <Box clone>
+          <div data-testid="cloned-children" />
+        </Box>
+      </React.Fragment>,
+    );
+
+    expect(getByTestId('regular-box').classList.contains('MuiBox-root')).to.equal(true);
+    expect(getByTestId('children-as-fn').classList.contains('MuiBox-root')).to.equal(true);
+    expect(getByTestId('cloned-children').classList.contains('MuiBox-root')).to.equal(true);
+  });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -164,6 +164,6 @@ describe('<Box />', () => {
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
     expect(getByTestId('children-as-fn')).to.have.class('MuiBox-root'));
-    expect(getByTestId('cloned-children'))to.have.class('MuiBox-root'));
+    expect(getByTestId('cloned-children')).to.have.class('MuiBox-root'));
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -162,7 +162,7 @@ describe('<Box />', () => {
       </React.Fragment>,
     );
 
-    expect(getByTestId('regular-box').classList.contains('MuiBox-root')).to.equal(true);
+    expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
     expect(getByTestId('children-as-fn').classList.contains('MuiBox-root')).to.equal(true);
     expect(getByTestId('cloned-children').classList.contains('MuiBox-root')).to.equal(true);
   });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -164,6 +164,6 @@ describe('<Box />', () => {
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
     expect(getByTestId('children-as-fn'))to.have.class('MuiBox-root'));
-    expect(getByTestId('cloned-children').classList.contains('MuiBox-root')).to.equal(true);
+    expect(getByTestId('cloned-children'))to.have.class('MuiBox-root'));
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -163,7 +163,7 @@ describe('<Box />', () => {
     );
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
-    expect(getByTestId('children-as-fn').classList.contains('MuiBox-root')).to.equal(true);
+    expect(getByTestId('children-as-fn'))to.have.class('MuiBox-root'));
     expect(getByTestId('cloned-children').classList.contains('MuiBox-root')).to.equal(true);
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -163,7 +163,7 @@ describe('<Box />', () => {
     );
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
-    expect(getByTestId('children-as-fn'))to.have.class('MuiBox-root'));
+    expect(getByTestId('children-as-fn')).to.have.class('MuiBox-root'));
     expect(getByTestId('cloned-children'))to.have.class('MuiBox-root'));
   });
 });


### PR DESCRIPTION
This PR adds the `MuiBox-root` class on the `Box` component to allow customization by selecting all Box instances. More for the motivation can be found here https://github.com/mui-org/material-ui/issues/25759#issuecomment-819503863