### PR TITLE
[internal][pickers] Rename DayPickerView to CalendarPickerView

### DIFF
--- a/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -14,10 +14,10 @@ import YearPicker, { ExportedYearPickerProps } from '../YearPicker/YearPicker';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
 import { IsStaticVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { findClosestEnabledDate } from '../internal/pickers/date-utils';
-import { DayPickerView } from './shared';
+import { CalendarPickerView } from './shared';
 import PickerView from '../internal/pickers/Picker/PickerView';
 
-export interface CalendarPickerProps<TDate, TView extends DayPickerView = DayPickerView>
+export interface CalendarPickerProps<TDate, TView extends CalendarPickerView = CalendarPickerView>
   extends ExportedCalendarProps<TDate>,
     ExportedYearPickerProps<TDate>,
     ExportedCalendarHeaderProps<TDate> {
@@ -123,7 +123,7 @@ export const defaultReduceAnimations =
 
 const CalendarPicker = React.forwardRef(function CalendarPicker<
   TDate extends any,
-  TView extends DayPickerView = DayPickerView
+  TView extends CalendarPickerView = CalendarPickerView
 >(
   props: CalendarPickerProps<TDate, TView> & WithStyles<typeof styles>,
   ref: React.Ref<HTMLDivElement>,
@@ -219,7 +219,7 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<
         views={views}
         openView={openView}
         currentMonth={calendarState.currentMonth}
-        onViewChange={setOpenView as (view: DayPickerView) => void}
+        onViewChange={setOpenView as (view: CalendarPickerView) => void}
         onMonthChange={(newMonth, direction) => handleChangeMonth({ newMonth, direction })}
         minDate={minDate}
         maxDate={maxDate}

--- a/packages/material-ui-lab/src/CalendarPicker/PickersCalendarHeader.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/PickersCalendarHeader.tsx
@@ -17,7 +17,7 @@ import {
   usePreviousMonthDisabled,
   useNextMonthDisabled,
 } from '../internal/pickers/hooks/date-helpers-hooks';
-import { DayPickerView } from './shared';
+import { CalendarPickerView } from './shared';
 
 export type ExportedCalendarHeaderProps<TDate> = Pick<
   PickersCalendarHeaderProps<TDate>,
@@ -48,15 +48,15 @@ export interface PickersCalendarHeaderProps<TDate>
     switchViewButton?: any;
   };
   currentMonth: TDate;
-  views: readonly DayPickerView[];
+  views: readonly CalendarPickerView[];
   /**
    * Get aria-label text for switching between views button.
    */
-  getViewSwitchingButtonText?: (currentView: DayPickerView) => string;
+  getViewSwitchingButtonText?: (currentView: CalendarPickerView) => string;
   onMonthChange: (date: TDate, slideDirection: SlideDirection) => void;
-  openView: DayPickerView;
+  openView: CalendarPickerView;
   reduceAnimations: boolean;
-  onViewChange?: (view: DayPickerView) => void;
+  onViewChange?: (view: CalendarPickerView) => void;
 }
 
 export type PickersCalendarHeaderClassKey =
@@ -107,7 +107,7 @@ export const styles: MuiStyles<PickersCalendarHeaderClassKey> = (
   },
 });
 
-function getSwitchingViewAriaText(view: DayPickerView) {
+function getSwitchingViewAriaText(view: CalendarPickerView) {
   return view === 'year'
     ? 'year view is open, switch to calendar view'
     : 'calendar view is open, switch to year view';

--- a/packages/material-ui-lab/src/CalendarPicker/shared.ts
+++ b/packages/material-ui-lab/src/CalendarPicker/shared.ts
@@ -1,1 +1,1 @@
-export type DayPickerView = 'year' | 'day' | 'month';
+export type CalendarPickerView = 'year' | 'day' | 'month';


### PR DESCRIPTION
Follow-up to https://github.com/mui-org/material-ui/pull/25810.

No more mention of `daypicker` in the repo (aside from stale translation files).