### PR TITLE
[Pickers] Remove `TView` generic in CalendarPicker

### DIFF
--- a/docs/pages/api-docs/date-picker.json
+++ b/docs/pages/api-docs/date-picker.json
@@ -61,7 +61,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -83,7 +83,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/desktop-date-picker.json
+++ b/docs/pages/api-docs/desktop-date-picker.json
@@ -52,7 +52,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -74,7 +74,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/desktop-time-picker.json
+++ b/docs/pages/api-docs/desktop-time-picker.json
@@ -43,7 +43,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/mobile-date-picker.json
+++ b/docs/pages/api-docs/mobile-date-picker.json
@@ -57,7 +57,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -79,7 +79,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/mobile-time-picker.json
+++ b/docs/pages/api-docs/mobile-time-picker.json
@@ -48,7 +48,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/static-date-picker.json
+++ b/docs/pages/api-docs/static-date-picker.json
@@ -56,7 +56,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -78,7 +78,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/static-time-picker.json
+++ b/docs/pages/api-docs/static-time-picker.json
@@ -47,7 +47,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'"
       }
     },
     "orientation": {

--- a/docs/pages/api-docs/time-picker.json
+++ b/docs/pages/api-docs/time-picker.json
@@ -52,7 +52,7 @@
     "openTo": {
       "type": {
         "name": "enum",
-        "description": "'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'"
+        "description": "'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'"
       }
     },
     "orientation": {

--- a/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -17,7 +17,7 @@ import { findClosestEnabledDate } from '../internal/pickers/date-utils';
 import { CalendarPickerView } from './shared';
 import PickerView from '../internal/pickers/Picker/PickerView';
 
-export interface CalendarPickerProps<TDate, TView extends CalendarPickerView = CalendarPickerView>
+export interface CalendarPickerProps<TDate>
   extends ExportedCalendarProps<TDate>,
     ExportedYearPickerProps<TDate>,
     ExportedCalendarHeaderProps<TDate> {
@@ -46,7 +46,7 @@ export interface CalendarPickerProps<TDate, TView extends CalendarPickerView = C
   /**
    * Callback fired on view change.
    */
-  onViewChange?: (view: TView) => void;
+  onViewChange?: (view: CalendarPickerView) => void;
   /**
    * Callback fired on date change
    */
@@ -59,7 +59,7 @@ export interface CalendarPickerProps<TDate, TView extends CalendarPickerView = C
    * Initially open view.
    * @default 'day'
    */
-  openTo?: TView;
+  openTo?: CalendarPickerView;
   /**
    * Disable heavy animations.
    * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
@@ -77,12 +77,12 @@ export interface CalendarPickerProps<TDate, TView extends CalendarPickerView = C
   /**
    * Controlled open view.
    */
-  view?: TView;
+  view?: CalendarPickerView;
   /**
    * Views for calendar picker.
    * @default ['year', 'day']
    */
-  views?: readonly TView[];
+  views?: readonly CalendarPickerView[];
 }
 
 export type ExportedCalendarPickerProps<TDate> = Omit<
@@ -121,11 +121,8 @@ export const styles: MuiStyles<CalendarPickerClassKey> = {
 export const defaultReduceAnimations =
   typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent);
 
-const CalendarPicker = React.forwardRef(function CalendarPicker<
-  TDate extends any,
-  TView extends CalendarPickerView = CalendarPickerView
->(
-  props: CalendarPickerProps<TDate, TView> & WithStyles<typeof styles>,
+const CalendarPicker = React.forwardRef(function CalendarPicker<TDate extends any>(
+  props: CalendarPickerProps<TDate> & WithStyles<typeof styles>,
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {
@@ -146,10 +143,8 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<
     shouldDisableDate,
     shouldDisableYear,
     view,
-    // TODO: unsound. `TView` could be `'day'`. `T extends Literal` does not mean there are more constituents but less.
-    // Probably easiest to remove `TView`. How would one even pass this type parameter?
-    views = ['year', 'day'] as TView[],
-    openTo = 'day' as TView,
+    views = ['year', 'day'],
+    openTo = 'day',
     className,
     ...other
   } = props;
@@ -219,7 +214,7 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<
         views={views}
         openView={openView}
         currentMonth={calendarState.currentMonth}
-        onViewChange={setOpenView as (view: CalendarPickerView) => void}
+        onViewChange={setOpenView}
         onMonthChange={(newMonth, direction) => handleChangeMonth({ newMonth, direction })}
         minDate={minDate}
         maxDate={maxDate}

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -53,7 +53,6 @@ export interface BaseDatePickerProps<TDate>
    * First view to show.
    */
   openTo?: DatePickerView;
-
   /**
    * Array of views to show.
    */

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import DatePickerToolbar from './DatePickerToolbar';
-import { AllSharedPickerProps, WithViewsProps } from '../internal/pickers/Picker/SharedPickerProps';
+import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import {
   ResponsiveWrapper,
   ResponsiveWrapperProps,
@@ -47,9 +47,18 @@ type SharedPickerProps<TDate, PublicWrapperProps> = PublicWrapperProps &
 export type DatePickerView = 'year' | 'day' | 'month';
 
 export interface BaseDatePickerProps<TDate>
-  extends WithViewsProps<DatePickerView>,
-    ValidationProps<DateValidationError, ParsableDate>,
-    OverrideParsableDateProps<TDate, ExportedCalendarPickerProps<TDate>, 'minDate' | 'maxDate'> {}
+  extends ValidationProps<DateValidationError, ParsableDate>,
+    OverrideParsableDateProps<TDate, ExportedCalendarPickerProps<TDate>, 'minDate' | 'maxDate'> {
+  /**
+   * First view to show.
+   */
+  openTo?: DatePickerView;
+
+  /**
+   * Array of views to show.
+   */
+  views?: readonly DatePickerView[];
+}
 
 export const datePickerConfig = {
   useValidation: makeValidationHook<

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -393,7 +393,7 @@ DatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -14,7 +14,7 @@ import {
   OverrideParsableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
-import { WithViewsProps, AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
+import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import { DateAndTimeValidationError, validateDateAndTime } from './date-time-utils';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
 import {
@@ -50,8 +50,7 @@ type DateTimePickerViewsProps<TDate> = OverrideParsableDateProps<
 >;
 
 export interface BaseDateTimePickerProps<TDate>
-  extends WithViewsProps<DateTimePickerView>,
-    ValidationProps<DateAndTimeValidationError, ParsableDate>,
+  extends ValidationProps<DateAndTimeValidationError, ParsableDate>,
     DateTimePickerViewsProps<TDate> {
   /**
    * To show tabs.
@@ -74,9 +73,17 @@ export interface BaseDateTimePickerProps<TDate>
    */
   maxDateTime?: ParsableDate<TDate>;
   /**
+   * First view to show.
+   */
+  openTo?: DateTimePickerView;
+  /**
    * Date format, that is displaying in toolbar.
    */
   toolbarFormat?: string;
+  /**
+   * Array of views to show.
+   */
+  views?: readonly DateTimePickerView[];
 }
 
 function useInterceptProps({

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -528,7 +528,7 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -292,7 +292,7 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -369,7 +369,7 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -255,7 +255,7 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -316,7 +316,7 @@ MobileDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -393,7 +393,7 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -279,7 +279,7 @@ MobileTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -297,7 +297,7 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -374,7 +374,7 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'year']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -260,7 +260,7 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -12,7 +12,7 @@ import {
 import { pick12hOr24hFormat } from '../internal/pickers/text-field-helper';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { validateTime, TimeValidationError } from '../internal/pickers/time-utils';
-import { WithViewsProps, AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
+import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import { ValidationProps, makeValidationHook } from '../internal/pickers/hooks/useValidation';
 import {
   useParsedDate,
@@ -42,8 +42,16 @@ export type TimePickerView = 'hours' | 'minutes' | 'seconds';
 
 export interface BaseTimePickerProps<TDate = unknown>
   extends ValidationProps<TimeValidationError, ParsableDate<TDate>>,
-    WithViewsProps<TimePickerView>,
-    OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'> {}
+    OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'> {
+  /**
+   * First view to show.
+   */
+  openTo?: TimePickerView;
+  /**
+   * Array of views to show.
+   */
+  views?: readonly TimePickerView[];
+}
 
 export function getTextFieldAriaText(value: ParsableDate, utils: MuiPickersAdapter) {
   return value && utils.isValid(utils.date(value))

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -369,7 +369,7 @@ TimePicker.propTypes /* remove-proptypes */ = {
   /**
    * First view to show.
    */
-  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
   /**
    * Force rendering in particular orientation.
    */

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -12,16 +12,22 @@ import { WrapperVariant, WrapperVariantContext } from '../wrappers/WrapperVarian
 import { DateInputPropsLike } from '../wrappers/WrapperProps';
 import { PickerSelectionState } from '../hooks/usePickerState';
 import { BasePickerProps, CalendarAndClockProps } from '../typings/BasePicker';
-import { WithViewsProps } from './SharedPickerProps';
 import { AllAvailableViews } from '../typings/Views';
 import PickerView from './PickerView';
 
 export interface ExportedPickerProps<TView extends AllAvailableViews>
   extends Omit<BasePickerProps, 'value' | 'onChange'>,
-    CalendarAndClockProps<unknown>,
-    WithViewsProps<TView> {
+    CalendarAndClockProps<unknown> {
   dateRangeIcon?: React.ReactNode;
+  /**
+   * First view to show.
+   */
+  openTo?: TView;
   timeIcon?: React.ReactNode;
+  /**
+   * Array of views to show.
+   */
+  views?: readonly TView[];
 }
 
 export interface PickerProps<TView extends AllAvailableViews, TDateValue = any>

--- a/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
@@ -1,18 +1,6 @@
 import { BasePickerProps } from '../typings/BasePicker';
 import { ExportedDateInputProps } from '../PureDateInput';
-import { AllAvailableViews } from '../typings/Views';
 
 export interface AllSharedPickerProps<TInputValue = any, TDateValue = any>
   extends BasePickerProps<TInputValue, TDateValue>,
     ExportedDateInputProps<TInputValue, TDateValue> {}
-
-export interface WithViewsProps<T extends AllAvailableViews> {
-  /**
-   * First view to show.
-   */
-  openTo?: T;
-  /**
-   * Array of views to show.
-   */
-  views?: readonly T[];
-}

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useViews.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useViews.tsx
@@ -9,33 +9,33 @@ export type PickerOnChangeFn<TDate> = (
   selectionState?: PickerSelectionState,
 ) => void;
 
-interface UseViewsOptions<TDate, TView extends AllAvailableViews> {
+interface UseViewsOptions<TDate, View extends AllAvailableViews> {
   onChange: PickerOnChangeFn<TDate>;
-  onViewChange?: (newView: TView) => void;
-  openTo?: TView;
-  view: TView | undefined;
-  views: readonly TView[];
+  onViewChange?: (newView: View) => void;
+  openTo?: View;
+  view: View | undefined;
+  views: readonly View[];
 }
 
-export function useViews<TDate, TView extends AllAvailableViews>({
+export function useViews<TDate, View extends AllAvailableViews>({
   onChange,
   onViewChange,
   openTo,
   view,
   views,
-}: UseViewsOptions<TDate, TView>) {
-  const [openView, setOpenView] = useControlled<TView>({
+}: UseViewsOptions<TDate, View>) {
+  const [openView, setOpenView] = useControlled<View>({
     name: 'Picker',
     state: 'view',
     controlled: view,
     default: openTo && arrayIncludes(views, openTo) ? openTo : views[0],
   });
 
-  const previousView: TView | null = views[views.indexOf(openView) - 1] ?? null;
-  const nextView: TView | null = views[views.indexOf(openView) + 1] ?? null;
+  const previousView: View | null = views[views.indexOf(openView) - 1] ?? null;
+  const nextView: View | null = views[views.indexOf(openView) + 1] ?? null;
 
   const changeView = React.useCallback(
-    (newView: TView) => {
+    (newView: View) => {
       setOpenView(newView);
 
       if (onViewChange) {

--- a/packages/material-ui-lab/src/internal/pickers/typings/BasePicker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/typings/BasePicker.tsx
@@ -6,10 +6,8 @@ export type CalendarAndClockProps<
 > = import('@material-ui/lab/CalendarPicker/CalendarPicker').ExportedCalendarPickerProps<TDate> &
   import('@material-ui/lab/ClockPicker/ClockPicker').ExportedClockPickerProps<TDate>;
 
-export type ToolbarComponentProps<
-  TDate = unknown,
-  TView extends AllAvailableViews = AllAvailableViews
-> = CalendarAndClockProps<TDate> & {
+// TODO: TDate should be required
+export type ToolbarComponentProps<TDate = unknown> = CalendarAndClockProps<TDate> & {
   ampmInClock?: boolean;
   date: TDate;
   dateRangeIcon?: React.ReactNode;
@@ -18,14 +16,14 @@ export type ToolbarComponentProps<
   isLandscape: boolean;
   isMobileKeyboardViewOpen: boolean;
   onChange: import('../hooks/useViews').PickerOnChangeFn<TDate>;
-  openView: TView;
-  setOpenView: (view: TView) => void;
+  openView: AllAvailableViews;
+  setOpenView: (view: AllAvailableViews) => void;
   timeIcon?: React.ReactNode;
   toggleMobileKeyboardView: () => void;
   toolbarFormat?: string;
   toolbarPlaceholder?: React.ReactNode;
   toolbarTitle?: React.ReactNode;
-  views: readonly TView[];
+  views: readonly AllAvailableViews[];
 };
 
 export interface BasePickerProps<TInputValue = ParsableDate, TDateValue = unknown> {


### PR DESCRIPTION
Was only accessible from within `CalendarPickerProps` but not the actual component. In this state it only complicates the types and is in many scenarios unsound anyway.

Removed the internal `WithViewProps` as well. Just more indirection that doesn't accomplish anything. It even resulted in too wide types documentation.