### PR TITLE
[Pickers] Use passive effect to attach close-on-escape listener

### DIFF
--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -28,6 +28,26 @@ function TestKeyboardDatePicker(
 describe('<DesktopDatePicker /> keyboard interactions', () => {
   const render = createPickerRender();
 
+  it('closes on Escape press', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDatePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+    act(() => {
+      (document.activeElement as HTMLElement).blur();
+    });
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    expect(handleClose.callCount).to.equal(1);
+  });
+
   context('input', () => {
     it('allows to change selected date from the input according to `format`', () => {
       const onChangeMock = spy();

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, screen, fireEvent } from 'test/utils';
+import { act, describeConformance, screen, fireEvent } from 'test/utils';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import { DateRange } from '@material-ui/lab/DateRangePicker';
@@ -95,6 +95,26 @@ describe('<DesktopDateRangePicker />', () => {
     fireEvent.click(screen.getAllByLabelText('Previous month')[0]);
 
     expect(handleClose.callCount).to.equal(0);
+  });
+
+  it('closes on Escape press', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateRangePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={[null, null]}
+        open
+        onClose={handleClose}
+      />,
+    );
+    act(() => {
+      (document.activeElement as HTMLElement).blur();
+    });
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    expect(handleClose.callCount).to.equal(1);
   });
 
   it('allows to select date range end-to-end', () => {

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import { expect } from 'chai';
 import { useFakeTimers, SinonFakeTimers, spy } from 'sinon';
-import { fireEvent, screen } from 'test/utils';
+import { act, fireEvent, screen } from 'test/utils';
 import 'dayjs/locale/ru';
 import DesktopDateTimePicker from '@material-ui/lab/DesktopDateTimePicker';
 import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
@@ -81,6 +81,26 @@ describe('<DesktopDateTimePicker />', () => {
     fireEvent.click(screen.getByLabelText('pick time'));
 
     expect(handleClose.callCount).to.equal(0);
+  });
+
+  it('closes on Escape press', () => {
+    const handleClose = spy();
+    render(
+      <DesktopDateTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+    act(() => {
+      (document.activeElement as HTMLElement).blur();
+    });
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    expect(handleClose.callCount).to.equal(1);
   });
 
   it('prop: mask – should take the mask prop into account', () => {

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import { spy, useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import { describeConformance, fireEvent, fireDiscreteEvent, screen } from 'test/utils';
+import { act, describeConformance, fireEvent, fireDiscreteEvent, screen } from 'test/utils';
 import { TransitionProps } from '@material-ui/core/transitions';
 import { TimePickerProps } from '@material-ui/lab/TimePicker';
 import DesktopTimePicker from '@material-ui/lab/DesktopTimePicker';
@@ -123,6 +123,26 @@ describe('<DesktopTimePicker />', () => {
     fireEvent.click(screen.getByLabelText('open next view'));
 
     expect(handleClose.callCount).to.equal(0);
+  });
+
+  it('closes on Escape press', () => {
+    const handleClose = spy();
+    render(
+      <DesktopTimePicker
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        value={null}
+        open
+        onClose={handleClose}
+      />,
+    );
+    act(() => {
+      (document.activeElement as HTMLElement).blur();
+    });
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    expect(handleClose.callCount).to.equal(1);
   });
 
   it('allows to navigate between timepicker views using arrow switcher', () => {

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -9,7 +9,6 @@ import TrapFocus, {
 import { useForkRef, useEventCallback, ownerDocument } from '@material-ui/core/utils';
 import { MuiStyles, StyleRules, WithStyles, withStyles } from '@material-ui/core/styles';
 import { TransitionProps as MuiTransitionProps } from '@material-ui/core/transitions';
-import { useGlobalKeyDown, keycode } from './hooks/useKeyDown';
 
 export interface ExportedPickerPopperProps {
   /**
@@ -199,9 +198,20 @@ const PickersPopper: React.FC<PickerPopperProps & WithStyles<typeof styles>> = (
     TrapFocusProps,
   } = props;
 
-  useGlobalKeyDown(open, {
-    [keycode.Esc]: onClose,
-  });
+  React.useEffect(() => {
+    function handleKeyDown(nativeEvent: KeyboardEvent) {
+      // IE11, Edge (prior to using Bink?) use 'Esc'
+      if (nativeEvent.key === 'Escape' || nativeEvent.key === 'Esc') {
+        onClose();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
 
   const lastFocusedElementRef = React.useRef<Element | null>(null);
   React.useEffect(() => {

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useIsLandscape.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useIsLandscape.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useIsomorphicEffect } from './useKeyDown';
+import { unstable_useEnhancedEffect as useEnhancedEffect } from '@material-ui/utils';
 import { arrayIncludes } from '../utils';
 import { BasePickerProps } from '../typings/BasePicker';
 import { AllAvailableViews } from '../typings/Views';
@@ -30,7 +30,7 @@ export function useIsLandscape(
     getOrientation(),
   );
 
-  useIsomorphicEffect(() => {
+  useEnhancedEffect(() => {
     const eventHandler = () => {
       setOrientation(getOrientation());
     };

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useKeyDown.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useKeyDown.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
-
-export const useIsomorphicEffect =
-  typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
+import { unstable_useEnhancedEffect as useEnhancedEffect } from '@material-ui/utils';
 
 type KeyHandlers = Record<number, () => void>;
 
@@ -19,7 +17,7 @@ export function useGlobalKeyDown(active: boolean, keyHandlers: KeyHandlers) {
   const keyHandlersRef = React.useRef(keyHandlers);
   keyHandlersRef.current = keyHandlers;
 
-  useIsomorphicEffect(() => {
+  useEnhancedEffect(() => {
     if (active) {
       const handleKeyDown = (nativeEvent: KeyboardEvent) => {
         runKeyHandler(nativeEvent, keyHandlersRef.current);

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useKeyDown.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useKeyDown.ts
@@ -5,10 +5,7 @@ export const useIsomorphicEffect =
 
 type KeyHandlers = Record<number, () => void>;
 
-export function runKeyHandler(
-  event: KeyboardEvent | React.KeyboardEvent,
-  keyHandlers: KeyHandlers,
-) {
+function runKeyHandler(event: KeyboardEvent | React.KeyboardEvent, keyHandlers: KeyHandlers) {
   // tslint:disable-next-line deprecation IE11
   const handler = keyHandlers[event.keyCode];
   if (handler) {
@@ -16,20 +13,6 @@ export function runKeyHandler(
     // if event was handled prevent other side effects (e.g. page scroll)
     event.preventDefault();
   }
-}
-
-export function useKeyDownHandler(active: boolean, keyHandlers: KeyHandlers) {
-  const keyHandlersRef = React.useRef(keyHandlers);
-  keyHandlersRef.current = keyHandlers;
-
-  return React.useCallback(
-    (event: React.KeyboardEvent) => {
-      if (active) {
-        runKeyHandler(event, keyHandlersRef.current);
-      }
-    },
-    [active],
-  );
 }
 
 export function useGlobalKeyDown(active: boolean, keyHandlers: KeyHandlers) {


### PR DESCRIPTION
Affects desktop variants of the pickers. Should not cause any change in behavior.

Main goal is to trim down picker-specific utils.
