### PR TITLE
[docs] Fix aria on the anchor header links

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -141,13 +141,14 @@ function getTranslatedHeader(t, header) {
 function Heading(props) {
   const { hash, level: Level = 'h2' } = props;
   const t = useTranslate();
+  const translatedHeader = getTranslatedHeader(t, hash);
 
   return (
     <Level>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content */}
       <a className="anchor-link" id={hash} />
-      {getTranslatedHeader(t, hash)}
-      <a className="anchor-link-style" aria-hidden="true" aria-label="anchor" href={`#${hash}`}>
+      {translatedHeader}
+      <a className="anchor-link-style" aria-label={translatedHeader} href={`#${hash}`}>
         <svg>
           <use xlinkHref="#anchor-link-icon" />
         </svg>

--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -192,7 +192,7 @@ export function createRender(context) {
         `<h${level}>`,
         `<a class="anchor-link" id="${hash}"></a>`,
         headingHtml,
-        `<a class="anchor-link-style" aria-hidden="true" href="#${hash}">`,
+        `<a class="anchor-link-style" aria-label="${headingText}" href="#${hash}">`,
         '<svg><use xlink:href="#anchor-link-icon" /></svg>',
         '</a>',
         `</h${level}>`,


### PR DESCRIPTION
Preview: https://deploy-preview-25832--material-ui.netlify.app/components/alert/#description

## The problem

There are currently 3 issues with the anchor headers:

1. It's an empty link. When focused, there is no announcement read related to the header.

<img width="430" alt="Screenshot 2021-04-19 at 00 35 38" src="https://user-images.githubusercontent.com/3165635/115163391-2ffda000-a0a9-11eb-945c-1dc911948d5a.png">

https://next.material-ui.com/components/checkboxes/#basic-checkboxes

2. aria-hidden shouldn't be used on focusable elements: https://www.w3.org/TR/using-aria/#4thrule
3. The API pages and Demo pages handle the problem differently.

We started the discussion at [#23791](https://github.com/mui-org/material-ui/pull/23791/commits/267e78ddf9dbc57ed3e705238ad63a45fdb6a715#r601897006.)

## The solution

The proposed solution is to remove the aria-hidden, align API and Demo pages to the same approach and add aria-label with the content of the header. This solution is copied from https://www.gatsbyjs.com/docs/how-to/local-development/gatsby-on-windows/#if-npm-install-still-fails and https://www.typescriptlang.org/docs/handbook/2/basic-types.html.

<img width="433" alt="Screenshot 2021-04-19 at 00 56 51" src="https://user-images.githubusercontent.com/3165635/115163587-2b85b700-a0aa-11eb-84ea-750abd1eb954.png">

I have been hesitating to use the section symbol §, copying https://www.w3.org/TR/using-aria/#4thrule.