### PR TITLE
[core] Remove unused public types

### DIFF
--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.d.ts
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.d.ts
@@ -3,7 +3,6 @@ import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps } from '@material-ui/core';
 
 export interface TimelineDotPropsVariantOverrides {}
-export type TimelineDotVariantDefaults = Record<'filled' | 'outlined', true>;
 
 export interface TimelineDotProps extends StandardProps<React.HTMLAttributes<HTMLSpanElement>> {
   /**
@@ -42,7 +41,10 @@ export interface TimelineDotProps extends StandardProps<React.HTMLAttributes<HTM
    * The dot can appear filled or outlined.
    * @default 'filled'
    */
-  variant?: OverridableStringUnion<TimelineDotVariantDefaults, TimelineDotPropsVariantOverrides>;
+  variant?: OverridableStringUnion<
+    Record<'filled' | 'outlined', true>,
+    TimelineDotPropsVariantOverrides
+  >;
 }
 
 export type TimelineDotClassKey = keyof NonNullable<TimelineDotProps['classes']>;

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.d.ts
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.d.ts
@@ -41,10 +41,7 @@ export interface TimelineDotProps extends StandardProps<React.HTMLAttributes<HTM
    * The dot can appear filled or outlined.
    * @default 'filled'
    */
-  variant?: OverridableStringUnion<
-    Record<'filled' | 'outlined', true>,
-    TimelineDotPropsVariantOverrides
-  >;
+  variant?: OverridableStringUnion<'filled' | 'outlined', TimelineDotPropsVariantOverrides>;
 }
 
 export type TimelineDotClassKey = keyof NonNullable<TimelineDotProps['classes']>;

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -48,7 +48,9 @@ export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K
  *
  * @internal
  */
-export type OverridableStringUnion<T, U = {}> = GenerateStringUnion<Overwrite<T, U>>;
+export type OverridableStringUnion<T extends string | number, U = {}> = GenerateStringUnion<
+  Overwrite<Record<T, true>, U>
+>;
 
 /**
  * Like `T & U`, but using the value types from `U` where their properties overlap.

--- a/packages/material-ui/src/Alert/Alert.d.ts
+++ b/packages/material-ui/src/Alert/Alert.d.ts
@@ -100,10 +100,7 @@ export interface AlertProps extends StandardProps<PaperProps, 'variant'> {
    * The variant to use.
    * @default 'standard'
    */
-  variant?: OverridableStringUnion<
-    Record<'standard' | 'filled' | 'outlined', true>,
-    AlertPropsVariantOverrides
-  >;
+  variant?: OverridableStringUnion<'standard' | 'filled' | 'outlined', AlertPropsVariantOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Alert/Alert.d.ts
+++ b/packages/material-ui/src/Alert/Alert.d.ts
@@ -7,7 +7,6 @@ import { PaperProps } from '../Paper';
 export type Color = 'success' | 'info' | 'warning' | 'error';
 
 export interface AlertPropsVariantOverrides {}
-export type AlertVariantDefaults = Record<'standard' | 'filled' | 'outlined', true>;
 
 export interface AlertProps extends StandardProps<PaperProps, 'variant'> {
   /**
@@ -101,7 +100,10 @@ export interface AlertProps extends StandardProps<PaperProps, 'variant'> {
    * The variant to use.
    * @default 'standard'
    */
-  variant?: OverridableStringUnion<AlertVariantDefaults, AlertPropsVariantOverrides>;
+  variant?: OverridableStringUnion<
+    Record<'standard' | 'filled' | 'outlined', true>,
+    AlertPropsVariantOverrides
+  >;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -41,10 +41,7 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
        * The color of the component. It supports those theme colors that make sense for this component.
        * @default 'primary'
        */
-      color?: OverridableStringUnion<
-        Record<PropTypes.Color | 'transparent', true>,
-        AppBarPropsColorOverrides
-      >;
+      color?: OverridableStringUnion<PropTypes.Color | 'transparent', AppBarPropsColorOverrides>;
       /**
        * The positioning type. The behavior of the different options is described
        * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -5,7 +5,6 @@ import { OverridableStringUnion } from '@material-ui/types';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface AvatarPropsVariantOverrides {}
-export type AvatarVariantDefaults = Record<'circular' | 'rounded' | 'square', true>;
 
 export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -64,7 +63,10 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The shape of the avatar.
      * @default 'circular'
      */
-    variant?: OverridableStringUnion<AvatarVariantDefaults, AvatarPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'circular' | 'rounded' | 'square', true>,
+      AvatarPropsVariantOverrides
+    >;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -64,7 +64,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * @default 'circular'
      */
     variant?: OverridableStringUnion<
-      Record<'circular' | 'rounded' | 'square', true>,
+      'circular' | 'rounded' | 'square',
       AvatarPropsVariantOverrides
     >;
   };

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.d.ts
@@ -4,7 +4,6 @@ import { OverridableStringUnion } from '@material-ui/types';
 import { SxProps } from '@material-ui/system';
 
 export interface AvatarGroupPropsVariantOverrides {}
-export type AvatarGroupVariantDefaults = Record<'circular' | 'rounded' | 'square', true>;
 
 export interface AvatarGroupProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**
@@ -38,7 +37,10 @@ export interface AvatarGroupProps extends StandardProps<React.HTMLAttributes<HTM
    * The variant to use.
    * @default 'circular'
    */
-  variant?: OverridableStringUnion<AvatarGroupVariantDefaults, AvatarGroupPropsVariantOverrides>;
+  variant?: OverridableStringUnion<
+    Record<'circular' | 'rounded' | 'square', true>,
+    AvatarGroupPropsVariantOverrides
+  >;
 }
 
 export type AvatarGroupClassKey = keyof NonNullable<AvatarGroupProps['classes']>;

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.d.ts
@@ -38,7 +38,7 @@ export interface AvatarGroupProps extends StandardProps<React.HTMLAttributes<HTM
    * @default 'circular'
    */
   variant?: OverridableStringUnion<
-    Record<'circular' | 'rounded' | 'square', true>,
+    'circular' | 'rounded' | 'square',
     AvatarGroupPropsVariantOverrides
   >;
 }

--- a/packages/material-ui/src/Badge/Badge.d.ts
+++ b/packages/material-ui/src/Badge/Badge.d.ts
@@ -33,7 +33,7 @@ export type BadgeTypeMap<
      * @default 'default'
      */
     color?: OverridableStringUnion<
-      Record<'primary' | 'secondary' | 'default' | 'error', true>,
+      'primary' | 'secondary' | 'default' | 'error',
       BadgePropsColorOverrides
     >;
     /**
@@ -44,7 +44,7 @@ export type BadgeTypeMap<
      * The variant to use.
      * @default 'standard'
      */
-    variant?: OverridableStringUnion<Record<'standard' | 'dot', true>, BadgePropsVariantOverrides>;
+    variant?: OverridableStringUnion<'standard' | 'dot', BadgePropsVariantOverrides>;
   };
   defaultComponent: D;
 }>;

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -101,10 +101,7 @@ export type ButtonTypeMap<
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'primary'
      */
-    color?: OverridableStringUnion<
-      Record<'inherit' | 'primary' | 'secondary', true>,
-      ButtonPropsColorOverrides
-    >;
+    color?: OverridableStringUnion<'inherit' | 'primary' | 'secondary', ButtonPropsColorOverrides>;
     /**
      * If `true`, the component is disabled.
      * @default false
@@ -139,10 +136,7 @@ export type ButtonTypeMap<
      * `small` is equivalent to the dense button styling.
      * @default 'medium'
      */
-    size?: OverridableStringUnion<
-      Record<'small' | 'medium' | 'large', true>,
-      ButtonPropsSizeOverrides
-    >;
+    size?: OverridableStringUnion<'small' | 'medium' | 'large', ButtonPropsSizeOverrides>;
     /**
      * Element placed before the children.
      */
@@ -156,7 +150,7 @@ export type ButtonTypeMap<
      * @default 'text'
      */
     variant?: OverridableStringUnion<
-      Record<'text' | 'outlined' | 'contained', true>,
+      'text' | 'outlined' | 'contained',
       ButtonPropsVariantOverrides
     >;
   };

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
@@ -75,7 +75,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
      * @default 'primary'
      */
     color?: OverridableStringUnion<
-      Record<'inherit' | 'primary' | 'secondary', true>,
+      'inherit' | 'primary' | 'secondary',
       ButtonGroupPropsColorOverrides
     >;
     /**
@@ -119,7 +119,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
      * @default 'outlined'
      */
     variant?: OverridableStringUnion<
-      Record<'text' | 'outlined' | 'contained', true>,
+      'text' | 'outlined' | 'contained',
       ButtonGroupPropsVariantOverrides
     >;
     /**

--- a/packages/material-ui/src/Chip/Chip.d.ts
+++ b/packages/material-ui/src/Chip/Chip.d.ts
@@ -145,10 +145,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The variant to use.
      * @default 'filled'
      */
-    variant?: OverridableStringUnion<
-      Record<'filled' | 'outlined', true>,
-      ChipPropsVariantOverrides
-    >;
+    variant?: OverridableStringUnion<'filled' | 'outlined', ChipPropsVariantOverrides>;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Chip/Chip.d.ts
+++ b/packages/material-ui/src/Chip/Chip.d.ts
@@ -5,7 +5,6 @@ import { PropTypes, Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ChipPropsVariantOverrides {}
-export type ChipVariantDefaults = Record<'filled' | 'outlined', true>;
 
 export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -146,7 +145,10 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The variant to use.
      * @default 'filled'
      */
-    variant?: OverridableStringUnion<ChipVariantDefaults, ChipPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'filled' | 'outlined', true>,
+      ChipPropsVariantOverrides
+    >;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.d.ts
@@ -37,7 +37,7 @@ export interface CircularProgressProps
    * @default 'primary'
    */
   color?: OverridableStringUnion<
-    Record<'primary' | 'secondary' | 'inherit', true>,
+    'primary' | 'secondary' | 'inherit',
     CircularProgressPropsColorOverrides
   >;
   /**

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -5,7 +5,6 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface DividerPropsVariantOverrides {}
-export type DividerVariantDefaults = Record<'fullWidth' | 'inset' | 'middle', true>;
 
 export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
   props: P & {
@@ -80,7 +79,10 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
      * The variant to use.
      * @default 'fullWidth'
      */
-    variant?: OverridableStringUnion<DividerVariantDefaults, DividerPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'fullWidth' | 'inset' | 'middle', true>,
+      DividerPropsVariantOverrides
+    >;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -80,7 +80,7 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
      * @default 'fullWidth'
      */
     variant?: OverridableStringUnion<
-      Record<'fullWidth' | 'inset' | 'middle', true>,
+      'fullWidth' | 'inset' | 'middle',
       DividerPropsVariantOverrides
     >;
   };

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -73,10 +73,7 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      * The variant to use.
      * @default 'circular'
      */
-    variant?: OverridableStringUnion<
-      Record<'circular' | 'extended', true>,
-      FabPropsVariantOverrides
-    >;
+    variant?: OverridableStringUnion<'circular' | 'extended', FabPropsVariantOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -5,7 +5,6 @@ import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 
 export interface FabPropsVariantOverrides {}
-export type FabVariantDefaults = Record<'circular' | 'extended', true>;
 
 export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendButtonBaseTypeMap<{
   props: P & {
@@ -74,7 +73,10 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      * The variant to use.
      * @default 'circular'
      */
-    variant?: OverridableStringUnion<FabVariantDefaults, FabPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'circular' | 'extended', true>,
+      FabPropsVariantOverrides
+    >;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -30,10 +30,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'primary'
      */
-    color?: OverridableStringUnion<
-      Record<'primary' | 'secondary', true>,
-      FormControlPropsColorOverrides
-    >;
+    color?: OverridableStringUnion<'primary' | 'secondary', FormControlPropsColorOverrides>;
     /**
      * If `true`, the label, input and helper text should be displayed in a disabled state.
      * @default false
@@ -74,7 +71,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
      * The size of the component.
      * @default 'medium'
      */
-    size?: OverridableStringUnion<Record<'small' | 'medium', true>, FormControlPropsSizeOverrides>;
+    size?: OverridableStringUnion<'small' | 'medium', FormControlPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/ImageList/ImageList.d.ts
+++ b/packages/material-ui/src/ImageList/ImageList.d.ts
@@ -5,7 +5,7 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ImageListPropsVariantOverrides {}
-export type ImageListVariantDefaults = Record<'masonry' | 'quilted' | 'standard' | 'woven', true>;
+
 export interface ImageListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
   props: P & {
     /**
@@ -50,7 +50,10 @@ export interface ImageListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      * The variant to use.
      * @default 'standard'
      */
-    variant?: OverridableStringUnion<ImageListVariantDefaults, ImageListPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'masonry' | 'quilted' | 'standard' | 'woven', true>,
+      ImageListPropsVariantOverrides
+    >;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/ImageList/ImageList.d.ts
+++ b/packages/material-ui/src/ImageList/ImageList.d.ts
@@ -51,7 +51,7 @@ export interface ImageListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      * @default 'standard'
      */
     variant?: OverridableStringUnion<
-      Record<'masonry' | 'quilted' | 'standard' | 'woven', true>,
+      'masonry' | 'quilted' | 'standard' | 'woven',
       ImageListPropsVariantOverrides
     >;
   };

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -216,7 +216,7 @@ export interface InputBaseProps
   /**
    * The size of the component.
    */
-  size?: OverridableStringUnion<Record<'small' | 'medium', true>, InputBasePropsSizeOverrides>;
+  size?: OverridableStringUnion<'small' | 'medium', InputBasePropsSizeOverrides>;
   /**
    * Start `InputAdornment` for this component.
    */

--- a/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
@@ -53,7 +53,7 @@ export interface LinearProgressProps
    * @default 'primary'
    */
   color?: OverridableStringUnion<
-    Record<'primary' | 'secondary' | 'inherit', true>,
+    'primary' | 'secondary' | 'inherit',
     LinearProgressPropsColorOverrides
   >;
   /**

--- a/packages/material-ui/src/Pagination/Pagination.d.ts
+++ b/packages/material-ui/src/Pagination/Pagination.d.ts
@@ -76,10 +76,7 @@ export interface PaginationProps
    * The variant to use.
    * @default 'text'
    */
-  variant?: OverridableStringUnion<
-    Record<'text' | 'outlined', true>,
-    PaginationPropsVariantOverrides
-  >;
+  variant?: OverridableStringUnion<'text' | 'outlined', PaginationPropsVariantOverrides>;
 }
 
 export type PaginationClassKey = keyof NonNullable<PaginationProps['classes']>;

--- a/packages/material-ui/src/Pagination/Pagination.d.ts
+++ b/packages/material-ui/src/Pagination/Pagination.d.ts
@@ -13,7 +13,6 @@ export interface PaginationRenderItemParams extends UsePaginationItem {
 }
 
 export interface PaginationPropsVariantOverrides {}
-export type PaginationVariantDefaults = Record<'text' | 'outlined', true>;
 
 export interface PaginationProps
   extends UsePaginationProps,
@@ -77,7 +76,10 @@ export interface PaginationProps
    * The variant to use.
    * @default 'text'
    */
-  variant?: OverridableStringUnion<PaginationVariantDefaults, PaginationPropsVariantOverrides>;
+  variant?: OverridableStringUnion<
+    Record<'text' | 'outlined', true>,
+    PaginationPropsVariantOverrides
+  >;
 }
 
 export type PaginationClassKey = keyof NonNullable<PaginationProps['classes']>;

--- a/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
@@ -92,10 +92,7 @@ export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'di
      * The variant to use.
      * @default 'text'
      */
-    variant?: OverridableStringUnion<
-      Record<'text' | 'outlined', true>,
-      PaginationItemPropsVariantOverrides
-    >;
+    variant?: OverridableStringUnion<'text' | 'outlined', PaginationItemPropsVariantOverrides>;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
@@ -6,7 +6,6 @@ import { Theme } from '../styles';
 import { UsePaginationItem } from '../usePagination/usePagination';
 
 export interface PaginationItemPropsVariantOverrides {}
-export type PaginationItemVariantDefaults = Record<'text' | 'outlined', true>;
 
 export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -94,7 +93,7 @@ export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'di
      * @default 'text'
      */
     variant?: OverridableStringUnion<
-      PaginationItemVariantDefaults,
+      Record<'text' | 'outlined', true>,
       PaginationItemPropsVariantOverrides
     >;
   };

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -69,10 +69,7 @@ export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The variant to use.
      * @default 'elevation'
      */
-    variant?: OverridableStringUnion<
-      Record<'elevation' | 'outlined', true>,
-      PaperPropsVariantOverrides
-    >;
+    variant?: OverridableStringUnion<'elevation' | 'outlined', PaperPropsVariantOverrides>;
   };
   defaultComponent: D;
 }

--- a/packages/material-ui/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui/src/Skeleton/Skeleton.d.ts
@@ -5,7 +5,6 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface SkeletonPropsVariantOverrides {}
-export type SkeletonVariantDefaults = Record<'text' | 'rectangular' | 'circular', true>;
 
 export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P & {
@@ -55,7 +54,10 @@ export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
      * The type of content that will be rendered.
      * @default 'text'
      */
-    variant?: OverridableStringUnion<SkeletonVariantDefaults, SkeletonPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'text' | 'rectangular' | 'circular', true>,
+      SkeletonPropsVariantOverrides
+    >;
     /**
      * Width of the skeleton.
      * Useful when the skeleton is inside an inline element with no width of its own.

--- a/packages/material-ui/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui/src/Skeleton/Skeleton.d.ts
@@ -55,7 +55,7 @@ export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
      * @default 'text'
      */
     variant?: OverridableStringUnion<
-      Record<'text' | 'rectangular' | 'circular', true>,
+      'text' | 'rectangular' | 'circular',
       SkeletonPropsVariantOverrides
     >;
     /**

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -47,10 +47,7 @@ export interface BaseTextFieldProps
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'primary'
    */
-  color?: OverridableStringUnion<
-    Record<'primary' | 'secondary', true>,
-    TextFieldPropsColorOverrides
-  >;
+  color?: OverridableStringUnion<'primary' | 'secondary', TextFieldPropsColorOverrides>;
   /**
    * The default value. Use when the component is not controlled.
    */
@@ -144,7 +141,7 @@ export interface BaseTextFieldProps
   /**
    * The size of the component.
    */
-  size?: OverridableStringUnion<Record<'small' | 'medium', true>, TextFieldPropsSizeOverrides>;
+  size?: OverridableStringUnion<'small' | 'medium', TextFieldPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Toolbar/Toolbar.d.ts
+++ b/packages/material-ui/src/Toolbar/Toolbar.d.ts
@@ -5,7 +5,6 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ToolbarPropsVariantOverrides {}
-export type ToolbarVariantDefaults = Record<'regular' | 'dense', true>;
 
 export interface ToolbarTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -36,7 +35,10 @@ export interface ToolbarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The variant to use.
      * @default 'regular'
      */
-    variant?: OverridableStringUnion<ToolbarVariantDefaults, ToolbarPropsVariantOverrides>;
+    variant?: OverridableStringUnion<
+      Record<'regular' | 'dense', true>,
+      ToolbarPropsVariantOverrides
+    >;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Toolbar/Toolbar.d.ts
+++ b/packages/material-ui/src/Toolbar/Toolbar.d.ts
@@ -35,10 +35,7 @@ export interface ToolbarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The variant to use.
      * @default 'regular'
      */
-    variant?: OverridableStringUnion<
-      Record<'regular' | 'dense', true>,
-      ToolbarPropsVariantOverrides
-    >;
+    variant?: OverridableStringUnion<'regular' | 'dense', ToolbarPropsVariantOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -94,10 +94,7 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
        * Applies the theme typography styles.
        * @default 'body1'
        */
-      variant?: OverridableStringUnion<
-        Record<Variant | 'inherit', true>,
-        TypographyPropsVariantOverrides
-      >;
+      variant?: OverridableStringUnion<Variant | 'inherit', TypographyPropsVariantOverrides>;
       /**
        * The component maps the variant prop to a range of different HTML element types.
        * For instance, subtitle1 to `<h6>`.
@@ -118,13 +115,7 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
        * }
        */
       variantMapping?: Partial<
-        Record<
-          OverridableStringUnion<
-            Record<Variant | 'inherit', true>,
-            TypographyPropsVariantOverrides
-          >,
-          string
-        >
+        Record<OverridableStringUnion<Variant | 'inherit', TypographyPropsVariantOverrides>, string>
       >;
     };
   defaultComponent: D;

--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -6,7 +6,6 @@ import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Variant } from '../styles/createTypography';
 
 export interface TypographyPropsVariantOverrides {}
-export type TypographyVariantDefaults = Record<Variant | 'inherit', true>;
 
 export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P &
@@ -95,7 +94,10 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
        * Applies the theme typography styles.
        * @default 'body1'
        */
-      variant?: OverridableStringUnion<TypographyVariantDefaults, TypographyPropsVariantOverrides>;
+      variant?: OverridableStringUnion<
+        Record<Variant | 'inherit', true>,
+        TypographyPropsVariantOverrides
+      >;
       /**
        * The component maps the variant prop to a range of different HTML element types.
        * For instance, subtitle1 to `<h6>`.
@@ -117,7 +119,10 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
        */
       variantMapping?: Partial<
         Record<
-          OverridableStringUnion<TypographyVariantDefaults, TypographyPropsVariantOverrides>,
+          OverridableStringUnion<
+            Record<Variant | 'inherit', true>,
+            TypographyPropsVariantOverrides
+          >,
           string
         >
       >;

--- a/packages/material-ui/src/styles/createBreakpoints.d.ts
+++ b/packages/material-ui/src/styles/createBreakpoints.d.ts
@@ -1,9 +1,11 @@
 import { OverridableStringUnion } from '@material-ui/types';
 
-export type BreakpointDefaults = Record<'xs' | 'sm' | 'md' | 'lg' | 'xl', true>;
 export interface BreakpointOverrides {}
 
-export type Breakpoint = OverridableStringUnion<BreakpointDefaults, BreakpointOverrides>;
+export type Breakpoint = OverridableStringUnion<
+  'xs' | 'sm' | 'md' | 'lg' | 'xl',
+  BreakpointOverrides
+>;
 export type BreakpointValues = { [key in Breakpoint]: number };
 export const keys: Breakpoint[];
 


### PR DESCRIPTION
**BREAKING CHANGE**

- [types] Reduce boilerplate with the OverridableStringUnion helper

```diff
import { OverridableStringUnion } from '@material-ui/types';

interface VariantOverrides {}
-type Variant = OverridableStringUnion<Record<'foo' | 'bar', true>, VariantOverrides>
+type Variant = OverridableStringUnion<'foo' | 'bar', VariantOverrides>
```

The intent is to reduce the number of exported types as well as improving the abstraction (easier to read).