### PR TITLE
[docs] Fix inline-preview selection controls

### DIFF
--- a/docs/src/pages/components/checkboxes/Checkboxes.js
+++ b/docs/src/pages/components/checkboxes/Checkboxes.js
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 
+const ariaLabel = { inputProps: { 'aria-label': 'Checkbox demo' } };
+
 export default function Checkboxes() {
   return (
     <div>
-      <Checkbox defaultChecked inputProps={{ 'aria-label': 'checked' }} />
-      <Checkbox inputProps={{ 'aria-label': 'uncontrolled' }} />
-      <Checkbox disabled inputProps={{ 'aria-label': 'disabled' }} />
-      <Checkbox disabled checked inputProps={{ 'aria-label': 'disabled checked' }} />
+      <Checkbox {...ariaLabel} defaultChecked />
+      <Checkbox {...ariaLabel} />
+      <Checkbox {...ariaLabel} disabled />
+      <Checkbox {...ariaLabel} disabled checked />
     </div>
   );
 }

--- a/docs/src/pages/components/checkboxes/Checkboxes.tsx
+++ b/docs/src/pages/components/checkboxes/Checkboxes.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 
+const ariaLabel = { inputProps: { 'aria-label': 'Checkbox demo' } };
+
 export default function Checkboxes() {
   return (
     <div>
-      <Checkbox defaultChecked inputProps={{ 'aria-label': 'checked' }} />
-      <Checkbox inputProps={{ 'aria-label': 'uncontrolled' }} />
-      <Checkbox disabled inputProps={{ 'aria-label': 'disabled' }} />
-      <Checkbox disabled checked inputProps={{ 'aria-label': 'disabled checked' }} />
+      <Checkbox {...ariaLabel} defaultChecked />
+      <Checkbox {...ariaLabel} />
+      <Checkbox {...ariaLabel} disabled />
+      <Checkbox {...ariaLabel} disabled checked />
     </div>
   );
 }


### PR DESCRIPTION
The current inline previews are 💩 (a first iteration in did in the past)

<img width="859" alt="Screenshot 2021-04-19 at 01 42 19" src="https://user-images.githubusercontent.com/3165635/115166041-69d2a480-a0b1-11eb-8dac-885c0345657b.png">

The input props is introducing a lot of noise. In this draft PR I propose this direction:

<img width="871" alt="Screenshot 2021-04-19 at 01 49 59" src="https://user-images.githubusercontent.com/3165635/115166075-925a9e80-a0b1-11eb-8700-83a64859b38e.png">

If it's approve, I will update all the relevant checkboxes, radio and switched demos.