### PR TITLE
add dependencies icons not support floating action button

### DIFF
--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -7,6 +7,7 @@
     "@emotion/react": "latest",
     "@emotion/styled": "latest",
     "@emotion/server": "latest",
+    "@material-ui/icons": "latest",
     "@material-ui/core": "next",
     "clsx": "latest",
     "next": "latest",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
[FAB](https://material-ui.com/components/floating-action-button/)
not support for next.js import @material-ui/icons
after add dependencise icons it's work