### PR TITLE
[core] Update overridesResolver for slots

### DIFF
--- a/benchmark/browser/scenarios/slider-current-implementation/index.js
+++ b/benchmark/browser/scenarios/slider-current-implementation/index.js
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import Slider from '@material-ui/core/Slider';
+
+const iOSBoxShadow =
+  '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1px rgba(0,0,0,0.02)';
+
+const theme = createMuiTheme({
+  components: {
+    MuiSlider: {
+      styleOverrides: {
+        root: {
+          color: '#3880ff',
+          height: 2,
+          padding: '15px 0',
+        },
+        thumb: {
+          height: 28,
+          width: 28,
+          backgroundColor: '#fff',
+          boxShadow: iOSBoxShadow,
+          marginTop: -14,
+          marginLeft: -14,
+          '&:focus, &:hover, &.Mui-active': {
+            boxShadow:
+              '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.02)',
+            // Reset on touch devices, it doesn't add specificity
+            '@media (hover: none)': {
+              boxShadow: iOSBoxShadow,
+            },
+          },
+        },
+        valueLabel: {
+          left: 'calc(-50% + 12px)',
+          top: -22,
+          '& *': {
+            background: 'transparent',
+            color: '#000',
+          },
+        },
+        track: {
+          height: 2,
+        },
+        rail: {
+          height: 2,
+          opacity: 0.5,
+          backgroundColor: '#bfbfbf',
+        },
+        mark: {
+          backgroundColor: '#bfbfbf',
+          height: 8,
+          width: 1,
+          marginTop: -3,
+          '&.MuiSlider-markActive': {
+            opacity: 1,
+            backgroundColor: 'currentColor',
+          },
+        },
+      },
+    },
+  },
+});
+
+export default function StyledSC() {
+  return (
+    <ThemeProvider theme={theme}>
+      {new Array(1000).fill().map(() => (
+        <Slider defaultValue={30} />
+      ))}
+    </ThemeProvider>
+  );
+}

--- a/benchmark/browser/scenarios/slider-multiple-overrides-resolver/index.js
+++ b/benchmark/browser/scenarios/slider-multiple-overrides-resolver/index.js
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { SliderOption1 as Slider } from '@material-ui/core/Slider';
+
+const iOSBoxShadow =
+  '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1px rgba(0,0,0,0.02)';
+
+const theme = createMuiTheme({
+  components: {
+    MuiSlider: {
+      styleOverrides: {
+        root: {
+          color: '#3880ff',
+          height: 2,
+          padding: '15px 0',
+        },
+        thumb: {
+          height: 28,
+          width: 28,
+          backgroundColor: '#fff',
+          boxShadow: iOSBoxShadow,
+          marginTop: -14,
+          marginLeft: -14,
+          '&:focus, &:hover, &.Mui-active': {
+            boxShadow:
+              '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.02)',
+            // Reset on touch devices, it doesn't add specificity
+            '@media (hover: none)': {
+              boxShadow: iOSBoxShadow,
+            },
+          },
+        },
+        valueLabel: {
+          left: 'calc(-50% + 12px)',
+          top: -22,
+          '& *': {
+            background: 'transparent',
+            color: '#000',
+          },
+        },
+        track: {
+          height: 2,
+        },
+        rail: {
+          height: 2,
+          opacity: 0.5,
+          backgroundColor: '#bfbfbf',
+        },
+        mark: {
+          backgroundColor: '#bfbfbf',
+          height: 8,
+          width: 1,
+          marginTop: -3,
+          '&.MuiSlider-markActive': {
+            opacity: 1,
+            backgroundColor: 'currentColor',
+          },
+        },
+      },
+    },
+  },
+});
+
+export default function StyledSC() {
+  return (
+    <ThemeProvider theme={theme}>
+      {new Array(1000).fill().map(() => (
+        <Slider defaultValue={30} />
+      ))}
+    </ThemeProvider>
+  );
+}

--- a/benchmark/browser/scenarios/slider-single-overrides-resolver/index.js
+++ b/benchmark/browser/scenarios/slider-single-overrides-resolver/index.js
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { SliderOption2 as Slider } from '@material-ui/core/Slider';
+
+const iOSBoxShadow =
+  '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1px rgba(0,0,0,0.02)';
+
+const theme = createMuiTheme({
+  components: {
+    MuiSlider: {
+      styleOverrides: {
+        root: {
+          color: '#3880ff',
+          height: 2,
+          padding: '15px 0',
+        },
+        thumb: {
+          height: 28,
+          width: 28,
+          backgroundColor: '#fff',
+          boxShadow: iOSBoxShadow,
+          marginTop: -14,
+          marginLeft: -14,
+          '&:focus, &:hover, &.Mui-active': {
+            boxShadow:
+              '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.02)',
+            // Reset on touch devices, it doesn't add specificity
+            '@media (hover: none)': {
+              boxShadow: iOSBoxShadow,
+            },
+          },
+        },
+        valueLabel: {
+          left: 'calc(-50% + 12px)',
+          top: -22,
+          '& *': {
+            background: 'transparent',
+            color: '#000',
+          },
+        },
+        track: {
+          height: 2,
+        },
+        rail: {
+          height: 2,
+          opacity: 0.5,
+          backgroundColor: '#bfbfbf',
+        },
+        mark: {
+          backgroundColor: '#bfbfbf',
+          height: 8,
+          width: 1,
+          marginTop: -3,
+          '&.MuiSlider-markActive': {
+            opacity: 1,
+            backgroundColor: 'currentColor',
+          },
+        },
+      },
+    },
+  },
+});
+
+export default function StyledSC() {
+  return (
+    <ThemeProvider theme={theme}>
+      {new Array(1000).fill().map(() => (
+        <Slider defaultValue={30} />
+      ))}
+    </ThemeProvider>
+  );
+}

--- a/benchmark/browser/scripts/benchmark.js
+++ b/benchmark/browser/scripts/benchmark.js
@@ -154,64 +154,79 @@ async function run() {
         name: 'noop (baseline)',
         path: './noop/index.js',
       },
+      // {
+      //   name: 'Table',
+      //   path: './table-cell/index.js',
+      // },
+      // // Test the cost of React primitives
+      // {
+      //   name: 'React primitives',
+      //   path: './primitives/index.js',
+      // },
+      // // Test the cost of React components abstraction
+      // {
+      //   name: 'React components',
+      //   path: './components/index.js',
+      // },
+      // // Test that @material-ui/styled-engine doesn't add an signifiant overhead
+      // {
+      //   name: 'Styled Material-UI',
+      //   path: './styled-material-ui/index.js',
+      // },
+      // {
+      //   name: 'Styled emotion',
+      //   path: './styled-emotion/index.js',
+      // },
+      // {
+      //   name: 'Styled SC',
+      //   path: './styled-sc/index.js',
+      // },
+      // // Test the performance compared to the v4 standard
+      // {
+      //   name: 'makeStyles',
+      //   path: './make-styles/index.js',
+      // },
+      // // Test the Box perf with alternatives
+      // {
+      //   name: 'Box Baseline',
+      //   path: './box-baseline/index.js',
+      // },
+      // {
+      //   name: 'Box Material-UI',
+      //   path: './box-material-ui/index.js',
+      // },
+      // {
+      //   name: 'Box Theme-UI',
+      //   path: './box-theme-ui/index.js',
+      // },
+      // {
+      //   name: 'Box Chakra-UI',
+      //   path: './box-chakra-ui/index.js',
+      // },
+      // // Test the system perf difference with alternatives
+      // {
+      //   name: 'styled-components Box + @material-ui/system',
+      //   path: './styled-components-box-material-ui-system/index.js',
+      // },
+      // {
+      //   name: 'styled-components Box + styled-system',
+      //   path: './styled-components-box-styled-system/index.js',
+      // },
+      // Current Slider implementation
       {
-        name: 'Table',
-        path: './table-cell/index.js',
+        name: 'slider-current-implementation',
+        path: './slider-current-implementation/index.js',
       },
-      // Test the cost of React primitives
+      // Slier with multiple overrides resolvers
       {
-        name: 'React primitives',
-        path: './primitives/index.js',
+        name: 'slider-multiple-overrides-resolver',
+        path: './slider-multiple-overrides-resolver/index.js',
       },
-      // Test the cost of React components abstraction
+      // Slider with root only overrides resolver
       {
-        name: 'React components',
-        path: './components/index.js',
-      },
-      // Test that @material-ui/styled-engine doesn't add an signifiant overhead
-      {
-        name: 'Styled Material-UI',
-        path: './styled-material-ui/index.js',
-      },
-      {
-        name: 'Styled emotion',
-        path: './styled-emotion/index.js',
-      },
-      {
-        name: 'Styled SC',
-        path: './styled-sc/index.js',
-      },
-      // Test the performance compared to the v4 standard
-      {
-        name: 'makeStyles',
-        path: './make-styles/index.js',
-      },
-      // Test the Box perf with alternatives
-      {
-        name: 'Box Baseline',
-        path: './box-baseline/index.js',
-      },
-      {
-        name: 'Box Material-UI',
-        path: './box-material-ui/index.js',
-      },
-      {
-        name: 'Box Theme-UI',
-        path: './box-theme-ui/index.js',
-      },
-      {
-        name: 'Box Chakra-UI',
-        path: './box-chakra-ui/index.js',
-      },
-      // Test the system perf difference with alternatives
-      {
-        name: 'styled-components Box + @material-ui/system',
-        path: './styled-components-box-material-ui-system/index.js',
-      },
-      {
-        name: 'styled-components Box + styled-system',
-        path: './styled-components-box-styled-system/index.js',
-      },
+        name: 'slider-single-overrides-resolver',
+        path: './slider-single-overrides-resolver/index.js',
+      },      
     ];
 
     let baseline;

--- a/packages/material-ui/src/Slider/SliderOption1.js
+++ b/packages/material-ui/src/Slider/SliderOption1.js
@@ -42,19 +42,6 @@ const overridesResolver = (props, styles) => {
       ...styles[`color${capitalize(styleProps.color)}`],
       ...(marked && styles.marked),
       ...(styleProps.orientation === 'vertical' && styles.vertical),
-      [`& .${sliderClasses.rail}`]: styles.rail,
-      [`& .${sliderClasses.track}`]: {
-        ...styles.track,
-        ...(styleProps.track === 'inverted' && styles.trackInverted),
-        ...(styleProps.track === false && styles.trackFalse),
-      },
-      [`& .${sliderClasses.mark}`]: styles.mark,
-      [`& .${sliderClasses.markLabel}`]: styles.markLabel,
-      [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
-      [`& .${sliderClasses.thumb}`]: {
-        ...styles.thumb,
-        ...styles[`thumbColor${capitalize(styleProps.color)}`],
-      },
     },
     styles.root || {},
   );
@@ -135,7 +122,7 @@ export const SliderRoot = experimentalStyled(
 export const SliderRail = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Rail' },
+  { name: 'MuiSlider', slot: 'Rail', overridesResolver: (props, styles) => styles.rail },
 )(({ styleProps }) => ({
   display: 'block',
   position: 'absolute',
@@ -156,7 +143,15 @@ export const SliderRail = experimentalStyled(
 export const SliderTrack = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Track' },
+  {
+    name: 'MuiSlider',
+    slot: 'Track',
+    overridesResolver: ({ styleProps = {} }, styles) => ({
+      ...styles.track,
+      ...(styleProps.track === 'inverted' && styles.trackInverted),
+      ...(styleProps.track === false && styles.trackFalse),
+    }),
+  },
 )(({ theme, styleProps }) => ({
   display: 'block',
   position: 'absolute',
@@ -184,7 +179,14 @@ export const SliderTrack = experimentalStyled(
 export const SliderThumb = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Thumb' },
+  {
+    name: 'MuiSlider',
+    slot: 'Thumb',
+    overridesResolver: ({ styleProps = {} }, styles) => ({
+      ...styles.thumb,
+      ...styles[`thumbColor${capitalize(styleProps.color)}`],
+    }),
+  },
 )(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 12,
@@ -250,7 +252,11 @@ export const SliderThumb = experimentalStyled(
 export const SliderValueLabel = experimentalStyled(
   SliderValueLabelUnstyled,
   {},
-  { name: 'MuiSlider', slot: 'ValueLabel' },
+  {
+    name: 'MuiSlider',
+    slot: 'ValueLabel',
+    overridesResolver: (props, styles) => styles.valueLabel,
+  },
 )(({ theme }) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
@@ -273,7 +279,7 @@ export const SliderValueLabel = experimentalStyled(
 export const SliderMark = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Mark' },
+  { name: 'MuiSlider', slot: 'Mark', overridesResolver: (props, styles) => styles.mark },
 )(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 2,
@@ -289,7 +295,7 @@ export const SliderMark = experimentalStyled(
 export const SliderMarkLabel = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'MarkLabel' },
+  { name: 'MuiSlider', slot: 'MarkLabel', overridesResolver: (props, styles) => styles.markLabel },
 )(({ theme, styleProps }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,

--- a/packages/material-ui/src/Slider/SliderOption2.js
+++ b/packages/material-ui/src/Slider/SliderOption2.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes } from '@material-ui/utils';
 import { generateUtilityClasses, isHostComponent } from '@material-ui/unstyled';
 import SliderUnstyled, {
   SliderValueLabelUnstyled,
@@ -37,27 +37,25 @@ const overridesResolver = (props, styles) => {
 
   const marked = marks.length > 0 && marks.some((mark) => mark.label);
 
-  return deepmerge(
-    {
-      ...styles[`color${capitalize(styleProps.color)}`],
-      ...(marked && styles.marked),
-      ...(styleProps.orientation === 'vertical' && styles.vertical),
-      [`& .${sliderClasses.rail}`]: styles.rail,
-      [`& .${sliderClasses.track}`]: {
-        ...styles.track,
-        ...(styleProps.track === 'inverted' && styles.trackInverted),
-        ...(styleProps.track === false && styles.trackFalse),
-      },
-      [`& .${sliderClasses.mark}`]: styles.mark,
-      [`& .${sliderClasses.markLabel}`]: styles.markLabel,
-      [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
-      [`& .${sliderClasses.thumb}`]: {
-        ...styles.thumb,
-        ...styles[`thumbColor${capitalize(styleProps.color)}`],
-      },
+  return {
+    [`& .${sliderClasses.rail}`]: styles.rail,
+    [`& .${sliderClasses.track}`]: {
+      ...styles.track,
+      ...(styleProps.track === 'inverted' && styles.trackInverted),
+      ...(styleProps.track === false && styles.trackFalse),
     },
-    styles.root || {},
-  );
+    [`& .${sliderClasses.mark}`]: styles.mark,
+    [`& .${sliderClasses.markLabel}`]: styles.markLabel,
+    [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
+    [`& .${sliderClasses.thumb}`]: {
+      ...styles.thumb,
+      ...styles[`thumbColor${capitalize(styleProps.color)}`],
+    },
+    ...styles.root,
+    ...styles[`color${capitalize(styleProps.color)}`],
+    ...(marked && styles.marked),
+    ...(styleProps.orientation === 'vertical' && styles.vertical),
+  };
 };
 
 export const SliderRoot = experimentalStyled(

--- a/packages/material-ui/src/Slider/index.d.ts
+++ b/packages/material-ui/src/Slider/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './Slider';
 export * from './Slider';
+
+export { default as SliderOption1 } from './SliderOption1';
+export { default as SliderOption2 } from './SliderOption2';

--- a/packages/material-ui/src/Slider/index.js
+++ b/packages/material-ui/src/Slider/index.js
@@ -1,2 +1,5 @@
 export { default } from './Slider';
 export * from './Slider';
+
+export { default as SliderOption1 } from './SliderOption1';
+export { default as SliderOption2 } from './SliderOption2';


### PR DESCRIPTION
## TL;DR

I proposed we go with Option 1 which is using `overridesResolver` per slot as original done in https://github.com/mui-org/material-ui/pull/25809 by @siriwatknp Perf compared to current implementation is way better and it is not slower compared to Option 2, but gives us much better readability + flatten specificity 🚀 

---

This PR set up benchmark test for the Slider component, where we can measure perf differences between two options of how we may define the `overridesResolver` for the slots components.

# Option 1 - use `overridesResolver` for each slot of the component:

```diff --git a/packages/material-ui/src/Slider/Slider.js b/packages/material-ui/src/Slider/Slider.js
index e55139e3d9..3578ed4ef9 100644
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -42,19 +42,6 @@ const overridesResolver = (props, styles) => {
       ...styles[`color${capitalize(styleProps.color)}`],
       ...(marked && styles.marked),
       ...(styleProps.orientation === 'vertical' && styles.vertical),
-      [`& .${sliderClasses.rail}`]: styles.rail,
-      [`& .${sliderClasses.track}`]: {
-        ...styles.track,
-        ...(styleProps.track === 'inverted' && styles.trackInverted),
-        ...(styleProps.track === false && styles.trackFalse),
-      },
-      [`& .${sliderClasses.mark}`]: styles.mark,
-      [`& .${sliderClasses.markLabel}`]: styles.markLabel,
-      [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
-      [`& .${sliderClasses.thumb}`]: {
-        ...styles.thumb,
-        ...styles[`thumbColor${capitalize(styleProps.color)}`],
-      },
     },
     styles.root || {},
   );
@@ -135,7 +122,7 @@ export const SliderRoot = experimentalStyled(
 export const SliderRail = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Rail' },
+  { name: 'MuiSlider', slot: 'Rail', overridesResolver: (props, styles) => styles.rail },
 )(({ styleProps }) => ({
   display: 'block',
   position: 'absolute',
@@ -156,7 +143,15 @@ export const SliderRail = experimentalStyled(
 export const SliderTrack = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Track' },
+  {
+    name: 'MuiSlider',
+    slot: 'Track',
+    overridesResolver: ({ styleProps = {} }, styles) => ({
+      ...styles.track,
+      ...(styleProps.track === 'inverted' && styles.trackInverted),
+      ...(styleProps.track === false && styles.trackFalse),
+    }),
+  },
 )(({ theme, styleProps }) => ({
   display: 'block',
   position: 'absolute',
@@ -184,7 +179,14 @@ export const SliderTrack = experimentalStyled(
 export const SliderThumb = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Thumb' },
+  {
+    name: 'MuiSlider',
+    slot: 'Thumb',
+    overridesResolver: ({ styleProps = {} }, styles) => ({
+      ...styles.thumb,
+      ...styles[`thumbColor${capitalize(styleProps.color)}`],
+    }),
+  },
 )(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 12,
@@ -250,7 +252,11 @@ export const SliderThumb = experimentalStyled(
 export const SliderValueLabel = experimentalStyled(
   SliderValueLabelUnstyled,
   {},
-  { name: 'MuiSlider', slot: 'ValueLabel' },
+  {
+    name: 'MuiSlider',
+    slot: 'ValueLabel',
+    overridesResolver: (props, styles) => styles.valueLabel,
+  },
 )(({ theme }) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
@@ -273,7 +279,7 @@ export const SliderValueLabel = experimentalStyled(
 export const SliderMark = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Mark' },
+  { name: 'MuiSlider', slot: 'Mark', overridesResolver: (props, styles) => styles.mark },
 )(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 2,
@@ -289,7 +295,7 @@ export const SliderMark = experimentalStyled(
 export const SliderMarkLabel = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'MarkLabel' },
+  { name: 'MuiSlider', slot: 'MarkLabel', overridesResolver: (props, styles) => styles.markLabel },
 )(({ theme, styleProps }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
```

# Option 2 - use one `overridesResolver` without `deepmerge`

```diff --git a/packages/material-ui/src/Slider/Slider.js b/packages/material-ui/src/Slider/Slider.js
index e55139e3d9..f11cadd859 100644
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes } from '@material-ui/utils';
 import { generateUtilityClasses, isHostComponent } from '@material-ui/unstyled';
 import SliderUnstyled, {
   SliderValueLabelUnstyled,
@@ -37,27 +37,25 @@ const overridesResolver = (props, styles) => {

   const marked = marks.length > 0 && marks.some((mark) => mark.label);

-  return deepmerge(
-    {
-      ...styles[`color${capitalize(styleProps.color)}`],
-      ...(marked && styles.marked),
-      ...(styleProps.orientation === 'vertical' && styles.vertical),
-      [`& .${sliderClasses.rail}`]: styles.rail,
-      [`& .${sliderClasses.track}`]: {
-        ...styles.track,
-        ...(styleProps.track === 'inverted' && styles.trackInverted),
-        ...(styleProps.track === false && styles.trackFalse),
-      },
-      [`& .${sliderClasses.mark}`]: styles.mark,
-      [`& .${sliderClasses.markLabel}`]: styles.markLabel,
-      [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
-      [`& .${sliderClasses.thumb}`]: {
-        ...styles.thumb,
-        ...styles[`thumbColor${capitalize(styleProps.color)}`],
-      },
+  return {
+    [`& .${sliderClasses.rail}`]: styles.rail,
+    [`& .${sliderClasses.track}`]: {
+      ...styles.track,
+      ...(styleProps.track === 'inverted' && styles.trackInverted),
+      ...(styleProps.track === false && styles.trackFalse),
     },
-    styles.root || {},
-  );
+    [`& .${sliderClasses.mark}`]: styles.mark,
+    [`& .${sliderClasses.markLabel}`]: styles.markLabel,
+    [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
+    [`& .${sliderClasses.thumb}`]: {
+      ...styles.thumb,
+      ...styles[`thumbColor${capitalize(styleProps.color)}`],
+    },
+    ...styles.root,
+    ...styles[`color${capitalize(styleProps.color)}`],
+    ...(marked && styles.marked),
+    ...(styleProps.orientation === 'vertical' && styles.vertical),
+  };
 };

 export const SliderRoot = experimentalStyled(
```
Benchmark Azure Job build - https://dev.azure.com/mui-org/Material-UI/_build/results?buildId=26337&view=logs&j=9ef21fd1-5d60-5fa4-f8b2-6dc79e173863&t=516d74c5-15a9-50a0-24d9-dba41a487a2d
```
noop (baseline):
  05.47 ±00.29ms
slider-current-implementation:
  769.04 ±27.65ms
slider-multiple-overrides-resolver:
  97 ±3%
slider-single-overrides-resolver:
  96 ±4%
Done in 56.24s.
```

Based on the benchmark, seems like both options are giving us way better perf over the current implementation that uses `deepmerge` 🚀 

769.04 ±27.65ms -> 97 ±3%
769.04 ±27.65ms ->96 ±4%

As the perf difference between the two options is negligible, I'd say we go with Option 1, which gives us better readability and flatter specificity. Credits go to @siriwatknp for giving us this idea in https://github.com/mui-org/material-ui/pull/25809