### PR TITLE
[docs] Fix global styles leaking on different pages

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -21,9 +21,7 @@ import { ThemeProvider } from 'docs/src/modules/components/ThemeContext';
 import { pathnameToLanguage, getCookie } from 'docs/src/modules/utils/helpers';
 import { ACTION_TYPES, CODE_VARIANTS, LANGUAGES } from 'docs/src/modules/constants';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
-import DocsStyledEngineProvider, { cacheLtr } from 'docs/src/modules/utils/StyledEngineProvider';
-
-export { cacheLtr };
+import DocsStyledEngineProvider from 'docs/src/modules/utils/StyledEngineProvider';
 
 // Configure JSS
 const jss = create({

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -130,6 +130,7 @@ MyDocument.getInitialProps = async (ctx) => {
       originalRenderPage({
         enhanceApp: (App) => (props) =>
           styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
+        // Take precedence over the CacheProvider in our custom _app.js
         enhanceComponent: (Component) => (props) => (
           <CacheProvider value={getCache()}>
             <Component {...props} />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -2,13 +2,15 @@ import * as React from 'react';
 import { ServerStyleSheets } from '@material-ui/styles';
 import { ServerStyleSheet } from 'styled-components';
 import createEmotionServer from '@emotion/server/create-instance';
+import { CacheProvider } from '@emotion/react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import { themeColor } from 'docs/src/modules/components/ThemeContext';
 import createCache from '@emotion/cache';
 
-const { extractCritical } = createEmotionServer(createCache({ key: 'css', prepend: true }));
+const cache = createCache({ key: 'css', prepend: true })
+const { extractCritical } = createEmotionServer(cache);
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -125,8 +127,8 @@ MyDocument.getInitialProps = async (ctx) => {
   try {
     ctx.renderPage = () =>
       originalRenderPage({
-        enhanceApp: (App) => (props) =>
-          styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
+        enhanceApp: (App) => (props) => styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
+        enhanceComponent: Component => (props) => <CacheProvider value={cache}><Component {...props} /></CacheProvider>
       });
 
     const initialProps = await Document.getInitialProps(ctx);

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -16,8 +16,6 @@ const getCache = () => {
   return cache;
 };
 
-const { extractCritical } = createEmotionServer(getCache());
-
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
 // We have found that clean-css is faster than cssnano but the output is larger.
@@ -130,6 +128,9 @@ MyDocument.getInitialProps = async (ctx) => {
   const styledComponentsSheet = new ServerStyleSheet();
   const originalRenderPage = ctx.renderPage;
 
+  const cache = getCache();
+  const { extractCritical } = createEmotionServer(cache);
+
   try {
     ctx.renderPage = () =>
       originalRenderPage({
@@ -137,7 +138,7 @@ MyDocument.getInitialProps = async (ctx) => {
           styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
         // Take precedence over the CacheProvider in our custom _app.js
         enhanceComponent: (Component) => (props) => (
-          <CacheProvider value={getCache()}>
+          <CacheProvider value={cache}>
             <Component {...props} />
           </CacheProvider>
         ),

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -9,8 +9,9 @@ import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import { themeColor } from 'docs/src/modules/components/ThemeContext';
 import createCache from '@emotion/cache';
 
-const cache = createCache({ key: 'css', prepend: true });
-const { extractCritical } = createEmotionServer(cache);
+const getCache = () => createCache({ key: 'css', prepend: true });
+
+const { extractCritical } = createEmotionServer(getCache());
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -130,7 +131,7 @@ MyDocument.getInitialProps = async (ctx) => {
         enhanceApp: (App) => (props) =>
           styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
         enhanceComponent: (Component) => (props) => (
-          <CacheProvider value={cache}>
+          <CacheProvider value={getCache()}>
             <Component {...props} />
           </CacheProvider>
         ),

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -6,9 +6,9 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import { themeColor } from 'docs/src/modules/components/ThemeContext';
-import { cacheLtr } from 'docs/pages/_app';
+import createCache from '@emotion/cache';
 
-const { extractCritical } = createEmotionServer(cacheLtr);
+const { extractCritical } = createEmotionServer(createCache({ key: 'css', prepend: true }));
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -14,7 +14,7 @@ const getCache = () => {
   cache.compat = true;
 
   return cache;
-}
+};
 
 const { extractCritical } = createEmotionServer(getCache());
 

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -9,7 +9,12 @@ import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import { themeColor } from 'docs/src/modules/components/ThemeContext';
 import createCache from '@emotion/cache';
 
-const getCache = () => createCache({ key: 'css', prepend: true });
+const getCache = () => {
+  const cache = createCache({ key: 'css', prepend: true });
+  cache.compat = true;
+
+  return cache;
+}
 
 const { extractCritical } = createEmotionServer(getCache());
 

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -9,7 +9,7 @@ import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import { themeColor } from 'docs/src/modules/components/ThemeContext';
 import createCache from '@emotion/cache';
 
-const cache = createCache({ key: 'css', prepend: true })
+const cache = createCache({ key: 'css', prepend: true });
 const { extractCritical } = createEmotionServer(cache);
 
 // You can find a benchmark of the available CSS minifiers under
@@ -127,8 +127,13 @@ MyDocument.getInitialProps = async (ctx) => {
   try {
     ctx.renderPage = () =>
       originalRenderPage({
-        enhanceApp: (App) => (props) => styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
-        enhanceComponent: Component => (props) => <CacheProvider value={cache}><Component {...props} /></CacheProvider>
+        enhanceApp: (App) => (props) =>
+          styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
+        enhanceComponent: (Component) => (props) => (
+          <CacheProvider value={cache}>
+            <Component {...props} />
+          </CacheProvider>
+        ),
       });
 
     const initialProps = await Document.getInitialProps(ctx);

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -7,18 +7,6 @@ import rtlPlugin from 'stylis-plugin-rtl';
 import rtlPluginSc from 'stylis-plugin-rtl-sc';
 import { useTheme } from '@material-ui/core/styles';
 
-// Cache for the ltr version of the styles
-export const cacheLtr = createCache({ key: 'css', prepend: true });
-cacheLtr.compat = true;
-
-// Cache for the rtl version of the styles
-const cacheRtl = createCache({
-  key: 'rtl',
-  prepend: true,
-  stylisPlugins: [rtlPlugin],
-});
-cacheRtl.compat = true;
-
 export default function StyledEngineProvider(props) {
   const theme = useTheme();
 
@@ -26,7 +14,19 @@ export default function StyledEngineProvider(props) {
 
   return (
     <StyleSheetManager stylisPlugins={rtl ? [rtlPluginSc] : []}>
-      <CacheProvider value={rtl ? cacheRtl : cacheLtr}>{props.children}</CacheProvider>
+      <CacheProvider
+        value={
+          rtl
+            ? createCache({
+                key: 'rtl',
+                prepend: true,
+                stylisPlugins: [rtlPlugin],
+              })
+            : createCache({ key: 'css', prepend: true })
+        }
+      >
+        {props.children}
+      </CacheProvider>
     </StyleSheetManager>
   );
 }

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -7,6 +7,18 @@ import rtlPlugin from 'stylis-plugin-rtl';
 import rtlPluginSc from 'stylis-plugin-rtl-sc';
 import { useTheme } from '@material-ui/core/styles';
 
+// Cache for the ltr version of the styles
+export const cacheLtr = createCache({ key: 'css', prepend: true });
+cacheLtr.compat = true;
+
+// Cache for the rtl version of the styles
+const cacheRtl = createCache({
+  key: 'rtl',
+  prepend: true,
+  stylisPlugins: [rtlPlugin],
+});
+cacheRtl.compat = true;
+
 export default function StyledEngineProvider(props) {
   const theme = useTheme();
 
@@ -14,19 +26,7 @@ export default function StyledEngineProvider(props) {
 
   return (
     <StyleSheetManager stylisPlugins={rtl ? [rtlPluginSc] : []}>
-      <CacheProvider
-        value={
-          rtl
-            ? createCache({
-                key: 'rtl',
-                prepend: true,
-                stylisPlugins: [rtlPlugin],
-              })
-            : createCache({ key: 'css', prepend: true })
-        }
-      >
-        {props.children}
-      </CacheProvider>
+      <CacheProvider value={rtl ? cacheRtl : cacheLtr}>{props.children}</CacheProvider>
     </StyleSheetManager>
   );
 }


### PR DESCRIPTION
As per emotoin's documentation, the cache should be re-created per request (see the note https://emotion.sh/docs/ssr#extractcritical). So far we've been reusing the same cache instance, which was leading to global styles leaking on different pages. 

Preview: https://deploy-preview-25855--material-ui.netlify.app/components/grid/#interactive