### PR TITLE
[docs] Expose heading links in a11y tree

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -141,13 +141,13 @@ function getTranslatedHeader(t, header) {
 function Heading(props) {
   const { hash, level: Level = 'h2' } = props;
   const t = useTranslate();
+  const headingId = `heading-${hash}`;
 
   return (
-    <Level>
-      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content */}
-      <a className="anchor-link" id={hash} />
+    <Level id={headingId}>
+      <span className="anchor-link" id={hash} />
       {getTranslatedHeader(t, hash)}
-      <a className="anchor-link-style" aria-hidden="true" aria-label="anchor" href={`#${hash}`}>
+      <a aria-labelledby={headingId} className="anchor-link-style" href={`#${hash}`} tabIndex={-1}>
         <svg>
           <use xlinkHref="#anchor-link-icon" />
         </svg>

--- a/docs/src/modules/utils/parseMarkdown.js
+++ b/docs/src/modules/utils/parseMarkdown.js
@@ -187,12 +187,13 @@ export function createRender(context) {
           hash,
         });
       }
+      const headingId = `heading-${hash}`;
 
       return [
-        `<h${level}>`,
-        `<a class="anchor-link" id="${hash}"></a>`,
+        `<h${level} id="${headingId}">`,
+        `<span class="anchor-link" id="${hash}"></span>`,
         headingHtml,
-        `<a class="anchor-link-style" aria-hidden="true" href="#${hash}">`,
+        `<a aria-labelledby="${headingId}" class="anchor-link-style" href="#${hash}" tabindex="-1">`,
         '<svg><use xlink:href="#anchor-link-icon" /></svg>',
         '</a>',
         `</h${level}>`,


### PR DESCRIPTION
Preview:  
https://deploy-preview-25861--material-ui.netlify.app/components/buttons/
https://deploy-preview-25861--material-ui.netlify.app/api/button/

These were visible on hover but not exposed to the a11y tree. Visible elements should be exposed to the a11y tree.

Used this opportunity to get rid of an empty anchor element which is unneccessary.

Closes https://github.com/mui-org/material-ui/pull/25832

Clicking a header link in nvda:
`next`: "empty"; "clickable heading level 2"
https://github.com/mui-org/material-ui/pull/25861 (this PR): "contained buttons, visited link, heading level 2"; "heading level 2 contained buttons visited link contained buttons"
https://github.com/mui-org/material-ui/pull/25832:  "contained buttons, visited link, heading level 2"; "heading level 2 clickable"

Clicking a header link in VO:
`next`: "visited, link, buttons"
https://github.com/mui-org/material-ui/pull/25861 and https://github.com/mui-org/material-ui/pull/25832:  "visited, link, contained buttons"

Notice how https://github.com/mui-org/material-ui/pull/25832 just announces the heading as clickable but  does not say what this click would do. In this PR we get the announcement that there is a link.