### PR TITLE
[core] Update slot components to use overridesResolver part 2

### DIFF
--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { deepmerge } from '@material-ui/utils';
 import { isHostComponent } from '@material-ui/unstyled';
 import BackdropUnstyled, { backdropUnstyledClasses } from '@material-ui/unstyled/BackdropUnstyled';
 import experimentalStyled from '../styles/experimentalStyled';
@@ -8,17 +7,6 @@ import useThemeProps from '../styles/useThemeProps';
 import Fade from '../Fade';
 
 export const backdropClasses = backdropUnstyledClasses;
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.invisible && styles.invisible),
-    },
-    styles.root || {},
-  );
-};
 
 const extendUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -31,7 +19,14 @@ const BackdropRoot = experimentalStyled(
   {
     name: 'MuiBackdrop',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.invisible && styles.invisible),
+      };
+    },
   },
 )(({ styleProps }) => ({
   position: 'fixed',

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -53,6 +53,7 @@ const BadgeBadge = styled(
       const { styleProps } = props;
 
       return {
+        ...styles.root,
         ...styles.badge,
         ...styles[styleProps.variant],
         ...styles[

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -34,7 +34,12 @@ const extendUtilityClasses = (styleProps) => {
 const BadgeRoot = styled(
   'span',
   {},
-  { name: 'MuiBadge', slot: 'Root', overridesResolver: (props, styles) => styles.root },
+  {
+    name: 'MuiBadge',
+    slot: 'Root',
+    skipVariantsResolver: true,
+    overridesResolver: (props, styles) => styles.root,
+  },
 )({
   position: 'relative',
   display: 'inline-flex',
@@ -49,6 +54,7 @@ const BadgeBadge = styled(
   {
     name: 'MuiBadge',
     slot: 'Badge',
+    skipVariantsResolver: false,
     overridesResolver: (props, styles) => {
       const { styleProps } = props;
 

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { usePreviousProps, deepmerge } from '@material-ui/utils';
+import { usePreviousProps } from '@material-ui/utils';
 import { generateUtilityClasses, isHostComponent } from '@material-ui/unstyled';
 import BadgeUnstyled, {
   badgeUnstyledClasses,
@@ -19,27 +19,6 @@ export const badgeClasses = {
 const RADIUS_STANDARD = 10;
 const RADIUS_DOT = 4;
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      [`& .${badgeClasses.badge}`]: {
-        ...styles.badge,
-        ...styles[styleProps.variant],
-        ...styles[
-          `anchorOrigin${capitalize(styleProps.anchorOrigin.vertical)}${capitalize(
-            styleProps.anchorOrigin.horizontal,
-          )}${capitalize(styleProps.overlap)}`
-        ],
-        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
-        ...(styleProps.invisible && styles.invisible),
-      },
-    },
-    styles.root || {},
-  );
-};
-
 const extendUtilityClasses = (styleProps) => {
   const { color, classes = {} } = styleProps;
 
@@ -55,7 +34,7 @@ const extendUtilityClasses = (styleProps) => {
 const BadgeRoot = styled(
   'span',
   {},
-  { name: 'MuiBadge', slot: 'Root', overridesResolver },
+  { name: 'MuiBadge', slot: 'Root', overridesResolver: (props, styles) => styles.root },
 )({
   position: 'relative',
   display: 'inline-flex',
@@ -67,7 +46,25 @@ const BadgeRoot = styled(
 const BadgeBadge = styled(
   'span',
   {},
-  { name: 'MuiBadge', slot: 'Badge', overridesResolver },
+  {
+    name: 'MuiBadge',
+    slot: 'Badge',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.badge,
+        ...styles[styleProps.variant],
+        ...styles[
+          `anchorOrigin${capitalize(styleProps.anchorOrigin.vertical)}${capitalize(
+            styleProps.anchorOrigin.horizontal,
+          )}${capitalize(styleProps.overlap)}`
+        ],
+        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
+        ...(styleProps.invisible && styles.invisible),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   display: 'flex',
   flexDirection: 'row',

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -37,7 +37,6 @@ const BadgeRoot = styled(
   {
     name: 'MuiBadge',
     slot: 'Root',
-    skipVariantsResolver: true,
     overridesResolver: (props, styles) => styles.root,
   },
 )({
@@ -54,7 +53,6 @@ const BadgeBadge = styled(
   {
     name: 'MuiBadge',
     slot: 'Badge',
-    skipVariantsResolver: false,
     overridesResolver: (props, styles) => {
       const { styleProps } = props;
 

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -57,7 +57,6 @@ const BadgeBadge = styled(
       const { styleProps } = props;
 
       return {
-        ...styles.root,
         ...styles.badge,
         ...styles[styleProps.variant],
         ...styles[

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -31,7 +31,6 @@ describe('<Badge />', () => {
       mount,
       refInstanceof: window.HTMLSpanElement,
       muiName: 'MuiBadge',
-      testDeepOverrides: { slotName: 'badge', slotClassName: classes.badge },
       testVariantProps: { color: 'secondary', variant: 'dot' },
     }),
   );

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -7,8 +7,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getBottomNavigationUtilityClass } from './bottomNavigationClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -25,7 +23,7 @@ const BottomNavigationRoot = experimentalStyled(
   {
     name: 'MuiBottomNavigation',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -10,19 +9,6 @@ import unsupportedProp from '../utils/unsupportedProp';
 import bottomNavigationActionClasses, {
   getBottomNavigationActionUtilityClass,
 } from './bottomNavigationActionClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.showLabel && !styleProps.selected && styles.iconOnly),
-      [`& .${bottomNavigationActionClasses.wrapper}`]: styles.wrapper,
-      [`& .${bottomNavigationActionClasses.label}`]: styles.label,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, showLabel, selected } = styleProps;
@@ -42,7 +28,14 @@ const BottomNavigationActionRoot = experimentalStyled(
   {
     name: 'MuiBottomNavigationAction',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(!styleProps.showLabel && !styleProps.selected && styles.iconOnly),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -70,6 +63,7 @@ const BottomNavigationActionWrapper = experimentalStyled(
   {
     name: 'MuiBottomNavigationAction',
     slot: 'Wrapper',
+    overridesResolver: (props, styles) => styles.wrapper,
   },
 )({
   /* Styles applied to the span element that wraps the icon and label. */
@@ -86,6 +80,7 @@ const BottomNavigationActionLabel = experimentalStyled(
   {
     name: 'MuiBottomNavigationAction',
     slot: 'Label',
+    overridesResolver: (props, styles) => styles.label,
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the label's span element. */

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -2,24 +2,13 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import Typography from '../Typography';
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';
 import breadcrumbsClasses, { getBreadcrumbsUtilityClass } from './breadcrumbsClasses';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(
-    {
-      [`& .${breadcrumbsClasses.ol}`]: styles.ol,
-      [`& .${breadcrumbsClasses.li}`]: styles.li,
-      [`& .${breadcrumbsClasses.separator}`]: styles.separator,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -40,7 +29,12 @@ const BreadcrumbsRoot = experimentalStyled(
   {
     name: 'MuiBreadcrumbs',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      return {
+        [`& .${breadcrumbsClasses.li}`]: styles.li,
+        ...styles.root,
+      };
+    },
   },
 )({});
 
@@ -50,6 +44,7 @@ const BreadcrumbsOl = experimentalStyled(
   {
     name: 'MuiBreadcrumbs',
     slot: 'Ol',
+    overridesResolver: (props, styles) => styles.ol,
   },
 )({
   display: 'flex',
@@ -66,6 +61,7 @@ const BreadcrumbsSeparator = experimentalStyled(
   {
     name: 'MuiBreadcrumbs',
     slot: 'Separator',
+    overridesResolver: (props, styles) => styles.separator,
   },
 )({
   display: 'flex',

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -9,32 +8,6 @@ import { alpha } from '../styles/colorManipulator';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
 import buttonClasses, { getButtonUtilityClass } from './buttonClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...styles[`${styleProps.variant}${capitalize(styleProps.color)}`],
-      ...styles[`size${capitalize(styleProps.size)}`],
-      ...styles[`${styleProps.variant}Size${capitalize(styleProps.size)}`],
-      ...(styleProps.color === 'inherit' && styles.colorInherit),
-      ...(styleProps.disableElevation && styles.disableElevation),
-      ...(styleProps.fullWidth && styles.fullWidth),
-      [`& .${buttonClasses.label}`]: styles.label,
-      [`& .${buttonClasses.startIcon}`]: {
-        ...styles.startIcon,
-        ...styles[`iconSize${capitalize(styleProps.size)}`],
-      },
-      [`& .${buttonClasses.endIcon}`]: {
-        ...styles.endIcon,
-        ...styles[`iconSize${capitalize(styleProps.size)}`],
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { color, disableElevation, fullWidth, size, variant, classes } = styleProps;
@@ -87,7 +60,20 @@ const ButtonRoot = experimentalStyled(
   {
     name: 'MuiButton',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+        ...styles[`${styleProps.variant}${capitalize(styleProps.color)}`],
+        ...styles[`size${capitalize(styleProps.size)}`],
+        ...styles[`${styleProps.variant}Size${capitalize(styleProps.size)}`],
+        ...(styleProps.color === 'inherit' && styles.colorInherit),
+        ...(styleProps.disableElevation && styles.disableElevation),
+        ...(styleProps.fullWidth && styles.fullWidth),
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => ({
@@ -264,6 +250,7 @@ const ButtonLabel = experimentalStyled(
   {
     name: 'MuiButton',
     slot: 'Label',
+    overridesResolver: (props, styles) => styles.label,
   },
 )({
   width: '100%', // Ensure the correct width for iOS Safari
@@ -278,6 +265,14 @@ const ButtonStartIcon = experimentalStyled(
   {
     name: 'MuiButton',
     slot: 'StartIcon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.startIcon,
+        ...styles[`iconSize${capitalize(styleProps.size)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   display: 'inherit',
@@ -295,6 +290,14 @@ const ButtonEndIcon = experimentalStyled(
   {
     name: 'MuiButton',
     slot: 'EndIcon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.endIcon,
+        ...styles[`iconSize${capitalize(styleProps.size)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   display: 'inherit',

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -11,8 +11,6 @@ import useIsFocusVisible from '../utils/useIsFocusVisible';
 import TouchRipple from './TouchRipple';
 import buttonBaseClasses, { getButtonBaseUtilityClass } from './buttonBaseClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { disabled, focusVisible, focusVisibleClassName, classes } = styleProps;
 
@@ -32,7 +30,7 @@ const useUtilityClasses = (styleProps) => {
 export const ButtonBaseRoot = experimentalStyled(
   'button',
   {},
-  { name: 'MuiButtonBase', slot: 'Root', overridesResolver },
+  { name: 'MuiButtonBase', slot: 'Root', overridesResolver: (props, styles) => styles.root },
 )({
   display: 'inline-flex',
   alignItems: 'center',

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import capitalize from '../utils/capitalize';
 import { alpha } from '../styles/colorManipulator';
@@ -13,22 +12,20 @@ import buttonGroupClasses, { getButtonGroupUtilityClass } from './buttonGroupCla
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...(styleProps.disableElevation === true && styles.disableElevation),
-      ...(styleProps.fullWidth && styles.fullWidth),
-      ...(styleProps.orientation === 'vertical' && styles.vertical),
-      [`& .${buttonGroupClasses.grouped}`]: {
-        ...styles.grouped,
-        ...styles[`grouped${capitalize(styleProps.orientation)}`],
-        ...styles[`grouped${capitalize(styleProps.variant)}`],
-        ...styles[`grouped${capitalize(styleProps.variant)}${capitalize(styleProps.orientation)}`],
-        ...styles[`grouped${capitalize(styleProps.variant)}${capitalize(styleProps.color)}`],
-      },
+  return {
+    [`& .${buttonGroupClasses.grouped}`]: {
+      ...styles.grouped,
+      ...styles[`grouped${capitalize(styleProps.orientation)}`],
+      ...styles[`grouped${capitalize(styleProps.variant)}`],
+      ...styles[`grouped${capitalize(styleProps.variant)}${capitalize(styleProps.orientation)}`],
+      ...styles[`grouped${capitalize(styleProps.variant)}${capitalize(styleProps.color)}`],
     },
-    styles.root || {},
-  );
+    ...styles.root,
+    ...styles[styleProps.variant],
+    ...(styleProps.disableElevation === true && styles.disableElevation),
+    ...(styleProps.fullWidth && styles.fullWidth),
+    ...(styleProps.orientation === 'vertical' && styles.vertical),
+  };
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -21,7 +21,6 @@ describe('<ButtonGroup />', () => {
       testComponentPropWith: 'span',
       muiName: 'MuiButtonGroup',
       testVariantProps: { variant: 'contained' },
-      testDeepOverrides: { slotName: 'grouped', slotClassName: classes.grouped },
       skip: ['componentsProp'],
     }),
   );

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -72,7 +72,12 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   const componentSlot = muiOptions.slot;
 
   const overridesResolver = muiOptions.overridesResolver;
-  const skipVariantsResolver = muiOptions.skipVariantsResolver || false;
+  // if skipVariantsResolver option is defined, take the value, otherwise, true for root and false for other slots
+  const skipVariantsResolver =
+    muiOptions.skipVariantsResolver !== undefined
+      ? muiOptions.skipVariantsResolver
+      : (componentSlot && componentSlot !== 'Root') || false;
+
   const skipSx = muiOptions.skipSx || false;
 
   let displayName;


### PR DESCRIPTION
Updates component starting with `B` to use the `overridesResolver` on the slots components

Part 1: #25853