### PR TITLE
[styled-engine] Skip variants resolver for non root slots by default

### DIFF
--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -59,6 +59,7 @@ const SpeedDialActionFab = experimentalStyled(
   {
     name: 'MuiSpeedDialAction',
     slot: 'Fab',
+    skipVariantsResolver: false,
     overridesResolver: overridesResolverFab,
   },
 )(({ theme, styleProps }) => ({

--- a/packages/material-ui/src/styles/experimentalStyled.js
+++ b/packages/material-ui/src/styles/experimentalStyled.js
@@ -72,7 +72,12 @@ const experimentalStyled = (tag, options, muiOptions = {}) => {
   const componentSlot = muiOptions.slot;
 
   const overridesResolver = muiOptions.overridesResolver;
-  const skipVariantsResolver = muiOptions.skipVariantsResolver || false;
+  // if skipVariantsResolver option is defined, take the value, otherwise, true for root and false for other slots
+  const skipVariantsResolver =
+    muiOptions.skipVariantsResolver !== undefined
+      ? muiOptions.skipVariantsResolver
+      : (componentSlot && componentSlot !== 'Root') || false;
+
   const skipSx = muiOptions.skipSx || false;
 
   let displayName;

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -284,6 +284,59 @@ describe('experimentalStyled', () => {
       });
     });
 
+    it('variants should be skipped for non root slots', () => {
+      const TestSlot = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        { name: 'MuiTest', slot: 'Slot', overridesResolver: (props, styles) => styles.slot },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestSlot variant="rect" size="large">
+            Test
+          </TestSlot>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '200px',
+        height: '300px',
+      });
+    });
+
+    it('variants should respect skipVariantsResolver if defined', () => {
+      const TestSlot = styled(
+        'div',
+        { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx' },
+        {
+          name: 'MuiTest',
+          slot: 'Slot',
+          overridesResolver: (props, styles) => styles.slot,
+          skipVariantsResolver: false,
+        },
+      )`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestSlot variant="rect" size="large">
+            Test
+          </TestSlot>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '400px',
+        height: '400px',
+      });
+    });
+
     it('variants should win over overrides', () => {
       const { container } = render(
         <ThemeProvider theme={theme}>


### PR DESCRIPTION
Now that we are adding `overridesResolver` for every slot, we need to not resolve variants for non root slots, unless specified otherwise with the `skipVariantsResolver` option.

The issue surfaced in https://github.com/mui-org/material-ui/pull/25864, see https://www.argos-ci.com/mui-org/material-ui/builds/2358