### PR TITLE
[Container] Fix maxWidth="false" resulting in incorrect css

### DIFF
--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -78,7 +78,7 @@ const ContainerRoot = experimentalStyled(
         maxWidth: Math.max(theme.breakpoints.values.xs, 444),
       },
     }),
-    ...(styleProps.maxWidth !== 'xs' && {
+    ...(styleProps.maxWidth && styleProps.maxWidth !== 'xs' && {
       [theme.breakpoints.up(styleProps.maxWidth)]: {
         maxWidth: `${theme.breakpoints.values[styleProps.maxWidth]}${theme.breakpoints.unit}`,
       },

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -78,11 +78,12 @@ const ContainerRoot = experimentalStyled(
         maxWidth: Math.max(theme.breakpoints.values.xs, 444),
       },
     }),
-    ...(styleProps.maxWidth && styleProps.maxWidth !== 'xs' && {
-      [theme.breakpoints.up(styleProps.maxWidth)]: {
-        maxWidth: `${theme.breakpoints.values[styleProps.maxWidth]}${theme.breakpoints.unit}`,
-      },
-    }),
+    ...(styleProps.maxWidth &&
+      styleProps.maxWidth !== 'xs' && {
+        [theme.breakpoints.up(styleProps.maxWidth)]: {
+          maxWidth: `${theme.breakpoints.values[styleProps.maxWidth]}${theme.breakpoints.unit}`,
+        },
+      }),
   }),
 );
 


### PR DESCRIPTION
Fixes the issues with creating invalid CSS:

```css     
@media (min-width: falsepx) {
  .css-2bi4m2-MuiContainer-root {
    max-width:undefinedpx;
  }
}
```

Issue was spotted here https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext.material-ui.com%2Fcomponents%2Falert%2F%23main-content#interactive