### PR TITLE
[core] Update slot components to use overridesResolver part 3

### DIFF
--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -8,8 +8,6 @@ import useThemeProps from '../styles/useThemeProps';
 import Paper from '../Paper';
 import { getCardUtilityClass } from './cardClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -26,7 +24,7 @@ const CardRoot = experimentalStyled(
   {
     name: 'MuiCard',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(() => {
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -1,21 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import cardActionAreaClasses, { getCardActionAreaUtilityClass } from './cardActionAreaClasses';
 import ButtonBase from '../ButtonBase';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(
-    {
-      [`& .${cardActionAreaClasses.focusHighlight}`]: styles.focusHighlight,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -34,7 +24,7 @@ const CardActionAreaRoot = experimentalStyled(
   {
     name: 'MuiCardActionArea',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => ({
   /* Styles applied to the root element. */
@@ -58,6 +48,7 @@ const CardActionAreaFocusHighlight = experimentalStyled(
   {
     name: 'MuiCardActionArea',
     slot: 'FocusHighlight',
+    overridesResolver: (props, styles) => styles.focusHighlight,
   },
 )(({ theme }) => ({
   /* Styles applied to the overlay that covers the action area when it is keyboard focused. */

--- a/packages/material-ui/src/CardActions/CardActions.js
+++ b/packages/material-ui/src/CardActions/CardActions.js
@@ -1,22 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getCardActionsUtilityClass } from './cardActionsClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.disableSpacing && styles.spacing),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disableSpacing } = styleProps;
@@ -34,7 +22,14 @@ const CardActionsRoot = experimentalStyled(
   {
     name: 'MuiCardActions',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(!styleProps.disableSpacing && styles.spacing),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/CardContent/CardContent.js
+++ b/packages/material-ui/src/CardContent/CardContent.js
@@ -6,8 +6,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getCardContentUtilityClass } from './cardContentClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -24,7 +22,7 @@ const CardContentRoot = experimentalStyled(
   {
     name: 'MuiCardContent',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(() => {
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/CardHeader/CardHeader.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.js
@@ -1,25 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Typography from '../Typography';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import cardHeaderClasses, { getCardHeaderUtilityClass } from './cardHeaderClasses';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(
-    {
-      [`& .${cardHeaderClasses.avatar}`]: styles.avatar,
-      [`& .${cardHeaderClasses.action}`]: styles.action,
-      [`& .${cardHeaderClasses.content}`]: styles.content,
-      [`& .${cardHeaderClasses.title}`]: styles.title,
-      [`& .${cardHeaderClasses.subheader}`]: styles.subheader,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -42,7 +28,11 @@ const CardHeaderRoot = experimentalStyled(
   {
     name: 'MuiCardHeader',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => ({
+      [`& .${cardHeaderClasses.title}`]: styles.title,
+      [`& .${cardHeaderClasses.subheader}`]: styles.subheader,
+      ...styles.root,
+    }),
   },
 )({
   /* Styles applied to the root element. */
@@ -57,6 +47,7 @@ const CardHeaderAvatar = experimentalStyled(
   {
     name: 'MuiCardHeader',
     slot: 'Avatar',
+    overridesResolver: (props, styles) => styles.avatar,
   },
 )({
   /* Styles applied to the avatar element. */
@@ -71,6 +62,7 @@ const CardHeaderAction = experimentalStyled(
   {
     name: 'MuiCardHeader',
     slot: 'Action',
+    overridesResolver: (props, styles) => styles.action,
   },
 )({
   /* Styles applied to the action element. */
@@ -87,6 +79,7 @@ const CardHeaderContent = experimentalStyled(
   {
     name: 'MuiCardHeader',
     slot: 'Content',
+    overridesResolver: (props, styles) => styles.content,
   },
 )({
   /* Styles applied to the content wrapper element. */

--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -1,24 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getCardMediaUtilityClass } from './cardMediaClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  const { isMediaComponent, isImageComponent } = styleProps;
-
-  return deepmerge(
-    {
-      ...(isMediaComponent && styles.media),
-      ...(isImageComponent && styles.img),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, isMediaComponent, isImageComponent } = styleProps;
@@ -36,7 +23,16 @@ const CardMediaRoot = experimentalStyled(
   {
     name: 'MuiCardMedia',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      const { isMediaComponent, isImageComponent } = styleProps;
+
+      return {
+        ...styles.root,
+        ...(isMediaComponent && styles.media),
+        ...(isImageComponent && styles.img),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { refType, deepmerge } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import SwitchBase from '../internal/SwitchBase';
 import CheckBoxOutlineBlankIcon from '../internal/svg-icons/CheckBoxOutlineBlank';
@@ -11,18 +11,6 @@ import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
 import checkboxClasses, { getCheckboxUtilityClass } from './checkboxClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.indeterminate && styles.indeterminate),
-      ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, indeterminate, color } = styleProps;
@@ -45,7 +33,15 @@ const CheckboxRoot = experimentalStyled(
   {
     name: 'MuiCheckbox',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.indeterminate && styles.indeterminate),
+        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import CancelIcon from '../internal/svg-icons/Cancel';
 import { alpha } from '../styles/colorManipulator';
@@ -12,45 +11,6 @@ import ButtonBase from '../ButtonBase';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import chipClasses, { getChipUtilityClass } from './chipClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  const { color, clickable, onDelete, size, variant } = styleProps;
-
-  return deepmerge(
-    {
-      ...styles[`size${capitalize(size)}`],
-      ...styles[`color${capitalize(color)}`],
-      ...(clickable && styles.clickable),
-      ...(clickable && color !== 'default' && styles[`clickableColor${capitalize(color)})`]),
-      ...(onDelete && styles.deletable),
-      ...(onDelete && color !== 'default' && styles[`deletableColor${capitalize(color)}`]),
-      ...styles[variant],
-      ...(variant === 'outlined' && styles[`outlined${capitalize(color)}`]),
-      [`& .${chipClasses.avatar}`]: {
-        ...styles.avatar,
-        ...styles[`avatar${capitalize(size)}`],
-        ...styles[`avatarColor${capitalize(color)}`],
-      },
-      [`& .${chipClasses.icon}`]: {
-        ...styles.icon,
-        ...styles[`icon${capitalize(size)}`],
-        ...styles[`iconColor${capitalize(color)}`],
-      },
-      [`& .${chipClasses.label}`]: {
-        ...styles.label,
-        ...styles[`label${capitalize(size)}`],
-      },
-      [`& .${chipClasses.deleteIcon}`]: {
-        ...styles.deleteIcon,
-        ...styles[`deleteIcon${capitalize(size)}`],
-        ...styles[`deleteIconColor${capitalize(color)}`],
-        ...styles[`deleteIconOutlinedColor${capitalize(color)}`],
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disabled, size, color, onDelete, clickable, variant } = styleProps;
@@ -88,7 +48,38 @@ const ChipRoot = experimentalStyled(
   {
     name: 'MuiChip',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      const { color, clickable, onDelete, size, variant } = styleProps;
+
+      return {
+        [`& .${chipClasses.avatar}`]: {
+          ...styles.avatar,
+          ...styles[`avatar${capitalize(size)}`],
+          ...styles[`avatarColor${capitalize(color)}`],
+        },
+        [`& .${chipClasses.icon}`]: {
+          ...styles.icon,
+          ...styles[`icon${capitalize(size)}`],
+          ...styles[`iconColor${capitalize(color)}`],
+        },
+        [`& .${chipClasses.deleteIcon}`]: {
+          ...styles.deleteIcon,
+          ...styles[`deleteIcon${capitalize(size)}`],
+          ...styles[`deleteIconColor${capitalize(color)}`],
+          ...styles[`deleteIconOutlinedColor${capitalize(color)}`],
+        },
+        ...styles.root,
+        ...styles[`size${capitalize(size)}`],
+        ...styles[`color${capitalize(color)}`],
+        ...(clickable && styles.clickable),
+        ...(clickable && color !== 'default' && styles[`clickableColor${capitalize(color)})`]),
+        ...(onDelete && styles.deletable),
+        ...(onDelete && color !== 'default' && styles[`deletableColor${capitalize(color)}`]),
+        ...styles[variant],
+        ...(variant === 'outlined' && styles[`outlined${capitalize(color)}`]),
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => {
@@ -306,6 +297,15 @@ const ChipLabel = experimentalStyled(
   {
     name: 'MuiChip',
     slot: 'Label',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      const { size } = styleProps;
+
+      return {
+        ...styles.label,
+        ...styles[`label${capitalize(size)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the label `span` element. */

--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -1,15 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { keyframes, css } from '@material-ui/styled-engine';
 import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
-import circularProgressClasses, {
-  getCircularProgressUtilityClass,
-} from './circularProgressClasses';
+import { getCircularProgressUtilityClass } from './circularProgressClasses';
 
 const SIZE = 44;
 
@@ -40,24 +38,6 @@ const circularDashKeyframe = keyframes`
   }
 `;
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...styles[`color${capitalize(styleProps.color)}`],
-      [`& .${circularProgressClasses.svg}`]: styles.svg,
-      [`& .${circularProgressClasses.circle}`]: {
-        ...styles.circle,
-        ...styles[`circle${capitalize(styleProps.variant)}`],
-        ...(styleProps.disableShrink && styles.circleDisableShrink),
-      },
-    },
-    styles.root || {},
-  );
-};
-
 const useUtilityClasses = (styleProps) => {
   const { classes, variant, color, disableShrink } = styleProps;
 
@@ -76,7 +56,15 @@ const CircularProgressRoot = experimentalStyled(
   {
     name: 'MuiCircularProgress',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+        ...styles[`color${capitalize(styleProps.color)}`],
+      };
+    },
   },
 )(
   ({ styleProps, theme }) => ({
@@ -105,6 +93,7 @@ const CircularProgressSVG = experimentalStyled(
   {
     name: 'MuiCircularProgress',
     slot: 'Svg',
+    overridesResolver: (props, styles) => styles.svg,
   },
 )({
   /* Styles applied to the svg element. */
@@ -117,6 +106,15 @@ const CircularProgressCircle = experimentalStyled(
   {
     name: 'MuiCircularProgress',
     slot: 'Circle',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.circle,
+        ...styles[`circle${capitalize(styleProps.variant)}`],
+        ...(styleProps.disableShrink && styles.circleDisableShrink),
+      };
+    },
   },
 )(
   ({ styleProps, theme }) => ({

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
-import { deepmerge, elementTypeAcceptingRef } from '@material-ui/utils';
+import { elementTypeAcceptingRef } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -10,25 +10,7 @@ import { duration } from '../styles/transitions';
 import { getTransitionProps } from '../transitions/utils';
 import useTheme from '../styles/useTheme';
 import { useForkRef } from '../utils';
-import collapseClasses, { getCollapseUtilityClass } from './collapseClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.orientation],
-      ...(styleProps.state === 'entered' && styles.entered),
-      ...(styleProps.state === 'exited' &&
-        !styleProps.in &&
-        styleProps.collapsedSize === '0px' &&
-        styles.hidden),
-      [`& .${collapseClasses.wrapper}`]: styles.wrapper,
-      [`& .${collapseClasses.wrapperInner}`]: styles.wrapperInner,
-    },
-    styles.root || {},
-  );
-};
+import { getCollapseUtilityClass } from './collapseClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { orientation, classes } = styleProps;
@@ -50,7 +32,19 @@ const CollapseRoot = experimentalStyled(
   {
     name: 'MuiCollapse',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.orientation],
+        ...(styleProps.state === 'entered' && styles.entered),
+        ...(styleProps.state === 'exited' &&
+          !styleProps.in &&
+          styleProps.collapsedSize === '0px' &&
+          styles.hidden),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -85,6 +79,7 @@ const CollapseWrapper = experimentalStyled(
   {
     name: 'MuiCollapse',
     slot: 'Wrapper',
+    overridesResolver: (props, styles) => styles.wrapper,
   },
 )(({ styleProps }) => ({
   // Hack to get children with a negative margin to not falsify the height computation.
@@ -103,6 +98,7 @@ const CollapseWrapperInner = experimentalStyled(
   {
     name: 'MuiCollapse',
     slot: 'WrapperInner',
+    overridesResolver: (props, styles) => styles.wrapperInner,
   },
 )(({ styleProps }) => ({
   width: '100%',

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -1,25 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getContainerUtilityClass } from './containerClasses';
 import capitalize from '../utils/capitalize';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`maxWidth${capitalize(String(styleProps.maxWidth))}`],
-      ...(styleProps.fixed && styles.fixed),
-      ...(styleProps.disableGutters && styles.disableGutters),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, fixed, disableGutters, maxWidth } = styleProps;
@@ -42,7 +28,16 @@ const ContainerRoot = experimentalStyled(
   {
     name: 'MuiContainer',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`maxWidth${capitalize(String(styleProps.maxWidth))}`],
+        ...(styleProps.fixed && styles.fixed),
+        ...(styleProps.disableGutters && styles.disableGutters),
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => ({

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import capitalize from '../utils/capitalize';
 import Modal from '../Modal';
@@ -13,33 +12,13 @@ import experimentalStyled from '../styles/experimentalStyled';
 import dialogClasses, { getDialogUtilityClass } from './dialogClasses';
 import Backdrop from '../Backdrop';
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      [`& .${dialogClasses.container}`]: {
-        ...styles.container,
-        ...styles[`scroll${capitalize(styleProps.scroll)}`],
-      },
-      [`& .${dialogClasses.paper}`]: {
-        ...styles.paper,
-        ...styles[`scrollPaper${capitalize(styleProps.scroll)}`],
-        ...styles[`paperWidth${capitalize(String(styleProps.maxWidth))})`],
-        ...(styleProps.fullWidth && styles.paperFullWidth),
-        ...(styleProps.fullScreen && styles.paperFullScreen),
-      },
-    },
-    styles.root || {},
-  );
-};
-
 const DialogBackdrop = experimentalStyled(
   Backdrop,
   {},
   {
     name: 'MuiDialog',
     slot: 'Backdrop',
+    overrides: (props, styles) => styles.backdrop,
   },
 )({
   // Improve scrollable dialog support.
@@ -70,7 +49,7 @@ const DialogRoot = experimentalStyled(
   {
     name: 'MuiDialog',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   /* Styles applied to the root element. */
@@ -86,6 +65,14 @@ const DialogContainer = experimentalStyled(
   {
     name: 'MuiDialog',
     slot: 'Container',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.container,
+        ...styles[`scroll${capitalize(styleProps.scroll)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the container element. */
@@ -122,6 +109,17 @@ const DialogPaper = experimentalStyled(
   {
     name: 'MuiDialog',
     slot: 'Paper',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.paper,
+        ...styles[`scrollPaper${capitalize(styleProps.scroll)}`],
+        ...styles[`paperWidth${capitalize(String(styleProps.maxWidth))})`],
+        ...(styleProps.fullWidth && styles.paperFullWidth),
+        ...(styleProps.fullScreen && styles.paperFullScreen),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the Paper component. */

--- a/packages/material-ui/src/DialogActions/DialogActions.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.js
@@ -1,22 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getDialogActionsUtilityClass } from './dialogActionsClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.disableSpacing && styles.spacing),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disableSpacing } = styleProps;
@@ -34,7 +22,14 @@ const DialogActionsRoot = experimentalStyled(
   {
     name: 'MuiDialogActions',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(!styleProps.disableSpacing && styles.spacing),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/DialogContent/DialogContent.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.js
@@ -1,22 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getDialogContentUtilityClass } from './dialogContentClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.dividers && styles.dividers),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, dividers } = styleProps;
@@ -34,7 +22,14 @@ const DialogContentRoot = experimentalStyled(
   {
     name: 'MuiDialogContent',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.dividers && styles.dividers),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/DialogContentText/DialogContentText.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.js
@@ -1,15 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import experimentalStyled, { shouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import Typography from '../Typography';
 import { getDialogContentTextUtilityClass } from './dialogContentTextClasses';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(styles.root || {}, {});
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -32,7 +27,7 @@ const DialogContentTextRoot = experimentalStyled(
   {
     name: 'MuiDialogContentText',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({ marginBottom: 12 });
 

--- a/packages/material-ui/src/DialogTitle/DialogTitle.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.js
@@ -7,8 +7,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getDialogTitleUtilityClass } from './dialogTitleClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -25,7 +23,7 @@ const DialogTitleRoot = experimentalStyled(
   {
     name: 'MuiDialogTitle',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(() => {
   return {

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -1,41 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { alpha } from '../styles/colorManipulator';
-import dividerClasses, { getDividerUtilityClass } from './dividerClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.absolute && styles.absolute),
-      ...styles[styleProps.variant],
-      ...(styleProps.light && styles.light),
-      ...(styleProps.orientation === 'vertical' && styles.vertical),
-      ...(styleProps.flexItem && styles.flexItem),
-      ...(styleProps.children && styles.withChildren),
-      ...(styleProps.children &&
-        styleProps.orientation === 'vertical' &&
-        styles.withChildrenVertical),
-      ...(styleProps.textAlign === 'right' &&
-        styleProps.orientation !== 'vertical' &&
-        styles.textAlignRight),
-      ...(styleProps.textAlign === 'left' &&
-        styleProps.orientation !== 'vertical' &&
-        styles.textAlignLeft),
-      [`& .${dividerClasses.wrapper}`]: {
-        ...styles.wrapper,
-        ...(styleProps.orientation === 'vertical' && styles.wrapperVertical),
-      },
-    },
-    styles.root || {},
-  );
-};
+import { getDividerUtilityClass } from './dividerClasses';
 
 const useUtilityClasses = (styleProps) => {
   const {
@@ -74,7 +44,28 @@ const DividerRoot = experimentalStyled(
   {
     name: 'MuiDivider',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.absolute && styles.absolute),
+        ...styles[styleProps.variant],
+        ...(styleProps.light && styles.light),
+        ...(styleProps.orientation === 'vertical' && styles.vertical),
+        ...(styleProps.flexItem && styles.flexItem),
+        ...(styleProps.children && styles.withChildren),
+        ...(styleProps.children &&
+          styleProps.orientation === 'vertical' &&
+          styles.withChildrenVertical),
+        ...(styleProps.textAlign === 'right' &&
+          styleProps.orientation !== 'vertical' &&
+          styles.textAlignRight),
+        ...(styleProps.textAlign === 'left' &&
+          styleProps.orientation !== 'vertical' &&
+          styles.textAlignLeft),
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => ({
@@ -186,6 +177,14 @@ const DividerWrapper = experimentalStyled(
   {
     name: 'MuiDivider',
     slot: 'Wrapper',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.wrapper,
+        ...(styleProps.orientation === 'vertical' && styles.wrapperVertical),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   display: 'inline-block',

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Modal from '../Modal';
 import Slide from '../Slide';
@@ -11,25 +11,17 @@ import { duration } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
-import drawerClasses, { getDrawerUtilityClass } from './drawerClasses';
+import { getDrawerUtilityClass } from './drawerClasses';
 
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(
-    {
-      ...((styleProps.variant === 'permanent' || styleProps.variant === 'persistent') &&
-        styles.docked),
-      ...styles.modal,
-      [`& .${drawerClasses.paper}`]: {
-        ...styles.paper,
-        ...styles[`paperAnchor${capitalize(styleProps.anchor)}`],
-        ...(styleProps.variant !== 'temporary' &&
-          styles[`paperAnchorDocked${capitalize(styleProps.anchor)}`]),
-      },
-    },
-    styles.root || {},
-  );
+  return {
+    ...styles.root,
+    ...((styleProps.variant === 'permanent' || styleProps.variant === 'persistent') &&
+      styles.docked),
+    ...styles.modal,
+  };
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -65,6 +57,7 @@ const DrawerDockedRoot = experimentalStyled(
   {
     name: 'MuiDrawer',
     slot: 'Docked',
+    skipVariantsResolver: false,
     overridesResolver,
   },
 )({
@@ -78,6 +71,16 @@ const DrawerPaper = experimentalStyled(
   {
     name: 'MuiDrawer',
     slot: 'Paper',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.paper,
+        ...styles[`paperAnchor${capitalize(styleProps.anchor)}`],
+        ...(styleProps.variant !== 'temporary' &&
+          styles[`paperAnchorDocked${capitalize(styleProps.anchor)}`]),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the Paper component. */


### PR DESCRIPTION
Updates component starting with `[C-D]` to use the `overridesResolver` on the slots components

Part 1: #25853
Part 2: #25864