### PR TITLE
[core] Update slot components to use overridesResolver part 4

### DIFF
--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -1,29 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import fabClasses, { getFabUtilityClass } from './fabClasses';
 import experimentalStyled from '../styles/experimentalStyled';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...styles[`size${capitalize(styleProps.size)}`],
-      ...(styleProps.color === 'inherit' && styles.colorInherit),
-      ...(styleProps.color === 'primary' && styles.primary),
-      ...(styleProps.color === 'secondary' && styles.secondary),
-      [`& .${fabClasses.label}`]: styles.label,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { color, variant, classes, size } = styleProps;
@@ -49,7 +32,18 @@ const FabRoot = experimentalStyled(
   {
     name: 'MuiFab',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+        ...styles[`size${capitalize(styleProps.size)}`],
+        ...(styleProps.color === 'inherit' && styles.colorInherit),
+        ...(styleProps.color === 'primary' && styles.primary),
+        ...(styleProps.color === 'secondary' && styles.secondary),
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => ({
@@ -160,6 +154,7 @@ const FabLabel = experimentalStyled(
   {
     name: 'MuiFab',
     slot: 'Label',
+    overridesResolver: (props, styles) => styles.label,
   },
 )({
   /* Styles applied to the span element that wraps the children. */

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { deepmerge, refType } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import InputBase from '../InputBase';
@@ -7,17 +7,11 @@ import experimentalStyled, { rootShouldForwardProp } from '../styles/experimenta
 import useThemeProps from '../styles/useThemeProps';
 import filledInputClasses, { getFilledInputUtilityClass } from './filledInputClasses';
 import {
-  overridesResolver as inputBaseOverridesResolver,
+  rootOverridesResolver as inputBaseRootOverridesResolver,
+  inputOverridesResolver as inputBaseInputOverridesResolver,
   InputBaseRoot,
   InputBaseComponent as InputBaseInput,
 } from '../InputBase/InputBase';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(inputBaseOverridesResolver(props, styles), {
-    ...(!styleProps.disableUnderline && styles.underline),
-  });
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disableUnderline } = styleProps;
@@ -33,7 +27,17 @@ const useUtilityClasses = (styleProps) => {
 const FilledInputRoot = experimentalStyled(
   InputBaseRoot,
   { shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes' },
-  { name: 'MuiFilledInput', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiFilledInput',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...inputBaseRootOverridesResolver(props, styles),
+        ...(!styleProps.disableUnderline && styles.underline),
+      };
+    },
+  },
 )(({ theme, styleProps }) => {
   const light = theme.palette.mode === 'light';
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
@@ -127,7 +131,7 @@ const FilledInputRoot = experimentalStyled(
 const FilledInputInput = experimentalStyled(
   InputBaseInput,
   {},
-  { name: 'MuiFilledInput', slot: 'Input' },
+  { name: 'MuiFilledInput', slot: 'Input', overridesResolver: inputBaseInputOverridesResolver },
 )(({ theme, styleProps }) => ({
   paddingTop: 25,
   paddingRight: 12,

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
@@ -10,16 +9,6 @@ import capitalize from '../utils/capitalize';
 import isMuiElement from '../utils/isMuiElement';
 import FormControlContext from './FormControlContext';
 import { getFormControlUtilityClasses } from './formControlClasses';
-
-const overridesResolver = ({ styleProps }, styles) => {
-  return deepmerge(
-    {
-      ...styles[`margin${capitalize(styleProps.margin)}`],
-      ...(styleProps.fullWidth && styles.fullWidth),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, margin, fullWidth } = styleProps;
@@ -36,7 +25,13 @@ const FormControlRoot = experimentalStyled(
   {
     name: 'MuiFormControl',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: ({ styleProps }, styles) => {
+      return {
+        ...styles.root,
+        ...styles[`margin${capitalize(styleProps.margin)}`],
+        ...(styleProps.fullWidth && styles.fullWidth),
+      };
+    },
   },
 )(({ styleProps }) => ({
   display: 'inline-flex',

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType, deepmerge } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { useFormControl } from '../FormControl';
 import Typography from '../Typography';
@@ -11,18 +11,6 @@ import useThemeProps from '../styles/useThemeProps';
 import formControlLabelClasses, {
   getFormControlLabelUtilityClasses,
 } from './formControlLabelClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`labelPlacement${capitalize(styleProps.labelPlacement)}`],
-      [`& .${formControlLabelClasses.label}`]: styles.label,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disabled, labelPlacement } = styleProps;
@@ -37,7 +25,19 @@ const useUtilityClasses = (styleProps) => {
 export const FormControlLabelRoot = experimentalStyled(
   'label',
   {},
-  { name: 'MuiFormControlLabel', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiFormControlLabel',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${formControlLabelClasses.label}`]: styles.label,
+        ...styles.root,
+        ...styles[`labelPlacement${capitalize(styleProps.labelPlacement)}`],
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   display: 'inline-flex',
   alignItems: 'center',

--- a/packages/material-ui/src/FormGroup/FormGroup.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.js
@@ -1,22 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getFormGroupUtilityClass } from './formGroupClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.row && styles.row),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, row } = styleProps;
@@ -34,7 +22,14 @@ const FormGroupRoot = experimentalStyled(
   {
     name: 'MuiFormGroup',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.row && styles.row),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -2,26 +2,12 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import experimentalStyled from '../styles/experimentalStyled';
 import capitalize from '../utils/capitalize';
 import formHelperTextClasses, { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
 import useThemeProps from '../styles/useThemeProps';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.size && styles[`size${capitalize(styleProps.size)}`]),
-      ...(styleProps.contained && styles.contained),
-      ...(styleProps.filled && styles.filled),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, contained, size, disabled, error, filled, focused, required } = styleProps;
@@ -44,7 +30,20 @@ const useUtilityClasses = (styleProps) => {
 const FormHelperTextRoot = experimentalStyled(
   'p',
   {},
-  { name: 'MuiFormHelperText', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiFormHelperText',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.size && styles[`size${capitalize(styleProps.size)}`]),
+        ...(styleProps.contained && styles.contained),
+        ...(styleProps.filled && styles.filled),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   color: theme.palette.text.secondary,
   ...theme.typography.caption,

--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
@@ -9,19 +8,6 @@ import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import formLabelClasses, { getFormLabelUtilityClasses } from './formLabelClasses';
-
-export const overridesResolver = ({ styleProps }, styles) => {
-  return deepmerge(
-    {
-      ...(styleProps.color === 'secondary' && styles.colorSecondary),
-      ...(styleProps.filled && styles.filled),
-      [`& .${formLabelClasses.asterisk}`]: {
-        ...styles.asterisk,
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, color, focused, disabled, error, filled, required } = styleProps;
@@ -44,7 +30,17 @@ const useUtilityClasses = (styleProps) => {
 export const FormLabelRoot = experimentalStyled(
   'label',
   {},
-  { name: 'MuiFormLabel', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiFormLabel',
+    slot: 'Root',
+    overridesResolver: ({ styleProps }, styles) => {
+      return {
+        ...styles.root,
+        ...(styleProps.color === 'secondary' && styles.colorSecondary),
+        ...(styleProps.filled && styles.filled),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   color: theme.palette.text.secondary,
   ...theme.typography.body1,
@@ -64,7 +60,7 @@ export const FormLabelRoot = experimentalStyled(
 const AsteriskComponent = experimentalStyled(
   'span',
   {},
-  { name: 'MuiFormLabel', slot: 'Asterisk' },
+  { name: 'MuiFormLabel', slot: 'Asterisk', overridesResolver: (props, styles) => styles.asterisk },
 )(({ theme }) => ({
   [`&.${formLabelClasses.error}`]: {
     color: theme.palette.error.main,

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -12,7 +12,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_extendSxProp as extendSxProp } from '@material-ui/system';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import requirePropFactory from '../utils/requirePropFactory';
@@ -103,39 +102,6 @@ function generateGap({ theme, styleProps }) {
   return styles;
 }
 
-const overridesResolver = (props, styles) => {
-  const {
-    container,
-    direction,
-    item,
-    lg,
-    md,
-    sm,
-    spacing,
-    wrap,
-    xl,
-    xs,
-    zeroMinWidth,
-  } = props.styleProps;
-
-  return deepmerge(
-    {
-      ...(container && styles.container),
-      ...(item && styles.item),
-      ...(zeroMinWidth && styles.zeroMinWidth),
-      ...(container && spacing !== 0 && styles[`spacing-xs-${String(spacing)}`]),
-      ...(direction !== 'row' && styles[`direction-xs-${String(direction)}`]),
-      ...(wrap !== 'wrap' && styles[`wrap-xs-${String(wrap)}`]),
-      ...(xs !== false && styles[`grid-xs-${String(xs)}`]),
-      ...(sm !== false && styles[`grid-sm-${String(sm)}`]),
-      ...(md !== false && styles[`grid-md-${String(md)}`]),
-      ...(lg !== false && styles[`grid-lg-${String(lg)}`]),
-      ...(xl !== false && styles[`grid-xl-${String(xl)}`]),
-    },
-    styles.root || {},
-  );
-};
-
 // Default CSS values
 // flex: '0 1 auto',
 // flexDirection: 'row',
@@ -145,7 +111,40 @@ const overridesResolver = (props, styles) => {
 const GridRoot = experimentalStyled(
   'div',
   {},
-  { name: 'MuiGrid', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiGrid',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const {
+        container,
+        direction,
+        item,
+        lg,
+        md,
+        sm,
+        spacing,
+        wrap,
+        xl,
+        xs,
+        zeroMinWidth,
+      } = props.styleProps;
+
+      return {
+        ...styles.root,
+        ...(container && styles.container),
+        ...(item && styles.item),
+        ...(zeroMinWidth && styles.zeroMinWidth),
+        ...(container && spacing !== 0 && styles[`spacing-xs-${String(spacing)}`]),
+        ...(direction !== 'row' && styles[`direction-xs-${String(direction)}`]),
+        ...(wrap !== 'wrap' && styles[`wrap-xs-${String(wrap)}`]),
+        ...(xs !== false && styles[`grid-xs-${String(xs)}`]),
+        ...(sm !== false && styles[`grid-sm-${String(sm)}`]),
+        ...(md !== false && styles[`grid-md-${String(md)}`]),
+        ...(lg !== false && styles[`grid-lg-${String(lg)}`]),
+        ...(xl !== false && styles[`grid-xl-${String(xl)}`]),
+      };
+    },
+  },
 )(
   ({ styleProps }) => ({
     boxSizing: 'border-box',

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -2,23 +2,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import { getIconUtilityClass } from './iconClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.color !== 'inherit' && styles[`color${capitalize(styleProps.color)}`]),
-      ...styles[`fontSize${capitalize(styleProps.fontSize)}`],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { color, fontSize, classes } = styleProps;
@@ -40,7 +27,15 @@ const IconRoot = experimentalStyled(
   {
     name: 'MuiIcon',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.color !== 'inherit' && styles[`color${capitalize(styleProps.color)}`]),
+        ...styles[`fontSize${capitalize(styleProps.fontSize)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -9,20 +9,6 @@ import { alpha } from '../styles/colorManipulator';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
 import iconButtonClasses, { getIconButtonUtilityClass } from './iconButtonClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
-      ...(styleProps.edge && styles[`edge${capitalize(styleProps.edge)}`]),
-      ...styles[`size${capitalize(styleProps.size)}`],
-      [`& .${iconButtonClasses.label}`]: styles.label,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disabled, color, edge, size } = styleProps;
@@ -47,7 +33,16 @@ const IconButtonRoot = experimentalStyled(
   {
     name: 'MuiIconButton',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
+        ...(styleProps.edge && styles[`edge${capitalize(styleProps.edge)}`]),
+        ...styles[`size${capitalize(styleProps.size)}`],
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => ({
@@ -124,6 +119,7 @@ const IconButtonLabel = experimentalStyled(
   {
     name: 'MuiIconButton',
     slot: 'Label',
+    overridesResolver: (props, styles) => styles.label,
   },
 )({
   /* Styles applied to the children container element. */

--- a/packages/material-ui/src/ImageList/ImageList.js
+++ b/packages/material-ui/src/ImageList/ImageList.js
@@ -1,5 +1,5 @@
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -7,17 +7,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getImageListUtilityClass } from './imageListClasses';
 import ImageListContext from './ImageListContext';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, variant } = styleProps;
@@ -35,7 +24,14 @@ const ImageListRoot = experimentalStyled(
   {
     name: 'MuiImageList',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+      };
+    },
   },
 )(({ styleProps }) => {
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -1,5 +1,5 @@
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -9,18 +9,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import isMuiElement from '../utils/isMuiElement';
 import imageListItemClasses, { getImageListItemUtilityClass } from './imageListItemClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      [`& .${imageListItemClasses.img}`]: styles.img,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, variant } = styleProps;
@@ -39,7 +27,15 @@ const ImageListItemRoot = experimentalStyled(
   {
     name: 'MuiImageListItem',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${imageListItemClasses.img}`]: styles.img,
+        ...styles.root,
+        ...styles[styleProps.variant],
+      };
+    },
   },
 )(({ styleProps }) => ({
   display: 'inline-block',

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -1,37 +1,11 @@
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
-import imageListItemBarClasses, {
-  getImageListItemBarUtilityClass,
-} from './imageListItemBarClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`position${capitalize(styleProps.position)}`],
-      [`& .${imageListItemBarClasses.titleWrap}`]: {
-        ...styles.titleWrap,
-        ...styles[`titleWrap${capitalize(styleProps.position)}`],
-        ...(styleProps.actionIcon &&
-          styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
-      },
-      [`& .${imageListItemBarClasses.title}`]: styles.title,
-      [`& .${imageListItemBarClasses.subtitle}`]: styles.subtitle,
-      [`& .${imageListItemBarClasses.actionIcon}`]: {
-        ...styles.actionIcon,
-        ...styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`],
-      },
-    },
-    styles.root || {},
-  );
-};
+import { getImageListItemBarUtilityClass } from './imageListItemBarClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { classes, position, actionIcon, actionPosition } = styleProps;
@@ -57,7 +31,14 @@ const ImageListItemBarRoot = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`position${capitalize(styleProps.position)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => {
   return {
@@ -92,6 +73,16 @@ const ImageListItemBarTitleWrap = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'TitleWrap',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.titleWrap,
+        ...styles[`titleWrap${capitalize(styleProps.position)}`],
+        ...(styleProps.actionIcon &&
+          styles[`titleWrapActionPos${capitalize(styleProps.actionPosition)}`]),
+      };
+    },
   },
 )(({ theme, styleProps }) => {
   return {
@@ -124,6 +115,7 @@ const ImageListItemBarTitle = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'Title',
+    overridesResolver: (props, styles) => styles.title,
   },
 )(({ theme }) => {
   return {
@@ -142,6 +134,7 @@ const ImageListItemBarSubtitle = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'Subtitle',
+    overridesResolver: (props, styles) => styles.subtitle,
   },
 )(({ theme }) => {
   return {
@@ -160,6 +153,14 @@ const ImageListItemBarActionIcon = experimentalStyled(
   {
     name: 'MuiImageListItemBar',
     slot: 'ActionIcon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.actionIcon,
+        ...styles[`actionIconActionPos${capitalize(styleProps.actionPosition)}`],
+      };
+    },
   },
 )(({ styleProps }) => {
   return {

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge, refType } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import InputBase from '../InputBase';
 import experimentalStyled, { rootShouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import inputClasses, { getInputUtilityClass } from './inputClasses';
 import {
-  overridesResolver as inputBaseOverridesResolver,
+  rootOverridesResolver as inputBaseRootOverridesResolver,
+  inputOverridesResolver as inputBaseInputOverridesResolver,
   InputBaseRoot,
+  InputBaseInput,
 } from '../InputBase/InputBase';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(inputBaseOverridesResolver(props, styles), {
-    ...(!styleProps.disableUnderline && styles.underline),
-  });
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disableUnderline } = styleProps;
@@ -37,7 +32,18 @@ const useUtilityClasses = (styleProps) => {
 const InputRoot = experimentalStyled(
   InputBaseRoot,
   { shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes' },
-  { name: 'MuiInput', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiInput',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...inputBaseRootOverridesResolver(props, styles),
+        ...(!styleProps.disableUnderline && styles.underline),
+      };
+    },
+  },
 )(({ theme, styleProps }) => {
   const light = theme.palette.mode === 'light';
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
@@ -98,6 +104,12 @@ const InputRoot = experimentalStyled(
   };
 });
 
+const InputInput = experimentalStyled(
+  InputBaseInput,
+  {},
+  { name: 'MuiInput', slot: 'Input', overridesResolver: inputBaseInputOverridesResolver },
+)({});
+
 const Input = React.forwardRef(function Input(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiInput' });
   const {
@@ -115,7 +127,7 @@ const Input = React.forwardRef(function Input(inProps, ref) {
 
   return (
     <InputBase
-      components={{ Root: InputRoot }}
+      components={{ Root: InputRoot, Input: InputInput }}
       componentsProps={{ root: { styleProps } }}
       fullWidth={fullWidth}
       inputComponent={inputComponent}

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -10,7 +10,7 @@ import {
   rootOverridesResolver as inputBaseRootOverridesResolver,
   inputOverridesResolver as inputBaseInputOverridesResolver,
   InputBaseRoot,
-  InputBaseInput,
+  InputBaseComponent as InputBaseInput,
 } from '../InputBase/InputBase';
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType, elementTypeAcceptingRef, deepmerge } from '@material-ui/utils';
+import { refType, elementTypeAcceptingRef } from '@material-ui/utils';
 import MuiError from '@material-ui/utils/macros/MuiError.macro';
 import { unstable_composeClasses as composeClasses, isHostComponent } from '@material-ui/unstyled';
 import formControlState from '../FormControl/formControlState';
@@ -16,32 +16,35 @@ import GlobalStyles from '../GlobalStyles';
 import { isFilled } from './utils';
 import inputBaseClasses, { getInputBaseUtilityClass } from './inputBaseClasses';
 
-export const overridesResolver = (props, styles) => {
+export const rootOverridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(
-    {
-      ...(styleProps.formControl && styles.formControl),
-      ...(styleProps.startAdornment && styles.adornedStart),
-      ...(styleProps.endAdornment && styles.adornedEnd),
-      ...(styleProps.error && styles.error),
-      ...(styleProps.size === 'small' && styles.sizeSmall),
-      ...(styleProps.multiline && styles.multiline),
-      ...(styleProps.color && styles[`color${capitalize(styleProps.color)}`]),
-      ...(styleProps.fullWidth && styles.fullWidth),
-      ...(styleProps.hiddenLabel && styles.hiddenLabel),
-      [`& .${inputBaseClasses.input}`]: {
-        ...styles.input,
-        ...(styleProps.size === 'small' && styles.inputSizeSmall),
-        ...(styleProps.multiline && styles.inputMultiline),
-        ...(styleProps.type === 'search' && styles.inputTypeSearch),
-        ...(styleProps.startAdornment && styles.inputAdornedStart),
-        ...(styleProps.endAdornment && styles.inputAdornedEnd),
-        ...(styleProps.hiddenLabel && styles.inputHiddenLabel),
-      },
-    },
-    styles.root || {},
-  );
+  return {
+    ...styles.root,
+    ...(styleProps.formControl && styles.formControl),
+    ...(styleProps.startAdornment && styles.adornedStart),
+    ...(styleProps.endAdornment && styles.adornedEnd),
+    ...(styleProps.error && styles.error),
+    ...(styleProps.size === 'small' && styles.sizeSmall),
+    ...(styleProps.multiline && styles.multiline),
+    ...(styleProps.color && styles[`color${capitalize(styleProps.color)}`]),
+    ...(styleProps.fullWidth && styles.fullWidth),
+    ...(styleProps.hiddenLabel && styles.hiddenLabel),
+  };
+};
+
+export const inputOverridesResolver = (props, styles) => {
+  const { styleProps } = props;
+
+  return {
+    ...styles.input,
+    ...(styleProps.size === 'small' && styles.inputSizeSmall),
+    ...(styleProps.multiline && styles.inputMultiline),
+    ...(styleProps.type === 'search' && styles.inputTypeSearch),
+    ...(styleProps.startAdornment && styles.inputAdornedStart),
+    ...(styleProps.endAdornment && styles.inputAdornedEnd),
+    ...(styleProps.hiddenLabel && styles.inputHiddenLabel),
+  };
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -96,7 +99,7 @@ export const InputBaseRoot = experimentalStyled(
   {
     name: 'MuiInputBase',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: rootOverridesResolver,
   },
 )(({ theme, styleProps }) => ({
   ...theme.typography.body1,
@@ -128,6 +131,7 @@ export const InputBaseComponent = experimentalStyled(
   {
     name: 'MuiInputBase',
     slot: 'Input',
+    overridesResolver: inputOverridesResolver,
   },
 )(({ theme, styleProps }) => {
   const light = theme.palette.mode === 'light';

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -38,8 +38,8 @@ const InputLabelRoot = experimentalStyled(
     overridesResolver: (props, styles) => {
       const { styleProps } = props;
       return {
-        ...styles.root,
         [`& .${formLabelClasses.asterisk}`]: styles.asterisk,
+        ...styles.root,
         ...(!styleProps.formControl && styles.formControl),
         ...(styleProps.size === 'small' && styles.sizeSmall),
         ...(styleProps.shrink && styles.shrink),

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
@@ -8,21 +7,6 @@ import FormLabel, { formLabelClasses } from '../FormLabel';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled, { rootShouldForwardProp } from '../styles/experimentalStyled';
 import { getInputLabelUtilityClasses } from './inputLabelClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(
-    {
-      ...(!styleProps.formControl && styles.formControl),
-      ...(styleProps.size === 'small' && styles.sizeSmall),
-      ...(styleProps.shrink && styles.shrink),
-      ...(!styleProps.disableAnimation && styles.animated),
-      ...styles[styleProps.variant],
-      [`& .${formLabelClasses.asterisk}`]: styles.asterisk,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, formControl, size, shrink, disableAnimation, variant } = styleProps;
@@ -48,7 +32,22 @@ const useUtilityClasses = (styleProps) => {
 const InputLabelRoot = experimentalStyled(
   FormLabel,
   { shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes' },
-  { name: 'MuiInputLabel', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiInputLabel',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.root,
+        [`& .${formLabelClasses.asterisk}`]: styles.asterisk,
+        ...(!styleProps.formControl && styles.formControl),
+        ...(styleProps.size === 'small' && styles.sizeSmall),
+        ...(styleProps.shrink && styles.shrink),
+        ...(!styleProps.disableAnimation && styles.animated),
+        ...styles[styleProps.variant],
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   display: 'block',
   transformOrigin: 'top left',

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -15,7 +15,6 @@ describe('<ListItemText />', () => {
     render,
     muiName: 'MuiListItemText',
     testVariantProps: { inset: true },
-    testDeepOverrides: { slotName: 'primary', slotClassName: classes.primary },
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp'],
   }));

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -15,6 +15,7 @@ describe('<ListItemText />', () => {
     render,
     muiName: 'MuiListItemText',
     testVariantProps: { inset: true },
+    testDeepOverrides: { slotName: 'primary', slotClassName: classes.primary },
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp'],
   }));

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { deepmerge, refType } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import NotchedOutline from './NotchedOutline';
 import experimentalStyled, { rootShouldForwardProp } from '../styles/experimentalStyled';
 import outlinedInputClasses, { getOutlinedInputUtilityClass } from './outlinedInputClasses';
 import InputBase, {
-  overridesResolver as inputBaseOverridesResolver,
+  rootOverridesResolver as inputBaseRootOverridesResolver,
+  inputOverridesResolver as inputBaseInputOverridesResolver,
   InputBaseRoot,
   InputBaseComponent as InputBaseInput,
 } from '../InputBase/InputBase';
 import useThemeProps from '../styles/useThemeProps';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(inputBaseOverridesResolver(props, styles), {
-    ...styles.notchedOutline,
-  });
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -38,7 +33,16 @@ const useUtilityClasses = (styleProps) => {
 const OutlinedInputRoot = experimentalStyled(
   InputBaseRoot,
   { shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes' },
-  { name: 'MuiOutlinedInput', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiOutlinedInput',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      return {
+        ...inputBaseRootOverridesResolver(props, styles),
+        ...styles.notchedOutline,
+      };
+    },
+  },
 )(({ theme, styleProps }) => {
   const borderColor =
     theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
@@ -82,7 +86,11 @@ const OutlinedInputRoot = experimentalStyled(
 const NotchedOutlineRoot = experimentalStyled(
   NotchedOutline,
   {},
-  { name: 'MuiOutlinedInput', slot: 'NotchedOutline' },
+  {
+    name: 'MuiOutlinedInput',
+    slot: 'NotchedOutline',
+    overridesResolver: inputBaseInputOverridesResolver,
+  },
 )(({ theme }) => ({
   borderColor: theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)',
 }));

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -36,12 +36,7 @@ const OutlinedInputRoot = experimentalStyled(
   {
     name: 'MuiOutlinedInput',
     slot: 'Root',
-    overridesResolver: (props, styles) => {
-      return {
-        ...inputBaseRootOverridesResolver(props, styles),
-        ...styles.notchedOutline,
-      };
-    },
+    overridesResolver: inputBaseRootOverridesResolver,
   },
 )(({ theme, styleProps }) => {
   const borderColor =
@@ -89,7 +84,7 @@ const NotchedOutlineRoot = experimentalStyled(
   {
     name: 'MuiOutlinedInput',
     slot: 'NotchedOutline',
-    overridesResolver: inputBaseInputOverridesResolver,
+    overridesResolver: (props, styles) => styles.notchedOutline,
   },
 )(({ theme }) => ({
   borderColor: theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)',
@@ -98,7 +93,7 @@ const NotchedOutlineRoot = experimentalStyled(
 const OutlinedInputInput = experimentalStyled(
   InputBaseInput,
   {},
-  { name: 'MuiOutlinedInput', slot: 'Input' },
+  { name: 'MuiOutlinedInput', slot: 'Input', overridesResolver: inputBaseInputOverridesResolver },
 )(({ theme, styleProps }) => ({
   padding: '16.5px 14px',
   '&:-webkit-autofill': {


### PR DESCRIPTION
Updates component starting with `[E-I]` + `OutlinedInput` to use the `overridesResolver` on the slots components

Part 1: #25853
Part 2: #25864
Part 3: #25881