### PR TITLE
[system] Add missing `main` entry for styleFunctionSx

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -48,7 +48,7 @@ async function run(argv) {
     .filter((file) => {
       return path.basename(file, path.extname(file)) !== 'index';
     });
-  const topLevelPathImportsArePackages = topLevelNonIndexFiles.length === 0;
+  const topLevelPathImportsCanBePackages = topLevelNonIndexFiles.length === 0;
 
   const outDir = path.resolve(
     relativeOutDir,
@@ -60,9 +60,9 @@ async function run(argv) {
     // Different extensions are not viable yet since they require additional bundler config for users and additional transpilation steps in our repo.
     // Switch to `exports` field in v6.
     {
-      node: topLevelPathImportsArePackages ? './node' : './',
+      node: topLevelPathImportsCanBePackages ? './node' : './',
       modern: './modern',
-      stable: topLevelPathImportsArePackages ? './' : './esm',
+      stable: topLevelPathImportsCanBePackages ? './' : './esm',
       legacy: './legacy',
     }[bundle],
   );


### PR DESCRIPTION
We should've verified these entries to begin with (happy-path fallacy). 

Can't wait to use `exports` field and get rid of all the aliasing and path shenanigans.

## Test plan

- [x] CI fails without fix: https://github.com/mui-org/material-ui/pull/25885/checks?check_run_id=2409374000#step:6:153
- [x] CI green with fix
