### PR TITLE
[core] Update slot components to use overridesResolver part 5

### DIFF
--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { keyframes, css } from '@material-ui/styled-engine';
 import capitalize from '../utils/capitalize';
@@ -9,7 +8,7 @@ import { darken, lighten } from '../styles/colorManipulator';
 import useTheme from '../styles/useTheme';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
-import linearProgressClasses, { getLinearProgressUtilityClass } from './linearProgressClasses';
+import { getLinearProgressUtilityClass } from './linearProgressClasses';
 
 const TRANSITION_DURATION = 4; // seconds
 const indeterminate1Keyframe = keyframes`
@@ -63,35 +62,6 @@ const bufferKeyframe = keyframes`
   }
 `;
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(styles.root || {}, {
-    ...styles[`color${capitalize(styleProps.color)}`],
-    ...styles[styleProps.variant],
-    [`& .${linearProgressClasses.dashed}`]: styleProps.variant === 'buffer' && {
-      ...styles.dashed,
-      ...styles[`dashedColor${capitalize(styleProps.color)}`],
-    },
-    [`& .${linearProgressClasses.bar}`]: {
-      ...styles.bar,
-      ...styles[`barColor${capitalize(styleProps.color)}`],
-    },
-    [`& .${linearProgressClasses.bar1Indeterminate}`]:
-      (styleProps.variant === 'indeterminate' || styleProps.variant === 'query') &&
-      styles.bar1Indeterminate,
-    [`& .${linearProgressClasses.bar1Determinate}`]:
-      styleProps.variant === 'determinate' && styles.bar1Determinate,
-    [`& .${linearProgressClasses.bar1Buffer}`]:
-      styleProps.variant === 'buffer' && styles.bar1Buffer,
-    [`& .${linearProgressClasses.bar2Indeterminate}`]:
-      (styleProps.variant === 'indeterminate' || styleProps.variant === 'query') &&
-      styles.bar2Indeterminate,
-    [`& .${linearProgressClasses.bar2Buffer}`]:
-      styleProps.variant === 'buffer' && styles.bar2Buffer,
-  });
-};
-
 const useUtilityClasses = (styleProps) => {
   const { classes, variant, color } = styleProps;
 
@@ -132,7 +102,15 @@ const LinearProgressRoot = experimentalStyled(
   {
     name: 'MuiLinearProgress',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`color${capitalize(styleProps.color)}`],
+        ...styles[styleProps.variant],
+      };
+    },
   },
 )(({ styleProps, theme }) => ({
   /* Styles applied to the root element. */
@@ -171,6 +149,14 @@ const LinearProgressDashed = experimentalStyled(
   {
     name: 'MuiLinearProgress',
     slot: 'Dashed',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.dashed,
+        ...styles[`dashedColor${capitalize(styleProps.color)}`],
+      };
+    },
   },
 )(
   ({ styleProps, theme }) => {
@@ -201,6 +187,18 @@ const LinearProgressBar1 = experimentalStyled(
   {
     name: 'MuiLinearProgress',
     slot: 'Bar1',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.bar,
+        ...styles[`barColor${capitalize(styleProps.color)}`],
+        ...((styleProps.variant === 'indeterminate' || styleProps.variant === 'query') &&
+          styles.bar1Indeterminate),
+        ...(styleProps.variant === 'determinate' && styles.bar1Determinate),
+        ...(styleProps.variant === 'buffer' && styles.bar1Buffer),
+      };
+    },
   },
 )(
   ({ styleProps, theme }) => ({
@@ -239,6 +237,17 @@ const LinearProgressBar2 = experimentalStyled(
   {
     name: 'MuiLinearProgress',
     slot: 'Bar2',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.bar,
+        ...styles[`barColor${capitalize(styleProps.color)}`],
+        ...((styleProps.variant === 'indeterminate' || styleProps.variant === 'query') &&
+          styles.bar2Indeterminate),
+        ...(styleProps.variant === 'buffer' && styles.bar2Buffer),
+      };
+    },
   },
 )(
   ({ styleProps, theme }) => ({

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge, elementTypeAcceptingRef } from '@material-ui/utils';
+import { elementTypeAcceptingRef } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import capitalize from '../utils/capitalize';
 import experimentalStyled from '../styles/experimentalStyled';
@@ -10,18 +10,6 @@ import useIsFocusVisible from '../utils/useIsFocusVisible';
 import useForkRef from '../utils/useForkRef';
 import Typography from '../Typography';
 import linkClasses, { getLinkUtilityClass } from './linkClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`underline${capitalize(styleProps.underline)}`],
-      ...(styleProps.component === 'button' && styles.button),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, component, focusVisible, underline } = styleProps;
@@ -44,7 +32,15 @@ const LinkRoot = experimentalStyled(
   {
     name: 'MuiLink',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`underline${capitalize(styleProps.underline)}`],
+        ...(styleProps.component === 'button' && styles.button),
+      };
+    },
   },
 )(({ styleProps }) => {
   return {

--- a/packages/material-ui/src/List/List.js
+++ b/packages/material-ui/src/List/List.js
@@ -1,25 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import ListContext from './ListContext';
 import { getListUtilityClass } from './listClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.disablePadding && styles.padding),
-      ...(styleProps.dense && styles.dense),
-      ...(styleProps.subheader && styles.subheader),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disablePadding, dense, subheader } = styleProps;
@@ -37,7 +23,16 @@ const ListRoot = experimentalStyled(
   {
     name: 'MuiList',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(!styleProps.disablePadding && styles.padding),
+        ...(styleProps.dense && styles.dense),
+        ...(styleProps.subheader && styles.subheader),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses, isHostComponent } from '@material-ui/unstyled';
-import { deepmerge, chainPropTypes, elementTypeAcceptingRef } from '@material-ui/utils';
+import { chainPropTypes, elementTypeAcceptingRef } from '@material-ui/utils';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { alpha } from '../styles/colorManipulator';
@@ -16,17 +16,15 @@ import listItemClasses, { getListItemUtilityClass } from './listItemClasses';
 export const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(
-    {
-      ...(styleProps.dense && styles.dense),
-      ...(styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart),
-      ...(styleProps.divider && styles.divider),
-      ...(!styleProps.disableGutters && styles.gutters),
-      ...(styleProps.button && styles.button),
-      ...(styleProps.hasSecondaryAction && styles.secondaryAction),
-    },
-    styles.root || {},
-  );
+  return {
+    ...styles.root,
+    ...(styleProps.dense && styles.dense),
+    ...(styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart),
+    ...(styleProps.divider && styles.divider),
+    ...(!styleProps.disableGutters && styles.gutters),
+    ...(styleProps.button && styles.button),
+    ...(styleProps.hasSecondaryAction && styles.secondaryAction),
+  };
 };
 
 const useUtilityClasses = (styleProps) => {

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
@@ -1,23 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import ListContext from '../List/ListContext';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getListItemAvatarUtilityClass } from './listItemAvatarClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { alignItems, classes } = styleProps;
@@ -35,7 +23,14 @@ const ListItemAvatarRoot = experimentalStyled(
   {
     name: 'MuiListItemAvatar',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -1,23 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getListItemIconUtilityClass } from './listItemIconClasses';
 import ListContext from '../List/ListContext';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { alignItems, classes } = styleProps;
@@ -35,7 +23,14 @@ const ListItemIconRoot = experimentalStyled(
   {
     name: 'MuiListItemIcon',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -1,23 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import ListContext from '../List/ListContext';
 import { getListItemSecondaryActionClassesUtilityClass } from './listItemSecondaryActionClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.disableGutters && styles.disableGutters),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { disableGutters, classes } = styleProps;
@@ -35,7 +23,14 @@ const ListItemSecondaryActionRoot = experimentalStyled(
   {
     name: 'MuiListItemSecondaryAction',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.disableGutters && styles.disableGutters),
+      };
+    },
   },
 )(({ styleProps }) => ({
   position: 'absolute',

--- a/packages/material-ui/src/ListItemText/ListItemText.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.js
@@ -1,28 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Typography from '../Typography';
 import ListContext from '../List/ListContext';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import listItemTextClasses, { getListItemTextUtilityClass } from './listItemTextClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.inset && styles.inset),
-      ...(styleProps.primary && styleProps.secondary && styles.multiline),
-      ...(styleProps.dense && styles.dense),
-      [`& .${listItemTextClasses.primary}`]: styles.primary,
-      [`& .${listItemTextClasses.secondary}`]: styles.secondary,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, inset, primary, secondary, dense } = styleProps;
@@ -42,7 +26,18 @@ const ListItemTextRoot = experimentalStyled(
   {
     name: 'MuiListItemText',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${listItemTextClasses.primary}`]: styles.primary,
+        [`& .${listItemTextClasses.secondary}`]: styles.secondary,
+        ...styles.root,
+        ...(styleProps.inset && styles.inset),
+        ...(styleProps.primary && styleProps.secondary && styles.multiline),
+        ...(styleProps.dense && styles.dense),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -15,7 +15,6 @@ describe('<ListItemText />', () => {
     render,
     muiName: 'MuiListItemText',
     testVariantProps: { inset: true },
-    testDeepOverrides: { slotName: 'primary', slotClassName: classes.primary },
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp'],
   }));

--- a/packages/material-ui/src/ListSubheader/ListSubheader.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.js
@@ -1,26 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import { getListSubheaderUtilityClass } from './listSubheaderClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
-      ...(!styleProps.disableGutters && styles.gutters),
-      ...(styleProps.inset && styles.inset),
-      ...(!styleProps.disableSticky && styles.sticky),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, color, disableGutters, inset, disableSticky } = styleProps;
@@ -44,7 +29,17 @@ const ListSubheaderRoot = experimentalStyled(
   {
     name: 'MuiListSubheader',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
+        ...(!styleProps.disableGutters && styles.gutters),
+        ...(styleProps.inset && styles.inset),
+        ...(!styleProps.disableSticky && styles.sticky),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -3,13 +3,13 @@ import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge, HTMLElementType } from '@material-ui/utils';
+import { HTMLElementType } from '@material-ui/utils';
 import MenuList from '../MenuList';
 import Paper from '../Paper';
 import Popover from '../Popover';
 import experimentalStyled, { rootShouldForwardProp } from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
-import menuClasses, { getMenuUtilityClass } from './menuClasses';
+import { getMenuUtilityClass } from './menuClasses';
 
 const RTL_ORIGIN = {
   vertical: 'top',
@@ -19,16 +19,6 @@ const RTL_ORIGIN = {
 const LTR_ORIGIN = {
   vertical: 'top',
   horizontal: 'left',
-};
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(
-    {
-      [`& .${menuClasses.paper}`]: styles.paper,
-      [`& .${menuClasses.list}`]: styles.list,
-    },
-    styles.root || {},
-  );
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -49,7 +39,7 @@ const MenuRoot = experimentalStyled(
   {
     name: 'MuiMenu',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({});
 
@@ -59,6 +49,7 @@ const MenuPaper = experimentalStyled(
   {
     name: 'MuiMenu',
     slot: 'Paper',
+    overridesResolver: (props, styles) => styles.paper,
   },
 )({
   // specZ: The maximum height of a simple menu should be one or more rows less than the view
@@ -75,6 +66,7 @@ const MenuMenuList = experimentalStyled(
   {
     name: 'MuiMenu',
     slot: 'List',
+    overridesResolver: (props, styles) => styles.list,
   },
 )({
   // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { deepmerge } from '@material-ui/utils';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
@@ -8,13 +7,6 @@ import useThemeProps from '../styles/useThemeProps';
 import { getMenuItemUtilityClass } from './menuItemClasses';
 import ListItem from '../ListItem';
 import { overridesResolver as listItemOverridesResolver, ListItemRoot } from '../ListItem/ListItem';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(listItemOverridesResolver(props, styles), {
-    ...(styleProps.dense && styles.dense),
-  });
-};
 
 const useUtilityClasses = (styleProps) => {
   const { selected, dense, classes } = styleProps;
@@ -31,7 +23,13 @@ const MenuItemRoot = experimentalStyled(
   {
     name: 'MuiMenuItem',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...listItemOverridesResolver(props, styles),
+        ...(styleProps.dense && styles.dense),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   ...theme.typography.body1,

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { integerPropType, deepmerge } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Paper from '../Paper';
 import capitalize from '../utils/capitalize';
@@ -9,25 +9,7 @@ import LinearProgress from '../LinearProgress';
 
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
-import mobileStepperClasses, { getMobileStepperUtilityClass } from './mobileStepperClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`position${capitalize(styleProps.position)}`],
-      [`& .${mobileStepperClasses.dots}`]: styles.dots,
-      [`& .${mobileStepperClasses.dot}`]: {
-        ...styles.dot,
-        ...(styleProps.dotActive && styles.dotActive),
-      },
-      [`& .${mobileStepperClasses.dotActive}`]: styles.dotActive,
-      [`& .${mobileStepperClasses.progress}`]: styles.progress,
-    },
-    styles.root || {},
-  );
-};
+import { getMobileStepperUtilityClass } from './mobileStepperClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { classes, position } = styleProps;
@@ -49,7 +31,14 @@ const MobileStepperRoot = experimentalStyled(
   {
     name: 'MuiMobileStepper',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`position${capitalize(styleProps.position)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -80,7 +69,7 @@ const MobileStepperRoot = experimentalStyled(
 const MobileStepperDots = experimentalStyled(
   'div',
   {},
-  { name: 'MuiMobileStepper', slot: 'Dots' },
+  { name: 'MuiMobileStepper', slot: 'Dots', overridesResolver: (props, styles) => styles.dots },
 )(({ styleProps }) => ({
   /* Styles applied to the dots container if `variant="dots"`. */
   ...(styleProps.variant === 'dots' && {
@@ -92,7 +81,18 @@ const MobileStepperDots = experimentalStyled(
 const MobileStepperDot = experimentalStyled(
   'div',
   {},
-  { name: 'MuiMobileStepper', slot: 'Dot' },
+  {
+    name: 'MuiMobileStepper',
+    slot: 'Dot',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.dot,
+        ...(styleProps.dotActive && styles.dotActive),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   /* Styles applied to each dot if `variant="dots"`. */
   ...(styleProps.variant === 'dots' && {
@@ -114,7 +114,11 @@ const MobileStepperDot = experimentalStyled(
 const MobileStepperProgress = experimentalStyled(
   LinearProgress,
   {},
-  { name: 'MuiMobileStepper', slot: 'Progress' },
+  {
+    name: 'MuiMobileStepper',
+    slot: 'Progress',
+    overridesResolver: (props, styles) => styles.progress,
+  },
 )(({ styleProps }) => ({
   /* Styles applied to the Linear Progress component if `variant="progress"`. */
   ...(styleProps.variant === 'progress' && {

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -1,24 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { isHostComponent } from '@material-ui/unstyled';
-import { deepmerge, elementAcceptingRef, HTMLElementType } from '@material-ui/utils';
+import { elementAcceptingRef, HTMLElementType } from '@material-ui/utils';
 import ModalUnstyled, { modalUnstyledClasses } from '@material-ui/unstyled/ModalUnstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import Backdrop from '../Backdrop';
 
 export const modalClasses = modalUnstyledClasses;
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.open && styleProps.exited && styles.hidden),
-    },
-    styles.root || {},
-  );
-};
 
 const extendUtilityClasses = (styleProps) => {
   return styleProps.classes;
@@ -30,7 +19,14 @@ const ModalRoot = experimentalStyled(
   {
     name: 'MuiModal',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(!styleProps.open && styleProps.exited && styles.hidden),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType, deepmerge } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import capitalize from '../utils/capitalize';
 import nativeSelectClasses, { getNativeSelectUtilityClasses } from './nativeSelectClasses';
@@ -10,13 +10,11 @@ import experimentalStyled from '../styles/experimentalStyled';
 const overridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(
-    {
-      ...styles.select,
-      ...styles[styleProps.variant],
-    },
-    styles.root || {},
-  );
+  return {
+    ...styles.root,
+    ...styles.select,
+    ...styles[styleProps.variant],
+  };
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -86,13 +84,11 @@ const NativeSelectRoot = experimentalStyled(
 
 const iconOverridesResolver = (props, styles) => {
   const { styleProps } = props;
-  return deepmerge(
-    {
-      ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
-      ...(styleProps.open && styles.iconOpen),
-    },
-    styles.icon || {},
-  );
+  return {
+    ...styles.icon,
+    ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
+    ...(styleProps.open && styles.iconOpen),
+  };
 };
 
 export const nativeSelectIconStyles = ({ styleProps, theme }) => ({

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -7,16 +7,6 @@ import capitalize from '../utils/capitalize';
 import nativeSelectClasses, { getNativeSelectUtilityClasses } from './nativeSelectClasses';
 import experimentalStyled from '../styles/experimentalStyled';
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return {
-    ...styles.root,
-    ...styles.select,
-    ...styles[styleProps.variant],
-  };
-};
-
 const useUtilityClasses = (styleProps) => {
   const { classes, variant, disabled, open } = styleProps;
 
@@ -79,17 +69,20 @@ export const nativeSelectRootStyles = ({ styleProps, theme }) => ({
 const NativeSelectRoot = experimentalStyled(
   'select',
   {},
-  { name: 'MuiNativeSelect', slot: 'Root', overridesResolver },
-)(nativeSelectRootStyles);
+  {
+    name: 'MuiNativeSelect',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
 
-const iconOverridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return {
-    ...styles.icon,
-    ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
-    ...(styleProps.open && styles.iconOpen),
-  };
-};
+      return {
+        ...styles.root,
+        ...styles.select,
+        ...styles[styleProps.variant],
+      };
+    },
+  },
+)(nativeSelectRootStyles);
 
 export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
   // We use a position absolute over a flexbox in order to forward the pointer events
@@ -116,7 +109,18 @@ export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
 const NativeSelectIcon = experimentalStyled(
   'svg',
   {},
-  { name: 'MuiNativeSelect', slot: 'Icon', overridesResolver: iconOverridesResolver },
+  {
+    name: 'MuiNativeSelect',
+    slot: 'Icon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.icon,
+        ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
+        ...(styleProps.open && styles.iconOpen),
+      };
+    },
+  },
 )(nativeSelectIconStyles);
 
 /**


### PR DESCRIPTION
Updates component starting with `[J-O]` to use the `overridesResolver` on the slots components

Part 1: #25853
Part 2: #25864
Part 3: #25881
Part 4: #25884