### PR TITLE
[TextField] Make the `position` prop required in InputAdornment

### DIFF
--- a/docs/pages/api-docs/input-adornment.json
+++ b/docs/pages/api-docs/input-adornment.json
@@ -1,11 +1,14 @@
 {
   "props": {
+    "position": {
+      "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" },
+      "required": true
+    },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
     "disablePointerEvents": { "type": { "name": "bool" } },
     "disableTypography": { "type": { "name": "bool" } },
-    "position": { "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" } },
     "sx": { "type": { "name": "object" } },
     "variant": {
       "type": {

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1236,6 +1236,15 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Input size="small" />
   ```
 
+- Set the InputAdornment `position` prop to `start` or `end`. Use `start` if used as the value of the `startAdornment` prop. Use `end` if used as the value of the `endAdornment` prop.
+
+  ```diff
+  -<TextField endAdornment={<InputAdornment>Kg</InputAdornment>} />
+  +<TextField endAdornment={<InputAdornment position="end">Kg</InputAdornment>} />
+  -<TextField startAdornment={<InputAdornment>Kg</InputAdornment>} />
+  +<TextField startAdornment={<InputAdornment position="start">Kg</InputAdornment>} />
+  ```
+
 ### TextareaAutosize
 
 - Remove the `rows` prop, use the `minRows` prop instead.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1239,10 +1239,10 @@ As the core components use emotion as a styled engine, the props used by emotion
 - Set the InputAdornment `position` prop to `start` or `end`. Use `start` if used as the value of the `startAdornment` prop. Use `end` if used as the value of the `endAdornment` prop.
 
   ```diff
-  -<TextField endAdornment={<InputAdornment>Kg</InputAdornment>} />
-  +<TextField endAdornment={<InputAdornment position="end">Kg</InputAdornment>} />
   -<TextField startAdornment={<InputAdornment>Kg</InputAdornment>} />
+  -<TextField endAdornment={<InputAdornment>Kg</InputAdornment>} />
   +<TextField startAdornment={<InputAdornment position="start">Kg</InputAdornment>} />
+  +<TextField endAdornment={<InputAdornment position="end">Kg</InputAdornment>} />
   ```
 
 ### TextareaAutosize

--- a/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
@@ -42,7 +42,7 @@ export interface InputAdornmentTypeMap<P = {}, D extends React.ElementType = 'di
     /**
      * The position this adornment should appear relative to the `Input`.
      */
-    position?: 'start' | 'end';
+    position: 'start' | 'end';
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -180,7 +180,7 @@ InputAdornment.propTypes /* remove-proptypes */ = {
   /**
    * The position this adornment should appear relative to the `Input`.
    */
-  position: PropTypes.oneOf(['end', 'start']),
+  position: PropTypes.oneOf(['end', 'start']).isRequired,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012