### PR TITLE
[core] Update slot components to use overridesResolver part 6

### DIFF
--- a/packages/material-ui/src/Pagination/Pagination.js
+++ b/packages/material-ui/src/Pagination/Pagination.js
@@ -2,24 +2,12 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import useThemeProps from '../styles/useThemeProps';
-import paginationClasses, { getPaginationUtilityClass } from './paginationClasses';
+import { getPaginationUtilityClass } from './paginationClasses';
 import usePagination from '../usePagination';
 import PaginationItem from '../PaginationItem';
 import experimentalStyled from '../styles/experimentalStyled';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      [`& .${paginationClasses.ul}`]: styles.ul,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, variant } = styleProps;
@@ -38,7 +26,14 @@ const PaginationRoot = experimentalStyled(
   {
     name: 'MuiPagination',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+      };
+    },
   },
 )({});
 
@@ -48,6 +43,7 @@ const PaginationUl = experimentalStyled(
   {
     name: 'MuiPagination',
     slot: 'Ul',
+    overridesResolver: (props, styles) => styles.ul,
   },
 )({
   display: 'flex',

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import paginationItemClasses, { getPaginationItemUtilityClass } from './paginationItemClasses';
@@ -15,24 +14,22 @@ import NavigateBeforeIcon from '../internal/svg-icons/NavigateBefore';
 import NavigateNextIcon from '../internal/svg-icons/NavigateNext';
 import experimentalStyled from '../styles/experimentalStyled';
 
-const overridesResolver = (props, styles) => {
+const rootOverridesResolver = (props, styles) => {
   const { styleProps } = props;
 
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...styles[`size${capitalize(styleProps.size)}`],
-      ...(styleProps.variant === 'text' && styles[`text${capitalize(styleProps.color)}`]),
-      ...(styleProps.variant === 'outlined' && styles[`outlined${capitalize(styleProps.color)}`]),
-      ...(styleProps.shape === 'rounded' && styles.rounded),
-      [`&.${paginationItemClasses.ellipsis}`]: styles.ellipsis,
-      [`&.${paginationItemClasses.previousLast}`]: styles.previousLast,
-      [`&.${paginationItemClasses.firstLast}`]: styles.firstLast,
-      [`&.${paginationItemClasses.page}`]: styles.page,
-      [`& .${paginationItemClasses.icon}`]: styles.icon,
-    },
-    styles.root || {},
-  );
+  return {
+    ...styles.root,
+    ...styles[styleProps.variant],
+    ...styles[`size${capitalize(styleProps.size)}`],
+    ...(styleProps.variant === 'text' && styles[`text${capitalize(styleProps.color)}`]),
+    ...(styleProps.variant === 'outlined' && styles[`outlined${capitalize(styleProps.color)}`]),
+    ...(styleProps.shape === 'rounded' && styles.rounded),
+    ...(styleProps.type === 'page' && styles.page),
+    ...((styleProps.type === 'start-ellipsis' || styleProps.type === 'end-ellipsis') &&
+      styles.ellipsis),
+    ...((styleProps.type === 'previous' || styleProps.type === 'next') && styles.previousNext),
+    ...((styleProps.type === 'first' || styleProps.type === 'last') && styles.firstLast),
+  };
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -69,7 +66,7 @@ const PaginationItemEllipsis = experimentalStyled(
   {
     name: 'MuiPaginationItem',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: rootOverridesResolver,
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -108,7 +105,7 @@ const PaginationItemPage = experimentalStyled(
   {
     name: 'MuiPaginationItem',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: rootOverridesResolver,
   },
 )(
   ({ theme, styleProps }) => ({
@@ -255,6 +252,7 @@ const PaginationItemPageIcon = experimentalStyled(
   {
     name: 'MuiPaginationItem',
     slot: 'Icon',
+    overridesResolver: (props, styles) => styles.icon,
   },
 )(({ theme, styleProps }) => ({
   fontSize: theme.typography.pxToRem(20),

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, integerPropType, deepmerge } from '@material-ui/utils';
+import { chainPropTypes, integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -18,19 +18,6 @@ const getOverlayAlpha = (elevation) => {
     alphaValue = 4.5 * Math.log(elevation + 1) + 2;
   }
   return (alphaValue / 100).toFixed(2);
-};
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...(!styleProps.square && styles.rounded),
-      ...(styleProps.variant === 'elevation' && styles[`elevation${styleProps.elevation}`]),
-    },
-    styles.root || {},
-  );
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -54,7 +41,16 @@ const PaperRoot = experimentalStyled(
   {
     name: 'MuiPaper',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+        ...(!styleProps.square && styles.rounded),
+        ...(styleProps.variant === 'elevation' && styles[`elevation${styleProps.elevation}`]),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -5,7 +5,6 @@ import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled
 import {
   chainPropTypes,
   integerPropType,
-  deepmerge,
   elementTypeAcceptingRef,
   refType,
   HTMLElementType,
@@ -18,7 +17,7 @@ import ownerWindow from '../utils/ownerWindow';
 import Grow from '../Grow';
 import Modal from '../Modal';
 import Paper from '../Paper';
-import popoverClasses, { getPopoverUtilityClass } from './popoverClasses';
+import { getPopoverUtilityClass } from './popoverClasses';
 
 export function getOffsetTop(rect, vertical) {
   let offset = 0;
@@ -58,12 +57,6 @@ function getAnchorEl(anchorEl) {
   return typeof anchorEl === 'function' ? anchorEl() : anchorEl;
 }
 
-const overridesResolver = (props, styles) => {
-  return deepmerge(styles.root || {}, {
-    [`& .${popoverClasses.paper}`]: styles.paper,
-  });
-};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -81,7 +74,7 @@ const PopoverRoot = experimentalStyled(
   {
     name: 'MuiPopover',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({});
 
@@ -91,6 +84,7 @@ const PopoverPaper = experimentalStyled(
   {
     name: 'MuiPopover',
     slot: 'Paper',
+    overridesResolver: (props, styles) => styles.paper,
   },
 )({
   position: 'absolute',

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { deepmerge, refType } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import SwitchBase from '../internal/SwitchBase';
 import useThemeProps from '../styles/useThemeProps';
@@ -11,12 +11,6 @@ import createChainedFunction from '../utils/createChainedFunction';
 import useRadioGroup from '../RadioGroup/useRadioGroup';
 import radioClasses, { getRadioUtilityClass } from './radioClasses';
 import experimentalStyled, { rootShouldForwardProp } from '../styles/experimentalStyled';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(styles.root || {}, styles[`color${capitalize(styleProps.color)}`]);
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, color } = styleProps;
@@ -37,7 +31,14 @@ const RadioRoot = experimentalStyled(
   {
     name: 'MuiRadio',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`color${capitalize(styleProps.color)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, visuallyHidden, deepmerge } from '@material-ui/utils';
+import { chainPropTypes, visuallyHidden } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { useTheme } from '../styles';
 import {
@@ -41,27 +41,6 @@ function roundValueToPrecision(value, precision) {
   return Number(nearest.toFixed(getDecimalPrecision(precision)));
 }
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`size${capitalize(styleProps.size)}`],
-      ...(styleProps.readOnly && styles.readOnly),
-      [`& .${ratingClasses.label}`]: styles.label,
-      [`& .${ratingClasses.icon}`]: styles.icon,
-      [`& .${ratingClasses.iconEmpty}`]: styles.iconEmpty,
-      [`& .${ratingClasses.iconFilled}`]: styles.iconFilled,
-      [`& .${ratingClasses.iconHover}`]: styles.iconHover,
-      [`& .${ratingClasses.iconFocus}`]: styles.iconFocus,
-      [`& .${ratingClasses.iconActive}`]: styles.iconActive,
-      [`& .${ratingClasses.decimal}`]: styles.decimal,
-      [`& .${ratingClasses.visuallyHidden}`]: styles.visuallyHidden,
-    },
-    styles.root || {},
-  );
-};
-
 const useUtilityClasses = (styleProps) => {
   const { classes, size, readOnly, disabled, emptyValueFocused, focusVisible } = styleProps;
 
@@ -94,7 +73,16 @@ const RatingRoot = experimentalStyled(
   {
     name: 'MuiRating',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${ratingClasses.visuallyHidden}`]: styles.visuallyHidden,
+        ...styles.root,
+        ...styles[`size${capitalize(styleProps.size)}`],
+        ...(styleProps.readOnly && styles.readOnly),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -131,7 +119,7 @@ const RatingRoot = experimentalStyled(
 const RatingLabel = experimentalStyled(
   'label',
   {},
-  { name: 'MuiRating', slot: 'Label' },
+  { name: 'MuiRating', slot: 'Label', overridesResolver: (props, styles) => styles.label },
 )(({ styleProps }) => ({
   /* Styles applied to the label elements. */
   cursor: 'inherit',
@@ -148,7 +136,22 @@ const RatingLabel = experimentalStyled(
 const RatingIcon = experimentalStyled(
   'span',
   {},
-  { name: 'MuiRating', slot: 'Icon' },
+  {
+    name: 'MuiRating',
+    slot: 'Icon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.icon,
+        ...(styleProps.iconEmpty && styles.iconEmpty),
+        ...(styleProps.iconFilled && styles.iconFilled),
+        ...(styleProps.iconHover && styles.iconHover),
+        ...(styleProps.iconFocus && styles.iconFocus),
+        ...(styleProps.iconActive && styles.iconActive),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the icon wrapping elements. */
   // Fit wrapper to actual icon size.
@@ -172,7 +175,18 @@ const RatingIcon = experimentalStyled(
 const RatingDecimal = experimentalStyled(
   'span',
   {},
-  { name: 'MuiRating', slot: 'Decimal' },
+  {
+    name: 'MuiRating',
+    slot: 'Decimal',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.decimal,
+        ...(styleProps.iconActive && styles.iconActive),
+      };
+    },
+  },
 )(({ styleProps }) => ({
   /* Styles applied to the icon wrapping elements when decimals are necessary. */
   position: 'relative',

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -7,10 +7,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import { html, body } from '../CssBaseline/CssBaseline';
 import { getScopedCssBaselineUtilityClass } from './scopedCssBaselineClasses';
 
-const overridesResolver = (props, styles) => {
-  return styles.root || {};
-};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -27,7 +23,7 @@ const ScopedCssBaselineRoot = experimentalStyled(
   {
     name: 'MuiScopedCssBaseline',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -15,23 +15,25 @@ import useForkRef from '../utils/useForkRef';
 import useControlled from '../utils/useControlled';
 import selectClasses, { getSelectUtilityClasses } from './selectClasses';
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return {
-    [`&.${selectClasses.select}`]: {
-      // TODO v5: remove `root` and `selectMenu`
-      ...styles.root,
-      ...styles.select,
-      ...styles.selectMenu,
-      ...styles[styleProps.variant],
-    },
-  };
-};
-
 const SelectRoot = experimentalStyled(
   'div',
   {},
-  { name: 'MuiSelect', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiSelect',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        [`&.${selectClasses.select}`]: {
+          // TODO v5: remove `root` and `selectMenu`
+          ...styles.root,
+          ...styles.select,
+          ...styles.selectMenu,
+          ...styles[styleProps.variant],
+        },
+      };
+    },
+  },
 )(nativeSelectRootStyles, {
   // Win specificity over the input base
   [`&.${selectClasses.selectMenu}`]: {
@@ -43,19 +45,21 @@ const SelectRoot = experimentalStyled(
   },
 });
 
-const iconOverridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return {
-    ...styles.icon,
-    ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
-    ...(styleProps.open && styles.iconOpen),
-  };
-};
-
 const SelectIcon = experimentalStyled(
   'svg',
   {},
-  { name: 'MuiSelect', slot: 'Icon', overridesResolver: iconOverridesResolver },
+  {
+    name: 'MuiSelect',
+    slot: 'Icon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.icon,
+        ...(styleProps.variant && styles[`icon${capitalize(styleProps.variant)}`]),
+        ...(styleProps.open && styles.iconOpen),
+      };
+    },
+  },
 )(nativeSelectIconStyles);
 
 const SelectNativeInput = experimentalStyled(

--- a/packages/material-ui/src/Skeleton/Skeleton.js
+++ b/packages/material-ui/src/Skeleton/Skeleton.js
@@ -3,26 +3,10 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { keyframes, css } from '@material-ui/styled-engine';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import { alpha, unstable_getUnit as getUnit, unstable_toUnitless as toUnitless } from '../styles';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { getSkeletonUtilityClass } from './skeletonClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...(styleProps.animation !== false && styles[styleProps.animation]),
-      ...(styleProps.hasChildren && styles.withChildren),
-      ...(styleProps.hasChildren && !styleProps.width && styles.fitContent),
-      ...(styleProps.hasChildren && !styleProps.height && styles.heightAuto),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, variant, animation, hasChildren, width, height } = styleProps;
@@ -73,7 +57,22 @@ const waveKeyframe = keyframes`
 const SkeletonRoot = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSkeleton', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiSkeleton',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+        ...(styleProps.animation !== false && styles[styleProps.animation]),
+        ...(styleProps.hasChildren && styles.withChildren),
+        ...(styleProps.hasChildren && !styleProps.width && styles.fitContent),
+        ...(styleProps.hasChildren && !styleProps.height && styles.heightAuto),
+      };
+    },
+  },
 )(
   ({ theme, styleProps }) => {
     const radiusUnit = getUnit(theme.shape.borderRadius) || 'px';

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -48,6 +48,8 @@ export const SliderRoot = experimentalStyled(
         ...styles[`color${capitalize(styleProps.color)}`],
         ...(marked && styles.marked),
         ...(styleProps.orientation === 'vertical' && styles.vertical),
+        ...(styleProps.track === 'inverted' && styles.trackInverted),
+        ...(styleProps.track === false && styles.trackFalse),
       };
     },
   },
@@ -142,15 +144,7 @@ export const SliderTrack = experimentalStyled(
   {
     name: 'MuiSlider',
     slot: 'Track',
-    overridesResolver: (props, styles) => {
-      const { styleProps } = props;
-
-      return {
-        ...styles.track,
-        ...(styleProps.track === 'inverted' && styles.trackInverted),
-        ...(styleProps.track === false && styles.trackFalse),
-      };
-    },
+    overridesResolver: (props, styles) => styles.track,
   },
 )(({ theme, styleProps }) => ({
   display: 'block',

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes, deepmerge } from '@material-ui/utils';
+import { chainPropTypes } from '@material-ui/utils';
 import { generateUtilityClasses, isHostComponent } from '@material-ui/unstyled';
 import SliderUnstyled, {
   SliderValueLabelUnstyled,
@@ -23,50 +23,33 @@ export const sliderClasses = {
   ]),
 };
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  const marks =
-    styleProps.marksProp === true && styleProps.step !== null
-      ? [...Array(Math.floor((styleProps.max - styleProps.min) / styleProps.step) + 1)].map(
-          (_, index) => ({
-            value: styleProps.min + styleProps.step * index,
-          }),
-        )
-      : styleProps.marksProp || [];
-
-  const marked = marks.length > 0 && marks.some((mark) => mark.label);
-
-  return deepmerge(
-    {
-      ...styles[`color${capitalize(styleProps.color)}`],
-      [`&.${sliderClasses.disabled}`]: styles.disabled,
-      ...(marked && styles.marked),
-      ...(styleProps.orientation === 'vertical' && styles.vertical),
-      ...(styleProps.track === 'inverted' && styles.trackInverted),
-      ...(styleProps.track === false && styles.trackFalse),
-      [`& .${sliderClasses.rail}`]: styles.rail,
-      [`& .${sliderClasses.track}`]: styles.track,
-      [`& .${sliderClasses.mark}`]: styles.mark,
-      [`& .${sliderClasses.markLabel}`]: styles.markLabel,
-      [`& .${sliderClasses.valueLabel}`]: styles.valueLabel,
-      [`& .${sliderClasses.thumb}`]: {
-        ...styles.thumb,
-        ...styles[`thumbColor${capitalize(styleProps.color)}`],
-        [`&.${sliderClasses.disabled}`]: styles.disabled,
-      },
-    },
-    styles.root || {},
-  );
-};
-
 export const SliderRoot = experimentalStyled(
   'span',
   {},
   {
     name: 'MuiSlider',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      const marks =
+        styleProps.marksProp === true && styleProps.step !== null
+          ? [...Array(Math.floor((styleProps.max - styleProps.min) / styleProps.step) + 1)].map(
+              (_, index) => ({
+                value: styleProps.min + styleProps.step * index,
+              }),
+            )
+          : styleProps.marksProp || [];
+
+      const marked = marks.length > 0 && marks.some((mark) => mark.label);
+
+      return {
+        ...styles.root,
+        ...styles[`color${capitalize(styleProps.color)}`],
+        ...(marked && styles.marked),
+        ...(styleProps.orientation === 'vertical' && styles.vertical),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   height: 2,
@@ -135,7 +118,7 @@ export const SliderRoot = experimentalStyled(
 export const SliderRail = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Rail' },
+  { name: 'MuiSlider', slot: 'Rail', overridesResolver: (props, styles) => styles.rail },
 )(({ styleProps }) => ({
   display: 'block',
   position: 'absolute',
@@ -156,7 +139,19 @@ export const SliderRail = experimentalStyled(
 export const SliderTrack = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Track' },
+  {
+    name: 'MuiSlider',
+    slot: 'Track',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.track,
+        ...(styleProps.track === 'inverted' && styles.trackInverted),
+        ...(styleProps.track === false && styles.trackFalse),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   display: 'block',
   position: 'absolute',
@@ -184,7 +179,17 @@ export const SliderTrack = experimentalStyled(
 export const SliderThumb = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Thumb' },
+  {
+    name: 'MuiSlider',
+    slot: 'Thumb',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.thumb,
+        ...styles[`thumbColor${capitalize(styleProps.color)}`],
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 12,
@@ -250,7 +255,11 @@ export const SliderThumb = experimentalStyled(
 export const SliderValueLabel = experimentalStyled(
   SliderValueLabelUnstyled,
   {},
-  { name: 'MuiSlider', slot: 'ValueLabel' },
+  {
+    name: 'MuiSlider',
+    slot: 'ValueLabel',
+    overridesResolver: (props, styles) => styles.valueLabel,
+  },
 )(({ theme }) => ({
   // IE 11 centering bug, to remove from the customization demos once no longer supported
   left: 'calc(-50% - 4px)',
@@ -273,7 +282,7 @@ export const SliderValueLabel = experimentalStyled(
 export const SliderMark = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'Mark' },
+  { name: 'MuiSlider', slot: 'Mark', overridesResolver: (props, styles) => styles.mark },
 )(({ theme, styleProps }) => ({
   position: 'absolute',
   width: 2,
@@ -289,7 +298,7 @@ export const SliderMark = experimentalStyled(
 export const SliderMarkLabel = experimentalStyled(
   'span',
   {},
-  { name: 'MuiSlider', slot: 'MarkLabel' },
+  { name: 'MuiSlider', slot: 'MarkLabel', overridesResolver: (props, styles) => styles.markLabel },
 )(({ theme, styleProps }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -26,28 +25,24 @@ const useUtilityClasses = (styleProps) => {
   return composeClasses(slots, getSnackbarUtilityClass, classes);
 };
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[
-        `anchorOrigin${capitalize(styleProps.anchorOrigin.vertical)}${capitalize(
-          styleProps.anchorOrigin.horizontal,
-        )}`
-      ],
-    },
-    styles.root || {},
-  );
-};
-
 const SnackbarRoot = experimentalStyled(
   'div',
   {},
   {
     name: 'MuiSnackbar',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[
+          `anchorOrigin${capitalize(styleProps.anchorOrigin.vertical)}${capitalize(
+            styleProps.anchorOrigin.horizontal,
+          )}`
+        ],
+      };
+    },
   },
 )(({ theme, styleProps }) => {
   const center = {

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -1,23 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import { emphasize } from '../styles/colorManipulator';
 import Paper from '../Paper';
-import snackbarContentClasses, { getSnackbarContentUtilityClass } from './snackbarContentClasses';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(
-    {
-      [`& .${snackbarContentClasses.action}`]: styles.action,
-      [`& .${snackbarContentClasses.message}`]: styles.message,
-    },
-    styles.root || {},
-  );
-};
+import { getSnackbarContentUtilityClass } from './snackbarContentClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -37,7 +26,7 @@ const SnackbarContentRoot = experimentalStyled(
   {
     name: 'MuiSnackbarContent',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => {
   const emphasis = theme.palette.mode === 'light' ? 0.8 : 0.98;
@@ -66,6 +55,7 @@ const SnackbarContentMessage = experimentalStyled(
   {
     name: 'MuiSnackbarContent',
     slot: 'Message',
+    overridesResolver: (props, styles) => styles.message,
   },
 )({
   padding: '8px 0',
@@ -77,6 +67,7 @@ const SnackbarContentAction = experimentalStyled(
   {
     name: 'MuiSnackbarContent',
     slot: 'Action',
+    overridesResolver: (props, styles) => styles.action,
   },
 )({
   display: 'flex',

--- a/packages/material-ui/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -14,22 +13,6 @@ import isMuiElement from '../utils/isMuiElement';
 import useForkRef from '../utils/useForkRef';
 import useControlled from '../utils/useControlled';
 import speedDialClasses, { getSpeedDialUtilityClass } from './speedDialClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`direction${capitalize(styleProps.direction)}`],
-      [`& .${speedDialClasses.fab}`]: styles.fab,
-      [`& .${speedDialClasses.actions}`]: {
-        ...styles.actions,
-        ...(!styleProps.open && styles.actionsClosed),
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, open, direction } = styleProps;
@@ -72,7 +55,14 @@ const SpeedDialRoot = experimentalStyled(
   {
     name: 'MuiSpeedDial',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`direction${capitalize(styleProps.direction)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   zIndex: theme.zIndex.speedDial,
@@ -116,7 +106,7 @@ const SpeedDialRoot = experimentalStyled(
 const SpeedDialFab = experimentalStyled(
   Fab,
   {},
-  { name: 'MuiSpeedDial', slot: 'Fab' },
+  { name: 'MuiSpeedDial', slot: 'Fab', overridesResolver: (props, styles) => styles.fab },
 )(() => ({
   pointerEvents: 'auto',
 }));
@@ -124,7 +114,18 @@ const SpeedDialFab = experimentalStyled(
 const SpeedDialActions = experimentalStyled(
   'div',
   {},
-  { name: 'MuiSpeedDial', slot: 'Actions' },
+  {
+    name: 'MuiSpeedDial',
+    slot: 'Actions',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.actions,
+        ...(!styleProps.open && styles.actionsClosed),
+      };
+    },
+  },
 )(({ styleProps }) => ({
   display: 'flex',
   pointerEvents: 'auto',

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.js
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -12,30 +11,6 @@ import Fab from '../Fab';
 import Tooltip from '../Tooltip';
 import capitalize from '../utils/capitalize';
 import speedDialActionClasses, { getSpeedDialActionUtilityClass } from './speedDialActionClasses';
-
-const overridesResolverFab = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.open && styles.fabClosed),
-    },
-    styles.fab || {},
-  );
-};
-
-const overridesResolverStatic = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.open && styles.staticTooltipClosed),
-      ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
-      [`& .${speedDialActionClasses.staticTooltipLabel}`]: styles.staticTooltipLabel,
-    },
-    styles.staticTooltip || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { open, tooltipPlacement, classes } = styleProps;
@@ -60,7 +35,14 @@ const SpeedDialActionFab = experimentalStyled(
     name: 'MuiSpeedDialAction',
     slot: 'Fab',
     skipVariantsResolver: false,
-    overridesResolver: overridesResolverFab,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.fab,
+        ...(!styleProps.open && styles.fabClosed),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   margin: 8,
@@ -85,7 +67,15 @@ const SpeedDialActionStaticTooltip = experimentalStyled(
   {
     name: 'MuiSpeedDialAction',
     slot: 'StaticTooltip',
-    overridesResolver: overridesResolverStatic,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.staticTooltip,
+        ...(!styleProps.open && styles.staticTooltipClosed),
+        ...styles[`tooltipPlacement${capitalize(styleProps.tooltipPlacement)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   position: 'relative',
@@ -119,6 +109,7 @@ const SpeedDialActionStaticTooltipLabel = experimentalStyled(
   {
     name: 'MuiSpeedDialAction',
     slot: 'StaticTooltipLabel',
+    overridesResolver: (props, styles) => styles.staticTooltipLabel,
   },
 )(({ theme }) => ({
   position: 'absolute',

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.js
@@ -1,31 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import AddIcon from '../internal/svg-icons/Add';
 import speedDialIconClasses, { getSpeedDialIconUtilityClass } from './speedDialIconClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      [`& .${speedDialIconClasses.icon}`]: {
-        ...styles.icon,
-        ...(styleProps.open && styles.iconOpen),
-        ...(styleProps.open && styleProps.openIcon && styles.iconWithOpenIconOpen),
-      },
-      [`& .${speedDialIconClasses.openIcon}`]: {
-        ...styles.openIcon,
-        ...(styleProps.open && styles.openIconOpen),
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, open, openIcon } = styleProps;
@@ -45,7 +25,22 @@ const SpeedDialIconRoot = experimentalStyled(
   {
     name: 'MuiSpeedDialIcon',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${speedDialIconClasses.icon}`]: {
+          ...styles.icon,
+          ...(styleProps.open && styles.iconOpen),
+          ...(styleProps.open && styleProps.openIcon && styles.iconWithOpenIconOpen),
+        },
+        [`& .${speedDialIconClasses.openIcon}`]: {
+          ...styles.openIcon,
+          ...(styleProps.open && styles.openIconOpen),
+        },
+        ...styles.root,
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   height: 24,

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -1,26 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge, integerPropType } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from './StepContext';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getStepUtilityClass } from './stepClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.orientation],
-      ...(styleProps.alternativeLabel && styles.alternativeLabel),
-      ...(styleProps.completed && styles.completed),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, orientation, alternativeLabel, completed } = styleProps;
@@ -38,7 +25,16 @@ const StepRoot = experimentalStyled(
   {
     name: 'MuiStep',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.orientation],
+        ...(styleProps.alternativeLabel && styles.alternativeLabel),
+        ...(styleProps.completed && styles.completed),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element if `orientation="horizontal"`. */

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -11,18 +10,6 @@ import isMuiElement from '../utils/isMuiElement';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
 import stepButtonClasses, { getStepButtonUtilityClass } from './stepButtonClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.orientation],
-      [`& .${stepButtonClasses.touchRipple}`]: styles.touchRipple,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, orientation } = styleProps;
@@ -41,7 +28,15 @@ const StepButtonRoot = experimentalStyled(
   {
     name: 'MuiStepButton',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${stepButtonClasses.touchRipple}`]: styles.touchRipple,
+        ...styles.root,
+        ...styles[styleProps.orientation],
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -1,31 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import capitalize from '../utils/capitalize';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
-import stepConnectorClasses, { getStepConnectorUtilityClass } from './stepConnectorClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.orientation],
-      ...(styleProps.alternativeLabel && styles.alternativeLabel),
-      ...(styleProps.completed && styles.completed),
-      [`& .${stepConnectorClasses.line}`]: {
-        ...styles.line,
-        ...styles[`line${capitalize(styleProps.orientation)}`],
-      },
-    },
-    styles.root || {},
-  );
-};
+import { getStepConnectorUtilityClass } from './stepConnectorClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { classes, orientation, alternativeLabel, active, completed, disabled } = styleProps;
@@ -51,7 +33,16 @@ const StepConnectorRoot = experimentalStyled(
   {
     name: 'MuiStepConnector',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.orientation],
+        ...(styleProps.alternativeLabel && styles.alternativeLabel),
+        ...(styleProps.completed && styles.completed),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */
@@ -75,6 +66,14 @@ const StepConnectorLine = experimentalStyled(
   {
     name: 'MuiStepConnector',
     slot: 'Line',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.line,
+        ...styles[`line${capitalize(styleProps.orientation)}`],
+      };
+    },
   },
 )(({ styleProps, theme }) => ({
   /* Styles applied to the line element. */

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -1,26 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import Collapse from '../Collapse';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
-import stepContentClasses, { getStepContentUtilityClass } from './stepContentClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.last && styles.last),
-      [`& .${stepContentClasses.transition}`]: styles.transition,
-    },
-    styles.root || {},
-  );
-};
+import { getStepContentUtilityClass } from './stepContentClasses';
 
 const useUtilityClasses = (styleProps) => {
   const { classes, last } = styleProps;
@@ -36,7 +23,14 @@ const StepContentRoot = experimentalStyled(
   {
     name: 'MuiStepContent',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.last && styles.last),
+      };
+    },
   },
 )(({ styleProps, theme }) => ({
   /* Styles applied to the root element. */
@@ -59,6 +53,7 @@ const StepContentTransition = experimentalStyled(
   {
     name: 'MuiStepContent',
     slot: 'Transition',
+    overridesResolver: (props, styles) => styles.transition,
   },
 )();
 

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -9,15 +8,6 @@ import CheckCircle from '../internal/svg-icons/CheckCircle';
 import Warning from '../internal/svg-icons/Warning';
 import SvgIcon from '../SvgIcon';
 import stepIconClasses, { getStepIconUtilityClass } from './stepIconClasses';
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(
-    {
-      [`& .${stepIconClasses.text}`]: styles.text,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, active, completed, error } = styleProps;
@@ -36,7 +26,7 @@ const StepIconRoot = experimentalStyled(
   {
     name: 'MuiStepIcon',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => ({
   /* Styles applied to the root element. */
@@ -62,6 +52,7 @@ const StepIconText = experimentalStyled(
   {
     name: 'MuiStepIcon',
     slot: 'Text',
+    overridesResolver: (props, styles) => styles.text,
   },
 )(({ theme }) => ({
   /* Styles applied to the SVG text element. */

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -10,20 +9,6 @@ import StepIcon from '../StepIcon';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
 import stepLabelClasses, { getStepLabelUtilityClass } from './stepLabelClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.orientation],
-      [`& .${stepLabelClasses.label}`]: styles.label,
-      [`& .${stepLabelClasses.iconContainer}`]: styles.iconContainer,
-      [`& .${stepLabelClasses.labelContainer}`]: styles.labelContainer,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, orientation, active, completed, error, disabled, alternativeLabel } = styleProps;
@@ -57,7 +42,14 @@ const StepLabelRoot = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.orientation],
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */
@@ -82,6 +74,7 @@ const StepLabelLabel = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'Label',
+    overridesResolver: (props, styles) => styles.label,
   },
 )(({ theme }) => ({
   /* Styles applied to the Typography component that wraps `children`. */
@@ -111,6 +104,7 @@ const StepLabelIconContainer = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'IconContainer',
+    overridesResolver: (props, styles) => styles.iconContainer,
   },
 )(() => ({
   /* Styles applied to the `icon` container element. */
@@ -128,6 +122,7 @@ const StepLabelLabelContainer = experimentalStyled(
   {
     name: 'MuiStepLabel',
     slot: 'LabelContainer',
+    overridesResolver: (props, styles) => styles.labelContainer,
   },
 )(({ theme }) => ({
   /* Styles applied to the container element which wraps `Typography` and `optional`. */

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -1,24 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { integerPropType, deepmerge } from '@material-ui/utils';
+import { integerPropType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getStepperUtilityClass } from './stepperClasses';
 import StepConnector from '../StepConnector';
 import StepperContext from './StepperContext';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(
-    {
-      ...styles[styleProps.orientation],
-      ...(styleProps.alternativeLabel && styles.alternativeLabel),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { orientation, alternativeLabel, classes } = styleProps;
@@ -35,7 +24,14 @@ const StepperRoot = experimentalStyled(
   {
     name: 'MuiStepper',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.root,
+        ...styles[styleProps.orientation],
+        ...(styleProps.alternativeLabel && styles.alternativeLabel),
+      };
+    },
   },
 )(({ styleProps }) => ({
   display: 'flex',

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -2,23 +2,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getSvgIconUtilityClass } from './svgIconClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.color !== 'inherit' && styles[`color${capitalize(styleProps.color)}`]),
-      ...styles[`fontSize${capitalize(styleProps.fontSize)}`],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { color, fontSize, classes } = styleProps;
@@ -40,7 +27,15 @@ const SvgIconRoot = experimentalStyled(
   {
     name: 'MuiSvgIcon',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.color !== 'inherit' && styles[`color${capitalize(styleProps.color)}`]),
+        ...styles[`fontSize${capitalize(styleProps.fontSize)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType, deepmerge } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { alpha, darken, lighten } from '../styles/colorManipulator';
 import capitalize from '../utils/capitalize';
@@ -10,25 +10,6 @@ import SwitchBase from '../internal/SwitchBase';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import switchClasses, { getSwitchUtilityClass } from './switchClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.edge && styles[`edge${capitalize(styleProps.edge)}`]),
-      ...styles[`size${capitalize(styleProps.size)}`],
-      [`& .${switchClasses.switchBase}`]: {
-        ...styles.switchBase,
-        ...styles.input,
-        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
-      },
-      [`& .${switchClasses.thumb}`]: styles.thumb,
-      [`& .${switchClasses.track}`]: styles.track,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, edge, size, color, checked, disabled } = styleProps;
@@ -60,7 +41,15 @@ const SwitchRoot = experimentalStyled(
   {
     name: 'MuiSwitch',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.edge && styles[`edge${capitalize(styleProps.edge)}`]),
+        ...styles[`size${capitalize(styleProps.size)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */
@@ -108,6 +97,15 @@ const SwitchSwitchBase = experimentalStyled(
   {
     name: 'MuiSwitch',
     slot: 'SwitchBase',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.switchBase,
+        ...styles.input,
+        ...(styleProps.color !== 'default' && styles[`color${capitalize(styleProps.color)}`]),
+      };
+    },
   },
 )(
   ({ theme }) => ({
@@ -172,6 +170,7 @@ const SwitchTrack = experimentalStyled(
   {
     name: 'MuiSwitch',
     slot: 'Track',
+    overridesResolver: (props, styles) => styles.track,
   },
 )(({ theme }) => ({
   /* Styles applied to the track element. */
@@ -193,6 +192,7 @@ const SwitchThumb = experimentalStyled(
   {
     name: 'MuiSwitch',
     slot: 'Thumb',
+    overridesResolver: (props, styles) => styles.thumb,
   },
 )(({ theme }) => ({
   /* Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop. */


### PR DESCRIPTION
Updates component starting with `[P-S]` to use the `overridesResolver` on the slots components

Part 1: #25853
Part 2: #25864
Part 3: #25881
Part 4: #25884
Part 5: #25887