### PR TITLE
[theme] Remove fade color helper

### DIFF
--- a/docs/src/modules/branding/ComparisonTable.tsx
+++ b/docs/src/modules/branding/ComparisonTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { experimentalStyled as styled, fade } from '@material-ui/core/styles';
+import { experimentalStyled as styled, alpha } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import Box from '@material-ui/core/Box';
 import TableBody from '@material-ui/core/TableBody';
@@ -72,7 +72,7 @@ function PlanStatus(props: PlanStatusProps) {
       {checkIcon ? (
         <CheckIcon
           sx={{
-            bgcolor: (theme) => fade(theme.palette.primary.main, 0.2),
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.2),
             color: 'primary.main',
             borderRadius: '50%',
             p: 0.5,

--- a/packages/material-ui/src/styles/colorManipulator.d.ts
+++ b/packages/material-ui/src/styles/colorManipulator.d.ts
@@ -13,11 +13,6 @@ export function recomposeColor(color: ColorObject): string;
 export function getContrastRatio(foreground: string, background: string): number;
 export function getLuminance(color: string): number;
 export function emphasize(color: string, coefficient?: number): string;
-/**
- * @deprecated
- * Use `import { alpha } from '@material-ui/core/styles'` instead.
- */
-export function fade(color: string, value: number): string;
 export function alpha(color: string, value: number): string;
 export function darken(color: string, coefficient: number): string;
 export function lighten(color: string, coefficient: number): string;

--- a/packages/material-ui/src/styles/colorManipulator.js
+++ b/packages/material-ui/src/styles/colorManipulator.js
@@ -237,36 +237,6 @@ export function alpha(color, value) {
   return recomposeColor(color);
 }
 
-let warnedOnce = false;
-
-/**
- * Set the absolute transparency of a color.
- * Any existing alpha values are overwritten.
- *
- * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
- * @param {number} value - value to set the alpha channel to in the range 0 -1
- * @returns {string} A CSS color string. Hex input values are returned as rgb
- *
- * @deprecated
- * Use `import { alpha } from '@material-ui/core/styles'` instead.
- */
-export function fade(color, value) {
-  if (process.env.NODE_ENV !== 'production') {
-    if (!warnedOnce) {
-      warnedOnce = true;
-      console.error(
-        [
-          'Material-UI: The `fade` color utility was renamed to `alpha` to better describe its functionality.',
-          '',
-          "You should use `import { alpha } from '@material-ui/core/styles'`",
-        ].join('\n'),
-      );
-    }
-  }
-
-  return alpha(color, value);
-}
-
 /**
  * Darkens a color.
  * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()


### PR DESCRIPTION
Part of #20012 

The deprecation warning is already in the v4-deprecations branch: https://github.com/mui-org/material-ui/commit/6db7fb2fe09b60a3137df0211e3c29d7dc53abfa: https://next.material-ui.com/guides/migration-v4/#styles.