### PR TITLE
[docs] add document for useFormControl

### DIFF
--- a/docs/pages/components/use-form-control.js
+++ b/docs/pages/components/use-form-control.js
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import { prepareMarkdown } from 'docs/src/modules/utils/parseMarkdown';
+
+const pageFilename = 'components/use-form-control';
+const requireDemo = require.context(
+  'docs/src/pages/components/use-form-control',
+  false,
+  /\.(js|tsx)$/,
+);
+const requireRaw = require.context(
+  '!raw-loader!../../src/pages/components/use-form-control',
+  false,
+  /\.(js|md|tsx)$/,
+);
+
+export default function Page({ demos, docs }) {
+  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+}
+
+Page.getInitialProps = () => {
+  const { demos, docs } = prepareMarkdown({ pageFilename, requireRaw });
+  return { demos, docs };
+};

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -165,6 +165,7 @@ const pages: readonly MuiPage[] = [
           { pathname: '/components/textarea-autosize' },
           { pathname: '/components/transitions' },
           { pathname: '/components/use-media-query', title: 'useMediaQuery' },
+          { pathname: '/components/use-form-control', title: 'useFormControl' },
         ],
       },
       {

--- a/docs/src/pages/components/use-form-control/SimpleUseFormControl.js
+++ b/docs/src/pages/components/use-form-control/SimpleUseFormControl.js
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import FormControl, { useFormControl } from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import Input from '@material-ui/core/Input';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useCustomChildStyles = makeStyles({
+  root: {
+    paddingTop: 16,
+  },
+});
+
+const FormControlCustomChild = () => {
+  const formControlContext = useFormControl();
+  const { root } = useCustomChildStyles();
+
+  if (!formControlContext) {
+    return null;
+  }
+
+  const { focused, filled, disabled, required } = formControlContext;
+
+  const displayBooleanValue = (booleanValue) => (booleanValue ? 'Yes' : 'No');
+
+  return (
+    <div className={root}>
+      <div>{`Is focused: ${displayBooleanValue(focused)}`}</div>
+      <div>{`Is filled: ${displayBooleanValue(filled)}`}</div>
+      <div>{`Is disabled: ${displayBooleanValue(disabled)}`}</div>
+      <div>{`Is required: ${displayBooleanValue(required)}`}</div>
+    </div>
+  );
+};
+
+export default function SimpleUseFormControl() {
+  return (
+    <Grid spacing={2} container>
+      <Grid item sm={4}>
+        <FormControl variant="standard">
+          <InputLabel htmlFor="component-simple">Simple</InputLabel>
+          <Input id="component-simple" />
+          <FormControlCustomChild />
+        </FormControl>
+      </Grid>
+      <Grid item sm={4}>
+        <FormControl disabled variant="standard">
+          <InputLabel htmlFor="component-simple">Disabled</InputLabel>
+          <Input id="component-simple" />
+          <FormControlCustomChild />
+        </FormControl>
+      </Grid>
+      <Grid item sm={4}>
+        <FormControl required variant="standard">
+          <InputLabel htmlFor="component-simple">Required</InputLabel>
+          <Input id="component-simple" />
+          <FormControlCustomChild />
+        </FormControl>
+      </Grid>
+    </Grid>
+  );
+}

--- a/docs/src/pages/components/use-form-control/SimpleUseFormControl.tsx
+++ b/docs/src/pages/components/use-form-control/SimpleUseFormControl.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import FormControl, { useFormControl } from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import Input from '@material-ui/core/Input';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useCustomChildStyles = makeStyles({
+  root: {
+    paddingTop: 16,
+  },
+});
+
+const FormControlCustomChild: React.FC = () => {
+  const formControlContext = useFormControl();
+  const { root } = useCustomChildStyles();
+
+  if (!formControlContext) {
+    return null;
+  }
+
+  const { focused, filled, disabled, required } = formControlContext;
+
+  const displayBooleanValue = (booleanValue?: boolean) =>
+    booleanValue ? 'Yes' : 'No';
+
+  return (
+    <div className={root}>
+      <div>{`Is focused: ${displayBooleanValue(focused)}`}</div>
+      <div>{`Is filled: ${displayBooleanValue(filled)}`}</div>
+      <div>{`Is disabled: ${displayBooleanValue(disabled)}`}</div>
+      <div>{`Is required: ${displayBooleanValue(required)}`}</div>
+    </div>
+  );
+};
+
+export default function SimpleUseFormControl() {
+  return (
+    <Grid spacing={2} container>
+      <Grid item sm={4}>
+        <FormControl variant="standard">
+          <InputLabel htmlFor="component-simple">Simple</InputLabel>
+          <Input id="component-simple" />
+          <FormControlCustomChild />
+        </FormControl>
+      </Grid>
+      <Grid item sm={4}>
+        <FormControl disabled variant="standard">
+          <InputLabel htmlFor="component-simple">Disabled</InputLabel>
+          <Input id="component-simple" />
+          <FormControlCustomChild />
+        </FormControl>
+      </Grid>
+      <Grid item sm={4}>
+        <FormControl required variant="standard">
+          <InputLabel htmlFor="component-simple">Required</InputLabel>
+          <Input id="component-simple" />
+          <FormControlCustomChild />
+        </FormControl>
+      </Grid>
+    </Grid>
+  );
+}

--- a/docs/src/pages/components/use-form-control/use-form-control.md
+++ b/docs/src/pages/components/use-form-control/use-form-control.md
@@ -1,0 +1,51 @@
+---
+title: Form Control Context Hook
+githubLabel: 'hook: useFormControl'
+---
+
+# useFormControl
+
+<p class="description">This is a custom React hook that provides form context such as `filled/focused/error/required` for children of the FormControl component.</p>
+
+The context is used by the following `material-ui` components:
+
+- [FormLabel](/api/form-label).
+- [FormHelperText](/api/form-helper-text)
+- [Input](/api/input)
+- [InputLabel](/api/input-label)
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
+## Usage
+
+```jsx
+import { useFormControl } from '@material-ui/core/FormControl';
+```
+
+Using the hook, you can access the form control context from inside your components that are children of `FormControl` component.
+
+{{"demo": "pages/components/use-form-control/SimpleUseFormControl.js", "defaultCodeOpen": true}}
+
+## Context value
+
+Below is the full list of the form control context attributes that can be accessed using the custom hook.
+
+| Name            | Type                                                                              | Default    | Description                                                                                                                                                                                |
+| :-------------- | :-------------------------------------------------------------------------------- | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| adornedStart    | <span class="prop-type">bool</span>                                               | false      | Indicate whether the child `Input` or `Select` component has a start adornment                                                                                                             |
+| setAdornedStart | <span class="prop-type">func</span>                                               |            | Setter function for `adornedStart` value                                                                                                                                                   |
+| color           | <span class="prop-type">'primary'&nbsp;\|<br>'secondary'&nbsp;\|<br>string</span> | primary    | The theme color is being used, inherited from `FormControl` `color` prop                                                                                                                   |
+| disabled        | <span class="prop-type">bool</span>                                               | false      | Indicate whether the child label, input and helper text are being displayed in a disabled state, inherited from `FormControl` `disabled` prop                                              |
+| error           | <span class="prop-type">bool</span>                                               | false      | Indicate whether the child label, input and helper text are being displayed in an error state, inherited from `FormControl` `error` prop                                                   |
+| filled          | <span class="prop-type">bool</span>                                               | false      | Indicate whether the child `Input` or `Select` component is being filled                                                                                                                   |
+| focused         | <span class="prop-type">bool</span>                                               | false      | Indicate whether the component and its children are being displayed in a focused state                                                                                                     |
+| fullWidth       | <span class="prop-type">bool</span>                                               | false      | Indicate whether the component is taking up the full width of its container, inherited from `FormControl` `fullWidth` prop                                                                 |
+| hiddenLabel     | <span class="prop-type">bool</span>                                               | false      | Indicate whether the label is being hidden, inherited from `FormControl` `hiddenLabel` prop                                                                                                |
+| required        | <span class="prop-type">bool</span>                                               | false      | Indicate whether the label is indicating that the input is required input, inherited from the `FormControl` `required` prop                                                                |
+| size            | <span class="prop-type">'medium'&nbsp;\|<br>'small'&nbsp;\|<br>string</span>      | 'medium'   | The size of the `FormControl` component, inherited from the `FormControl` `size` prop                                                                                                      |
+| variant         | <span class="prop-type">'filled', 'outlined', 'standard'</span>                   | 'outlined' | The variant is being used by the `FormControl` component and its children, inherited from `FormControl` `variant` prop                                                                     |
+| onBlur          | <span class="prop-type">func</span>                                               |            | Set `focused` value to `false`                                                                                                                                                             |
+| onFocus         | <span class="prop-type">func</span>                                               |            | Set `focused` value to `true`                                                                                                                                                              |
+| onEmpty         | <span class="prop-type">func</span>                                               |            | Set `filled` value to `false`                                                                                                                                                              |
+| onFilled        | <span class="prop-type">func</span>                                               |            | Set `filled` value to `true`                                                                                                                                                               |
+| registerEffect  | <span class="prop-type">func</span>                                               |            | This function will be called inside child `InputBase` components in non `production` mode to log a console error if more than one `InputBase` component is included within a `FormControl` |


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Add a simple documentation for `useFormControl` hook as required in #19861.
