### PR TITLE
[docs] Explicitly list demos of unstyled components

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -492,13 +492,7 @@ async function annotateComponentDefinition(context: {
 
   const demos = uniqBy<ReactApi['pagesMarkdown'][0]>(
     api.pagesMarkdown.filter((page) => {
-      // Testing for Unstyled avoids the need to mention the unstyled components in the
-      // `components` key of the markdown header YAML.
-      return (
-        page.components.includes(api.name) ||
-        (api.name.endsWith('Unstyled') &&
-          page.components.includes(api.name.replace('Unstyled', '')))
-      );
+      return page.components.includes(api.name);
     }, []),
     (page) => page.pathname,
   );

--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.d.ts
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.d.ts
@@ -124,7 +124,6 @@ export type BadgeUnstyledClassKey = keyof NonNullable<BadgeUnstyledTypeMap['prop
  *
  * Demos:
  *
- * - [Avatars](https://material-ui.com/components/avatars/)
  * - [Badges](https://material-ui.com/components/badges/)
  *
  * API:


### PR DESCRIPTION
We already list them explicitly so let's not try to be too clever about it in `yarn docs:api`.