### PR TITLE
[core] Update slot components to use overridesResolver part 7

### DIFF
--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
@@ -9,21 +8,6 @@ import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import unsupportedProp from '../utils/unsupportedProp';
 import tabClasses, { getTabUtilityClass } from './tabClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.label && styleProps.icon && styles.labelIcon),
-      ...styles[`textColor${capitalize(styleProps.textColor)}`],
-      ...(styleProps.fullWidth && styles.fullWidth),
-      ...(styleProps.wrapped && styles.wrapped),
-      [`& .${tabClasses.wrapper}`]: styles.wrapper,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, textColor, fullWidth, wrapped, icon, label, selected, disabled } = styleProps;
@@ -50,7 +34,17 @@ const TabRoot = experimentalStyled(
   {
     name: 'MuiTab',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.label && styleProps.icon && styles.labelIcon),
+        ...styles[`textColor${capitalize(styleProps.textColor)}`],
+        ...(styleProps.fullWidth && styles.fullWidth),
+        ...(styleProps.wrapped && styles.wrapped),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -127,6 +121,7 @@ const TabWrapper = experimentalStyled(
   {
     name: 'MuiTab',
     slot: 'Wrapper',
+    overridesResolver: (props, styles) => styles.wrapper,
   },
 )({
   /* Styles applied to the `icon` and `label`'s wrapper element. */

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
@@ -11,17 +10,6 @@ import ButtonBase from '../ButtonBase';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import tabScrollButtonClasses, { getTabScrollButtonUtilityClass } from './tabScrollButtonClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.orientation && styles[styleProps.orientation]),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, orientation, disabled } = styleProps;
@@ -39,7 +27,14 @@ const TabScrollButtonRoot = experimentalStyled(
   {
     name: 'MuiTabScrollButton',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.orientation && styles[styleProps.orientation]),
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -1,24 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import TableContext from './TableContext';
 
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getTableUtilityClass } from './tableClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.stickyHeader && styles.stickyHeader),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, stickyHeader } = styleProps;
@@ -36,7 +24,14 @@ const TableRoot = experimentalStyled(
   {
     name: 'MuiTable',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.stickyHeader && styles.stickyHeader),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableBody/TableBody.js
+++ b/packages/material-ui/src/TableBody/TableBody.js
@@ -7,8 +7,6 @@ import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getTableBodyUtilityClass } from './tableBodyClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -25,7 +23,7 @@ const TableBodyRoot = experimentalStyled(
   {
     name: 'MuiTableBody',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import capitalize from '../utils/capitalize';
 import { darken, alpha, lighten } from '../styles/colorManipulator';
@@ -10,21 +9,6 @@ import Tablelvl2Context from '../Table/Tablelvl2Context';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import tableCellClasses, { getTableCellUtilityClass } from './tableCellClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[styleProps.variant],
-      ...styles[`size${capitalize(styleProps.size)}`],
-      ...(styleProps.padding !== 'default' && styles[`padding${capitalize(styleProps.padding)}`]),
-      ...(styleProps.align !== 'inherit' && styles[`align${capitalize(styleProps.align)}`]),
-      ...(styleProps.stickyHeader && styles.stickyHeader),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, variant, align, padding, size, stickyHeader } = styleProps;
@@ -49,7 +33,18 @@ const TableCellRoot = experimentalStyled(
   {
     name: 'MuiTableCell',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[styleProps.variant],
+        ...styles[`size${capitalize(styleProps.size)}`],
+        ...(styleProps.padding !== 'default' && styles[`padding${capitalize(styleProps.padding)}`]),
+        ...(styleProps.align !== 'inherit' && styles[`align${capitalize(styleProps.align)}`]),
+        ...(styleProps.stickyHeader && styles.stickyHeader),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableContainer/TableContainer.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.js
@@ -6,8 +6,6 @@ import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getTableContainerUtilityClass } from './tableContainerClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -24,7 +22,7 @@ const TableContainerRoot = experimentalStyled(
   {
     name: 'MuiTableContainer',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableFooter/TableFooter.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.js
@@ -7,8 +7,6 @@ import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getTableFooterUtilityClass } from './tableFooterClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -25,7 +23,7 @@ const TableFooterRoot = experimentalStyled(
   {
     name: 'MuiTableFooter',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableHead/TableHead.js
+++ b/packages/material-ui/src/TableHead/TableHead.js
@@ -7,8 +7,6 @@ import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getTableHeadUtilityClass } from './tableHeadClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -25,7 +23,7 @@ const TableHeadRoot = experimentalStyled(
   {
     name: 'MuiTableHead',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableRow/TableRow.js
+++ b/packages/material-ui/src/TableRow/TableRow.js
@@ -1,25 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 import { alpha } from '../styles/colorManipulator';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import tableRowClasses, { getTableRowUtilityClass } from './tableRowClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.head && styles.head),
-      ...(styleProps.footer && styles.footer),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, selected, hover, head, footer } = styleProps;
@@ -37,7 +24,15 @@ const TableRowRoot = experimentalStyled(
   {
     name: 'MuiTableRow',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.head && styles.head),
+        ...(styleProps.footer && styles.footer),
+      };
+    },
   },
 )(({ theme }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -1,5 +1,4 @@
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge } from '@material-ui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -9,21 +8,6 @@ import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import tableSortLabelClasses, { getTableSortLabelUtilityClass } from './tableSortLabelClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.active && styles.active),
-      [`& .${tableSortLabelClasses.icon}`]: {
-        ...styles.icon,
-        ...styles[`iconDirection${capitalize(styleProps.direction)}`],
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, direction, active } = styleProps;
@@ -42,7 +26,14 @@ const TableSortLabelRoot = experimentalStyled(
   {
     name: 'MuiTableSortLabel',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.active && styles.active),
+      };
+    },
   },
 )(({ theme }) => ({
   /* Styles applied to the root element. */
@@ -72,7 +63,18 @@ const TableSortLabelRoot = experimentalStyled(
 const TableSortLabelIcon = experimentalStyled(
   'span',
   {},
-  { name: 'MuiTableSortLabel', slot: 'Icon' },
+  {
+    name: 'MuiTableSortLabel',
+    slot: 'Icon',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.icon,
+        ...styles[`iconDirection${capitalize(styleProps.direction)}`],
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the icon component. */
   fontSize: 18,

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
-import { deepmerge, refType } from '@material-ui/utils';
+import { refType } from '@material-ui/utils';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import Input from '../Input';
@@ -18,10 +18,6 @@ const variantComponent = {
   standard: Input,
   filled: FilledInput,
   outlined: OutlinedInput,
-};
-
-const overridesResolver = (props, styles) => {
-  return deepmerge(styles.root || {}, {});
 };
 
 const useUtilityClasses = (styleProps) => {
@@ -40,7 +36,7 @@ const TextFieldRoot = experimentalStyled(
   {
     name: 'MuiTextField',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({});
 

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { alpha } from '../styles';
 import ButtonBase from '../ButtonBase';
@@ -10,18 +9,6 @@ import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import toggleButtonClasses, { getToggleButtonUtilityClass } from './toggleButtonClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[`size${capitalize(styleProps.size)}`],
-      [`& .${toggleButtonClasses.label}`]: styles.label,
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, fullWidth, selected, disabled, size, color } = styleProps;
@@ -47,7 +34,14 @@ const ToggleButtonRoot = experimentalStyled(
   {
     name: 'MuiToggleButton',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`size${capitalize(styleProps.size)}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
@@ -130,6 +124,7 @@ const ToggleButtonLabel = experimentalStyled(
   {
     name: 'MuiToggleButton',
     slot: 'Label',
+    overridesResolver: (props, styles) => styles.label,
   },
 )({
   /* Styles applied to the label wrapper element. */

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
@@ -11,22 +10,6 @@ import isValueSelected from './isValueSelected';
 import toggleButtonGroupClasses, {
   getToggleButtonGroupUtilityClass,
 } from './toggleButtonGroupClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.orientation === 'vertical' && styles.vertical),
-      ...(styleProps.fullWidth && styles.fullWidth),
-      [`& .${toggleButtonGroupClasses.grouped}`]: {
-        ...styles.grouped,
-        ...styles[`grouped${capitalize(styleProps.orientation)}`],
-      },
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, orientation, fullWidth } = styleProps;
@@ -45,7 +28,19 @@ const ToggleButtonGroupRoot = experimentalStyled(
   {
     name: 'MuiToggleButtonGroup',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        [`& .${toggleButtonGroupClasses.grouped}`]: {
+          ...styles.grouped,
+          ...styles[`grouped${capitalize(styleProps.orientation)}`],
+        },
+        ...styles.root,
+        ...(styleProps.orientation === 'vertical' && styles.vertical),
+        ...(styleProps.fullWidth && styles.fullWidth),
+      };
+    },
   },
 )(({ styleProps, theme }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -1,23 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import useThemeProps from '../styles/useThemeProps';
 import experimentalStyled from '../styles/experimentalStyled';
 import { getToolbarUtilityClass } from './toolbarClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.disableGutters && styles.gutters),
-      ...styles[styleProps.variant],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disableGutters, variant } = styleProps;
@@ -35,7 +22,15 @@ const ToolbarRoot = experimentalStyled(
   {
     name: 'MuiToolbar',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(!styleProps.disableGutters && styles.gutters),
+        ...styles[styleProps.variant],
+      };
+    },
   },
 )(
   ({ theme, styleProps }) => ({

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge, elementAcceptingRef } from '@material-ui/utils';
+import { elementAcceptingRef } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { alpha } from '../styles/colorManipulator';
 import experimentalStyled from '../styles/experimentalStyled';
@@ -19,25 +19,6 @@ import tooltipClasses, { getTooltipUtilityClass } from './tooltipClasses';
 function round(value) {
   return Math.round(value * 1e5) / 1e5;
 }
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(!styleProps.disableInteractive && styles.popperInteractive),
-      ...(styleProps.arrow && styles.popperArrow),
-      [`& .${tooltipClasses.tooltip}`]: {
-        ...styles.tooltip,
-        ...(styleProps.touch && styles.touch),
-        ...(styleProps.arrow && styles.tooltipArrow),
-        ...styles[`tooltipPlacement${capitalize(styleProps.placement.split('-')[0])}`],
-      },
-      [`& .${tooltipClasses.arrow}`]: styles.arrow,
-    },
-    styles.popper || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { classes, disableInteractive, arrow, touch, placement } = styleProps;
@@ -62,7 +43,15 @@ const TooltipPopper = experimentalStyled(
   {
     name: 'MuiTooltip',
     slot: 'Popper',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.popper,
+        ...(!styleProps.disableInteractive && styles.popperInteractive),
+        ...(styleProps.arrow && styles.popperArrow),
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the Popper element. */
@@ -117,6 +106,16 @@ const TooltipTooltip = experimentalStyled(
   {
     name: 'MuiTooltip',
     slot: 'Tooltip',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.tooltip,
+        ...(styleProps.touch && styles.touch),
+        ...(styleProps.arrow && styles.tooltipArrow),
+        ...styles[`tooltipPlacement${capitalize(styleProps.placement.split('-')[0])}`],
+      };
+    },
   },
 )(({ theme, styleProps }) => ({
   /* Styles applied to the tooltip (label wrapper) element. */
@@ -182,6 +181,7 @@ const TooltipArrow = experimentalStyled(
   {
     name: 'MuiTooltip',
     slot: 'Arrow',
+    overridesResolver: (props, styles) => styles.arrow,
   },
 )(({ theme }) => ({
   /* Styles applied to the arrow element. */

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -2,27 +2,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_extendSxProp as extendSxProp } from '@material-ui/system';
-import { deepmerge } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import { getTypographyUtilityClass } from './typographyClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...(styleProps.variant && styles[styleProps.variant]),
-      ...(styleProps.align !== 'inherit' && styles[`align${capitalize(styleProps.align)}`]),
-      ...(styleProps.noWrap && styles.noWrap),
-      ...(styleProps.gutterBottom && styles.gutterBottom),
-      ...(styleProps.paragraph && styles.paragraph),
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { align, gutterBottom, noWrap, paragraph, variant, classes } = styleProps;
@@ -44,7 +28,22 @@ const useUtilityClasses = (styleProps) => {
 export const TypographyRoot = experimentalStyled(
   'span',
   {},
-  { name: 'MuiTypography', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiTypography',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...(styleProps.variant && styles[styleProps.variant]),
+        ...(styleProps.align !== 'inherit' && styles[`align${capitalize(styleProps.align)}`]),
+        ...(styleProps.noWrap && styles.noWrap),
+        ...(styleProps.gutterBottom && styles.gutterBottom),
+        ...(styleProps.paragraph && styles.paragraph),
+      };
+    },
+  },
 )(({ theme, styleProps }) => ({
   margin: 0,
   ...(styleProps.variant && theme.typography[styleProps.variant]),


### PR DESCRIPTION
Updates component starting with `[T-Z]` to use the `overridesResolver` on the slots components

Part 1: #25853
Part 2: #25864
Part 3: #25881
Part 4: #25884
Part 5: #25887
Part 6: #25892