### PR TITLE
[lab] Update slot components to use overridesResolver

### DIFF
--- a/packages/material-ui-lab/src/TabPanel/TabPanel.js
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.js
@@ -9,8 +9,6 @@ import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled
 import { getTabPanelUtilityClass } from './tabPanelClasses';
 import { getPanelId, getTabId, useTabContext } from '../TabContext';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -27,7 +25,7 @@ const TabPanelRoot = experimentalStyled(
   {
     name: 'MuiTabPanel',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => ({
   padding: theme.spacing(3),

--- a/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js
@@ -8,8 +8,6 @@ import {
 } from '@material-ui/core/styles';
 import { getTimelineConnectorUtilityClass } from './timelineConnectorClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -26,7 +24,7 @@ const TimelineConnectorRoot = experimentalStyled(
   {
     name: 'MuiTimelineConnector',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )(({ theme }) => {
   /* Styles applied to the root element. */

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@material-ui/utils';
 import { capitalize } from '@material-ui/core/utils';
 import {
   experimentalStyled,
@@ -11,16 +10,6 @@ import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled
 import Typography from '@material-ui/core/Typography';
 import TimelineContext from '../Timeline/TimelineContext';
 import { getTimelineContentUtilityClass } from './timelineContentClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(
-    {
-      ...styles[`align${capitalize(styleProps.align)}`],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { align, classes } = styleProps;
@@ -35,7 +24,17 @@ const useUtilityClasses = (styleProps) => {
 const TimelineContentRoot = experimentalStyled(
   Typography,
   {},
-  { name: 'MuiTimelineContent', slot: 'Root', overridesResolver },
+  {
+    name: 'MuiTimelineContent',
+    slot: 'Root',
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.root,
+        ...styles[`align${capitalize(styleProps.align)}`],
+      };
+    },
+  },
 )(({ styleProps }) => ({
   flex: 1,
   padding: '6px 16px',

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
@@ -5,24 +5,9 @@ import {
   experimentalStyled,
   unstable_useThemeProps as useThemeProps,
 } from '@material-ui/core/styles';
-import { deepmerge } from '@material-ui/utils';
 import { capitalize } from '@material-ui/core/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { getTimelineDotUtilityClass } from './timelineDotClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return deepmerge(
-    {
-      ...styles[
-        styleProps.color !== 'inherit' && `${styleProps.variant}${capitalize(styleProps.color)}`
-      ],
-      ...styles[styleProps.variant],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { color, variant, classes } = styleProps;
@@ -40,7 +25,17 @@ const TimelineDotRoot = experimentalStyled(
   {
     name: 'MuiTimelineDot',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[
+          styleProps.color !== 'inherit' && `${styleProps.variant}${capitalize(styleProps.color)}`
+        ],
+        ...styles[styleProps.variant],
+      };
+    },
   },
 )(({ styleProps, theme }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -12,15 +12,6 @@ import { timelineOppositeContentClasses } from '../TimelineOppositeContent';
 import TimelineContext from '../Timeline/TimelineContext';
 import { getTimelineItemUtilityClass } from './timelineItemClasses';
 
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-
-  return {
-    ...styles.root,
-    ...styles[`align${capitalize(styleProps.align)}`],
-  };
-};
-
 const useUtilityClasses = (styleProps) => {
   const { align, classes, hasOppositeContent } = styleProps;
 
@@ -37,7 +28,14 @@ const TimelineItemRoot = experimentalStyled(
   {
     name: 'MuiTimelineItem',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+
+      return {
+        ...styles.root,
+        ...styles[`align${capitalize(styleProps.align)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   listStyle: 'none',

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -5,22 +5,11 @@ import {
   experimentalStyled,
   unstable_useThemeProps as useThemeProps,
 } from '@material-ui/core/styles';
-import { deepmerge } from '@material-ui/utils';
 import { capitalize } from '@material-ui/core/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import Typography from '@material-ui/core/Typography';
 import TimelineContext from '../Timeline/TimelineContext';
 import { getTimelineOppositeContentUtilityClass } from './timelineOppositeContentClasses';
-
-const overridesResolver = (props, styles) => {
-  const { styleProps } = props;
-  return deepmerge(
-    {
-      ...styles[`align${capitalize(styleProps.align)}`],
-    },
-    styles.root || {},
-  );
-};
 
 const useUtilityClasses = (styleProps) => {
   const { align, classes } = styleProps;
@@ -38,7 +27,13 @@ const TimelineOppositeContentRoot = experimentalStyled(
   {
     name: 'MuiTimelineOppositeContent',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => {
+      const { styleProps } = props;
+      return {
+        ...styles.root,
+        ...styles[`align${capitalize(styleProps.align)}`],
+      };
+    },
   },
 )(({ styleProps }) => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.js
+++ b/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.js
@@ -8,8 +8,6 @@ import {
 } from '@material-ui/core/styles';
 import { getTimelineSeparatorUtilityClass } from './timelineSeparatorClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -26,7 +24,7 @@ const TimelineSeparatorRoot = experimentalStyled(
   {
     name: 'MuiTimelineSeparator',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   display: 'flex',

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -17,8 +17,6 @@ import TreeViewContext from './TreeViewContext';
 import { DescendantProvider } from './descendants';
 import { getTreeViewUtilityClass } from './treeViewClasses';
 
-const overridesResolver = (props, styles) => styles.root || {};
-
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
 
@@ -35,7 +33,7 @@ const TreeViewRoot = experimentalStyled(
   {
     name: 'MuiTreeView',
     slot: 'Root',
-    overridesResolver,
+    overridesResolver: (props, styles) => styles.root,
   },
 )({
   padding: 0,


### PR DESCRIPTION
Updates all components in the lab which are migrated to emotion to use the overridesResolver on the slots components.