### PR TITLE
[docs] Fix Slider's classes wrong description

### DIFF
--- a/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
+++ b/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
@@ -61,12 +61,12 @@
     },
     "trackFalse": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the track element",
+      "nodeName": "the root element",
       "conditions": "<code>track={false}</code>"
     },
     "trackInverted": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the track element",
+      "nodeName": "the root element",
       "conditions": "<code>track=\"inverted\"</code>"
     },
     "thumb": {

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -63,12 +63,12 @@
     },
     "trackFalse": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the track element",
+      "nodeName": "the root element",
       "conditions": "<code>track={false}</code>"
     },
     "trackInverted": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the track element",
+      "nodeName": "the root element",
       "conditions": "<code>track=\"inverted\"</code>"
     },
     "thumb": {

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.d.ts
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.d.ts
@@ -44,9 +44,9 @@ export interface SliderUnstyledTypeMap<P = {}, D extends React.ElementType = 'sp
       rail?: string;
       /** Class name applied to the track element. */
       track?: string;
-      /** Class name applied to the track element if `track={false}`. */
+      /** Class name applied to the root element if `track={false}`. */
       trackFalse?: string;
-      /** Class name applied to the track element if `track="inverted"`. */
+      /** Class name applied to the root element if `track="inverted"`. */
       trackInverted?: string;
       /** Class name applied to the thumb element. */
       thumb?: string;


### PR DESCRIPTION
Fixes the descriptions for the `trackFalse` and `trackInverted` classes. They were always applied on the `root` element, but the description is incorrect.

v4: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Slider/Slider.js#L685
v5: https://github.com/mui-org/material-ui/blob/next/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js#L165