### PR TITLE
[TextField] Add `isRequired` to position prop in InputAdornment

### DIFF
--- a/docs/pages/api-docs/input-adornment.md
+++ b/docs/pages/api-docs/input-adornment.md
@@ -33,7 +33,7 @@ The `MuiInputAdornment` name can be used for providing [default props](/customiz
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">disablePointerEvents</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable pointer events on the root. This allows for the content of the adornment to focus the input on click. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If children is a string then disable wrapping in a Typography component. |
-| <span class="prop-name">position</span> | <span class="prop-type">'start'<br>&#124;&nbsp;'end'</span> |  | The position this adornment should appear relative to the `Input`. |
+| <span class="prop-name required">position<abbr title="required">*</abbr></span> | <span class="prop-type">'start'<br>&#124;&nbsp;'end'</span> |  | The position this adornment should appear relative to the `Input`. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'standard'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'filled'</span> |  | The variant to use. Note: If you are using the `TextField` component or the `FormControl` component you do not have to set this manually. |
 
 The `ref` is forwarded to the root element.

--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -132,7 +132,7 @@ InputAdornment.propTypes = {
   /**
    * The position this adornment should appear relative to the `Input`.
    */
-  position: PropTypes.oneOf(['start', 'end']),
+  position: PropTypes.oneOf(['start', 'end']).isRequired,
   /**
    * The variant to use.
    * Note: If you are using the `TextField` component or the `FormControl` component

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -194,7 +194,9 @@ describe('<InputAdornment />', () => {
   it('applies a marginDense class inside <FormControl margin="dense" />', () => {
     const { getByTestId } = render(
       <FormControl margin="dense">
-        <InputAdornment data-testid="root">$</InputAdornment>
+        <InputAdornment data-testid="root" position="start">
+          $
+        </InputAdornment>
       </FormControl>,
     );
 
@@ -204,7 +206,9 @@ describe('<InputAdornment />', () => {
   it('applies a hiddenLabel class inside <FormControl hiddenLabel />', () => {
     const { getByTestId } = render(
       <FormControl hiddenLabel>
-        <InputAdornment data-testid="root">$</InputAdornment>
+        <InputAdornment data-testid="root" position="start">
+          $
+        </InputAdornment>
       </FormControl>,
     );
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

A warning for #25891. This prop is already required for TypeScript users, but the `propTypes` definition was not matching it.