### PR TITLE
[theme] Remove theme.typography.round helper

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -158,6 +158,14 @@ export default function PlainCssPriority() {
   +theme.palette.augmentColor({ color: red, name: 'brand' });
   ```
 
+- The `theme.typography.round` helper was removed because it was no longer used. If you need it, use the function below:
+
+  ```js
+  function round(value) {
+    return Math.round(value * 1e5) / 1e5;
+  }
+  ```
+
 #### Upgrade helper
 
 For a smoother transition, the `adaptV4Theme` helper allows you to iteratively upgrade some of the theme changes to the new theme structure.

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -78,7 +78,6 @@ export default function createTypography(palette, typography) {
     {
       htmlFontSize,
       pxToRem,
-      round, // TODO v5: remove
       fontFamily,
       fontSize,
       fontWeightLight,


### PR DESCRIPTION
**BREAKING CHANGE**
The `theme.typography.round` helper was removed because it was no longer used. If you need it, use the function below:

```js
function round(value) {
  return Math.round(value * 1e5) / 1e5;
}
```
Part of #20012.

