### PR TITLE
[Timeline] Remove use of nth-child in favor of nth-of-type

### DIFF
--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -46,7 +46,7 @@ const TimelineItemRoot = experimentalStyled(
     flexDirection: 'row-reverse',
   }),
   ...(styleProps.align === 'alternate' && {
-    '&:nth-child(even)': {
+    '&:nth-of-type(even)': {
       flexDirection: 'row-reverse',
       [`& .${timelineContentClasses.root}`]: {
         textAlign: 'right',


### PR DESCRIPTION
* Uses nth-of-type instead of nth-child to target alternating timeline item elements
* Fixes issues where DOM element location matters, for example when emotion is
inserting Server Side Rendered content into the DOM outside of the component's hierarchy

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ --> 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #25875