### PR TITLE
[theme] Remove theme.breakpoints.width helper

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -151,6 +151,13 @@ export default function PlainCssPriority() {
   +<Hidden mdDown>{...}</Hidden> // '@media (min-width:600px)'
   ```
 
+- The `theme.breakpoints.width` utility was removed because it's redundant. Use `theme.breakpoints.values` to get the same values.
+
+  ```diff
+  -theme.breakpoints.width('md')
+  +theme.breakpoints.values.md
+  ```
+
 - The signature of `theme.palette.augmentColor` helper has changed:
 
   ```diff

--- a/packages/material-ui/src/styles/createBreakpoints.d.ts
+++ b/packages/material-ui/src/styles/createBreakpoints.d.ts
@@ -16,7 +16,6 @@ export interface Breakpoints {
   down: (key: Breakpoint | number) => string;
   between: (start: Breakpoint | number, end: Breakpoint | number) => string;
   only: (key: Breakpoint) => string;
-  width: (key: Breakpoint) => number;
 }
 
 export type BreakpointsOptions = Partial<

--- a/packages/material-ui/src/styles/createBreakpoints.js
+++ b/packages/material-ui/src/styles/createBreakpoints.js
@@ -55,10 +55,6 @@ export default function createBreakpoints(breakpoints) {
     return up(key);
   }
 
-  function width(key) {
-    return values[key];
-  }
-
   return {
     keys,
     values,
@@ -66,7 +62,6 @@ export default function createBreakpoints(breakpoints) {
     down,
     between,
     only,
-    width,
     unit,
     ...other,
   };

--- a/packages/material-ui/src/styles/createBreakpoints.test.js
+++ b/packages/material-ui/src/styles/createBreakpoints.test.js
@@ -96,14 +96,4 @@ describe('createBreakpoints', () => {
       );
     });
   });
-
-  describe('width', () => {
-    it('should work', () => {
-      expect(breakpoints.width('md')).to.equal(960);
-    });
-
-    it('should work for custom breakpoints', () => {
-      expect(customBreakpoints.width('tablet')).to.equal(640);
-    });
-  });
 });


### PR DESCRIPTION
### Breaking change

- [theme] Remove theme.breakpoints.width helper.
  It's redundant.

```diff
-theme.breakpoints.width('md')
+theme.breakpoints.values.md
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012.
