### PR TITLE
 [Table] Rename padding="default" to padding="normal"

### DIFF
--- a/docs/pages/api-docs/table-cell.json
+++ b/docs/pages/api-docs/table-cell.json
@@ -13,7 +13,7 @@
     "padding": {
       "type": {
         "name": "enum",
-        "description": "'checkbox'<br>&#124;&nbsp;'default'<br>&#124;&nbsp;'none'"
+        "description": "'checkbox'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'"
       }
     },
     "scope": { "type": { "name": "string" } },

--- a/docs/pages/api-docs/table.json
+++ b/docs/pages/api-docs/table.json
@@ -6,9 +6,9 @@
     "padding": {
       "type": {
         "name": "enum",
-        "description": "'checkbox'<br>&#124;&nbsp;'default'<br>&#124;&nbsp;'none'"
+        "description": "'checkbox'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'"
       },
-      "default": "'default'"
+      "default": "'normal'"
     },
     "size": {
       "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -154,7 +154,7 @@ function EnhancedTableHead(props) {
           <TableCell
             key={headCell.id}
             align={headCell.numeric ? 'right' : 'left'}
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -197,7 +197,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
           <TableCell
             key={headCell.id}
             align={headCell.numeric ? 'right' : 'left'}
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1175,6 +1175,15 @@ As the core components use emotion as a styled engine, the props used by emotion
   />
   ```
 
+- Rename the `default` value of the `padding` prop to `normal`.
+
+  ```diff
+  -<Table padding="default" />
+  -<TableCell padding="default" />
+  +<Table padding="normal" />
+  +<TableCell padding="normal" />
+  ```
+
 ### Tabs
 
 - Change the default `indicatorColor` and `textColor ` prop values to "primary".

--- a/packages/material-ui/src/Table/Table.d.ts
+++ b/packages/material-ui/src/Table/Table.d.ts
@@ -3,7 +3,7 @@ import { SxProps } from '@material-ui/system';
 import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-export type Padding = 'default' | 'checkbox' | 'none';
+export type Padding = 'normal' | 'checkbox' | 'none';
 
 export type Size = 'small' | 'medium';
 
@@ -24,7 +24,7 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
     };
     /**
      * Allows TableCells to inherit padding of the Table.
-     * @default 'default'
+     * @default 'normal'
      */
     padding?: Padding;
     /**

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -59,7 +59,7 @@ const Table = React.forwardRef(function Table(inProps, ref) {
   const {
     className,
     component = defaultComponent,
-    padding = 'default',
+    padding = 'normal',
     size = 'medium',
     stickyHeader = false,
     ...other
@@ -119,9 +119,9 @@ Table.propTypes /* remove-proptypes */ = {
   component: PropTypes.elementType,
   /**
    * Allows TableCells to inherit padding of the Table.
-   * @default 'default'
+   * @default 'normal'
    */
-  padding: PropTypes.oneOf(['checkbox', 'default', 'none']),
+  padding: PropTypes.oneOf(['checkbox', 'none', 'normal']),
   /**
    * Allows TableCells to inherit size of the Table.
    * @default 'medium'

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -65,7 +65,7 @@ describe('<Table />', () => {
 
     expect(context).to.deep.equal({
       size: 'medium',
-      padding: 'default',
+      padding: 'normal',
       stickyHeader: false,
     });
   });

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -19,7 +19,7 @@ const useUtilityClasses = (styleProps) => {
       variant,
       stickyHeader && 'stickyHeader',
       align !== 'inherit' && `align${capitalize(align)}`,
-      padding !== 'default' && `padding${capitalize(padding)}`,
+      padding !== 'normal' && `padding${capitalize(padding)}`,
       `size${capitalize(size)}`,
     ],
   };
@@ -40,7 +40,7 @@ const TableCellRoot = experimentalStyled(
         ...styles.root,
         ...styles[styleProps.variant],
         ...styles[`size${capitalize(styleProps.size)}`],
-        ...(styleProps.padding !== 'default' && styles[`padding${capitalize(styleProps.padding)}`]),
+        ...(styleProps.padding !== 'normal' && styles[`padding${capitalize(styleProps.padding)}`]),
         ...(styleProps.align !== 'inherit' && styles[`align${capitalize(styleProps.align)}`]),
         ...(styleProps.stickyHeader && styles.stickyHeader),
       };
@@ -165,7 +165,7 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
     ...props,
     align,
     component,
-    padding: paddingProp || (table && table.padding ? table.padding : 'default'),
+    padding: paddingProp || (table && table.padding ? table.padding : 'normal'),
     size: sizeProp || (table && table.size ? table.size : 'medium'),
     sortDirection,
     stickyHeader: variant === 'head' && table && table.stickyHeader,
@@ -226,7 +226,7 @@ TableCell.propTypes /* remove-proptypes */ = {
    * Sets the padding applied to the cell.
    * The prop defaults to the value (`'default'`) inherited from the parent Table component.
    */
-  padding: PropTypes.oneOf(['checkbox', 'default', 'none']),
+  padding: PropTypes.oneOf(['checkbox', 'none', 'normal']),
   /**
    * Set scope attribute.
    */

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -49,8 +49,8 @@ describe('<TableCell />', () => {
 
   describe('prop: padding', () => {
     it("doesn't not have a class for padding by default", () => {
-      const { container } = renderInTable(<TableCell padding="default" />);
-      expect(container.querySelector('td')).not.to.have.class(classes.paddingDefault);
+      const { container } = renderInTable(<TableCell padding="normal" />);
+      expect(container.querySelector('td')).not.to.have.class(classes.paddingNormal);
     });
 
     it('has a class when `none`', () => {


### PR DESCRIPTION
### Breaking change

```diff
-<Table padding="default" />
-<TableCell padding="default" />
+<Table padding="normal" />
+<TableCell padding="normal" />
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012.