### PR TITLE
[doc]: add a section for useFormControl to TextField doc

### DIFF
--- a/docs/src/pages/components/text-fields/UseFormControl.js
+++ b/docs/src/pages/components/text-fields/UseFormControl.js
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import FormControl, { useFormControl } from '@material-ui/core/FormControl';
+import Input from '@material-ui/core/Input';
+import Box from '@material-ui/core/Box';
+import FormHelperText from '@material-ui/core/FormHelperText';
+
+const MyFormHelperText = () => {
+  const formControlContext = useFormControl();
+
+  const { focused, filled, disabled, required } = formControlContext || {};
+
+  const helperText = React.useMemo(() => {
+    if (focused) {
+      return 'This field is being focused';
+    }
+
+    if (filled) {
+      return 'This field is filled';
+    }
+
+    if (disabled) {
+      return 'This field is disabled';
+    }
+
+    if (required) {
+      return 'This field is required';
+    }
+
+    return '';
+  }, [focused, filled, disabled, required]);
+
+  return <FormHelperText>{helperText}</FormHelperText>;
+};
+
+export default function UseFormControl() {
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& > :not(style)': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <FormControl required>
+        <Input placeholder="Please enter text" />
+        <MyFormHelperText />
+      </FormControl>
+
+      <FormControl disabled>
+        <Input placeholder="Disabled field" />
+        <MyFormHelperText />
+      </FormControl>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/text-fields/UseFormControl.tsx
+++ b/docs/src/pages/components/text-fields/UseFormControl.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import FormControl, { useFormControl } from '@material-ui/core/FormControl';
+import Input from '@material-ui/core/Input';
+import Box from '@material-ui/core/Box';
+import FormHelperText from '@material-ui/core/FormHelperText';
+
+const MyFormHelperText: React.FC = () => {
+  const formControlContext = useFormControl();
+
+  const { focused, filled, disabled, required } = formControlContext || {};
+
+  const helperText = React.useMemo(() => {
+    if (focused) {
+      return 'This field is being focused';
+    }
+
+    if (filled) {
+      return 'This field is filled';
+    }
+
+    if (disabled) {
+      return 'This field is disabled';
+    }
+
+    if (required) {
+      return 'This field is required';
+    }
+
+    return '';
+  }, [focused, filled, disabled, required]);
+
+  return <FormHelperText>{helperText}</FormHelperText>;
+};
+
+export default function UseFormControl() {
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& > :not(style)': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <FormControl required>
+        <Input placeholder="Please enter text" />
+        <MyFormHelperText />
+      </FormControl>
+
+      <FormControl disabled>
+        <Input placeholder="Disabled field" />
+        <MyFormHelperText />
+      </FormControl>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -135,6 +135,44 @@ Below is an example using the [`InputBase`](/api/input-base/) component, inspire
 
 🎨 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/styles/text-field).
 
+## `useFormControl`
+
+For advanced customization use cases, a `useFormControl()` hook is exposed.
+It returns the context value of the parent form control.
+The `FormLabel`, `FormHelperText`, `Input`, `InputLabel` components use this hook internally.
+
+#### API
+
+```jsx
+import { useFormControl } from '@material-ui/core/FormControl';
+```
+
+#### Returns
+
+`value` (_Object_):
+
+- `value.adornedStart` (_Bool_): Indicate whether the child `Input` or `Select` component has a start adornment.
+- `value.setAdornedStart` (_Func_): Setter function for `adornedStart` state value.
+- `value.color` (_String_): The theme color is being used, inherited from `FormControl` `color` prop .
+- `value.disabled` (_Bool_): Indicate whether the component is being displayed in a disabled state, inherited from `FormControl` `disabled` prop.
+- `value.error` (_Bool_): Indicate whether the component is being displayed in an error state, inherited from `FormControl` `error` prop
+- `value.filled` (_Bool_): Indicate whether the child `Input` or `Select` component is being filled
+- `value.focused` (_Bool_): Indicate whether the component and its children are being displayed in a focused state
+- `value.fullWidth` (_Bool_): Indicate whether the component is taking up the full width of its container, inherited from `FormControl` `fullWidth` prop
+- `value.hiddenLabel` (_Bool_): Indicate whether the label is being hidden, inherited from `FormControl` `hiddenLabel` prop
+- `value.required` (_Bool_): Indicate whether the label is indicating that the input is required input, inherited from the `FormControl` `required` prop
+- `value.size` (_String_): The size of the component, inherited from the `FormControl` `size` prop
+- `value.variant` (_String_): The variant is being used by the `FormControl` component and its children, inherited from `FormControl` `variant` prop
+- `value.onBlur` (_Func_): Function to set `focused` value to `false`
+- `value.onFocus` (_Func_): Function to set `focused` value to `true`
+- `value.onEmpty` (_Func_): Function to set `filled` value to `false`
+- `value.onFilled` (_Func_): Function to set `filled` value to `true`
+- `value.registerEffect` (_Func_): This function will be called inside child `InputBase` components in non `production` mode to log a console error if more than one `InputBase` component is included within a `FormControl`
+
+#### Example
+
+{{"demo": "pages/components/text-fields/UseFormControl.js"}}
+
 ## Limitations
 
 ### Shrink


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Add a doc section for the hook `useFormControl` to TextField doc page as required by #19861.