### PR TITLE
[core] Enable trailing comma in TypeScript files

### DIFF
--- a/docs/types/react-docgen.d.ts
+++ b/docs/types/react-docgen.d.ts
@@ -18,7 +18,7 @@ declare module 'react-docgen' {
   export type Handler = (
     documentation: Documentation,
     componentDefinition: NodePath,
-    importer: Importer
+    importer: Importer,
   ) => void;
 
   export const defaultHandlers: readonly Handler[];
@@ -27,7 +27,7 @@ declare module 'react-docgen' {
   export type Resolver = (
     ast: ASTNode,
     parser: unknown,
-    importer: Importer
+    importer: Importer,
   ) => NodePath | NodePath[] | undefined;
 
   export namespace resolver {
@@ -180,7 +180,7 @@ declare module 'react-docgen' {
     source: string,
     componentResolver: null | Resolver,
     handlers: null | readonly Handler[],
-    options: { filename: string }
+    options: { filename: string },
   ): any;
 
   export namespace utils {

--- a/packages/material-ui-lab/src/TreeItem/useTreeItem.d.ts
+++ b/packages/material-ui-lab/src/TreeItem/useTreeItem.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export default function useTreeItem(
-  nodeId: string
+  nodeId: string,
 ): {
   disabled: boolean;
   expanded: boolean;

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.d.ts
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.d.ts
@@ -5,5 +5,5 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
   theme: Partial<Theme> | ((outerTheme: Theme) => Theme);
 }
 export default function ThemeProvider<T = DefaultTheme>(
-  props: ThemeProviderProps<T>
+  props: ThemeProviderProps<T>,
 ): React.ReactElement<ThemeProviderProps<T>>;

--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -11,5 +11,5 @@ import { StyleRules } from '@material-ui/styles/withStyles';
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
 export default function createStyles<ClassKey extends string, Props extends {}>(
-  styles: StyleRules<Props, ClassKey>
+  styles: StyleRules<Props, ClassKey>,
 ): StyleRules<Props, ClassKey>;

--- a/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
+++ b/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
@@ -7,5 +7,5 @@ export interface StylesCreator<Theme, Props extends object, ClassKey extends str
 }
 
 export default function getStylesCreator<S extends Styles<any, any>>(
-  style: S
+  style: S,
 ): StylesCreator<any, any>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -7,7 +7,7 @@ export default function makeStyles<
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,
-  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>
+  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
 ): keyof Props extends never
   ? // `makeStyles` where the passed `styles` do not depend on props
     (props?: any) => ClassNameMap<ClassKey>

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -20,7 +20,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
   styles:
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
-  options?: WithStylesOptions<Theme>
+  options?: WithStylesOptions<Theme>,
 ) => StyledComponent<
   DistributiveOmit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
@@ -35,5 +35,5 @@ export interface StyledProps {
 }
 
 export default function styled<Component extends React.ElementType>(
-  Component: Component
+  Component: Component,
 ): ComponentCreator<Component>;

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -66,7 +66,7 @@ export type StyleRules<Props extends object = {}, ClassKey extends string = stri
  * @internal
  */
 export type StyleRulesCallback<Theme, Props extends object, ClassKey extends string = string> = (
-  theme: Theme
+  theme: Theme,
 ) => StyleRules<Props, ClassKey>;
 
 export type Styles<Theme, Props extends object, ClassKey extends string = string> =
@@ -125,7 +125,7 @@ export default function withStyles<
   Options extends WithStylesOptions<ThemeOfStyles<StylesType>> = {}
 >(
   style: StylesType,
-  options?: Options
+  options?: Options,
 ): PropInjector<
   WithStyles<StylesType, Options['withTheme']>,
   StyledComponentProps<ClassKeyOfStyles<StylesType>> & PropsOfStyles<StylesType>

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -21,14 +21,14 @@ export interface ThemedComponentProps extends Partial<WithTheme> {
 }
 
 export function withThemeCreator<Theme = DefaultTheme>(
-  option?: WithThemeCreatorOption<Theme>
+  option?: WithThemeCreatorOption<Theme>,
 ): PropInjector<WithTheme<Theme>, ThemedComponentProps>;
 
 export default function withTheme<
   Theme,
   C extends React.ComponentType<ConsistentWith<React.ComponentProps<C>, WithTheme<Theme>>>
 >(
-  component: C
+  component: C,
 ): React.ComponentType<
   DistributiveOmit<
     JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>,

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -40,14 +40,14 @@ type DefaultBreakPoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export function handleBreakpoints<Props>(
   props: Props,
   propValue: any,
-  styleFromPropValue: (value: any) => any
+  styleFromPropValue: (value: any) => any,
 ): any;
 
 /**
  * @returns An enhanced stylefunction that considers breakpoints
  */
 export function breakpoints<Props, Breakpoints extends string = DefaultBreakPoints>(
-  styleFunction: StyleFunction<Props>
+  styleFunction: StyleFunction<Props>,
 ): StyleFunction<Partial<Record<Breakpoints, Props>> & Props>;
 
 // restructures the breakpoints in the in the correct order and merges all styles args
@@ -241,7 +241,7 @@ export interface StyleOptions<PropKey> {
   transform?: (cssValue: unknown) => number | string | React.CSSProperties | CSSObject;
 }
 export function style<PropKey extends string, Theme extends object>(
-  options: StyleOptions<PropKey>
+  options: StyleOptions<PropKey>,
 ): StyleFunction<{ [K in PropKey]?: unknown } & { theme: Theme }>;
 
 // typography.js
@@ -308,7 +308,7 @@ export type SimpleSystemKeys = keyof Omit<
         typeof shadows,
         typeof sizing,
         typeof spacing,
-        typeof typography
+        typeof typography,
       ]
     >
   >,

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -25,7 +25,7 @@ export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
 export type PropInjector<InjectedProps, AdditionalProps = {}> = <
   C extends React.JSXElementConstructor<ConsistentWith<React.ComponentProps<C>, InjectedProps>>
 >(
-  component: C
+  component: C,
 ) => React.JSXElementConstructor<
   DistributiveOmit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
     AdditionalProps

--- a/packages/material-ui-unstyled/src/OverridableComponent.d.ts
+++ b/packages/material-ui-unstyled/src/OverridableComponent.d.ts
@@ -14,7 +14,7 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
        * Either a string to use a HTML element or a component.
        */
       component: C;
-    } & OverrideProps<M, C>
+    } & OverrideProps<M, C>,
   ): JSX.Element;
   (props: DefaultComponentProps<M>): JSX.Element;
 }

--- a/packages/material-ui-utils/src/debounce.d.ts
+++ b/packages/material-ui-utils/src/debounce.d.ts
@@ -4,5 +4,5 @@ export interface Cancelable {
 
 export default function debounce<T extends (...args: any[]) => any>(
   func: T,
-  wait?: number
+  wait?: number,
 ): T & Cancelable;

--- a/packages/material-ui-utils/src/requirePropFactory.d.ts
+++ b/packages/material-ui-utils/src/requirePropFactory.d.ts
@@ -2,5 +2,5 @@ import * as React from 'react';
 
 export default function requirePropFactory(
   componentNameInError: string,
-  Component?: React.ComponentType
+  Component?: React.ComponentType,
 ): any;

--- a/packages/material-ui-utils/src/unsupportedProp.d.ts
+++ b/packages/material-ui-utils/src/unsupportedProp.d.ts
@@ -3,5 +3,5 @@ export default function unsupportedProp(
   propName: string,
   componentName: string,
   location: string,
-  propFullName: string
+  propFullName: string,
 ): Error | null;

--- a/packages/material-ui-utils/src/useControlled.d.ts
+++ b/packages/material-ui-utils/src/useControlled.d.ts
@@ -18,5 +18,5 @@ export interface UseControlledProps<T = unknown> {
 }
 
 export default function useControlled<T = unknown>(
-  props: UseControlledProps<T>
+  props: UseControlledProps<T>,
 ): [T, (newValue: T | ((prevValue: T) => T)) => void];

--- a/packages/material-ui-utils/src/useEnhancedEffect.d.ts
+++ b/packages/material-ui-utils/src/useEnhancedEffect.d.ts
@@ -2,5 +2,5 @@ import * as React from 'react';
 
 export default function useEnhancedEffect(
   effect: React.EffectCallback,
-  deps?: React.DependencyList
+  deps?: React.DependencyList,
 ): void;

--- a/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
@@ -252,7 +252,7 @@ export interface AutocompleteProps<
   renderOption?: (
     props: React.HTMLAttributes<HTMLLIElement>,
     option: T,
-    state: AutocompleteRenderOptionState
+    state: AutocompleteRenderOptionState,
   ) => React.ReactNode;
   /**
    * Render the selected value.

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -168,7 +168,7 @@ export interface ExtendButtonTypeMap<M extends OverridableTypeMap> {
 }
 
 export type ExtendButton<M extends OverridableTypeMap> = ((
-  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>
+  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>,
 ) => JSX.Element) &
   OverridableComponent<ExtendButtonBaseTypeMap<M>>;
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -102,7 +102,7 @@ export interface ExtendButtonBaseTypeMap<M extends OverridableTypeMap> {
 }
 
 export type ExtendButtonBase<M extends OverridableTypeMap> = ((
-  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>
+  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>,
 ) => JSX.Element) &
   OverridableComponent<ExtendButtonBaseTypeMap<M>>;
 

--- a/packages/material-ui/src/CardHeader/CardHeader.d.ts
+++ b/packages/material-ui/src/CardHeader/CardHeader.d.ts
@@ -99,7 +99,7 @@ export interface OverridableCardHeader extends OverridableComponent<CardHeaderTy
       Props,
       TitleTypographyComponent,
       SubheaderTypographyComponent
-    >
+    >,
   ): JSX.Element;
 }
 

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -15,7 +15,7 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
        * Either a string to use a HTML element or a component.
        */
       component: C;
-    } & OverrideProps<M, C>
+    } & OverrideProps<M, C>,
   ): JSX.Element;
   (props: DefaultComponentProps<M>): JSX.Element;
 }

--- a/packages/material-ui/src/Pagination/Pagination.d.ts
+++ b/packages/material-ui/src/Pagination/Pagination.d.ts
@@ -48,7 +48,7 @@ export interface PaginationProps
   getItemAriaLabel?: (
     type: 'page' | 'first' | 'last' | 'next' | 'previous',
     page: number,
-    selected: boolean
+    selected: boolean,
   ) => string;
   /**
    * Render the item.

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -9,7 +9,7 @@ export interface SelectInputProps<T = unknown> {
   disabled?: boolean;
   IconComponent?: React.ElementType;
   inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<T>['value'] }
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<T>['value'] },
   ) => void;
   MenuProps?: Partial<MenuProps>;
   multiple: boolean;
@@ -18,7 +18,7 @@ export interface SelectInputProps<T = unknown> {
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (
     event: React.ChangeEvent<{ name?: string; value: T; event: Event | React.SyntheticEvent }>,
-    child: React.ReactNode
+    child: React.ReactNode,
   ) => void;
   onClose?: (event: React.SyntheticEvent) => void;
   onFocus?: React.FocusEventHandler<any>;

--- a/packages/material-ui/src/styles/ThemeProvider.d.ts
+++ b/packages/material-ui/src/styles/ThemeProvider.d.ts
@@ -13,5 +13,5 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
  * - [ThemeProvider API](https://material-ui.com/api/theme-provider/)
  */
 export default function ThemeProvider<T = DefaultTheme>(
-  props: ThemeProviderProps<T>
+  props: ThemeProviderProps<T>,
 ): React.ReactElement<ThemeProviderProps<T>>;

--- a/packages/material-ui/src/styles/createMixins.d.ts
+++ b/packages/material-ui/src/styles/createMixins.d.ts
@@ -14,5 +14,5 @@ export interface MixinsOptions extends Partial<Mixins> {
 export default function createMixins(
   breakpoints: Breakpoints,
   spacing: Spacing,
-  mixins: MixinsOptions
+  mixins: MixinsOptions,
 ): Mixins;

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -49,5 +49,5 @@ export interface TypographyOptions
 
 export default function createTypography(
   palette: Palette,
-  typography: TypographyOptions | ((palette: Palette) => TypographyOptions)
+  typography: TypographyOptions | ((palette: Palette) => TypographyOptions),
 ): Typography;

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -85,10 +85,10 @@ export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
    * @desc this method is type-unsafe
    */
   withComponent<NewTag extends keyof JSXInEl>(
-    tag: NewTag
+    tag: NewTag,
   ): StyledComponent<JSXInEl[NewTag], StyleProps, Theme>;
   withComponent<Tag extends React.ComponentType<any>>(
-    tag: Tag
+    tag: Tag,
   ): StyledComponent<PropsOf<Tag>, StyleProps, Theme>;
 }
 
@@ -160,7 +160,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>,
-    muiOptions?: MuiStyledOptions
+    muiOptions?: MuiStyledOptions,
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme;
@@ -176,7 +176,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <C extends React.ComponentClass<React.ComponentProps<C>>>(
     component: C,
     options?: StyledOptions,
-    muiOptions?: MuiStyledOptions
+    muiOptions?: MuiStyledOptions,
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme;
@@ -195,7 +195,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>,
-    muiOptions?: MuiStyledOptions
+    muiOptions?: MuiStyledOptions,
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme;
@@ -207,7 +207,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <C extends React.ComponentType<React.ComponentProps<C>>>(
     component: C,
     options?: StyledOptions,
-    muiOptions?: MuiStyledOptions
+    muiOptions?: MuiStyledOptions,
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme;
@@ -222,7 +222,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   >(
     tag: Tag,
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps>,
-    muiOptions?: MuiStyledOptions
+    muiOptions?: MuiStyledOptions,
   ): CreateStyledComponent<
     { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme> },
     Pick<JSX.IntrinsicElements[Tag], ForwardedProps>
@@ -231,7 +231,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <Tag extends keyof JSX.IntrinsicElements>(
     tag: Tag,
     options?: StyledOptions,
-    muiOptions?: MuiStyledOptions
+    muiOptions?: MuiStyledOptions,
   ): CreateStyledComponent<
     { theme?: Theme; as?: React.ElementType; sx?: SxProps<Theme> },
     JSX.IntrinsicElements[Tag]

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -8,7 +8,7 @@ export default function makeStyles<
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,
-  options?: DistributiveOmit<WithStylesOptions<Theme>, 'withTheme'>
+  options?: DistributiveOmit<WithStylesOptions<Theme>, 'withTheme'>,
 ): keyof Props extends never
   ? // `makeStyles` where the passed `styles` do not depend on props
     (props?: any) => ClassNameMap<ClassKey>

--- a/packages/material-ui/src/styles/responsiveFontSizes.d.ts
+++ b/packages/material-ui/src/styles/responsiveFontSizes.d.ts
@@ -11,5 +11,5 @@ export interface ResponsiveFontSizesOptions {
 
 export default function responsiveFontSizes(
   theme: Theme,
-  options?: ResponsiveFontSizesOptions
+  options?: ResponsiveFontSizesOptions,
 ): Theme;

--- a/packages/material-ui/src/styles/shadows.d.ts
+++ b/packages/material-ui/src/styles/shadows.d.ts
@@ -23,7 +23,7 @@ export type Shadows = [
   string,
   string,
   string,
-  string
+  string,
 ];
 declare const shadows: Shadows;
 export default shadows;

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -21,7 +21,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
   styles:
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
-  options?: WithStylesOptions<Theme>
+  options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   DistributiveOmit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
@@ -37,5 +37,5 @@ export interface StyledProps {
 }
 
 export default function styled<Component extends React.ElementType>(
-  Component: Component
+  Component: Component,
 ): ComponentCreator<Component>;

--- a/packages/material-ui/src/styles/transitions.d.ts
+++ b/packages/material-ui/src/styles/transitions.d.ts
@@ -22,7 +22,7 @@ export interface TransitionsOptions {
   duration?: Partial<Duration>;
   create?: (
     props: string | string[],
-    options?: Partial<{ duration: number | string; easing: string; delay: number | string }>
+    options?: Partial<{ duration: number | string; easing: string; delay: number | string }>,
   ) => string;
   getAutoHeightDuration?: (height: number) => number;
 }
@@ -34,7 +34,7 @@ export interface TransitionsOptions {
  */
 export function create(
   props: string | string[],
-  options?: Partial<{ duration: number | string; easing: string; delay: number | string }>
+  options?: Partial<{ duration: number | string; easing: string; delay: number | string }>,
 ): string;
 
 /**

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -57,5 +57,5 @@ export default function withStyles<
   Props extends object = {}
 >(
   style: Styles<Theme, Props, ClassKey>,
-  options?: Options
+  options?: Options,
 ): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey> & Props>;

--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -22,7 +22,7 @@ export interface AutocompleteGroupedOption<T = string> {
 }
 
 export function createFilterOptions<T>(
-  config?: CreateFilterOptionsConfig<T>
+  config?: CreateFilterOptionsConfig<T>,
 ): (options: T[], state: FilterOptionsState<T>) => T[];
 
 export type AutocompleteFreeSoloValueMapping<FreeSolo> = FreeSolo extends true ? string : never;
@@ -195,7 +195,7 @@ export interface UseAutocompleteProps<
   onInputChange?: (
     event: React.SyntheticEvent,
     value: string,
-    reason: AutocompleteInputChangeReason
+    reason: AutocompleteInputChangeReason,
   ) => void;
   /**
    * Callback fired when the popup requests to be opened.
@@ -214,7 +214,7 @@ export interface UseAutocompleteProps<
   onHighlightChange?: (
     event: React.SyntheticEvent,
     option: T | null,
-    reason: AutocompleteHighlightChangeReason
+    reason: AutocompleteHighlightChangeReason,
   ) => void;
   /**
    * If `true`, the component is shown.
@@ -264,7 +264,7 @@ export interface UseAutocompleteProps<
     event: React.SyntheticEvent,
     value: Value<T, Multiple, DisableClearable, FreeSolo>,
     reason: AutocompleteChangeReason,
-    details?: AutocompleteChangeDetails<T>
+    details?: AutocompleteChangeDetails<T>,
   ) => void;
 }
 
@@ -304,7 +304,7 @@ export default function useAutocomplete<
   DisableClearable extends boolean | undefined = undefined,
   FreeSolo extends boolean | undefined = undefined
 >(
-  props: UseAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>
+  props: UseAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
 ): {
   getRootProps: () => React.HTMLAttributes<HTMLDivElement>;
   getInputProps: () => React.HTMLAttributes<HTMLInputElement>;

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.d.ts
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.d.ts
@@ -18,5 +18,5 @@ export interface Options {
 
 export default function useMediaQuery<Theme = unknown>(
   query: string | ((theme: Theme) => string),
-  options?: Options
+  options?: Options,
 ): boolean;

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -19,15 +19,15 @@ export interface WithWidthProps extends Partial<WithWidth> {
 export function isWidthDown(
   breakpoint: Breakpoint,
   screenWidth: Breakpoint,
-  inclusive?: boolean
+  inclusive?: boolean,
 ): boolean;
 
 export function isWidthUp(
   breakpoint: Breakpoint,
   screenWidth: Breakpoint,
-  inclusive?: boolean
+  inclusive?: boolean,
 ): boolean;
 
 export default function withWidth(
-  options?: WithWidthOptions
+  options?: WithWidthOptions,
 ): PropInjector<WithWidth, WithWidthProps>;

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,13 +4,6 @@ module.exports = {
   trailingComma: 'all',
   overrides: [
     {
-      files: '*.d.ts',
-      options: {
-        // This is needed for TypeScript 3.2 support
-        trailingComma: 'es5',
-      },
-    },
-    {
       files: ['docs/**/*.md', 'docs/src/pages/**/*.{js,tsx}'],
       options: {
         // otherwise code blocks overflow on the docs website


### PR DESCRIPTION
Was blocked by TypeScript 3.2 support which was dropped in https://github.com/mui-org/material-ui/pull/24795