### PR TITLE
[core] Improve support for extended props in theme

### DIFF
--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -69,7 +69,10 @@
     "renderTags": { "type": { "name": "func" } },
     "selectOnFocus": { "type": { "name": "bool" }, "default": "!props.freeSolo" },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      },
       "default": "'medium'"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/checkbox.json
+++ b/docs/pages/api-docs/checkbox.json
@@ -5,8 +5,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'secondary'"
     },
@@ -22,7 +22,10 @@
     "onChange": { "type": { "name": "func" } },
     "required": { "type": { "name": "bool" } },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      },
       "default": "'medium'"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/checkbox.json
+++ b/docs/pages/api-docs/checkbox.json
@@ -5,8 +5,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "union",
-        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+        "name": "enum",
+        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
       },
       "default": "'secondary'"
     },
@@ -22,10 +22,7 @@
     "onChange": { "type": { "name": "func" } },
     "required": { "type": { "name": "bool" } },
     "size": {
-      "type": {
-        "name": "union",
-        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
-      },
+      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
       "default": "'medium'"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/chip.json
+++ b/docs/pages/api-docs/chip.json
@@ -6,8 +6,8 @@
     "clickable": { "type": { "name": "bool" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'default'"
     },
@@ -18,7 +18,10 @@
     "label": { "type": { "name": "node" } },
     "onDelete": { "type": { "name": "func" } },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      },
       "default": "'medium'"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/fab.json
+++ b/docs/pages/api-docs/fab.json
@@ -4,8 +4,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'default'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'default'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'default'"
     },
@@ -16,8 +16,8 @@
     "href": { "type": { "name": "string" } },
     "size": {
       "type": {
-        "name": "enum",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'large'"
     },

--- a/docs/pages/api-docs/filled-input.json
+++ b/docs/pages/api-docs/filled-input.json
@@ -3,7 +3,12 @@
     "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
-    "color": { "type": { "name": "enum", "description": "'primary'<br>&#124;&nbsp;'secondary'" } },
+    "color": {
+      "type": {
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+      }
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableUnderline": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/icon.json
+++ b/docs/pages/api-docs/icon.json
@@ -5,16 +5,16 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'action'<br>&#124;&nbsp;'disabled'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'action'<br>&#124;&nbsp;'disabled'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'inherit'"
     },
     "component": { "type": { "name": "elementType" } },
     "fontSize": {
       "type": {
-        "name": "enum",
-        "description": "'inherit'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'inherit'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/input-base.json
+++ b/docs/pages/api-docs/input-base.json
@@ -3,7 +3,12 @@
     "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
-    "color": { "type": { "name": "enum", "description": "'primary'<br>&#124;&nbsp;'secondary'" } },
+    "color": {
+      "type": {
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+      }
+    },
     "components": {
       "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
       "default": "{}"

--- a/docs/pages/api-docs/input.json
+++ b/docs/pages/api-docs/input.json
@@ -3,7 +3,12 @@
     "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
-    "color": { "type": { "name": "enum", "description": "'primary'<br>&#124;&nbsp;'secondary'" } },
+    "color": {
+      "type": {
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+      }
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableUnderline": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/outlined-input.json
+++ b/docs/pages/api-docs/outlined-input.json
@@ -3,7 +3,12 @@
     "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
-    "color": { "type": { "name": "enum", "description": "'primary'<br>&#124;&nbsp;'secondary'" } },
+    "color": {
+      "type": {
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+      }
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "endAdornment": { "type": { "name": "node" } },

--- a/docs/pages/api-docs/pagination-item.json
+++ b/docs/pages/api-docs/pagination-item.json
@@ -3,8 +3,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'standard'"
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'standard'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
     },
@@ -18,8 +18,8 @@
     },
     "size": {
       "type": {
-        "name": "enum",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/pagination.json
+++ b/docs/pages/api-docs/pagination.json
@@ -4,8 +4,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'standard'"
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'standard'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
     },
@@ -30,8 +30,8 @@
     "siblingCount": { "type": { "name": "custom", "description": "integer" }, "default": "1" },
     "size": {
       "type": {
-        "name": "enum",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/radio.json
+++ b/docs/pages/api-docs/radio.json
@@ -5,8 +5,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'secondary'"
     },
@@ -20,7 +20,10 @@
     "onChange": { "type": { "name": "func" } },
     "required": { "type": { "name": "bool" } },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      },
       "default": "'medium'"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -5,7 +5,10 @@
     "aria-valuetext": { "type": { "name": "custom", "description": "string" } },
     "classes": { "type": { "name": "object" } },
     "color": {
-      "type": { "name": "enum", "description": "'primary'<br>&#124;&nbsp;'secondary'" },
+      "type": {
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+      },
       "default": "'primary'"
     },
     "component": { "type": { "name": "elementType" } },

--- a/docs/pages/api-docs/svg-icon.json
+++ b/docs/pages/api-docs/svg-icon.json
@@ -4,16 +4,16 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'action'<br>&#124;&nbsp;'disabled'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'action'<br>&#124;&nbsp;'disabled'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'inherit'"
     },
     "component": { "type": { "name": "elementType" } },
     "fontSize": {
       "type": {
-        "name": "enum",
-        "description": "'inherit'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'inherit'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/switch.json
+++ b/docs/pages/api-docs/switch.json
@@ -5,8 +5,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'"
+        "name": "union",
+        "description": "'default'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'secondary'"
     },
@@ -27,7 +27,10 @@
     "onChange": { "type": { "name": "func" } },
     "required": { "type": { "name": "bool" } },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      },
       "default": "'medium'"
     },
     "sx": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/table.json
+++ b/docs/pages/api-docs/table.json
@@ -11,7 +11,10 @@
       "default": "'default'"
     },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      },
       "default": "'medium'"
     },
     "stickyHeader": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/toggle-button-group.json
+++ b/docs/pages/api-docs/toggle-button-group.json
@@ -18,8 +18,8 @@
     },
     "size": {
       "type": {
-        "name": "enum",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/toggle-button.json
+++ b/docs/pages/api-docs/toggle-button.json
@@ -17,8 +17,8 @@
     "selected": { "type": { "name": "bool" } },
     "size": {
       "type": {
-        "name": "enum",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "name": "union",
+        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export function Checkbox(props: Props): JSX.Element {
-  const { checked: checkedProp, label, onChange, ...other } = props;
+  const { checked: checkedProp, label, onChange, size, ...other } = props;
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -28,7 +28,7 @@ export function Checkbox(props: Props): JSX.Element {
     setChecked(checkedProp);
   }, [checkedProp]);
 
-  const control = <MuiCheckbox checked={checked} onChange={handleChange} />;
+  const control = <MuiCheckbox checked={checked} onChange={handleChange} size={size} />;
 
   return <FormControlLabel control={control} label={label} {...other} />;
 }

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -22,7 +22,7 @@ export function Checkbox(props: Props): JSX.Element {
     size,
     ...other
   } = props;
-  
+
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -5,10 +5,8 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 interface Props {
   checked: boolean;
-  color: 'default' | 'primary' | 'secondary';
   defaultChecked?: boolean;
   disabled: boolean;
-  size: 'medium' | 'small';
   label: string;
   width: number | string;
   height: number;
@@ -16,7 +14,7 @@ interface Props {
 }
 
 export function Checkbox(props: Props): JSX.Element {
-  const { checked: checkedProp, label, onChange, size, ...other } = props;
+  const { checked: checkedProp, label, onChange, ...other } = props;
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,16 +28,14 @@ export function Checkbox(props: Props): JSX.Element {
     setChecked(checkedProp);
   }, [checkedProp]);
 
-  const control = <MuiCheckbox checked={checked} onChange={handleChange} size={size} />;
+  const control = <MuiCheckbox checked={checked} onChange={handleChange} />;
 
   return <FormControlLabel control={control} label={label} {...other} />;
 }
 
 Checkbox.defaultProps = {
   checked: false,
-  color: 'secondary' as 'secondary',
   disabled: false,
-  size: 'medium' as 'medium',
   label: 'Checkbox',
   width: 100,
   height: 42,
@@ -50,11 +46,6 @@ addPropertyControls(Checkbox, {
     type: ControlType.Boolean,
     title: 'Checked',
   },
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['default', 'primary', 'secondary'],
-  },
   defaultChecked: {
     type: ControlType.Boolean,
     title: 'Default checked',
@@ -62,11 +53,6 @@ addPropertyControls(Checkbox, {
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',
-  },
-  size: {
-    type: ControlType.Enum,
-    title: 'Size',
-    options: ['medium', 'small'],
   },
   label: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -5,7 +5,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 interface Props {
   checked: boolean;
-  color: 'default' | 'primary' | 'secondary' | 'custom';
+  color: 'default' | 'primary' | 'secondary';
   defaultChecked?: boolean;
   disabled: boolean;
   size: 'medium' | 'small';

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -22,6 +22,7 @@ export function Checkbox(props: Props): JSX.Element {
     size,
     ...other
   } = props;
+  
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -5,8 +5,10 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 interface Props {
   checked: boolean;
+  color: 'default' | 'primary' | 'secondary' | 'custom';
   defaultChecked?: boolean;
   disabled: boolean;
+  size: 'medium' | 'small';
   label: string;
   width: number | string;
   height: number;
@@ -35,7 +37,9 @@ export function Checkbox(props: Props): JSX.Element {
 
 Checkbox.defaultProps = {
   checked: false,
+  color: 'secondary' as 'secondary',
   disabled: false,
+  size: 'medium' as 'medium',
   label: 'Checkbox',
   width: 100,
   height: 42,
@@ -46,6 +50,11 @@ addPropertyControls(Checkbox, {
     type: ControlType.Boolean,
     title: 'Checked',
   },
+  color: {
+    type: ControlType.Enum,
+    title: 'Color',
+    options: ['default', 'primary', 'secondary'],
+  },
   defaultChecked: {
     type: ControlType.Boolean,
     title: 'Default checked',
@@ -53,6 +62,11 @@ addPropertyControls(Checkbox, {
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',
+  },
+  size: {
+    type: ControlType.Enum,
+    title: 'Size',
+    options: ['medium', 'small'],
   },
   label: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Checkbox.tsx
+++ b/framer/Material-UI.framerfx/code/Checkbox.tsx
@@ -5,10 +5,8 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 interface Props {
   checked: boolean;
-  color: 'default' | 'primary' | 'secondary';
   defaultChecked?: boolean;
   disabled: boolean;
-  size: 'medium' | 'small';
   label: string;
   width: number | string;
   height: number;
@@ -16,7 +14,14 @@ interface Props {
 }
 
 export function Checkbox(props: Props): JSX.Element {
-  const { checked: checkedProp, label, onChange, size, ...other } = props;
+  const {
+    checked: checkedProp,
+    label,
+    onChange,
+    // @ts-ignore -- untyped
+    size,
+    ...other
+  } = props;
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,9 +42,7 @@ export function Checkbox(props: Props): JSX.Element {
 
 Checkbox.defaultProps = {
   checked: false,
-  color: 'secondary' as 'secondary',
   disabled: false,
-  size: 'medium' as 'medium',
   label: 'Checkbox',
   width: 100,
   height: 42,
@@ -50,11 +53,6 @@ addPropertyControls(Checkbox, {
     type: ControlType.Boolean,
     title: 'Checked',
   },
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['default', 'primary', 'secondary'],
-  },
   defaultChecked: {
     type: ControlType.Boolean,
     title: 'Default checked',
@@ -62,11 +60,6 @@ addPropertyControls(Checkbox, {
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',
-  },
-  size: {
-    type: ControlType.Enum,
-    title: 'Size',
-    options: ['medium', 'small'],
   },
   label: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Chip.tsx
+++ b/framer/Material-UI.framerfx/code/Chip.tsx
@@ -6,12 +6,10 @@ import { Avatar } from './Avatar';
 
 interface Props {
   clickable: boolean;
-  color: 'default' | 'primary' | 'secondary';
   deleteIcon: string;
   disabled: boolean;
   icon: string;
   label: string;
-  size: 'medium' | 'small';
   avatarImageFile: string;
   avatarImageUrl: string;
   deletable: boolean;
@@ -50,12 +48,10 @@ export function Chip(props: Props): JSX.Element {
 
 Chip.defaultProps = {
   clickable: true,
-  color: 'default' as 'default',
   deleteIcon: '',
   disabled: false,
   icon: 'star',
   label: 'Chip',
-  size: 'medium' as 'medium',
   avatarImageFile: '',
   avatarImageUrl: '',
   deletable: false,
@@ -68,11 +64,6 @@ addPropertyControls(Chip, {
   clickable: {
     type: ControlType.Boolean,
     title: 'Clickable',
-  },
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['default', 'primary', 'secondary'],
   },
   deleteIcon: {
     type: ControlType.String,
@@ -89,11 +80,6 @@ addPropertyControls(Chip, {
   label: {
     type: ControlType.String,
     title: 'Label',
-  },
-  size: {
-    type: ControlType.Enum,
-    title: 'Size',
-    options: ['medium', 'small'],
   },
   avatarImageFile: {
     type: ControlType.Image,

--- a/framer/Material-UI.framerfx/code/Fab.tsx
+++ b/framer/Material-UI.framerfx/code/Fab.tsx
@@ -4,10 +4,8 @@ import MuiFab from '@material-ui/core/Fab';
 import { Icon } from './Icon';
 
 interface Props {
-  color: 'default' | 'inherit' | 'primary' | 'secondary';
   disabled: boolean;
   href?: string;
-  size: 'large' | 'medium' | 'small';
   icon: string;
   iconTheme: 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
   label: string;
@@ -31,9 +29,7 @@ export function Fab(props: Props): JSX.Element {
 }
 
 Fab.defaultProps = {
-  color: 'default' as 'default',
   disabled: false,
-  size: 'large' as 'large',
   icon: 'add',
   iconTheme: 'Filled' as 'Filled',
   label: 'extended',
@@ -42,11 +38,6 @@ Fab.defaultProps = {
 };
 
 addPropertyControls(Fab, {
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['default', 'inherit', 'primary', 'secondary'],
-  },
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',
@@ -54,11 +45,6 @@ addPropertyControls(Fab, {
   href: {
     type: ControlType.String,
     title: 'Href',
-  },
-  size: {
-    type: ControlType.Enum,
-    title: 'Size',
-    options: ['large', 'medium', 'small'],
   },
   icon: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Icon.tsx
+++ b/framer/Material-UI.framerfx/code/Icon.tsx
@@ -6,7 +6,6 @@ import { pascalCase } from './utils';
 
 interface Props extends SvgIconProps {
   baseClassName: string;
-  color: 'action' | 'disabled' | 'error' | 'inherit' | 'primary' | 'secondary';
   icon: string;
   theme: 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
   width: number | string;
@@ -25,7 +24,6 @@ export function Icon(props: Props): JSX.Element | null {
 
 Icon.defaultProps = {
   baseClassName: 'material-icons',
-  color: 'inherit' as 'inherit',
   icon: 'add',
   theme: 'Filled' as 'Filled',
   width: 24,
@@ -36,11 +34,6 @@ addPropertyControls(Icon, {
   baseClassName: {
     type: ControlType.String,
     title: 'Base class name',
-  },
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['action', 'disabled', 'error', 'inherit', 'primary', 'secondary'],
   },
   icon: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Radio.tsx
+++ b/framer/Material-UI.framerfx/code/Radio.tsx
@@ -4,43 +4,34 @@ import FormControlLabel, { FormControlLabelProps } from '@material-ui/core/FormC
 import MuiRadio from '@material-ui/core/Radio';
 
 interface Props extends Omit<FormControlLabelProps, 'control'> {
-  color: 'default' | 'primary' | 'secondary';
   disabled: boolean;
-  size: 'medium' | 'small';
   label: string;
   width: number | string;
   height: number;
 }
 
 export function Radio(props: Props): JSX.Element {
-  const { label, size, ...other } = props;
+  const {
+    label,
+    // @ts-ignore -- untyped
+    size,
+    ...other
+  } = props;
 
   return <FormControlLabel control={<MuiRadio size={size} />} label={label} {...other} />;
 }
 
 Radio.defaultProps = {
-  color: 'secondary' as 'secondary',
   disabled: false,
-  size: 'medium' as 'medium',
   label: 'Radio',
   width: '100%',
   height: 42,
 };
 
 addPropertyControls(Radio, {
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['default', 'primary', 'secondary'],
-  },
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',
-  },
-  size: {
-    type: ControlType.Enum,
-    title: 'Size',
-    options: ['medium', 'small'],
   },
   label: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Slider.tsx
+++ b/framer/Material-UI.framerfx/code/Slider.tsx
@@ -3,7 +3,6 @@ import { addPropertyControls, ControlType } from 'framer';
 import MuiSlider from '@material-ui/core/Slider';
 
 interface Props {
-  color: 'primary' | 'secondary';
   disabled?: boolean;
   disableSwap?: boolean;
   max?: number;
@@ -23,17 +22,11 @@ export function Slider(props: Props): JSX.Element {
 }
 
 Slider.defaultProps = {
-  color: 'primary' as 'primary',
   width: 160,
   height: 24,
 };
 
 addPropertyControls(Slider, {
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['primary', 'secondary'],
-  },
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',

--- a/framer/Material-UI.framerfx/code/Switch.tsx
+++ b/framer/Material-UI.framerfx/code/Switch.tsx
@@ -5,10 +5,8 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 interface Props {
   checked: boolean;
-  color: 'default' | 'primary' | 'secondary';
   defaultChecked?: boolean;
   disabled: boolean;
-  size: 'medium' | 'small';
   label: string;
   width: number | string;
   height: number;
@@ -43,9 +41,7 @@ export function Switch(props: Props) {
 
 Switch.defaultProps = {
   checked: false,
-  color: 'secondary' as 'secondary',
   disabled: false,
-  size: 'medium' as 'medium',
   label: 'Switch',
   width: 100,
   height: 38,
@@ -56,11 +52,6 @@ addPropertyControls(Switch, {
     type: ControlType.Boolean,
     title: 'Checked',
   },
-  color: {
-    type: ControlType.Enum,
-    title: 'Color',
-    options: ['default', 'primary', 'secondary'],
-  },
   defaultChecked: {
     type: ControlType.Boolean,
     title: 'Default checked',
@@ -68,11 +59,6 @@ addPropertyControls(Switch, {
   disabled: {
     type: ControlType.Boolean,
     title: 'Disabled',
-  },
-  size: {
-    type: ControlType.Enum,
-    title: 'Size',
-    options: ['medium', 'small'],
   },
   label: {
     type: ControlType.String,

--- a/framer/Material-UI.framerfx/code/Switch.tsx
+++ b/framer/Material-UI.framerfx/code/Switch.tsx
@@ -18,6 +18,7 @@ export function Switch(props: Props) {
     label,
     // @ts-ignore -- untyped
     onChange,
+    // @ts-ignore -- untyped
     size,
     ...other
   } = props;

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -316,7 +316,18 @@ export const componentSettings = {
     template: 'snackbar_content.txt',
   },
   Switch: {
-    ignoredProps: ['checkedIcon', 'edge', 'icon', 'onChange', 'required', 'sx', 'type', 'value'],
+    ignoredProps: [
+      'checkedIcon',
+      'edge',
+      'icon',
+      'onChange',
+      'required',
+      'sx',
+      'type',
+      'value',
+      'color',
+      'size',
+    ],
     propValues: {
       label: "'Switch'",
       width: 100,

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -112,8 +112,6 @@ export const componentSettings = {
       'sx',
       'type',
       'value',
-      'color',
-      'size',
     ],
     propValues: {
       label: "'Checkbox'",

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -294,7 +294,6 @@ export const componentSettings = {
       'sx',
       // FIXME: `Union`
       'color',
-      'size',
     ],
     propValues: {
       width: 160,

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -130,6 +130,8 @@ export const componentSettings = {
       // FIXME: `Union`
       'sx',
       'variant',
+      'color',
+      'size',
     ],
     propValues: {
       avatarImageFile: "''",

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -263,7 +263,18 @@ export const componentSettings = {
     template: 'paper.txt',
   },
   Radio: {
-    ignoredProps: ['checked', 'checkedIcon', 'icon', 'onChange', 'required', 'sx', 'type', 'value'],
+    ignoredProps: [
+      'checked',
+      'checkedIcon',
+      'icon',
+      'onChange',
+      'required',
+      'sx',
+      'type',
+      'value',
+      'color',
+      'size',
+    ],
     propValues: {
       label: "'Radio'",
       width: "'100%'",

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -167,6 +167,8 @@ export const componentSettings = {
       'disableFocusRipple',
       // FIXME: `Union`
       'variant',
+      'color',
+      'size',
       'sx',
     ],
     propValues: {

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -112,6 +112,8 @@ export const componentSettings = {
       'sx',
       'type',
       'value',
+      'color',
+      'size',
     ],
     propValues: {
       label: "'Checkbox'",

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -181,7 +181,7 @@ export const componentSettings = {
     template: 'fab.txt',
   },
   Icon: {
-    ignoredProps: ['children', 'fontSize', 'sx'],
+    ignoredProps: ['children', 'fontSize', 'sx', 'color'],
     propValues: {
       icon: "'add'",
       theme: 'Filled',

--- a/framer/scripts/framerConfig.js
+++ b/framer/scripts/framerConfig.js
@@ -292,6 +292,9 @@ export const componentSettings = {
       'valueLabelFormat',
       'marks',
       'sx',
+      // FIXME: `Union`
+      'color',
+      'size',
     ],
     propValues: {
       width: 160,

--- a/framer/scripts/templates/radio.txt
+++ b/framer/scripts/templates/radio.txt
@@ -9,7 +9,12 @@ interface Props extends Omit<FormControlLabelProps, 'control'> {
 }
 
 export function «componentName»(props: Props): JSX.Element {
-  const { label, size, ...other } = props;
+  const { 
+    label,
+    // @ts-ignore -- untyped
+    size,
+    ...other
+  } = props;
 
   return (
     <FormControlLabel control={<MuiRadio size={size} />} label={label} {...other} />

--- a/framer/scripts/templates/selection_control.txt
+++ b/framer/scripts/templates/selection_control.txt
@@ -10,7 +10,15 @@ interface Props {
 }
 
 export function «componentName»(props: Props): JSX.Element {
-  const { checked: checkedProp, label, onChange, size, ...other } = props;
+  const { 
+    checked: checkedProp,
+    label,
+    onChange,
+    // @ts-ignore -- untyped
+    size,
+    ...other
+  } = props;
+
   const [checked, setChecked] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/framer/scripts/templates/switch.txt
+++ b/framer/scripts/templates/switch.txt
@@ -14,6 +14,7 @@ export function «componentName»(props: Props) {
     label,
     // @ts-ignore -- untyped
     onChange,
+    // @ts-ignore -- untyped
     size,
     ...other
   } = props;

--- a/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
@@ -3,6 +3,7 @@ import { InternalStandardProps as StandardProps, Theme } from '@material-ui/core
 import { ChipProps, ChipTypeMap } from '@material-ui/core/Chip';
 import { PopperProps } from '@material-ui/core/Popper';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import useAutocomplete, {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,
@@ -58,6 +59,8 @@ export interface AutocompleteRenderInputParams {
   };
   inputProps: ReturnType<ReturnType<typeof useAutocomplete>['getInputProps']>;
 }
+
+export interface AutocompletePropsSizeOverrides {}
 
 export interface AutocompleteProps<
   T,
@@ -266,7 +269,7 @@ export interface AutocompleteProps<
    * The size of the component.
    * @default 'medium'
    */
-  size?: 'small' | 'medium';
+  size?: OverridableStringUnion<'small' | 'medium', AutocompletePropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -1046,7 +1046,10 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * The size of the component.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Checkbox/Checkbox.d.ts
+++ b/packages/material-ui/src/Checkbox/Checkbox.d.ts
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps, Theme } from '..';
 import { SwitchBaseProps } from '../internal/SwitchBase';
+
+export interface CheckboxPropsSizeOverrides {}
+
+export interface CheckboxPropsColorOverrides {}
 
 export interface CheckboxProps
   extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon' | 'type'> {
@@ -35,7 +40,7 @@ export interface CheckboxProps
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color?: 'primary' | 'secondary' | 'default';
+  color?: OverridableStringUnion<'primary' | 'secondary' | 'default', CheckboxPropsColorOverrides>;
   /**
    * If `true`, the component is disabled.
    */
@@ -90,7 +95,7 @@ export interface CheckboxProps
    * `small` is equivalent to the dense checkbox styling.
    * @default 'medium'
    */
-  size?: 'small' | 'medium';
+  size?: OverridableStringUnion<'small' | 'medium', CheckboxPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Checkbox/Checkbox.d.ts
+++ b/packages/material-ui/src/Checkbox/Checkbox.d.ts
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
-import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps, Theme } from '..';
 import { SwitchBaseProps } from '../internal/SwitchBase';
-
-export interface CheckboxPropsSizeOverrides {}
-
-export interface CheckboxPropsColorOverrides {}
 
 export interface CheckboxProps
   extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon' | 'type'> {
@@ -40,7 +35,7 @@ export interface CheckboxProps
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color?: OverridableStringUnion<'primary' | 'secondary' | 'default', CheckboxPropsColorOverrides>;
+  color?: 'primary' | 'secondary' | 'default';
   /**
    * If `true`, the component is disabled.
    */
@@ -95,7 +90,7 @@ export interface CheckboxProps
    * `small` is equivalent to the dense checkbox styling.
    * @default 'medium'
    */
-  size?: OverridableStringUnion<'small' | 'medium', CheckboxPropsSizeOverrides>;
+  size?: 'small' | 'medium';
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -144,7 +144,10 @@ Checkbox.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color: PropTypes.oneOf(['default', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The default checked state. Use when the component is not controlled.
    */
@@ -203,7 +206,10 @@ Checkbox.propTypes /* remove-proptypes */ = {
    * `small` is equivalent to the dense checkbox styling.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -144,10 +144,7 @@ Checkbox.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['default', 'primary', 'secondary']),
-    PropTypes.string,
-  ]),
+  color: PropTypes.oneOf(['default', 'primary', 'secondary']),
   /**
    * The default checked state. Use when the component is not controlled.
    */
@@ -206,10 +203,7 @@ Checkbox.propTypes /* remove-proptypes */ = {
    * `small` is equivalent to the dense checkbox styling.
    * @default 'medium'
    */
-  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['medium', 'small']),
-    PropTypes.string,
-  ]),
+  size: PropTypes.oneOf(['medium', 'small']),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Chip/Chip.d.ts
+++ b/packages/material-ui/src/Chip/Chip.d.ts
@@ -6,6 +6,10 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface ChipPropsVariantOverrides {}
 
+export interface ChipPropsSizeOverrides {}
+
+export interface ChipPropsColorOverrides {}
+
 export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
     /**
@@ -109,7 +113,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'default'
      */
-    color?: Exclude<PropTypes.Color, 'inherit'>;
+    color?: OverridableStringUnion<Exclude<PropTypes.Color, 'inherit'>, ChipPropsColorOverrides>;
     /**
      * Override the default delete icon element. Shown only if `onDelete` is set.
      */
@@ -136,7 +140,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The size of the component.
      * @default 'medium'
      */
-    size?: 'small' | 'medium';
+    size?: OverridableStringUnion<'small' | 'medium', ChipPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -519,7 +519,10 @@ Chip.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'default'
    */
-  color: PropTypes.oneOf(['default', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -563,7 +566,10 @@ Chip.propTypes /* remove-proptypes */ = {
    * The size of the component.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -6,6 +6,10 @@ import { OverrideProps } from '../OverridableComponent';
 
 export interface FabPropsVariantOverrides {}
 
+export interface FabPropsSizeOverrides {}
+
+export interface FabPropsColorOverrides {}
+
 export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendButtonBaseTypeMap<{
   props: P & {
     /**
@@ -43,7 +47,7 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'default'
      */
-    color?: PropTypes.Color;
+    color?: OverridableStringUnion<PropTypes.Color, FabPropsColorOverrides>;
     /**
      * If `true`, the component is disabled.
      * @default false
@@ -68,7 +72,7 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      * `small` is equivalent to the dense button styling.
      * @default 'large'
      */
-    size?: 'small' | 'medium' | 'large';
+    size?: OverridableStringUnion<'small' | 'medium' | 'large', FabPropsSizeOverrides>;
     /**
      * The variant to use.
      * @default 'circular'

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -230,7 +230,10 @@ Fab.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'default'
    */
-  color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -264,7 +267,10 @@ Fab.propTypes /* remove-proptypes */ = {
    * `small` is equivalent to the dense button styling.
    * @default 'large'
    */
-  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -234,7 +234,10 @@ FilledInput.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/material-ui/src/Icon/Icon.d.ts
+++ b/packages/material-ui/src/Icon/Icon.d.ts
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { PropTypes } from '..';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+
+export interface IconPropsSizeOverrides {}
+
+export interface IconPropsColorOverrides {}
 
 export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P & {
@@ -43,12 +48,18 @@ export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'inherit'
      */
-    color?: Exclude<PropTypes.Color, 'default'> | 'action' | 'disabled' | 'error';
+    color?: OverridableStringUnion<
+      Exclude<PropTypes.Color, 'default'> | 'action' | 'disabled' | 'error',
+      IconPropsColorOverrides
+    >;
     /**
      * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
      * @default 'medium'
      */
-    fontSize?: 'inherit' | 'large' | 'medium' | 'small';
+    fontSize?: OverridableStringUnion<
+      'inherit' | 'large' | 'medium' | 'small',
+      IconPropsSizeOverrides
+    >;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -132,7 +132,10 @@ Icon.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'inherit'
    */
-  color: PropTypes.oneOf(['action', 'disabled', 'error', 'inherit', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['action', 'disabled', 'error', 'inherit', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -142,7 +145,10 @@ Icon.propTypes /* remove-proptypes */ = {
    * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
    * @default 'medium'
    */
-  fontSize: PropTypes.oneOf(['inherit', 'large', 'medium', 'small']),
+  fontSize: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['inherit', 'large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -163,7 +163,10 @@ Input.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -6,6 +6,8 @@ import { InternalStandardProps as StandardProps } from '..';
 
 export interface InputBasePropsSizeOverrides {}
 
+export interface InputBasePropsColorOverrides {}
+
 export interface InputBaseProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement>,
@@ -74,7 +76,7 @@ export interface InputBaseProps
    * The color of the component. It supports those theme colors that make sense for this component.
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color?: 'primary' | 'secondary';
+  color?: OverridableStringUnion<'primary' | 'secondary', InputBasePropsColorOverrides>;
   /**
    * The components used for each slot inside the InputBase.
    * Either a string to use a HTML element or a component.

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -587,7 +587,10 @@ InputBase.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The components used for each slot inside the InputBase.
    * Either a string to use a HTML element or a component.

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -183,7 +183,10 @@ OutlinedInput.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/material-ui/src/Pagination/Pagination.d.ts
+++ b/packages/material-ui/src/Pagination/Pagination.d.ts
@@ -14,6 +14,10 @@ export interface PaginationRenderItemParams extends UsePaginationItem {
 
 export interface PaginationPropsVariantOverrides {}
 
+export interface PaginationPropsSizeOverrides {}
+
+export interface PaginationPropsColorOverrides {}
+
 export interface PaginationProps
   extends UsePaginationProps,
     StandardProps<React.HTMLAttributes<HTMLElement>, 'children' | 'onChange'> {
@@ -34,7 +38,10 @@ export interface PaginationProps
    * The active color.
    * @default 'standard'
    */
-  color?: 'primary' | 'secondary' | 'standard';
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'standard',
+    PaginationPropsColorOverrides
+  >;
   /**
    * Accepts a function which returns a string value that provides a user-friendly name for the current page.
    *
@@ -67,7 +74,7 @@ export interface PaginationProps
    * The size of the component.
    * @default 'medium'
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: OverridableStringUnion<'small' | 'medium' | 'large', PaginationPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Pagination/Pagination.js
+++ b/packages/material-ui/src/Pagination/Pagination.js
@@ -158,7 +158,10 @@ Pagination.propTypes /* remove-proptypes */ = {
    * The active color.
    * @default 'standard'
    */
-  color: PropTypes.oneOf(['primary', 'secondary', 'standard']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary', 'standard']),
+    PropTypes.string,
+  ]),
   /**
    * The total number of pages.
    * @default 1
@@ -238,7 +241,10 @@ Pagination.propTypes /* remove-proptypes */ = {
    * The size of the component.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.d.ts
@@ -7,6 +7,10 @@ import { UsePaginationItem } from '../usePagination/usePagination';
 
 export interface PaginationItemPropsVariantOverrides {}
 
+export interface PaginationItemPropsSizeOverrides {}
+
+export interface PaginationItemPropsColorOverrides {}
+
 export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
     /**
@@ -54,7 +58,10 @@ export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'di
      * The active color.
      * @default 'standard'
      */
-    color?: 'standard' | 'primary' | 'secondary';
+    color?: OverridableStringUnion<
+      'standard' | 'primary' | 'secondary',
+      PaginationItemPropsColorOverrides
+    >;
     /**
      * If `true`, the component is disabled.
      * @default false
@@ -78,7 +85,7 @@ export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'di
      * The size of the component.
      * @default 'medium'
      */
-    size?: 'small' | 'medium' | 'large';
+    size?: OverridableStringUnion<'small' | 'medium' | 'large', PaginationItemPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -359,7 +359,10 @@ PaginationItem.propTypes /* remove-proptypes */ = {
    * The active color.
    * @default 'standard'
    */
-  color: PropTypes.oneOf(['primary', 'secondary', 'standard']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary', 'standard']),
+    PropTypes.string,
+  ]),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -388,7 +391,10 @@ PaginationItem.propTypes /* remove-proptypes */ = {
    * The size of the component.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Radio/Radio.d.ts
+++ b/packages/material-ui/src/Radio/Radio.d.ts
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps, Theme } from '..';
 import { SwitchBaseProps } from '../internal/SwitchBase';
+
+export interface RadioPropsSizeOverrides {}
+
+export interface RadioPropsColorOverrides {}
 
 export interface RadioProps
   extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon' | 'type'> {
@@ -28,7 +33,7 @@ export interface RadioProps
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color?: 'primary' | 'secondary' | 'default';
+  color?: OverridableStringUnion<'primary' | 'secondary' | 'default', RadioPropsColorOverrides>;
   /**
    * If `true`, the component is disabled.
    */
@@ -42,7 +47,7 @@ export interface RadioProps
    * `small` is equivalent to the dense radio styling.
    * @default 'medium'
    */
-  size?: 'small' | 'medium';
+  size?: OverridableStringUnion<'small' | 'medium', RadioPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -139,7 +139,10 @@ Radio.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color: PropTypes.oneOf(['default', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * If `true`, the component is disabled.
    */
@@ -185,7 +188,10 @@ Radio.propTypes /* remove-proptypes */ = {
    * `small` is equivalent to the dense radio styling.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -5,8 +5,11 @@ import {
   SliderUnstyledTypeMap,
 } from '@material-ui/unstyled/SliderUnstyled';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '../styles';
 import { OverrideProps } from '../OverridableComponent';
+
+export interface SliderPropsColorOverrides {}
 
 export type SliderTypeMap<
   D extends React.ElementType = 'span',
@@ -17,7 +20,7 @@ export type SliderTypeMap<
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'primary'
      */
-    color?: 'primary' | 'secondary';
+    color?: OverridableStringUnion<'primary' | 'secondary', SliderPropsColorOverrides>;
     /**
      * Override or extend the styles applied to the component.
      */

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -476,7 +476,10 @@ Slider.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'primary'
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The components used for each slot inside the Slider.
    * Either a string to use a HTML element or a component.

--- a/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+
+export interface SvgIconPropsSizeOverrides {}
+
+export interface SvgIconPropsColorOverrides {}
 
 export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
   props: P & {
@@ -37,12 +42,18 @@ export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
      * You can use the `htmlColor` prop to apply a color attribute to the SVG element.
      * @default 'inherit'
      */
-    color?: 'inherit' | 'primary' | 'secondary' | 'action' | 'disabled' | 'error';
+    color?: OverridableStringUnion<
+      'inherit' | 'primary' | 'secondary' | 'action' | 'disabled' | 'error',
+      SvgIconPropsColorOverrides
+    >;
     /**
      * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
      * @default 'medium'
      */
-    fontSize?: 'inherit' | 'large' | 'medium' | 'small';
+    fontSize?: OverridableStringUnion<
+      'inherit' | 'large' | 'medium' | 'small',
+      SvgIconPropsSizeOverrides
+    >;
     /**
      * Applies a color attribute to the SVG element.
      */

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -130,7 +130,10 @@ SvgIcon.propTypes /* remove-proptypes */ = {
    * You can use the `htmlColor` prop to apply a color attribute to the SVG element.
    * @default 'inherit'
    */
-  color: PropTypes.oneOf(['action', 'disabled', 'error', 'inherit', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['action', 'disabled', 'error', 'inherit', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -140,7 +143,10 @@ SvgIcon.propTypes /* remove-proptypes */ = {
    * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
    * @default 'medium'
    */
-  fontSize: PropTypes.oneOf(['inherit', 'large', 'medium', 'small']),
+  fontSize: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['inherit', 'large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * Applies a color attribute to the SVG element.
    */

--- a/packages/material-ui/src/Switch/Switch.d.ts
+++ b/packages/material-ui/src/Switch/Switch.d.ts
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps, Theme } from '..';
 import { SwitchBaseProps } from '../internal/SwitchBase';
+
+export interface SwitchPropsSizeOverrides {}
+
+export interface SwitchPropsColorOverrides {}
 
 export interface SwitchProps
   extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon'> {
@@ -44,7 +49,7 @@ export interface SwitchProps
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color?: 'primary' | 'secondary' | 'default';
+  color?: OverridableStringUnion<'primary' | 'secondary' | 'default', SwitchPropsColorOverrides>;
   /**
    * If `true`, the component is disabled.
    */
@@ -58,7 +63,7 @@ export interface SwitchProps
    * `small` is equivalent to the dense switch styling.
    * @default 'medium'
    */
-  size?: 'small' | 'medium';
+  size?: OverridableStringUnion<'small' | 'medium', SwitchPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -260,7 +260,10 @@ Switch.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'secondary'
    */
-  color: PropTypes.oneOf(['default', 'primary', 'secondary']),
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'primary', 'secondary']),
+    PropTypes.string,
+  ]),
   /**
    * The default checked state. Use when the component is not controlled.
    */
@@ -314,7 +317,10 @@ Switch.propTypes /* remove-proptypes */ = {
    * `small` is equivalent to the dense switch styling.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Table/Table.d.ts
+++ b/packages/material-ui/src/Table/Table.d.ts
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export type Padding = 'default' | 'checkbox' | 'none';
 
 export type Size = 'small' | 'medium';
+
+export interface TablePropsSizeOverrides {}
 
 export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
   props: P & {
@@ -31,7 +34,7 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
      * Allows TableCells to inherit size of the Table.
      * @default 'medium'
      */
-    size?: Size;
+    size?: OverridableStringUnion<Size, TablePropsSizeOverrides>;
     /**
      * Set the header sticky.
      *

--- a/packages/material-ui/src/Table/Table.d.ts
+++ b/packages/material-ui/src/Table/Table.d.ts
@@ -25,7 +25,7 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
      * Allows TableCells to inherit padding of the Table.
      * @default 'normal'
      */
-    padding?: 'default' | 'checkbox' | 'none';
+    padding?: 'normal' | 'checkbox' | 'none';
     /**
      * Allows TableCells to inherit size of the Table.
      * @default 'medium'

--- a/packages/material-ui/src/Table/Table.d.ts
+++ b/packages/material-ui/src/Table/Table.d.ts
@@ -4,10 +4,6 @@ import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-export type Padding = 'default' | 'checkbox' | 'none';
-
-export type Size = 'small' | 'medium';
-
 export interface TablePropsSizeOverrides {}
 
 export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
@@ -29,12 +25,12 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
      * Allows TableCells to inherit padding of the Table.
      * @default 'default'
      */
-    padding?: Padding;
+    padding?: 'default' | 'checkbox' | 'none';
     /**
      * Allows TableCells to inherit size of the Table.
      * @default 'medium'
      */
-    size?: OverridableStringUnion<Size, TablePropsSizeOverrides>;
+    size?: OverridableStringUnion<'small' | 'medium', TablePropsSizeOverrides>;
     /**
      * Set the header sticky.
      *

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -126,7 +126,10 @@ Table.propTypes /* remove-proptypes */ = {
    * Allows TableCells to inherit size of the Table.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * Set the header sticky.
    *

--- a/packages/material-ui/src/Table/TableContext.d.ts
+++ b/packages/material-ui/src/Table/TableContext.d.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Padding, Size } from './Table';
 
 interface TableContextProps {
-  padding: Padding;
-  size: Size;
+  padding: 'default' | 'checkbox' | 'none';
+  size: 'default' | 'checkbox' | 'none';
 }
 
 declare const TableContext: React.Context<TableContextProps | undefined>;

--- a/packages/material-ui/src/TableCell/TableCell.d.ts
+++ b/packages/material-ui/src/TableCell/TableCell.d.ts
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
 import { InternalStandardProps as StandardProps, Theme } from '..';
-import { Padding, Size } from '../Table';
-
-export { Padding, Size };
 
 /**
  * `<TableCell>` will be rendered as an `<th>`or `<td>` depending
@@ -66,7 +63,7 @@ export interface TableCellProps extends StandardProps<TableCellBaseProps, 'align
    * Sets the padding applied to the cell.
    * The prop defaults to the value (`'default'`) inherited from the parent Table component.
    */
-  padding?: Padding;
+  padding?: 'default' | 'checkbox' | 'none';
   /**
    * Set scope attribute.
    */
@@ -75,7 +72,7 @@ export interface TableCellProps extends StandardProps<TableCellBaseProps, 'align
    * Specify the size of the cell.
    * The prop defaults to the value (`'medium'`) inherited from the parent Table component.
    */
-  size?: Size;
+  size?: 'small' | 'medium';
   /**
    * Set aria-sort direction.
    */

--- a/packages/material-ui/src/TableCell/TableCell.d.ts
+++ b/packages/material-ui/src/TableCell/TableCell.d.ts
@@ -63,7 +63,7 @@ export interface TableCellProps extends StandardProps<TableCellBaseProps, 'align
    * Sets the padding applied to the cell.
    * The prop defaults to the value (`'default'`) inherited from the parent Table component.
    */
-  padding?: 'default' | 'checkbox' | 'none';
+  padding?: 'normal' | 'checkbox' | 'none';
   /**
    * Set scope attribute.
    */

--- a/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
@@ -1,7 +1,10 @@
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { Theme } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
+
+export interface ToggleButtonPropsSizeOverrides {}
 
 export type ToggleButtonTypeMap<
   P = {},
@@ -66,7 +69,7 @@ export type ToggleButtonTypeMap<
      * The prop defaults to the value inherited from the parent ToggleButtonGroup component.
      * @default 'medium'
      */
-    size?: 'small' | 'medium' | 'large';
+    size?: OverridableStringUnion<'small' | 'medium' | 'large', ToggleButtonPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -261,7 +261,10 @@ ToggleButton.propTypes /* remove-proptypes */ = {
    * The prop defaults to the value inherited from the parent ToggleButtonGroup component.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps } from '..';
 import { Theme } from '../styles';
+
+export interface ToggleButtonGroupPropsSizeOverrides {}
 
 export interface ToggleButtonGroupProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {
@@ -57,7 +60,7 @@ export interface ToggleButtonGroupProps
    * The size of the component.
    * @default 'medium'
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: OverridableStringUnion<'small' | 'medium' | 'large', ToggleButtonGroupPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -227,7 +227,10 @@ ToggleButtonGroup.propTypes /* remove-proptypes */ = {
    * The size of the component.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Added support custom for

- Autocomplete -> size
- Table -> size
- ToggleButton -> size
- ToggleButtonGroup -> size
- Slider -> color
- Pagination -> color, size
- PaginationItem -> color, size
- Fab -> color, size
- SvgIcon -> color, size
- Icon -> color, size
- Chip -> color, size
- InputBase -> color
- OutlinedInput -> color
- FilledInput -> color
- Input -> color
- Switch -> color, size
- Checkbox -> color, size
- Radio -> color, size

Closes #13875