### PR TITLE
[internal][pickers] Entangle what *Props vs All*Props means

### DIFF
--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  datePickerConfig,
-  DatePickerGenericComponent,
-  BaseDatePickerProps,
-} from '../DatePicker/DatePicker';
+import { datePickerConfig, BaseDatePickerProps } from '../DatePicker/DatePicker';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
-
-type AllDesktopDatePickerProps = BaseDatePickerProps<unknown> &
-  AllSharedPickerProps &
-  DesktopWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +19,12 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = datePickerConfig;
 
 export interface DesktopDatePickerProps<TDate = unknown>
-  extends BaseDatePickerProps<unknown>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate>,
+  extends BaseDatePickerProps<TDate>,
     DesktopWrapperProps {}
+
+type DesktopDatePickerComponent = (<TDate>(
+  props: DesktopDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -47,20 +40,20 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   inProps: DesktopDatePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllDesktopDatePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: DesktopDatePickerProps<unknown> = useInterceptProps(
+    inProps as DesktopDatePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllDesktopDatePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiDesktopDatePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
@@ -84,7 +77,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
       />
     </DesktopWrapper>
   );
-}) as DatePickerGenericComponent<DesktopWrapperProps>;
+}) as DesktopDatePickerComponent;
 
 DesktopDatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseDateTimePickerProps,
-  dateTimePickerConfig,
-  DateTimePickerGenericComponent,
-} from '../DateTimePicker/DateTimePicker';
+import { BaseDateTimePickerProps, dateTimePickerConfig } from '../DateTimePicker/DateTimePicker';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
-
-type AllDesktopDateTimePickerProps = BaseDateTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  DesktopWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +19,12 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = dateTimePickerConfig;
 
 export interface DesktopDateTimePickerProps<TDate = unknown>
-  extends BaseDateTimePickerProps<unknown>,
-    DesktopWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends BaseDateTimePickerProps<TDate>,
+    DesktopWrapperProps {}
+
+type DesktopDateTimePickerComponent = (<TDate>(
+  props: DesktopDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -47,20 +40,20 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
   inProps: DesktopDateTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllDesktopDateTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: DesktopDateTimePickerProps<unknown> = useInterceptProps(
+    inProps as DesktopDateTimePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllDesktopDateTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiDesktopDateTimePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
@@ -84,7 +77,7 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
       />
     </DesktopWrapper>
   );
-}) as DateTimePickerGenericComponent<DesktopWrapperProps>;
+}) as DesktopDateTimePickerComponent;
 
 DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -16,9 +16,9 @@ import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
-type AllDesktopTimePickerProps = BaseTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  DesktopWrapperProps;
+type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
+  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
+  PublicWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +29,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
 export interface DesktopTimePickerProps<TDate = unknown>
-  extends BaseTimePickerProps,
-    DesktopWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends GenericTimePickerProps<TDate, DesktopWrapperProps> {}
 
 /**
  *
@@ -47,20 +45,20 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   inProps: DesktopTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllDesktopTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps = useInterceptProps(
+    inProps as DesktopTimePickerProps<unknown>,
+  ) as DesktopTimePickerProps<unknown>;
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllDesktopTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiDesktopTimePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -4,13 +4,11 @@ import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/style
 import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -22,7 +20,6 @@ const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePicker
 
 export interface DesktopTimePickerProps<TDate = unknown>
   extends BaseTimePickerProps<TDate>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
     DesktopWrapperProps {}
 
 type DesktopTimePickerComponent = (<TDate>(

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -12,10 +12,6 @@ import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
-type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
-  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
-  PublicWrapperProps;
-
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
@@ -25,7 +21,9 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
 export interface DesktopTimePickerProps<TDate = unknown>
-  extends GenericTimePickerProps<TDate, DesktopWrapperProps> {}
+  extends BaseTimePickerProps<TDate>,
+    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
+    DesktopWrapperProps {}
 
 type DesktopTimePickerComponent = (<TDate>(
   props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseTimePickerProps,
-  timePickerConfig,
-  TimePickerGenericComponent,
-} from '../TimePicker/TimePicker';
+import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
 import { ParsableDate } from '../internal/pickers/constants/prop-types';
@@ -30,6 +26,10 @@ const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePicker
 
 export interface DesktopTimePickerProps<TDate = unknown>
   extends GenericTimePickerProps<TDate, DesktopWrapperProps> {}
+
+type DesktopTimePickerComponent = (<TDate>(
+  props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -82,7 +82,7 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
       />
     </DesktopWrapper>
   );
-}) as TimePickerGenericComponent<DesktopWrapperProps>;
+}) as DesktopTimePickerComponent;
 
 DesktopTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseDatePickerProps,
-  datePickerConfig,
-  DatePickerGenericComponent,
-} from '../DatePicker/DatePicker';
+import { BaseDatePickerProps, datePickerConfig } from '../DatePicker/DatePicker';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
-
-type AllMobileDatePickerProps = BaseDatePickerProps<unknown> &
-  AllSharedPickerProps &
-  MobileWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +19,12 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = datePickerConfig;
 
 export interface MobileDatePickerProps<TDate = unknown>
-  extends BaseDatePickerProps<unknown>,
-    MobileWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends BaseDatePickerProps<TDate>,
+    MobileWrapperProps {}
+
+type MobileDatePickerComponent = (<TDate>(
+  props: MobileDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -47,20 +40,20 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
   inProps: MobileDatePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllMobileDatePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: MobileDatePickerProps<unknown> = useInterceptProps(
+    inProps as MobileDatePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllMobileDatePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiMobileDatePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
@@ -84,7 +77,7 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
       />
     </MobileWrapper>
   );
-}) as DatePickerGenericComponent<MobileWrapperProps>;
+}) as MobileDatePickerComponent;
 
 MobileDatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseDateTimePickerProps,
-  dateTimePickerConfig,
-  DateTimePickerGenericComponent,
-} from '../DateTimePicker/DateTimePicker';
+import { BaseDateTimePickerProps, dateTimePickerConfig } from '../DateTimePicker/DateTimePicker';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
-
-type AllMobileDateTimePickerProps = BaseDateTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  MobileWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +19,12 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = dateTimePickerConfig;
 
 export interface MobileDateTimePickerProps<TDate = unknown>
-  extends BaseDateTimePickerProps<unknown>,
-    MobileWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends BaseDateTimePickerProps<TDate>,
+    MobileWrapperProps {}
+
+type MobileDateTimePickerComponent = (<TDate>(
+  props: MobileDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -47,20 +40,20 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
   inProps: MobileDateTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllMobileDateTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: MobileDateTimePickerProps<unknown> = useInterceptProps(
+    inProps as MobileDateTimePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllMobileDateTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiMobileDateTimePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
@@ -84,7 +77,7 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
       />
     </MobileWrapper>
   );
-}) as DateTimePickerGenericComponent<MobileWrapperProps>;
+}) as MobileDateTimePickerComponent;
 
 MobileDateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -4,13 +4,11 @@ import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/style
 import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -22,7 +20,6 @@ const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePicker
 
 export interface MobileTimePickerProps<TDate = unknown>
   extends BaseTimePickerProps<TDate>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
     MobileWrapperProps {}
 
 type MobileTimePickerComponent = (<TDate>(

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -12,10 +12,6 @@ import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
-type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
-  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
-  PublicWrapperProps;
-
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
@@ -25,7 +21,9 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
 export interface MobileTimePickerProps<TDate = unknown>
-  extends GenericTimePickerProps<TDate, MobileWrapperProps> {}
+  extends BaseTimePickerProps<TDate>,
+    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
+    MobileWrapperProps {}
 
 type MobileTimePickerComponent = (<TDate>(
   props: MobileTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseTimePickerProps,
-  timePickerConfig,
-  TimePickerGenericComponent,
-} from '../TimePicker/TimePicker';
+import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
 import { ParsableDate } from '../internal/pickers/constants/prop-types';
@@ -30,6 +26,10 @@ const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePicker
 
 export interface MobileTimePickerProps<TDate = unknown>
   extends GenericTimePickerProps<TDate, MobileWrapperProps> {}
+
+type MobileTimePickerComponent = (<TDate>(
+  props: MobileTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -82,7 +82,7 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
       />
     </MobileWrapper>
   );
-}) as TimePickerGenericComponent<MobileWrapperProps>;
+}) as MobileTimePickerComponent;
 
 MobileTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -16,9 +16,9 @@ import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
-type AllMobileTimePickerProps = BaseTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  MobileWrapperProps;
+type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
+  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
+  PublicWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +29,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
 export interface MobileTimePickerProps<TDate = unknown>
-  extends BaseTimePickerProps,
-    MobileWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends GenericTimePickerProps<TDate, MobileWrapperProps> {}
 
 /**
  *
@@ -47,20 +45,20 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
   inProps: MobileTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllMobileTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps = useInterceptProps(
+    inProps as MobileTimePickerProps<unknown>,
+  ) as MobileTimePickerProps<unknown>;
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllMobileTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiMobileTimePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseDatePickerProps,
-  datePickerConfig,
-  DatePickerGenericComponent,
-} from '../DatePicker/DatePicker';
+import { BaseDatePickerProps, datePickerConfig } from '../DatePicker/DatePicker';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
-
-type AllStaticDatePickerProps = BaseDatePickerProps<unknown> &
-  AllSharedPickerProps &
-  StaticWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +19,12 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = datePickerConfig;
 
 export interface StaticDatePickerProps<TDate = unknown>
-  extends BaseDatePickerProps<unknown>,
-    StaticWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends BaseDatePickerProps<TDate>,
+    StaticWrapperProps {}
+
+type StaticDatePickerComponent = (<TDate>(
+  props: StaticDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -47,20 +40,20 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
   inProps: StaticDatePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllStaticDatePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: StaticDatePickerProps<unknown> = useInterceptProps(
+    inProps as StaticDatePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllStaticDatePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiStaticDatePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
@@ -84,7 +77,7 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
       />
     </StaticWrapper>
   );
-}) as DatePickerGenericComponent<StaticWrapperProps>;
+}) as StaticDatePickerComponent;
 
 StaticDatePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseDateTimePickerProps,
-  dateTimePickerConfig,
-  DateTimePickerGenericComponent,
-} from '../DateTimePicker/DateTimePicker';
+import { BaseDateTimePickerProps, dateTimePickerConfig } from '../DateTimePicker/DateTimePicker';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
-
-type AllStaticDateTimePickerProps = BaseDateTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  StaticWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +19,12 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = dateTimePickerConfig;
 
 export interface StaticDateTimePickerProps<TDate = unknown>
-  extends BaseDateTimePickerProps<unknown>,
-    StaticWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends BaseDateTimePickerProps<TDate>,
+    StaticWrapperProps {}
+
+type StaticDateTimePickerComponent = (<TDate>(
+  props: StaticDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -47,20 +40,20 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
   inProps: StaticDateTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllStaticDateTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: StaticDateTimePickerProps<unknown> = useInterceptProps(
+    inProps as StaticDateTimePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllStaticDateTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiStaticDateTimePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
@@ -84,7 +77,7 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
       />
     </StaticWrapper>
   );
-}) as DateTimePickerGenericComponent<StaticWrapperProps>;
+}) as StaticDateTimePickerComponent;
 
 StaticDateTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import {
-  BaseTimePickerProps,
-  timePickerConfig,
-  TimePickerGenericComponent,
-} from '../TimePicker/TimePicker';
+import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
 import { ParsableDate } from '../internal/pickers/constants/prop-types';
@@ -30,6 +26,10 @@ const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePicker
 
 export interface StaticTimePickerProps<TDate = unknown>
   extends GenericTimePickerProps<TDate, StaticWrapperProps> {}
+
+type StaticTimePickerComponent = (<TDate>(
+  props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -82,7 +82,7 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
       />
     </StaticWrapper>
   );
-}) as TimePickerGenericComponent<StaticWrapperProps>;
+}) as StaticTimePickerComponent;
 
 StaticTimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -12,10 +12,6 @@ import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
-type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
-  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
-  PublicWrapperProps;
-
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
@@ -25,7 +21,9 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
 export interface StaticTimePickerProps<TDate = unknown>
-  extends GenericTimePickerProps<TDate, StaticWrapperProps> {}
+  extends BaseTimePickerProps<TDate>,
+    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
+    StaticWrapperProps {}
 
 type StaticTimePickerComponent = (<TDate>(
   props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -16,9 +16,9 @@ import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
-type AllStaticTimePickerProps = BaseTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  StaticWrapperProps;
+type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
+  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
+  PublicWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -29,9 +29,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
 export interface StaticTimePickerProps<TDate = unknown>
-  extends BaseTimePickerProps,
-    StaticWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends GenericTimePickerProps<TDate, StaticWrapperProps> {}
 
 /**
  *
@@ -47,20 +45,20 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
   inProps: StaticTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllStaticTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: StaticTimePickerProps<unknown> = useInterceptProps(
+    inProps as StaticTimePickerProps<unknown>,
+  );
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllStaticTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiStaticTimePicker',
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -4,13 +4,11 @@ import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/style
 import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -22,7 +20,6 @@ const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePicker
 
 export interface StaticTimePickerProps<TDate = unknown>
   extends BaseTimePickerProps<TDate>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
     StaticWrapperProps {}
 
 type StaticTimePickerComponent = (<TDate>(

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -30,8 +30,7 @@ type AllResponsiveTimePickerProps = BaseTimePickerProps<unknown> &
 
 type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
   AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
-  PublicWrapperProps &
-  React.RefAttributes<HTMLInputElement>;
+  PublicWrapperProps;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
@@ -104,7 +103,7 @@ export const timePickerConfig = {
 };
 
 export type TimePickerGenericComponent<PublicWrapperProps> = (<TDate>(
-  props: GenericTimePickerProps<TDate, PublicWrapperProps>,
+  props: GenericTimePickerProps<TDate, PublicWrapperProps> & React.RefAttributes<HTMLInputElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 const { DefaultToolbarComponent, useValidation } = timePickerConfig;

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -98,14 +98,14 @@ export const timePickerConfig = {
   DefaultToolbarComponent: TimePickerToolbar,
 };
 
-export type TimePickerGenericComponent<PublicWrapperProps> = (<TDate>(
-  props: GenericTimePickerProps<TDate, PublicWrapperProps> & React.RefAttributes<HTMLInputElement>,
-) => JSX.Element) & { propTypes?: any };
-
 const { DefaultToolbarComponent, useValidation } = timePickerConfig;
 
 export interface TimePickerProps<TDate = unknown>
   extends GenericTimePickerProps<TDate, ResponsiveWrapperProps> {}
+
+type TimePickerComponent = (<TDate>(
+  props: TimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+) => JSX.Element) & { propTypes?: any };
 
 /**
  *
@@ -156,7 +156,7 @@ const TimePicker = React.forwardRef(function TimePicker<TDate>(
       />
     </ResponsiveWrapper>
   );
-}) as TimePickerGenericComponent<ResponsiveWrapperProps>;
+}) as TimePickerComponent;
 
 TimePicker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -28,7 +28,7 @@ type AllResponsiveTimePickerProps = BaseTimePickerProps<unknown> &
   AllSharedPickerProps &
   ResponsiveWrapperProps;
 
-type SharedPickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
+type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
   AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
   PublicWrapperProps &
   React.RefAttributes<HTMLInputElement>;
@@ -104,7 +104,7 @@ export const timePickerConfig = {
 };
 
 export type TimePickerGenericComponent<PublicWrapperProps> = (<TDate>(
-  props: SharedPickerProps<TDate, PublicWrapperProps>,
+  props: GenericTimePickerProps<TDate, PublicWrapperProps>,
 ) => JSX.Element) & { propTypes?: any };
 
 const { DefaultToolbarComponent, useValidation } = timePickerConfig;

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -24,10 +24,6 @@ import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
-type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
-  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
-  PublicWrapperProps;
-
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
@@ -101,7 +97,9 @@ export const timePickerConfig = {
 const { DefaultToolbarComponent, useValidation } = timePickerConfig;
 
 export interface TimePickerProps<TDate = unknown>
-  extends GenericTimePickerProps<TDate, ResponsiveWrapperProps> {}
+  extends BaseTimePickerProps<TDate>,
+    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
+    ResponsiveWrapperProps {}
 
 type TimePickerComponent = (<TDate>(
   props: TimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -24,10 +24,6 @@ import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
-type AllResponsiveTimePickerProps = BaseTimePickerProps<unknown> &
-  AllSharedPickerProps &
-  ResponsiveWrapperProps;
-
 type GenericTimePickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
   AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
   PublicWrapperProps;
@@ -109,9 +105,7 @@ export type TimePickerGenericComponent<PublicWrapperProps> = (<TDate>(
 const { DefaultToolbarComponent, useValidation } = timePickerConfig;
 
 export interface TimePickerProps<TDate = unknown>
-  extends BaseTimePickerProps,
-    ResponsiveWrapperProps,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate> {}
+  extends GenericTimePickerProps<TDate, ResponsiveWrapperProps> {}
 
 /**
  *
@@ -127,20 +121,18 @@ const TimePicker = React.forwardRef(function TimePicker<TDate>(
   inProps: TimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const allProps = useInterceptProps(inProps) as AllResponsiveTimePickerProps;
+  // TODO: TDate needs to be instantiated at every usage.
+  const allProps: TimePickerProps<unknown> = useInterceptProps(inProps as TimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props: AllResponsiveTimePickerProps = useThemeProps({
+  const props = useThemeProps({
     props: allProps,
     name: 'MuiTimePicker',
-  });
+  }) as TimePickerProps<unknown>;
 
-  const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState<ParsableDate<TDate>, TDate>(
-    props,
-    valueManager as PickerStateValueManager<ParsableDate<TDate>, TDate>,
-  );
+  const validationError = useValidation(props.value, props as TimePickerProps<unknown>) !== null;
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -34,7 +34,8 @@ export type TimePickerView = 'hours' | 'minutes' | 'seconds';
 
 export interface BaseTimePickerProps<TDate = unknown>
   extends ValidationProps<TimeValidationError, ParsableDate<TDate>>,
-    OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'> {
+    OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'>,
+    AllSharedPickerProps<ParsableDate<TDate>, TDate | null> {
   /**
    * First view to show.
    */
@@ -98,7 +99,6 @@ const { DefaultToolbarComponent, useValidation } = timePickerConfig;
 
 export interface TimePickerProps<TDate = unknown>
   extends BaseTimePickerProps<TDate>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null>,
     ResponsiveWrapperProps {}
 
 type TimePickerComponent = (<TDate>(

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -28,10 +28,8 @@ type AllResponsiveTimePickerProps = BaseTimePickerProps<unknown> &
   AllSharedPickerProps &
   ResponsiveWrapperProps;
 
-type SharedPickerProps<TDate, PublicWrapperProps> = AllSharedPickerProps<
-  ParsableDate<TDate>,
-  TDate | null
-> &
+type SharedPickerProps<TDate, PublicWrapperProps> = BaseTimePickerProps<TDate> &
+  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
   PublicWrapperProps &
   React.RefAttributes<HTMLInputElement>;
 
@@ -106,7 +104,7 @@ export const timePickerConfig = {
 };
 
 export type TimePickerGenericComponent<PublicWrapperProps> = (<TDate>(
-  props: BaseTimePickerProps<TDate> & SharedPickerProps<TDate, PublicWrapperProps>,
+  props: SharedPickerProps<TDate, PublicWrapperProps>,
 ) => JSX.Element) & { propTypes?: any };
 
 const { DefaultToolbarComponent, useValidation } = timePickerConfig;

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -28,15 +28,15 @@ type AllResponsiveTimePickerProps = BaseTimePickerProps<unknown> &
   AllSharedPickerProps &
   ResponsiveWrapperProps;
 
+type SharedPickerProps<TDate, PublicWrapperProps> = PublicWrapperProps &
+  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
+  React.RefAttributes<HTMLInputElement>;
+
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-type SharedPickerProps<TDate, PublicWrapperProps> = PublicWrapperProps &
-  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
-  React.RefAttributes<HTMLInputElement>;
 
 export type TimePickerView = 'hours' | 'minutes' | 'seconds';
 

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -28,8 +28,11 @@ type AllResponsiveTimePickerProps = BaseTimePickerProps<unknown> &
   AllSharedPickerProps &
   ResponsiveWrapperProps;
 
-type SharedPickerProps<TDate, PublicWrapperProps> = PublicWrapperProps &
-  AllSharedPickerProps<ParsableDate<TDate>, TDate | null> &
+type SharedPickerProps<TDate, PublicWrapperProps> = AllSharedPickerProps<
+  ParsableDate<TDate>,
+  TDate | null
+> &
+  PublicWrapperProps &
   React.RefAttributes<HTMLInputElement>;
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {


### PR DESCRIPTION
Review on a per-commit basis advised.

The goal is to get rid of `BasePickerProps` which currently lives completely decoupled from its implementation. Though it previously leaked through `AllSharedPickerProps` into all picker implementations.

We can isolate its usage while at the same time resolving some naming issues regarding `All*Props` vs `*Props`. I've only applied it to the TimePicker for now in detail. The other pickers will be handled in a single commit. But in order to show that this refactoring is sound I did every step in a single commit.