### PR TITLE
[core] Ensure props spreading works as expected

### DIFF
--- a/docs/pages/api-docs/switch.json
+++ b/docs/pages/api-docs/switch.json
@@ -53,7 +53,7 @@
     "globalClasses": { "checked": "Mui-checked", "disabled": "Mui-disabled" },
     "name": "MuiSwitch"
   },
-  "spread": true,
+  "spread": false,
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/material-ui/src/Switch/Switch.js",
   "inheritance": { "component": "IconButton", "pathname": "/api/icon-button/" },

--- a/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.test.tsx
@@ -22,6 +22,7 @@ describe('<CalendarPicker />', () => {
   describeConformance(<CalendarPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
     classes,
     inheritComponent: 'div',
+    render,
     mount: localizedMount,
     refInstanceof: window.HTMLDivElement,
     // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.test.tsx
+++ b/packages/material-ui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { getClasses, createMount, describeConformance } from 'test/utils';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
 import CalendarPickerSkeleton from '@material-ui/lab/CalendarPickerSkeleton';
 
 describe('<CalendarPickerSkeleton />', () => {
   let classes: Record<string, string>;
+  const render = createClientRender();
   const mount = createMount();
 
   before(() => {
@@ -13,6 +14,7 @@ describe('<CalendarPickerSkeleton />', () => {
   describeConformance(<CalendarPickerSkeleton />, () => ({
     classes,
     inheritComponent: 'div',
+    render,
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'refForwarding'],

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { getClasses, createMount, describeConformance } from 'test/utils';
+import { getClasses, createMount, createClientRender, describeConformance } from 'test/utils';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateRangePickerDay from '@material-ui/lab/DateRangePickerDay';
 import { adapterToUse, AdapterClassToUse } from '../internal/pickers/test-utils';
 
 describe('<DateRangePickerDay />', () => {
   const mount = createMount();
+  const render = createClientRender();
   let classes: Record<string, string>;
 
   const localizedMount = (node: React.ReactNode) => {
@@ -47,6 +48,8 @@ describe('<DateRangePickerDay />', () => {
     () => ({
       classes,
       inheritComponent: 'button',
+      render: (node: React.ReactNode) =>
+        render(<LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>),
       mount: localizedMount,
       refInstanceof: window.HTMLButtonElement,
       // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
@@ -22,6 +22,7 @@ describe('<LoadingButton />', () => {
   describeConformance(<LoadingButton>Conformance?</LoadingButton>, () => ({
     classes,
     inheritComponent: Button,
+    render,
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
@@ -37,6 +37,7 @@ describe('<MonthPicker />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
+      render,
       mount: localizedMount,
       refInstanceof: window.HTMLDivElement,
       // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
@@ -35,6 +35,7 @@ describe('<PickersDay />', () => {
     () => ({
       classes,
       inheritComponent: 'button',
+      render,
       mount,
       refInstanceof: window.HTMLButtonElement,
       // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-lab/src/TabList/TabList.test.js
+++ b/packages/material-ui-lab/src/TabList/TabList.test.js
@@ -23,6 +23,10 @@ describe('<TabList />', () => {
   describeConformance(<TabList />, () => ({
     classes,
     inheritComponent: Tabs,
+    /**
+     * @param {React.ReactNode} node
+     */
+    render: (node) => render(<TabContext value="0">{node}</TabContext>),
     mount: mountInContext,
     refInstanceof: window.HTMLDivElement,
     // TODO: no idea why reactTestRenderer fails

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -27,6 +27,7 @@ describe('<TreeItem />', () => {
   describeConformance(<TreeItem nodeId="one" label="one" />, () => ({
     classes,
     inheritComponent: 'li',
+    render,
     mount,
     refInstanceof: window.HTMLLIElement,
     skip: ['componentProp'],

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
@@ -39,6 +39,7 @@ describe('<YearPicker />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
+      render,
       mount: localizedMount,
       refInstanceof: window.HTMLDivElement,
       // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-unstyled/src/BackdropUnstyled/BackdropUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/BackdropUnstyled/BackdropUnstyled.test.js
@@ -16,6 +16,7 @@ describe('<BackdropUnstyled />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
+      render,
       mount,
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'div',

--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.test.js
@@ -16,6 +16,7 @@ describe('<BadgeUnstyled />', () => {
     () => ({
       classes,
       inheritComponent: 'span',
+      render,
       mount,
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformance } from 'test/utils';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import ModalUnstyled, {
   modalUnstyledClasses as classes,
 } from '@material-ui/unstyled/ModalUnstyled';
@@ -18,7 +18,7 @@ describe('<ModalUnstyled />', () => {
     document.body.setAttribute('style', savedBodyStyle);
   });
 
-  describeConformance(
+  describeConformanceV5(
     <ModalUnstyled open>
       <div />
     </ModalUnstyled>,
@@ -28,8 +28,14 @@ describe('<ModalUnstyled />', () => {
       render,
       mount,
       refInstanceof: window.HTMLDivElement,
-      testComponentPropWith: 'div',
-      skip: ['reactTestRenderer'],
+      skip: [
+        'rootClass', // the root is portal
+        'componentProp',
+        'componentsProp',
+        'themeDefaultProps', // the root is portal
+        'themeStyleOverrides',
+        'reactTestRenderer', // https://github.com/facebook/react/issues/11565
+      ],
     }),
   );
 

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
@@ -25,6 +25,7 @@ describe('<ModalUnstyled />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
+      render,
       mount,
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'div',

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
@@ -29,12 +29,11 @@ describe('<ModalUnstyled />', () => {
       mount,
       refInstanceof: window.HTMLDivElement,
       skip: [
-        'rootClass', // the root is portal
-        'componentProp',
-        'componentsProp',
-        'themeDefaultProps', // the root is portal
-        'themeStyleOverrides',
-        'reactTestRenderer', // https://github.com/facebook/react/issues/11565
+        'rootClass', // portal, can't determin the root
+        'themeDefaultProps', // unstyled
+        'themeStyleOverrides', // unstyled
+        'themeVariants', // unstyled
+        'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
       ],
     }),
   );

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.test.js
@@ -18,6 +18,7 @@ describe('<SliderUnstyled />', () => {
   describeConformance(<SliderUnstyled value={0} />, () => ({
     classes,
     inheritComponent: 'span',
+    render,
     mount,
     refInstanceof: window.HTMLSpanElement,
     testComponentPropWith: 'span',

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -28,11 +28,11 @@ describe('<Menu />', () => {
     testRootOverrides: { slotName: 'root', slotClassName: classes.root },
     testVariantProps: { variant: 'menu' },
     skip: [
-      'rootClass', // the root is portal
+      'rootClass', // portal, can't determin the root
       'componentProp',
       'componentsProp',
       'reactTestRenderer', // react-transition-group issue
-      'themeDefaultProps', // the root is portal
+      'themeDefaultProps', // portal, can't determin the root
     ],
   }));
 

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -43,12 +43,11 @@ describe('<Modal />', () => {
       refInstanceof: window.HTMLDivElement,
       testVariantProps: { hideBackdrop: true },
       skip: [
-        'rootClass', // the root is portal
-        'componentProp',
-        'componentsProp',
-        'themeDefaultProps', // the root is portal
-        'themeStyleOverrides',
-        'reactTestRenderer', // https://github.com/facebook/react/issues/11565
+        'rootClass', // portal, can't determin the root
+        'componentsProp', // TODO isRTL is leaking, why do we even have it in the first place?
+        'themeDefaultProps', // portal, can't determin the root
+        'themeStyleOverrides', // portal, can't determin the root
+        'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
       ],
     }),
   );

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -56,6 +56,7 @@ describe('<Popover />', () => {
     refInstanceof: window.HTMLDivElement,
     testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },
     skip: [
+      'rootClass', // the root is portal
       'componentProp',
       'componentsProp',
       'themeDefaultProps', // the root is portal

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -56,11 +56,11 @@ describe('<Popover />', () => {
     refInstanceof: window.HTMLDivElement,
     testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },
     skip: [
-      'rootClass', // the root is portal
+      'rootClass', // portal, can't determin the root
       'componentProp',
       'componentsProp',
-      'themeDefaultProps', // the root is portal
-      'themeStyleOverrides',
+      'themeDefaultProps', // portal, can't determin the root
+      'themeStyleOverrides', // portal, can't determin the root
       'themeVariants',
       'reactTestRenderer', // react-transition-group issue
     ],

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -205,7 +205,7 @@ const SwitchThumb = experimentalStyled(
 
 const Switch = React.forwardRef(function Switch(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiSwitch' });
-  const { className, color = 'secondary', edge = false, size = 'medium', ...other } = props;
+  const { className, color = 'secondary', edge = false, size = 'medium', sx, ...other } = props;
 
   const styleProps = {
     ...props,
@@ -215,20 +215,21 @@ const Switch = React.forwardRef(function Switch(inProps, ref) {
   };
 
   const classes = useUtilityClasses(styleProps);
-
   const icon = <SwitchThumb className={classes.thumb} styleProps={styleProps} />;
 
   return (
-    <SwitchRoot className={clsx(classes.root, className)} styleProps={styleProps}>
+    <SwitchRoot className={clsx(classes.root, className)} sx={sx} styleProps={styleProps}>
       <SwitchSwitchBase
-        className={classes.switchBase}
         type="checkbox"
         icon={icon}
         checkedIcon={icon}
         ref={ref}
         styleProps={styleProps}
         {...other}
-        classes={classes}
+        classes={{
+          ...classes,
+          root: classes.switchBase,
+        }}
       />
       <SwitchTrack className={classes.track} styleProps={styleProps} />
     </SwitchRoot>

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -9,15 +9,14 @@ describe('<Switch />', () => {
   const mount = createMount();
 
   describeConformanceV5(<Switch />, () => ({
+    classes,
     render,
     mount,
     muiName: 'MuiSwitch',
     testVariantProps: { variant: 'foo' },
     testDeepOverrides: { slotName: 'track', slotClassName: classes.track },
-    // TODO Switch violates root component
-    only: ['refForwarding'],
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp', 'componentsProp', 'propsSpread', 'themeDefaultProps'],
   }));
 
   describe('styleSheet', () => {

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -13,10 +13,9 @@ describe('<Switch />', () => {
     render,
     mount,
     muiName: 'MuiSwitch',
-    testVariantProps: { variant: 'foo' },
     testDeepOverrides: { slotName: 'track', slotClassName: classes.track },
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp', 'propsSpread', 'themeDefaultProps'],
+    skip: ['componentProp', 'componentsProp', 'propsSpread', 'themeDefaultProps', 'themeVariants'],
   }));
 
   describe('styleSheet', () => {

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -148,28 +148,31 @@ export function describeRef(element, getOptions) {
  */
 export function testRootClass(element, getOptions) {
   it('applies the root class to the root component if it has this class', () => {
-    const { classes, mount } = getOptions();
+    const { classes, render } = getOptions();
     if (classes.root == null) {
       return;
     }
 
     const className = randomStringValue();
-    let wrapper = mount(React.cloneElement(element, { className }));
+    const { container, setProps } = render(React.cloneElement(element, { className }));
+
+    // The component is portaled
+    if (!container.firstChild) {
+      return;
+    }
 
     // we established that the root component renders the outermost host previously. We immediately
     // jump to the host component because some components pass the `root` class
     // to the `classes` prop of the root component.
     // https://github.com/mui-org/material-ui/blob/f9896bcd129a1209153106296b3d2487547ba205/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L101
-    expect(findOutermostIntrinsic(wrapper).hasClass(className)).to.equal(true);
-    expect(findOutermostIntrinsic(wrapper).hasClass(classes.root)).to.equal(true);
+    expect(container.firstChild).to.have.class(className);
+    expect(container.firstChild).to.have.class(classes.root);
+    expect(document.querySelectorAll(`.${classes.root}`).length).to.equal(1);
 
     // Test that classes prop works
-    const classesProp = { ...classes };
-    classesProp.root = `${classesProp.root} ${className}`;
-
-    wrapper = mount(React.cloneElement(element, { classes: classesProp }));
-    expect(findOutermostIntrinsic(wrapper).hasClass(className)).to.equal(true);
-    expect(findOutermostIntrinsic(wrapper).getDOMNode().getAttribute('classes')).to.equal(null);
+    setProps({ classes: { ...classes, root: `${classes.root} ${className}` } });
+    expect(container.firstChild).to.have.class(className);
+    expect(container.firstChild).not.to.have.attribute('classes');
   });
 }
 

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -156,11 +156,6 @@ export function testRootClass(element, getOptions) {
     const className = randomStringValue();
     const { container, setProps } = render(React.cloneElement(element, { className }));
 
-    // The component is portaled
-    if (!container.firstChild) {
-      return;
-    }
-
     // we established that the root component renders the outermost host previously. We immediately
     // jump to the host component because some components pass the `root` class
     // to the `classes` prop of the root component.


### PR DESCRIPTION
This is a follow-up on https://github.com/mui-org/material-ui/pull/25776#issuecomment-821132005. Take the following case:

```js
import * as React from "react";
import Switch from "@material-ui/core/Switch";
import Box from "@material-ui/core/Box";

export default function BasicSwitches() {
  return (
    <Box
      sx={{
        "& .MuiSwitch-root": {
          border: "1px solid red"
        }
      }}
    >
      <Switch sx={{ bgcolor: "yellow" }} />
    </Box>
  );
}

```

**Actual**

<img width="77" alt="Screenshot 2021-04-24 at 21 27 21" src="https://user-images.githubusercontent.com/3165635/115970622-de8b6000-a543-11eb-8f3c-9ac2ee419e4b.png">

https://codesandbox.io/s/basicswitches-material-demo-forked-k1xpw?file=/demo.tsx:0-347

**Expected**:

<img width="81" alt="Screenshot 2021-04-24 at 20 43 16" src="https://user-images.githubusercontent.com/3165635/115970626-e4814100-a543-11eb-86ba-8bd970ba9825.png">


I have also used the opportunity to write a test case that would cover all the components. I had to use react-testing-library instead of enzyme.