### PR TITLE
[TextField] Reduce spam of class names

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -13,7 +13,7 @@ import { getFormControlUtilityClasses } from './formControlClasses';
 const useUtilityClasses = (styleProps) => {
   const { classes, margin, fullWidth } = styleProps;
   const slots = {
-    root: ['root', `margin${capitalize(margin)}`, fullWidth && 'fullWidth'],
+    root: ['root', margin !== 'none' && `margin${capitalize(margin)}`, fullWidth && 'fullWidth'],
   };
 
   return composeClasses(slots, getFormControlUtilityClasses, classes);


### PR DESCRIPTION
We didn't use to apply this class name in v4. Proof: https://github.com/mui-org/material-ui/blob/10d331b63486086b581099c9cae6d7578f49103c/packages/material-ui/src/FormControl/FormControl.js#L189

and it doesn't seem to fill a purpose, so I went on removing it. The DOM feels heavy with all these class names, it makes it more challenging to read the dev tools output. 