### PR TITLE
[pickers] Ensure input value is reset in the same commit as the value

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -67,9 +67,7 @@ export function useMaskedInput({
   );
 
   React.useEffect(() => {
-    // We do not need to update the input value on keystroke
-    // Because library formatters can change inputs from 12/12/2 to 12/12/0002
-    if ((rawValue === null || utils.isValid(rawValue)) && !isFocusedRef.current) {
+    if (rawValue === null || utils.isValid(rawValue)) {
       setInnerInputValue(getInputValue());
     }
   }, [utils, getInputValue, rawValue]);

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useRifm } from 'rifm';
 import { useUtils } from './useUtils';
-import { createDelegatedEventHandler } from '../utils';
 import { DateInputProps, MuiTextFieldProps } from '../PureDateInput';
 import {
   maskedDateFormatter,
@@ -40,7 +39,6 @@ export function useMaskedInput({
   validationError,
 }: MaskedInputProps): MuiTextFieldProps {
   const utils = useUtils();
-  const isFocusedRef = React.useRef(false);
 
   const getInputValue = React.useCallback(() => getDisplayDate(utils, rawValue, inputFormat), [
     inputFormat,
@@ -111,12 +109,6 @@ export function useMaskedInput({
       readOnly,
       type: shouldUseMaskedInput ? 'tel' : 'text',
       ...inputProps,
-      onFocus: createDelegatedEventHandler(() => {
-        isFocusedRef.current = true;
-      }, inputProps?.onFocus),
-      onBlur: createDelegatedEventHandler(() => {
-        isFocusedRef.current = false;
-      }, inputProps?.onBlur),
     },
     ...TextFieldProps,
   };


### PR DESCRIPTION
The re-computation of state in `useEffect` was suspicious to me. 

It seems to me that the "input value" (named `innerInputValue`) was supposed to be what the user inputs. The implementation made sure that this value is reset if the actual date value changed. But only if the textbox isn't focused to avoid interrupting the user while typing. This created some weird states where outside value updates were dropped during input or when the textbox was still focused but the user is idle.

This requires some logic that leads to tearing (state updates in useEffect). The new implementation is a bit more verbose but is hopefully clearer in its intent. It's probably better to re-implement this by controlling the `rawValue` in `usePickerState` and then deciding whether we want to expose controlled vs uncontrolled input values.

Manual testing: https://deploy-preview-25972--material-ui.netlify.app/components/date-picker/#basic-usage