### PR TITLE
[docs] Avoid extracting classes twice

### DIFF
--- a/docs/pages/api-docs/date-range-picker-day.json
+++ b/docs/pages/api-docs/date-range-picker-day.json
@@ -12,7 +12,24 @@
     "selected": { "type": { "name": "bool" } }
   },
   "name": "DateRangePickerDay",
-  "styles": { "classes": [], "globalClasses": {}, "name": null },
+  "styles": {
+    "classes": [
+      "root",
+      "rangeIntervalDayHighlight",
+      "rangeIntervalDayHighlightStart",
+      "rangeIntervalDayHighlightEnd",
+      "day",
+      "dayOutsideRangeInterval",
+      "dayInsideRangeInterval",
+      "notSelectedDate",
+      "rangeIntervalPreview",
+      "rangeIntervalDayPreview",
+      "rangeIntervalDayPreviewStart",
+      "rangeIntervalDayPreviewEnd"
+    ],
+    "globalClasses": {},
+    "name": "MuiDateRangePickerDay"
+  },
   "spread": false,
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx",

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -693,11 +693,11 @@ async function updateStylesDefinition(context: {
  * Add class descriptions to type definitions
  */
 async function annotateClassesDefinition(context: {
-  styles: ReactApi['styles'];
+  api: ReactApi;
   component: { filename: string };
   prettierConfigPath: string;
 }) {
-  const { styles, component, prettierConfigPath } = context;
+  const { api, component, prettierConfigPath } = context;
 
   const typesFilename = component.filename.replace(/\.js$/, '.d.ts');
   const typesSource = readFileSync(typesFilename, { encoding: 'utf8' });
@@ -735,9 +735,9 @@ async function annotateClassesDefinition(context: {
 
   // colon is part of TSTypeAnnotation
   let classesDefinitionSource = ': {';
-  styles.classes.forEach((className) => {
-    if (styles.descriptions[className] !== undefined) {
-      classesDefinitionSource += `\n/** ${styles.descriptions[className]} */`;
+  api.styles.classes.forEach((className) => {
+    if (api.styles.descriptions[className] !== undefined) {
+      classesDefinitionSource += `\n/** ${api.styles.descriptions[className]} */`;
     }
     classesDefinitionSource += `\n'${className}'?: string;`;
   });
@@ -884,10 +884,16 @@ async function buildDocs(options: {
     globalClasses: {},
   };
 
-  const styledComponent = !component?.default?.options;
+  // styled components does not have the options static
+  const JssComponent = component?.default?.options;
+  if (!JssComponent) {
+    await updateStylesDefinition({
+      styles,
+      component: componentObject,
+    });
+  }
 
-  // TODO remove once all the components are migrated to styled-engine.
-  if (!styledComponent) {
+  if (component.styles && component.default.options) {
     // Collect the customization points of the `classes` property.
     styles.classes = Object.keys(getStylesCreator(component.styles).create(theme)).filter(
       (className) => !className.match(/^(@media|@keyframes|@global)/),
@@ -937,17 +943,6 @@ async function buildDocs(options: {
         return match;
       });
     }
-
-    await annotateClassesDefinition({
-      styles,
-      component: componentObject,
-      prettierConfigPath,
-    });
-  } else {
-    await updateStylesDefinition({
-      styles,
-      component: componentObject,
-    });
   }
 
   const reactApi: ReactApi = await parseComponentSource(src, componentObject);
@@ -1008,6 +1003,15 @@ async function buildDocs(options: {
         `Be sure to include \`components: ${reactApi.name}\` in the markdown pages where the \`${reactApi.name}\` component is relevant. ` +
         'Every public component should have a demo. ',
     );
+  }
+
+  // styled components does not have the options static
+  const styledComponent = !component?.default?.options;
+  if (styledComponent) {
+    await updateStylesDefinition({
+      styles,
+      component: componentObject,
+    });
   }
 
   const testInfo = await parseTest(componentObject.filename);
@@ -1224,6 +1228,14 @@ Page.getInitialProps = () => {
   console.log('Built API docs for', reactApi.name);
 
   await annotateComponentDefinition({ api: reactApi, component: componentObject });
+
+  if (JssComponent) {
+    await annotateClassesDefinition({
+      api: reactApi,
+      component: componentObject,
+      prettierConfigPath,
+    });
+  }
 
   return reactApi;
 }

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -57,7 +57,7 @@ export type DateRangePickerDayClassKey =
   | 'rangeIntervalDayPreviewStart'
   | 'rangeIntervalDayPreviewEnd';
 
-const styles: MuiStyles<DateRangePickerDayClassKey> = (
+export const styles: MuiStyles<DateRangePickerDayClassKey> = (
   theme,
 ): StyleRules<DateRangePickerDayClassKey> => ({
   root: {


### PR DESCRIPTION
~`updateStylesDefinition()` is always called twice but once is enough. I have noticed this inefficiency when diving into https://github.com/mui-org/material-ui/pull/25928#discussion_r619600334. I didn't benchmark the performance win.~

~I have used this as an opportunity to isolate what's for legacy components (JSS), so we can more easily remove the code later on.~

Fix `DateRangePickerDay` classes extraction.