### PR TITLE
[Timeline] Add support for position override on items

### DIFF
--- a/docs/pages/api-docs/timeline-content.json
+++ b/docs/pages/api-docs/timeline-content.json
@@ -6,7 +6,7 @@
   },
   "name": "TimelineContent",
   "styles": {
-    "classes": ["root", "alignRight", "alignLeft", "alignAlternate"],
+    "classes": ["root", "positionRight", "positionLeft", "positionAlternate"],
     "globalClasses": {},
     "name": "MuiTimelineContent"
   },

--- a/docs/pages/api-docs/timeline-item.json
+++ b/docs/pages/api-docs/timeline-item.json
@@ -1,13 +1,19 @@
 {
   "props": {
-    "align": { "type": { "name": "enum", "description": "'left'<br>&#124;&nbsp;'right'" } },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
+    "position": { "type": { "name": "enum", "description": "'left'<br>&#124;&nbsp;'right'" } },
     "sx": { "type": { "name": "object" } }
   },
   "name": "TimelineItem",
   "styles": {
-    "classes": ["root", "alignLeft", "alignRight", "alignAlternate", "missingOppositeContent"],
+    "classes": [
+      "root",
+      "positionLeft",
+      "positionRight",
+      "positionAlternate",
+      "missingOppositeContent"
+    ],
     "globalClasses": {},
     "name": "MuiTimelineItem"
   },

--- a/docs/pages/api-docs/timeline-item.json
+++ b/docs/pages/api-docs/timeline-item.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "align": { "type": { "name": "enum", "description": "'left'<br>&#124;&nbsp;'right'" } },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "sx": { "type": { "name": "object" } }

--- a/docs/pages/api-docs/timeline-opposite-content.json
+++ b/docs/pages/api-docs/timeline-opposite-content.json
@@ -6,7 +6,7 @@
   },
   "name": "TimelineOppositeContent",
   "styles": {
-    "classes": ["root", "alignRight", "alignLeft", "alignAlternate"],
+    "classes": ["root", "positionRight", "positionLeft", "positionAlternate"],
     "globalClasses": {},
     "name": "MuiTimelineOppositeContent"
   },

--- a/docs/pages/api-docs/timeline.json
+++ b/docs/pages/api-docs/timeline.json
@@ -1,20 +1,20 @@
 {
   "props": {
-    "align": {
+    "children": { "type": { "name": "node" } },
+    "classes": { "type": { "name": "object" } },
+    "className": { "type": { "name": "string" } },
+    "position": {
       "type": {
         "name": "enum",
         "description": "'alternate'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'"
       },
-      "default": "'left'"
+      "default": "'right'"
     },
-    "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } },
-    "className": { "type": { "name": "string" } },
     "sx": { "type": { "name": "object" } }
   },
   "name": "Timeline",
   "styles": {
-    "classes": ["root", "alignLeft", "alignRight", "alignAlternate"],
+    "classes": ["root", "positionLeft", "positionRight", "positionAlternate"],
     "globalClasses": {},
     "name": "MuiTimeline"
   },

--- a/docs/src/pages/components/timeline/AlternateTimeline.js
+++ b/docs/src/pages/components/timeline/AlternateTimeline.js
@@ -8,7 +8,7 @@ import TimelineDot from '@material-ui/lab/TimelineDot';
 
 export default function AlternateTimeline() {
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot />

--- a/docs/src/pages/components/timeline/AlternateTimeline.tsx
+++ b/docs/src/pages/components/timeline/AlternateTimeline.tsx
@@ -8,7 +8,7 @@ import TimelineDot from '@material-ui/lab/TimelineDot';
 
 export default function AlternateTimeline() {
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot />

--- a/docs/src/pages/components/timeline/ColorsTimeline.js
+++ b/docs/src/pages/components/timeline/ColorsTimeline.js
@@ -8,7 +8,7 @@ import TimelineDot from '@material-ui/lab/TimelineDot';
 
 export default function ColorsTimeline() {
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot />

--- a/docs/src/pages/components/timeline/ColorsTimeline.tsx
+++ b/docs/src/pages/components/timeline/ColorsTimeline.tsx
@@ -8,7 +8,7 @@ import TimelineDot from '@material-ui/lab/TimelineDot';
 
 export default function ColorsTimeline() {
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot />

--- a/docs/src/pages/components/timeline/CustomizedTimeline.js
+++ b/docs/src/pages/components/timeline/CustomizedTimeline.js
@@ -29,7 +29,7 @@ export default function CustomizedTimeline() {
   const classes = useStyles();
 
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineOppositeContent
           className={classes.verticallyCenterContent}

--- a/docs/src/pages/components/timeline/CustomizedTimeline.tsx
+++ b/docs/src/pages/components/timeline/CustomizedTimeline.tsx
@@ -29,7 +29,7 @@ export default function CustomizedTimeline() {
   const classes = useStyles();
 
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineOppositeContent
           className={classes.verticallyCenterContent}

--- a/docs/src/pages/components/timeline/LeftPositionedTimeline.js
+++ b/docs/src/pages/components/timeline/LeftPositionedTimeline.js
@@ -6,9 +6,9 @@ import TimelineConnector from '@material-ui/lab/TimelineConnector';
 import TimelineContent from '@material-ui/lab/TimelineContent';
 import TimelineDot from '@material-ui/lab/TimelineDot';
 
-export default function RightAlignedTimeline() {
+export default function LeftPositionedTimeline() {
   return (
-    <Timeline align="right">
+    <Timeline position="left">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot />

--- a/docs/src/pages/components/timeline/LeftPositionedTimeline.tsx
+++ b/docs/src/pages/components/timeline/LeftPositionedTimeline.tsx
@@ -6,9 +6,9 @@ import TimelineConnector from '@material-ui/lab/TimelineConnector';
 import TimelineContent from '@material-ui/lab/TimelineContent';
 import TimelineDot from '@material-ui/lab/TimelineDot';
 
-export default function RightAlignedTimeline() {
+export default function LeftPositionedTimeline() {
   return (
-    <Timeline align="right">
+    <Timeline position="left">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot />

--- a/docs/src/pages/components/timeline/OppositeContentTimeline.js
+++ b/docs/src/pages/components/timeline/OppositeContentTimeline.js
@@ -10,7 +10,7 @@ import TimelineOppositeContent from '@material-ui/lab/TimelineOppositeContent';
 export default function OppositeContentTimeline() {
   return (
     <React.Fragment>
-      <Timeline align="alternate">
+      <Timeline position="alternate">
         <TimelineItem>
           <TimelineOppositeContent color="text.secondary">
             09:30 am

--- a/docs/src/pages/components/timeline/OppositeContentTimeline.tsx
+++ b/docs/src/pages/components/timeline/OppositeContentTimeline.tsx
@@ -10,7 +10,7 @@ import TimelineOppositeContent from '@material-ui/lab/TimelineOppositeContent';
 export default function OppositeContentTimeline() {
   return (
     <React.Fragment>
-      <Timeline align="alternate">
+      <Timeline position="alternate">
         <TimelineItem>
           <TimelineOppositeContent color="text.secondary">
             09:30 am

--- a/docs/src/pages/components/timeline/OutlinedTimeline.js
+++ b/docs/src/pages/components/timeline/OutlinedTimeline.js
@@ -8,7 +8,7 @@ import TimelineDot from '@material-ui/lab/TimelineDot';
 
 export default function OutlinedTimeline() {
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot variant="outlined" />

--- a/docs/src/pages/components/timeline/OutlinedTimeline.tsx
+++ b/docs/src/pages/components/timeline/OutlinedTimeline.tsx
@@ -8,7 +8,7 @@ import TimelineDot from '@material-ui/lab/TimelineDot';
 
 export default function OutlinedTimeline() {
   return (
-    <Timeline align="alternate">
+    <Timeline position="alternate">
       <TimelineItem>
         <TimelineSeparator>
           <TimelineDot variant="outlined" />

--- a/docs/src/pages/components/timeline/timeline.md
+++ b/docs/src/pages/components/timeline/timeline.md
@@ -19,11 +19,11 @@ A basic timeline showing list of events.
 
 {{"demo": "pages/components/timeline/BasicTimeline.js"}}
 
-## Right-aligned timeline
+## Left-positioned timeline
 
-The timeline can be positioned on the right side of the events.
+The main content of the timeline can be positioned on the left side relative to the time axis.
 
-{{"demo": "pages/components/timeline/RightAlignedTimeline.js"}}
+{{"demo": "pages/components/timeline/LeftPositionedTimeline.js"}}
 
 ## Alternating timeline
 

--- a/docs/translations/api-docs/timeline-content/timeline-content.json
+++ b/docs/translations/api-docs/timeline-content/timeline-content.json
@@ -7,20 +7,20 @@
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },
-    "alignRight": {
+    "positionRight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"right\"</code>"
+      "conditions": "<code>position=\"right\"</code>"
     },
-    "alignLeft": {
+    "positionLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"left\"</code>"
+      "conditions": "<code>position=\"left\"</code>"
     },
-    "alignAlternate": {
+    "positionAlternate": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"alternate\"</code>"
+      "conditions": "<code>position=\"alternate\"</code>"
     }
   }
 }

--- a/docs/translations/api-docs/timeline-item/timeline-item.json
+++ b/docs/translations/api-docs/timeline-item/timeline-item.json
@@ -1,27 +1,27 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "align": "The position where the timeline&#39;s item should appear.",
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "position": "The position where the timeline&#39;s item should appear.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },
-    "alignLeft": {
+    "positionLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"left\"</code>"
+      "conditions": "<code>position=\"left\"</code>"
     },
-    "alignRight": {
+    "positionRight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"right\"</code>"
+      "conditions": "<code>position=\"right\"</code>"
     },
-    "alignAlternate": {
+    "positionAlternate": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"alternate\"</code>"
+      "conditions": "<code>position=\"alternate\"</code>"
     },
     "missingOppositeContent": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/timeline-item/timeline-item.json
+++ b/docs/translations/api-docs/timeline-item/timeline-item.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "align": "The position where the timeline&#39;s item should appear.",
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."

--- a/docs/translations/api-docs/timeline-opposite-content/timeline-opposite-content.json
+++ b/docs/translations/api-docs/timeline-opposite-content/timeline-opposite-content.json
@@ -7,20 +7,20 @@
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },
-    "alignRight": {
+    "positionRight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"right\"</code>"
+      "conditions": "<code>position=\"right\"</code>"
     },
-    "alignLeft": {
+    "positionLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"left\"</code>"
+      "conditions": "<code>position=\"left\"</code>"
     },
-    "alignAlternate": {
+    "positionAlternate": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"alternate\"</code>"
+      "conditions": "<code>position=\"alternate\"</code>"
     }
   }
 }

--- a/docs/translations/api-docs/timeline/timeline.json
+++ b/docs/translations/api-docs/timeline/timeline.json
@@ -1,28 +1,28 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "align": "The position where the timeline&#39;s content should appear.",
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "className": "className applied to the root element.",
+    "position": "The position where the TimelineContent should appear relative to the time axis.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },
-    "alignLeft": {
+    "positionLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"left\"</code>"
+      "conditions": "<code>position=\"left\"</code>"
     },
-    "alignRight": {
+    "positionRight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"right\"</code>"
+      "conditions": "<code>position=\"right\"</code>"
     },
-    "alignAlternate": {
+    "positionAlternate": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>align=\"alternate\"</code>"
+      "conditions": "<code>position=\"alternate\"</code>"
     }
   }
 }

--- a/packages/material-ui-lab/src/Timeline/Timeline.test.tsx
+++ b/packages/material-ui-lab/src/Timeline/Timeline.test.tsx
@@ -13,8 +13,8 @@ describe('<Timeline />', () => {
     render,
     muiName: 'MuiTimeline',
     refInstanceof: window.HTMLUListElement,
-    testVariantProps: { align: 'right' },
-    testStateOverrides: { prop: 'align', value: 'right', styleKey: 'alignRight' },
+    testVariantProps: { position: 'left' },
+    testStateOverrides: { prop: 'position', value: 'left', styleKey: 'positionLeft' },
     skip: ['componentProp', 'componentsProp'],
   }));
 });

--- a/packages/material-ui-lab/src/Timeline/Timeline.tsx
+++ b/packages/material-ui-lab/src/Timeline/Timeline.tsx
@@ -18,10 +18,10 @@ export type TimelineClassKey = keyof NonNullable<TimelineProps['classes']>;
 
 export interface TimelineProps extends StandardProps<React.HTMLAttributes<HTMLUListElement>> {
   /**
-   * The position where the timeline's content should appear.
-   * @default 'left'
+   * The position where the TimelineContent should appear relative to the time axis.
+   * @default 'right'
    */
-  align?: 'left' | 'right' | 'alternate';
+  position?: 'left' | 'right' | 'alternate';
   /**
    * The content of the component.
    */
@@ -32,12 +32,12 @@ export interface TimelineProps extends StandardProps<React.HTMLAttributes<HTMLUL
   classes?: {
     /** Styles applied to the root element. */
     root?: string;
-    /** Styles applied to the root element if `align="left"`. */
-    alignLeft?: string;
-    /** Styles applied to the root element if `align="right"`. */
-    alignRight?: string;
-    /** Styles applied to the root element if `align="alternate"`. */
-    alignAlternate?: string;
+    /** Styles applied to the root element if `position="left"`. */
+    positionLeft?: string;
+    /** Styles applied to the root element if `position="right"`. */
+    positionRight?: string;
+    /** Styles applied to the root element if `position="alternate"`. */
+    positionAlternate?: string;
   };
 
   /**
@@ -53,10 +53,10 @@ export interface TimelineProps extends StandardProps<React.HTMLAttributes<HTMLUL
 type StyleProps = TimelineProps;
 
 const useUtilityClasses = (styleProps: StyleProps) => {
-  const { align, classes } = styleProps;
+  const { position, classes } = styleProps;
 
   const slots = {
-    root: ['root', align && `align${capitalize(align)}`],
+    root: ['root', position && `position${capitalize(position)}`],
   };
 
   return composeClasses(slots, getTimelineUtilityClass, classes);
@@ -72,7 +72,8 @@ const TimelineRoot = experimentalStyled(
       const { styleProps } = props;
       return {
         ...styles.root,
-        ...(styleProps.align && styles[`align${capitalize(styleProps.align)}` as TimelineClassKey]),
+        ...(styleProps.position &&
+          styles[`position${capitalize(styleProps.position)}` as TimelineClassKey]),
       };
     },
   },
@@ -95,11 +96,11 @@ const TimelineRoot = experimentalStyled(
  */
 const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(function Timeline(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiTimeline' });
-  const { align = 'left', className, ...other } = props;
-  const styleProps = { ...props, align };
+  const { position = 'right', className, ...other } = props;
+  const styleProps = { ...props, position };
   const classes = useUtilityClasses(styleProps);
   return (
-    <TimelineContext.Provider value={{ align }}>
+    <TimelineContext.Provider value={{ position }}>
       <TimelineRoot
         className={clsx(classes.root, className)}
         styleProps={styleProps}
@@ -117,11 +118,6 @@ Timeline.propTypes /* remove-proptypes */ = {
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * The position where the timeline's content should appear.
-   * @default 'left'
-   */
-  align: PropTypes.oneOf(['alternate', 'left', 'right']),
-  /**
    * The content of the component.
    */
   children: PropTypes.node,
@@ -133,6 +129,11 @@ Timeline.propTypes /* remove-proptypes */ = {
    * className applied to the root element.
    */
   className: PropTypes.string,
+  /**
+   * The position where the TimelineContent should appear relative to the time axis.
+   * @default 'right'
+   */
+  position: PropTypes.oneOf(['alternate', 'left', 'right']),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui-lab/src/Timeline/timelineClasses.ts
+++ b/packages/material-ui-lab/src/Timeline/timelineClasses.ts
@@ -6,9 +6,9 @@ export function getTimelineUtilityClass(slot: string) {
 
 const timelineClasses = generateUtilityClasses('MuiTimeline', [
   'root',
-  'alignLeft',
-  'alignRight',
-  'alignAlternate',
+  'positionLeft',
+  'positionRight',
+  'positionAlternate',
 ]);
 
 export default timelineClasses;

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.d.ts
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.d.ts
@@ -14,12 +14,12 @@ export interface TimelineContentProps extends StandardProps<TypographyProps> {
   classes?: {
     /** Styles applied to the root element. */
     root?: string;
-    /** Styles applied to the root element if `align="right"`. */
-    alignRight?: string;
-    /** Styles applied to the root element if `align="left"`. */
-    alignLeft?: string;
-    /** Styles applied to the root element if `align="alternate"`. */
-    alignAlternate?: string;
+    /** Styles applied to the root element if `position="right"`. */
+    positionRight?: string;
+    /** Styles applied to the root element if `position="left"`. */
+    positionLeft?: string;
+    /** Styles applied to the root element if `position="alternate"`. */
+    positionAlternate?: string;
   };
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
@@ -36,9 +36,12 @@ const TimelineContentRoot = experimentalStyled(
     },
   },
 )(({ styleProps }) => ({
+  /* Styles applied to the root element. */
   flex: 1,
   padding: '6px 16px',
-  ...(styleProps.align === 'right' && {
+  textAlign: 'left',
+  /* Styles applied to the root element if `align="left"`. */
+  ...(styleProps.align === 'left' && {
     textAlign: 'right',
   }),
 }));
@@ -47,11 +50,11 @@ const TimelineContent = React.forwardRef(function TimelineContent(inProps, ref) 
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineContent' });
   const { className, ...other } = props;
 
-  const { align = 'left' } = React.useContext(TimelineContext);
+  const { align: alignContext, position: positionContext } = React.useContext(TimelineContext);
 
   const styleProps = {
     ...props,
-    align,
+    align: alignContext || positionContext || 'left',
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
@@ -54,7 +54,7 @@ const TimelineContent = React.forwardRef(function TimelineContent(inProps, ref) 
 
   const styleProps = {
     ...props,
-    position: positionContext || 'left',
+    position: positionContext || 'right',
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
@@ -12,10 +12,10 @@ import TimelineContext from '../Timeline/TimelineContext';
 import { getTimelineContentUtilityClass } from './timelineContentClasses';
 
 const useUtilityClasses = (styleProps) => {
-  const { align, classes } = styleProps;
+  const { position, classes } = styleProps;
 
   const slots = {
-    root: ['root', `align${capitalize(align)}`],
+    root: ['root', `position${capitalize(position)}`],
   };
 
   return composeClasses(slots, getTimelineContentUtilityClass, classes);
@@ -31,7 +31,7 @@ const TimelineContentRoot = experimentalStyled(
       const { styleProps } = props;
       return {
         ...styles.root,
-        ...styles[`align${capitalize(styleProps.align)}`],
+        ...styles[`position${capitalize(styleProps.position)}`],
       };
     },
   },
@@ -40,8 +40,8 @@ const TimelineContentRoot = experimentalStyled(
   flex: 1,
   padding: '6px 16px',
   textAlign: 'left',
-  /* Styles applied to the root element if `align="left"`. */
-  ...(styleProps.align === 'left' && {
+  /* Styles applied to the root element if `position="left"`. */
+  ...(styleProps.position === 'left' && {
     textAlign: 'right',
   }),
 }));
@@ -50,11 +50,11 @@ const TimelineContent = React.forwardRef(function TimelineContent(inProps, ref) 
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineContent' });
   const { className, ...other } = props;
 
-  const { align: alignContext, position: positionContext } = React.useContext(TimelineContext);
+  const { position: positionContext } = React.useContext(TimelineContext);
 
   const styleProps = {
     ...props,
-    align: alignContext || positionContext || 'left',
+    position: positionContext || 'left',
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
@@ -22,71 +22,71 @@ describe('<TimelineContent />', () => {
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
-  it('should have alignLeft class when inside of a left-positioned timeline', () => {
+  it('should have positionLeft class when inside of a left-positioned timeline', () => {
     const { getByText } = render(
       <Timeline position="left">
         <TimelineContent>content</TimelineContent>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignLeft);
+    expect(getByText('content')).to.have.class(classes.positionLeft);
   });
 
-  it('should have alignRight class when inside of a right-positioned timeline', () => {
+  it('should have positionRight class when inside of a right-positioned timeline', () => {
     const { getByText } = render(
       <Timeline position="right">
         <TimelineContent>content</TimelineContent>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignRight);
+    expect(getByText('content')).to.have.class(classes.positionRight);
   });
 
-  it('should have alignLeft class when inside of a left-positioned timeline and a left-aligned item', () => {
+  it('should have positionLeft class when inside of a left-positioned timeline and a left-positioned item', () => {
     const { getByText } = render(
       <Timeline position="left">
-        <TimelineItem align="left">
+        <TimelineItem position="left">
           <TimelineContent>content</TimelineContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignLeft);
+    expect(getByText('content')).to.have.class(classes.positionLeft);
   });
 
-  it('should have alignLeft class when inside of a right-positioned timeline and a left-aligned item', () => {
+  it('should have positionLeft class when inside of a right-positioned timeline and a left-positioned item', () => {
     const { getByText } = render(
       <Timeline position="right">
-        <TimelineItem align="left">
+        <TimelineItem position="left">
           <TimelineContent>content</TimelineContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignLeft);
+    expect(getByText('content')).to.have.class(classes.positionLeft);
   });
 
-  it('should have alignRight class when inside of a left-positioned timeline and a right-aligned item', () => {
+  it('should have positionRight class when inside of a left-positioned timeline and a right-positioned item', () => {
     const { getByText } = render(
       <Timeline position="left">
-        <TimelineItem align="right">
+        <TimelineItem position="right">
           <TimelineContent>content</TimelineContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignRight);
+    expect(getByText('content')).to.have.class(classes.positionRight);
   });
 
-  it('should have alignRight class when inside of a right-positioned timeline and a right-aligned item', () => {
+  it('should have positionRight class when inside of a right-positioned timeline and a right-positioned item', () => {
     const { getByText } = render(
       <Timeline position="right">
-        <TimelineItem align="right">
+        <TimelineItem position="right">
           <TimelineContent>content</TimelineContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignRight);
+    expect(getByText('content')).to.have.class(classes.positionRight);
   });
 });

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import Typography from '@material-ui/core/Typography';
 import Timeline from '@material-ui/lab/Timeline';
+import TimelineItem from '@material-ui/lab/TimelineItem';
 import TimelineContent, {
   timelineContentClasses as classes,
 } from '@material-ui/lab/TimelineContent';
@@ -21,10 +22,68 @@ describe('<TimelineContent />', () => {
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
-  it('when align right should have alignRight class', () => {
+  it('should have alignLeft class when inside of a left-positioned timeline', () => {
     const { getByText } = render(
-      <Timeline align="right">
+      <Timeline position="left">
         <TimelineContent>content</TimelineContent>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignLeft);
+  });
+
+  it('should have alignRight class when inside of a right-positioned timeline', () => {
+    const { getByText } = render(
+      <Timeline position="right">
+        <TimelineContent>content</TimelineContent>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignRight);
+  });
+
+  it('should have alignLeft class when inside of a left-positioned timeline and a left-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="left">
+        <TimelineItem align="left">
+          <TimelineContent>content</TimelineContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignLeft);
+  });
+
+  it('should have alignLeft class when inside of a right-positioned timeline and a left-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="right">
+        <TimelineItem align="left">
+          <TimelineContent>content</TimelineContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignLeft);
+  });
+
+  it('should have alignRight class when inside of a left-positioned timeline and a right-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="left">
+        <TimelineItem align="right">
+          <TimelineContent>content</TimelineContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignRight);
+  });
+
+  it('should have alignRight class when inside of a right-positioned timeline and a right-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="right">
+        <TimelineItem align="right">
+          <TimelineContent>content</TimelineContent>
+        </TimelineItem>
       </Timeline>,
     );
 

--- a/packages/material-ui-lab/src/TimelineContent/timelineContentClasses.js
+++ b/packages/material-ui-lab/src/TimelineContent/timelineContentClasses.js
@@ -6,9 +6,9 @@ export function getTimelineContentUtilityClass(slot) {
 
 const timelineContentClasses = generateUtilityClasses('MuiTimelineContent', [
   'root',
-  'alignLeft',
-  'alignRight',
-  'alignAlternate',
+  'positionLeft',
+  'positionRight',
+  'positionAlternate',
 ]);
 
 export default timelineContentClasses;

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.d.ts
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.d.ts
@@ -7,7 +7,7 @@ export interface TimelineItemProps extends StandardProps<React.HTMLAttributes<HT
   /**
    * The position where the timeline's item should appear.
    */
-  align?: 'left' | 'right';
+  position?: 'left' | 'right';
   /**
    * The content of the component.
    */
@@ -18,12 +18,12 @@ export interface TimelineItemProps extends StandardProps<React.HTMLAttributes<HT
   classes?: {
     /** Styles applied to the root element. */
     root?: string;
-    /** Styles applied to the root element if `align="left"`. */
-    alignLeft?: string;
-    /** Styles applied to the root element if `align="right"`. */
-    alignRight?: string;
-    /** Styles applied to the root element if `align="alternate"`. */
-    alignAlternate?: string;
+    /** Styles applied to the root element if `position="left"`. */
+    positionLeft?: string;
+    /** Styles applied to the root element if `position="right"`. */
+    positionRight?: string;
+    /** Styles applied to the root element if `position="alternate"`. */
+    positionAlternate?: string;
     /** Styles applied to the root element if TimelineOppositeContent isn't provided. */
     missingOppositeContent?: string;
   };

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.d.ts
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.d.ts
@@ -5,6 +5,10 @@ import { InternalStandardProps as StandardProps } from '@material-ui/core';
 
 export interface TimelineItemProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**
+   * The position where the timeline's item should appear.
+   */
+  align?: 'left' | 'right';
+  /**
    * The content of the component.
    */
   children?: React.ReactNode;

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -13,10 +13,14 @@ import TimelineContext from '../Timeline/TimelineContext';
 import { getTimelineItemUtilityClass } from './timelineItemClasses';
 
 const useUtilityClasses = (styleProps) => {
-  const { align, classes, hasOppositeContent } = styleProps;
+  const { position, classes, hasOppositeContent } = styleProps;
 
   const slots = {
-    root: ['root', `align${capitalize(align)}`, !hasOppositeContent && 'missingOppositeContent'],
+    root: [
+      'root',
+      `position${capitalize(position)}`,
+      !hasOppositeContent && 'missingOppositeContent',
+    ],
   };
 
   return composeClasses(slots, getTimelineItemUtilityClass, classes);
@@ -33,7 +37,7 @@ const TimelineItemRoot = experimentalStyled(
 
       return {
         ...styles.root,
-        ...styles[`align${capitalize(styleProps.align)}`],
+        ...styles[`position${capitalize(styleProps.position)}`],
       };
     },
   },
@@ -42,10 +46,10 @@ const TimelineItemRoot = experimentalStyled(
   display: 'flex',
   position: 'relative',
   minHeight: 70,
-  ...(styleProps.align === 'left' && {
+  ...(styleProps.position === 'left' && {
     flexDirection: 'row-reverse',
   }),
-  ...(styleProps.align === 'alternate' && {
+  ...(styleProps.position === 'alternate' && {
     '&:nth-of-type(even)': {
       flexDirection: 'row-reverse',
       [`& .${timelineContentClasses.root}`]: {
@@ -67,7 +71,7 @@ const TimelineItemRoot = experimentalStyled(
 
 const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineItem' });
-  const { align: alignProp, className, ...other } = props;
+  const { position: positionProp, className, ...other } = props;
   const { position: positionContext } = React.useContext(TimelineContext);
 
   let hasOppositeContent = false;
@@ -80,14 +84,14 @@ const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
 
   const styleProps = {
     ...props,
-    align: alignProp || positionContext || 'left',
+    position: positionProp || positionContext || 'left',
     hasOppositeContent,
   };
 
   const classes = useUtilityClasses(styleProps);
 
   return (
-    <TimelineContext.Provider value={{ align: styleProps.align }}>
+    <TimelineContext.Provider value={{ position: styleProps.position }}>
       <TimelineItemRoot
         className={clsx(classes.root, className)}
         styleProps={styleProps}
@@ -104,10 +108,6 @@ TimelineItem.propTypes /* remove-proptypes */ = {
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
   /**
-   * The position where the timeline's item should appear.
-   */
-  align: PropTypes.oneOf(['left', 'right']),
-  /**
    * The content of the component.
    */
   children: PropTypes.node,
@@ -119,6 +119,10 @@ TimelineItem.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The position where the timeline's item should appear.
+   */
+  position: PropTypes.oneOf(['left', 'right']),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -67,8 +67,8 @@ const TimelineItemRoot = experimentalStyled(
 
 const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineItem' });
-  const { className, ...other } = props;
-  const { align = 'left' } = React.useContext(TimelineContext);
+  const { align: alignProp, className, ...other } = props;
+  const { align: alignContext } = React.useContext(TimelineContext);
 
   let hasOppositeContent = false;
 
@@ -80,19 +80,21 @@ const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
 
   const styleProps = {
     ...props,
-    align,
+    align: alignProp || alignContext || 'left',
     hasOppositeContent,
   };
 
   const classes = useUtilityClasses(styleProps);
 
   return (
-    <TimelineItemRoot
-      className={clsx(classes.root, className)}
-      styleProps={styleProps}
-      ref={ref}
-      {...other}
-    />
+    <TimelineContext.Provider value={{ align: styleProps.align }}>
+      <TimelineItemRoot
+        className={clsx(classes.root, className)}
+        styleProps={styleProps}
+        ref={ref}
+        {...other}
+      />
+    </TimelineContext.Provider>
   );
 });
 
@@ -101,6 +103,10 @@ TimelineItem.propTypes /* remove-proptypes */ = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * The position where the timeline's item should appear.
+   */
+  align: PropTypes.oneOf(['left', 'right']),
   /**
    * The content of the component.
    */

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -84,7 +84,7 @@ const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
 
   const styleProps = {
     ...props,
-    position: positionProp || positionContext || 'left',
+    position: positionProp || positionContext || 'right',
     hasOppositeContent,
   };
 

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.js
@@ -42,7 +42,7 @@ const TimelineItemRoot = experimentalStyled(
   display: 'flex',
   position: 'relative',
   minHeight: 70,
-  ...(styleProps.align === 'right' && {
+  ...(styleProps.align === 'left' && {
     flexDirection: 'row-reverse',
   }),
   ...(styleProps.align === 'alternate' && {
@@ -68,7 +68,7 @@ const TimelineItemRoot = experimentalStyled(
 const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineItem' });
   const { align: alignProp, className, ...other } = props;
-  const { align: alignContext } = React.useContext(TimelineContext);
+  const { position: positionContext } = React.useContext(TimelineContext);
 
   let hasOppositeContent = false;
 
@@ -80,7 +80,7 @@ const TimelineItem = React.forwardRef(function TimelineItem(inProps, ref) {
 
   const styleProps = {
     ...props,
-    align: alignProp || alignContext || 'left',
+    align: alignProp || positionContext || 'left',
     hasOppositeContent,
   };
 

--- a/packages/material-ui-lab/src/TimelineItem/timelineItemClasses.js
+++ b/packages/material-ui-lab/src/TimelineItem/timelineItemClasses.js
@@ -6,9 +6,9 @@ export function getTimelineItemUtilityClass(slot) {
 
 const timelineItemClasses = generateUtilityClasses('MuiTimelineItem', [
   'root',
-  'alignLeft',
-  'alignRight',
-  'alignAlternate',
+  'positionLeft',
+  'positionRight',
+  'positionAlternate',
   'missingOppositeContent',
 ]);
 

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.d.ts
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.d.ts
@@ -14,12 +14,12 @@ export interface TimelineOppositeContentProps extends StandardProps<TypographyPr
   classes?: {
     /** Styles applied to the root element. */
     root?: string;
-    /** Styles applied to the root element if `align="right"`. */
-    alignRight?: string;
-    /** Styles applied to the root element if `align="left"`. */
-    alignLeft?: string;
-    /** Styles applied to the root element if `align="alternate"`. */
-    alignAlternate?: string;
+    /** Styles applied to the root element if `position="right"`. */
+    positionRight?: string;
+    /** Styles applied to the root element if `position="left"`. */
+    positionLeft?: string;
+    /** Styles applied to the root element if `position="alternate"`. */
+    positionAlternate?: string;
   };
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -41,8 +41,8 @@ const TimelineOppositeContentRoot = experimentalStyled(
   marginRight: 'auto',
   textAlign: 'right',
   flex: 1,
-  /* Styles applied to the root element if `align="right"`. */
-  ...(styleProps.align === 'right' && {
+  /* Styles applied to the root element if `align="left"`. */
+  ...(styleProps.align === 'left' && {
     textAlign: 'left',
   }),
 }));
@@ -51,11 +51,11 @@ const TimelineOppositeContent = React.forwardRef(function TimelineOppositeConten
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineOppositeContent' });
   const { className, ...other } = props;
 
-  const { align = 'left' } = React.useContext(TimelineContext);
+  const { align: alignContext, position: positionContext } = React.useContext(TimelineContext);
 
   const styleProps = {
     ...props,
-    align,
+    align: alignContext || positionContext || 'left',
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -12,10 +12,10 @@ import TimelineContext from '../Timeline/TimelineContext';
 import { getTimelineOppositeContentUtilityClass } from './timelineOppositeContentClasses';
 
 const useUtilityClasses = (styleProps) => {
-  const { align, classes } = styleProps;
+  const { position, classes } = styleProps;
 
   const slots = {
-    root: ['root', `align${capitalize(align)}`],
+    root: ['root', `position${capitalize(position)}`],
   };
 
   return composeClasses(slots, getTimelineOppositeContentUtilityClass, classes);
@@ -31,7 +31,7 @@ const TimelineOppositeContentRoot = experimentalStyled(
       const { styleProps } = props;
       return {
         ...styles.root,
-        ...styles[`align${capitalize(styleProps.align)}`],
+        ...styles[`position${capitalize(styleProps.position)}`],
       };
     },
   },
@@ -41,8 +41,8 @@ const TimelineOppositeContentRoot = experimentalStyled(
   marginRight: 'auto',
   textAlign: 'right',
   flex: 1,
-  /* Styles applied to the root element if `align="left"`. */
-  ...(styleProps.align === 'left' && {
+  /* Styles applied to the root element if `position="left"`. */
+  ...(styleProps.position === 'left' && {
     textAlign: 'left',
   }),
 }));
@@ -51,11 +51,11 @@ const TimelineOppositeContent = React.forwardRef(function TimelineOppositeConten
   const props = useThemeProps({ props: inProps, name: 'MuiTimelineOppositeContent' });
   const { className, ...other } = props;
 
-  const { align: alignContext, position: positionContext } = React.useContext(TimelineContext);
+  const { position: positionContext } = React.useContext(TimelineContext);
 
   const styleProps = {
     ...props,
-    align: alignContext || positionContext || 'left',
+    position: positionContext || 'left',
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import Typography from '@material-ui/core/Typography';
 import Timeline from '@material-ui/lab/Timeline';
+import TimelineItem from '@material-ui/lab/TimelineItem';
 import TimelineOppositeContent, {
   timelineOppositeContentClasses as classes,
 } from '@material-ui/lab/TimelineOppositeContent';
@@ -21,10 +22,68 @@ describe('<TimelineOppositeContent />', () => {
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
-  it('when align right should have alignRight class', () => {
+  it('should have alignLeft class when inside of a left-positioned timeline', () => {
     const { getByText } = render(
-      <Timeline align="right">
+      <Timeline position="left">
         <TimelineOppositeContent>content</TimelineOppositeContent>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignLeft);
+  });
+
+  it('should have alignRight class when inside of a right-positioned timeline', () => {
+    const { getByText } = render(
+      <Timeline position="right">
+        <TimelineOppositeContent>content</TimelineOppositeContent>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignRight);
+  });
+
+  it('should have alignLeft class when inside of a left-positioned timeline and a left-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="left">
+        <TimelineItem align="left">
+          <TimelineOppositeContent>content</TimelineOppositeContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignLeft);
+  });
+
+  it('should have alignLeft class when inside of a right-positioned timeline and a left-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="right">
+        <TimelineItem align="left">
+          <TimelineOppositeContent>content</TimelineOppositeContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignLeft);
+  });
+
+  it('should have alignRight class when inside of a left-positioned timeline and a right-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="left">
+        <TimelineItem align="right">
+          <TimelineOppositeContent>content</TimelineOppositeContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    expect(getByText('content')).to.have.class(classes.alignRight);
+  });
+
+  it('should have alignRight class when inside of a right-positioned timeline and a right-aligned item', () => {
+    const { getByText } = render(
+      <Timeline position="right">
+        <TimelineItem align="right">
+          <TimelineOppositeContent>content</TimelineOppositeContent>
+        </TimelineItem>
       </Timeline>,
     );
 

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -22,71 +22,71 @@ describe('<TimelineOppositeContent />', () => {
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
-  it('should have alignLeft class when inside of a left-positioned timeline', () => {
+  it('should have positionLeft class when inside of a left-positioned timeline', () => {
     const { getByText } = render(
       <Timeline position="left">
         <TimelineOppositeContent>content</TimelineOppositeContent>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignLeft);
+    expect(getByText('content')).to.have.class(classes.positionLeft);
   });
 
-  it('should have alignRight class when inside of a right-positioned timeline', () => {
+  it('should have positionRight class when inside of a right-positioned timeline', () => {
     const { getByText } = render(
       <Timeline position="right">
         <TimelineOppositeContent>content</TimelineOppositeContent>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignRight);
+    expect(getByText('content')).to.have.class(classes.positionRight);
   });
 
-  it('should have alignLeft class when inside of a left-positioned timeline and a left-aligned item', () => {
+  it('should have positionLeft class when inside of a left-positioned timeline and a left-positioned item', () => {
     const { getByText } = render(
       <Timeline position="left">
-        <TimelineItem align="left">
+        <TimelineItem position="left">
           <TimelineOppositeContent>content</TimelineOppositeContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignLeft);
+    expect(getByText('content')).to.have.class(classes.positionLeft);
   });
 
-  it('should have alignLeft class when inside of a right-positioned timeline and a left-aligned item', () => {
+  it('should have positionLeft class when inside of a right-positioned timeline and a left-positioned item', () => {
     const { getByText } = render(
       <Timeline position="right">
-        <TimelineItem align="left">
+        <TimelineItem position="left">
           <TimelineOppositeContent>content</TimelineOppositeContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignLeft);
+    expect(getByText('content')).to.have.class(classes.positionLeft);
   });
 
-  it('should have alignRight class when inside of a left-positioned timeline and a right-aligned item', () => {
+  it('should have positionRight class when inside of a left-positioned timeline and a right-positioned item', () => {
     const { getByText } = render(
       <Timeline position="left">
-        <TimelineItem align="right">
+        <TimelineItem position="right">
           <TimelineOppositeContent>content</TimelineOppositeContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignRight);
+    expect(getByText('content')).to.have.class(classes.positionRight);
   });
 
-  it('should have alignRight class when inside of a right-positioned timeline and a right-aligned item', () => {
+  it('should have positionRight class when inside of a right-positioned timeline and a right-positioned item', () => {
     const { getByText } = render(
       <Timeline position="right">
-        <TimelineItem align="right">
+        <TimelineItem position="right">
           <TimelineOppositeContent>content</TimelineOppositeContent>
         </TimelineItem>
       </Timeline>,
     );
 
-    expect(getByText('content')).to.have.class(classes.alignRight);
+    expect(getByText('content')).to.have.class(classes.positionRight);
   });
 });

--- a/packages/material-ui-lab/src/TimelineOppositeContent/timelineOppositeContentClasses.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/timelineOppositeContentClasses.js
@@ -6,9 +6,9 @@ export function getTimelineOppositeContentUtilityClass(slot) {
 
 const timelineOppositeContentClasses = generateUtilityClasses('MuiTimelineOppositeContent', [
   'root',
-  'alignLeft',
-  'alignRight',
-  'alignAlternate',
+  'positionLeft',
+  'positionRight',
+  'positionAlternate',
 ]);
 
 export default timelineOppositeContentClasses;


### PR DESCRIPTION
### Breaking changes

- [Timeline] Rename the `align` prop to `position` to reduce confusion.

  ```diff
  -<Timeline align="alternate">
  +<Timeline position="alternate">
  ```
  ```diff
  -<Timeline align="left">
  +<Timeline position="right">
  ```
  ```diff
  -<Timeline align="right">
  +<Timeline position="left">
  ```

---

A proof of concept of the proposed solution from #25862

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #25862

Preview: https://deploy-preview-25974--material-ui.netlify.app/components/timeline/#left-positioned-timeline