### PR TITLE
[types] Ensure Omit type exists

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -52,7 +52,7 @@
     "react-is": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
-    "@material-ui/types": "^5.1.0"
+    "@material-ui/types": "5.1.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@emotion/hash": "^0.8.0",
-    "@material-ui/types": "^5.1.0",
+    "@material-ui/types": "5.1.0",
     "@material-ui/utils": "^4.11.2",
     "clsx": "^1.0.4",
     "csstype": "^2.5.2",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -52,7 +52,7 @@
     "@babel/runtime": "^7.4.4",
     "@material-ui/styles": "^4.11.3",
     "@material-ui/system": "^4.11.3",
-    "@material-ui/types": "^5.1.0",
+    "@material-ui/types": "5.1.0",
     "@material-ui/utils": "^4.11.2",
     "@types/react-transition-group": "^4.2.0",
     "clsx": "^1.0.4",


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/25165

Will do a release today. The next v5 release should bump `@material-ui/types` to v6.

Deprecating `@material-ui/types@5.1.7` would not help since existing alpha releases depend on that package without issues. I don't think deprecating the core release is helpful either. It's not a critical fixed after all.