### PR TITLE
[Table] Deprecate padding="default"

### DIFF
--- a/docs/pages/api-docs/table-cell.md
+++ b/docs/pages/api-docs/table-cell.md
@@ -33,7 +33,7 @@ The `MuiTableCell` name can be used for providing [default props](/customization
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The table cell contents. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> |  | The component used for the root node. Either a string to use a HTML element or a component. |
-| <span class="prop-name">padding</span> | <span class="prop-type">'checkbox'<br>&#124;&nbsp;'default'<br>&#124;&nbsp;'none'</span> |  | Sets the padding applied to the cell. By default, the Table parent component set the value (`default`). |
+| <span class="prop-name">padding</span> | <span class="prop-type">'normal'<br>&#124;&nbsp;'checkbox'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'default'</span> |  | Sets the padding applied to the cell. By default, the Table parent component set the value (`normal`). `default` is deprecated, use `normal` instead. |
 | <span class="prop-name">scope</span> | <span class="prop-type">string</span> |  | Set scope attribute. |
 | <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | Specify the size of the cell. By default, the Table parent component set the value (`medium`). |
 | <span class="prop-name">sortDirection</span> | <span class="prop-type">'asc'<br>&#124;&nbsp;'desc'<br>&#124;&nbsp;false</span> |  | Set aria-sort direction. |

--- a/docs/pages/api-docs/table.md
+++ b/docs/pages/api-docs/table.md
@@ -31,7 +31,7 @@ The `MuiTable` name can be used for providing [default props](/customization/glo
 | <span class="prop-name required">children<abbr title="required">*</abbr></span> | <span class="prop-type">node</span> |  | The content of the table, normally `TableHead` and `TableBody`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'table'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
-| <span class="prop-name">padding</span> | <span class="prop-type">'default'<br>&#124;&nbsp;'checkbox'<br>&#124;&nbsp;'none'</span> | <span class="prop-default">'default'</span> | Allows TableCells to inherit padding of the Table. |
+| <span class="prop-name">padding</span> | <span class="prop-type">'normal'<br>&#124;&nbsp;'checkbox'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'default'</span> | <span class="prop-default">'normal'</span> | Allows TableCells to inherit padding of the Table. `default` is deprecated, use `normal` instead. |
 | <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'</span> | <span class="prop-default">'medium'</span> | Allows TableCells to inherit size of the Table. |
 | <span class="prop-name">stickyHeader</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Set the header sticky.<br>⚠️ It doesn't work with IE 11. |
 

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -96,7 +96,7 @@ function EnhancedTableHead(props) {
           <TableCell
             key={headCell.id}
             align={headCell.numeric ? 'right' : 'left'}
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -131,7 +131,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
           <TableCell
             key={headCell.id}
             align={headCell.numeric ? 'right' : 'left'}
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel

--- a/packages/material-ui/src/Table/Table.d.ts
+++ b/packages/material-ui/src/Table/Table.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-export type Padding = 'default' | 'checkbox' | 'none';
+export type Padding = 'normal' | 'checkbox' | 'none' | 'default';
 
 export type Size = 'small' | 'medium';
 

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import TableContext from './TableContext';
 
@@ -32,7 +33,7 @@ const Table = React.forwardRef(function Table(props, ref) {
     classes,
     className,
     component: Component = defaultComponent,
-    padding = 'default',
+    padding = 'normal',
     size = 'medium',
     stickyHeader = false,
     ...other
@@ -76,8 +77,17 @@ Table.propTypes = {
   component: PropTypes /* @typescript-to-proptypes-ignore */.elementType,
   /**
    * Allows TableCells to inherit padding of the Table.
+   * `default` is deprecated, use `normal` instead.
    */
-  padding: PropTypes.oneOf(['default', 'checkbox', 'none']),
+  padding: chainPropTypes(PropTypes.oneOf(['normal', 'checkbox', 'none', 'default']), (props) => {
+    if (props.padding === 'default') {
+      throw new Error(
+        'Material-UI: padding="default" was renamed to padding="normal" for consistency.',
+      );
+    }
+
+    return null;
+  }),
   /**
    * Allows TableCells to inherit size of the Table.
    */

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -81,7 +81,7 @@ Table.propTypes = {
    */
   padding: chainPropTypes(PropTypes.oneOf(['normal', 'checkbox', 'none', 'default']), (props) => {
     if (props.padding === 'default') {
-      throw new Error(
+      return new Error(
         'Material-UI: padding="default" was renamed to padding="normal" for consistency.',
       );
     }

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -69,7 +69,7 @@ describe('<Table />', () => {
 
     expect(context).to.deep.equal({
       size: 'medium',
-      padding: 'default',
+      padding: 'normal',
       stickyHeader: false,
     });
   });

--- a/packages/material-ui/src/TableCell/TableCell.d.ts
+++ b/packages/material-ui/src/TableCell/TableCell.d.ts
@@ -32,7 +32,8 @@ export interface TableCellProps
   component?: React.ElementType<TableCellBaseProps>;
   /**
    * Sets the padding applied to the cell.
-   * By default, the Table parent component set the value (`default`).
+   * By default, the Table parent component set the value (`normal`).
+   * `default` is deprecated, use `normal` instead.
    */
   padding?: Padding;
   /**

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import capitalize from '../utils/capitalize';
 import { darken, alpha, lighten } from '../styles/colorManipulator';
@@ -136,7 +137,7 @@ const TableCell = React.forwardRef(function TableCell(props, ref) {
   if (!scope && isHeadCell) {
     scope = 'col';
   }
-  const padding = paddingProp || (table && table.padding ? table.padding : 'default');
+  const padding = paddingProp || (table && table.padding ? table.padding : 'normal');
   const size = sizeProp || (table && table.size ? table.size : 'medium');
   const variant = variantProp || (tablelvl2 && tablelvl2.variant);
 
@@ -154,7 +155,7 @@ const TableCell = React.forwardRef(function TableCell(props, ref) {
         {
           [classes.stickyHeader]: variant === 'head' && table && table.stickyHeader,
           [classes[`align${capitalize(align)}`]]: align !== 'inherit',
-          [classes[`padding${capitalize(padding)}`]]: padding !== 'default',
+          [classes[`padding${capitalize(padding)}`]]: padding !== 'normal',
           [classes[`size${capitalize(size)}`]]: size !== 'medium',
         },
         className,
@@ -168,10 +169,6 @@ const TableCell = React.forwardRef(function TableCell(props, ref) {
 });
 
 TableCell.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // |     To update them edit the d.ts file and run "yarn proptypes"     |
-  // ----------------------------------------------------------------------
   /**
    * Set the text-align on the table cell content.
    *
@@ -199,9 +196,18 @@ TableCell.propTypes = {
   component: PropTypes /* @typescript-to-proptypes-ignore */.elementType,
   /**
    * Sets the padding applied to the cell.
-   * By default, the Table parent component set the value (`default`).
+   * By default, the Table parent component set the value (`normal`).
+   * `default` is deprecated, use `normal` instead.
    */
-  padding: PropTypes.oneOf(['checkbox', 'default', 'none']),
+  padding: chainPropTypes(PropTypes.oneOf(['normal', 'checkbox', 'none', 'default']), (props) => {
+    if (props.padding === 'default') {
+      throw new Error(
+        'Material-UI: padding="default" was renamed to padding="normal" for consistency.',
+      );
+    }
+
+    return null;
+  }),
   /**
    * Set scope attribute.
    */

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -201,7 +201,7 @@ TableCell.propTypes = {
    */
   padding: chainPropTypes(PropTypes.oneOf(['normal', 'checkbox', 'none', 'default']), (props) => {
     if (props.padding === 'default') {
-      throw new Error(
+      return new Error(
         'Material-UI: padding="default" was renamed to padding="normal" for consistency.',
       );
     }

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -45,8 +45,8 @@ describe('<TableCell />', () => {
 
   describe('prop: padding', () => {
     it('doesn not have a class for padding by default', () => {
-      const { container } = renderInTable(<TableCell padding="default" />);
-      expect(container.querySelector('td')).to.not.have.class(classes.paddingDefault);
+      const { container } = renderInTable(<TableCell padding="normal" />);
+      expect(container.querySelector('td')).to.not.have.class(classes.paddingNormal);
     });
 
     it('has a class when `none`', () => {

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -47,6 +47,7 @@ const todoComponents = [
   'Tab',
   'Table',
   'TableBody',
+  'TableCell',
   'TableContainer',
   'TableFooter',
   'TableHead',


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Add deprecation for #25924.