### PR TITLE
[theme] Rename `createMuiTheme` to `createTheme`

### DIFF
--- a/benchmark/browser/scenarios/styled-components-box-material-ui-system/index.js
+++ b/benchmark/browser/scenarios/styled-components-box-material-ui-system/index.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import styledComponents, {
   ThemeProvider as StyledComponentsThemeProvider,
 } from 'styled-components';
 import { spacing, palette, typography, compose } from '@material-ui/system';
 
 const materialSystem = compose(palette, spacing, typography);
-const materialSystemTheme = createMuiTheme();
+const materialSystemTheme = createTheme();
 const BoxMaterialSystem = styledComponents('div')(materialSystem);
 
 export default function StyledComponentsBoxMaterialUISystem() {

--- a/benchmark/browser/scenarios/styled-components-box-styled-system/index.js
+++ b/benchmark/browser/scenarios/styled-components-box-styled-system/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import styledComponents, {
   ThemeProvider as StyledComponentsThemeProvider,
 } from 'styled-components';
@@ -8,7 +8,7 @@ import { space, color, fontFamily, fontSize, compose } from 'styled-system';
 const styledSystem = compose(color, space, fontFamily, fontSize);
 const BoxStyledSystem = styledComponents('div')(styledSystem);
 
-const styledSystemTheme = createMuiTheme();
+const styledSystemTheme = createTheme();
 styledSystemTheme.breakpoints = ['40em', '52em', '64em'];
 styledSystemTheme.colors = styledSystemTheme.palette;
 styledSystemTheme.fontSizes = styledSystemTheme.typography;

--- a/benchmark/browser/scenarios/styled-emotion/index.js
+++ b/benchmark/browser/scenarios/styled-emotion/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import emotionStyled from '@emotion/styled';
 
 const Div = emotionStyled('div')(
@@ -18,7 +18,7 @@ const Div = emotionStyled('div')(
 `,
 );
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function StyledEmotion() {
   return (

--- a/benchmark/browser/scenarios/styled-sc/index.js
+++ b/benchmark/browser/scenarios/styled-sc/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import styledComponents, {
   ThemeProvider as StyledComponentsThemeProvider,
 } from 'styled-components';
@@ -20,7 +20,7 @@ const Div = styledComponents('div')(
 `,
 );
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function StyledSC() {
   return (

--- a/benchmark/server/scenarios/server.js
+++ b/benchmark/server/scenarios/server.js
@@ -3,7 +3,7 @@ import express from 'express';
 import * as React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { SheetsRegistry } from 'jss';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import {
   styled as materialStyled,
   StylesProvider,
@@ -35,7 +35,7 @@ function renderFullPage(html, css) {
   `;
 }
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: green,
     accent: red,

--- a/benchmark/server/scenarios/system.js
+++ b/benchmark/server/scenarios/system.js
@@ -2,7 +2,7 @@
 import Benchmark from 'benchmark';
 import { unstable_styleFunctionSx as styleFunctionSx } from '@material-ui/system';
 import styledSystemCss from '@styled-system/css';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { css as chakraCss } from '@chakra-ui/system';
 
 const suite = new Benchmark.Suite('system', {
@@ -12,7 +12,7 @@ const suite = new Benchmark.Suite('system', {
 });
 Benchmark.options.minSamples = 100;
 
-const materialSystemTheme = createMuiTheme();
+const materialSystemTheme = createTheme();
 
 const styledSystemTheme = {
   breakpoints: ['40em', '52em', '64em'],

--- a/docs/public/static/error-codes.json
+++ b/docs/public/static/error-codes.json
@@ -3,12 +3,12 @@
   "2": "Material-UI: The `value` prop must be an array when using the `Select` component with `multiple`.",
   "3": "Material-UI: Unsupported `%s` color.\nWe support the following formats: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla().",
   "4": "Material-UI: The color provided to augmentColor(color) is invalid.\nThe color object needs to have a `main` property or a `%s` property.",
-  "5": "Material-UI: The color provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createMuiTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createMuiTheme({ palette: {\n  primary: { main: green[500] },\n} });",
+  "5": "Material-UI: The color provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createTheme({ palette: {\n  primary: { main: green[500] },\n} });",
   "6": "Material-UI: Unsupported non-unitless line height with grid alignment.\nUse unitless line heights instead.",
   "7": "Material-UI: `capitalize(string)` expects a string argument.",
   "8": "Material-UI: Unsupported `%s` color.\nWe support the following formats: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().",
   "9": "Material-UI: Unsupported `%s` color.\nThe following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().",
   "10": "Material-UI: unsupported `%s` color space.\nThe following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rgb, rec-2020.",
   "11": "Material-UI: The color%s provided to augmentColor(color) is invalid.\nThe color object needs to have a `main` property or a `%s` property.",
-  "12": "Material-UI: The color%s provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createMuiTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createMuiTheme({ palette: {\n  primary: { main: green[500] },\n} });"
+  "12": "Material-UI: The color%s provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createTheme({ palette: {\n  primary: { main: green[500] },\n} });"
 }

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -34,7 +34,7 @@ import {
 import { pageToTitle } from 'docs/src/modules/utils/helpers';
 import createGenerateClassName from '@material-ui/styles/createGenerateClassName';
 import getStylesCreator from '@material-ui/styles/getStylesCreator';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { getLineFeed, getUnstyledFilename } from './helpers';
 
 const apiDocsTranslationsDirectory = path.resolve('docs', 'translations', 'api-docs');
@@ -1306,7 +1306,7 @@ async function run(argv: {
 
   mkdirSync(outputDirectory, { mode: 0o777, recursive: true });
 
-  const theme = createMuiTheme();
+  const theme = createTheme();
 
   /**
    * pageMarkdown: Array<{ components: string[]; filename: string; pathname: string }>

--- a/docs/src/modules/branding/BrandingRoot.tsx
+++ b/docs/src/modules/branding/BrandingRoot.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { lighten, darken, createMuiTheme, alpha, ThemeProvider } from '@material-ui/core/styles';
+import { lighten, darken, createTheme, alpha, ThemeProvider } from '@material-ui/core/styles';
 import NProgressBar from '@material-ui/docs/NProgressBar';
 import BrandingFooter from 'docs/src/modules/branding/BrandingFooter';
 
@@ -50,7 +50,7 @@ function round(value: number) {
 
 const oxfordBlue = '#001E3C';
 
-let theme = createMuiTheme({
+let theme = createTheme({
   palette: {
     text: {
       primary: oxfordBlue,
@@ -104,7 +104,7 @@ let theme = createMuiTheme({
   },
 });
 
-theme = createMuiTheme(theme, {
+theme = createTheme(theme, {
   palette: {
     action: {
       active: theme.palette.grey87,

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
   ThemeProvider as MuiThemeProvider,
-  createMuiTheme as createLegacyModeTheme,
+  createTheme as createLegacyModeTheme,
   unstable_createMuiStrictModeTheme as createStrictModeTheme,
   darken,
 } from '@material-ui/core/styles';
@@ -122,11 +122,11 @@ if (process.env.NODE_ENV !== 'production') {
   DispatchContext.displayName = 'ThemeDispatchContext';
 }
 
-let createMuiTheme;
+let createTheme;
 if (process.env.REACT_MODE === 'legacy') {
-  createMuiTheme = createLegacyModeTheme;
+  createTheme = createLegacyModeTheme;
 } else {
-  createMuiTheme = createStrictModeTheme;
+  createTheme = createStrictModeTheme;
 }
 
 export function ThemeProvider(props) {
@@ -203,7 +203,7 @@ export function ThemeProvider(props) {
   }, [direction]);
 
   const theme = React.useMemo(() => {
-    const nextTheme = createMuiTheme(
+    const nextTheme = createTheme(
       {
         direction,
         nprogress: {
@@ -247,7 +247,7 @@ export function ThemeProvider(props) {
     // Expose the theme as a global variable so people can play with it.
     if (process.browser) {
       window.theme = theme;
-      window.createMuiTheme = createMuiTheme;
+      window.createTheme = createTheme;
     }
   }, [theme]);
 

--- a/docs/src/modules/utils/parseMarkdown.test.js
+++ b/docs/src/modules/utils/parseMarkdown.test.js
@@ -103,7 +103,7 @@ authors: ['foo', 'bar']
 # Theming
 ## API
 ### responsiveFontSizes(theme, options) => theme
-### createMuiTheme(options, ...args) => theme
+### createTheme(options, ...args) => theme
 `;
       // mock require.context
       function requireRaw() {
@@ -129,9 +129,9 @@ authors: ['foo', 'bar']
               text: 'responsiveFontSizes(&#8203;theme, options) =&gt; theme',
             },
             {
-              hash: 'createmuitheme-options-args-theme',
+              hash: 'createtheme-options-args-theme',
               level: 3,
-              text: 'createMuiTheme(&#8203;options, ...args) =&gt; theme',
+              text: 'createTheme(&#8203;options, ...args) =&gt; theme',
             },
           ],
           hash: 'api',

--- a/docs/src/modules/utils/textToHash.test.js
+++ b/docs/src/modules/utils/textToHash.test.js
@@ -5,7 +5,7 @@ import textToHash from './textToHash';
 describe('textToHash', () => {
   it('should hash as expected', () => {
     const table = [
-      ['createMuiTheme(options) => theme', 'createmuitheme-options-theme'],
+      ['createTheme(options) => theme', 'createtheme-options-theme'],
       ['Typography - Font family', 'typography-font-family'],
       ["barre d'application", 'barre-dapplication'],
       [

--- a/docs/src/pages/components/about-the-lab/about-the-lab-de.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-de.md
@@ -44,7 +44,7 @@ In order to benefit from the [CSS overrides](/customization/theme-components/#gl
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab-es.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-es.md
@@ -44,7 +44,7 @@ Con el fin de beneficiarse de la [sobrescritura de CSS](/customization/theme-com
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab-fr.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-fr.md
@@ -44,7 +44,7 @@ De manière à pouvoir [ outrepasser le CSS ](/customization/theme-components/#g
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab-ja.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-ja.md
@@ -44,7 +44,7 @@ yarn add @material-ui/core
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab-pt.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-pt.md
@@ -44,7 +44,7 @@ Para se beneficiar de [CSS overrides](/customization/theme-components/#global-st
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab-ru.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-ru.md
@@ -44,7 +44,7 @@ yarn add @material-ui/core
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab-zh.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab-zh.md
@@ -44,7 +44,7 @@ yarn add @material-ui/core@next
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab.md
@@ -45,7 +45,7 @@ In order to benefit from the [CSS overrides](/customization/theme-components/#gl
 ```tsx
 import '@material-ui/lab/themeAugmentation';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTimeline: {
       styleOverrides: {

--- a/docs/src/pages/components/buttons/CustomizedButtons.js
+++ b/docs/src/pages/components/buttons/CustomizedButtons.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   experimentalStyled,
   makeStyles,
   ThemeProvider,
@@ -58,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: green,
   },

--- a/docs/src/pages/components/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/components/buttons/CustomizedButtons.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   createStyles,
   experimentalStyled,
   makeStyles,
@@ -62,7 +62,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: green,
   },

--- a/docs/src/pages/components/css-baseline/css-baseline.md
+++ b/docs/src/pages/components/css-baseline/css-baseline.md
@@ -72,7 +72,7 @@ The colors of the scrollbars can be customized to improve the contrast (especial
 ```jsx
 import darkScrollbar from '@material-ui/core/darkScrollbar';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiCssBaseline: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/FontAwesomeIconSize.js
+++ b/docs/src/pages/components/icons/FontAwesomeIconSize.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Icon from '@material-ui/core/Icon';
 import MdPhone from '@material-ui/icons/Phone';
 import Chip from '@material-ui/core/Chip';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/FontAwesomeIconSize.tsx
+++ b/docs/src/pages/components/icons/FontAwesomeIconSize.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Icon from '@material-ui/core/Icon';
 import MdPhone from '@material-ui/icons/Phone';
 import Chip from '@material-ui/core/Chip';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons-de.md
+++ b/docs/src/pages/components/icons/icons-de.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 Modifying the `baseClassName` prop for each component usage is repetitive. You can change the default prop globally with the theme
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {

--- a/docs/src/pages/components/icons/icons-es.md
+++ b/docs/src/pages/components/icons/icons-es.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 Modifying the `baseClassName` prop for each component usage is repetitive. You can change the default prop globally with the theme
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -247,7 +247,7 @@ Then, you can use the two-tone font directly:
 Note that the Font Awesome icons weren't designed like the Material Design icons (compare the two previous demos). The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons-fr.md
+++ b/docs/src/pages/components/icons/icons-fr.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 Modifying the `baseClassName` prop for each component usage is repetitive. You can change the default prop globally with the theme
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -247,7 +247,7 @@ Then, you can use the two-tone font directly:
 Note that the Font Awesome icons weren't designed like the Material Design icons (compare the two previous demos). The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons-ja.md
+++ b/docs/src/pages/components/icons/icons-ja.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 Modifying the `baseClassName` prop for each component usage is repetitive. You can change the default prop globally with the theme
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -247,7 +247,7 @@ Then, you can use the two-tone font directly:
 Note that the Font Awesome icons weren't designed like the Material Design icons (compare the two previous demos). The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons-pt.md
+++ b/docs/src/pages/components/icons/icons-pt.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 Modificar a propriedade `baseClassName` para cada uso feito do componente é repetitivo. Você pode alterar a propriedade padrão globalmente com o tema
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -247,7 +247,7 @@ Então, você pode usar a fonte de dois tons diretamente:
 Note que os ícones da fonte Awesome não foram projetados como os ícones do Material Design (compare as duas demonstrações anteriores). Os ícones fa são cortados para usar todo o espaço disponível. Você pode ajustar isso com uma sobrescrita global:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons-ru.md
+++ b/docs/src/pages/components/icons/icons-ru.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 Modifying the `baseClassName` prop for each component usage is repetitive. You can change the default prop globally with the theme
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -247,7 +247,7 @@ Then, you can use the two-tone font directly:
 Note that the Font Awesome icons weren't designed like the Material Design icons (compare the two previous demos). The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons-zh.md
+++ b/docs/src/pages/components/icons/icons-zh.md
@@ -220,7 +220,7 @@ import Icon from '@material-ui/core/Icon';
 为了每个组件的使用都去修改 `baseClassName` 属性是很繁琐的。 你可以在全局范围内使用主题来改变默认属性。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -247,7 +247,7 @@ const theme = createMuiTheme({
 需要注意的是，Font Awesome icons 的设计并不像 Material Design icons 那样（你可以对比之前的两个 demo）。 fa icons 经过裁剪，以利用所有可用空间。 你可以通过全局覆盖的方式来适配它：
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -237,7 +237,7 @@ Modifying the `baseClassName` prop for each component usage is repetitive.
 You can change the default prop globally with the theme
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       defaultProps: {
@@ -265,7 +265,7 @@ Note that the Font Awesome icons weren't designed like the Material Design icons
 The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiIcon: {
       styleOverrides: {

--- a/docs/src/pages/components/paper/Elevation.js
+++ b/docs/src/pages/components/paper/Elevation.js
@@ -3,7 +3,7 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Box from '@material-ui/core/Box';
 import {
-  createMuiTheme,
+  createTheme,
   ThemeProvider,
   experimentalStyled as styled,
 } from '@material-ui/core/styles';
@@ -17,8 +17,8 @@ const Item = styled(Paper)(({ theme }) => ({
   lineHeight: '60px',
 }));
 
-const darkTheme = createMuiTheme({ palette: { mode: 'dark' } });
-const lightTheme = createMuiTheme({ palette: { mode: 'light' } });
+const darkTheme = createTheme({ palette: { mode: 'dark' } });
+const lightTheme = createTheme({ palette: { mode: 'light' } });
 
 export default function Elevation() {
   return (

--- a/docs/src/pages/components/paper/Elevation.tsx
+++ b/docs/src/pages/components/paper/Elevation.tsx
@@ -3,7 +3,7 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Box from '@material-ui/core/Box';
 import {
-  createMuiTheme,
+  createTheme,
   ThemeProvider,
   experimentalStyled as styled,
 } from '@material-ui/core/styles';
@@ -18,8 +18,8 @@ const Item = styled(Paper)(({ theme }) => ({
   lineHeight: '60px',
 }));
 
-const darkTheme = createMuiTheme({ palette: { mode: 'dark' } });
-const lightTheme = createMuiTheme({ palette: { mode: 'light' } });
+const darkTheme = createTheme({ palette: { mode: 'dark' } });
+const lightTheme = createTheme({ palette: { mode: 'light' } });
 
 export default function Elevation() {
   return (

--- a/docs/src/pages/components/typography/typography-de.md
+++ b/docs/src/pages/components/typography/typography-de.md
@@ -73,7 +73,7 @@ Die Komponente Typografie verwendet die Eigenschaft `variantMapping` um eine UI-
 - Sie können das Mapping [global mit dem Theme](/customization/theme-components/#default-props) ändern:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiTypography: {
       variantMapping: {

--- a/docs/src/pages/components/typography/typography-es.md
+++ b/docs/src/pages/components/typography/typography-es.md
@@ -73,7 +73,7 @@ The Typography component uses the `variantMapping` property to associate a UI va
 - You can change the mapping [globally using the theme](/customization/theme-components/#default-props):
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiTypography: {
       variantMapping: {

--- a/docs/src/pages/components/typography/typography-fr.md
+++ b/docs/src/pages/components/typography/typography-fr.md
@@ -73,7 +73,7 @@ The Typography component uses the `variantMapping` property to associate a UI va
 - You can change the mapping [globally using the theme](/customization/theme-components/#default-props):
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiTypography: {
       variantMapping: {

--- a/docs/src/pages/components/typography/typography-ja.md
+++ b/docs/src/pages/components/typography/typography-ja.md
@@ -73,7 +73,7 @@ Typographyコンポーネントは、 `variantMapping` プロパティを使用�
 - 以下のようにテーマ使用して、[マッピング をグローバルに](/customization/theme-components/#default-props)変更できます。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiTypography: {
       variantMapping: {

--- a/docs/src/pages/components/typography/typography-pt.md
+++ b/docs/src/pages/components/typography/typography-pt.md
@@ -73,7 +73,7 @@ O componente de Tipografia (Typography) usa a propriedade `variantMapping` para 
 - Você pode alterar o mapeamento [globalmente usando o tema](/customization/theme-components/#default-props):
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiTypography: {
       variantMapping: {

--- a/docs/src/pages/components/typography/typography-ru.md
+++ b/docs/src/pages/components/typography/typography-ru.md
@@ -73,7 +73,7 @@ The Typography component uses the `variantMapping` property to associate a UI va
 - Вы можете изменить сопоставление вариантов [глобально используя тему](/customization/theme-components/#default-props):
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiTypography: {
       variantMapping: {

--- a/docs/src/pages/components/typography/typography-zh.md
+++ b/docs/src/pages/components/typography/typography-zh.md
@@ -77,7 +77,7 @@ import '@fontsource/roboto/700.css';
 - 您也可以 [使用 theme](/customization/theme-components/#default-props) 来修改全局字体映射。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTypography: {
       defaultProps: {

--- a/docs/src/pages/components/typography/typography.md
+++ b/docs/src/pages/components/typography/typography.md
@@ -84,7 +84,7 @@ It's important to realize that the style of a typography component is independen
 - You can change the mapping [globally using the theme](/customization/theme-components/#default-props):
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiTypography: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/ThemeHelper.js
+++ b/docs/src/pages/components/use-media-query/ThemeHelper.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider, useTheme } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider, useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 function MyComponent() {
@@ -9,7 +9,7 @@ function MyComponent() {
   return <span>{`theme.breakpoints.up('sm') matches: ${matches}`}</span>;
 }
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function ThemeHelper() {
   return (

--- a/docs/src/pages/components/use-media-query/ThemeHelper.tsx
+++ b/docs/src/pages/components/use-media-query/ThemeHelper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider, useTheme } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider, useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 function MyComponent() {
@@ -9,7 +9,7 @@ function MyComponent() {
   return <span>{`theme.breakpoints.up('sm') matches: ${matches}`}</span>;
 }
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function ThemeHelper() {
   return (

--- a/docs/src/pages/components/use-media-query/UseWidth.js
+++ b/docs/src/pages/components/use-media-query/UseWidth.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, useTheme, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, useTheme, createTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 /**
@@ -24,7 +24,7 @@ function MyComponent() {
   return <span>{`width: ${width}`}</span>;
 }
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function UseWidth() {
   return (

--- a/docs/src/pages/components/use-media-query/UseWidth.tsx
+++ b/docs/src/pages/components/use-media-query/UseWidth.tsx
@@ -4,7 +4,7 @@ import {
   Theme,
   ThemeProvider,
   useTheme,
-  createMuiTheme,
+  createTheme,
 } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
@@ -32,7 +32,7 @@ function MyComponent() {
   return <span>{`width: ${width}`}</span>;
 }
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function UseWidth() {
   return (

--- a/docs/src/pages/components/use-media-query/use-media-query-de.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-de.md
@@ -97,7 +97,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 or it can turn it on globally with the theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query-es.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-es.md
@@ -97,7 +97,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 or it can turn it on globally with the theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query-fr.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-fr.md
@@ -97,7 +97,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 or it can turn it on globally with the theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query-ja.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-ja.md
@@ -97,7 +97,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 or it can turn it on globally with the theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query-pt.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-pt.md
@@ -97,7 +97,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 ou pode ativar globalmente com o tema:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query-ru.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-ru.md
@@ -97,7 +97,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 или он может включить его глобально с помощью темы:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query-zh.md
+++ b/docs/src/pages/components/use-media-query/use-media-query-zh.md
@@ -99,7 +99,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 或者你可以通过全局主题设置来启用它：
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -104,7 +104,7 @@ const matches = useMediaQuery('(min-width:600px)', { noSsr: true });
 or it can turn it on globally with the theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiUseMediaQuery: {
       defaultProps: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-de.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-de.md
@@ -75,7 +75,7 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 If you change the default breakpoints's values, you need to provide them all:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -91,7 +91,7 @@ const theme = createMuiTheme({
 Feel free to have as few or as many breakpoints as you want, naming them in whatever way you'd prefer for your project.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -249,7 +249,7 @@ Einige Implementierungsdetails, die interessant sein könnten:
 - `options.initialWidth` (*Breakpoint* [optional]): Da `window.innerWidth` auf dem Server nicht verfügbar ist, wird eine leere Komponente während der ersten Mounts standardmäßig gerendert. Vielleicht mögen Sie eine Heuristik verwenden, um annähernd die Bildschirmbreite des Client-Browsers zu bestimmen. Sie könnten beispielsweise den Benutzeragenten oder die Client-Hinweise verwenden. Um die Anfangsbreite festzulegen, müssen wir eine benutzerdefinierte Eigenschaft mit dieser Form übergeben: Mit https://caniuse.com/#search=client%20hint, können wir die anfängliche Breite global festlegen, indem Sie die [`benutzerdefinierten Eigenschaften`](/customization/theme-components/#default-props) zum Theme verwenden.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // withWidth Komponente ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-es.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-es.md
@@ -75,7 +75,7 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 If you change the default breakpoints's values, you need to provide them all:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -91,7 +91,7 @@ const theme = createMuiTheme({
 Feel free to have as few or as many breakpoints as you want, naming them in whatever way you'd prefer for your project.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -249,7 +249,7 @@ Some implementation details that might be interesting to being aware of:
 - `options.initialWidth` (*Breakpoint* [optional]): As `window.innerWidth` is unavailable on the server, we default to rendering an empty component during the first mount. You might want to use an heuristic to approximate the screen width of the client browser screen width. For instance, you could be using the user-agent or the client-hints. In order to set the initialWidth we need to pass a custom property with this shape: https://caniuse.com/#search=client%20hint, we also can set the initial width globally using [`custom properties`](/customization/theme-components/#default-props) on the theme.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // withWidth component ⚛️
     MuiWithWidth: {
@@ -277,7 +277,7 @@ const theme = createMuiTheme({
 #### Ejemplos
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // withWidth component ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-fr.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-fr.md
@@ -75,7 +75,7 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 If you change the default breakpoints's values, you need to provide them all:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -91,7 +91,7 @@ const theme = createMuiTheme({
 Feel free to have as few or as many breakpoints as you want, naming them in whatever way you'd prefer for your project.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -249,7 +249,7 @@ Some implementation details that might be interesting to being aware of:
 - `options.initialWidth` (*Breakpoint* [optional]): As `window.innerWidth` is unavailable on the server, we default to rendering an empty component during the first mount. You might want to use an heuristic to approximate the screen width of the client browser screen width. For instance, you could be using the user-agent or the client-hints. In order to set the initialWidth we need to pass a custom property with this shape: https://caniuse.com/#search=client%20hint, we also can set the initial width globally using [`custom properties`](/customization/theme-components/#default-props) on the theme.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // withWidth component ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-ja.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-ja.md
@@ -75,7 +75,7 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 If you change the default breakpoints's values, you need to provide them all:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -91,7 +91,7 @@ const theme = createMuiTheme({
 Feel free to have as few or as many breakpoints as you want, naming them in whatever way you'd prefer for your project.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -250,7 +250,7 @@ type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 グローバルに設定することもできます`](/customization/theme-components/#default-props)。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // withWidth component ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-pt.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-pt.md
@@ -87,7 +87,7 @@ export default withWidth()(MyComponent);
 Sinta-se à vontade para ter quantos pontos de quebra você quiser, nomeando-os da maneira que preferir para o seu projeto.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -245,7 +245,7 @@ Alguns detalhes de implementação que podem ser interessantes para estar ciente
 - `options.initialWidth` (*Breakpoint* [opcional]): Como `window.innerWidth` não esta disponível no servidor, retornamos uma correspondência padrão durante a primeira montagem. Você pode querer usar uma heurística para aproximar a largura da tela no navegador do cliente. Por exemplo, você poderia estar usando o user-agent ou o client-hint. Para definir o initialWidth, precisamos passar uma propriedade customizada com esta forma: https://caniuse.com/#search=client%20hint, também podemos definir a largura inicial globalmente usando [`propriedades customizadas`](/customization/theme-components/#default-props) no tema.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // Componente withWidth ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-ru.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-ru.md
@@ -75,7 +75,7 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 If you change the default breakpoints's values, you need to provide them all:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -91,7 +91,7 @@ const theme = createMuiTheme({
 Feel free to have as few or as many breakpoints as you want, naming them in whatever way you'd prefer for your project.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -249,7 +249,7 @@ type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 - `options.initialWidth` (*Breakpoint* [optional]): As `window.innerWidth` is unavailable on the server, we default to rendering an empty component during the first mount. You might want to use an heuristic to approximate the screen width of the client browser screen width. For instance, you could be using the user-agent or the client-hints. In order to set the initialWidth we need to pass a custom property with this shape: https://caniuse.com/#search=client%20hint, we also can set the initial width globally using [`custom properties`](/customization/theme-components/#default-props) on the theme.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // withWidth component ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints-zh.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints-zh.md
@@ -85,7 +85,7 @@ export default withWidth()(MyComponent);
 如果您需要更改断点的默认值，则需要提供所有的断点值：
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -101,7 +101,7 @@ const theme = createMuiTheme({
 您可以随意设置任意数量的断点，并且也可以在项目中以您喜欢的任何方式为断点命名。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -256,7 +256,7 @@ type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 - `options.initialWidth` （*Breakpoint* [可选的]）： 为`window.innerWidth`在服务器上不可用， 我们默认在第一次安装期间呈现空组件。 你可能需要使用一个启发式方法来估计客户端浏览器的屏幕宽度。 例如，你可以使用 user-agent 或 [client-hints](https://caniuse.com/#search=client%20hint)。 为了设置 initialWidth，我们需要传递一个类似于以下结构的自定义属性： 我们也可以在主题中使用 [`自定义属性`](/customization/theme-components/#default-props) 来设置全局的初始宽度。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // withWidth component ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -91,7 +91,7 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 If you change the default breakpoints's values, you need to provide them all:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
@@ -107,7 +107,7 @@ const theme = createMuiTheme({
 Feel free to have as few or as many breakpoints as you want, naming them in whatever way you'd prefer for your project.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,
@@ -277,7 +277,7 @@ Some implementation details that might be interesting to being aware of:
   In order to set the initialWidth we need to pass a custom prop with this shape:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // withWidth component ⚛️
     MuiWithWidth: {

--- a/docs/src/pages/customization/color/color-de.md
+++ b/docs/src/pages/customization/color/color-de.md
@@ -17,12 +17,12 @@ The Material Design team has also built an awesome palette configuration tool: [
 <br />
 <br />
 
-Die Ausgabe kann in die `createMuiTheme()` Funktion eingegeben werden:
+Die Ausgabe kann in die `createTheme()` Funktion eingegeben werden:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -46,13 +46,13 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 });
 ```
 
-Nur die `Haupttöne` müssen bereitgestellt werden (es sei denn, Sie möchten `light`, `dark` oder `contrastText` weiter anpassen), da die anderen Farben von `createMuiTheme()` berechnet werden, wie in der Sektion [ Designanpassung ](/customization/palette/) beschrieben.
+Nur die `Haupttöne` müssen bereitgestellt werden (es sei denn, Sie möchten `light`, `dark` oder `contrastText` weiter anpassen), da die anderen Farben von `createTheme()` berechnet werden, wie in der Sektion [ Designanpassung ](/customization/palette/) beschrieben.
 
-Wenn Sie die standardmäßigen primären und / oder sekundären Farbtöne verwenden, wird durch das Bereitstellen von dem Farbobjekt die entsprechenden Farbtöne der Materialfarbe für main, light und dark von `createMuiTheme()` berechnet.
+Wenn Sie die standardmäßigen primären und / oder sekundären Farbtöne verwenden, wird durch das Bereitstellen von dem Farbobjekt die entsprechenden Farbtöne der Materialfarbe für main, light und dark von `createTheme()` berechnet.
 
 ### Werkzeuge von der Community
 

--- a/docs/src/pages/customization/color/color-de.md
+++ b/docs/src/pages/customization/color/color-de.md
@@ -46,7 +46,7 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createtheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color-es.md
+++ b/docs/src/pages/customization/color/color-es.md
@@ -17,12 +17,12 @@ The Material Design team has also built an awesome palette configuration tool: [
 <br />
 <br />
 
-The output can be fed into `createMuiTheme()` function:
+The output can be fed into `createTheme()` function:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -46,13 +46,13 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 });
 ```
 
-Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createMuiTheme()`, as described in the [Theme customization](/customization/palette/) section.
+Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createTheme()`, as described in the [Theme customization](/customization/palette/) section.
 
-If you are using the default primary and / or secondary shades then by providing the color object, `createMuiTheme()` will use the appropriate shades from the material color for main, light and dark.
+If you are using the default primary and / or secondary shades then by providing the color object, `createTheme()` will use the appropriate shades from the material color for main, light and dark.
 
 ### Herramientas de la comunidad
 

--- a/docs/src/pages/customization/color/color-es.md
+++ b/docs/src/pages/customization/color/color-es.md
@@ -46,7 +46,7 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createtheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color-fr.md
+++ b/docs/src/pages/customization/color/color-fr.md
@@ -17,12 +17,12 @@ The Material Design team has also built an awesome palette configuration tool: [
 <br />
 <br />
 
-The output can be fed into `createMuiTheme()` function:
+The output can be fed into `createTheme()` function:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -46,13 +46,13 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 });
 ```
 
-Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createMuiTheme()`, as described in the [Theme customization](/customization/palette/) section.
+Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createTheme()`, as described in the [Theme customization](/customization/palette/) section.
 
-If you are using the default primary and / or secondary shades then by providing the color object, `createMuiTheme()` will use the appropriate shades from the material color for main, light and dark.
+If you are using the default primary and / or secondary shades then by providing the color object, `createTheme()` will use the appropriate shades from the material color for main, light and dark.
 
 ### Tools by the community
 

--- a/docs/src/pages/customization/color/color-fr.md
+++ b/docs/src/pages/customization/color/color-fr.md
@@ -46,7 +46,7 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createtheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color-ja.md
+++ b/docs/src/pages/customization/color/color-ja.md
@@ -17,12 +17,12 @@ The Material Design team has also built an awesome palette configuration tool: [
 <br />
 <br />
 
-出力は、`createMuiTheme()`関数に渡すことができます。
+出力は、`createTheme()`関数に渡すことができます。
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -46,13 +46,13 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 });
 ```
 
-他の色は [Theme customization](/customization/palette/)セクションで説明されているように`createMuiTheme()`によって計算されるので、`main`シェーディングのみを提供する必要があります(`light`、`dark`、`contrastText`をさらにカスタマイズする場合を除きます)。
+他の色は [Theme customization](/customization/palette/)セクションで説明されているように`createTheme()`によって計算されるので、`main`シェーディングのみを提供する必要があります(`light`、`dark`、`contrastText`をさらにカスタマイズする場合を除きます)。
 
-デフォルトの一次または二次シェード、あるいはその両方を使用している場合にカラーオブジェクトを指定すると、`createMuiTheme()`はメイン、ライト、およびダークにマテリアルカラーからの適切なシェードを使用します。
+デフォルトの一次または二次シェード、あるいはその両方を使用している場合にカラーオブジェクトを指定すると、`createTheme()`はメイン、ライト、およびダークにマテリアルカラーからの適切なシェードを使用します。
 
 ### コミュニティによるツール
 

--- a/docs/src/pages/customization/color/color-ja.md
+++ b/docs/src/pages/customization/color/color-ja.md
@@ -46,7 +46,7 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createtheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color-pt.md
+++ b/docs/src/pages/customization/color/color-pt.md
@@ -17,12 +17,12 @@ A equipe do Material Design também criou uma ferramenta de configuração de pa
 <br />
 <br />
 
-A saída pode ser alimentada na função `createMuiTheme()`:
+A saída pode ser alimentada na função `createTheme()`:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -46,13 +46,13 @@ Para testar um esquema de cores do [material.io/design/color](https://material.i
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-A saída exibida na amostra de cores pode ser colada diretamente na função [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) (para ser usada com [`ThemeProvider`](/customization/theming/#theme-provider)):
+A saída exibida na amostra de cores pode ser colada diretamente na função [`createTheme()`](/customization/theming/#createmuitheme-options-theme) (para ser usada com [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 });
 ```
 
-Apenas o tom `main` precisa ser fornecido (a menos que você deseje customizar ainda mais `light`, `dark` ou `contrastText`), já que as outras cores serão calculadas por `createMuiTheme()`, como descrito na seção de [customização de tema](/customization/palette/).
+Apenas o tom `main` precisa ser fornecido (a menos que você deseje customizar ainda mais `light`, `dark` ou `contrastText`), já que as outras cores serão calculadas por `createTheme()`, como descrito na seção de [customização de tema](/customization/palette/).
 
-Se você estiver usando os tons primário e / ou secundário por padrão, fornecendo o objeto de cor, `createMuiTheme()` usará tons apropriados da cor do material para `main`, `light` e `dark`.
+Se você estiver usando os tons primário e / ou secundário por padrão, fornecendo o objeto de cor, `createTheme()` usará tons apropriados da cor do material para `main`, `light` e `dark`.
 
 ### Ferramentas da comunidade
 

--- a/docs/src/pages/customization/color/color-pt.md
+++ b/docs/src/pages/customization/color/color-pt.md
@@ -46,7 +46,7 @@ Para testar um esquema de cores do [material.io/design/color](https://material.i
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-A saída exibida na amostra de cores pode ser colada diretamente na função [`createTheme()`](/customization/theming/#createmuitheme-options-theme) (para ser usada com [`ThemeProvider`](/customization/theming/#theme-provider)):
+A saída exibida na amostra de cores pode ser colada diretamente na função [`createTheme()`](/customization/theming/#createtheme-options-theme) (para ser usada com [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color-ru.md
+++ b/docs/src/pages/customization/color/color-ru.md
@@ -17,12 +17,12 @@ The Material Design team has also built an awesome palette configuration tool: [
 <br />
 <br />
 
-The output can be fed into `createMuiTheme()` function:
+The output can be fed into `createTheme()` function:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -46,13 +46,13 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 });
 ```
 
-Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createMuiTheme()`, as described in the [Theme customization](/customization/palette/) section.
+Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createTheme()`, as described in the [Theme customization](/customization/palette/) section.
 
-If you are using the default primary and / or secondary shades then by providing the color object, `createMuiTheme()` will use the appropriate shades from the material color for main, light and dark.
+If you are using the default primary and / or secondary shades then by providing the color object, `createTheme()` will use the appropriate shades from the material color for main, light and dark.
 
 ### Инструменты, созданные сообществом
 

--- a/docs/src/pages/customization/color/color-ru.md
+++ b/docs/src/pages/customization/color/color-ru.md
@@ -46,7 +46,7 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createtheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color-zh.md
+++ b/docs/src/pages/customization/color/color-zh.md
@@ -18,12 +18,12 @@ Material Design 团队也搭建了一个非常棒的调色板配置工具： [ma
 <br />
 <br />
 
-输出的结果可以被传入到 `createMuiTheme()` 函数中：
+输出的结果可以被传入到 `createTheme()` 函数中：
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -47,13 +47,13 @@ const theme = createMuiTheme({
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-您可以把颜色的例子中显示的输出结果直接粘贴到一个 [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) 函数里（需要与 [`ThemeProvider`](/customization/theming/#theme-provider) 配合使用）：
+您可以把颜色的例子中显示的输出结果直接粘贴到一个 [`createTheme()`](/customization/theming/#createmuitheme-options-theme) 函数里（需要与 [`ThemeProvider`](/customization/theming/#theme-provider) 配合使用）：
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -65,9 +65,9 @@ const theme = createMuiTheme({
 });
 ```
 
-您只需提供 `主要的` 阴影（shades）（除非您希望进一步自定义 `light`，`dark` 或 `contrastText` 这几个属性），在 [定制主题](/customization/palette/) 章节中提到，这是因为其他颜色会由 `createMuiTheme()` 自动计算。
+您只需提供 `主要的` 阴影（shades）（除非您希望进一步自定义 `light`，`dark` 或 `contrastText` 这几个属性），在 [定制主题](/customization/palette/) 章节中提到，这是因为其他颜色会由 `createTheme()` 自动计算。
 
-如果你在使用默认的主要和/或次要阴影，那么通过提供一个颜色对象（color object） ，`createMuiTheme()` 将会根据主（main）、亮（light）和暗（dark）三种 material 颜色使用合适的阴影。
+如果你在使用默认的主要和/或次要阴影，那么通过提供一个颜色对象（color object） ，`createTheme()` 将会根据主（main）、亮（light）和暗（dark）三种 material 颜色使用合适的阴影。
 
 ### 社区提供的一些工具
 

--- a/docs/src/pages/customization/color/color-zh.md
+++ b/docs/src/pages/customization/color/color-zh.md
@@ -47,7 +47,7 @@ const theme = createTheme({
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-您可以把颜色的例子中显示的输出结果直接粘贴到一个 [`createTheme()`](/customization/theming/#createmuitheme-options-theme) 函数里（需要与 [`ThemeProvider`](/customization/theming/#theme-provider) 配合使用）：
+您可以把颜色的例子中显示的输出结果直接粘贴到一个 [`createTheme()`](/customization/theming/#createtheme-options-theme) 函数里（需要与 [`ThemeProvider`](/customization/theming/#theme-provider) 配合使用）：
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color.md
+++ b/docs/src/pages/customization/color/color.md
@@ -47,7 +47,7 @@ Alternatively, you can enter hex values in the Primary and Secondary text fields
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createtheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
 import { createTheme } from '@material-ui/core/styles';

--- a/docs/src/pages/customization/color/color.md
+++ b/docs/src/pages/customization/color/color.md
@@ -17,12 +17,12 @@ This can help you create a color palette for your UI, as well as measure the acc
 <br />
 <br />
 
-The output can be fed into `createMuiTheme()` function:
+The output can be fed into `createTheme()` function:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
@@ -47,13 +47,13 @@ Alternatively, you can enter hex values in the Primary and Secondary text fields
 
 {{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
-The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
+The output shown in the color sample can be pasted directly into a [`createTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 
 ```jsx
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -65,9 +65,9 @@ const theme = createMuiTheme({
 });
 ```
 
-Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createMuiTheme()`, as described in the [Theme customization](/customization/palette/) section.
+Only the `main` shades need be provided (unless you wish to further customize `light`, `dark` or `contrastText`), as the other colors will be calculated by `createTheme()`, as described in the [Theme customization](/customization/palette/) section.
 
-If you are using the default primary and / or secondary shades then by providing the color object, `createMuiTheme()` will use the appropriate shades from the material color for main, light and dark.
+If you are using the default primary and / or secondary shades then by providing the color object, `createTheme()` will use the appropriate shades from the material color for main, light and dark.
 
 ### Tools by the community
 

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import {
   makeStyles,
   withStyles,
-  createMuiTheme,
+  createTheme,
   lighten,
 } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -290,7 +290,7 @@ function DefaultTheme(props) {
   }, []);
 
   const data = React.useMemo(() => {
-    return createMuiTheme({
+    return createTheme({
       palette: { mode: darkTheme ? 'dark' : 'light' },
     });
   }, [darkTheme]);

--- a/docs/src/pages/customization/default-theme/default-theme-de.md
+++ b/docs/src/pages/customization/default-theme/default-theme-de.md
@@ -12,4 +12,4 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-Wenn Sie mehr darüber erfahren möchten, wie das Theme zusammengestellt wird, werfen Sie einen Blick auf [`material-ui / style / createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js), und die zugehörigen Importe, die `createMuiTheme` verwendet.
+Wenn Sie mehr darüber erfahren möchten, wie das Theme zusammengestellt wird, werfen Sie einen Blick auf [`material-ui / style / createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js), und die zugehörigen Importe, die `createTheme` verwendet.

--- a/docs/src/pages/customization/default-theme/default-theme-es.md
+++ b/docs/src/pages/customization/default-theme/default-theme-es.md
@@ -12,4 +12,4 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-Si deseas obtener más información sobre cómo se monta el tema, echa un vistazo a [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js), y los imports que utiliza `createMuiTheme`.
+Si deseas obtener más información sobre cómo se monta el tema, echa un vistazo a [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js), y los imports que utiliza `createTheme`.

--- a/docs/src/pages/customization/default-theme/default-theme-fr.md
+++ b/docs/src/pages/customization/default-theme/default-theme-fr.md
@@ -12,4 +12,4 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js), and the related imports which `createMuiTheme` uses.
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js), and the related imports which `createTheme` uses.

--- a/docs/src/pages/customization/default-theme/default-theme-ja.md
+++ b/docs/src/pages/customization/default-theme/default-theme-ja.md
@@ -12,4 +12,4 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-テーマについてもっと知りたい場合は、[`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js)又は `createMuiTheme`に関連するものをインポートして使って下さい。
+テーマについてもっと知りたい場合は、[`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js)又は `createTheme`に関連するものをインポートして使って下さい。

--- a/docs/src/pages/customization/default-theme/default-theme-pt.md
+++ b/docs/src/pages/customization/default-theme/default-theme-pt.md
@@ -12,4 +12,4 @@ Explore o objeto de tema padrão:
 
 <!-- #default-branch-switch -->
 
-Se você quiser aprender mais sobre como o tema é montado, dê uma olhada em [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js), e as importações relacionadas que `createMuiTheme` usa.
+Se você quiser aprender mais sobre como o tema é montado, dê uma olhada em [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js), e as importações relacionadas que `createTheme` usa.

--- a/docs/src/pages/customization/default-theme/default-theme-ru.md
+++ b/docs/src/pages/customization/default-theme/default-theme-ru.md
@@ -12,4 +12,4 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-Подробности о структуре темы изнутри можно посмотреть здесь [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js), а также изучив зависимости, используемые `createMuiTheme`.
+Подробности о структуре темы изнутри можно посмотреть здесь [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js), а также изучив зависимости, используемые `createTheme`.

--- a/docs/src/pages/customization/default-theme/default-theme-zh.md
+++ b/docs/src/pages/customization/default-theme/default-theme-zh.md
@@ -12,4 +12,4 @@
 
 <!-- #default-branch-switch -->
 
-如果你想了解更多有关主题是如何组合的信息，请看看 [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js) 和 如何用`createMuiTheme` 导入主题
+如果你想了解更多有关主题是如何组合的信息，请看看 [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js) 和 如何用`createTheme` 导入主题

--- a/docs/src/pages/customization/default-theme/default-theme.md
+++ b/docs/src/pages/customization/default-theme/default-theme.md
@@ -14,5 +14,5 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createMuiTheme.js),
-and the related imports which `createMuiTheme` uses.
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/styles/createTheme.js),
+and the related imports which `createTheme` uses.

--- a/docs/src/pages/customization/density/density-de.md
+++ b/docs/src/pages/customization/density/density-de.md
@@ -37,7 +37,7 @@ If you enable high density a custom theme is applied to the docs. This theme is 
 The theme is configured with the following options:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiButton: {
       size: 'small',

--- a/docs/src/pages/customization/density/density-es.md
+++ b/docs/src/pages/customization/density/density-es.md
@@ -37,7 +37,7 @@ If you enable high density a custom theme is applied to the docs. This theme is 
 The theme is configured with the following options:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiButton: {
       size: 'small',

--- a/docs/src/pages/customization/density/density-fr.md
+++ b/docs/src/pages/customization/density/density-fr.md
@@ -37,7 +37,7 @@ If you enable high density a custom theme is applied to the docs. This theme is 
 The theme is configured with the following options:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiButton: {
       size: 'small',

--- a/docs/src/pages/customization/density/density-ja.md
+++ b/docs/src/pages/customization/density/density-ja.md
@@ -37,7 +37,7 @@ This section explains how to apply density. Material design ガイドライン�
 テーマは、次のオプションで構成されます。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiButton: {
       size: 'small',

--- a/docs/src/pages/customization/density/density-pt.md
+++ b/docs/src/pages/customization/density/density-pt.md
@@ -37,7 +37,7 @@ Se você ativar alta densidade, um tema personalizado será aplicado a documenta
 O tema é configurado com as seguintes opções:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiButton: {
       size: 'small',

--- a/docs/src/pages/customization/density/density-ru.md
+++ b/docs/src/pages/customization/density/density-ru.md
@@ -37,7 +37,7 @@ If you enable high density a custom theme is applied to the docs. This theme is 
 The theme is configured with the following options:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     MuiButton: {
       size: 'small',

--- a/docs/src/pages/customization/density/density-zh.md
+++ b/docs/src/pages/customization/density/density-zh.md
@@ -37,7 +37,7 @@
 主题配置有以下选项：
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       defaultProps: {

--- a/docs/src/pages/customization/density/density.md
+++ b/docs/src/pages/customization/density/density.md
@@ -45,7 +45,7 @@ for when not to apply density.
 The theme is configured with the following options:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       defaultProps: {

--- a/docs/src/pages/customization/how-to-customize/DynamicThemeNesting.js
+++ b/docs/src/pages/customization/how-to-customize/DynamicThemeNesting.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Slider from '@material-ui/core/Slider';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { green } from '@material-ui/core/colors';
 import Switch from '@material-ui/core/Switch';
@@ -14,7 +14,7 @@ export default function DynamicThemeNesting() {
 
   const theme = React.useMemo(() => {
     if (success) {
-      return createMuiTheme({
+      return createTheme({
         palette: {
           primary: {
             light: green[300],
@@ -24,7 +24,7 @@ export default function DynamicThemeNesting() {
         },
       });
     }
-    return createMuiTheme();
+    return createTheme();
   }, [success]);
 
   return (

--- a/docs/src/pages/customization/how-to-customize/DynamicThemeNesting.tsx
+++ b/docs/src/pages/customization/how-to-customize/DynamicThemeNesting.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Slider from '@material-ui/core/Slider';
-import { createMuiTheme, ThemeProvider, Theme } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider, Theme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { green } from '@material-ui/core/colors';
 import Switch from '@material-ui/core/Switch';
@@ -14,7 +14,7 @@ export default function DynamicThemeNesting() {
 
   const theme = React.useMemo(() => {
     if (success) {
-      return createMuiTheme({
+      return createTheme({
         palette: {
           primary: {
             light: green[300],
@@ -24,7 +24,7 @@ export default function DynamicThemeNesting() {
         },
       });
     }
-    return createMuiTheme();
+    return createTheme();
   }, [success]);
 
   return (

--- a/docs/src/pages/customization/how-to-customize/OverrideCssBaseline.js
+++ b/docs/src/pages/customization/how-to-customize/OverrideCssBaseline.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiCssBaseline: {
       styleOverrides: `

--- a/docs/src/pages/customization/how-to-customize/OverrideCssBaseline.tsx
+++ b/docs/src/pages/customization/how-to-customize/OverrideCssBaseline.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiCssBaseline: {
       styleOverrides: `

--- a/docs/src/pages/customization/palette/DarkTheme.js
+++ b/docs/src/pages/customization/palette/DarkTheme.js
@@ -5,7 +5,7 @@ import {
   makeStyles,
   ThemeProvider,
   useTheme,
-  createMuiTheme,
+  createTheme,
 } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
@@ -98,8 +98,8 @@ function Demo() {
   );
 }
 
-const lightTheme = createMuiTheme();
-const darkTheme = createMuiTheme({
+const lightTheme = createTheme();
+const darkTheme = createTheme({
   palette: {
     // Switching the dark mode on is a single property value change.
     mode: 'dark',

--- a/docs/src/pages/customization/palette/Palette.js
+++ b/docs/src/pages/customization/palette/Palette.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import { purple } from '@material-ui/core/colors';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // Purple and green play nicely together.

--- a/docs/src/pages/customization/palette/Palette.tsx
+++ b/docs/src/pages/customization/palette/Palette.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import { purple } from '@material-ui/core/colors';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // Purple and green play nicely together.

--- a/docs/src/pages/customization/palette/ToggleColorMode.js
+++ b/docs/src/pages/customization/palette/ToggleColorMode.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Box from '@material-ui/core/Box';
-import { useTheme, ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { useTheme, ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Brightness4Icon from '@material-ui/icons/Brightness4';
 import Brightness7Icon from '@material-ui/icons/Brightness7';
 
@@ -44,7 +44,7 @@ export default function ToggleColorMode() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode,
         },

--- a/docs/src/pages/customization/palette/ToggleColorMode.tsx
+++ b/docs/src/pages/customization/palette/ToggleColorMode.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Box from '@material-ui/core/Box';
-import { useTheme, ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { useTheme, ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Brightness4Icon from '@material-ui/icons/Brightness4';
 import Brightness7Icon from '@material-ui/icons/Brightness7';
 
@@ -44,7 +44,7 @@ export default function ToggleColorMode() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode,
         },

--- a/docs/src/pages/customization/palette/palette-de.md
+++ b/docs/src/pages/customization/palette/palette-de.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 Die einfachste Möglichkeit, eine Absicht anzupassen, besteht darin, eine oder mehrere der angegebenen Farben zu importieren und auf eine Palettenabsicht anzuwenden:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 Wenn Sie mehr benutzerdefinierte Farben bereitstellen möchten, können Sie entweder ein eigenes Farbobjekt erstellen oder Farben für einige oder alle Schlüssel der Absichten direkt angeben:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: will be calculated from palette.primary.main,
@@ -127,9 +127,9 @@ Note that "contrastThreshold" follows a non-linear curve.
 You can add new colors inside and outside the palette of the theme as follow:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -146,7 +146,7 @@ If you are using TypeScript, you would also need to use [module augmentation](/g
 <!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'],
@@ -178,7 +178,7 @@ Etwas Inspiration gefällig? The Material Design team has built an [palette conf
 Material-UI comes with two palette types, light (the default) and dark. You can make the theme dark by setting `mode: 'dark'`. While it's only a single property value change, internally it modifies several palette values.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -200,7 +200,7 @@ For instance, you can enable the dark mode automatically:
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -208,7 +208,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette-es.md
+++ b/docs/src/pages/customization/palette/palette-es.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 La forma más sencilla de personalizar un propósito de color es importar uno o más de los colores proporcionados y aplicarlos a una intención de paleta:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 Si desea proporcionar colores más personalizados, puede crear su propio objeto de color, o directamente proporciona colores a algunas o todas las claves del propósito de color:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: will be calculated from palette.primary.main,
@@ -127,9 +127,9 @@ Note that "contrastThreshold" follows a non-linear curve.
 You can add new colors inside and outside the palette of the theme as follow:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -148,7 +148,7 @@ If you are using TypeScript, you would also need to use [module augmentation](/g
 ```ts
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -156,7 +156,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           type: prefersDarkMode ? 'dark' : 'light',
         },
@@ -182,7 +182,7 @@ Need inspiration? The Material Design team has built an [palette configuration t
 Material-UI comes with two palette types, light (the default) and dark. Puedes convertir el tema a obscuro cambiando la configuración `mode: 'dark'`. While it's only a single property value change, internally it modifies several palette values.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -204,7 +204,7 @@ For instance, you can enable the dark mode automatically:
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -212,7 +212,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette-fr.md
+++ b/docs/src/pages/customization/palette/palette-fr.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 The simplest way to customize an intention is to import one or more of the provided colors and apply them to a palette intention:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 If you wish to provide more customized colors, you can either create your own color object, or directly supply colors to some or all of the intention's keys:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: will be calculated from palette.primary.main,
@@ -127,9 +127,9 @@ Note that "contrastThreshold" follows a non-linear curve.
 You can add new colors inside and outside the palette of the theme as follow:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -146,7 +146,7 @@ If you are using TypeScript, you would also need to use [module augmentation](/g
 <!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'],
@@ -178,7 +178,7 @@ Need inspiration? The Material Design team has built an [palette configuration t
 Material-UI comes with two palette types, light (the default) and dark. You can make the theme dark by setting `mode: 'dark'`. While it's only a single property value change, internally it modifies several palette values.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -200,7 +200,7 @@ For instance, you can enable the dark mode automatically:
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -208,7 +208,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette-ja.md
+++ b/docs/src/pages/customization/palette/palette-ja.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 意図をカスタマイズする最も簡単な方法は、提供されている1つまたは複数のカラーをインポートすることです。
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 よりカスタマイズされた色を提供する場合は、独自の色オブジェクト 作成するか、意図のキーの一部またはすべてに直接色を指定できます。
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: will be calculated from palette.primary.main,
@@ -121,9 +121,9 @@ Note that "contrastThreshold" follows a non-linear curve.
 You can add new colors inside and outside the palette of the theme as follow:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -140,7 +140,7 @@ If you are using TypeScript, you would also need to use [module augmentation](/g
 <!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'],
@@ -172,7 +172,7 @@ declare module "@material-ui/core/styles/createPalette" {
 Material-UI comes with two palette types, light (the default) and dark. You can make the theme dark by setting `mode: 'dark'`. While it's only a single property value change, internally it modifies several palette values.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -194,7 +194,7 @@ For instance, you can enable the dark mode automatically:
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -202,7 +202,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette-pt.md
+++ b/docs/src/pages/customization/palette/palette-pt.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 A maneira mais simples de customizar uma intenção é importar uma ou mais das cores fornecidas e aplicá-las a uma intenção da paleta:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 Se você deseja fornecer cores mais personalizadas, você pode criar seu próprio objeto de cor, ou fornecer cores diretamente para algumas ou todas as chaves da intenção:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: será calculada com base em palette.primary.main,
@@ -121,9 +121,9 @@ Observe que "contrastThreshold" segue uma curva não linear.
 Você pode adicionar novas cores dentro e fora da paleta do tema da seguinte maneira:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -140,7 +140,7 @@ Se você estiver usando TypeScript, você também deverá usar a [extensão de m
 <!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'],
@@ -172,7 +172,7 @@ Precisa de inspiração? A equipe do Material Design construiu uma [ferramenta d
 O Material-UI vem com dois tipos de paletas, claro (o padrão) e escuro. Você pode deixar o tema escuro definindo `mode: 'dark'`. Embora seja apenas uma alteração no valor de uma propriedade única, internamente ela modifica vários valores da paleta.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -194,7 +194,7 @@ Por exemplo, você pode ativar o modo escuro automaticamente:
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -202,7 +202,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette-ru.md
+++ b/docs/src/pages/customization/palette/palette-ru.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 The simplest way to customize an intention is to import one or more of the provided colors and apply them to a palette intention:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 If you wish to provide more customized colors, you can either create your own color object, or directly supply colors to some or all of the intention's keys:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: will be calculated from palette.primary.main,
@@ -127,9 +127,9 @@ Note that "contrastThreshold" follows a non-linear curve.
 You can add new colors inside and outside the palette of the theme as follow:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -146,7 +146,7 @@ If you are using TypeScript, you would also need to use [module augmentation](/g
 <!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'],
@@ -178,7 +178,7 @@ declare module "@material-ui/core/styles/createPalette" {
 Material-UI comes with two palette types, light (the default) and dark. Вы можете сделать тему темной, установив режим `mode: 'dark'`. While it's only a single property value change, internally it modifies several palette values.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -200,7 +200,7 @@ You can leverage this preference dynamically with the [useMediaQuery](/component
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -208,7 +208,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette-zh.md
+++ b/docs/src/pages/customization/palette/palette-zh.md
@@ -52,10 +52,10 @@ interface PaletteColor {
 自定义调色板的最简单方法是导入一个或多个提供的颜色：
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -67,9 +67,9 @@ const theme = createMuiTheme({
 如果你想要提供更多的自定义颜色，你可以创建你自己的调色板，或者直接为一些或者所有的 `theme.palette` 键提供颜色：
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: 这将从 palette.primary.main 中进行计算，
@@ -123,9 +123,9 @@ type PaletteTonalOffset =
 您可以在主题的调色板内外添加新的颜色，如下所示：
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -146,7 +146,7 @@ const theme = createMuiTheme({
 <!-- tested with packages/material-ui/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     status: {
       danger: React.CSSProperties['color'];
@@ -184,7 +184,7 @@ declare module '@material-ui/core/styles/createPalette' {
 材质界面有两种调色板的类型，亮色（light）（默认值）和 暗色（dark）模式。 你可以通过设置 `mode: 'dark'` 来启用夜间模式。 虽然只是单一的数值变化，但在其内部却修改了多个调色板的数值。
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
@@ -206,7 +206,7 @@ const darkTheme = createMuiTheme({
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -214,7 +214,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -55,10 +55,10 @@ The simplest way to customize a palette color is to import one or more of the pr
 and apply them:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import blue from '@material-ui/core/colors/blue';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: blue,
   },
@@ -71,9 +71,9 @@ If you wish to provide more customized colors, you can either create your own pa
 or directly supply colors to some or all of the `theme.palette` keys:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       // light: will be calculated from palette.primary.main,
@@ -133,9 +133,9 @@ Note that "contrastThreshold" follows a non-linear curve.
 You can add new colors inside and outside the palette of the theme as follow:
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },
@@ -194,14 +194,14 @@ Material-UI comes with two palette modes: light (the default) and dark.
 You can make the theme dark by setting `mode: 'dark'`.
 
 ```js
-const darkTheme = createMuiTheme({
+const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
 });
 ```
 
-While it's only a single value change, the `createMuiTheme` helper modifies several palette values.
+While it's only a single value change, the `createTheme` helper modifies several palette values.
 The colors modified by the palette mode are the following:
 
 {{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
@@ -224,7 +224,7 @@ For instance, you can enable the dark mode automatically:
 ```jsx
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 function App() {
@@ -232,7 +232,7 @@ function App() {
 
   const theme = React.useMemo(
     () =>
-      createMuiTheme({
+      createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
         },

--- a/docs/src/pages/customization/spacing/spacing-de.md
+++ b/docs/src/pages/customization/spacing/spacing-de.md
@@ -5,7 +5,7 @@
 Material-UI uses [a recommended 8px scaling factor](https://material.io/design/layout/understanding-layout.html) by default.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ Sie können die Abstandstransformation ändern, indem Sie Folgendes angeben:
 - eine Zahl
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - eine Funktion
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: factor => `${0.25 * factor}rem`, // (Bootstrap Strategie)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - eine Array
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing-es.md
+++ b/docs/src/pages/customization/spacing/spacing-es.md
@@ -5,7 +5,7 @@
 Material-UI utiliza [un factor recomendado de escalado de 8px](https://material.io/design/layout/understanding-layout.html) por defecto.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ Puede cambiar la transformacin de espaciado proporcionando:
 - un número
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - una función
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: factor => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - una lista
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing-fr.md
+++ b/docs/src/pages/customization/spacing/spacing-fr.md
@@ -5,7 +5,7 @@
 Material-UI uses [a recommended 8px scaling factor](https://material.io/design/layout/understanding-layout.html) by default.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ You can change the spacing transformation by providing:
 - a number
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - a function
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: factor => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - an array
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing-ja.md
+++ b/docs/src/pages/customization/spacing/spacing-ja.md
@@ -5,7 +5,7 @@
 Material-UI uses [a recommended 8px scaling factor](https://material.io/design/layout/understanding-layout.html) by default.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ theme.spacing(2); // `${8 * 2}px` = '16px'
 - a number
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - a function
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: factor => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - an array
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing-pt.md
+++ b/docs/src/pages/customization/spacing/spacing-pt.md
@@ -5,7 +5,7 @@
 Material-UI usa [um fator de escala recomendado de 8px](https://material.io/design/layout/understanding-layout.html) por padrão.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ Você pode alterar a transformação do espaçamento fornecendo:
 - um número
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - uma função
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: factor => `${0.25 * factor}rem`, // (estratégia do Bootstrap)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - uma matriz
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing-ru.md
+++ b/docs/src/pages/customization/spacing/spacing-ru.md
@@ -5,7 +5,7 @@
 Material-UI uses [a recommended 8px scaling factor](https://material.io/design/layout/understanding-layout.html) by default.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ theme.spacing(2); // `${8 * 2}px` = '16px'
 - число
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - функция
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: factor => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - массив
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing-zh.md
+++ b/docs/src/pages/customization/spacing/spacing-zh.md
@@ -5,7 +5,7 @@
 Material-UI 默认使用的是 [设计指南上建议的 8px 缩放系数](https://material.io/design/layout/understanding-layout.html)。
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ theme.spacing(2); // `${8 * 2}px` = '16px'
 - 一个数字
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - 一个函数
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: (factor) => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - 一个数组
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/spacing/spacing.md
+++ b/docs/src/pages/customization/spacing/spacing.md
@@ -5,7 +5,7 @@
 Material-UI uses [a recommended 8px scaling factor](https://material.io/design/layout/understanding-layout.html) by default.
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.spacing(2); // `${8 * 2}px` = '16px'
 ```
@@ -17,7 +17,7 @@ You can change the spacing transformation by providing:
 - a number
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: 4,
 });
 
@@ -27,7 +27,7 @@ theme.spacing(2); // `${4 * 2}px` = '8px'
 - a function
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: (factor) => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
@@ -37,7 +37,7 @@ theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
 - an array
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   spacing: [0, 4, 8, 16, 32, 64],
 });
 

--- a/docs/src/pages/customization/theme-components/DefaultProps.js
+++ b/docs/src/pages/customization/theme-components/DefaultProps.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiButtonBase: {

--- a/docs/src/pages/customization/theme-components/DefaultProps.tsx
+++ b/docs/src/pages/customization/theme-components/DefaultProps.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiButtonBase: {

--- a/docs/src/pages/customization/theme-components/GlobalCss.js
+++ b/docs/src/pages/customization/theme-components/GlobalCss.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       // Style sheet name ⚛️

--- a/docs/src/pages/customization/theme-components/GlobalCss.tsx
+++ b/docs/src/pages/customization/theme-components/GlobalCss.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       // Style sheet name ⚛️

--- a/docs/src/pages/customization/theme-components/GlobalThemeOverride.js
+++ b/docs/src/pages/customization/theme-components/GlobalThemeOverride.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       styleOverrides: {

--- a/docs/src/pages/customization/theme-components/GlobalThemeOverride.tsx
+++ b/docs/src/pages/customization/theme-components/GlobalThemeOverride.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       styleOverrides: {

--- a/docs/src/pages/customization/theme-components/GlobalThemeVariants.js
+++ b/docs/src/pages/customization/theme-components/GlobalThemeVariants.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles((theme) => ({
@@ -10,9 +10,9 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const defaultTheme = createMuiTheme();
+const defaultTheme = createTheme();
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [

--- a/docs/src/pages/customization/theme-components/GlobalThemeVariants.tsx
+++ b/docs/src/pages/customization/theme-components/GlobalThemeVariants.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   makeStyles,
   Theme,
   ThemeProvider,
@@ -21,9 +21,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const defaultTheme = createMuiTheme();
+const defaultTheme = createTheme();
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [

--- a/docs/src/pages/customization/theme-components/ThemeVariables.js
+++ b/docs/src/pages/customization/theme-components/ThemeVariables.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/ThemeVariables.tsx
+++ b/docs/src/pages/customization/theme-components/ThemeVariables.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-de.md
+++ b/docs/src/pages/customization/theme-components/theme-components-de.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ To override a lab component's styles with TypeScript, check [this section of the
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -57,7 +57,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 The definitions are specified in an array, under the component's name. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -99,7 +99,7 @@ declare module '@material-ui/core/Button/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-es.md
+++ b/docs/src/pages/customization/theme-components/theme-components-es.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ To override a lab component's styles with TypeScript, check [this section of the
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -62,7 +62,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 The definitions are specified in an array, under the component's name. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -104,7 +104,7 @@ declare module '@material-ui/core/Button/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-fr.md
+++ b/docs/src/pages/customization/theme-components/theme-components-fr.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ To override a lab component's styles with TypeScript, check [this section of the
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -57,7 +57,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 The definitions are specified in an array, under the component's name. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -99,7 +99,7 @@ declare module '@material-ui/core/Button/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-ja.md
+++ b/docs/src/pages/customization/theme-components/theme-components-ja.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ To override a lab component's styles with TypeScript, check [this section of the
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -57,7 +57,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 The definitions are specified in an array, under the component's name. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -99,7 +99,7 @@ declare module '@material-ui/core/Button/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-pt.md
+++ b/docs/src/pages/customization/theme-components/theme-components-pt.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ To override a lab component's styles with TypeScript, check [this section of the
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -57,7 +57,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 As definições são especificadas em um array, sob o nome do componente. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -99,7 +99,7 @@ declare module '@material-ui/core/Button/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-ru.md
+++ b/docs/src/pages/customization/theme-components/theme-components-ru.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ To override a lab component's styles with TypeScript, check [this section of the
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -57,7 +57,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 The definitions are specified in an array, under the component's name. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -99,7 +99,7 @@ declare module '@material-ui/core/Button/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components-zh.md
+++ b/docs/src/pages/customization/theme-components/theme-components-zh.md
@@ -7,7 +7,7 @@
 可以使用theme的 `styleOverrides` 属性来改变每一个在 DOM 中由 Material-UI 生成的样式。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -34,7 +34,7 @@ const theme = createMuiTheme({
 You can change the default of every prop of a Material-UI component. A `defaultProps` key is exposed in the theme's `components` key for this use case. 下面示例就是指定`defaultProps`属性覆盖`components`下组件的默认属性。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -63,7 +63,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 在组件名称（如：MuiButton）下以数组形式定义组件变量。 数组中的每个变量都会对应一个CSS类添加到HTML`<head>`中。 For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -105,7 +105,7 @@ declare module '@material-ui/core/Button/Button' {
 覆盖所有组件实例的另一种方式是调整 [theme configuration variables](/customization/theming/#theme-configuration-variables)。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theme-components/theme-components.md
+++ b/docs/src/pages/customization/theme-components/theme-components.md
@@ -7,7 +7,7 @@
 You can use the theme's `styleOverrides` key to potentially change every single style injected by Material-UI into the DOM.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButton: {
@@ -35,7 +35,7 @@ You can change the default of every prop of a Material-UI component.
 A `defaultProps` key is exposed in the theme's `components` key for this use case.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component
     MuiButtonBase: {
@@ -59,7 +59,7 @@ You can use the `variants` key in the theme's `components` section to add new va
 The definitions are specified in an array, under the component's name. For each of them a CSS class is added to the HTML `<head>`. The order is important, so make sure that the styles that should win are specified last.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [
@@ -101,7 +101,7 @@ declare module '@material-ui/core/Button' {
 Another way to override the look of all component instances is to adjust the [theme configuration variables](/customization/theming/#theme-configuration-variables).
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     button: {
       fontSize: '1rem',

--- a/docs/src/pages/customization/theming/CustomStyles.js
+++ b/docs/src/pages/customization/theming/CustomStyles.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import {
-  createMuiTheme,
+  createTheme,
   ThemeProvider,
   experimentalStyled as styled,
 } from '@material-ui/core/styles';
@@ -14,7 +14,7 @@ const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
   },
 }));
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: orange[500],
   },

--- a/docs/src/pages/customization/theming/CustomStyles.tsx
+++ b/docs/src/pages/customization/theming/CustomStyles.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import {
-  createMuiTheme,
+  createTheme,
   ThemeProvider,
   experimentalStyled as styled,
 } from '@material-ui/core/styles';
@@ -13,7 +13,7 @@ declare module '@material-ui/core/styles' {
       danger: string;
     };
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     status?: {
       danger?: string;
@@ -28,7 +28,7 @@ const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
   },
 }));
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: orange[500],
   },

--- a/docs/src/pages/customization/theming/ThemeNesting.js
+++ b/docs/src/pages/customization/theming/ThemeNesting.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
 import { green, orange } from '@material-ui/core/colors';
 
-const outerTheme = createMuiTheme({
+const outerTheme = createTheme({
   palette: {
     secondary: {
       main: orange[500],
@@ -11,7 +11,7 @@ const outerTheme = createMuiTheme({
   },
 });
 
-const innerTheme = createMuiTheme({
+const innerTheme = createTheme({
   palette: {
     secondary: {
       main: green[500],

--- a/docs/src/pages/customization/theming/ThemeNesting.tsx
+++ b/docs/src/pages/customization/theming/ThemeNesting.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
 import { green, orange } from '@material-ui/core/colors';
 
-const outerTheme = createMuiTheme({
+const outerTheme = createTheme({
   palette: {
     secondary: {
       main: orange[500],
@@ -11,7 +11,7 @@ const outerTheme = createMuiTheme({
   },
 });
 
-const innerTheme = createMuiTheme({
+const innerTheme = createTheme({
   palette: {
     secondary: {
       main: green[500],

--- a/docs/src/pages/customization/theming/ThemeNestingExtend.js
+++ b/docs/src/pages/customization/theming/ThemeNestingExtend.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
 import { green, orange } from '@material-ui/core/colors';
 
-const outerTheme = createMuiTheme({
+const outerTheme = createTheme({
   palette: {
     secondary: {
       main: orange[500],
@@ -17,7 +17,7 @@ export default function ThemeNestingExtend() {
       <Checkbox defaultChecked />
       <ThemeProvider
         theme={(theme) =>
-          createMuiTheme({
+          createTheme({
             ...theme,
             palette: {
               ...theme.palette,

--- a/docs/src/pages/customization/theming/ThemeNestingExtend.tsx
+++ b/docs/src/pages/customization/theming/ThemeNestingExtend.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, Theme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, Theme, ThemeProvider } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
 import { green, orange } from '@material-ui/core/colors';
 
-const outerTheme = createMuiTheme({
+const outerTheme = createTheme({
   palette: {
     secondary: {
       main: orange[500],
@@ -17,7 +17,7 @@ export default function ThemeNestingExtend() {
       <Checkbox defaultChecked />
       <ThemeProvider
         theme={(theme: Theme) =>
-          createMuiTheme({
+          createTheme({
             ...theme,
             palette: {
               ...theme.palette,

--- a/docs/src/pages/customization/theming/theming-de.md
+++ b/docs/src/pages/customization/theming/theming-de.md
@@ -69,7 +69,7 @@ Die Auswirkungen der Verschachtelung der `ThemeProviders` Komponente auf die Per
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 Generieren Sie eine Themenbasis von den gegebenen Optionen.
 
@@ -85,11 +85,11 @@ Generieren Sie eine Themenbasis von den gegebenen Optionen.
 #### Beispiele
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ Generieren Sie responsive Typografieeinstellungen basierend auf den erhaltenen O
 #### Beispiele
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming-es.md
+++ b/docs/src/pages/customization/theming/theming-es.md
@@ -69,7 +69,7 @@ Las implicaciones de rendimiento de anidar el componente ` ThemeProvider ` está
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 Generar un tema en base a las opciones recibidas.
 
@@ -85,11 +85,11 @@ Generar un tema en base a las opciones recibidas.
 #### Ejemplos
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ Generate responsive typography settings based on the options received.
 #### Ejemplos
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming-fr.md
+++ b/docs/src/pages/customization/theming/theming-fr.md
@@ -69,7 +69,7 @@ The performance implications of nesting the `ThemeProvider` component are linked
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 Générer un thème basé sur les options reçues.
 
@@ -85,11 +85,11 @@ Générer un thème basé sur les options reçues.
 #### Exemples
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ Generate responsive typography settings based on the options received.
 #### Exemples
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming-ja.md
+++ b/docs/src/pages/customization/theming/theming-ja.md
@@ -69,7 +69,7 @@ Otherwise you'll encounter `Error: Function component cannot be given refs`. See
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 受け取ったオプションに基づいてテーマを生成します。
 
@@ -85,11 +85,11 @@ Otherwise you'll encounter `Error: Function component cannot be given refs`. See
 #### 例
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ const theme = createMuiTheme({
 #### 例
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming-pt.md
+++ b/docs/src/pages/customization/theming/theming-pt.md
@@ -69,7 +69,7 @@ As implicações de desempenho de aninhamento do componente `ThemeProvider`, est
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 Gere uma base de temas sobre as opções recebidas.
 
@@ -85,11 +85,11 @@ Gere uma base de temas sobre as opções recebidas.
 #### Exemplos
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ Gera configurações de tipografia responsivas com base nas opções recebidas.
 #### Exemplos
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming-ru.md
+++ b/docs/src/pages/customization/theming/theming-ru.md
@@ -69,7 +69,7 @@ The performance implications of nesting the `ThemeProvider` component are linked
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 Generate a theme base on the options received.
 
@@ -85,11 +85,11 @@ Generate a theme base on the options received.
 #### Примеры
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ Generate responsive typography settings based on the options received.
 #### Примеры
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming-zh.md
+++ b/docs/src/pages/customization/theming/theming-zh.md
@@ -69,7 +69,7 @@
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 通过接收的选项生成一个主题基础。
 
@@ -85,11 +85,11 @@
 #### 例子
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -122,9 +122,9 @@ const theme = createMuiTheme({
 #### 例子
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -37,7 +37,7 @@ When using Material-UI's theme with the [styling solution](/styles/basics/) or [
 For instance:
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: orange[500],
   },
@@ -53,7 +53,7 @@ declare module '@material-ui/core/styles' {
       danger: string;
     };
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     status?: {
       danger?: string;
@@ -101,7 +101,7 @@ The main point to understand is that the injected CSS is cached with the followi
 
 ## API
 
-### `createMuiTheme(options, ...args) => theme`
+### `createTheme(options, ...args) => theme`
 
 Generate a theme base on the options received.
 
@@ -117,11 +117,11 @@ Generate a theme base on the options received.
 #### Examples
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -157,9 +157,9 @@ Generate responsive typography settings based on the options received.
 #### Examples
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 

--- a/docs/src/pages/customization/transitions/TransitionHover.js
+++ b/docs/src/pages/customization/transitions/TransitionHover.js
@@ -2,13 +2,13 @@ import * as React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import NoSsr from '@material-ui/core/NoSsr';
 import {
-  createMuiTheme,
+  createTheme,
   ThemeProvider as MuiThemeProvider,
 } from '@material-ui/core/styles';
 import { deepPurple } from '@material-ui/core/colors';
 import Avatar from '@material-ui/core/Avatar';
 
-const customTheme = createMuiTheme({
+const customTheme = createTheme({
   palette: {
     primary: {
       main: deepPurple[500],

--- a/docs/src/pages/customization/transitions/TransitionHover.tsx
+++ b/docs/src/pages/customization/transitions/TransitionHover.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import NoSsr from '@material-ui/core/NoSsr';
 import {
-  createMuiTheme,
+  createTheme,
   ThemeProvider as MuiThemeProvider,
 } from '@material-ui/core/styles';
 import { deepPurple } from '@material-ui/core/colors';
 import Avatar from '@material-ui/core/Avatar';
 
-const customTheme = createMuiTheme({
+const customTheme = createTheme({
   palette: {
     primary: {
       main: deepPurple[500],

--- a/docs/src/pages/customization/transitions/transitions-de.md
+++ b/docs/src/pages/customization/transitions/transitions-de.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 You can change some or all of the duration values, or provide your own (for use in the `create()` helper). This example shows all the default values (in milliseconds), but you only need to provide the keys you wish to change or add.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 You can change some or all of the easing values, or provide your own, by providing a custom CSS <code>transition-timing-function</code> value.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // This is the most common easing curve.

--- a/docs/src/pages/customization/transitions/transitions-es.md
+++ b/docs/src/pages/customization/transitions/transitions-es.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 You can change some or all of the duration values, or provide your own (for use in the `create()` helper). This example shows all the default values (in milliseconds), but you only need to provide the keys you wish to change or add.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 You can change some or all of the easing values, or provide your own, by providing a custom CSS <code>transition-timing-function</code> value.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // This is the most common easing curve.

--- a/docs/src/pages/customization/transitions/transitions-fr.md
+++ b/docs/src/pages/customization/transitions/transitions-fr.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 You can change some or all of the duration values, or provide your own (for use in the `create()` helper). This example shows all the default values (in milliseconds), but you only need to provide the keys you wish to change or add.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 You can change some or all of the easing values, or provide your own, by providing a custom CSS <code>transition-timing-function</code> value.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // This is the most common easing curve.

--- a/docs/src/pages/customization/transitions/transitions-ja.md
+++ b/docs/src/pages/customization/transitions/transitions-ja.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 You can change some or all of the duration values, or provide your own (for use in the `create()` helper). This example shows all the default values (in milliseconds), but you only need to provide the keys you wish to change or add.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 You can change some or all of the easing values, or provide your own, by providing a custom CSS <code>transition-timing-function</code> value.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // This is the most common easing curve.

--- a/docs/src/pages/customization/transitions/transitions-pt.md
+++ b/docs/src/pages/customization/transitions/transitions-pt.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 Você pode alterar alguns ou todos os valores de duração, ou fornecer valores próprios (para usar com o utilitário `create()`). Este exemplo mostra todos os valores padrão (em milissegundos), mas você só precisa fornecer as chaves que deseja alterar ou adicionar.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 Você pode alterar alguns ou todos os valores de atenuação, ou fornecer valores próprios, fornecendo um valor customizado de CSS <code>transition-timing-function</code>.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // Esta é a curva de atenuação mais comum.

--- a/docs/src/pages/customization/transitions/transitions-ru.md
+++ b/docs/src/pages/customization/transitions/transitions-ru.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 You can change some or all of the duration values, or provide your own (for use in the `create()` helper). This example shows all the default values (in milliseconds), but you only need to provide the keys you wish to change or add.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 You can change some or all of the easing values, or provide your own, by providing a custom CSS <code>transition-timing-function</code> value.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // This is the most common easing curve.

--- a/docs/src/pages/customization/transitions/transitions-zh.md
+++ b/docs/src/pages/customization/transitions/transitions-zh.md
@@ -45,7 +45,7 @@ theme.transitions.create(['background-color', 'transform']);
 你可以更改其中部分或全部的时长，或者提供你想要的时长（供 `create()` 助手使用）。 此示例显示了所有默认值（以毫秒为单位），但你只需要提供你想要更改或添加的键。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -69,7 +69,7 @@ const theme = createMuiTheme({
 你可以通过提供一个自定义的 CSS <code>transition-timing-function</code> 值来改变部分或全部的缓动值，或者提供你自己的缓动值。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // 这是最常见的缓和曲线（easing curve）。

--- a/docs/src/pages/customization/transitions/transitions.md
+++ b/docs/src/pages/customization/transitions/transitions.md
@@ -44,7 +44,7 @@ theme.transitions.create(['background-color', 'transform']);
 You can change some or all of the duration values, or provide your own (for use in the `create()` helper). This example shows all the default values (in milliseconds), but you only need to provide the keys you wish to change or add.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     duration: {
       shortest: 150,
@@ -68,7 +68,7 @@ const theme = createMuiTheme({
 You can change some or all of the easing values, or provide your own, by providing a custom CSS <code>transition-timing-function</code> value.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     easing: {
       // This is the most common easing curve.

--- a/docs/src/pages/customization/typography/CustomResponsiveFontSizes.js
+++ b/docs/src/pages/customization/typography/CustomResponsiveFontSizes.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',

--- a/docs/src/pages/customization/typography/CustomResponsiveFontSizes.tsx
+++ b/docs/src/pages/customization/typography/CustomResponsiveFontSizes.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',

--- a/docs/src/pages/customization/typography/FontSizeTheme.js
+++ b/docs/src/pages/customization/typography/FontSizeTheme.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what the font-size on the html element is.
     htmlFontSize: 10,

--- a/docs/src/pages/customization/typography/FontSizeTheme.tsx
+++ b/docs/src/pages/customization/typography/FontSizeTheme.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what the font-size on the html element is.
     htmlFontSize: 10,

--- a/docs/src/pages/customization/typography/ResponsiveFontSizes.js
+++ b/docs/src/pages/customization/typography/ResponsiveFontSizes.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   responsiveFontSizes,
   ThemeProvider,
 } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 
 export default function ResponsiveFontSizes() {

--- a/docs/src/pages/customization/typography/ResponsiveFontSizes.tsx
+++ b/docs/src/pages/customization/typography/ResponsiveFontSizes.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   responsiveFontSizes,
   ThemeProvider,
 } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 
 export default function ResponsiveFontSizes() {

--- a/docs/src/pages/customization/typography/ResponsiveFontSizesChart.js
+++ b/docs/src/pages/customization/typography/ResponsiveFontSizesChart.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { convertLength } from '@material-ui/core/styles/cssUtils';
 import {
   makeStyles,
-  createMuiTheme,
+  createTheme,
   responsiveFontSizes,
 } from '@material-ui/core/styles';
 import {
@@ -19,7 +19,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 
 const colors = [

--- a/docs/src/pages/customization/typography/TypographyCustomVariant.js
+++ b/docs/src/pages/customization/typography/TypographyCustomVariant.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // @ts-ignore
     poster: {

--- a/docs/src/pages/customization/typography/TypographyCustomVariant.tsx
+++ b/docs/src/pages/customization/typography/TypographyCustomVariant.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // @ts-ignore
     poster: {

--- a/docs/src/pages/customization/typography/TypographyVariants.js
+++ b/docs/src/pages/customization/typography/TypographyVariants.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,

--- a/docs/src/pages/customization/typography/TypographyVariants.tsx
+++ b/docs/src/pages/customization/typography/TypographyVariants.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,

--- a/docs/src/pages/customization/typography/typography-de.md
+++ b/docs/src/pages/customization/typography/typography-de.md
@@ -9,7 +9,7 @@ You can change the font family with the `theme.typography.fontFamily` property.
 For instance, this demo uses the system font instead of the default Roboto font:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 Next, you need to change the theme to use this new font. In order to globally define Raleway as a font face, the [`CssBaseline`](/components/css-baseline/) component can be used (or any other CSS solution of your choice).
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ Material-UI verwendet `rem` Einheiten für die Schriftgröße. The browser `<htm
 Um die Schriftgröße der Material-UI zu ändern, können Sie eine `fontSize` Eigenschaft angeben. Der Standardwert ist `14px`.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // In Chinesisch und Japanisch sind die Zeichen normalerweise größer,
     // daher kann eine kleinere Schriftgröße angemessen sein.
@@ -103,7 +103,7 @@ Die vom Browser berechnete Schriftgröße folgt dieser mathematischen Gleichung:
 Die Eigenschaften der Typografievarianten werden direkt dem generierten CSS zugeordnet. Sie können in ihnen [Medienabfragen](/customization/breakpoints/#api) verwenden:
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ Um dieses Setup zu automatisieren, können Sie die Funktion [`responsiveFontSize
 Sie können dies in dem folgenden Beispiel in Aktion sehen. Passen Sie die Fenstergröße Ihres Browsers an und beachten Sie, wie sich die Schriftgröße ändert, wenn die Breite die unterschiedlichen [Haltepunkte](/customization/breakpoints/) überschreitet:
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ Möglicherweise möchten Sie die Standardschriftgröße des `<html>` Elements ä
 An `htmlFontSize` theme property is provided for this use case, which tells Material-UI what the font-size on the `<html>` element is. This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Informiere die Material-UI über die Schriftgröße des HTML-Elements.
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ The typography object comes with [13 variants](/components/typography/#component
 Each of these variants can be customized individually:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography-es.md
+++ b/docs/src/pages/customization/typography/typography-es.md
@@ -9,7 +9,7 @@ Puedes Cambiar la familia de fuente con la propiedad `theme.typography.fontFamil
 Por ejemplo, en este caso se utiliza la fuente del sistema en vez de la fuente por defecto, Roboto:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 Luego, usted podrá lo necesario en el cambiar el tema para usar la nueva fuente. En aras de definir de forma global como una cara de fuente, el componente [`CssBaseline`](/components/css-baseline/) podra ser usado (o cualquier otra solucion CSS de su eleccion).
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ Material-UI usa unidades `rem` para el tamaño de fuente. El navegador `<html>` 
 Para cambiar el tamaño de fuente de Material-UI Puedes proveer una propiedad llamada `fontSize` . The default value is `14px`.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // In Chinese and Japanese the characters are usually larger,
     // so a smaller fontsize may be appropriate.
@@ -103,7 +103,7 @@ The computed font size by the browser follows this mathematical equation:
 Las propiedades [variantes](#variants) de `theme.typography.*`  se mapean directamente al CSS generado. puedes usar [media queries](/customization/breakpoints/#api) dentro de ellos:
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ Para automatizar el setup, puedes usar el ayudante [`responsiveFontSizes()`](/cu
 Puedes ver esto en acción en ejemplo debajo. Ajusta el tamaño de la ventana de tu navegador y observa como el tamaño de la fuente cambia a medida que el ancho sobrepasa los diferentes [breakpoints](/customization/breakpoints/):
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ You might want to change the `<html>` element default font size. For instance, w
 La propiedad `theme.typography.htmlFontSize` puede ser utilizada en estos casos, le informa a Material-UI cual es el tamaño de la fuente en el elemento `<html>`. This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what's the font-size on the html element is.
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ The typography object comes with [13 variants](/components/typography/#component
 Each of these variants can be customized individually:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React. CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React. CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography-fr.md
+++ b/docs/src/pages/customization/typography/typography-fr.md
@@ -9,7 +9,7 @@ You can change the font family with the `theme.typography.fontFamily` property.
 For instance, this demo uses the system font instead of the default Roboto font:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 Next, you need to change the theme to use this new font. In order to globally define Raleway as a font face, the [`CssBaseline`](/components/css-baseline/) component can be used (or any other CSS solution of your choice).
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ Material-UI uses `rem` units for the font size. The browser `<html>` element def
 To change the font-size of Material-UI you can provide a `fontSize` property. The default value is `14px`.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // In Chinese and Japanese the characters are usually larger,
     // so a smaller fontsize may be appropriate.
@@ -103,7 +103,7 @@ The computed font size by the browser follows this mathematical equation:
 The typography variants properties map directly to the generated CSS. You can use [media queries](/customization/breakpoints/#api) inside them:
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ To automate this setup, you can use the [`responsiveFontSizes()`](/customization
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ You might want to change the `<html>` element default font size. For instance, w
 An `htmlFontSize` theme property is provided for this use case, which tells Material-UI what the font-size on the `<html>` element is. This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what's the font-size on the html element is.
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ The typography object comes with [13 variants](/components/typography/#component
 Each of these variants can be customized individually:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography-ja.md
+++ b/docs/src/pages/customization/typography/typography-ja.md
@@ -9,7 +9,7 @@ You can change the font family with the `theme.typography.fontFamily` property.
 For instance, this demo uses the system font instead of the default Roboto font:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 Next, you need to change the theme to use this new font. In order to globally define Raleway as a font face, the [`CssBaseline`](/components/css-baseline/) component can be used (or any other CSS solution of your choice).
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ An `htmlFontSize` theme property is provided for this use case, which tells Mate
 An `htmlFontSize` theme property is provided for this use case, which tells Material-UI what the font-size on the `<html>` element is. This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // In Chinese and Japanese the characters are usually larger,
     // so a smaller fontsize may be appropriate.
@@ -103,7 +103,7 @@ const theme = createMuiTheme({
 [media queries](/customization/breakpoints/#api) を使用できます： Typographyバリアント型プロパティは、生成されたCSSに直接マップされます。 Typographyバリアント型プロパティは、生成されたCSSに直接マップされます。 [media queries](/customization/breakpoints/#api) を使用できます： Typographyバリアント型プロパティは、生成されたCSSに直接マップされます。 [media queries](/customization/breakpoints/#api) を使用できます：
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ theme.typography.h3 = {
 以下の例で実際にこれを見ることができます。 ブラウザのウィンドウサイズを調整し、幅が異なる[ブレークポイント](/customization/breakpoints/)を横切るときにフォントサイズがどのように変化するかを確認します。
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ An `htmlFontSize` theme property is provided for this use case, which tells Mate
 An `htmlFontSize` theme property is provided for this use case, which tells Material-UI what the font-size on the `<html>` element is. This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what's the font-size on the html element is.
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ The typography object comes with [13 variants](/components/typography/#component
 これらのバリアントは各々個別にカスタマイズ可能です。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography-pt.md
+++ b/docs/src/pages/customization/typography/typography-pt.md
@@ -9,7 +9,7 @@ Você pode alterar a família de fontes com a propriedade `theme.typography.font
 Por exemplo, esta demonstração usa a fonte do sistema em vez da fonte padrão Roboto:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 Em seguida, você precisa alterar o tema para usar essa nova fonte. Para definir globalmente Raleway como uma fonte, o componente [`CssBaseline`](/components/css-baseline/) pode ser usado (ou qualquer outra solução CSS de sua escolha).
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ Material-UI usa a unidade `rem` para o tamanho da fonte. O tamanho da fonte padr
 Para alterar o tamanho da fonte do Material-UI, você pode definir a propriedade `fontSize`. O valor padrão é `14px`.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Em chinês e japonês os caracteres são geralmente maiores,
     // então um tamanho de letra menor pode ser apropriado.
@@ -103,7 +103,7 @@ O tamanho da fonte computada pelo navegador segue esta equação matemática:
 As propriedades de variações de tipografia são mapeadas diretamente para o CSS gerado. Você pode usar [consultas de mídia](/customization/breakpoints/#api) dentro delas:
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ Para automatizar estas configurações, você pode usar a função auxiliar [`re
 Você pode ver isso em ação no exemplo abaixo. Ajuste o tamanho da janela do navegador e observe como o tamanho da fonte muda à medida que a largura cruza os diferentes [pontos de quebra](/customization/breakpoints/):
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ Você pode querer alterar o tamanho da fonte padrão do elemento `<html>`. Por e
 Uma propriedade de tema `htmlFontSize` é fornecida para este caso de uso, que informa ao Material-UI qual é o tamanho da fonte no elemento `<html>`. Isso é usado para ajustar o valor `rem`, para que o tamanho da fonte calculado sempre corresponda à especificação.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Diz ao Material-UI qual é o font-size no elemento html.
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ O objeto de tipografia vem com [13 variantes](/components/typography/#component)
 Cada uma dessas variantes pode ser customizada individualmente:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography-ru.md
+++ b/docs/src/pages/customization/typography/typography-ru.md
@@ -9,7 +9,7 @@ You can change the font family with the `theme.typography.fontFamily` property.
 For instance, this demo uses the system font instead of the default Roboto font:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 Next, you need to change the theme to use this new font. In order to globally define Raleway as a font face, the [`CssBaseline`](/components/css-baseline/) component can be used (or any other CSS solution of your choice).
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ Material-UI uses `rem` units for the font size. The browser `<html>` element def
 To change the font-size of Material-UI you can provide a `fontSize` property. The default value is `14px`.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // In Chinese and Japanese the characters are usually larger,
     // so a smaller fontsize may be appropriate.
@@ -103,7 +103,7 @@ The computed font size by the browser follows this mathematical equation:
 The typography variants properties map directly to the generated CSS. You can use [media queries](/customization/breakpoints/#api) inside them:
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ To automate this setup, you can use the [`responsiveFontSizes()`](/customization
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ You might want to change the `<html>` element default font size. For instance, w
 An `htmlFontSize` theme property is provided for this use case, which tells Material-UI what the font-size on the `<html>` element is. This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what's the font-size on the html element is.
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ The typography object comes with [13 variants](/components/typography/#component
 Each of these variants can be customized individually:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography-zh.md
+++ b/docs/src/pages/customization/typography/typography-zh.md
@@ -9,7 +9,7 @@
 例如，这个例子使用是系统字体而不是默认的 Roboto 字体：
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -54,7 +54,7 @@ const raleway = {
 接下来，您需要做的是修改主题，来使用这一个新的字体。 如果想在全局定义 Raleway 作为一个字体，您可以使用 [`CssBaseline`](/components/css-baseline/) 组件（或者你也可以选择你想要的任意其他 CSS 方案)。
 
 ```jsx
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -83,7 +83,7 @@ Material-UI 使用 `rem` 单元来定义字体的大小。 浏览器 `<html>` �
 若想更改  Material-UI 的字体大小，您可以提供一个 `fontSize ` 属性。 它的默认值为 `14px`。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // 中文字符和日文字符通常比较大，
     // 所以选用一个略小的 fontsize 会比较合适。
@@ -103,7 +103,7 @@ const theme = createMuiTheme({
 `theme.typography.*` [variant](#variants) 属性会直接映射到生成的 CSS。 您可以在当中使用 [媒体查询（media queries）](/customization/breakpoints/#api)：
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -125,9 +125,9 @@ theme.typography.h3 = {
 您可以在下面的示例中看到这个操作。 请尝试调整浏览器的窗口大小，您可以注意到当切换到不同的 [breakpoints](/customization/breakpoints/) 设置的宽度，字体的大小也随之改变。
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -146,7 +146,7 @@ theme = responsiveFontSizes(theme);
 `theme.typography.htmlFontSize` 属性是为这个用例提供的，它将会告诉 Material-UI `<html>` 元素的字体大小是多少。 这可以用于调整  `rem`  值，如此一来计算后的 font-size 总是与规范相符合。
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // 告知 Material-UI 此 html 元素的具体字体大小。
     htmlFontSize: 10,
@@ -185,7 +185,7 @@ _您需要在此页面的 html 元素上应用上述的 CSS 才能看到以下�
 每个变体都可以被单独地定制：
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -209,7 +209,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -234,7 +234,7 @@ declare module '@material-ui/core/styles/createTypography' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/customization/typography/typography.md
+++ b/docs/src/pages/customization/typography/typography.md
@@ -9,7 +9,7 @@ You can change the font family with the `theme.typography.fontFamily` property.
 For instance, this example uses the system font instead of the default Roboto font:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: [
       '-apple-system',
@@ -45,7 +45,7 @@ In order to globally define Raleway as a font face, the [`CssBaseline`](/compone
 ```jsx
 import RalewayWoff2 from './fonts/Raleway-Regular.woff2';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     fontFamily: 'Raleway, Arial',
   },
@@ -94,7 +94,7 @@ To change the font-size of Material-UI you can provide a `fontSize` property.
 The default value is `14px`.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // In Chinese and Japanese the characters are usually larger,
     // so a smaller fontsize may be appropriate.
@@ -115,7 +115,7 @@ The `theme.typography.*` [variant](#variants) properties map directly to the gen
 You can use [media queries](/customization/breakpoints/#api) inside them:
 
 ```js
-const theme = createMuiTheme();
+const theme = createTheme();
 
 theme.typography.h3 = {
   fontSize: '1.2rem',
@@ -137,9 +137,9 @@ To automate this setup, you can use the [`responsiveFontSizes()`](/customization
 You can see this in action in the example below. Adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 
 ```js
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { createTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
-let theme = createMuiTheme();
+let theme = createTheme();
 theme = responsiveFontSizes(theme);
 ```
 
@@ -160,7 +160,7 @@ which tells Material-UI what the font-size on the `<html>` element is.
 This is used to adjust the `rem` value so the calculated font-size always match the specification.
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     // Tell Material-UI what's the font-size on the html element is.
     htmlFontSize: 10,
@@ -199,7 +199,7 @@ The typography object comes with [13 variants](/components/typography/#component
 Each of these variants can be customized individually:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     subtitle1: {
       fontSize: 12,
@@ -223,7 +223,7 @@ In addition to using the default typography variants, you can add custom ones, o
 **Step 1. Update the theme's typography object**
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',
@@ -248,7 +248,7 @@ declare module '@material-ui/core/styles' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyVariantsOptions {
     poster?: React.CSSProperties;
   }

--- a/docs/src/pages/getting-started/faq/faq-de.md
+++ b/docs/src/pages/getting-started/faq/faq-de.md
@@ -44,9 +44,9 @@ Scrolling is blocked as soon as a modal is opened. This prevents interacting wit
 Der Ripple-Effekt kommt ausschließlich von der `BaseButton` Komponente. Sie können den Ripple-Effekt global deaktivieren, indem Sie in Ihrem Theme folgendes angeben:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // Name of the component ⚛️
     MuiButtonBase: {
@@ -62,9 +62,9 @@ const theme = createMuiTheme({
 Material-UI uses the same theme helper for creating all its transitions. Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // Jetzt haven wir überall `transition: none;`
     create: () => 'none',
@@ -77,9 +77,9 @@ It can be useful to disable transitions during visual testing or to improve perf
 You can go one step further by disabling all transitions and animations effects:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq-es.md
+++ b/docs/src/pages/getting-started/faq/faq-es.md
@@ -65,9 +65,9 @@ module.exports = {
 Material-UI uses the same theme helper for creating all its transitions. Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // Então temos `transition: none;` everywhere
     create: () => 'none',
@@ -80,9 +80,9 @@ It can be useful to disable transitions during visual testing or to improve perf
 You can go one step further by disabling all transitions and animations effects:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq-fr.md
+++ b/docs/src/pages/getting-started/faq/faq-fr.md
@@ -44,9 +44,9 @@ Scrolling is blocked as soon as a modal is opened. This prevents interacting wit
 The ripple effect is exclusively coming from the `BaseButton` component. You can disable the ripple effect globally by providing the following in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // Name of the component ⚛️
     MuiButtonBase: {
@@ -62,9 +62,9 @@ const theme = createMuiTheme({
 Material-UI uses the same theme helper for creating all its transitions. Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // So we have `transition: none;` everywhere
     create: () => 'none',
@@ -77,9 +77,9 @@ It can be useful to disable transitions during visual testing or to improve perf
 You can go one step further by disabling all transitions and animations effects:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq-ja.md
+++ b/docs/src/pages/getting-started/faq/faq-ja.md
@@ -44,9 +44,9 @@ Scrolling is blocked as soon as a modal is opened. This prevents interacting wit
 Material-UI uses the same theme helper for creating all its transitions. Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // Name of the component ⚛️
     MuiButtonBase: {
@@ -62,9 +62,9 @@ const theme = createMuiTheme({
 Material-UI uses the same theme helper for creating all its transitions. Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // So we have `transition: none;` everywhere
     create: () => 'none',
@@ -77,9 +77,9 @@ It can be useful to disable transitions during visual testing or to improve perf
 You can go one step further by disabling all transitions and animations effects:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq-pt.md
+++ b/docs/src/pages/getting-started/faq/faq-pt.md
@@ -44,9 +44,9 @@ A rolagem é bloqueada assim que um modal é aberto. Isto impede a interação c
 O efeito cascata é exclusivamente proveniente do componente `BaseButton`. Você pode desativar o efeito cascata globalmente aplicando as seguintes configurações no seu tema:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // Nome do componente ⚛️
     MuiButtonBase: {
@@ -62,9 +62,9 @@ const theme = createMuiTheme({
 Material-UI usa o mesmo auxiliar de tema para criar todas as transições. Portanto, você pode desativar todas as transições substituindo o auxiliar no seu tema:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // Então temos `transition: none;` em todo lugar
     create: () => 'none',
@@ -77,9 +77,9 @@ Pode ser útil desabilitar transições durante testes visuais ou para melhorar 
 Você pode ir além, desabilitando todas as transições e efeitos de animações:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq-ru.md
+++ b/docs/src/pages/getting-started/faq/faq-ru.md
@@ -44,9 +44,9 @@ Scrolling is blocked as soon as a modal is opened. This prevents interacting wit
 The ripple effect is exclusively coming from the `BaseButton` component. You can disable the ripple effect globally by providing the following in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   props: {
     // Name of the component ⚛️
     MuiButtonBase: {
@@ -62,9 +62,9 @@ const theme = createMuiTheme({
 Material-UI uses the same theme helper for creating all its transitions. Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // Então temos `transition: none;` everywhere
     create: () => 'none',
@@ -77,9 +77,9 @@ It can be useful to disable transitions during visual testing or to improve perf
 You can go one step further by disabling all transitions and animations effects:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq-zh.md
+++ b/docs/src/pages/getting-started/faq/faq-zh.md
@@ -44,9 +44,9 @@
 涟漪效果完全来自 `BaseButton` 组件。 您可以通过在您的主题中提供以下内容，来全局地禁用涟漪效果：
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiButtonBase: {
@@ -64,9 +64,9 @@ const theme = createMuiTheme({
 Material-UI 使用相同的主题助手来创建其所有的过渡动画。 因此，您可以通过覆盖主题助手来禁用所有的过渡：
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // 这样就设定了全局的 `transition: none;`
     create: () => 'none',
@@ -79,9 +79,9 @@ const theme = createMuiTheme({
 您可以更进一步地禁用所有的过渡和动画效果。
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -52,9 +52,9 @@ The ripple effect is exclusively coming from the `BaseButton` component.
 You can disable the ripple effect globally by providing the following in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiButtonBase: {
@@ -73,9 +73,9 @@ Material-UI uses the same theme helper for creating all its transitions.
 Therefore you can disable all transitions by overriding the helper in your theme:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   transitions: {
     // So we have `transition: none;` everywhere
     create: () => 'none',
@@ -88,9 +88,9 @@ It can be useful to disable transitions during visual testing or to improve perf
 You can go one step further by disabling all transitions and animations effects:
 
 ```js
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     // Name of the component ⚛️
     MuiCssBaseline: {

--- a/docs/src/pages/guides/interoperability/StyledComponentsTheme.js
+++ b/docs/src/pages/guides/interoperability/StyledComponentsTheme.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   experimentalStyled as styled,
   ThemeProvider,
   darken,
@@ -8,7 +8,7 @@ import {
 import Slider from '@material-ui/core/Slider';
 import Box from '@material-ui/core/Box';
 
-const customTheme = createMuiTheme({
+const customTheme = createTheme({
   palette: {
     primary: {
       main: '#20b2aa',

--- a/docs/src/pages/guides/interoperability/StyledComponentsTheme.tsx
+++ b/docs/src/pages/guides/interoperability/StyledComponentsTheme.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   experimentalStyled as styled,
   ThemeProvider,
   darken,
@@ -8,7 +8,7 @@ import {
 import Slider from '@material-ui/core/Slider';
 import Box from '@material-ui/core/Box';
 
-const customTheme = createMuiTheme({
+const customTheme = createTheme({
   palette: {
     primary: {
       main: '#20b2aa',

--- a/docs/src/pages/guides/localization/Locales.js
+++ b/docs/src/pages/guides/localization/Locales.js
@@ -3,7 +3,7 @@ import TablePagination from '@material-ui/core/TablePagination';
 import Autocomplete from '@material-ui/core/Autocomplete';
 import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import * as locales from '@material-ui/core/locale';
 
 export default function Locales() {
@@ -12,7 +12,7 @@ export default function Locales() {
   return (
     <Box sx={{ width: '100%' }}>
       <ThemeProvider
-        theme={(outerTheme) => createMuiTheme(outerTheme, locales[locale])}
+        theme={(outerTheme) => createTheme(outerTheme, locales[locale])}
       >
         <Autocomplete
           options={Object.keys(locales)}

--- a/docs/src/pages/guides/localization/Locales.tsx
+++ b/docs/src/pages/guides/localization/Locales.tsx
@@ -3,7 +3,7 @@ import TablePagination from '@material-ui/core/TablePagination';
 import Autocomplete from '@material-ui/core/Autocomplete';
 import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import * as locales from '@material-ui/core/locale';
 
 type SupportedLocales = keyof typeof locales;
@@ -14,7 +14,7 @@ export default function Locales() {
   return (
     <Box sx={{ width: '100%' }}>
       <ThemeProvider
-        theme={(outerTheme) => createMuiTheme(outerTheme, locales[locale])}
+        theme={(outerTheme) => createTheme(outerTheme, locales[locale])}
       >
         <Autocomplete
           options={Object.keys(locales)}

--- a/docs/src/pages/guides/localization/localization-de.md
+++ b/docs/src/pages/guides/localization/localization-de.md
@@ -9,10 +9,10 @@ The default locale of Material-UI is English (United States). If you want to use
 Use the theme to configure the locale text globally:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: { main: '#1976d2' },
   },

--- a/docs/src/pages/guides/localization/localization-es.md
+++ b/docs/src/pages/guides/localization/localization-es.md
@@ -9,10 +9,10 @@ La localización predeterminada de Material-UI es Inglés (Estados Unidos). Si q
 Utilice el tema para configurar el texto regional globalmente:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: { main: '#1976d2' },
   },

--- a/docs/src/pages/guides/localization/localization-fr.md
+++ b/docs/src/pages/guides/localization/localization-fr.md
@@ -9,10 +9,10 @@ The default locale of Material-UI is English (United States). If you want to use
 Use the theme to configure the locale text globally:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: { main: '#1976d2' },
   },

--- a/docs/src/pages/guides/localization/localization-ja.md
+++ b/docs/src/pages/guides/localization/localization-ja.md
@@ -9,10 +9,10 @@ The default locale of Material-UI is English (United States). If you want to use
 Use the theme to configure the locale text globally:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: { main: '#1976d2' },
   },

--- a/docs/src/pages/guides/localization/localization-pt.md
+++ b/docs/src/pages/guides/localization/localization-pt.md
@@ -9,10 +9,10 @@ A localidade padrão do Material-UI é em inglês (Estados Unidos). Se você qui
 Use o tema para configurar os textos da localização globalmente:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: { main: '#1976d2' },
   },

--- a/docs/src/pages/guides/localization/localization-ru.md
+++ b/docs/src/pages/guides/localization/localization-ru.md
@@ -9,10 +9,10 @@ The default locale of Material-UI is English (United States). If you want to use
 Use the theme to configure the locale text globally:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: { main: '#1976d2' },
   },

--- a/docs/src/pages/guides/localization/localization-zh.md
+++ b/docs/src/pages/guides/localization/localization-zh.md
@@ -9,10 +9,10 @@ Material-UI 的默认语言环境是 English（United States）。 如果您想�
 使用 theme 来全局地配置语言环境文本：
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme(
+const theme = createTheme(
   {
     palette: {
       primary: { main: '#1976d2' },

--- a/docs/src/pages/guides/localization/localization.md
+++ b/docs/src/pages/guides/localization/localization.md
@@ -9,10 +9,10 @@ The default locale of Material-UI is English (United States). If you want to use
 Use the theme to configure the locale text globally:
 
 ```jsx
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme(
+const theme = createTheme(
   {
     palette: {
       primary: { main: '#1976d2' },

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -125,6 +125,16 @@ export default function PlainCssPriority() {
 
 ### Theme
 
+- The function `createMuiTheme` was renamed to `createTheme` to make more intuitive to use with `ThemeProvider`.
+
+  ```diff
+  -import { createMuiTheme } from '@material-ui/core/styles';
+  +import { createTheme } from '@material-ui/core/styles';
+
+  -const theme = createMuiTheme({
+  +const theme = createTheme({
+  ```
+
 - The default background color is now `#fff` in light mode and `#121212` in dark mode.
   This matches the material design guidelines.
 - Breakpoints are now treated as values instead of ranges. The behavior of `down(key)` was changed to define media query less than the value defined with the corresponding breakpoint (exclusive).
@@ -179,10 +189,10 @@ For a smoother transition, the `adaptV4Theme` helper allows you to iteratively u
 
 ```diff
 -import { createMuiTheme } from '@material-ui/core/styles';
-+import { createMuiTheme, adaptV4Theme } from '@material-ui/core/styles';
++import { createTheme, adaptV4Theme } from '@material-ui/core/styles';
 
 -const theme = createMuiTheme({
-+const theme = createMuiTheme(adaptV4Theme({
++const theme = createTheme(adaptV4Theme({
   // v4 theme
 -});
 +}));
@@ -222,19 +232,19 @@ The following changes are supported by the adapter.
 - The `theme.palette.type` was renamed to `theme.palette.mode`, to better follow the "dark mode" term that is usually used for describing this feature.
 
   ```diff
-  import { createMuiTheme } from '@material-ui/core/styles';
-  -const theme = createMuiTheme({palette: { type: 'dark' }}),
-  +const theme = createMuiTheme({palette: { mode: 'dark' }}),
+  import { createTheme } from '@material-ui/core/styles';
+  -const theme = createTheme({palette: { type: 'dark' }}),
+  +const theme = createTheme({palette: { mode: 'dark' }}),
   ```
 
 - The `theme.palette.text.hint` key was unused in Material-UI components, and has been removed.
   If you depend on it, you can add it back:
 
   ```diff
-  import { createMuiTheme } from '@material-ui/core/styles';
+  import { createTheme } from '@material-ui/core/styles';
 
-  -const theme = createMuiTheme(),
-  +const theme = createMuiTheme({
+  -const theme = createTheme(),
+  +const theme = createTheme({
   +  palette: { text: { hint: 'rgba(0, 0, 0, 0.38)' } },
   +});
   ```
@@ -244,9 +254,9 @@ The following changes are supported by the adapter.
 1. `props`
 
 ```diff
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
 -  props: {
 -    MuiButton: {
 -      disableRipple: true,
@@ -265,9 +275,9 @@ const theme = createMuiTheme({
 2. `overrides`
 
 ```diff
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
 -  overrides: {
 -    MuiButton: {
 -      root: { padding: 0 },
@@ -557,7 +567,7 @@ As the core components use emotion as a styled engine, the props used by emotion
 - The component was migrated to use the `@material-ui/styled-engine` (`emotion` or `styled-components`) instead of `jss`. You should remove the `@global` key when defining the style overrides for it. You could also start using the CSS template syntax over the JavaScript object syntax.
 
   ```diff
-  const theme = createMuiTheme({
+  const theme = createTheme({
     components: {
       MuiCssBaseline: {
   -      styleOverrides: {
@@ -581,7 +591,7 @@ As the core components use emotion as a styled engine, the props used by emotion
   To return to the previous size, you can override it in the theme:
 
   ```js
-  const theme = createMuiTheme({
+  const theme = createTheme({
     typography: {
       body1: {
         fontSize: '0.875rem',
@@ -756,7 +766,7 @@ As the core components use emotion as a styled engine, the props used by emotion
 - The props: `alignItems` `alignContent` and `justifyContent` and their `classes` and style overrides keys were removed: "align-items-xs-center", "align-items-xs-flex-start", "align-items-xs-flex-end", "align-items-xs-baseline", "align-content-xs-center", "align-content-xs-flex-start", "align-content-xs-flex-end", "align-content-xs-space-between", "align-content-xs-space-around", "justify-content-xs-center", "justify-content-xs-flex-end", "justify-content-xs-space-between", "justify-content-xs-space-around" and "justify-content-xs-space-evenly". These props are now considered part of the system, not on the `Grid` component itself. If you still wish to add overrides for them, you can use the `theme.components.MuiGrid.variants` options. For example
 
   ```diff
-  const theme = createMuiTheme({
+  const theme = createTheme({
     components: {
       MuiGrid: {
   -     styleOverrides: {
@@ -1393,7 +1403,7 @@ As the core components use emotion as a styled engine, the props used by emotion
 - The following `classes` and style overrides keys were removed: "colorInherit", "colorPrimary", "colorSecondary", "colorTextPrimary", "colorTextSecondary", "colorError", "displayInline" and "displayBlock". These props are now considered part of the system, not on the `Typography` component itself. If you still wish to add overrides for them, you can use the `theme.components.MuiTypography.variants` options. For example
 
   ```diff
-  const theme = createMuiTheme({
+  const theme = createTheme({
     components: {
       MuiTypography: {
   -     styleOverrides: {

--- a/docs/src/pages/guides/right-to-left/Direction.js
+++ b/docs/src/pages/guides/right-to-left/Direction.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl', // Both here and <body dir="rtl">
 });
 

--- a/docs/src/pages/guides/right-to-left/Direction.tsx
+++ b/docs/src/pages/guides/right-to-left/Direction.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl', // Both here and <body dir="rtl">
 });
 

--- a/docs/src/pages/guides/right-to-left/RtlOptOutStylis.js
+++ b/docs/src/pages/guides/right-to-left/RtlOptOutStylis.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import styled from '@emotion/styled';
 import { ThemeProvider } from '@emotion/react';
 
@@ -18,7 +18,7 @@ const UnaffectedText = styled('div')`
   text-align: left;
 `;
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function RtlOptOut() {
   return (

--- a/docs/src/pages/guides/right-to-left/RtlOptOutStylis.tsx
+++ b/docs/src/pages/guides/right-to-left/RtlOptOutStylis.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme, Theme } from '@material-ui/core/styles';
+import { createTheme, Theme } from '@material-ui/core/styles';
 import styled from '@emotion/styled';
 import { ThemeProvider } from '@emotion/react';
 
@@ -18,7 +18,7 @@ const UnaffectedText = styled('div')`
   text-align: left;
 `;
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function RtlOptOut() {
   return (

--- a/docs/src/pages/guides/right-to-left/RtlOptOutStylist.js
+++ b/docs/src/pages/guides/right-to-left/RtlOptOutStylist.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import styled from '@emotion/styled';
 import { ThemeProvider } from '@emotion/react';
 
@@ -18,7 +18,7 @@ const UnaffectedText = styled('div')({
   textAlign: 'right',
 });
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 export default function RtlOptOut() {
   return (

--- a/docs/src/pages/guides/right-to-left/right-to-left-de.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-de.md
@@ -17,7 +17,7 @@ Stellen Sie sicher, dass das `dir` Attribut in body gesetzt wird, sonst werden n
 Legen Sie die Richtung in Ihrem benutzerdefinierten Theme fest:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left-es.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-es.md
@@ -17,7 +17,7 @@ Asegúrese de que el atributo `dir` está establecido en el body, de lo contrari
 Establece la dirección en su tema personalizado:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left-fr.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-fr.md
@@ -17,7 +17,7 @@ Make sure the `dir` attribute is set on the body, otherwise native components wi
 Set the direction in your custom theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left-ja.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-ja.md
@@ -17,7 +17,7 @@ Make sure the `dir` attribute is set on the body, otherwise native components wi
 Set the direction in your custom theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left-pt.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-pt.md
@@ -17,7 +17,7 @@ Certifique-se de que o atributo `dir` é definido no corpo (body), caso contrár
 Defina a direção no seu tema customizado:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left-ru.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-ru.md
@@ -17,7 +17,7 @@ Make sure the `dir` attribute is set on the body, otherwise native components wi
 Set the direction in your custom theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left-zh.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left-zh.md
@@ -17,7 +17,7 @@
 在您自定义的主题中设置方向：
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/right-to-left/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left.md
@@ -31,7 +31,7 @@ This can be helpful for creating components to toggle language settings in the l
 Set the direction in your custom theme:
 
 ```js
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 ```

--- a/docs/src/pages/guides/routing/LinkRouterWithTheme.js
+++ b/docs/src/pages/guides/routing/LinkRouterWithTheme.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { MemoryRouter as Router } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Stack from '@material-ui/core/Stack';
 import Link from '@material-ui/core/Link';
@@ -19,7 +19,7 @@ LinkBehavior.propTypes = {
 };
 
 const themeSetter = (outerTheme) =>
-  createMuiTheme(outerTheme, {
+  createTheme(outerTheme, {
     components: {
       MuiLink: {
         defaultProps: {

--- a/docs/src/pages/guides/routing/LinkRouterWithTheme.tsx
+++ b/docs/src/pages/guides/routing/LinkRouterWithTheme.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MemoryRouter as Router } from 'react-router';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
-import { Theme, ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { Theme, ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Stack from '@material-ui/core/Stack';
 import Link from '@material-ui/core/Link';
@@ -16,7 +16,7 @@ const LinkBehavior = React.forwardRef<
 });
 
 const themeSetter = (outerTheme: Theme) =>
-  createMuiTheme(outerTheme, {
+  createTheme(outerTheme, {
     components: {
       MuiLink: {
         defaultProps: {

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -33,7 +33,7 @@ const LinkBehavior = React.forwardRef<
   return <RouterLink ref={ref} to={href} {...other} />;
 });
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiLink: {
       defaultProps: {

--- a/docs/src/pages/guides/server-rendering/server-rendering-de.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-de.md
@@ -26,11 +26,11 @@ Create a theme that will be shared between the client and the server:
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Erstellen Sie eine Theme-Instanz.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering-es.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-es.md
@@ -26,11 +26,11 @@ Create a theme that will be shared between the client and the server:
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering-fr.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-fr.md
@@ -26,11 +26,11 @@ Create a theme that will be shared between the client and the server:
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering-ja.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-ja.md
@@ -26,11 +26,11 @@ Material-UIは、サーバーでのレンダリングの制約を考慮してゼ
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering-pt.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-pt.md
@@ -26,11 +26,11 @@ Crie um tema que será compartilhado entre o cliente e o servidor:
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Cria a instância do tema.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering-ru.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-ru.md
@@ -26,11 +26,11 @@ Create a theme that will be shared between the client and the server:
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering-zh.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering-zh.md
@@ -26,11 +26,11 @@ Material-UI 最初设计受到了在服务器端渲染的约束，但是您可�
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // 创建一个主题的实例。
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -29,11 +29,11 @@ Create a theme that will be shared between the client and the server:
 `theme.js`
 
 ```js
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/docs/src/pages/guides/typescript/typescript-de.md
+++ b/docs/src/pages/guides/typescript/typescript-de.md
@@ -218,17 +218,17 @@ Beim Hinzufügen benutzerdefinierter Eigenschaften zum `Theme` können Sie es we
 Im folgenden Beispiel wird eine `appDrawer` Eigenschaft hinzugefügt, welche in das von `material-ui` exportierte Theme eingefügt wird:
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -243,10 +243,10 @@ Und eine benutzerdefinierte Theme Generierung mit zusätzlichen Standardoptionen
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript-es.md
+++ b/docs/src/pages/guides/typescript/typescript-es.md
@@ -216,17 +216,17 @@ When adding custom properties to the `Theme`, you may continue to use it in a st
 The following example adds an `appDrawer` property that is merged into the one exported by `material-ui`:
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -241,10 +241,10 @@ And a custom theme factory with additional defaulted options:
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript-fr.md
+++ b/docs/src/pages/guides/typescript/typescript-fr.md
@@ -216,17 +216,17 @@ When adding custom properties to the `Theme`, you may continue to use it in a st
 The following example adds an `appDrawer` property that is merged into the one exported by `material-ui`:
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -241,10 +241,10 @@ And a custom theme factory with additional defaulted options:
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript-ja.md
+++ b/docs/src/pages/guides/typescript/typescript-ja.md
@@ -216,17 +216,17 @@ const DecoratedClass = withStyles(styles)(
 次の例では、`material-ui`によって書き出されたプロパティに合成される`appDrawer`プロパティを追加します。
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -241,10 +241,10 @@ declare module '@material-ui/core/styles/createMuiTheme' {
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript-pt.md
+++ b/docs/src/pages/guides/typescript/typescript-pt.md
@@ -216,17 +216,17 @@ Ao adicionar propriedades customizadas ao `Theme`, você pode continuar a utiliz
 O exemplo a seguir adiciona uma propriedade `appDrawer` que é mesclada na que foi exportada pelo `material-ui`:
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // permitir configuração usando `createMuiTheme`
+  // permitir configuração usando `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -241,10 +241,10 @@ E uma fábrica customizada de temas com opções padrão adicionais:
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript-ru.md
+++ b/docs/src/pages/guides/typescript/typescript-ru.md
@@ -216,17 +216,17 @@ When adding custom properties to the `Theme`, you may continue to use it in a st
 The following example adds an `appDrawer` property that is merged into the one exported by `material-ui`:
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -241,10 +241,10 @@ And a custom theme factory with additional defaulted options:
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript-zh.md
+++ b/docs/src/pages/guides/typescript/typescript-zh.md
@@ -231,17 +231,17 @@ const DecoratedClass = withStyles(styles)(
 以下示例添加了一个 `appDrawer` 属性，并将其合并到由 `material-ui` 提供的属性中：
 
 ```ts
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
+import { Theme } from '@material-ui/core/styles/createTheme';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     appDrawer: {
       width: React.CSSProperties['width']
       breakpoint: Breakpoint
     }
   }
-  // 使用 `createMuiTheme` 来配置
+  // 使用 `createTheme` 来配置
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width']
@@ -256,10 +256,10 @@ declare module '@material-ui/core/styles/createMuiTheme' {
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -244,7 +244,7 @@ declare module '@material-ui/core/styles' {
       breakpoint: Breakpoint;
     };
   }
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface ThemeOptions {
     appDrawer?: {
       width?: React.CSSProperties['width'];
@@ -259,10 +259,10 @@ And a custom theme factory with additional defaulted options:
 **./styles/createMyTheme**:
 
 ```ts
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
-  return createMuiTheme({
+  return createTheme({
     appDrawer: {
       width: 225,
       breakpoint: 'lg',

--- a/docs/src/pages/premium-themes/onepirate/modules/theme.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/theme.js
@@ -1,7 +1,7 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { green, grey, red } from '@material-ui/core/colors';
 
-const rawTheme = createMuiTheme({
+const rawTheme = createTheme({
   palette: {
     primary: {
       light: '#69696a',

--- a/docs/src/pages/premium-themes/onepirate/modules/theme.ts
+++ b/docs/src/pages/premium-themes/onepirate/modules/theme.ts
@@ -1,7 +1,7 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { green, grey, red } from '@material-ui/core/colors';
 
-const rawTheme = createMuiTheme({
+const rawTheme = createTheme({
   palette: {
     primary: {
       light: '#69696a',

--- a/docs/src/pages/premium-themes/paperbase/Paperbase.js
+++ b/docs/src/pages/premium-themes/paperbase/Paperbase.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { createMuiTheme, ThemeProvider, withStyles } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider, withStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Hidden from '@material-ui/core/Hidden';
 import Typography from '@material-ui/core/Typography';
@@ -21,7 +21,7 @@ function Copyright() {
   );
 }
 
-let theme = createMuiTheme({
+let theme = createTheme({
   palette: {
     primary: {
       light: '#63ccff',

--- a/docs/src/pages/premium-themes/paperbase/Paperbase.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Paperbase.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  createMuiTheme,
+  createTheme,
   createStyles,
   ThemeProvider,
   withStyles,
@@ -26,7 +26,7 @@ function Copyright() {
   );
 }
 
-let theme = createMuiTheme({
+let theme = createTheme({
   palette: {
     primary: {
       light: '#63ccff',

--- a/docs/src/pages/styles/advanced/advanced-de.md
+++ b/docs/src/pages/styles/advanced/advanced-de.md
@@ -6,7 +6,7 @@
 
 Sie können das äußere Theme erweitern, indem Sie eine Funktion bereitstellen: Das innere Theme ** überschreibt** das äußere Theme.
 
-> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createMuiTheme()` method. Head to the the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
+> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createTheme()` method. Head to the the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced-es.md
+++ b/docs/src/pages/styles/advanced/advanced-es.md
@@ -6,7 +6,7 @@
 
 Add a `ThemeProvider` to the top level of your app to pass a theme down the React component tree. Then, you can access the theme object in style functions.
 
-> Este ejemplo crea un objeto de tema para componentes construidos a medida. Si pretende utilizar algunos de los componentes de Material-UI, necesita proporcionar una estructura de tema más rica utilizando el método `createMuiTheme()`. Dirígete a la sección [temática](/customization/theming/) para aprender cómo construir tu tema personalizado de Material-UI.
+> Este ejemplo crea un objeto de tema para componentes construidos a medida. Si pretende utilizar algunos de los componentes de Material-UI, necesita proporcionar una estructura de tema más rica utilizando el método `createTheme()`. Dirígete a la sección [temática](/customization/theming/) para aprender cómo construir tu tema personalizado de Material-UI.
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced-fr.md
+++ b/docs/src/pages/styles/advanced/advanced-fr.md
@@ -6,7 +6,7 @@
 
 Add a `ThemeProvider` to the top level of your app to pass a theme down the React component tree. Then, you can access the theme object in style functions.
 
-> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createMuiTheme()` method. Head to the the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
+> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createTheme()` method. Head to the the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced-ja.md
+++ b/docs/src/pages/styles/advanced/advanced-ja.md
@@ -6,7 +6,7 @@
 
 Add a `ThemeProvider` to the top level of your app to pass a theme down the React component tree. Then, you can access the theme object in style functions.
 
-> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createMuiTheme()` method. カスタムMaterial-UIテーマを構築する方法については、 [テーマセクション](/customization/theming/) を参照してください。
+> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createTheme()` method. カスタムMaterial-UIテーマを構築する方法については、 [テーマセクション](/customization/theming/) を参照してください。
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced-pt.md
+++ b/docs/src/pages/styles/advanced/advanced-pt.md
@@ -6,7 +6,7 @@
 
 Adicione um `ThemeProvider` para o nível superior de sua aplicação para passar um tema pela árvore de componentes do React. Dessa maneira, você poderá acessar o objeto de tema em funções de estilo.
 
-> Este exemplo cria um objeto de tema para componentes customizados. Se você pretende usar alguns dos componentes do Material-UI, você precisa fornecer uma estrutura de tema mais rica usando o método `createMuiTheme()`. Vá até a [seção de temas](/customization/theming/) para aprender como construir seu tema customizado do Material-UI.
+> Este exemplo cria um objeto de tema para componentes customizados. Se você pretende usar alguns dos componentes do Material-UI, você precisa fornecer uma estrutura de tema mais rica usando o método `createTheme()`. Vá até a [seção de temas](/customization/theming/) para aprender como construir seu tema customizado do Material-UI.
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced-ru.md
+++ b/docs/src/pages/styles/advanced/advanced-ru.md
@@ -6,7 +6,7 @@
 
 Add a `ThemeProvider` to the top level of your app to pass a theme down the React component tree. Then, you can access the theme object in style functions.
 
-> Этот пример создает объект темы для пользовательских компонентов. Если вы собираетесь использовать какие-либо компоненты Material-UI, вам необходимо использовать метод `createMuiTheme()` который обеспечивает более обширную структуру темы. Head to the the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
+> Этот пример создает объект темы для пользовательских компонентов. Если вы собираетесь использовать какие-либо компоненты Material-UI, вам необходимо использовать метод `createTheme()` который обеспечивает более обширную структуру темы. Head to the the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced-zh.md
+++ b/docs/src/pages/styles/advanced/advanced-zh.md
@@ -6,7 +6,7 @@
 
 若您想将主题传递到 React 组件树，请将添加 `ThemeProvider` 包装到应用程序的顶层。 然后，您可以在样式函数中访问主题对象。
 
-> 此示例为自定义组件创建了一个主题对象（theme object）。 如果你想要使用 Material-UI 的部分组件，那么则需要通过使用 `createMuiTheme()` 方法来提供一个更丰富的主题结构。 请前往 [theming 部分](/customization/theming/) 学习如何构建自己的 Material-UI 主题。
+> 此示例为自定义组件创建了一个主题对象（theme object）。 如果你想要使用 Material-UI 的部分组件，那么则需要通过使用 `createTheme()` 方法来提供一个更丰富的主题结构。 请前往 [theming 部分](/customization/theming/) 学习如何构建自己的 Material-UI 主题。
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/styles/advanced/advanced.md
+++ b/docs/src/pages/styles/advanced/advanced.md
@@ -6,7 +6,7 @@
 
 Add a `ThemeProvider` to the top level of your app to pass a theme down the React component tree. Then, you can access the theme object in style functions.
 
-> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createMuiTheme()` method. Head to the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
+> This example creates a theme object for custom-built components. If you intend to use some of the Material-UI's components you need to provide a richer theme structure using the `createTheme()` method. Head to the [theming section](/customization/theming/) to learn how to build your custom Material-UI theme.
 
 ```jsx
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/src/pages/system/advanced/StyleFunctionSxDemo.js
+++ b/docs/src/pages/system/advanced/StyleFunctionSxDemo.js
@@ -2,9 +2,9 @@ import * as React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import { unstable_styleFunctionSx } from '@material-ui/system';
 import NoSsr from '@material-ui/core/NoSsr';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 const Div = styled('div')(unstable_styleFunctionSx);
 

--- a/docs/src/pages/system/advanced/StyleFunctionSxDemo.tsx
+++ b/docs/src/pages/system/advanced/StyleFunctionSxDemo.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import styled, { InterpolationFunction, ThemeProvider } from 'styled-components';
 import { unstable_styleFunctionSx, SxProps } from '@material-ui/system';
 import NoSsr from '@material-ui/core/NoSsr';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 interface DivProps {
   sx?: SxProps;
 }
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 const Div = styled('div')<DivProps>(
   unstable_styleFunctionSx as InterpolationFunction<DivProps>,

--- a/docs/src/pages/system/basics/basics-de.md
+++ b/docs/src/pages/system/basics/basics-de.md
@@ -287,9 +287,9 @@ You can also specify your own custom breakpoints, and use them as keys when defi
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics-es.md
+++ b/docs/src/pages/system/basics/basics-es.md
@@ -287,9 +287,9 @@ You can also specify your own custom breakpoints, and use them as keys when defi
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics-fr.md
+++ b/docs/src/pages/system/basics/basics-fr.md
@@ -287,9 +287,9 @@ You can also specify your own custom breakpoints, and use them as keys when defi
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics-ja.md
+++ b/docs/src/pages/system/basics/basics-ja.md
@@ -287,9 +287,9 @@ You can also specify your own custom breakpoints, and use them as keys when defi
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics-pt.md
+++ b/docs/src/pages/system/basics/basics-pt.md
@@ -287,9 +287,9 @@ Você também pode especificar seus próprios pontos de quebras customizados, e 
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics-ru.md
+++ b/docs/src/pages/system/basics/basics-ru.md
@@ -287,9 +287,9 @@ You can also specify your own custom breakpoints, and use them as keys when defi
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics-zh.md
+++ b/docs/src/pages/system/basics/basics-zh.md
@@ -288,9 +288,9 @@ CSS 属性中有大量的速记语法。 这些语法在之后的文档中都有
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -296,9 +296,9 @@ You can also specify your own custom breakpoints, and use them as keys when defi
 ```jsx
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -22,7 +22,7 @@ const {
   ThemeProvider,
   Typography,
   Container,
-  createTheme,
+  createMuiTheme,
   Box,
   SvgIcon,
   Link,
@@ -30,7 +30,7 @@ const {
 } = MaterialUI;
 
 // Create a theme instance.
-const theme = createTheme({
+const theme = createMuiTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -22,7 +22,7 @@ const {
   ThemeProvider,
   Typography,
   Container,
-  createMuiTheme,
+  createTheme,
   Box,
   SvgIcon,
   Link,
@@ -30,7 +30,7 @@ const {
 } = MaterialUI;
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/create-react-app-with-typescript/src/theme.tsx
+++ b/examples/create-react-app-with-typescript/src/theme.tsx
@@ -1,8 +1,8 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { red } from '@material-ui/core/colors';
 
 // A custom theme for this app
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/create-react-app/src/theme.js
+++ b/examples/create-react-app/src/theme.js
@@ -1,8 +1,8 @@
 import { red } from '@material-ui/core/colors';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // A custom theme for this app
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/gatsby-theme/src/gatsby-theme-material-ui-top-layout/theme.js
+++ b/examples/gatsby-theme/src/gatsby-theme-material-ui-top-layout/theme.js
@@ -1,8 +1,8 @@
 import { red } from '@material-ui/core/colors';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // A custom theme for this app
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/gatsby/src/theme.js
+++ b/examples/gatsby/src/theme.js
@@ -1,8 +1,8 @@
 import { red } from '@material-ui/core/colors';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // A custom theme for this app
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/nextjs-with-typescript/src/theme.tsx
+++ b/examples/nextjs-with-typescript/src/theme.tsx
@@ -1,8 +1,8 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { red } from '@material-ui/core/colors';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -1,8 +1,8 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { red } from '@material-ui/core/colors';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/preact/src/theme.js
+++ b/examples/preact/src/theme.js
@@ -1,8 +1,8 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { red } from '@material-ui/core/colors';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/examples/ssr/theme.js
+++ b/examples/ssr/theme.js
@@ -1,8 +1,8 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { red } from '@material-ui/core/colors';
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',

--- a/framer/Material-UI.framerfx/code/ThemeProvider.tsx
+++ b/framer/Material-UI.framerfx/code/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { addPropertyControls, ControlType } from 'framer';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { MuiThemeProvider, createTheme } from '@material-ui/core/styles';
 import { parseColor } from './utils';
 
 interface Props {
@@ -27,7 +27,7 @@ export function Theme(props: Props): JSX.Element {
     ...other
   } = props;
 
-  const theme = createMuiTheme({
+  const theme = createTheme({
     palette: {
       mode: paletteMode,
       primary: { main: parseColor(primary) },

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -115,8 +115,8 @@ Converts all `@material-ui/core` imports more than 1 level deep to the optimal f
 
 ```diff
 -import withStyles from '@material-ui/core/styles/withStyles';
--import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
-+import { withStyles, createMuiTheme } from '@material-ui/core/styles';
+-import createTheme from '@material-ui/core/styles/createTheme';
++import { withStyles, createTheme } from '@material-ui/core/styles';
 ```
 
 ```sh

--- a/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test/actual.js
+++ b/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test/actual.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { withTheme } from '@material-ui/core/styles';
 import withStyles from '@material-ui/core/styles/withStyles';
-import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
+import createTheme from '@material-ui/core/styles/createTheme';
 import MenuItem from '@material-ui/core/MenuItem';
 import Tab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';

--- a/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test/expected.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withTheme, withStyles, createMuiTheme } from '@material-ui/core/styles';
+import { withTheme, withStyles, createTheme } from '@material-ui/core/styles';
 import MenuItem from '@material-ui/core/MenuItem';
 import Tab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, describeConformance, screen, fireEvent } from 'test/utils';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import { DateRange } from '@material-ui/lab/DateRangePicker';
 import DesktopDateRangePicker from '@material-ui/lab/DesktopDateRangePicker';
@@ -341,7 +341,7 @@ describe('<DesktopDateRangePicker />', () => {
 
   // TODO: remove once we use describeConformanceV5.
   it("respect theme's defaultProps", () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         MuiDesktopDateRangePicker: {
           defaultProps: { startText: 'Início', endText: 'Fim' },

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.test.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import TextField from '@material-ui/core/TextField';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { fireEvent, screen } from 'test/utils';
 import StaticDatePicker from '@material-ui/lab/StaticDatePicker';
 import {
@@ -54,7 +54,7 @@ describe('<StaticDatePicker />', () => {
 
   // TODO: remove once we use describeConformanceV5
   it("respect theme's defaultProps", () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: { MuiStaticDatePicker: { defaultProps: { toolbarTitle: 'Select A Date' } } },
     });
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { SheetsRegistry } from 'jss';
 import { act } from 'react-dom/test-utils';
 import { createMount } from 'test/utils';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import createGenerateClassName from '../createGenerateClassName';
 import makeStyles from './makeStyles';
 import useTheme from '../useTheme';
@@ -224,7 +224,7 @@ describe('makeStyles', () => {
       };
 
       const wrapper = mount(
-        <ThemeProvider theme={createMuiTheme()}>
+        <ThemeProvider theme={createTheme()}>
           <StylesProvider
             sheetsRegistry={sheetsRegistry}
             sheetsCache={new Map()}
@@ -239,7 +239,7 @@ describe('makeStyles', () => {
       wrapper.update();
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'makeStyles-root-1' });
-      wrapper.setProps({ theme: createMuiTheme() });
+      wrapper.setProps({ theme: createTheme() });
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'makeStyles-root-2' });
 
@@ -257,7 +257,7 @@ describe('makeStyles', () => {
       };
 
       const wrapper = mount(
-        <ThemeProvider theme={createMuiTheme()}>
+        <ThemeProvider theme={createTheme()}>
           <StylesProvider
             sheetsRegistry={sheetsRegistry}
             sheetsCache={new Map()}
@@ -270,7 +270,7 @@ describe('makeStyles', () => {
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'MuiTextField-root' });
 
-      wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
+      wrapper.setProps({ theme: createTheme({ foo: 'bar' }) });
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'MuiTextField-root' });
     });
@@ -295,7 +295,7 @@ describe('makeStyles', () => {
 
         mount(
           <ThemeProvider
-            theme={createMuiTheme({
+            theme={createTheme({
               components: {
                 MuiTextField: {
                   styleOverrides: {

--- a/packages/material-ui-styles/src/useThemeVariants/useThemeVariants.test.js
+++ b/packages/material-ui-styles/src/useThemeVariants/useThemeVariants.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import { createClientRender, screen } from 'test/utils';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import ThemeProvider from '../ThemeProvider';
 import useThemeVariants from './useThemeVariants';
 import withStyles from '../withStyles';
@@ -18,7 +18,7 @@ describe('useThemeVariants', () => {
   const Component = withStyles({}, { name: 'Test' })(ComponentInternal);
 
   it('returns variants classes if props do match', () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         Test: {
           variants: [
@@ -44,7 +44,7 @@ describe('useThemeVariants', () => {
   });
 
   it('does not return variants classes if props do not match', () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         Test: {
           variants: [
@@ -68,7 +68,7 @@ describe('useThemeVariants', () => {
   });
 
   it('matches correctly multiple props', () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         Test: {
           variants: [
@@ -113,7 +113,7 @@ describe('useThemeVariants', () => {
       return <div className={`${themeVariantsClasses} ${className}`} {...other} />;
     });
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         MuiButton: {
           variants: [

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -6,7 +6,7 @@ import { SheetsRegistry } from 'jss';
 import Input from '@material-ui/core/Input';
 import { createClientRender, screen } from 'test/utils';
 import { isMuiElement } from '@material-ui/core/utils';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import StylesProvider from '../StylesProvider';
 import createGenerateClassName from '../createGenerateClassName';
 import ThemeProvider from '../ThemeProvider';
@@ -93,7 +93,7 @@ describe('withStyles', () => {
       const sheetsRegistry = new SheetsRegistry();
 
       const { setProps, unmount } = render(
-        <ThemeProvider theme={createMuiTheme()}>
+        <ThemeProvider theme={createTheme()}>
           <StylesProvider sheetsRegistry={sheetsRegistry} generateClassName={generateClassName}>
             <StyledComponent />
           </StylesProvider>
@@ -108,7 +108,7 @@ describe('withStyles', () => {
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'Empty-root-1' });
 
-      setProps({ theme: createMuiTheme() });
+      setProps({ theme: createTheme() });
 
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'Empty-root-2' });
@@ -142,7 +142,7 @@ describe('withStyles', () => {
 
       const { container } = render(
         <ThemeProvider
-          theme={createMuiTheme({
+          theme={createTheme({
             components: {
               MuiFoo: {
                 defaultProps: {
@@ -170,7 +170,7 @@ describe('withStyles', () => {
 
       const { container } = render(
         <ThemeProvider
-          theme={createMuiTheme({
+          theme={createTheme({
             components: {
               MuiFoo: {
                 defaultProps: {
@@ -194,7 +194,7 @@ describe('withStyles', () => {
       const sheetsRegistry = new SheetsRegistry();
 
       const { setProps } = render(
-        <ThemeProvider theme={createMuiTheme()}>
+        <ThemeProvider theme={createTheme()}>
           <StylesProvider sheetsRegistry={sheetsRegistry} generateClassName={generateClassName}>
             <StyledComponent />
           </StylesProvider>
@@ -204,7 +204,7 @@ describe('withStyles', () => {
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'MuiTextField-root' });
 
-      setProps({ theme: createMuiTheme({ foo: 'bar' }) });
+      setProps({ theme: createTheme({ foo: 'bar' }) });
 
       expect(sheetsRegistry.registry.length).to.equal(1);
       expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'MuiTextField-root' });
@@ -218,7 +218,7 @@ describe('withStyles', () => {
 
       render(
         <ThemeProvider
-          theme={createMuiTheme({
+          theme={createTheme({
             components: {
               MuiTextField: {
                 styleOverrides: {
@@ -248,7 +248,7 @@ describe('withStyles', () => {
 
       render(
         <ThemeProvider
-          theme={createMuiTheme({
+          theme={createTheme({
             components: {
               MuiButton: {
                 variants: [

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -10,7 +10,7 @@ import {
   screen,
 } from 'test/utils';
 import { spy } from 'sinon';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 import Chip from '@material-ui/core/Chip';
 import Autocomplete, {
@@ -55,7 +55,7 @@ describe('<Autocomplete />', () => {
   );
 
   it('should be customizable in the theme', () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         MuiAutocomplete: {
           styleOverrides: {

--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SystemProps, SxProps } from '@material-ui/system';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
-import { Theme } from '../styles/createMuiTheme';
+import { Theme } from '../styles/createTheme';
 
 export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -14,7 +14,7 @@ import {
   programmaticFocusTriggersFocusVisible,
 } from 'test/utils';
 import PropTypes from 'prop-types';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import ButtonBase, { buttonBaseClasses as classes } from '@material-ui/core/ButtonBase';
 
 describe('<ButtonBase />', () => {
@@ -104,7 +104,7 @@ describe('<ButtonBase />', () => {
           </a>
         );
       });
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: {
           MuiButtonBase: {
             defaultProps: {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Collapse, { collapseClasses as classes } from '@material-ui/core/Collapse';
 
@@ -143,7 +143,7 @@ describe('<Collapse />', () => {
     });
 
     it('should delay based on height when timeout is auto', () => {
-      const theme = createMuiTheme({
+      const theme = createTheme({
         transitions: {
           getAutoHeightDuration: (n) => n,
         },

--- a/packages/material-ui/src/CssBaseline/CssBaseline.test.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 
 describe('<CssBaseline />', () => {
   const render = createClientRender();
@@ -20,7 +20,7 @@ describe('<CssBaseline />', () => {
   });
 
   it('supports theme overrides as string', () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: { MuiCssBaseline: { styleOverrides: `strong { font-weight: 500; }` } },
     });
 
@@ -38,7 +38,7 @@ describe('<CssBaseline />', () => {
   });
 
   it('supports theme overrides as object', () => {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: { MuiCssBaseline: { styleOverrides: { strong: { fontWeight: '500' } } } },
     });
 

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -6,7 +6,7 @@ import {
   createClientRender,
   describeConformanceV5,
 } from 'test/utils';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Slide from '@material-ui/core/Slide';
 import Paper from '@material-ui/core/Paper';
 import Modal from '@material-ui/core/Modal';
@@ -248,7 +248,7 @@ describe('<Drawer />', () => {
 
   describe('Right To Left', () => {
     it('should switch left and right anchor when theme is right-to-left', () => {
-      const theme = createMuiTheme({
+      const theme = createTheme({
         direction: 'rtl',
       });
       const wrapper1 = mount(

--- a/packages/material-ui/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/material-ui/src/GlobalStyles/GlobalStyles.test.js
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils';
 import GlobalStyles from '@material-ui/core/GlobalStyles';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core//styles/';
+import { ThemeProvider, createTheme } from '@material-ui/core//styles/';
 
-const customTheme = createMuiTheme({
+const customTheme = createTheme({
   spacing: 10,
 });
 

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, describeConformanceV5, createClientRender, screen } from 'test/utils';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Grid, { gridClasses as classes } from '@material-ui/core/Grid';
 
 describe('<Grid />', () => {
@@ -85,7 +85,7 @@ describe('<Grid />', () => {
 
       const parentWidth = 500;
       const remValue = 16;
-      const remTheme = createMuiTheme({
+      const remTheme = createTheme({
         spacing: (factor) => `${0.25 * factor}rem`,
       });
 

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -4,7 +4,7 @@ import { spy, useFakeTimers } from 'sinon';
 // use act from test/utils/createClientRender once we drop createMount from this test
 import { createClientRender, createMount, describeConformance } from 'test/utils';
 import { act } from 'react-dom/test-utils';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Grow from '@material-ui/core/Grow';
 import useForkRef from '../utils/useForkRef';
@@ -138,7 +138,7 @@ describe('<Grow />', () => {
 
       it('should delay based on height when timeout is auto', () => {
         const handleEntered = spy();
-        const theme = createMuiTheme({
+        const theme = createTheme({
           transitions: {
             getAutoHeightDuration: (n) => n,
           },

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, createClientRender } from 'test/utils';
 import HiddenCss from './HiddenCss';
-import { createMuiTheme, MuiThemeProvider } from '../styles';
+import { createTheme, MuiThemeProvider } from '../styles';
 import classes from './hiddenCssClasses';
 
 const TestChild = () => <div data-testid="test-child">bar</div>;
@@ -84,7 +84,7 @@ describe('<HiddenCss />', () => {
     });
 
     it('allows custom breakpoints', () => {
-      const theme = createMuiTheme({ breakpoints: { keys: ['xxl'] } });
+      const theme = createTheme({ breakpoints: { keys: ['xxl'] } });
       const { container } = render(
         <MuiThemeProvider theme={theme}>
           <HiddenCss xxlUp className="testid" classes={{ xxlUp: 'xxlUp' }}>

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -9,7 +9,7 @@ import {
   fireEvent,
   queries,
 } from 'test/utils';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItem, { listItemClasses as classes } from '@material-ui/core/ListItem';
@@ -214,7 +214,7 @@ describe('<ListItem />', () => {
       marginTop: '13px',
     };
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         MuiListItem: {
           styleOverrides: {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -11,7 +11,7 @@ import {
   createMount,
   describeConformanceV5,
 } from 'test/utils';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Fade from '@material-ui/core/Fade';
 import Backdrop from '@material-ui/core/Backdrop';
 import Modal, { modalClasses as classes } from '@material-ui/core/Modal';
@@ -64,7 +64,7 @@ describe('<Modal />', () => {
     });
 
     it('should consume theme default props', () => {
-      const theme = createMuiTheme({ components: { MuiModal: { defaultProps: { container } } } });
+      const theme = createTheme({ components: { MuiModal: { defaultProps: { container } } } });
       render(
         <ThemeProvider theme={theme}>
           <Modal open>

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMuiTheme, ThemeProvider, experimentalStyled } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider, experimentalStyled } from '@material-ui/core/styles';
 import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import NativeSelect, { nativeSelectClasses as classes } from '@material-ui/core/NativeSelect';
 import Input, { inputClasses } from '@material-ui/core/Input';
@@ -74,7 +74,7 @@ describe('<NativeSelect />', () => {
       marginTop: '13px',
     };
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         MuiNativeSelect: {
           styleOverrides: {

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender } from 'test/utils';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import NotchedOutline from './NotchedOutline';
 
 describe('<NotchedOutline />', () => {
@@ -31,7 +31,7 @@ describe('<NotchedOutline />', () => {
   it('should set alignment rtl', () => {
     const { container: container1 } = render(
       <ThemeProvider
-        theme={createMuiTheme({
+        theme={createTheme({
           direction: 'ltr',
         })}
       >
@@ -44,7 +44,7 @@ describe('<NotchedOutline />', () => {
 
     const { container: container2 } = render(
       <ThemeProvider
-        theme={createMuiTheme({
+        theme={createTheme({
           direction: 'rtl',
         })}
       >

--- a/packages/material-ui/src/Pagination/Pagination.test.js
+++ b/packages/material-ui/src/Pagination/Pagination.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Pagination, { paginationClasses as classes } from '@material-ui/core/Pagination';
 
 describe('<Pagination />', () => {
@@ -52,7 +52,7 @@ describe('<Pagination />', () => {
   it('renders controls with correct order in rtl theme', () => {
     const { getAllByRole } = render(
       <ThemeProvider
-        theme={createMuiTheme({
+        theme={createTheme({
           direction: 'rtl',
         })}
       >
@@ -73,7 +73,7 @@ describe('<Pagination />', () => {
   it('renders correct amount of buttons on correct order when boundaryCount is zero', () => {
     const { getAllByRole } = render(
       <ThemeProvider
-        theme={createMuiTheme({
+        theme={createTheme({
           direction: 'rtl',
         })}
       >

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import * as PropTypes from 'prop-types';
 import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
 import Paper, { paperClasses as classes } from '@material-ui/core/Paper';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
 describe('<Paper />', () => {
   const render = createClientRender();
@@ -72,7 +72,7 @@ describe('<Paper />', () => {
   });
 
   it('allows custom elevations via theme.shadows', () => {
-    const theme = createMuiTheme();
+    const theme = createTheme();
     theme.shadows.push('20px 20px');
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -10,7 +10,7 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Grow from '@material-ui/core/Grow';
 import Popper from '@material-ui/core/Popper';
 
@@ -25,7 +25,7 @@ describe('<Popper />', () => {
   };
 
   before(() => {
-    rtlTheme = createMuiTheme({
+    rtlTheme = createTheme({
       direction: 'rtl',
     });
   });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -10,7 +10,7 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import MenuItem from '@material-ui/core/MenuItem';
 import InputBase from '@material-ui/core/InputBase';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
@@ -1160,7 +1160,7 @@ describe('<Select />', () => {
       marginTop: '10px',
     };
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       components: {
         MuiSelect: {
           styleOverrides: {

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createClientRender, createMount, describeConformance } from 'test/utils';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Slide from '@material-ui/core/Slide';
 import { setTranslateValue } from './Slide';
@@ -39,7 +39,7 @@ describe('<Slide />', () => {
       <Slide
         {...defaultProps}
         style={{ color: 'red', backgroundColor: 'yellow' }}
-        theme={createMuiTheme()}
+        theme={createTheme()}
       >
         <div id="with-slide" style={{ color: 'blue' }} />
       </Slide>,

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -10,7 +10,7 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { SliderUnstyled } from '@material-ui/unstyled';
 import Slider, { sliderClasses as classes } from '@material-ui/core/Slider';
 
@@ -538,7 +538,7 @@ describe('<Slider />', () => {
     });
 
     it('should be customizable in the theme', () => {
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: {
           MuiSlider: {
             styleOverrides: {
@@ -818,7 +818,7 @@ describe('<Slider />', () => {
     it('should add direction css', () => {
       const { getByRole } = render(
         <ThemeProvider
-          theme={createMuiTheme({
+          theme={createTheme({
             direction: 'rtl',
           })}
         >
@@ -837,7 +837,7 @@ describe('<Slider />', () => {
       const handleChange = spy();
       const { container, getByTestId } = render(
         <ThemeProvider
-          theme={createMuiTheme({
+          theme={createTheme({
             direction: 'rtl',
           })}
         >

--- a/packages/material-ui/src/Stack/Stack.d.ts
+++ b/packages/material-ui/src/Stack/Stack.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ResponsiveStyleValue, SxProps, SystemProps } from '@material-ui/system';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
-import { Theme } from '../styles/createMuiTheme';
+import { Theme } from '../styles/createTheme';
 
 export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &

--- a/packages/material-ui/src/Stack/Stack.test.js
+++ b/packages/material-ui/src/Stack/Stack.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
 import Stack from '@material-ui/core/Stack';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { style } from './Stack';
 
 describe('<Stack />', () => {
@@ -18,7 +18,7 @@ describe('<Stack />', () => {
     skip: ['componentProp', 'componentsProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],
   }));
 
-  const theme = createMuiTheme();
+  const theme = createTheme();
 
   it('should handle breakpoints with a missing key', () => {
     expect(

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -12,7 +12,7 @@ import {
 } from 'test/utils';
 import Tab from '@material-ui/core/Tab';
 import Tabs, { tabsClasses as classes } from '@material-ui/core/Tabs';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import capitalize from '../utils/capitalize';
 
 function findScrollButton(container, direction) {
@@ -775,7 +775,7 @@ describe('<Tabs />', () => {
 
       let wrapper;
       before(() => {
-        const theme = createMuiTheme({ direction });
+        const theme = createTheme({ direction });
         wrapper = ({ children }) => <ThemeProvider theme={theme}>{children}</ThemeProvider>;
       });
 

--- a/packages/material-ui/src/styles/adaptV4Theme.d.ts
+++ b/packages/material-ui/src/styles/adaptV4Theme.d.ts
@@ -10,7 +10,7 @@ import { ZIndexOptions } from './zIndex';
 import { ComponentsOverrides } from './overrides';
 import { ComponentsVariants } from './variants';
 import { ComponentsProps } from './props';
-import { Theme } from './createMuiTheme';
+import { Theme } from './createTheme';
 
 export type Direction = 'ltr' | 'rtl';
 

--- a/packages/material-ui/src/styles/createMixins.spec.ts
+++ b/packages/material-ui/src/styles/createMixins.spec.ts
@@ -1,7 +1,7 @@
-import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
+import { createTheme, makeStyles } from '@material-ui/core/styles';
 
 {
-  const theme = createMuiTheme({
+  const theme = createTheme({
     mixins: {
       toolbar: {
         background: '#fff',

--- a/packages/material-ui/src/styles/createMixins.test.js
+++ b/packages/material-ui/src/styles/createMixins.test.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import createMixins from './createMixins';
-import createMuiTheme from './createMuiTheme';
+import createTheme from './createTheme';
 
 describe('createMixins', () => {
   it('should be able add other mixins', () => {
-    const theme = createMuiTheme();
+    const theme = createTheme();
     const mixins = createMixins(theme.breakpoints, theme.spacing, { test: { display: 'block' } });
 
     expect(mixins.test).to.deep.equal({

--- a/packages/material-ui/src/styles/createMuiStrictModeTheme.js
+++ b/packages/material-ui/src/styles/createMuiStrictModeTheme.js
@@ -1,8 +1,8 @@
 import { deepmerge } from '@material-ui/utils';
-import createMuiTheme from './createMuiTheme';
+import createTheme from './createTheme';
 
 export default function createMuiStrictModeTheme(options, ...args) {
-  return createMuiTheme(
+  return createTheme(
     deepmerge(
       {
         unstable_strictMode: true,

--- a/packages/material-ui/src/styles/createPalette.js
+++ b/packages/material-ui/src/styles/createPalette.js
@@ -178,11 +178,11 @@ export default function createPalette(palette) {
           '\n' +
           'import { green } from "@material-ui/core/colors";\n' +
           '\n' +
-          'const theme1 = createMuiTheme({ palette: {\n' +
+          'const theme1 = createTheme({ palette: {\n' +
           '  primary: green,\n' +
           '} });\n' +
           '\n' +
-          'const theme2 = createMuiTheme({ palette: {\n' +
+          'const theme2 = createTheme({ palette: {\n' +
           '  primary: { main: green[500] },\n' +
           '} });',
         name ? ` (${name})` : '',

--- a/packages/material-ui/src/styles/createPalette.spec.ts
+++ b/packages/material-ui/src/styles/createPalette.spec.ts
@@ -1,9 +1,9 @@
 import { Color } from '@material-ui/core';
 import { blue, common } from '@material-ui/core/colors';
-import { createMuiTheme, Theme } from '@material-ui/core/styles';
+import { createTheme, Theme } from '@material-ui/core/styles';
 
 {
-  const palette = createMuiTheme().palette;
+  const palette = createTheme().palette;
   const color: Color = blue;
   const option = { color: { main: blue[400] } };
 

--- a/packages/material-ui/src/styles/createTheme.d.ts
+++ b/packages/material-ui/src/styles/createTheme.d.ts
@@ -49,4 +49,4 @@ export interface Theme {
  * @param args Deep merge the arguments with the about to be returned theme.
  * @returns A complete, ready to use theme object.
  */
-export default function createMuiTheme(options?: ThemeOptions, ...args: object[]): Theme;
+export default function createTheme(options?: ThemeOptions, ...args: object[]): Theme;

--- a/packages/material-ui/src/styles/createTheme.d.ts
+++ b/packages/material-ui/src/styles/createTheme.d.ts
@@ -44,6 +44,12 @@ export interface Theme {
 }
 
 /**
+ * @deprecated
+ * Use `import { createTheme } from '@material-ui/core/styles'` instead.
+ */
+export function createMuiTheme(options?: ThemeOptions, ...args: object[]): Theme;
+
+/**
  * Generate a theme base on the options received.
  * @param options Takes an incomplete theme object and adds the missing parts.
  * @param args Deep merge the arguments with the about to be returned theme.

--- a/packages/material-ui/src/styles/createTheme.js
+++ b/packages/material-ui/src/styles/createTheme.js
@@ -106,4 +106,23 @@ function createTheme(options = {}, ...args) {
   return muiTheme;
 }
 
+let warnedOnce = false;
+
+export function createMuiTheme(...args) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!warnedOnce) {
+      warnedOnce = true;
+      console.error(
+        [
+          'Material-UI: the createMuiTheme function was renamed to createTheme.',
+          '',
+          "You should use `import { createTheme } from '@material-ui/core/styles'`",
+        ].join('\n'),
+      );
+    }
+  }
+
+  return createTheme(...args);
+}
+
 export default createTheme;

--- a/packages/material-ui/src/styles/createTheme.js
+++ b/packages/material-ui/src/styles/createTheme.js
@@ -10,7 +10,7 @@ import createSpacing from './createSpacing';
 import { duration, easing, create, getAutoHeightDuration } from './transitions';
 import zIndex from './zIndex';
 
-function createMuiTheme(options = {}, ...args) {
+function createTheme(options = {}, ...args) {
   const {
     breakpoints: breakpointsInput = {},
     mixins: mixinsInput = {},
@@ -106,4 +106,4 @@ function createMuiTheme(options = {}, ...args) {
   return muiTheme;
 }
 
-export default createMuiTheme;
+export default createTheme;

--- a/packages/material-ui/src/styles/createTheme.test.js
+++ b/packages/material-ui/src/styles/createTheme.test.js
@@ -1,31 +1,31 @@
 import { expect } from 'chai';
-import createMuiTheme from './createMuiTheme';
+import createTheme from './createTheme';
 import { deepOrange, green } from '../colors';
 
-describe('createMuiTheme', () => {
+describe('createTheme', () => {
   it('should have a palette', () => {
-    const muiTheme = createMuiTheme();
-    expect(typeof createMuiTheme).to.equal('function');
-    expect(typeof muiTheme.palette).to.equal('object');
+    const theme = createTheme();
+    expect(typeof createTheme).to.equal('function');
+    expect(typeof theme.palette).to.equal('object');
   });
 
   it('should have the custom palette', () => {
-    const muiTheme = createMuiTheme({
+    const theme = createTheme({
       palette: { primary: { main: deepOrange[500] }, secondary: { main: green.A400 } },
     });
-    expect(muiTheme.palette.primary.main).to.equal(deepOrange[500]);
-    expect(muiTheme.palette.secondary.main).to.equal(green.A400);
+    expect(theme.palette.primary.main).to.equal(deepOrange[500]);
+    expect(theme.palette.secondary.main).to.equal(green.A400);
   });
 
   it('should allow providing a partial structure', () => {
-    const muiTheme = createMuiTheme({ transitions: { duration: { shortest: 150 } } });
-    expect(muiTheme.transitions.duration.shorter).not.to.equal(undefined);
+    const theme = createTheme({ transitions: { duration: { shortest: 150 } } });
+    expect(theme.transitions.duration.shorter).not.to.equal(undefined);
   });
 
   describe('shadows', () => {
     it('should provide the default array', () => {
-      const muiTheme = createMuiTheme();
-      expect(muiTheme.shadows[2]).to.equal(
+      const theme = createTheme();
+      expect(theme.shadows[2]).to.equal(
         '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)',
       );
     });
@@ -58,8 +58,8 @@ describe('createMuiTheme', () => {
         11,
         11,
       ];
-      const muiTheme = createMuiTheme({ shadows });
-      expect(muiTheme.shadows).to.equal(shadows);
+      const theme = createTheme({ shadows });
+      expect(theme.shadows).to.equal(shadows);
     });
   });
 
@@ -83,8 +83,8 @@ describe('createMuiTheme', () => {
           },
         },
       };
-      const muiTheme = createMuiTheme({ components });
-      expect(muiTheme.components).to.deep.equal(components);
+      const theme = createTheme({ components });
+      expect(theme.components).to.deep.equal(components);
     });
   });
 
@@ -93,20 +93,20 @@ describe('createMuiTheme', () => {
       let theme;
 
       expect(() => {
-        theme = createMuiTheme({
+        theme = createTheme({
           components: { Button: { styleOverrides: { disabled: { color: 'blue' } } } },
         });
       }).not.toErrorDev();
       expect(Object.keys(theme.components.Button.styleOverrides.disabled).length).to.equal(1);
 
       expect(() => {
-        theme = createMuiTheme({
+        theme = createTheme({
           components: { MuiButton: { styleOverrides: { root: { color: 'blue' } } } },
         });
       }).not.toErrorDev();
 
       expect(() => {
-        theme = createMuiTheme({
+        theme = createTheme({
           components: { MuiButton: { styleOverrides: { disabled: { color: 'blue' } } } },
         });
       }).toErrorDev(
@@ -117,17 +117,14 @@ describe('createMuiTheme', () => {
   });
 
   it('shallow merges multiple arguments', () => {
-    const muiTheme = createMuiTheme({ foo: 'I am foo' }, { bar: 'I am bar' });
-    expect(muiTheme.foo).to.equal('I am foo');
-    expect(muiTheme.bar).to.equal('I am bar');
+    const theme = createTheme({ foo: 'I am foo' }, { bar: 'I am bar' });
+    expect(theme.foo).to.equal('I am foo');
+    expect(theme.bar).to.equal('I am bar');
   });
 
   it('deep merges multiple arguments', () => {
-    const muiTheme = createMuiTheme(
-      { custom: { foo: 'I am foo' } },
-      { custom: { bar: 'I am bar' } },
-    );
-    expect(muiTheme.custom.foo).to.equal('I am foo');
-    expect(muiTheme.custom.bar).to.equal('I am bar');
+    const theme = createTheme({ custom: { foo: 'I am foo' } }, { custom: { bar: 'I am bar' } });
+    expect(theme.custom.foo).to.equal('I am foo');
+    expect(theme.custom.bar).to.equal('I am bar');
   });
 });

--- a/packages/material-ui/src/styles/createTypography.spec.ts
+++ b/packages/material-ui/src/styles/createTypography.spec.ts
@@ -1,9 +1,9 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { expectType } from '@material-ui/types';
 
 {
   // properties of the variants can be "unset"
-  const theme = createMuiTheme({
+  const theme = createTheme({
     typography: {
       allVariants: {
         fontStyle: undefined,

--- a/packages/material-ui/src/styles/defaultTheme.js
+++ b/packages/material-ui/src/styles/defaultTheme.js
@@ -1,5 +1,5 @@
-import createMuiTheme from './createMuiTheme';
+import createTheme from './createTheme';
 
-const defaultTheme = createMuiTheme();
+const defaultTheme = createTheme();
 
 export default defaultTheme;

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as CSS from 'csstype';
 import { SxProps } from '@material-ui/system';
-import { Theme as DefaultTheme } from './createMuiTheme';
+import { Theme as DefaultTheme } from './createTheme';
 
 export interface SerializedStyles {
   name: string;

--- a/packages/material-ui/src/styles/experimentalStyled.test.js
+++ b/packages/material-ui/src/styles/experimentalStyled.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createClientRender, screen } from 'test/utils';
-import createMuiTheme from './createMuiTheme';
+import createTheme from './createTheme';
 import styled from './experimentalStyled';
 import ThemeProvider from './ThemeProvider';
 
@@ -61,7 +61,7 @@ describe('experimentalStyled', () => {
       width: ${(props) => props.theme.spacing(1)};
     `;
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       spacing: 10,
     });
 
@@ -81,7 +81,7 @@ describe('experimentalStyled', () => {
       width: props.theme.spacing(1),
     }));
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       spacing: 10,
     });
 
@@ -126,7 +126,7 @@ describe('experimentalStyled', () => {
 
   describe('muiOptions', () => {
     /**
-     * @type {ReturnType<typeof createMuiTheme>}
+     * @type {ReturnType<typeof createTheme>}
      */
     let theme;
     /**
@@ -139,7 +139,7 @@ describe('experimentalStyled', () => {
     let TestObj;
 
     before(() => {
-      theme = createMuiTheme({
+      theme = createTheme({
         palette: {
           primary: {
             main: 'rgb(0, 0, 255)',

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -1,13 +1,13 @@
 export * from './colorManipulator';
 export {
-  default as createMuiTheme,
+  default as createTheme,
   default as unstable_createMuiStrictModeTheme,
   Breakpoint,
   BreakpointOverrides,
   ThemeOptions,
   Theme,
   Direction,
-} from './createMuiTheme';
+} from './createTheme';
 export { default as adaptV4Theme, DeprecatedThemeOptions } from './adaptV4Theme';
 export {
   Palette,

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -2,6 +2,7 @@ export * from './colorManipulator';
 export {
   default as createTheme,
   default as unstable_createMuiStrictModeTheme,
+  createMuiTheme,
   Breakpoint,
   BreakpointOverrides,
   ThemeOptions,

--- a/packages/material-ui/src/styles/index.js
+++ b/packages/material-ui/src/styles/index.js
@@ -1,6 +1,6 @@
 export { default as adaptV4Theme } from './adaptV4Theme';
 export * from './colorManipulator';
-export { default as createMuiTheme } from './createMuiTheme';
+export { default as createTheme } from './createTheme';
 export { default as unstable_createMuiStrictModeTheme } from './createMuiStrictModeTheme';
 export { default as createStyles } from './createStyles';
 export { getUnit as unstable_getUnit, toUnitless as unstable_toUnitless } from './cssUtils';

--- a/packages/material-ui/src/styles/index.js
+++ b/packages/material-ui/src/styles/index.js
@@ -1,6 +1,6 @@
 export { default as adaptV4Theme } from './adaptV4Theme';
 export * from './colorManipulator';
-export { default as createTheme } from './createTheme';
+export { default as createTheme, createMuiTheme } from './createTheme';
 export { default as unstable_createMuiStrictModeTheme } from './createMuiStrictModeTheme';
 export { default as createStyles } from './createStyles';
 export { getUnit as unstable_getUnit, toUnitless as unstable_toUnitless } from './cssUtils';

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -1,6 +1,6 @@
 import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
 import { DistributiveOmit } from '@material-ui/types';
-import { Theme as DefaultTheme } from './createMuiTheme';
+import { Theme as DefaultTheme } from './createTheme';
 
 export default function makeStyles<
   Theme = DefaultTheme,

--- a/packages/material-ui/src/styles/responsiveFontSizes.d.ts
+++ b/packages/material-ui/src/styles/responsiveFontSizes.d.ts
@@ -1,4 +1,4 @@
-import { Theme } from './createMuiTheme';
+import { Theme } from './createTheme';
 import { Breakpoint } from './createBreakpoints';
 import { Variant } from './createTypography';
 

--- a/packages/material-ui/src/styles/responsiveFontSizes.test.js
+++ b/packages/material-ui/src/styles/responsiveFontSizes.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import responsiveFontSizes from './responsiveFontSizes';
 
 describe('responsiveFontSizes', () => {
@@ -12,7 +12,7 @@ describe('responsiveFontSizes', () => {
       lineHeight: 1,
     };
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       typography: {
         h1: defaultVariant,
       },
@@ -36,7 +36,7 @@ describe('responsiveFontSizes', () => {
       lineHeight: '6rem',
     };
 
-    const theme = createMuiTheme({
+    const theme = createTheme({
       typography: {
         h1: defaultVariant,
       },
@@ -56,7 +56,7 @@ describe('responsiveFontSizes', () => {
 
   describe('when requesting a responsive typography with non unitless line height and alignment', () => {
     it('should throw an error, as this is not supported', () => {
-      const theme = createMuiTheme({
+      const theme = createTheme({
         typography: {
           h1: {
             lineHeight: '6rem',

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -5,7 +5,7 @@ import {
   StyledComponentProps,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
-import { Theme as DefaultTheme } from './createMuiTheme';
+import { Theme as DefaultTheme } from './createTheme';
 
 // These definitions are almost identical to the ones in @material-ui/styles/styled
 // Only difference is that ComponentCreator has a default theme type

--- a/packages/material-ui/src/styles/useTheme.d.ts
+++ b/packages/material-ui/src/styles/useTheme.d.ts
@@ -1,3 +1,3 @@
-import { Theme } from './createMuiTheme';
+import { Theme } from './createTheme';
 
 export default function useTheme<T = Theme>(): T;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -11,7 +11,7 @@ import {
   ClassKeyOfStyles,
   BaseCSSProperties,
 } from '@material-ui/styles/withStyles';
-import { Theme } from './createMuiTheme';
+import { Theme } from './createTheme';
 
 export {
   CreateCSSProperties,

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -1,5 +1,5 @@
 import { PropInjector } from '@material-ui/types';
-import { Theme } from './createMuiTheme';
+import { Theme } from './createTheme';
 
 export interface WithTheme {
   theme: Theme;

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 import { createShallow, createMount } from 'test/utils';
 import mediaQuery from 'css-mediaquery';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import withWidth, { isWidthDown, isWidthUp } from '@material-ui/core/withWidth';
 
 function createMatchMedia(width, ref) {
@@ -153,7 +153,7 @@ describe('withWidth', () => {
 
   describe('theme prop: MuiWithWidth.initialWidth', () => {
     it('should use theme prop', () => {
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: { MuiWithWidth: { defaultProps: { initialWidth: 'lg' } } },
       });
       const element = <EmptyWithWidth theme={theme} />;
@@ -176,7 +176,7 @@ describe('withWidth', () => {
 
     it('should forward the theme', () => {
       const EmptyWithWidth2 = withWidth({ withTheme: true })(Empty);
-      const theme = createMuiTheme();
+      const theme = createTheme();
       const wrapper = mount(<EmptyWithWidth2 theme={theme} />);
       expect(wrapper.find(Empty).props().theme).to.equal(theme);
     });

--- a/packages/material-ui/test/typescript/moduleAugmentation/badgeCustomProps.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/badgeCustomProps.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Badge from '@material-ui/core/Badge';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // Update the Button's extendable props options
 declare module '@material-ui/core/Badge' {
@@ -13,7 +13,7 @@ declare module '@material-ui/core/Badge' {
 }
 
 // theme typings should work as expected
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiBadge: {
       variants: [

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.ts
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // testing docs/src/pages/customization/breakpoints/breakpoints.md
 
@@ -15,7 +15,7 @@ declare module '@material-ui/core/styles' {
   }
 }
 
-createMuiTheme({
+createTheme({
   breakpoints: {
     values: {
       tablet: 640,

--- a/packages/material-ui/test/typescript/moduleAugmentation/buttonCustomProps.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/buttonCustomProps.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // Update the Button's extendable props options
 declare module '@material-ui/core/Button' {
@@ -16,7 +16,7 @@ declare module '@material-ui/core/Button' {
 }
 
 // theme typings should work as expected
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [

--- a/packages/material-ui/test/typescript/moduleAugmentation/paletteColors.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/paletteColors.spec.ts
@@ -1,5 +1,5 @@
 // testing docs/src/pages/customization/palette/palette.md
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 declare module '@material-ui/core/styles' {
   interface Theme {
@@ -28,7 +28,7 @@ declare module '@material-ui/core/styles' {
   }
 }
 
-const theme = createMuiTheme({
+const theme = createTheme({
   status: {
     danger: '#e53e3e',
   },

--- a/packages/material-ui/test/typescript/moduleAugmentation/textFieldCustomProps.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/textFieldCustomProps.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 // Update the TextField's extendable props options
 declare module '@material-ui/core/TextField' {
@@ -34,7 +34,7 @@ declare module '@material-ui/core/styles' {
 }
 
 // theme typings should work as expected
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiOutlinedInput: {
       variants: [

--- a/packages/material-ui/test/typescript/moduleAugmentation/themeComponents.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/themeComponents.spec.ts
@@ -1,6 +1,6 @@
 // testing docs/src/pages/customization/theme-components/theme-components.md
 import { blue, red } from '@material-ui/core/colors';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 declare module '@material-ui/core/Button' {
   interface ButtonPropsVariantOverrides {
@@ -8,7 +8,7 @@ declare module '@material-ui/core/Button' {
   }
 }
 
-const theme = createMuiTheme({
+const theme = createTheme({
   components: {
     MuiButton: {
       variants: [

--- a/packages/material-ui/test/typescript/moduleAugmentation/typographyVariants.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/typographyVariants.spec.tsx
@@ -1,5 +1,5 @@
 // testing docs/src/pages/customization/typography/typography.md
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import * as React from 'react';
 
@@ -8,7 +8,7 @@ declare module '@material-ui/core/styles' {
     poster: React.CSSProperties;
   }
 
-  // allow configuration using `createMuiTheme`
+  // allow configuration using `createTheme`
   interface TypographyVariantsOptions {
     poster?: React.CSSProperties;
   }
@@ -22,7 +22,7 @@ declare module '@material-ui/core/Typography' {
   }
 }
 
-const theme = createMuiTheme({
+const theme = createTheme({
   typography: {
     poster: {
       color: 'red',

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {
   createStyles,
   withStyles,
-  createMuiTheme,
+  createTheme,
   Theme,
   withTheme,
   StyleRulesCallback,
@@ -75,7 +75,7 @@ const AnotherStyledSFC = withStyles({
 
 {
   // Overriding styles
-  const theme = createMuiTheme({
+  const theme = createTheme({
     palette: {
       mode: 'dark',
       primary: blue,
@@ -139,7 +139,7 @@ const AnotherStyledSFC = withStyles({
     <Button>Overrides</Button>
   </ThemeProvider>;
 }
-const theme2 = createMuiTheme({
+const theme2 = createTheme({
   palette: {
     primary: {
       main: blue[500],
@@ -167,12 +167,12 @@ const theme2 = createMuiTheme({
   },
 });
 
-const t1: string = createMuiTheme().spacing(1);
-const t2: string = createMuiTheme().spacing(1, 2);
-const t3: string = createMuiTheme().spacing(1, 2, 3);
-const t4: string = createMuiTheme().spacing(1, 2, 3, 4);
+const t1: string = createTheme().spacing(1);
+const t2: string = createTheme().spacing(1, 2);
+const t3: string = createTheme().spacing(1, 2, 3);
+const t4: string = createTheme().spacing(1, 2, 3, 4);
 // @ts-expect-error
-const t5 = createMuiTheme().spacing(1, 2, 3, 4, 5);
+const t5 = createTheme().spacing(1, 2, 3, 4, 5);
 
 // withTheme
 const SomeComponentWithTheme = withTheme(({ theme }: WithTheme) => <div>{theme.spacing(1)}</div>);

--- a/packages/material-ui/test/umd/run.js
+++ b/packages/material-ui/test/umd/run.js
@@ -47,7 +47,7 @@ async function createApp() {
 
   let index = await fse.readFile(path.join(rootPath, 'examples/cdn/index.html'), 'utf8');
   index = index.replace(
-    'https://unpkg.com/@material-ui/core@next/umd/material-ui.development.js',
+    'https://unpkg.com/@material-ui/core@latest/umd/material-ui.development.js',
     umdPath,
   );
   index = index.replace(

--- a/packages/material-ui/test/umd/run.js
+++ b/packages/material-ui/test/umd/run.js
@@ -47,7 +47,7 @@ async function createApp() {
 
   let index = await fse.readFile(path.join(rootPath, 'examples/cdn/index.html'), 'utf8');
   index = index.replace(
-    'https://unpkg.com/@material-ui/core@latest/umd/material-ui.development.js',
+    'https://unpkg.com/@material-ui/core@next/umd/material-ui.development.js',
     umdPath,
   );
   index = index.replace(

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -72,8 +72,8 @@ async function getWebpackEntries() {
       path: 'packages/material-ui-system/build/esm/index.js',
     },
     {
-      name: '@material-ui/core/styles/createMuiTheme',
-      path: 'packages/material-ui/build/styles/createMuiTheme.js',
+      name: '@material-ui/core/styles/createTheme',
+      path: 'packages/material-ui/build/styles/createTheme.js',
     },
     {
       name: 'colorManipulator',

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
 import * as React from 'react';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import {
   testComponentProp,
   testClassName,
@@ -57,7 +57,7 @@ function testThemeDefaultProps(element, getOptions) {
         throwMissingPropError('render');
       }
 
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: {
           [muiName]: {
             defaultProps: {
@@ -104,7 +104,7 @@ function testThemeStyleOverrides(element, getOptions) {
         marginTop: '13px',
       };
 
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: {
           [muiName]: {
             styleOverrides: {
@@ -141,7 +141,7 @@ function testThemeStyleOverrides(element, getOptions) {
         mixBlendMode: 'darken',
       };
 
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: {
           [muiName]: {
             styleOverrides: {
@@ -183,7 +183,7 @@ function testThemeStyleOverrides(element, getOptions) {
           mixBlendMode: 'darken',
         });
 
-        const themeWithoutRootOverrides = createMuiTheme({
+        const themeWithoutRootOverrides = createTheme({
           components: {
             [muiName]: {
               styleOverrides: {
@@ -235,7 +235,7 @@ function testThemeVariants(element, getOptions) {
         marginTop: '13px',
       };
 
-      const theme = createMuiTheme({
+      const theme = createTheme({
         components: {
           [muiName]: {
             variants: [


### PR DESCRIPTION
### Depreciations

- [theme] Rename createMuiTheme to createTheme.
  Developers only need one theme in their application. A prefix would suggest a second theme is needed. It's not the case.

```diff
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';

-const theme = createMuiTheme({
+const theme = createTheme({
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012.

Sorry for the huge PR. 😅 I did a search & replace for `createMuiTheme` ignoring everything from the blog, CHANGELOG and migration guides of previous versions. I didn't rename variables names: `muiTheme` -> `theme`. 

Should we rename `unstable_createMuiStrictModeTheme`?