### PR TITLE
Update typography.md

### DIFF
--- a/docs/src/pages/components/typography/typography.md
+++ b/docs/src/pages/components/typography/typography.md
@@ -27,14 +27,17 @@ Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 ## Install with npm
 
-You can [install it](https://www.npmjs.com/package/fontsource-roboto) by typing the below command in your terminal:
+You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by typing the below command in your terminal:
 
-`npm install fontsource-roboto`
+`npm install @fontsource/roboto`
 
 Then, you can import it in your entry-point.
 
 ```js
-import 'fontsource-roboto';
+import "@fontsource/roboto/300.css"
+import "@fontsource/roboto/400.css"
+import "@fontsource/roboto/500.css"
+import "@fontsource/roboto/700.css"
 ```
 
 For more info check out [Fontsource](https://github.com/DecliningLotus/fontsource/blob/master/packages/roboto/README.md).

--- a/docs/src/pages/components/typography/typography.md
+++ b/docs/src/pages/components/typography/typography.md
@@ -40,7 +40,7 @@ import "@fontsource/roboto/500.css"
 import "@fontsource/roboto/700.css"
 ```
 
-For more info check out [Fontsource](https://github.com/DecliningLotus/fontsource/blob/master/packages/roboto/README.md).
+For more info check out [Fontsource](https://github.com/fontsource/fontsource/tree/main/packages/roboto#readme).
 
 ⚠️ Be careful when using this approach.
 Make sure your bundler doesn't eager load all the font variations (100/300/400/500/700/900, italic/regular, SVG/woff). Fontsource can be configured to load specific subsets, weights and styles.


### PR DESCRIPTION
It looks like the `fontsource-roboto` package has been deprecated in favor of `@fontsource/roboto`. I also changed the import to specify the weights that Material UI uses. This may need to be amended to also include some italic variants?

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
