### PR TITLE
[test] Remove redundant render option

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -21,7 +21,6 @@ describe('<TreeItem />', () => {
   describeConformanceV5(<TreeItem nodeId="one" label="one" />, () => ({
     classes,
     inheritComponent: 'li',
-    render,
     mount,
     render,
     muiName: 'MuiTreeItem',


### PR DESCRIPTION
Broke due to https://github.com/mui-org/material-ui/pull/25835 being outdated when mergin.