### PR TITLE
[internal][pickers] Remove `AllSharedPickerProps` and `AllSharedDateRangePickerProps`

### DIFF
--- a/docs/translations/api-docs/date-range-picker/date-range-picker.json
+++ b/docs/translations/api-docs/date-range-picker/date-range-picker.json
@@ -33,7 +33,7 @@
     "minDate": "Min selectable date. @DateIOType",
     "okText": "Ok button text.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
-    "onChange": "Callback fired when the value (the selected date) changes @DateIOType.",
+    "onChange": "Callback fired when the value (the selected date range) changes @DateIOType.",
     "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",
     "onError": "Callback that fired when input value or new <code>value</code> prop validation returns <strong>new</strong> validation error (or value is valid after error). In case of validation error detected <code>reason</code> prop return non-null value and <code>TextField</code> must be displayed in <code>error</code> state. This can be used to render appropriate form error.<br><a href=\"https://next.material-ui-pickers.dev/guides/forms\">Read the guide</a> about form integration and error displaying.",
     "onMonthChange": "Callback firing on month change. @DateIOType",
@@ -63,7 +63,7 @@
     "toolbarPlaceholder": "Mobile picker date value placeholder, displaying if <code>value</code> === <code>null</code>.",
     "toolbarTitle": "Mobile picker title, displaying in the toolbar.",
     "TransitionComponent": "Custom component for popper <a href=\"https://material-ui.com/components/transitions/#transitioncomponent-prop\">Transition</a>.",
-    "value": "The value of the picker."
+    "value": "The value of the date range picker."
   },
   "classDescriptions": {}
 }

--- a/docs/translations/api-docs/desktop-date-range-picker/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/desktop-date-range-picker/desktop-date-range-picker.json
@@ -27,7 +27,7 @@
     "maxDate": "Max selectable date. @DateIOType",
     "minDate": "Min selectable date. @DateIOType",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
-    "onChange": "Callback fired when the value (the selected date) changes @DateIOType.",
+    "onChange": "Callback fired when the value (the selected date range) changes @DateIOType.",
     "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",
     "onError": "Callback that fired when input value or new <code>value</code> prop validation returns <strong>new</strong> validation error (or value is valid after error). In case of validation error detected <code>reason</code> prop return non-null value and <code>TextField</code> must be displayed in <code>error</code> state. This can be used to render appropriate form error.<br><a href=\"https://next.material-ui-pickers.dev/guides/forms\">Read the guide</a> about form integration and error displaying.",
     "onMonthChange": "Callback firing on month change. @DateIOType",
@@ -55,7 +55,7 @@
     "toolbarPlaceholder": "Mobile picker date value placeholder, displaying if <code>value</code> === <code>null</code>.",
     "toolbarTitle": "Mobile picker title, displaying in the toolbar.",
     "TransitionComponent": "Custom component for popper <a href=\"https://material-ui.com/components/transitions/#transitioncomponent-prop\">Transition</a>.",
-    "value": "The value of the picker."
+    "value": "The value of the date range picker."
   },
   "classDescriptions": {}
 }

--- a/docs/translations/api-docs/mobile-date-range-picker/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/mobile-date-range-picker/mobile-date-range-picker.json
@@ -32,7 +32,7 @@
     "minDate": "Min selectable date. @DateIOType",
     "okText": "Ok button text.",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
-    "onChange": "Callback fired when the value (the selected date) changes @DateIOType.",
+    "onChange": "Callback fired when the value (the selected date range) changes @DateIOType.",
     "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",
     "onError": "Callback that fired when input value or new <code>value</code> prop validation returns <strong>new</strong> validation error (or value is valid after error). In case of validation error detected <code>reason</code> prop return non-null value and <code>TextField</code> must be displayed in <code>error</code> state. This can be used to render appropriate form error.<br><a href=\"https://next.material-ui-pickers.dev/guides/forms\">Read the guide</a> about form integration and error displaying.",
     "onMonthChange": "Callback firing on month change. @DateIOType",
@@ -60,7 +60,7 @@
     "toolbarFormat": "Date format, that is displaying in toolbar.",
     "toolbarPlaceholder": "Mobile picker date value placeholder, displaying if <code>value</code> === <code>null</code>.",
     "toolbarTitle": "Mobile picker title, displaying in the toolbar.",
-    "value": "The value of the picker."
+    "value": "The value of the date range picker."
   },
   "classDescriptions": {}
 }

--- a/docs/translations/api-docs/static-date-range-picker/static-date-range-picker.json
+++ b/docs/translations/api-docs/static-date-range-picker/static-date-range-picker.json
@@ -28,7 +28,7 @@
     "maxDate": "Max selectable date. @DateIOType",
     "minDate": "Min selectable date. @DateIOType",
     "onAccept": "Callback fired when date is accepted @DateIOType.",
-    "onChange": "Callback fired when the value (the selected date) changes @DateIOType.",
+    "onChange": "Callback fired when the value (the selected date range) changes @DateIOType.",
     "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",
     "onError": "Callback that fired when input value or new <code>value</code> prop validation returns <strong>new</strong> validation error (or value is valid after error). In case of validation error detected <code>reason</code> prop return non-null value and <code>TextField</code> must be displayed in <code>error</code> state. This can be used to render appropriate form error.<br><a href=\"https://next.material-ui-pickers.dev/guides/forms\">Read the guide</a> about form integration and error displaying.",
     "onMonthChange": "Callback firing on month change. @DateIOType",
@@ -54,7 +54,7 @@
     "toolbarFormat": "Date format, that is displaying in toolbar.",
     "toolbarPlaceholder": "Mobile picker date value placeholder, displaying if <code>value</code> === <code>null</code>.",
     "toolbarTitle": "Mobile picker title, displaying in the toolbar.",
-    "value": "The value of the picker."
+    "value": "The value of the date range picker."
   },
   "classDescriptions": {}
 }

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -9,12 +9,12 @@ import {
 } from '../internal/pickers/wrappers/ResponsiveWrapper';
 import {
   useParsedDate,
-  OverrideParsableDateProps,
+  OverrideParseableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
 import {
-  ParsableDate,
+  ParseableDate,
   defaultMinDate,
   defaultMaxDate,
 } from '../internal/pickers/constants/prop-types';
@@ -39,10 +39,10 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 export type DatePickerView = 'year' | 'day' | 'month';
 
 export interface BaseDatePickerProps<TDate>
-  extends ValidationProps<DateValidationError, ParsableDate<TDate>>,
-    OverrideParsableDateProps<TDate, ExportedCalendarPickerProps<TDate>, 'minDate' | 'maxDate'>,
-    BasePickerProps<ParsableDate<TDate>, TDate | null>,
-    ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
+  extends ValidationProps<DateValidationError, ParseableDate<TDate>>,
+    OverrideParseableDateProps<TDate, ExportedCalendarPickerProps<TDate>, 'minDate' | 'maxDate'>,
+    BasePickerProps<ParseableDate<TDate>, TDate | null>,
+    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
   /**
    * First view to show.
    */
@@ -56,7 +56,7 @@ export interface BaseDatePickerProps<TDate>
 export const datePickerConfig = {
   useValidation: makeValidationHook<
     DateValidationError,
-    ParsableDate<unknown>,
+    ParseableDate<unknown>,
     BaseDatePickerProps<unknown>
   >(validateDate),
   DefaultToolbarComponent: DatePickerToolbar,

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -39,7 +39,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 export type DatePickerView = 'year' | 'day' | 'month';
 
 export interface BaseDatePickerProps<TDate>
-  extends ValidationProps<DateValidationError, ParsableDate>,
+  extends ValidationProps<DateValidationError, ParsableDate<TDate>>,
     OverrideParsableDateProps<TDate, ExportedCalendarPickerProps<TDate>, 'minDate' | 'maxDate'>,
     BasePickerProps<ParsableDate<TDate>, TDate | null>,
     ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
@@ -56,7 +56,7 @@ export interface BaseDatePickerProps<TDate>
 export const datePickerConfig = {
   useValidation: makeValidationHook<
     DateValidationError,
-    ParsableDate,
+    ParsableDate<unknown>,
     BaseDatePickerProps<unknown>
   >(validateDate),
   DefaultToolbarComponent: DatePickerToolbar,

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -65,7 +65,7 @@ export const datePickerConfig = {
     minDate: __minDate = defaultMinDate,
     maxDate: __maxDate = defaultMaxDate,
     ...other
-  }: BaseDatePickerProps<unknown> & AllSharedPickerProps) => {
+  }: BaseDatePickerProps<unknown>) => {
     const utils = useUtils();
     const minDate = useParsedDate(__minDate);
     const maxDate = useParsedDate(__maxDate);

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import DatePickerToolbar from './DatePickerToolbar';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import {
   ResponsiveWrapper,
   ResponsiveWrapperProps,
@@ -25,8 +24,9 @@ import {
   parsePickerInputValue,
 } from '../internal/pickers/date-utils';
 import Picker from '../internal/pickers/Picker/Picker';
+import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
+import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { getFormatAndMaskByViews } from './shared';
 
@@ -41,7 +41,8 @@ export type DatePickerView = 'year' | 'day' | 'month';
 export interface BaseDatePickerProps<TDate>
   extends ValidationProps<DateValidationError, ParsableDate>,
     OverrideParsableDateProps<TDate, ExportedCalendarPickerProps<TDate>, 'minDate' | 'maxDate'>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null> {
+    BasePickerProps<ParsableDate<TDate>, TDate | null>,
+    ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
   /**
    * First view to show.
    */

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -8,9 +8,13 @@ import {
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
-import { RangeInput, AllSharedDateRangePickerProps, DateRange } from './RangeTypes';
+import { RangeInput, DateRange } from './RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
+import {
+  usePickerState,
+  PickerStateValueManager,
+  PickerStateProps,
+} from '../internal/pickers/hooks/usePickerState';
 import { DateRangePickerView, ExportedDateRangePickerViewProps } from './DateRangePickerView';
 import DateRangePickerInput, { ExportedDateRangePickerInputProps } from './DateRangePickerInput';
 import {
@@ -24,11 +28,6 @@ interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
-  /**
-   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
-   * @default '__/__/____'
-   */
-  mask?: AllSharedDateRangePickerProps<TDate>['mask'];
   /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
@@ -49,12 +48,15 @@ interface BaseDateRangePickerProps<TDate>
    * @default 'End'
    */
   endText?: React.ReactNode;
+
+  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
+  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
 }
 
 const useDateRangeValidation = makeValidationHook<
   DateRangeValidationError,
   RangeInput<unknown>,
-  BaseDateRangePickerProps<any>
+  DateRangePickerProps<any>
 >(validateDateRange, {
   isSameError: (a, b) => b !== null && a[1] === b[1] && a[0] === b[0],
 });
@@ -70,7 +72,6 @@ const rangePickerValueManager: PickerStateValueManager<any, any> = {
 
 export interface DateRangePickerProps<TDate>
   extends BaseDateRangePickerProps<TDate>,
-    AllSharedDateRangePickerProps<TDate>,
     ResponsiveWrapperProps {}
 
 type DateRangePickerComponent = (<TDate>(
@@ -131,7 +132,7 @@ const DateRangePicker = React.forwardRef(function DateRangePicker<TDate>(
     DateRange<TDate>
   >(pickerStateProps, rangePickerValueManager);
 
-  const validationError = useDateRangeValidation(value, restProps);
+  const validationError = useDateRangeValidation(value, props);
 
   const DateInputProps = {
     ...inputProps,

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -10,11 +10,7 @@ import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
 import { RangeInput, DateRange } from './RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import {
-  usePickerState,
-  PickerStateValueManager,
-  PickerStateProps,
-} from '../internal/pickers/hooks/usePickerState';
+import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { DateRangePickerView, ExportedDateRangePickerViewProps } from './DateRangePickerView';
 import DateRangePickerInput, { ExportedDateRangePickerInputProps } from './DateRangePickerInput';
 import {
@@ -29,6 +25,16 @@ interface BaseDateRangePickerProps<TDate>
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
   /**
+   * Text for end input label and toolbar placeholder.
+   * @default 'End'
+   */
+  endText?: React.ReactNode;
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   * @default '__/__/____'
+   */
+  mask?: ExportedDateRangePickerInputProps['mask'];
+  /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
    */
@@ -39,18 +45,18 @@ interface BaseDateRangePickerProps<TDate>
    */
   maxDate?: TDate;
   /**
+   * Callback fired when the value (the selected date range) changes @DateIOType.
+   */
+  onChange: (date: DateRange<TDate>, keyboardInputValue?: string) => void;
+  /**
    * Text for start input label and toolbar placeholder.
    * @default 'Start'
    */
   startText?: React.ReactNode;
   /**
-   * Text for end input label and toolbar placeholder.
-   * @default 'End'
+   * The value of the date range picker.
    */
-  endText?: React.ReactNode;
-
-  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
-  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
+  value: RangeInput<TDate>;
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -368,7 +374,7 @@ DateRangePicker.propTypes /* remove-proptypes */ = {
    */
   onAccept: PropTypes.func,
   /**
-   * Callback fired when the value (the selected date) changes @DateIOType.
+   * Callback fired when the value (the selected date range) changes @DateIOType.
    */
   onChange: PropTypes.func.isRequired,
   /**
@@ -520,7 +526,7 @@ DateRangePicker.propTypes /* remove-proptypes */ = {
    */
   TransitionComponent: PropTypes.elementType,
   /**
-   * The value of the picker.
+   * The value of the date range picker.
    */
   value: PropTypes.arrayOf(
     PropTypes.oneOfType([

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePickerInput.tsx
@@ -6,7 +6,11 @@ import { useMaskedInput } from '../internal/pickers/hooks/useMaskedInput';
 import { DateRangeValidationError } from '../internal/pickers/date-utils';
 import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { executeInTheNextEventLoopTick } from '../internal/pickers/utils';
-import { DateInputProps, MuiTextFieldProps } from '../internal/pickers/PureDateInput';
+import {
+  DateInputProps,
+  ExportedDateInputProps,
+  MuiTextFieldProps,
+} from '../internal/pickers/PureDateInput';
 
 export type DateRangePickerInputClassKey = 'root' | 'toLabelDelimiter';
 
@@ -29,7 +33,8 @@ export const styles: MuiStyles<DateRangePickerInputClassKey> = (
   },
 });
 
-export interface ExportedDateRangePickerInputProps {
+export interface ExportedDateRangePickerInputProps
+  extends Omit<ExportedDateInputProps<RangeInput<any>, DateRange<any>>, 'renderInput'> {
   /**
    * The `renderInput` prop allows you to customize the rendered input.
    * The `startProps` and `endProps` arguments of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api),

--- a/packages/material-ui-lab/src/DateRangePicker/RangeTypes.ts
+++ b/packages/material-ui-lab/src/DateRangePicker/RangeTypes.ts
@@ -1,13 +1,13 @@
 import { ParsableDate } from '../internal/pickers/constants/prop-types';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
+import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 
 export type RangeInput<TDate> = [ParsableDate<TDate>, ParsableDate<TDate>];
 export type DateRange<TDate> = [TDate | null, TDate | null];
 export type NonEmptyDateRange<TDate> = [TDate, TDate];
 
 export type AllSharedDateRangePickerProps<TDate> = Omit<
-  AllSharedPickerProps<RangeInput<TDate>, DateRange<TDate>>,
-  'renderInput' | 'orientation'
+  BasePickerProps<RangeInput<TDate>, DateRange<TDate>>,
+  'orientation'
 > &
   import('./DateRangePickerInput').ExportedDateRangePickerInputProps;
 

--- a/packages/material-ui-lab/src/DateRangePicker/RangeTypes.ts
+++ b/packages/material-ui-lab/src/DateRangePicker/RangeTypes.ts
@@ -1,7 +1,7 @@
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
+import { ParseableDate } from '../internal/pickers/constants/prop-types';
 import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 
-export type RangeInput<TDate> = [ParsableDate<TDate>, ParsableDate<TDate>];
+export type RangeInput<TDate> = [ParseableDate<TDate>, ParseableDate<TDate>];
 export type DateRange<TDate> = [TDate | null, TDate | null];
 export type NonEmptyDateRange<TDate> = [TDate, TDate];
 

--- a/packages/material-ui-lab/src/DateRangePicker/RangeTypes.ts
+++ b/packages/material-ui-lab/src/DateRangePicker/RangeTypes.ts
@@ -1,15 +1,8 @@
 import { ParseableDate } from '../internal/pickers/constants/prop-types';
-import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 
 export type RangeInput<TDate> = [ParseableDate<TDate>, ParseableDate<TDate>];
 export type DateRange<TDate> = [TDate | null, TDate | null];
 export type NonEmptyDateRange<TDate> = [TDate, TDate];
-
-export type AllSharedDateRangePickerProps<TDate> = Omit<
-  BasePickerProps<RangeInput<TDate>, DateRange<TDate>>,
-  'orientation'
-> &
-  import('./DateRangePickerInput').ExportedDateRangePickerInputProps;
 
 export interface CurrentlySelectingRangeEndProps {
   currentlySelectingRangeEnd: 'start' | 'end';

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -14,7 +14,6 @@ import {
   OverrideParsableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import { DateAndTimeValidationError, validateDateAndTime } from './date-time-utils';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
 import {
@@ -23,9 +22,10 @@ import {
   defaultMaxDate,
 } from '../internal/pickers/constants/prop-types';
 import Picker from '../internal/pickers/Picker/Picker';
+import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
+import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import { DateTimePickerView } from './shared';
 
@@ -42,7 +42,8 @@ export interface BaseDateTimePickerProps<TDate>
       ExportedClockPickerProps<TDate> & ExportedCalendarPickerProps<TDate>,
       'minDate' | 'maxDate' | 'minTime' | 'maxTime'
     >,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null> {
+    BasePickerProps<ParsableDate<TDate>, TDate | null>,
+    ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
   /**
    * To show tabs.
    */

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -90,7 +90,7 @@ function useInterceptProps({
   orientation = 'portrait',
   views = ['year', 'day', 'hours', 'minutes'],
   ...other
-}: BaseDateTimePickerProps<unknown> & AllSharedPickerProps) {
+}: BaseDateTimePickerProps<unknown>) {
   const utils = useUtils();
   const minTime = useParsedDate(__minTime);
   const maxTime = useParsedDate(__maxTime);

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -36,7 +36,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 };
 
 export interface BaseDateTimePickerProps<TDate>
-  extends ValidationProps<DateAndTimeValidationError, ParsableDate>,
+  extends ValidationProps<DateAndTimeValidationError, ParsableDate<TDate>>,
     OverrideParsableDateProps<
       TDate,
       ExportedClockPickerProps<TDate> & ExportedCalendarPickerProps<TDate>,
@@ -133,7 +133,7 @@ function useInterceptProps({
 
 const useValidation = makeValidationHook<
   DateAndTimeValidationError,
-  ParsableDate,
+  ParsableDate<unknown>,
   BaseDateTimePickerProps<unknown>
 >(validateDateAndTime);
 

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -11,13 +11,13 @@ import {
 import { pick12hOr24hFormat } from '../internal/pickers/text-field-helper';
 import {
   useParsedDate,
-  OverrideParsableDateProps,
+  OverrideParseableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
 import { DateAndTimeValidationError, validateDateAndTime } from './date-time-utils';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
 import {
-  ParsableDate,
+  ParseableDate,
   defaultMinDate,
   defaultMaxDate,
 } from '../internal/pickers/constants/prop-types';
@@ -36,14 +36,14 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 };
 
 export interface BaseDateTimePickerProps<TDate>
-  extends ValidationProps<DateAndTimeValidationError, ParsableDate<TDate>>,
-    OverrideParsableDateProps<
+  extends ValidationProps<DateAndTimeValidationError, ParseableDate<TDate>>,
+    OverrideParseableDateProps<
       TDate,
       ExportedClockPickerProps<TDate> & ExportedCalendarPickerProps<TDate>,
       'minDate' | 'maxDate' | 'minTime' | 'maxTime'
     >,
-    BasePickerProps<ParsableDate<TDate>, TDate | null>,
-    ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
+    BasePickerProps<ParseableDate<TDate>, TDate | null>,
+    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
   /**
    * To show tabs.
    */
@@ -59,11 +59,11 @@ export interface BaseDateTimePickerProps<TDate>
   /**
    * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
    */
-  minDateTime?: ParsableDate<TDate>;
+  minDateTime?: ParseableDate<TDate>;
   /**
    * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
    */
-  maxDateTime?: ParsableDate<TDate>;
+  maxDateTime?: ParseableDate<TDate>;
   /**
    * First view to show.
    */
@@ -133,7 +133,7 @@ function useInterceptProps({
 
 const useValidation = makeValidationHook<
   DateAndTimeValidationError,
-  ParsableDate<unknown>,
+  ParseableDate<unknown>,
   BaseDateTimePickerProps<unknown>
 >(validateDateAndTime);
 

--- a/packages/material-ui-lab/src/DateTimePicker/date-time-utils.ts
+++ b/packages/material-ui-lab/src/DateTimePicker/date-time-utils.ts
@@ -1,11 +1,11 @@
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
+import { ParseableDate } from '../internal/pickers/constants/prop-types';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { DateValidationProps, validateDate } from '../internal/pickers/date-utils';
 import { TimeValidationProps, validateTime } from '../internal/pickers/time-utils';
 
 export function validateDateAndTime<TDate>(
   utils: MuiPickersAdapter<TDate>,
-  value: ParsableDate<TDate>,
+  value: ParseableDate<TDate>,
   {
     minDate,
     maxDate,

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -7,11 +7,7 @@ import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
 import { RangeInput, DateRange } from '../DateRangePicker/RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import {
-  usePickerState,
-  PickerStateValueManager,
-  PickerStateProps,
-} from '../internal/pickers/hooks/usePickerState';
+import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
@@ -32,6 +28,16 @@ interface BaseDateRangePickerProps<TDate>
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
   /**
+   * Text for end input label and toolbar placeholder.
+   * @default 'End'
+   */
+  endText?: React.ReactNode;
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   * @default '__/__/____'
+   */
+  mask?: ExportedDateRangePickerInputProps['mask'];
+  /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
    */
@@ -42,17 +48,18 @@ interface BaseDateRangePickerProps<TDate>
    */
   maxDate?: TDate;
   /**
+   * Callback fired when the value (the selected date range) changes @DateIOType.
+   */
+  onChange: (date: DateRange<TDate>, keyboardInputValue?: string) => void;
+  /**
    * Text for start input label and toolbar placeholder.
    * @default 'Start'
    */
   startText?: React.ReactNode;
   /**
-   * Text for end input label and toolbar placeholder.
-   * @default 'End'
+   * The value of the date range picker.
    */
-  endText?: React.ReactNode;
-  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
-  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
+  value: RangeInput<TDate>;
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -340,7 +347,7 @@ DesktopDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   onAccept: PropTypes.func,
   /**
-   * Callback fired when the value (the selected date) changes @DateIOType.
+   * Callback fired when the value (the selected date range) changes @DateIOType.
    */
   onChange: PropTypes.func.isRequired,
   /**
@@ -482,7 +489,7 @@ DesktopDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   TransitionComponent: PropTypes.elementType,
   /**
-   * The value of the picker.
+   * The value of the date range picker.
    */
   value: PropTypes.arrayOf(
     PropTypes.oneOfType([

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -5,13 +5,13 @@ import DesktopTooltipWrapper from '../internal/pickers/wrappers/DesktopTooltipWr
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
-import {
-  RangeInput,
-  AllSharedDateRangePickerProps,
-  DateRange,
-} from '../DateRangePicker/RangeTypes';
+import { RangeInput, DateRange } from '../DateRangePicker/RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
+import {
+  usePickerState,
+  PickerStateValueManager,
+  PickerStateProps,
+} from '../internal/pickers/hooks/usePickerState';
 import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
@@ -27,15 +27,10 @@ import {
 import { DateInputPropsLike } from '../internal/pickers/wrappers/WrapperProps';
 import { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 
-export interface BaseDateRangePickerProps<TDate>
+interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
-  /**
-   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
-   * @default '__/__/____'
-   */
-  mask?: AllSharedDateRangePickerProps<TDate>['mask'];
   /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
@@ -56,6 +51,8 @@ export interface BaseDateRangePickerProps<TDate>
    * @default 'End'
    */
   endText?: React.ReactNode;
+  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
+  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -77,7 +74,6 @@ const rangePickerValueManager: PickerStateValueManager<any, any> = {
 
 export interface DesktopDateRangePickerProps<TDate = unknown>
   extends BaseDateRangePickerProps<TDate>,
-    AllSharedDateRangePickerProps<TDate>,
     DesktopWrapperProps {}
 
 type DesktopDateRangePickerComponent = (<TDate>(
@@ -138,7 +134,7 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
     DateRange<TDate>
   >(pickerStateProps, rangePickerValueManager);
 
-  const validationError = useDateRangeValidation(value, restProps);
+  const validationError = useDateRangeValidation(value, props);
 
   const DateInputProps = {
     ...inputProps,

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -5,13 +5,13 @@ import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
-import {
-  RangeInput,
-  AllSharedDateRangePickerProps,
-  DateRange,
-} from '../DateRangePicker/RangeTypes';
+import { RangeInput, DateRange } from '../DateRangePicker/RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
+import {
+  usePickerState,
+  PickerStateValueManager,
+  PickerStateProps,
+} from '../internal/pickers/hooks/usePickerState';
 import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
@@ -26,15 +26,10 @@ import {
 } from '../internal/pickers/date-utils';
 import { DateInputPropsLike } from '../internal/pickers/wrappers/WrapperProps';
 
-export interface BaseDateRangePickerProps<TDate>
+interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
-  /**
-   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
-   * @default '__/__/____'
-   */
-  mask?: AllSharedDateRangePickerProps<TDate>['mask'];
   /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
@@ -55,6 +50,8 @@ export interface BaseDateRangePickerProps<TDate>
    * @default 'End'
    */
   endText?: React.ReactNode;
+  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
+  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -76,7 +73,6 @@ const rangePickerValueManager: PickerStateValueManager<any, any> = {
 
 export interface MobileDateRangePickerProps<TDate = unknown>
   extends BaseDateRangePickerProps<TDate>,
-    AllSharedDateRangePickerProps<TDate>,
     MobileWrapperProps {}
 
 type MobileDateRangePickerComponent = (<TDate>(
@@ -137,7 +133,7 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
     DateRange<TDate>
   >(pickerStateProps, rangePickerValueManager);
 
-  const validationError = useDateRangeValidation(value, restProps);
+  const validationError = useDateRangeValidation(value, props);
 
   const DateInputProps = {
     ...inputProps,

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -7,11 +7,7 @@ import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
 import { RangeInput, DateRange } from '../DateRangePicker/RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import {
-  usePickerState,
-  PickerStateValueManager,
-  PickerStateProps,
-} from '../internal/pickers/hooks/usePickerState';
+import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
@@ -31,6 +27,16 @@ interface BaseDateRangePickerProps<TDate>
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
   /**
+   * Text for end input label and toolbar placeholder.
+   * @default 'End'
+   */
+  endText?: React.ReactNode;
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   * @default '__/__/____'
+   */
+  mask?: ExportedDateRangePickerInputProps['mask'];
+  /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
    */
@@ -41,17 +47,18 @@ interface BaseDateRangePickerProps<TDate>
    */
   maxDate?: TDate;
   /**
+   * Callback fired when the value (the selected date range) changes @DateIOType.
+   */
+  onChange: (date: DateRange<TDate>, keyboardInputValue?: string) => void;
+  /**
    * Text for start input label and toolbar placeholder.
    * @default 'Start'
    */
   startText?: React.ReactNode;
   /**
-   * Text for end input label and toolbar placeholder.
-   * @default 'End'
+   * The value of the date range picker.
    */
-  endText?: React.ReactNode;
-  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
-  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
+  value: RangeInput<TDate>;
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -363,7 +370,7 @@ MobileDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   onAccept: PropTypes.func,
   /**
-   * Callback fired when the value (the selected date) changes @DateIOType.
+   * Callback fired when the value (the selected date range) changes @DateIOType.
    */
   onChange: PropTypes.func.isRequired,
   /**
@@ -507,7 +514,7 @@ MobileDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   toolbarTitle: PropTypes.node,
   /**
-   * The value of the picker.
+   * The value of the date range picker.
    */
   value: PropTypes.arrayOf(
     PropTypes.oneOfType([

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -7,11 +7,7 @@ import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
 import { RangeInput, DateRange } from '../DateRangePicker/RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import {
-  usePickerState,
-  PickerStateValueManager,
-  PickerStateProps,
-} from '../internal/pickers/hooks/usePickerState';
+import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
@@ -31,6 +27,16 @@ interface BaseDateRangePickerProps<TDate>
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
   /**
+   * Text for end input label and toolbar placeholder.
+   * @default 'End'
+   */
+  endText?: React.ReactNode;
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   * @default '__/__/____'
+   */
+  mask?: ExportedDateRangePickerInputProps['mask'];
+  /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
    */
@@ -41,17 +47,18 @@ interface BaseDateRangePickerProps<TDate>
    */
   maxDate?: TDate;
   /**
+   * Callback fired when the value (the selected date range) changes @DateIOType.
+   */
+  onChange: (date: DateRange<TDate>, keyboardInputValue?: string) => void;
+  /**
    * Text for start input label and toolbar placeholder.
    * @default 'Start'
    */
   startText?: React.ReactNode;
   /**
-   * Text for end input label and toolbar placeholder.
-   * @default 'End'
+   * The value of the date range picker.
    */
-  endText?: React.ReactNode;
-  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
-  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
+  value: RangeInput<TDate>;
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -344,7 +351,7 @@ StaticDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   onAccept: PropTypes.func,
   /**
-   * Callback fired when the value (the selected date) changes @DateIOType.
+   * Callback fired when the value (the selected date range) changes @DateIOType.
    */
   onChange: PropTypes.func.isRequired,
   /**
@@ -478,7 +485,7 @@ StaticDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   toolbarTitle: PropTypes.node,
   /**
-   * The value of the picker.
+   * The value of the date range picker.
    */
   value: PropTypes.arrayOf(
     PropTypes.oneOfType([

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -5,13 +5,13 @@ import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/
 import { useUtils } from '../internal/pickers/hooks/useUtils';
 import { useParsedDate } from '../internal/pickers/hooks/date-helpers-hooks';
 import { defaultMinDate, defaultMaxDate } from '../internal/pickers/constants/prop-types';
-import {
-  RangeInput,
-  AllSharedDateRangePickerProps,
-  DateRange,
-} from '../DateRangePicker/RangeTypes';
+import { RangeInput, DateRange } from '../DateRangePicker/RangeTypes';
 import { makeValidationHook, ValidationProps } from '../internal/pickers/hooks/useValidation';
-import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
+import {
+  usePickerState,
+  PickerStateValueManager,
+  PickerStateProps,
+} from '../internal/pickers/hooks/usePickerState';
 import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
@@ -30,11 +30,6 @@ interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
     ValidationProps<DateRangeValidationError, RangeInput<TDate>>,
     ExportedDateRangePickerInputProps {
-  /**
-   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
-   * @default '__/__/____'
-   */
-  mask?: AllSharedDateRangePickerProps<TDate>['mask'];
   /**
    * Min selectable date. @DateIOType
    * @default defaultMinDate
@@ -55,6 +50,8 @@ interface BaseDateRangePickerProps<TDate>
    * @default 'End'
    */
   endText?: React.ReactNode;
+  onChange: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['onChange'];
+  value: PickerStateProps<RangeInput<TDate>, DateRange<TDate>>['value'];
 }
 
 const useDateRangeValidation = makeValidationHook<
@@ -76,7 +73,6 @@ const rangePickerValueManager: PickerStateValueManager<any, any> = {
 
 export interface StaticDateRangePickerProps<TDate = unknown>
   extends BaseDateRangePickerProps<TDate>,
-    AllSharedDateRangePickerProps<TDate>,
     StaticWrapperProps {}
 
 type StaticDateRangePickerComponent = (<TDate>(
@@ -137,7 +133,7 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
     DateRange<TDate>
   >(pickerStateProps, rangePickerValueManager);
 
-  const validationError = useDateRangeValidation(value, restProps);
+  const validationError = useDateRangeValidation(value, props);
 
   const DateInputProps = {
     ...inputProps,

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -47,7 +47,7 @@ export interface BaseTimePickerProps<TDate = unknown>
   views?: readonly TimePickerView[];
 }
 
-export function getTextFieldAriaText(value: ParsableDate, utils: MuiPickersAdapter) {
+export function getTextFieldAriaText<TDate>(value: ParsableDate<TDate>, utils: MuiPickersAdapter) {
   return value && utils.isValid(utils.date(value))
     ? `Choose time, selected time is ${utils.format(utils.date(value), 'fullTime')}`
     : 'Choose time';
@@ -90,9 +90,11 @@ function useInterceptProps({
 
 export const timePickerConfig = {
   useInterceptProps,
-  useValidation: makeValidationHook<TimeValidationError, ParsableDate, BaseTimePickerProps>(
-    validateTime,
-  ),
+  useValidation: makeValidationHook<
+    TimeValidationError,
+    ParsableDate<unknown>,
+    BaseTimePickerProps<unknown>
+  >(validateTime),
   DefaultToolbarComponent: TimePickerToolbar,
 };
 

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
 import ClockIcon from '../internal/svg-icons/Clock';
-import { ParsableDate } from '../internal/pickers/constants/prop-types';
+import { ParseableDate } from '../internal/pickers/constants/prop-types';
 import TimePickerToolbar from './TimePickerToolbar';
 import { ExportedClockPickerProps } from '../ClockPicker/ClockPicker';
 import {
@@ -15,7 +15,7 @@ import { validateTime, TimeValidationError } from '../internal/pickers/time-util
 import { ValidationProps, makeValidationHook } from '../internal/pickers/hooks/useValidation';
 import {
   useParsedDate,
-  OverrideParsableDateProps,
+  OverrideParseableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import Picker from '../internal/pickers/Picker/Picker';
 import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
@@ -33,10 +33,10 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 export type TimePickerView = 'hours' | 'minutes' | 'seconds';
 
 export interface BaseTimePickerProps<TDate = unknown>
-  extends ValidationProps<TimeValidationError, ParsableDate<TDate>>,
-    OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'>,
-    BasePickerProps<ParsableDate<TDate>, TDate | null>,
-    ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
+  extends ValidationProps<TimeValidationError, ParseableDate<TDate>>,
+    OverrideParseableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'>,
+    BasePickerProps<ParseableDate<TDate>, TDate | null>,
+    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
   /**
    * First view to show.
    */
@@ -47,7 +47,7 @@ export interface BaseTimePickerProps<TDate = unknown>
   views?: readonly TimePickerView[];
 }
 
-export function getTextFieldAriaText<TDate>(value: ParsableDate<TDate>, utils: MuiPickersAdapter) {
+export function getTextFieldAriaText<TDate>(value: ParseableDate<TDate>, utils: MuiPickersAdapter) {
   return value && utils.isValid(utils.date(value))
     ? `Choose time, selected time is ${utils.format(utils.date(value), 'fullTime')}`
     : 'Choose time';
@@ -92,7 +92,7 @@ export const timePickerConfig = {
   useInterceptProps,
   useValidation: makeValidationHook<
     TimeValidationError,
-    ParsableDate<unknown>,
+    ParseableDate<unknown>,
     BaseTimePickerProps<unknown>
   >(validateTime),
   DefaultToolbarComponent: TimePickerToolbar,

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -12,16 +12,16 @@ import {
 import { pick12hOr24hFormat } from '../internal/pickers/text-field-helper';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { validateTime, TimeValidationError } from '../internal/pickers/time-utils';
-import { AllSharedPickerProps } from '../internal/pickers/Picker/SharedPickerProps';
 import { ValidationProps, makeValidationHook } from '../internal/pickers/hooks/useValidation';
 import {
   useParsedDate,
   OverrideParsableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import Picker from '../internal/pickers/Picker/Picker';
+import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
+import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -35,7 +35,8 @@ export type TimePickerView = 'hours' | 'minutes' | 'seconds';
 export interface BaseTimePickerProps<TDate = unknown>
   extends ValidationProps<TimeValidationError, ParsableDate<TDate>>,
     OverrideParsableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'>,
-    AllSharedPickerProps<ParsableDate<TDate>, TDate | null> {
+    BasePickerProps<ParsableDate<TDate>, TDate | null>,
+    ExportedDateInputProps<ParsableDate<TDate>, TDate | null> {
   /**
    * First view to show.
    */

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -60,7 +60,7 @@ function useInterceptProps({
   openTo = 'hours',
   views = ['hours', 'minutes'],
   ...other
-}: BaseTimePickerProps & AllSharedPickerProps) {
+}: BaseTimePickerProps) {
   const utils = useUtils();
 
   const minTime = useParsedDate(__minTime);

--- a/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/SharedPickerProps.tsx
@@ -1,6 +1,0 @@
-import { BasePickerProps } from '../typings/BasePicker';
-import { ExportedDateInputProps } from '../PureDateInput';
-
-export interface AllSharedPickerProps<TInputValue = any, TDateValue = any>
-  extends BasePickerProps<TInputValue, TDateValue>,
-    ExportedDateInputProps<TInputValue, TDateValue> {}

--- a/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
@@ -4,14 +4,14 @@ import { TextFieldProps as MuiTextFieldPropsType } from '@material-ui/core/TextF
 import { IconButtonProps } from '@material-ui/core/IconButton';
 import { InputAdornmentProps } from '@material-ui/core/InputAdornment';
 import { onSpaceOrEnter } from './utils';
-import { ParsableDate } from './constants/prop-types';
+import { ParseableDate } from './constants/prop-types';
 import { useUtils, MuiPickersAdapter } from './hooks/useUtils';
 import { getDisplayDate, getTextFieldAriaText } from './text-field-helper';
 
 // make `variant` optional.
 export type MuiTextFieldProps = MuiTextFieldPropsType | Omit<MuiTextFieldPropsType, 'variant'>;
 
-export interface DateInputProps<TInputValue = ParsableDate<unknown>, TDateValue = unknown> {
+export interface DateInputProps<TInputValue = ParseableDate<unknown>, TDateValue = unknown> {
   /**
    * Regular expression to detect "accepted" symbols.
    * @default /\dap/gi
@@ -33,7 +33,7 @@ export interface DateInputProps<TInputValue = ParsableDate<unknown>, TDateValue 
    * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
    */
   getOpenDialogAriaText?: (
-    value: ParsableDate<TDateValue>,
+    value: ParseableDate<TDateValue>,
     utils: MuiPickersAdapter<TDateValue>,
   ) => string;
   // ?? TODO when it will be possible to display "empty" date in datepicker use it instead of ignoring invalid inputs.

--- a/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PureDateInput.tsx
@@ -11,7 +11,7 @@ import { getDisplayDate, getTextFieldAriaText } from './text-field-helper';
 // make `variant` optional.
 export type MuiTextFieldProps = MuiTextFieldPropsType | Omit<MuiTextFieldPropsType, 'variant'>;
 
-export interface DateInputProps<TInputValue = ParsableDate, TDateValue = unknown> {
+export interface DateInputProps<TInputValue = ParsableDate<unknown>, TDateValue = unknown> {
   /**
    * Regular expression to detect "accepted" symbols.
    * @default /\dap/gi
@@ -32,7 +32,10 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = unknown
    * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
    * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
    */
-  getOpenDialogAriaText?: (value: ParsableDate, utils: MuiPickersAdapter) => string;
+  getOpenDialogAriaText?: (
+    value: ParsableDate<TDateValue>,
+    utils: MuiPickersAdapter<TDateValue>,
+  ) => string;
   // ?? TODO when it will be possible to display "empty" date in datepicker use it instead of ignoring invalid inputs.
   ignoreInvalidInputs?: boolean;
   /**

--- a/packages/material-ui-lab/src/internal/pickers/constants/prop-types.ts
+++ b/packages/material-ui-lab/src/internal/pickers/constants/prop-types.ts
@@ -1,4 +1,4 @@
-export type ParsableDate<TDate> = string | number | Date | null | undefined | TDate;
+export type ParseableDate<TDate> = string | number | Date | null | undefined | TDate;
 
 export const defaultMinDate = new Date('1900-01-01') as unknown;
 

--- a/packages/material-ui-lab/src/internal/pickers/constants/prop-types.ts
+++ b/packages/material-ui-lab/src/internal/pickers/constants/prop-types.ts
@@ -1,4 +1,4 @@
-export type ParsableDate<TDate = unknown> = string | number | Date | null | undefined | TDate;
+export type ParsableDate<TDate> = string | number | Date | null | undefined | TDate;
 
 export const defaultMinDate = new Date('1900-01-01') as unknown;
 

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.ts
@@ -1,5 +1,5 @@
 import { RangeInput, NonEmptyDateRange, DateRange } from '../../DateRangePicker/RangeTypes';
-import { ParsableDate } from './constants/prop-types';
+import { ParseableDate } from './constants/prop-types';
 import { MuiPickersAdapter } from './hooks/useUtils';
 
 interface FindClosestDateParams<TDate> {
@@ -148,7 +148,7 @@ export interface DateValidationProps<TDate> {
 
 export const validateDate = <TDate>(
   utils: MuiPickersAdapter<TDate>,
-  value: TDate | ParsableDate<TDate>,
+  value: TDate | ParseableDate<TDate>,
   { disablePast, disableFuture, minDate, maxDate, shouldDisableDate }: DateValidationProps<TDate>,
 ) => {
   const now = utils.date()!;

--- a/packages/material-ui-lab/src/internal/pickers/date-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/date-utils.ts
@@ -148,7 +148,7 @@ export interface DateValidationProps<TDate> {
 
 export const validateDate = <TDate>(
   utils: MuiPickersAdapter<TDate>,
-  value: TDate | ParsableDate,
+  value: TDate | ParsableDate<TDate>,
   { disablePast, disableFuture, minDate, maxDate, shouldDisableDate }: DateValidationProps<TDate>,
 ) => {
   const now = utils.date()!;

--- a/packages/material-ui-lab/src/internal/pickers/hooks/date-helpers-hooks.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/date-helpers-hooks.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { useUtils } from './useUtils';
-import { ParsableDate } from '../constants/prop-types';
+import { ParseableDate } from '../constants/prop-types';
 import { PickerOnChangeFn } from './useViews';
 import { getMeridiem, convertToMeridiem } from '../time-utils';
 
-export type OverrideParsableDateProps<TDate, TProps, TKey extends keyof TProps> = Omit<
+export type OverrideParseableDateProps<TDate, TProps, TKey extends keyof TProps> = Omit<
   TProps,
   TKey
 > &
-  Partial<Record<TKey, ParsableDate<TDate>>>;
+  Partial<Record<TKey, ParseableDate<TDate>>>;
 
 export function useParsedDate<TDate>(
-  possiblyUnparsedValue: ParsableDate<TDate>,
+  possiblyUnparsedValue: ParseableDate<TDate>,
 ): TDate | undefined {
   const utils = useUtils<TDate>();
   return React.useMemo(

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
@@ -3,8 +3,8 @@ import { MuiPickersAdapterContext } from '../../../LocalizationProvider';
 
 // Required for babel https://github.com/vercel/next.js/issues/7882. Replace with `export type` in future
 export type MuiPickersAdapter<
-  T = unknown
-> = import('../../../LocalizationProvider/LocalizationProvider').MuiPickersAdapter<T>;
+  TDate = unknown
+> = import('../../../LocalizationProvider/LocalizationProvider').MuiPickersAdapter<TDate>;
 
 // TODO uncomment when syntax will be allowed by next babel
 function checkUtils(utils: MuiPickersAdapter | null) /* :asserts utils is MuiPickersAdapter */ {

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useValidation.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useValidation.ts
@@ -26,8 +26,8 @@ export function makeValidationHook<
 >(
   validateFn: (utils: MuiPickersAdapter, value: TDateValue, props: TProps) => TError,
   { isSameError = defaultIsSameError }: ValidationHookOptions<TError> = {},
-) {
-  return (value: TDateValue, props: TProps) => {
+): (value: TDateValue, props: TProps) => TError {
+  return function useValidation(value: TDateValue, props: TProps): TError {
     const utils = useUtils();
     const previousValidationErrorRef = React.useRef<TError | null>(null);
 

--- a/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
+++ b/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
@@ -1,15 +1,18 @@
 import { ParsableDate } from './constants/prop-types';
 import { MuiPickersAdapter } from './hooks/useUtils';
 
-export function getTextFieldAriaText(rawValue: ParsableDate, utils: MuiPickersAdapter) {
+export function getTextFieldAriaText<TDate>(
+  rawValue: ParsableDate<TDate>,
+  utils: MuiPickersAdapter<TDate>,
+) {
   return rawValue && utils.isValid(utils.date(rawValue))
     ? `Choose date, selected date is ${utils.format(utils.date(rawValue), 'fullDate')}`
     : 'Choose date';
 }
 
-export const getDisplayDate = (
-  utils: MuiPickersAdapter,
-  value: ParsableDate,
+export const getDisplayDate = <TDate>(
+  utils: MuiPickersAdapter<TDate>,
+  value: ParsableDate<TDate>,
   inputFormat: string,
 ) => {
   const date = utils.date(value);
@@ -19,7 +22,15 @@ export const getDisplayDate = (
     return '';
   }
 
-  return utils.isValid(date) ? utils.formatByString(date, inputFormat) : '';
+  return utils.isValid(date)
+    ? utils.formatByString(
+        // TODO: should `isValid` narrow `TDate | null` to `NonNullable<TDate>`?
+        // Either we allow `TDate | null` to be valid and guard against calling `formatByString` with `null`.
+        // Or we ensure `formatByString` is callable with `null`.
+        date!,
+        inputFormat,
+      )
+    : '';
 };
 
 export function pick12hOr24hFormat(

--- a/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
+++ b/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
@@ -5,8 +5,11 @@ export function getTextFieldAriaText<TDate>(
   rawValue: ParseableDate<TDate>,
   utils: MuiPickersAdapter<TDate>,
 ) {
+  // TODO: should `isValid` narrow `TDate | null` to `NonNullable<TDate>`?
+  // Either we allow `TDate | null` to be valid and guard against calling `formatByString` with `null`.
+  // Or we ensure `formatByString` is callable with `null`.
   return rawValue && utils.isValid(utils.date(rawValue))
-    ? `Choose date, selected date is ${utils.format(utils.date(rawValue), 'fullDate')}`
+    ? `Choose date, selected date is ${utils.format(utils.date(rawValue)!, 'fullDate')}`
     : 'Choose date';
 }
 

--- a/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
+++ b/packages/material-ui-lab/src/internal/pickers/text-field-helper.ts
@@ -1,8 +1,8 @@
-import { ParsableDate } from './constants/prop-types';
+import { ParseableDate } from './constants/prop-types';
 import { MuiPickersAdapter } from './hooks/useUtils';
 
 export function getTextFieldAriaText<TDate>(
-  rawValue: ParsableDate<TDate>,
+  rawValue: ParseableDate<TDate>,
   utils: MuiPickersAdapter<TDate>,
 ) {
   return rawValue && utils.isValid(utils.date(rawValue))
@@ -12,7 +12,7 @@ export function getTextFieldAriaText<TDate>(
 
 export const getDisplayDate = <TDate>(
   utils: MuiPickersAdapter<TDate>,
-  value: ParsableDate<TDate>,
+  value: ParseableDate<TDate>,
   inputFormat: string,
 ) => {
   const date = utils.date(value);

--- a/packages/material-ui-lab/src/internal/pickers/time-utils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/time-utils.ts
@@ -1,4 +1,4 @@
-import { ParsableDate } from './constants/prop-types';
+import { ParseableDate } from './constants/prop-types';
 import { MuiPickersAdapter } from './hooks/useUtils';
 
 type Meridiem = 'am' | 'pm' | null;
@@ -72,7 +72,7 @@ export interface TimeValidationProps<TDate> {
 
 export const validateTime = <TDate>(
   utils: MuiPickersAdapter,
-  value: TDate | ParsableDate<TDate>,
+  value: TDate | ParseableDate<TDate>,
   {
     minTime,
     maxTime,


### PR DESCRIPTION
They were just not helping. 

I think the goal is now clear that we want to move interface and implementation closer together. Looking at all interfaces and then creating the minimal amount of types is just not  helpful.