### PR TITLE
[pickers] Remove redundant aria-hidden

### DIFF
--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -176,7 +176,7 @@ describe('<DesktopDateRangePicker />', () => {
     expect(getAllByMuiTest('DateRangeHighlight')).to.have.length(31);
   });
 
-  it('selects the range from the next month', () => {
+  it('selects the range from the next month', function test() {
     const onChangeMock = spy();
     render(
       <DesktopDateRangePicker
@@ -188,9 +188,12 @@ describe('<DesktopDateRangePicker />', () => {
     );
 
     fireEvent.click(screen.getByLabelText('Jan 1, 2019'));
-    fireEvent.click(
-      screen.getByLabelText('Next month', { selector: ':not([aria-hidden="true"])' }),
-    );
+    // FIXME use `getByRole(role, {hidden: false})` and skip JSDOM once this suite can run in JSDOM
+    const [visibleButton] = screen.getAllByRole('button', {
+      hidden: true,
+      name: 'Next month',
+    });
+    fireEvent.click(visibleButton);
     fireEvent.click(screen.getByLabelText('Mar 19, 2019'));
 
     expect(onChangeMock.callCount).to.equal(2);

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -260,7 +260,7 @@ const PickersDay = React.forwardRef(function PickersDay<TDate>(
   );
 
   if (outsideCurrentMonth && !showDaysOutsideCurrentMonth) {
-    return <div aria-hidden className={clsx(dayClassName, classes.hiddenDaySpacingFiller)} />;
+    return <div className={clsx(dayClassName, classes.hiddenDaySpacingFiller)} />;
   }
 
   return (

--- a/packages/material-ui-lab/src/internal/pickers/PickersArrowSwitcher.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersArrowSwitcher.tsx
@@ -96,7 +96,6 @@ const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitcher(
     <div className={clsx(classes.root, className)} ref={ref} {...other}>
       <LeftArrowButton
         size="small"
-        aria-hidden={isLeftHidden}
         aria-label={leftArrowButtonText}
         title={leftArrowButtonText}
         disabled={isLeftDisabled}
@@ -118,7 +117,6 @@ const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitcher(
       )}
       <RightArrowButton
         size="small"
-        aria-hidden={isRightHidden}
         aria-label={rightArrowButtonText}
         title={rightArrowButtonText}
         edge="start"


### PR DESCRIPTION
`aria-hidden` was applied to elements which should have `visibility: hidden`. These elements are already excluded from the a11y tree. If they are visible then they should be part of the a11y tree.