### PR TITLE
[pickers] Toggle mobile keyboard view in the same commit as the view changes

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -108,12 +108,18 @@ function Picker({
     [onDateChange, wrapperVariant],
   );
 
+  const handleViewChange = React.useCallback(() => {
+    if (isMobileKeyboardViewOpen) {
+      toggleMobileKeyboardView();
+    }
+  }, [isMobileKeyboardViewOpen, toggleMobileKeyboardView]);
+
   const { openView, nextView, previousView, setOpenView, handleChangeAndOpenNext } = useViews({
     view: undefined,
     views,
     openTo,
     onChange: handleDateChange,
-    onViewChange: toggleMobileKeyboardView,
+    onViewChange: handleViewChange,
   });
 
   return (

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -116,7 +116,7 @@ function Picker({
   });
 
   React.useEffect(() => {
-    if (isMobileKeyboardViewOpen && toggleMobileKeyboardView) {
+    if (isMobileKeyboardViewOpen) {
       toggleMobileKeyboardView();
     }
     // React on `openView` change

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -113,14 +113,8 @@ function Picker({
     views,
     openTo,
     onChange: handleDateChange,
+    onViewChange: toggleMobileKeyboardView,
   });
-
-  React.useEffect(() => {
-    if (isMobileKeyboardViewOpen) {
-      toggleMobileKeyboardView();
-    }
-    // React on `openView` change
-  }, [openView]); // eslint-disable-line
 
   return (
     <div


### PR DESCRIPTION
Seems fishy that we toggled it in the next commit. Suspecting some animation related requirement.