### PR TITLE
[core] Remove deprecated `innerRef` prop

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1412,6 +1412,44 @@ As the core components use emotion as a styled engine, the props used by emotion
   });
   ```
 
+### withStyles
+
+- Replace the `innerRef` prop with the `ref` prop. Refs are now automatically forwarded to the inner component.
+
+  ```diff
+  import * as React from 'react';
+  import { withStyles } from '@material-ui/core/styles';
+
+  const MyComponent = withStyles({
+    root: {
+      backgroundColor: 'red',
+    },
+  })(({ classes }) => <div className={classes.root} />);
+
+  function MyOtherComponent(props) {
+    const ref = React.useRef();
+  - return <MyComponent innerRef={ref} />;
+  + return <MyComponent ref={ref} />;
+  }
+  ```
+
+### withTheme
+
+- Replace the `innerRef` prop with the `ref` prop. Refs are now automatically forwarded to the inner component.
+
+  ```diff
+  import * as React from 'react';
+  import { withTheme  } from '@material-ui/core/styles';
+
+  const MyComponent = withTheme(({ theme }) => <div>{props.theme.direction}</div>);
+
+  function MyOtherComponent(props) {
+    const ref = React.useRef();
+  - return <MyComponent innerRef={ref} />;
+  + return <MyComponent ref={ref} />;
+  }
+  ```
+
 ### `@material-ui/types`
 
 - Rename the exported `Omit` type in `@material-ui/types`. The module is now called `DistributiveOmit`. The change removes the confusion with the built-in `Omit` helper introduced in TypeScript v3.5. The built-in `Omit`, while similar, is non-distributive. This leads to differences when applied to union types. [See this StackOverflow answer for further details](https://stackoverflow.com/a/57103940/1009797).

--- a/docs/src/pages/styles/api/api.md
+++ b/docs/src/pages/styles/api/api.md
@@ -286,7 +286,6 @@ Some implementation details that might be interesting to being aware of:
 
 - It adds a `classes` prop so you can override the injected class names from the outside.
 - It forwards refs to the inner component.
-- The `innerRef` prop is deprecated. Use `ref` instead.
 - It does **not** copy over statics.
   For instance, it can be used to define a `getInitialProps()` static method (next.js).
 

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
@@ -109,7 +108,6 @@ export type WithStyles<
   IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: ThemeOfStyles<StylesType> } : {}) & {
   classes: ClassNameMap<ClassKeyOfStyles<StylesType>>;
-  innerRef?: React.Ref<any>;
 } & PropsOfStyles<StylesType>;
 
 export interface StyledComponentProps<ClassKey extends string = string> {
@@ -117,7 +115,6 @@ export interface StyledComponentProps<ClassKey extends string = string> {
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<ClassNameMap<ClassKey>>;
-  innerRef?: React.Ref<any>;
 }
 
 export default function withStyles<

--- a/packages/material-ui-styles/src/withStyles/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { chainPropTypes, getDisplayName } from '@material-ui/utils';
+import { getDisplayName } from '@material-ui/utils';
 import makeStyles from '../makeStyles';
 import getThemeProps from '../getThemeProps';
 import useTheme from '../useTheme';
@@ -44,7 +44,7 @@ const withStyles = (stylesOrCreator, options = {}) => (Component) => {
   });
 
   const WithStyles = React.forwardRef(function WithStyles(props, ref) {
-    const { classes: classesProp, innerRef, ...other } = props;
+    const { classes: classesProp, ...other } = props;
     // The wrapper receives only user supplied props, which could be a subset of
     // the actual props Component might receive due to merging with defaultProps.
     // So copying it here would give us the same result in the wrapper as well.
@@ -69,7 +69,7 @@ const withStyles = (stylesOrCreator, options = {}) => (Component) => {
       }
     }
 
-    return <Component ref={innerRef || ref} classes={classes} {...more} />;
+    return <Component ref={ref} classes={classes} {...more} />;
   });
 
   WithStyles.propTypes = {
@@ -77,21 +77,6 @@ const withStyles = (stylesOrCreator, options = {}) => (Component) => {
      * Override or extend the styles applied to the component.
      */
     classes: PropTypes.object,
-    /**
-     * Use that prop to pass a ref to the decorated component.
-     * @deprecated
-     */
-    innerRef: chainPropTypes(PropTypes.oneOfType([PropTypes.func, PropTypes.object]), (props) => {
-      if (props.innerRef == null) {
-        return null;
-      }
-
-      return null;
-      // return new Error(
-      //   'Material-UI: The `innerRef` prop is deprecated and will be removed in v5. ' +
-      //     'Refs are now automatically forwarded to the inner component.',
-      // );
-    }),
   };
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -8,12 +8,6 @@ export interface WithThemeCreatorOption<Theme = DefaultTheme> {
 
 export interface WithTheme<Theme = DefaultTheme> {
   theme: Theme;
-  /**
-   * Deprecated. Will be removed in v5. Refs are now automatically forwarded to
-   * the inner component.
-   * @deprecated since version 4.0
-   */
-  innerRef?: React.Ref<any>;
 }
 
 export interface ThemedComponentProps extends Partial<WithTheme> {

--- a/packages/material-ui-styles/src/withTheme/withTheme.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { chainPropTypes, getDisplayName } from '@material-ui/utils';
+import { getDisplayName } from '@material-ui/utils';
 import useTheme from '../useTheme';
 
 export function withThemeCreator(options = {}) {
@@ -20,27 +19,9 @@ export function withThemeCreator(options = {}) {
     }
 
     const WithTheme = React.forwardRef(function WithTheme(props, ref) {
-      const { innerRef, ...other } = props;
       const theme = useTheme() || defaultTheme;
-      return <Component theme={theme} ref={innerRef || ref} {...other} />;
+      return <Component theme={theme} ref={ref} {...props} />;
     });
-
-    WithTheme.propTypes = {
-      /**
-       * Use that prop to pass a ref to the decorated component.
-       * @deprecated
-       */
-      innerRef: chainPropTypes(PropTypes.oneOfType([PropTypes.func, PropTypes.object]), (props) => {
-        if (props.innerRef == null) {
-          return null;
-        }
-
-        return new Error(
-          'Material-UI: The `innerRef` prop is deprecated and will be removed in v5. ' +
-            'Refs are now automatically forwarded to the inner component.',
-        );
-      }),
-    };
 
     if (process.env.NODE_ENV !== 'production') {
       WithTheme.displayName = `WithTheme(${getDisplayName(Component)})`;

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -71,25 +71,6 @@ describe('withTheme', () => {
 
       expect(ref.current.nodeName).to.equal('DIV');
     });
-
-    describe('innerRef', () => {
-      beforeEach(() => {
-        PropTypes.resetWarningCache();
-      });
-
-      it('is deprecated', () => {
-        const ThemedDiv = withTheme('div');
-
-        expect(() => {
-          PropTypes.checkPropTypes(
-            ThemedDiv.propTypes,
-            { innerRef: React.createRef() },
-            'prop',
-            'ThemedDiv',
-          );
-        }).toErrorDev('Warning: Failed prop type: Material-UI: The `innerRef` prop is deprecated');
-      });
-    });
   });
 
   it('should throw is the import is invalid', () => {

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -416,7 +416,6 @@ function ForwardRefTest() {
   // forwarded to function components which can't hold refs
   // @ts-expect-error property 'ref' does not exists
   <StyledAnchor ref={anchorRef} />;
-  <StyledAnchor innerRef={anchorRef} />;
 
   const RefableAnchor = React.forwardRef<HTMLAnchorElement, WithStyles<typeof styles>>(
     (props, ref) => {
@@ -430,9 +429,6 @@ function ForwardRefTest() {
   const buttonRef = React.createRef<HTMLButtonElement>();
   // @ts-expect-error HTMLButtonElement is missing properties
   <StyledRefableAnchor ref={buttonRef} />;
-  // undesired: `innerRef` is currently typed as any but for backwards compat we're keeping it
-  // especially since `innerRef` will be removed in v5 and is equivalent to `ref`
-  <StyledRefableAnchor innerRef={buttonRef} />;
 }
 
 {

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -6,12 +6,6 @@ export interface WithTheme {
 }
 
 export interface ThemedComponentProps extends Partial<WithTheme> {
-  /**
-   * Deprecated. Will be removed in v5. Refs are now automatically forwarded to
-   * the inner component.
-   * @deprecated since version 4.0
-   */
-  innerRef?: React.Ref<any>;
   ref?: React.Ref<unknown>;
 }
 

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -12,10 +12,6 @@ export interface WithWidth {
   width: Breakpoint;
 }
 
-export interface WithWidthProps extends Partial<WithWidth> {
-  innerRef?: React.Ref<any>;
-}
-
 export function isWidthDown(
   breakpoint: Breakpoint,
   screenWidth: Breakpoint,
@@ -30,4 +26,4 @@ export function isWidthUp(
 
 export default function withWidth(
   options?: WithWidthOptions,
-): PropInjector<WithWidth, WithWidthProps>;
+): PropInjector<WithWidth, Partial<WithWidth>>;


### PR DESCRIPTION
**BREAKING CHANGES**

- **withStyles**

Replace the `innerRef` prop with the `ref` prop. Refs are now automatically forwarded to the inner component.

  ```diff
  import * as React from 'react';
  import { withStyles } from '@material-ui/core/styles';
  const MyComponent = withStyles({
    root: {
      backgroundColor: 'red',
    },
  })(({ classes }) => <div className={classes.root} />);
  function MyOtherComponent(props) {
    const ref = React.useRef();
  - return <MyComponent innerRef={ref} />;
  + return <MyComponent ref={ref} />;
  }
  ```

- **withTheme**

Replace the `innerRef` prop with the `ref` prop. Refs are now automatically forwarded to the inner component.

  ```diff
  import * as React from 'react';
  import { withTheme  } from '@material-ui/core/styles';
  const MyComponent = withTheme(({ theme }) => <div>{props.theme.direction}</div>);
  function MyOtherComponent(props) {
    const ref = React.useRef();
  - return <MyComponent innerRef={ref} />;
  + return <MyComponent ref={ref} />;
  }
  ```

Part of #20012
