### PR TITLE
[pickers] Remove unused components from static variants

### DIFF
--- a/docs/pages/api-docs/static-date-picker.json
+++ b/docs/pages/api-docs/static-date-picker.json
@@ -28,7 +28,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
-      "default": "\"static\""
+      "default": "'mobile'"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/static-date-range-picker.json
+++ b/docs/pages/api-docs/static-date-range-picker.json
@@ -40,7 +40,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
-      "default": "\"static\""
+      "default": "'mobile'"
     },
     "endText": { "type": { "name": "node" }, "default": "'End'" },
     "getOpenDialogAriaText": {

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -32,7 +32,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
-      "default": "\"static\""
+      "default": "'mobile'"
     },
     "getClockLabelText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/static-time-picker.json
+++ b/docs/pages/api-docs/static-time-picker.json
@@ -20,7 +20,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
-      "default": "\"static\""
+      "default": "'mobile'"
     },
     "getClockLabelText": {
       "type": { "name": "func" },

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -6,8 +6,6 @@ import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/
 import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
-import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -18,9 +16,13 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = datePickerConfig;
 
-export interface StaticDatePickerProps<TDate = unknown>
-  extends BaseDatePickerProps<TDate>,
-    StaticWrapperProps {}
+export interface StaticDatePickerProps<TDate = unknown> extends BaseDatePickerProps<TDate> {
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs?: StaticWrapperProps['displayStaticWrapperAs'];
+}
 
 type StaticDatePickerComponent = (<TDate>(
   props: StaticDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
@@ -53,21 +55,15 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
-  const { value, onChange, ...other } = props;
+  const { value, onChange, displayStaticWrapperAs = 'mobile', ...other } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (
-    <StaticWrapper
-      {...other}
-      {...wrapperProps}
-      DateInputProps={AllDateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInput}
-      PureDateInputComponent={PureDateInput}
-    >
+    <StaticWrapper displayStaticWrapperAs={displayStaticWrapperAs}>
       <Picker
         {...pickerProps}
         toolbarTitle={props.label || props.toolbarTitle}
@@ -99,10 +95,6 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
    * @default false
    */
   allowSameDateSelection: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  children: PropTypes.node,
   /**
    * className applied to the root component.
    */
@@ -163,7 +155,7 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
   disablePast: PropTypes.bool,
   /**
    * Force static wrapper inner components to be rendered in mobile or desktop mode.
-   * @default "static"
+   * @default 'mobile'
    */
   displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
   /**

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -12,15 +12,12 @@ import {
   DateRangePickerView,
   ExportedDateRangePickerViewProps,
 } from '../DateRangePicker/DateRangePickerView';
-import DateRangePickerInput, {
-  ExportedDateRangePickerInputProps,
-} from '../DateRangePicker/DateRangePickerInput';
+import { ExportedDateRangePickerInputProps } from '../DateRangePicker/DateRangePickerInput';
 import {
   parseRangeInputValue,
   validateDateRange,
   DateRangeValidationError,
 } from '../internal/pickers/date-utils';
-import { DateInputPropsLike } from '../internal/pickers/wrappers/WrapperProps';
 
 interface BaseDateRangePickerProps<TDate>
   extends ExportedDateRangePickerViewProps<TDate>,
@@ -69,9 +66,6 @@ const useDateRangeValidation = makeValidationHook<
   isSameError: (a, b) => b !== null && a[1] === b[1] && a[0] === b[0],
 });
 
-const KeyboardDateInputComponent = DateRangePickerInput as React.FC<DateInputPropsLike>;
-const PureDateInputComponent = DateRangePickerInput as React.FC<DateInputPropsLike>;
-
 const rangePickerValueManager: PickerStateValueManager<any, any> = {
   emptyValue: [null, null],
   parseInput: parseRangeInputValue,
@@ -79,8 +73,13 @@ const rangePickerValueManager: PickerStateValueManager<any, any> = {
 };
 
 export interface StaticDateRangePickerProps<TDate = unknown>
-  extends BaseDateRangePickerProps<TDate>,
-    StaticWrapperProps {}
+  extends BaseDateRangePickerProps<TDate> {
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs?: StaticWrapperProps['displayStaticWrapperAs'];
+}
 
 type StaticDateRangePickerComponent = (<TDate>(
   props: StaticDateRangePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
@@ -104,6 +103,7 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
 
   const {
     calendars = 2,
+    displayStaticWrapperAs = 'mobile',
     value,
     onChange,
     mask = '__/__/____',
@@ -155,13 +155,7 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
   };
 
   return (
-    <StaticWrapper
-      {...restProps}
-      {...wrapperProps}
-      DateInputProps={DateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInputComponent}
-      PureDateInputComponent={PureDateInputComponent}
-    >
+    <StaticWrapper displayStaticWrapperAs={displayStaticWrapperAs}>
       <DateRangePickerView<any>
         open={wrapperProps.open}
         DateInputProps={DateInputProps}
@@ -202,10 +196,6 @@ StaticDateRangePicker.propTypes /* remove-proptypes */ = {
    * @default 2
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
-  /**
-   * @ignore
-   */
-  children: PropTypes.node,
   /**
    * className applied to the root component.
    */
@@ -271,7 +261,7 @@ StaticDateRangePicker.propTypes /* remove-proptypes */ = {
   disablePast: PropTypes.bool,
   /**
    * Force static wrapper inner components to be rendered in mobile or desktop mode.
-   * @default "static"
+   * @default 'mobile'
    */
   displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
   /**

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -6,8 +6,6 @@ import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/
 import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
-import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -18,9 +16,13 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = dateTimePickerConfig;
 
-export interface StaticDateTimePickerProps<TDate = unknown>
-  extends BaseDateTimePickerProps<TDate>,
-    StaticWrapperProps {}
+export interface StaticDateTimePickerProps<TDate = unknown> extends BaseDateTimePickerProps<TDate> {
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs?: StaticWrapperProps['displayStaticWrapperAs'];
+}
 
 type StaticDateTimePickerComponent = (<TDate>(
   props: StaticDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
@@ -53,21 +55,15 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps } = usePickerState(props, valueManager);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
-  const { value, onChange, ...other } = props;
+  const { value, onChange, displayStaticWrapperAs = 'mobile', ...other } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (
-    <StaticWrapper
-      {...other}
-      {...wrapperProps}
-      DateInputProps={AllDateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInput}
-      PureDateInputComponent={PureDateInput}
-    >
+    <StaticWrapper displayStaticWrapperAs={displayStaticWrapperAs}>
       <Picker
         {...pickerProps}
         toolbarTitle={props.label || props.toolbarTitle}
@@ -109,10 +105,6 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  children: PropTypes.node,
   /**
    * className applied to the root component.
    */
@@ -182,7 +174,7 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
   disablePast: PropTypes.bool,
   /**
    * Force static wrapper inner components to be rendered in mobile or desktop mode.
-   * @default "static"
+   * @default 'mobile'
    */
   displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
   /**

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -6,8 +6,6 @@ import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/
 import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
-import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -18,9 +16,13 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
 
 const { DefaultToolbarComponent, useInterceptProps, useValidation } = timePickerConfig;
 
-export interface StaticTimePickerProps<TDate = unknown>
-  extends BaseTimePickerProps<TDate>,
-    StaticWrapperProps {}
+export interface StaticTimePickerProps<TDate = unknown> extends BaseTimePickerProps<TDate> {
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs?: StaticWrapperProps['displayStaticWrapperAs'];
+}
 
 type StaticTimePickerComponent = (<TDate>(
   props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
@@ -53,21 +55,13 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
   });
 
   const validationError = useValidation(props.value, props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps } = usePickerState(props, valueManager);
 
-  // Note that we are passing down all the value without spread.
-  // It saves us >1kb gzip and make any prop available automatically on any level down.
-  const { value, onChange, ...other } = props;
+  const { value, onChange, displayStaticWrapperAs = 'mobile', ...other } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (
-    <StaticWrapper
-      {...other}
-      {...wrapperProps}
-      DateInputProps={AllDateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInput}
-      PureDateInputComponent={PureDateInput}
-    >
+    <StaticWrapper displayStaticWrapperAs={displayStaticWrapperAs}>
       <Picker
         {...pickerProps}
         toolbarTitle={props.label || props.toolbarTitle}
@@ -105,10 +99,6 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
    */
   ampmInClock: PropTypes.bool,
   /**
-   * @ignore
-   */
-  children: PropTypes.node,
-  /**
    * className applied to the root component.
    */
   className: PropTypes.string,
@@ -138,7 +128,7 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
   disableOpenPicker: PropTypes.bool,
   /**
    * Force static wrapper inner components to be rendered in mobile or desktop mode.
-   * @default "static"
+   * @default 'mobile'
    */
   displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
   /**

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/StaticWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/StaticWrapper.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { WithStyles, withStyles, MuiStyles, StyleRules } from '@material-ui/core/styles';
 import { DIALOG_WIDTH } from '../constants/dimensions';
 import { WrapperVariantContext, IsStaticVariantContext } from './WrapperVariantContext';
-import { PrivateWrapperProps } from './WrapperProps';
 
 type StaticWrapperClassKey = 'root';
 
@@ -20,15 +19,12 @@ export interface StaticWrapperProps {
   children?: React.ReactNode;
   /**
    * Force static wrapper inner components to be rendered in mobile or desktop mode.
-   * @default "static"
    */
-  displayStaticWrapperAs?: 'desktop' | 'mobile';
+  displayStaticWrapperAs: 'desktop' | 'mobile';
 }
 
-const StaticWrapper: React.FC<
-  PrivateWrapperProps & StaticWrapperProps & WithStyles<typeof styles>
-> = (props) => {
-  const { classes, displayStaticWrapperAs = 'mobile', children } = props;
+function StaticWrapper(props: StaticWrapperProps & WithStyles<typeof styles>) {
+  const { classes, displayStaticWrapperAs, children } = props;
 
   const isStatic = true;
 
@@ -39,8 +35,6 @@ const StaticWrapper: React.FC<
       </WrapperVariantContext.Provider>
     </IsStaticVariantContext.Provider>
   );
-};
+}
 
-export default withStyles(styles, { name: 'MuiPickersStaticWrapper' })(StaticWrapper) as React.FC<
-  PrivateWrapperProps & StaticWrapperProps
->;
+export default withStyles(styles, { name: 'MuiPickersStaticWrapper' })(StaticWrapper);


### PR DESCRIPTION
The input components are unused in the static variants. This is now clear after all the inlining work. The input props are also unused but this requires refactoring of `Picker` (which is the goal). But we can reduce the amount of work we have to do to better compose `Picker` in smaller steps that can live on their own.

Savings are minimal probably because we bundle them in some other way. Once all these refactorings are done, the bundle should be much smaller.