### PR TITLE
[internal][pickers] Don't validate inputFormat in production

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -107,7 +107,7 @@ const DatePicker = React.forwardRef(function DatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: DatePickerProps<unknown> = useInterceptProps(inProps as DatePickerProps<unknown>);
+  const allProps = useInterceptProps(inProps as DatePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/DatePicker/shared.ts
+++ b/packages/material-ui-lab/src/DatePicker/shared.ts
@@ -13,7 +13,7 @@ export const isYearAndMonthViews = (
 export const getFormatAndMaskByViews = (
   views: readonly CalendarPickerView[],
   utils: MuiPickersAdapter,
-) => {
+): { disableMaskedInput?: boolean; inputFormat: string; mask?: string } => {
   if (isYearOnlyView(views)) {
     return {
       mask: '____',

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -124,7 +124,6 @@ const DateRangePicker = React.forwardRef(function DateRangePicker<TDate>(
     ...other,
     value,
     onChange,
-    inputFormat: passedInputFormat || utils.formats.keyboardDate,
   };
 
   const restProps = {
@@ -144,6 +143,7 @@ const DateRangePicker = React.forwardRef(function DateRangePicker<TDate>(
     ...inputProps,
     ...restProps,
     currentlySelectingRangeEnd,
+    inputFormat: passedInputFormat || utils.formats.keyboardDate,
     setCurrentlySelectingRangeEnd,
     startText,
     endText,

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -112,7 +112,6 @@ function useInterceptProps({
     ampmInClock: true,
     orientation,
     showToolbar: true,
-    showTabs: true,
     allowSameDateSelection: true,
     minDate: minDateTime || minDate,
     minTime: minDateTime || minTime,
@@ -168,9 +167,7 @@ const DateTimePicker = React.forwardRef(function DateTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: DateTimePickerProps<unknown> = useInterceptProps(
-    inProps as DateTimePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as DateTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -41,9 +41,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: DesktopDatePickerProps<unknown> = useInterceptProps(
-    inProps as DesktopDatePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as DesktopDatePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -127,7 +127,6 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
     ...other,
     value,
     onChange,
-    inputFormat: passedInputFormat || utils.formats.keyboardDate,
   };
 
   const restProps = {
@@ -147,6 +146,7 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
     ...inputProps,
     ...restProps,
     currentlySelectingRangeEnd,
+    inputFormat: passedInputFormat || utils.formats.keyboardDate,
     setCurrentlySelectingRangeEnd,
     startText,
     endText,

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -41,9 +41,7 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: DesktopDateTimePickerProps<unknown> = useInterceptProps(
-    inProps as DesktopDateTimePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as DesktopDateTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -41,9 +41,7 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(
-    inProps as DesktopTimePickerProps<unknown>,
-  ) as DesktopTimePickerProps<unknown>;
+  const allProps = useInterceptProps(inProps as DesktopTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -41,9 +41,7 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: MobileDatePickerProps<unknown> = useInterceptProps(
-    inProps as MobileDatePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as MobileDatePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -126,7 +126,6 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
     ...other,
     value,
     onChange,
-    inputFormat: passedInputFormat || utils.formats.keyboardDate,
   };
 
   const restProps = {
@@ -146,6 +145,7 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
     ...inputProps,
     ...restProps,
     currentlySelectingRangeEnd,
+    inputFormat: passedInputFormat || utils.formats.keyboardDate,
     setCurrentlySelectingRangeEnd,
     startText,
     endText,

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -41,9 +41,7 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: MobileDateTimePickerProps<unknown> = useInterceptProps(
-    inProps as MobileDateTimePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as MobileDateTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -41,9 +41,7 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(
-    inProps as MobileTimePickerProps<unknown>,
-  ) as MobileTimePickerProps<unknown>;
+  const allProps = useInterceptProps(inProps as MobileTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -41,9 +41,7 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: StaticDatePickerProps<unknown> = useInterceptProps(
-    inProps as StaticDatePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as StaticDatePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -126,7 +126,6 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
     ...other,
     value,
     onChange,
-    inputFormat: passedInputFormat || utils.formats.keyboardDate,
   };
 
   const restProps = {
@@ -146,6 +145,7 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
     ...inputProps,
     ...restProps,
     currentlySelectingRangeEnd,
+    inputFormat: passedInputFormat || utils.formats.keyboardDate,
     setCurrentlySelectingRangeEnd,
     startText,
     endText,

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -41,9 +41,7 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: StaticDateTimePickerProps<unknown> = useInterceptProps(
-    inProps as StaticDateTimePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as StaticDateTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -41,9 +41,7 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: StaticTimePickerProps<unknown> = useInterceptProps(
-    inProps as StaticTimePickerProps<unknown>,
-  );
+  const allProps = useInterceptProps(inProps as StaticTimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -123,14 +123,14 @@ const TimePicker = React.forwardRef(function TimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps: TimePickerProps<unknown> = useInterceptProps(inProps as TimePickerProps<unknown>);
+  const allProps = useInterceptProps(inProps as TimePickerProps<unknown>);
 
   // This is technically unsound if the type parameters appear in optional props.
   // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
   const props = useThemeProps({
     props: allProps,
     name: 'MuiTimePicker',
-  }) as TimePickerProps<unknown>;
+  });
 
   const validationError = useValidation(props.value, props as TimePickerProps<unknown>) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -28,7 +28,6 @@ interface DraftAction<DraftValue> {
 export interface PickerStateProps<TInput, TDateValue> {
   disableCloseOnSelect?: boolean;
   disabled?: boolean;
-  inputFormat?: string;
   open?: boolean;
   onAccept?: (date: TDateValue) => void;
   onChange: (date: TDateValue, keyboardInputValue?: string) => void;
@@ -42,19 +41,7 @@ export function usePickerState<TInput, TDateValue>(
   props: PickerStateProps<TInput, TDateValue>,
   valueManager: PickerStateValueManager<TInput, TDateValue>,
 ) {
-  const {
-    disableCloseOnSelect,
-    disabled,
-    inputFormat,
-    onAccept,
-    onChange,
-    readOnly,
-    value,
-  } = props;
-
-  if (!inputFormat) {
-    throw new Error('inputFormat prop is required');
-  }
+  const { disableCloseOnSelect, disabled, onAccept, onChange, readOnly, value } = props;
 
   const utils = useUtils();
   const { isOpen, setIsOpen } = useOpenState(props);
@@ -156,12 +143,11 @@ export function usePickerState<TInput, TDateValue>(
   const inputProps = React.useMemo(
     () => ({
       onChange,
-      inputFormat,
       open: isOpen,
       rawValue: value,
       openPicker: () => !readOnly && !disabled && setIsOpen(true),
     }),
-    [onChange, inputFormat, isOpen, value, readOnly, disabled, setIsOpen],
+    [onChange, isOpen, value, readOnly, disabled, setIsOpen],
   );
 
   const pickerState = { pickerProps, inputProps, wrapperProps };


### PR DESCRIPTION
Every implementation provides a default value for `inputFormat`. The current invariant would therefore only validate our own implementation and we generally don't do this. Especially since `usePickerState` does not use the  `inputFormat`.