### PR TITLE
[SwipeableDrawer] Migrate SwipeArea to emotion

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -1,26 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import {
-  unstable_composeClasses as composeClasses,
-  generateUtilityClass,
-} from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
-import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
 
-export function getSwipeAreaUtilityClass(slot) {
-  return generateUtilityClass('MuiSwipeableDrawer', slot);
-}
-
-const SwipeAreaRoot = experimentalStyled(
-  'span',
-  {},
-  {
-    name: 'PrivateSwipeArea',
-    slot: 'Root',
-  },
-)(({ theme, styleProps }) => ({
+const SwipeAreaRoot = experimentalStyled('div')(({ theme, styleProps }) => ({
   position: 'fixed',
   top: 0,
   left: 0,
@@ -44,25 +28,13 @@ const SwipeAreaRoot = experimentalStyled(
   }),
 }));
 
-const useUtilityClasses = (styleProps) => {
-  const { classes, anchor } = styleProps;
-
-  const slots = {
-    root: ['root', anchor && `anchor${capitalize(anchor)}`],
-  };
-
-  return composeClasses(slots, getSwipeAreaUtilityClass, classes);
-};
-
 /**
  * @ignore - internal component.
  */
 const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
-  const { anchor, className, width, ...other } = props;
+  const { anchor, classes = {}, className, width, ...other } = props;
 
   const styleProps = props;
-
-  const classes = useUtilityClasses(styleProps);
 
   return (
     <SwipeAreaRoot

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -38,7 +38,7 @@ const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
 
   return (
     <SwipeAreaRoot
-      className={clsx(classes.root, className)}
+      className={clsx(classes.root, classes[`anchor${capitalize(anchor)}`], className)}
       ref={ref}
       style={{
         [isHorizontal(anchor) ? 'width' : 'height']: width,

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import {
+  unstable_composeClasses as composeClasses,
+  generateUtilityClass,
+} from '@material-ui/unstyled';
 import experimentalStyled from '../styles/experimentalStyled';
 import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
-import { generateUtilityClass } from '@material-ui/unstyled';
 
 export function getSwipeAreaUtilityClass(slot) {
   return generateUtilityClass('MuiSwipeableDrawer', slot);

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -1,50 +1,75 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import withStyles from '../styles/withStyles';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import experimentalStyled from '../styles/experimentalStyled';
 import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
+import { generateUtilityClass } from '@material-ui/unstyled';
 
-export const styles = (theme) => ({
-  /* Styles applied to the root element. */
-  root: {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    zIndex: theme.zIndex.drawer - 1,
+export function getSwipeAreaUtilityClass(slot) {
+  return generateUtilityClass('MuiSwipeableDrawer', slot);
+}
+
+const SwipeAreaRoot = experimentalStyled(
+  'span',
+  {},
+  {
+    name: 'PrivateSwipeArea',
+    slot: 'Root',
   },
-  anchorLeft: {
+)(({ theme, styleProps }) => ({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  bottom: 0,
+  zIndex: theme.zIndex.drawer - 1,
+  ...(styleProps.anchor === 'left' && {
     right: 'auto',
-  },
-  anchorRight: {
+  }),
+  ...(styleProps.anchor === 'right' && {
     left: 'auto',
     right: 0,
-  },
-  anchorTop: {
+  }),
+  ...(styleProps.anchor === 'top' && {
     bottom: 'auto',
     right: 0,
-  },
-  anchorBottom: {
+  }),
+  ...(styleProps.anchor === 'bottom' && {
     top: 'auto',
     bottom: 0,
     right: 0,
-  },
-});
+  }),
+}));
+
+const useUtilityClasses = (styleProps) => {
+  const { classes, anchor } = styleProps;
+
+  const slots = {
+    root: ['root', anchor && `anchor${capitalize(anchor)}`],
+  };
+
+  return composeClasses(slots, getSwipeAreaUtilityClass, classes);
+};
 
 /**
  * @ignore - internal component.
  */
 const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
-  const { anchor, classes, className, width, ...other } = props;
+  const { anchor, className, width, ...other } = props;
+
+  const styleProps = props;
+
+  const classes = useUtilityClasses(styleProps);
 
   return (
-    <div
-      className={clsx(classes.root, classes[`anchor${capitalize(anchor)}`], className)}
+    <SwipeAreaRoot
+      className={clsx(classes.root, className)}
       ref={ref}
       style={{
         [isHorizontal(anchor) ? 'width' : 'height']: width,
       }}
+      styleProps={styleProps}
       {...other}
     />
   );
@@ -58,7 +83,7 @@ SwipeArea.propTypes = {
   /**
    * @ignore
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -70,4 +95,4 @@ SwipeArea.propTypes = {
   width: PropTypes.number.isRequired,
 };
 
-export default withStyles(styles, { name: 'PrivateSwipeArea' })(SwipeArea);
+export default SwipeArea;

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -39,7 +39,12 @@ const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
 
   return (
     <SwipeAreaRoot
-      className={clsx(classes.root, classes[`anchor${capitalize(anchor)}`], className)}
+      className={clsx(
+        'PrivateSwipeArea-root',
+        classes.root,
+        classes[`anchor${capitalize(anchor)}`],
+        className,
+      )}
       ref={ref}
       style={{
         [isHorizontal(anchor) ? 'width' : 'height']: width,
@@ -64,6 +69,10 @@ SwipeArea.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * @ignore
+   */
+  style: PropTypes.object,
   /**
    * The width of the left most (or right most) area in `px` where the
    * drawer can be swiped open from.

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import experimentalStyled from '../styles/experimentalStyled';
+import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
 
 const SwipeAreaRoot = experimentalStyled('div')(({ theme, styleProps }) => ({
@@ -32,7 +33,7 @@ const SwipeAreaRoot = experimentalStyled('div')(({ theme, styleProps }) => ({
  * @ignore - internal component.
  */
 const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
-  const { anchor, classes = {}, className, width, ...other } = props;
+  const { anchor, classes = {}, className, width, style, ...other } = props;
 
   const styleProps = props;
 
@@ -42,6 +43,7 @@ const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
       ref={ref}
       style={{
         [isHorizontal(anchor) ? 'width' : 'height']: width,
+        ...style,
       }}
       styleProps={styleProps}
       {...other}


### PR DESCRIPTION
While trying to remove the dependency to `withStyles`, I noticed that this private component wasn't migrated to emotion.