### PR TITLE
[test] Remove scheduler/tracing

### DIFF
--- a/benchmark/browser/utils/index.js
+++ b/benchmark/browser/utils/index.js
@@ -7,7 +7,6 @@ export const logReactMetrics = (
   baseDuration, // estimated time to render the entire subtree without memoization
   startTime, // when React began rendering this update
   commitTime, // when React committed this update
-  interactions, // the Set of interactions belonging to this update
 ) => {
   // eslint-disable-next-line no-console
   console.info({
@@ -17,6 +16,5 @@ export const logReactMetrics = (
     baseDuration,
     startTime,
     commitTime,
-    interactions,
   });
 };

--- a/benchmark/browser/webpack.config.js
+++ b/benchmark/browser/webpack.config.js
@@ -35,7 +35,6 @@ module.exports = {
   resolve: {
     alias: {
       'react-dom$': 'react-dom/profiling',
-      'scheduler/tracing': 'scheduler/tracing-profiling',
     },
     extensions: ['.js', '.ts', '.tsx'],
   },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/mocha": "^8.0.0",
     "@types/prettier": "^2.0.0",
     "@types/react": "^17.0.3",
-    "@types/scheduler": "^0.16.1",
     "@types/sinon": "^10.0.0",
     "@types/webpack": "^4.41.22",
     "@types/yargs": "^16.0.0",

--- a/test/karma.conf.profile.js
+++ b/test/karma.conf.profile.js
@@ -106,7 +106,6 @@ module.exports = function setKarmaConfig(config) {
           // "How to use profiling in production"
           // https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977#react-dom1660--scheduler0100
           'react-dom$': 'react-dom/profiling',
-          'scheduler/tracing': 'scheduler/tracing-profiling',
         },
         extensions: ['.js', '.ts', '.tsx'],
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3142,7 +3142,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/scheduler@*", "@types/scheduler@^0.16.1":
+"@types/scheduler@*":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==


### PR DESCRIPTION
It's been removed in https://github.com/facebook/react/pull/20037 so let's drop it as well. Compat testing with `react@next` is more important than tracing interactions. Edit: Too late for it to be pre-emptive. Already broke: https://app.circleci.com/pipelines/github/mui-org/material-ui/41292/workflows/23024986-c4d2-42ec-9eb6-852507c803b8/jobs/246993

We can re-implement it for most (if not all) updates with a stack based approach anyway. Mainly because the updates we track are all sync anyway. I'm not even sure we trace more than one interaction anyway.

test-profile of this PR: https://mui-dashboard.netlify.app/test-profile/247033