### PR TITLE
[docs] Add links for demo in different deploys

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -24,6 +24,10 @@ console.log(`Using React '${reactMode}' mode.`);
 const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
 const vercelDeploy = Boolean(process.env.VERCEL);
 
+const staging =
+  process.env.REPOSITORY_URL === undefined ||
+  /mui-org\/material-ui$/.test(process.env.REPOSITORY_URL);
+
 module.exports = {
   typescript: {
     // Motivated by https://github.com/zeit/next.js/issues/7687
@@ -147,13 +151,17 @@ module.exports = {
     COMMIT_REF: process.env.COMMIT_REF,
     ENABLE_AD: process.env.ENABLE_AD,
     GITHUB_AUTH: process.env.GITHUB_AUTH,
+    GIT_REVIEW_ID: process.env.REVIEW_ID,
     LIB_VERSION: pkg.version,
+    NETLIFY_DEPLOY_URL: process.env.DEPLOY_URL || 'http://localhost:3000',
+    NETLIFY_SITE_NAME: process.env.SITE_NAME || 'material-ui',
     PULL_REQUEST: process.env.PULL_REQUEST === 'true',
     REACT_MODE: reactMode,
     FEEDBACK_URL: process.env.FEEDBACK_URL,
     // #default-branch-switch
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui-org/material-ui/blob/next',
     SOURCE_CODE_REPO: 'https://github.com/mui-org/material-ui',
+    STAGING: staging,
   },
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -27,6 +27,10 @@ const vercelDeploy = Boolean(process.env.VERCEL);
 const staging =
   process.env.REPOSITORY_URL === undefined ||
   /mui-org\/material-ui$/.test(process.env.REPOSITORY_URL);
+if (staging) {
+  // eslint-disable-next-line no-console
+  console.log(`Staging deploy of ${process.env.REPOSITORY_URL || 'local repository'}`);
+}
 
 module.exports = {
   typescript: {

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -224,6 +224,7 @@ export default function Demo(props) {
 
   return (
     <div className={classes.root}>
+      <div className={classes.anchorLink} id={`${demoName}`} />
       <div
         className={clsx(classes.demo, {
           [classes.demoHiddenToolbar]: demoOptions.hideToolbar,

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -373,10 +373,10 @@ export default function DemoToolbar(props) {
     const defaultReviewID = process.env.GIT_REVIEW_ID ?? '20000';
     devMenuItems.push(
       <MenuItem
-        key="link-next"
+        key="link-deploy-preview"
         data-ga-event-category="demo"
         data-ga-event-label={demoOptions.demo}
-        data-ga-event-action="link-next"
+        data-ga-event-action="link-deploy-preview"
         component="a"
         href={`https://deploy-preview-${defaultReviewID}--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
         target="_blank"

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -24,6 +24,7 @@ import getDemoConfig from 'docs/src/modules/utils/getDemoConfig';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import { ACTION_TYPES, CODE_VARIANTS } from 'docs/src/modules/constants';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
+import { useRouter } from 'next/router';
 
 function compress(object) {
   return LZString.compressToBase64(JSON.stringify(object))
@@ -363,6 +364,71 @@ export default function DemoToolbar(props) {
     isFocusableControl,
   });
 
+  const devMenuItems = [];
+  if (process.env.STAGING === true) {
+    /* eslint-disable material-ui/no-hardcoded-labels -- staging only */
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- process.env.STAGING never changes
+    const router = useRouter();
+
+    const defaultReviewID = process.env.GIT_REVIEW_ID ?? '20000';
+    devMenuItems.push(
+      <MenuItem
+        key="link-next"
+        data-ga-event-category="demo"
+        data-ga-event-label={demoOptions.demo}
+        data-ga-event-action="link-next"
+        component="a"
+        href={`https://deploy-preview-${defaultReviewID}--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
+        target="_blank"
+        rel="noopener nofollow"
+        onClick={handleMoreClose}
+      >
+        demo on PR #{defaultReviewID}
+      </MenuItem>,
+      <MenuItem
+        key="link-next"
+        data-ga-event-category="demo"
+        data-ga-event-label={demoOptions.demo}
+        data-ga-event-action="link-next"
+        component="a"
+        href={`https://next--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
+        target="_blank"
+        rel="noopener nofollow"
+        onClick={handleMoreClose}
+      >
+        demo on&#160;<code>next</code>
+      </MenuItem>,
+      <MenuItem
+        key="permalink"
+        data-ga-event-category="demo"
+        data-ga-event-label={demoOptions.demo}
+        data-ga-event-action="permalink"
+        component="a"
+        href={`${process.env.NETLIFY_DEPLOY_URL}${router.route}#${demoName}`}
+        target="_blank"
+        rel="noopener nofollow"
+        onClick={handleMoreClose}
+      >
+        demo permalink
+      </MenuItem>,
+      <MenuItem
+        key="link-master"
+        data-ga-event-category="demo"
+        data-ga-event-label={demoOptions.demo}
+        data-ga-event-action="link-master"
+        component="a"
+        href={`https://master--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
+        target="_blank"
+        rel="noopener nofollow"
+        onClick={handleMoreClose}
+      >
+        demo on&#160;<code>master</code>
+      </MenuItem>,
+    );
+
+    /* eslint-enable material-ui/no-hardcoded-labels */
+  }
+
   return (
     <React.Fragment>
       <div aria-label={t('demoToolbarLabel')} className={classes.root} {...toolbarProps}>
@@ -521,6 +587,7 @@ export default function DemoToolbar(props) {
             >
               {t('copySourceLinkTS')}
             </MenuItem>
+            {devMenuItems}
           </Menu>
         </div>
       </div>


### PR DESCRIPTION
https://user-images.githubusercontent.com/12292047/116673275-7bfeed80-a9a3-11eb-88d9-451aac5512ba.mp4

Preview: http://deploy-preview-26065--material-ui.netlify.app/components/box

I often find myself switching between a PR and its base branch when doing manual testing. It was a bit annoying to constantly have to adjust these links manually so I just automatically include them now in deploys on `mui-org/material` (or local development). material-ui.com deploys should be minimally affected due to dead-code-elimination.

Also includes a permalink which was was not that trivial to get (always scrolled through netlify.com).


