### PR TITLE
[pickers] Remove unused components from mobile and desktop variants

### DIFF
--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -7,7 +7,6 @@ import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -64,7 +63,6 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
-      PureDateInputComponent={PureDateInput}
     >
       <Picker
         {...pickerProps}

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -71,7 +71,6 @@ const useDateRangeValidation = makeValidationHook<
 });
 
 const KeyboardDateInputComponent = DateRangePickerInput as React.FC<DateInputPropsLike>;
-const PureDateInputComponent = DateRangePickerInput as React.FC<DateInputPropsLike>;
 
 const rangePickerValueManager: PickerStateValueManager<any, any> = {
   emptyValue: [null, null],
@@ -161,7 +160,6 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
       {...wrapperProps}
       DateInputProps={DateInputProps}
       KeyboardDateInputComponent={KeyboardDateInputComponent}
-      PureDateInputComponent={PureDateInputComponent}
     >
       <DateRangePickerView<any>
         open={wrapperProps.open}

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -7,7 +7,6 @@ import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -64,7 +63,6 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
-      PureDateInputComponent={PureDateInput}
     >
       <Picker
         {...pickerProps}

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -7,7 +7,6 @@ import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
@@ -64,7 +63,6 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
-      PureDateInputComponent={PureDateInput}
     >
       <Picker
         {...pickerProps}

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -6,7 +6,6 @@ import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/
 import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
-import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
@@ -63,7 +62,6 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
       {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInput}
       PureDateInputComponent={PureDateInput}
     >
       <Picker

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -69,7 +69,6 @@ const useDateRangeValidation = makeValidationHook<
   isSameError: (a, b) => b !== null && a[1] === b[1] && a[0] === b[0],
 });
 
-const KeyboardDateInputComponent = DateRangePickerInput as React.FC<DateInputPropsLike>;
 const PureDateInputComponent = DateRangePickerInput as React.FC<DateInputPropsLike>;
 
 const rangePickerValueManager: PickerStateValueManager<any, any> = {
@@ -159,7 +158,6 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
       {...restProps}
       {...wrapperProps}
       DateInputProps={DateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInputComponent}
       PureDateInputComponent={PureDateInputComponent}
     >
       <DateRangePickerView<any>

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -6,7 +6,6 @@ import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/
 import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
-import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
@@ -63,7 +62,6 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
       {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInput}
       PureDateInputComponent={PureDateInput}
     >
       <Picker

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -6,7 +6,6 @@ import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/
 import Picker from '../internal/pickers/Picker/Picker';
 import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
-import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
 
@@ -63,7 +62,6 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
       {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
-      KeyboardDateInputComponent={KeyboardDateInput}
       PureDateInputComponent={PureDateInput}
     >
       <Picker

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopTooltipWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopTooltipWrapper.tsx
@@ -3,10 +3,9 @@ import { useForkRef } from '@material-ui/core/utils';
 import { WrapperVariantContext } from './WrapperVariantContext';
 import { executeInTheNextEventLoopTick } from '../utils';
 import PickersPopper from '../PickersPopper';
-import { PrivateWrapperProps } from './WrapperProps';
-import { DesktopWrapperProps } from './DesktopWrapper';
+import { InternalDesktopWrapperProps } from './DesktopWrapper';
 
-const DesktopTooltipWrapper: React.FC<PrivateWrapperProps & DesktopWrapperProps> = (props) => {
+function DesktopTooltipWrapper(props: InternalDesktopWrapperProps) {
   const {
     children,
     DateInputProps,
@@ -51,6 +50,6 @@ const DesktopTooltipWrapper: React.FC<PrivateWrapperProps & DesktopWrapperProps>
       </PickersPopper>
     </WrapperVariantContext.Provider>
   );
-};
+}
 
 export default DesktopTooltipWrapper;

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { useForkRef } from '@material-ui/core/utils';
 import { WrapperVariantContext } from './WrapperVariantContext';
 import PickersPopper, { ExportedPickerPopperProps } from '../PickersPopper';
-import { PrivateWrapperProps } from './WrapperProps';
+import { DateInputPropsLike, PrivateWrapperProps } from './WrapperProps';
 
 export interface DesktopWrapperProps extends ExportedPickerPopperProps {
   children?: React.ReactNode;
 }
 
-const DesktopWrapper: React.FC<PrivateWrapperProps & DesktopWrapperProps> = (props) => {
+export interface InternalDesktopWrapperProps extends DesktopWrapperProps, PrivateWrapperProps {
+  DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
+  KeyboardDateInputComponent: React.ComponentType<
+    DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> }
+  >;
+}
+
+function DesktopWrapper(props: InternalDesktopWrapperProps) {
   const {
     children,
     DateInputProps,
@@ -37,11 +43,6 @@ const DesktopWrapper: React.FC<PrivateWrapperProps & DesktopWrapperProps> = (pro
       </PickersPopper>
     </WrapperVariantContext.Provider>
   );
-};
-
-DesktopWrapper.propTypes = {
-  onOpen: PropTypes.func,
-  onClose: PropTypes.func,
-} as any;
+}
 
 export default DesktopWrapper;

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/MobileWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/MobileWrapper.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { WrapperVariantContext } from './WrapperVariantContext';
 import PickersModalDialog, { ExportedPickerModalProps } from '../PickersModalDialog';
-import { PrivateWrapperProps } from './WrapperProps';
+import { PrivateWrapperProps, DateInputPropsLike } from './WrapperProps';
 
 export interface MobileWrapperProps extends ExportedPickerModalProps {
   children?: React.ReactNode;
 }
 
-const MobileWrapper: React.FC<MobileWrapperProps & PrivateWrapperProps> = (props) => {
+export interface InternalMobileWrapperProps extends MobileWrapperProps, PrivateWrapperProps {
+  DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
+  PureDateInputComponent: React.ComponentType<DateInputPropsLike>;
+}
+
+function MobileWrapper(props: InternalMobileWrapperProps) {
   const {
     cancelText,
     children,
@@ -16,7 +20,6 @@ const MobileWrapper: React.FC<MobileWrapperProps & PrivateWrapperProps> = (props
     clearText,
     DateInputProps,
     DialogProps,
-    KeyboardDateInputComponent,
     okText,
     onAccept,
     onClear,
@@ -33,33 +36,23 @@ const MobileWrapper: React.FC<MobileWrapperProps & PrivateWrapperProps> = (props
     <WrapperVariantContext.Provider value="mobile">
       <PureDateInputComponent {...other} {...DateInputProps} />
       <PickersModalDialog
-        open={open}
-        onClear={onClear}
-        onAccept={onAccept}
-        onDismiss={onDismiss}
-        onSetToday={onSetToday}
-        clearText={clearText}
-        todayText={todayText}
-        okText={okText}
         cancelText={cancelText}
         clearable={clearable}
-        showTodayButton={showTodayButton}
+        clearText={clearText}
         DialogProps={DialogProps}
+        okText={okText}
+        onAccept={onAccept}
+        onClear={onClear}
+        onDismiss={onDismiss}
+        onSetToday={onSetToday}
+        open={open}
+        showTodayButton={showTodayButton}
+        todayText={todayText}
       >
         {children}
       </PickersModalDialog>
     </WrapperVariantContext.Provider>
   );
-};
-
-MobileWrapper.propTypes = {
-  cancelText: PropTypes.node,
-  clearable: PropTypes.bool,
-  clearText: PropTypes.node,
-  DialogProps: PropTypes.object,
-  okText: PropTypes.node,
-  showTodayButton: PropTypes.bool,
-  todayText: PropTypes.node,
-};
+}
 
 export default MobileWrapper;

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/ResponsiveWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/ResponsiveWrapper.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import MobileWrapper, { MobileWrapperProps } from './MobileWrapper';
-import DesktopWrapper, { DesktopWrapperProps } from './DesktopWrapper';
+import MobileWrapper, { InternalMobileWrapperProps, MobileWrapperProps } from './MobileWrapper';
+import DesktopWrapper, { InternalDesktopWrapperProps, DesktopWrapperProps } from './DesktopWrapper';
 import DesktopTooltipWrapper from './DesktopTooltipWrapper';
-import { PrivateWrapperProps } from './WrapperProps';
+import { DateInputPropsLike, PrivateWrapperProps } from './WrapperProps';
 
 export interface ResponsiveWrapperProps extends MobileWrapperProps, DesktopWrapperProps {
   /**
@@ -14,44 +14,60 @@ export interface ResponsiveWrapperProps extends MobileWrapperProps, DesktopWrapp
   desktopModeMediaQuery?: string;
 }
 
+interface InternalResponsiveWrapperProps extends ResponsiveWrapperProps, PrivateWrapperProps {
+  DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
+  KeyboardDateInputComponent: React.JSXElementConstructor<
+    DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> }
+  >;
+  PureDateInputComponent: React.JSXElementConstructor<DateInputPropsLike>;
+}
+
 export const makeResponsiveWrapper = (
-  DesktopWrapperComponent: React.FC<PrivateWrapperProps & DesktopWrapperProps>,
-  MobileWrapperComponent: React.FC<PrivateWrapperProps & MobileWrapperProps>,
+  DesktopWrapperComponent: React.JSXElementConstructor<InternalDesktopWrapperProps>,
+  MobileWrapperComponent: React.JSXElementConstructor<InternalMobileWrapperProps>,
 ) => {
-  const ResponsiveWrapper: React.FC<ResponsiveWrapperProps & PrivateWrapperProps> = ({
-    cancelText,
-    clearable,
-    clearText,
-    desktopModeMediaQuery = '@media (pointer: fine)',
-    DialogProps,
-    okText,
-    PopperProps,
-    showTodayButton,
-    todayText,
-    TransitionComponent,
-    ...other
-  }) => {
+  function ResponsiveWrapper(props: InternalResponsiveWrapperProps) {
+    const {
+      cancelText,
+      clearable,
+      clearText,
+      DateInputProps,
+      desktopModeMediaQuery = '@media (pointer: fine)',
+      DialogProps,
+      KeyboardDateInputComponent,
+      okText,
+      PopperProps,
+      PureDateInputComponent,
+      showTodayButton,
+      todayText,
+      TransitionComponent,
+      ...other
+    } = props;
     const isDesktop = useMediaQuery(desktopModeMediaQuery);
 
     return isDesktop ? (
       <DesktopWrapperComponent
+        DateInputProps={DateInputProps}
+        KeyboardDateInputComponent={KeyboardDateInputComponent}
         PopperProps={PopperProps}
         TransitionComponent={TransitionComponent}
         {...other}
       />
     ) : (
       <MobileWrapperComponent
-        okText={okText}
         cancelText={cancelText}
-        clearText={clearText}
-        todayText={todayText}
-        showTodayButton={showTodayButton}
         clearable={clearable}
+        clearText={clearText}
+        DateInputProps={DateInputProps}
         DialogProps={DialogProps}
+        okText={okText}
+        PureDateInputComponent={PureDateInputComponent}
+        showTodayButton={showTodayButton}
+        todayText={todayText}
         {...other}
       />
     );
-  };
+  }
 
   return ResponsiveWrapper;
 };

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/WrapperProps.ts
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/WrapperProps.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { DateInputProps } from '../PureDateInput';
 
 export type DateInputPropsLike = Omit<
@@ -10,14 +9,9 @@ export type DateInputPropsLike = Omit<
 };
 
 export interface PrivateWrapperProps {
-  DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
-  KeyboardDateInputComponent: React.ComponentType<
-    DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> }
-  >;
   onAccept: () => void;
   onClear: () => void;
   onDismiss: () => void;
   onSetToday: () => void;
   open: boolean;
-  PureDateInputComponent: React.ComponentType<DateInputPropsLike>;
 }


### PR DESCRIPTION
Same approach as https://github.com/mui-org/material-ui/pull/26052.

Used the opportunity to
1. get rid of some (implied) `React.FunctionComponent` usages
1. Remove unmaintained .propTypes
1. order props 