### PR TITLE
[Radio] Migrate RadioButtonIcon to emotion

### DIFF
--- a/packages/material-ui/src/Radio/RadioButtonIcon.js
+++ b/packages/material-ui/src/Radio/RadioButtonIcon.js
@@ -22,7 +22,7 @@ const RadioButtonIconBackground = experimentalStyled(RadioButtonUncheckedIcon)({
   transform: 'scale(1)',
 });
 
-const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme, styleProps }) => ({
+const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme }) => ({
   left: 0,
   position: 'absolute',
   transform: 'scale(0)',

--- a/packages/material-ui/src/Radio/RadioButtonIcon.js
+++ b/packages/material-ui/src/Radio/RadioButtonIcon.js
@@ -3,47 +3,49 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
-import withStyles from '../styles/withStyles';
+import experimentalStyled from '../styles/experimentalStyled';
 
-export const styles = (theme) => ({
-  root: {
-    position: 'relative',
-    display: 'flex',
-    '&$checked $dot': {
-      transform: 'scale(1)',
-      transition: theme.transitions.create('transform', {
-        easing: theme.transitions.easing.easeOut,
-        duration: theme.transitions.duration.shortest,
-      }),
-    },
-  },
-  checked: {},
-  background: {
-    // Scale applied to prevent dot misalignment in Safari
+const RadioButtonIconRoot = experimentalStyled('span')(({ theme }) => ({
+  position: 'relative',
+  display: 'flex',
+  '&.Mui-checked .MuiRadioButtonIcon-dot': {
     transform: 'scale(1)',
-  },
-  dot: {
-    left: 0,
-    position: 'absolute',
-    transform: 'scale(0)',
     transition: theme.transitions.create('transform', {
-      easing: theme.transitions.easing.easeIn,
+      easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.shortest,
     }),
   },
+}));
+
+const RadioButtonIconBackground = experimentalStyled(RadioButtonUncheckedIcon)({
+  // Scale applied to prevent dot misalignment in Safari
+  transform: 'scale(1)',
 });
+
+const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme, styleProps }) => ({
+  left: 0,
+  position: 'absolute',
+  transform: 'scale(0)',
+  transition: theme.transitions.create('transform', {
+    easing: theme.transitions.easing.easeIn,
+    duration: theme.transitions.duration.shortest,
+  }),
+}));
 
 /**
  * @ignore - internal component.
  */
 function RadioButtonIcon(props) {
-  const { checked, classes, fontSize } = props;
+  const { checked, classes = {}, fontSize } = props;
 
   return (
-    <span className={clsx(classes.root, { [classes.checked]: checked })}>
-      <RadioButtonUncheckedIcon fontSize={fontSize} className={classes.background} />
-      <RadioButtonCheckedIcon fontSize={fontSize} className={classes.dot} />
-    </span>
+    <RadioButtonIconRoot className={clsx(classes.root, { 'Mui-checked': checked })}>
+      <RadioButtonIconBackground fontSize={fontSize} className={classes.background} />
+      <RadioButtonIconDot
+        fontSize={fontSize}
+        className={clsx('MuiRadioButtonIcon-dot', classes.dot)}
+      />
+    </RadioButtonIconRoot>
   );
 }
 
@@ -64,4 +66,4 @@ RadioButtonIcon.propTypes = {
   fontSize: PropTypes.oneOf(['small', 'medium']),
 };
 
-export default withStyles(styles, { name: 'PrivateRadioButtonIcon' })(RadioButtonIcon);
+export default RadioButtonIcon;

--- a/packages/material-ui/src/Radio/RadioButtonIcon.js
+++ b/packages/material-ui/src/Radio/RadioButtonIcon.js
@@ -1,28 +1,20 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import experimentalStyled from '../styles/experimentalStyled';
 
-const RadioButtonIconRoot = experimentalStyled('span')(({ theme }) => ({
+const RadioButtonIconRoot = experimentalStyled('span')({
   position: 'relative',
   display: 'flex',
-  '&.Mui-checked .MuiRadioButtonIcon-dot': {
-    transform: 'scale(1)',
-    transition: theme.transitions.create('transform', {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.shortest,
-    }),
-  },
-}));
+});
 
 const RadioButtonIconBackground = experimentalStyled(RadioButtonUncheckedIcon)({
   // Scale applied to prevent dot misalignment in Safari
   transform: 'scale(1)',
 });
 
-const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme }) => ({
+const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme, styleProps }) => ({
   left: 0,
   position: 'absolute',
   transform: 'scale(0)',
@@ -30,20 +22,30 @@ const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme }
     easing: theme.transitions.easing.easeIn,
     duration: theme.transitions.duration.shortest,
   }),
+  ...(styleProps.checked && {
+    transform: 'scale(1)',
+    transition: theme.transitions.create('transform', {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.shortest,
+    }),
+  })
 }));
 
 /**
  * @ignore - internal component.
  */
 function RadioButtonIcon(props) {
-  const { checked, classes = {}, fontSize } = props;
+  const { classes = {}, fontSize } = props;
+
+  const styleProps = props;
 
   return (
-    <RadioButtonIconRoot className={clsx(classes.root, { 'Mui-checked': checked })}>
-      <RadioButtonIconBackground fontSize={fontSize} className={classes.background} />
+    <RadioButtonIconRoot className={classes.root} styleProps={styleProps} >
+      <RadioButtonIconBackground fontSize={fontSize} className={classes.background} styleProps={styleProps} />
       <RadioButtonIconDot
         fontSize={fontSize}
-        className={clsx('MuiRadioButtonIcon-dot', classes.dot)}
+        className={classes.dot}
+        styleProps={styleProps}
       />
     </RadioButtonIconRoot>
   );

--- a/packages/material-ui/src/Radio/RadioButtonIcon.js
+++ b/packages/material-ui/src/Radio/RadioButtonIcon.js
@@ -28,25 +28,25 @@ const RadioButtonIconDot = experimentalStyled(RadioButtonCheckedIcon)(({ theme, 
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.shortest,
     }),
-  })
+  }),
 }));
 
 /**
  * @ignore - internal component.
  */
 function RadioButtonIcon(props) {
-  const { classes = {}, fontSize } = props;
+  const { checked = false, classes = {}, fontSize } = props;
 
-  const styleProps = props;
+  const styleProps = { ...props, checked };
 
   return (
-    <RadioButtonIconRoot className={classes.root} styleProps={styleProps} >
-      <RadioButtonIconBackground fontSize={fontSize} className={classes.background} styleProps={styleProps} />
-      <RadioButtonIconDot
+    <RadioButtonIconRoot className={classes.root} styleProps={styleProps}>
+      <RadioButtonIconBackground
         fontSize={fontSize}
-        className={classes.dot}
+        className={classes.background}
         styleProps={styleProps}
       />
+      <RadioButtonIconDot fontSize={fontSize} className={classes.dot} styleProps={styleProps} />
     </RadioButtonIconRoot>
   );
 }

--- a/packages/material-ui/src/Radio/RadioButtonIcon.js
+++ b/packages/material-ui/src/Radio/RadioButtonIcon.js
@@ -58,7 +58,7 @@ RadioButtonIcon.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * The size of the component.
    * `small` is equivalent to the dense radio styling.


### PR DESCRIPTION
Seems like this is the last component from `@material-ui/core` that uses the `withStyles` API.