### PR TITLE
[styled-engine] Make styleProps required in styled()

### DIFF
--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -166,7 +166,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
-      styleProps?: Record<string, unknown>;
+      styleProps: Record<string, unknown>;
     },
     {},
     {
@@ -183,7 +183,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
-      styleProps?: Record<string, unknown>;
+      styleProps: Record<string, unknown>;
     },
     {},
     {
@@ -203,7 +203,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
-      styleProps?: Record<string, unknown>;
+      styleProps: Record<string, unknown>;
     }
   >;
 
@@ -216,7 +216,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
-      styleProps?: Record<string, unknown>;
+      styleProps: Record<string, unknown>;
     }
   >;
 
@@ -232,7 +232,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
-      styleProps?: Record<string, unknown>;
+      styleProps: Record<string, unknown>;
     },
     Pick<JSX.IntrinsicElements[Tag], ForwardedProps>
   >;
@@ -246,7 +246,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
-      styleProps?: Record<string, unknown>;
+      styleProps: Record<string, unknown>;
     },
     JSX.IntrinsicElements[Tag]
   >;


### PR DESCRIPTION
Opening to see what will be the implication of changing `styleProps` to be required in `experimentalStyled`. I could spot around 70 issues on usages of `experimentalStyled()` inside the docs. It is probably better to re-export the `experimentalStyled()` as `internalStyled()` too so that we can tweak the typings only on the internal usages.