### PR TITLE
[core] ComponentType -> JSXElementConstructor

### DIFF
--- a/docs/pages/api-docs/date-picker.json
+++ b/docs/pages/api-docs/date-picker.json
@@ -86,7 +86,7 @@
     "showTodayButton": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
     "todayText": { "type": { "name": "node" }, "default": "\"TODAY\"" },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DatePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DatePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -110,7 +110,7 @@
     "showToolbar": { "type": { "name": "bool" } },
     "timeIcon": { "type": { "name": "node" } },
     "todayText": { "type": { "name": "node" }, "default": "\"TODAY\"" },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DateTimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DateTimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/desktop-date-picker.json
+++ b/docs/pages/api-docs/desktop-date-picker.json
@@ -75,7 +75,7 @@
     "shouldDisableYear": { "type": { "name": "func" } },
     "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DatePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DatePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -99,7 +99,7 @@
     "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
     "timeIcon": { "type": { "name": "node" } },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DateTimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DateTimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/desktop-time-picker.json
+++ b/docs/pages/api-docs/desktop-time-picker.json
@@ -54,7 +54,7 @@
     "rifmFormatter": { "type": { "name": "func" } },
     "shouldDisableTime": { "type": { "name": "func" } },
     "showToolbar": { "type": { "name": "bool" } },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "TimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "TimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/mobile-date-picker.json
+++ b/docs/pages/api-docs/mobile-date-picker.json
@@ -81,7 +81,7 @@
     "showTodayButton": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
     "todayText": { "type": { "name": "node" }, "default": "\"TODAY\"" },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DatePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DatePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -105,7 +105,7 @@
     "showToolbar": { "type": { "name": "bool" } },
     "timeIcon": { "type": { "name": "node" } },
     "todayText": { "type": { "name": "node" }, "default": "\"TODAY\"" },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DateTimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DateTimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/mobile-time-picker.json
+++ b/docs/pages/api-docs/mobile-time-picker.json
@@ -60,7 +60,7 @@
     "showTodayButton": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
     "todayText": { "type": { "name": "node" }, "default": "\"TODAY\"" },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "TimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "TimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/static-date-picker.json
+++ b/docs/pages/api-docs/static-date-picker.json
@@ -78,7 +78,7 @@
     "shouldDisableYear": { "type": { "name": "func" } },
     "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DatePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DatePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -102,7 +102,7 @@
     "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
     "timeIcon": { "type": { "name": "node" } },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "DateTimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "DateTimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/static-time-picker.json
+++ b/docs/pages/api-docs/static-time-picker.json
@@ -57,7 +57,7 @@
     "rifmFormatter": { "type": { "name": "func" } },
     "shouldDisableTime": { "type": { "name": "func" } },
     "showToolbar": { "type": { "name": "bool" } },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "TimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "TimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/docs/pages/api-docs/time-picker.json
+++ b/docs/pages/api-docs/time-picker.json
@@ -65,7 +65,7 @@
     "showTodayButton": { "type": { "name": "bool" } },
     "showToolbar": { "type": { "name": "bool" } },
     "todayText": { "type": { "name": "node" }, "default": "\"TODAY\"" },
-    "ToolbarComponent": { "type": { "name": "func" }, "default": "TimePickerToolbar" },
+    "ToolbarComponent": { "type": { "name": "elementType" }, "default": "TimePickerToolbar" },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"–\"" },
     "toolbarTitle": { "type": { "name": "node" }, "default": "\"SELECT DATE\"" },

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -24,7 +24,7 @@ import {
 } from '../internal/pickers/constants/prop-types';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import Picker from '../internal/pickers/Picker/Picker';
-import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
+import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
@@ -55,7 +55,7 @@ export interface BaseDatePickerProps<TDate>
    * Component that will replace default toolbar renderer.
    * @default DatePickerToolbar
    */
-  ToolbarComponent?: BasePickerProps<ParseableDate<TDate>, TDate | null>['ToolbarComponent'];
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
   /**
    * Array of views to show.
    */
@@ -464,7 +464,7 @@ DatePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DatePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -25,7 +25,7 @@ import {
   defaultMaxDate,
 } from '../internal/pickers/constants/prop-types';
 import Picker from '../internal/pickers/Picker/Picker';
-import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
+import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
@@ -75,7 +75,7 @@ export interface BaseDateTimePickerProps<TDate>
    * Component that will replace default toolbar renderer.
    * @default DateTimePickerToolbar
    */
-  ToolbarComponent?: BasePickerProps<ParseableDate<TDate>, TDate | null>['ToolbarComponent'];
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
   /**
    * Date format, that is displaying in toolbar.
    */
@@ -601,7 +601,7 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DateTimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -353,7 +353,7 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DatePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -435,7 +435,7 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DateTimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -289,7 +289,7 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default TimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -383,7 +383,7 @@ MobileDatePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DatePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -465,7 +465,7 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DateTimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -319,7 +319,7 @@ MobileTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default TimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -354,7 +354,7 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DatePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -436,7 +436,7 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default DateTimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -288,7 +288,7 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default TimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -21,7 +21,7 @@ import {
   OverrideParseableDateProps,
 } from '../internal/pickers/hooks/date-helpers-hooks';
 import Picker from '../internal/pickers/Picker/Picker';
-import { BasePickerProps } from '../internal/pickers/typings/BasePicker';
+import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
 import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
@@ -48,7 +48,7 @@ export interface BaseTimePickerProps<TDate = unknown>
    * Component that will replace default toolbar renderer.
    * @default TimePickerToolbar
    */
-  ToolbarComponent?: BasePickerProps<ParseableDate<TDate>, TDate | null>['ToolbarComponent'];
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
   /**
    * Array of views to show.
    */
@@ -413,7 +413,7 @@ TimePicker.propTypes /* remove-proptypes */ = {
    * Component that will replace default toolbar renderer.
    * @default TimePickerToolbar
    */
-  ToolbarComponent: PropTypes.func,
+  ToolbarComponent: PropTypes.elementType,
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
@@ -41,7 +41,7 @@ export interface TreeItemProps
    * The component used for the content node.
    * @default TreeItemContent
    */
-  ContentComponent?: React.ComponentType<TreeItemContentProps>;
+  ContentComponent?: React.JSXElementConstructor<TreeItemContentProps>;
   /**
    * Props applied to ContentComponent
    */
@@ -80,7 +80,7 @@ export interface TreeItemProps
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Collapse
    */
-  TransitionComponent?: React.ComponentType<TransitionProps>;
+  TransitionComponent?: React.JSXElementConstructor<TransitionProps>;
   /**
    * Props applied to the transition element.
    * By default, the element is based on this [`Transition`](http://reactcommunity.org/react-transition-group/transition) component.

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -18,7 +18,7 @@ export interface ExportedPickerPopperProps {
   /**
    * Custom component for popper [Transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).
    */
-  TransitionComponent?: React.ComponentType<MuiTransitionProps>;
+  TransitionComponent?: React.JSXElementConstructor<MuiTransitionProps>;
 }
 
 export interface PickerPopperProps extends ExportedPickerPopperProps, MuiPaperProps {

--- a/packages/material-ui-lab/src/internal/pickers/typings/BasePicker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/typings/BasePicker.tsx
@@ -80,7 +80,7 @@ export interface BasePickerProps<TInputValue, TDateValue> {
   /**
    * Component that will replace default toolbar renderer.
    */
-  ToolbarComponent?: React.ComponentType<ToolbarComponentProps>;
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
   /**
    * Date format, that is displaying in toolbar.
    */

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
@@ -10,7 +10,7 @@ export interface DesktopWrapperProps extends ExportedPickerPopperProps {
 
 export interface InternalDesktopWrapperProps extends DesktopWrapperProps, PrivateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
-  KeyboardDateInputComponent: React.ComponentType<
+  KeyboardDateInputComponent: React.JSXElementConstructor<
     DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> }
   >;
 }

--- a/packages/material-ui-lab/src/internal/pickers/wrappers/MobileWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/MobileWrapper.tsx
@@ -9,7 +9,7 @@ export interface MobileWrapperProps extends ExportedPickerModalProps {
 
 export interface InternalMobileWrapperProps extends MobileWrapperProps, PrivateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
-  PureDateInputComponent: React.ComponentType<DateInputPropsLike>;
+  PureDateInputComponent: React.JSXElementConstructor<DateInputPropsLike>;
 }
 
 function MobileWrapper(props: InternalMobileWrapperProps) {

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.d.ts
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.d.ts
@@ -19,6 +19,6 @@ export interface StylesProviderProps extends StylesOptions {
   children?: React.ReactNode;
 }
 
-declare const StylesProvider: React.ComponentType<StylesProviderProps>;
+declare const StylesProvider: React.JSXElementConstructor<StylesProviderProps>;
 
 export default StylesProvider;

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -7,7 +7,7 @@ import {
 import * as React from 'react';
 import { DefaultTheme } from '../defaultTheme';
 
-// We don't want a union type here (like React.ComponentType) in order to support mapped types.
+// We don't want a union type here (like React.JSXElementConstructor) in order to support mapped types.
 export type StyledComponent<P extends {}> = (props: P) => React.ReactElement<P, any> | null;
 
 /**

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -20,10 +20,10 @@ export function withThemeCreator<Theme = DefaultTheme>(
 
 export default function withTheme<
   Theme,
-  C extends React.ComponentType<ConsistentWith<React.ComponentProps<C>, WithTheme<Theme>>>
+  C extends React.JSXElementConstructor<ConsistentWith<React.ComponentProps<C>, WithTheme<Theme>>>
 >(
   component: C,
-): React.ComponentType<
+): React.JSXElementConstructor<
   DistributiveOmit<
     JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>,
     keyof WithTheme<Theme>

--- a/packages/material-ui-utils/src/requirePropFactory.d.ts
+++ b/packages/material-ui-utils/src/requirePropFactory.d.ts
@@ -2,5 +2,5 @@ import * as React from 'react';
 
 export default function requirePropFactory(
   componentNameInError: string,
-  Component?: React.ComponentType,
+  Component?: React.JSXElementConstructor<unknown>,
 ): any;

--- a/packages/material-ui/src/Accordion/Accordion.d.ts
+++ b/packages/material-ui/src/Accordion/Accordion.d.ts
@@ -62,7 +62,7 @@ export interface AccordionProps extends StandardProps<PaperProps, 'onChange'> {
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Collapse
    */
-  TransitionComponent?: React.ComponentType<
+  TransitionComponent?: React.JSXElementConstructor<
     TransitionProps & { children?: React.ReactElement<any, any> }
   >;
   /**

--- a/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
@@ -178,7 +178,7 @@ export interface AutocompleteProps<
    * The component used to render the listbox.
    * @default 'ul'
    */
-  ListboxComponent?: React.ComponentType<React.HTMLAttributes<HTMLElement>>;
+  ListboxComponent?: React.JSXElementConstructor<React.HTMLAttributes<HTMLElement>>;
   /**
    * Props applied to the Listbox element.
    */
@@ -219,12 +219,12 @@ export interface AutocompleteProps<
    * The component used to render the body of the popup.
    * @default Paper
    */
-  PaperComponent?: React.ComponentType<React.HTMLAttributes<HTMLElement>>;
+  PaperComponent?: React.JSXElementConstructor<React.HTMLAttributes<HTMLElement>>;
   /**
    * The component used to position the popup.
    * @default Popper
    */
-  PopperComponent?: React.ComponentType<PopperProps>;
+  PopperComponent?: React.JSXElementConstructor<PopperProps>;
   /**
    * The icon to display in place of the default popup icon.
    * @default <ArrowDropDownIcon />

--- a/packages/material-ui/src/ButtonBase/TouchRipple.d.ts
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.d.ts
@@ -26,6 +26,6 @@ export type TouchRippleProps = StandardProps<React.HTMLAttributes<HTMLElement>> 
 
 export type TouchRippleClassKey = keyof NonNullable<TouchRippleProps['classes']>;
 
-declare const TouchRipple: React.ComponentType<TouchRippleProps>;
+declare const TouchRipple: React.JSXElementConstructor<TouchRippleProps>;
 
 export default TouchRipple;

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -97,7 +97,7 @@ export interface DialogProps
    * The component used to render the body of the dialog.
    * @default Paper
    */
-  PaperComponent?: React.ComponentType<PaperProps>;
+  PaperComponent?: React.JSXElementConstructor<PaperProps>;
   /**
    * Props applied to the [`Paper`](/api/paper/) element.
    * @default {}
@@ -117,7 +117,7 @@ export interface DialogProps
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Fade
    */
-  TransitionComponent?: React.ComponentType<
+  TransitionComponent?: React.JSXElementConstructor<
     TransitionProps & { children?: React.ReactElement<any, any> }
   >;
   /**

--- a/packages/material-ui/src/Hidden/Hidden.d.ts
+++ b/packages/material-ui/src/Hidden/Hidden.d.ts
@@ -91,6 +91,6 @@ export interface HiddenProps {
  *
  * - [Hidden API](https://material-ui.com/api/hidden/)
  */
-declare const Hidden: React.ComponentType<HiddenProps>;
+declare const Hidden: React.JSXElementConstructor<HiddenProps>;
 
 export default Hidden;

--- a/packages/material-ui/src/Hidden/HiddenCss.d.ts
+++ b/packages/material-ui/src/Hidden/HiddenCss.d.ts
@@ -15,6 +15,6 @@ export interface HiddenCssProps {
   xsUp?: boolean;
 }
 
-declare const HiddenCss: React.ComponentType<HiddenCssProps>;
+declare const HiddenCss: React.JSXElementConstructor<HiddenCssProps>;
 
 export default HiddenCss;

--- a/packages/material-ui/src/Hidden/HiddenJs.d.ts
+++ b/packages/material-ui/src/Hidden/HiddenJs.d.ts
@@ -16,6 +16,6 @@ export interface HiddenJsProps {
   xsUp?: boolean;
 }
 
-declare const HiddenJs: React.ComponentType<HiddenJsProps>;
+declare const HiddenJs: React.JSXElementConstructor<HiddenJsProps>;
 
 export default HiddenJs;

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
@@ -10,6 +10,6 @@ export interface NativeSelectInputProps extends React.SelectHTMLAttributes<HTMLS
   sx?: SxProps<Theme>;
 }
 
-declare const NativeSelectInput: React.ComponentType<NativeSelectInputProps>;
+declare const NativeSelectInput: React.JSXElementConstructor<NativeSelectInputProps>;
 
 export default NativeSelectInput;

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.d.ts
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.d.ts
@@ -11,6 +11,6 @@ export interface NotchedOutlineProps
 
 export type NotchedOutlineClassKey = keyof NonNullable<NotchedOutlineProps['classes']>;
 
-declare const NotchedOutline: React.ComponentType<NotchedOutlineProps>;
+declare const NotchedOutline: React.JSXElementConstructor<NotchedOutlineProps>;
 
 export default NotchedOutline;

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -118,7 +118,7 @@ export interface PopoverProps
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Grow
    */
-  TransitionComponent?: React.ComponentType<
+  TransitionComponent?: React.JSXElementConstructor<
     TransitionProps & { children?: React.ReactElement<any, any> }
   >;
   /**

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -33,6 +33,6 @@ export interface SelectInputProps<T = unknown> {
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-declare const SelectInput: React.ComponentType<SelectInputProps>;
+declare const SelectInput: React.JSXElementConstructor<SelectInputProps>;
 
 export default SelectInput;

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -112,7 +112,7 @@ export interface SnackbarProps
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Grow
    */
-  TransitionComponent?: React.ComponentType<
+  TransitionComponent?: React.JSXElementConstructor<
     TransitionProps & { children?: React.ReactElement<any, any> }
   >;
   /**

--- a/packages/material-ui/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.d.ts
@@ -94,7 +94,7 @@ export interface SpeedDialProps
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Zoom
    */
-  TransitionComponent?: React.ComponentType<TransitionProps>;
+  TransitionComponent?: React.JSXElementConstructor<TransitionProps>;
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.

--- a/packages/material-ui/src/StepContent/StepContent.d.ts
+++ b/packages/material-ui/src/StepContent/StepContent.d.ts
@@ -29,7 +29,7 @@ export interface StepContentProps extends StandardProps<React.HTMLAttributes<HTM
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Collapse
    */
-  TransitionComponent?: React.ComponentType<TransitionProps>;
+  TransitionComponent?: React.JSXElementConstructor<TransitionProps>;
   /**
    * Adjust the duration of the content expand transition.
    * Passed as a prop to the transition component.

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.d.ts
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.d.ts
@@ -72,6 +72,6 @@ export interface SwipeableDrawerProps extends Omit<DrawerProps, 'onClose' | 'ope
  * - [SwipeableDrawer API](https://material-ui.com/api/swipeable-drawer/)
  * - inherits [Drawer API](https://material-ui.com/api/drawer/)
  */
-declare const SwipeableDrawer: React.ComponentType<SwipeableDrawerProps>;
+declare const SwipeableDrawer: React.JSXElementConstructor<SwipeableDrawerProps>;
 
 export default SwipeableDrawer;

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -159,7 +159,7 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
  * - inherits [TableCell API](https://material-ui.com/api/table-cell/)
  */
 declare const TablePagination: OverridableComponent<
-  TablePaginationTypeMap<{}, React.ComponentType<TablePaginationBaseProps>>
+  TablePaginationTypeMap<{}, React.JSXElementConstructor<TablePaginationBaseProps>>
 >;
 
 export type TablePaginationClassKey = keyof NonNullable<TablePaginationProps['classes']>;
@@ -167,7 +167,7 @@ export type TablePaginationClassKey = keyof NonNullable<TablePaginationProps['cl
 export type TablePaginationBaseProps = Omit<TableCellProps, 'classes' | 'component' | 'children'>;
 
 export type TablePaginationProps<
-  D extends React.ElementType = React.ComponentType<TablePaginationBaseProps>,
+  D extends React.ElementType = React.JSXElementConstructor<TablePaginationBaseProps>,
   P = {}
 > = OverrideProps<TablePaginationTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/TablePagination/TablePaginationActions.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePaginationActions.d.ts
@@ -25,6 +25,6 @@ export interface TablePaginationActionsProps extends React.HTMLAttributes<HTMLDi
   showLastButton: boolean;
 }
 
-declare const TablePaginationActions: React.ComponentType<TablePaginationActionsProps>;
+declare const TablePaginationActions: React.JSXElementConstructor<TablePaginationActionsProps>;
 
 export default TablePaginationActions;

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -47,7 +47,7 @@ export type TableSortLabelTypeMap<
      * Sort icon to use.
      * @default ArrowDownwardIcon
      */
-    IconComponent?: React.ComponentType<{ className: string }>;
+    IconComponent?: React.JSXElementConstructor<{ className: string }>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -142,7 +142,7 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
    * The component used for the popper.
    * @default Popper
    */
-  PopperComponent?: React.ComponentType<PopperProps>;
+  PopperComponent?: React.JSXElementConstructor<PopperProps>;
   /**
    * Props applied to the [`Popper`](/api/popper/) element.
    * @default {}
@@ -161,7 +161,7 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
    * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Grow
    */
-  TransitionComponent?: React.ComponentType<
+  TransitionComponent?: React.JSXElementConstructor<
     TransitionProps & { children?: React.ReactElement<any, any> }
   >;
   /**

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -68,6 +68,6 @@ export interface SwitchBaseProps
 
 export type SwitchBaseClassKey = keyof NonNullable<SwitchBaseProps['classes']>;
 
-declare const SwitchBase: React.ComponentType<SwitchBaseProps>;
+declare const SwitchBase: React.JSXElementConstructor<SwitchBaseProps>;
 
 export default SwitchBase;

--- a/packages/material-ui/src/styles/experimentalStyled.d.ts
+++ b/packages/material-ui/src/styles/experimentalStyled.d.ts
@@ -87,7 +87,7 @@ export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
   withComponent<NewTag extends keyof JSXInEl>(
     tag: NewTag,
   ): StyledComponent<JSXInEl[NewTag], StyleProps, Theme>;
-  withComponent<Tag extends React.ComponentType<any>>(
+  withComponent<Tag extends React.JSXElementConstructor<any>>(
     tag: Tag,
   ): StyledComponent<PropsOf<Tag>, StyleProps, Theme>;
 }
@@ -192,7 +192,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   >;
 
   <
-    C extends React.ComponentType<React.ComponentProps<C>>,
+    C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
   >(
     component: C,
@@ -207,7 +207,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     }
   >;
 
-  <C extends React.ComponentType<React.ComponentProps<C>>>(
+  <C extends React.JSXElementConstructor<React.ComponentProps<C>>>(
     component: C,
     options?: StyledOptions,
     muiOptions?: MuiStyledOptions,

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -22,7 +22,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
-) => React.ComponentType<
+) => React.JSXElementConstructor<
   DistributiveOmit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'

--- a/packages/typescript-to-proptypes/src/parser.ts
+++ b/packages/typescript-to-proptypes/src/parser.ts
@@ -27,7 +27,7 @@ export interface ParserOptions {
   /**
    * Control if const declarations should be checked
    * @default false
-   * @example declare const Component: React.ComponentType<Props>;
+   * @example declare const Component: React.JSXElementConstructor<Props>;
    */
   checkDeclarations?: boolean;
 }
@@ -351,7 +351,7 @@ export function parseFromProgram(
       const name = declaration.type.typeName.getText();
       if (
         name === 'React.ElementType' ||
-        name === 'React.ComponentType' ||
+        name === 'React.JSXElementConstructor' ||
         name === 'React.ReactElement'
       ) {
         const elementNode = t.createElementType(
@@ -558,7 +558,7 @@ export function parseFromProgram(
               checkDeclarations &&
               type.aliasSymbol &&
               type.aliasTypeArguments &&
-              checker.getFullyQualifiedName(type.aliasSymbol) === 'React.ComponentType'
+              checker.getFullyQualifiedName(type.aliasSymbol) === 'React.JSXElementConstructor'
             ) {
               const propsSymbol = type.aliasTypeArguments[0].getSymbol();
               if (propsSymbol === undefined) {


### PR DESCRIPTION
`JSXElementConstructor` is the smallest possible type for `<Component />` that is not a host element type (e.g. `div`).

`ComponentType` contains a lot of "fluff" like `displayName` or `.propTypes` that we'll rarely need when defining input types. It could otherwise indicate that we either write these properties (side-effect bad) or read from them (irrelevant in a non-HoC world).

This switch has the nice side-effect of getting rid of implicit children in `React.ComponentType` since `ComponentType` is a union of `ClassComponent` (no implicit children) and `FunctionComponent` (implicit children). This could result in nasty error messages/inferences because the props were now also a union.