### PR TITLE
[docs] Update typography.md to non-deprecated fontsource

### DIFF
--- a/docs/src/pages/components/typography/typography.md
+++ b/docs/src/pages/components/typography/typography.md
@@ -27,14 +27,14 @@ Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 ## Install with npm
 
-You can [install it](https://www.npmjs.com/package/fontsource-roboto) by typing the below command in your terminal:
+You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by typing the below command in your terminal:
 
-`npm install fontsource-roboto`
+`npm install @fontsource/roboto`
 
 Then, you can import it in your entry-point.
 
 ```js
-import 'fontsource-roboto';
+import '@fontsource/roboto';
 ```
 
 For more info check out [Fontsource](https://github.com/DecliningLotus/fontsource/blob/master/packages/roboto/README.md).


### PR DESCRIPTION
Update references from fontsource-roboto to @fontsource/roboto. The author has indicated that fontsource-roboto is now deprecated ( https://www.npmjs.com/package/fontsource-roboto ), and points users to instead use @fontsource/roboto ( https://www.npmjs.com/package/@fontsource/roboto )

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
