### PR TITLE
[internal][pickers] Move useInterceptProps into module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -359,7 +359,13 @@ module.exports = {
 
         'material-ui/mui-name-matches-component-name': [
           'error',
-          { customHooks: ['useDatePickerDefaultizedProps', 'useTimePickerDefaultizedProps'] },
+          {
+            customHooks: [
+              'useDatePickerDefaultizedProps',
+              'useDateTimePickerDefaultizedProps',
+              'useTimePickerDefaultizedProps',
+            ],
+          },
         ],
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -359,7 +359,7 @@ module.exports = {
 
         'material-ui/mui-name-matches-component-name': [
           'error',
-          { customHooks: ['useDatePickerDefaultizedProps'] },
+          { customHooks: ['useDatePickerDefaultizedProps', 'useTimePickerDefaultizedProps'] },
         ],
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -357,7 +357,10 @@ module.exports = {
           },
         ],
 
-        'material-ui/mui-name-matches-component-name': 'error',
+        'material-ui/mui-name-matches-component-name': [
+          'error',
+          { customHooks: ['useDatePickerDefaultizedProps'] },
+        ],
       },
     },
   ],

--- a/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.js
+++ b/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.js
@@ -1,31 +1,79 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 const rule = {
   meta: {
     messages: {
       nameMismatch: "Expected `name` to be 'Mui{{ componentName }}' but instead got '{{ name }}'.",
       noComponent: 'Unable to find component for this call.',
       noNameProperty: 'Unable to find `name` property. Did you forget to pass `name`?',
+      noNameSecondArgument:
+        "Unable to find name argument. Expected `{{ customHook }}(firstParameter, 'MuiComponent')`.",
       noNameValue:
         'Unable to resolve `name`. Please hardcode the `name` i.e. use a string literal.',
     },
   },
   create(context) {
+    const [options = {}] = context.options;
+    const { customHooks = [] } = options;
+
+    function resolveUseThemePropsNameLiteral(node) {
+      const nameProperty = node.arguments[0].properties.find(
+        (property) => property.key.name === 'name',
+      );
+      if (nameProperty === undefined) {
+        context.report({ node: node.arguments[0], messageId: 'noNameProperty' });
+        return null;
+      }
+      if (nameProperty.value.type !== 'Literal') {
+        context.report({ node: nameProperty.value, messageId: 'noNameValue' });
+        return null;
+      }
+      return nameProperty.value;
+    }
+
+    function resolveCustomHookNameLiteral(node) {
+      const secondArgument = node.arguments[1];
+      if (secondArgument === undefined) {
+        context.report({
+          node: node.arguments[0],
+          messageId: 'noNameSecondArgument',
+          data: { customHook: node.callee.name },
+        });
+        return null;
+      }
+      if (secondArgument.type !== 'Literal') {
+        context.report({ node: secondArgument, messageId: 'noNameValue' });
+        return null;
+      }
+      return secondArgument;
+    }
+
     return {
       CallExpression(node) {
+        let nameLiteral = null;
         const isUseThemePropsCall = node.callee.name === 'useThemeProps';
         if (isUseThemePropsCall) {
-          const nameProperty = node.arguments[0].properties.find(
-            (property) => property.key.name === 'name',
-          );
-          if (nameProperty === undefined) {
-            context.report({ node: node.arguments[0], messageId: 'noNameProperty' });
-            return;
-          }
-          if (nameProperty.value.type !== 'Literal') {
-            context.report({ node: nameProperty.value, messageId: 'noNameValue' });
-            return;
-          }
-          const name = nameProperty.value.value;
+          let isCalledFromCustomHook = false;
+          let parent = node.parent;
+          while (parent != null) {
+            if (parent.type === 'FunctionExpression' || parent.type === 'FunctionDeclaration') {
+              if (customHooks.includes(parent.id.name)) {
+                isCalledFromCustomHook = true;
+              }
+              break;
+            }
 
+            parent = parent.parent;
+          }
+          if (!isCalledFromCustomHook) {
+            nameLiteral = resolveUseThemePropsNameLiteral(node);
+          }
+        } else if (customHooks.includes(node.callee.name)) {
+          nameLiteral = resolveCustomHookNameLiteral(node);
+        }
+
+        if (nameLiteral !== null) {
           let componentName = null;
           let parent = node.parent;
           while (parent != null && componentName === null) {
@@ -36,11 +84,12 @@ const rule = {
             parent = parent.parent;
           }
 
+          const name = nameLiteral.value;
           if (componentName === null) {
             context.report({ node, messageId: 'noComponent' });
           } else if (name !== `Mui${componentName}`) {
             context.report({
-              node: nameProperty.value,
+              node: nameLiteral,
               messageId: `nameMismatch`,
               data: { componentName, name },
             });

--- a/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.test.js
@@ -17,6 +17,25 @@ ruleTester.run('mui-name-matches-component-name', rule, {
         useThemeProps({ props: inProps, name: 'MuiCssBaseline' });
       }
     `,
+    {
+      code: `
+        const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
+          inProps: StaticDateRangePickerProps<TDate>,
+          ref: React.Ref<HTMLDivElement>,
+        ) {
+          const props = useDatePickerDefaultizedProps(inProps, 'MuiStaticDateRangePicker');
+        });
+      `,
+      options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
+    },
+    {
+      code: `
+        function useDatePickerDefaultizedProps(props, name) {
+          useThemeProps({ props, name });
+        }
+      `,
+      options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
+    },
   ],
   invalid: [
     {
@@ -58,6 +77,42 @@ ruleTester.run('mui-name-matches-component-name', rule, {
     {
       code: "useThemeProps({ props: inProps, name: 'MuiPickersDateRangePicker' })",
       errors: [{ message: 'Unable to find component for this call.', type: 'CallExpression' }],
+    },
+    {
+      code: `
+        const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
+          inProps: StaticDateRangePickerProps<TDate>,
+          ref: React.Ref<HTMLDivElement>,
+        ) {
+          const props = useDatePickerDefaultizedProps(inProps);
+        });
+      `,
+      options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
+      errors: [
+        {
+          message:
+            "Unable to find name argument. Expected `useDatePickerDefaultizedProps(firstParameter, 'MuiComponent')`.",
+          type: 'Identifier',
+        },
+      ],
+    },
+    {
+      code: `
+        const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
+          inProps: StaticDateRangePickerProps<TDate>,
+          ref: React.Ref<HTMLDivElement>,
+        ) {
+          const props = useDatePickerDefaultizedProps(inProps, 'MuiPickersDateRangePicker');
+        });
+      `,
+      options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
+      errors: [
+        {
+          message:
+            "Expected `name` to be 'MuiStaticDateRangePicker' but instead got 'MuiPickersDateRangePicker'.",
+          type: 'Literal',
+        },
+      ],
     },
   ],
 });

--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -1,93 +1,25 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
+import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import DatePickerToolbar from './DatePickerToolbar';
 import {
   ResponsiveWrapper,
   ResponsiveWrapperProps,
 } from '../internal/pickers/wrappers/ResponsiveWrapper';
-import {
-  useParsedDate,
-  OverrideParseableDateProps,
-} from '../internal/pickers/hooks/date-helpers-hooks';
-import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
-import {
-  DateValidationError,
-  useDateValidation,
-  ValidationProps,
-} from '../internal/pickers/hooks/useValidation';
-import {
-  ParseableDate,
-  defaultMinDate,
-  defaultMaxDate,
-} from '../internal/pickers/constants/prop-types';
+import { useDateValidation } from '../internal/pickers/hooks/useValidation';
+
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import Picker from '../internal/pickers/Picker/Picker';
-import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
+import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { getFormatAndMaskByViews } from './shared';
+import { BaseDatePickerProps, useDatePickerDefaultizedProps } from './shared';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-export type DatePickerView = 'year' | 'day' | 'month';
-
-export interface BaseDatePickerProps<TDate>
-  extends OverrideParseableDateProps<
-      TDate,
-      ExportedCalendarPickerProps<TDate>,
-      'minDate' | 'maxDate'
-    >,
-    BasePickerProps<ParseableDate<TDate>, TDate | null>,
-    ValidationProps<DateValidationError, ParseableDate<TDate>>,
-    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
-  /**
-   * First view to show.
-   */
-  openTo?: DatePickerView;
-  /**
-   * Component that will replace default toolbar renderer.
-   * @default DatePickerToolbar
-   */
-  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
-  /**
-   * Array of views to show.
-   */
-  views?: readonly DatePickerView[];
-}
-
-type InterceptedProps<Props> = Props & { inputFormat: string };
-
-export const datePickerConfig = {
-  useInterceptProps: <Props extends BaseDatePickerProps<unknown>>({
-    openTo = 'day',
-    views = ['year', 'day'],
-    minDate: __minDate = defaultMinDate,
-    maxDate: __maxDate = defaultMaxDate,
-    ...other
-  }: Props): InterceptedProps<Props> => {
-    const utils = useUtils();
-    const minDate = useParsedDate(__minDate);
-    const maxDate = useParsedDate(__maxDate);
-
-    return {
-      views,
-      openTo,
-      minDate,
-      maxDate,
-      ...getFormatAndMaskByViews(views, utils),
-      ...(other as Props),
-    };
-  },
-};
-
-const { useInterceptProps } = datePickerConfig;
 
 export interface DatePickerProps<TDate = unknown>
   extends BaseDatePickerProps<TDate>,
@@ -112,14 +44,7 @@ const DatePicker = React.forwardRef(function DatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as DatePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiDatePicker',
-  });
+  const props = useDatePickerDefaultizedProps(inProps as DatePickerProps<unknown>, 'MuiDatePicker');
 
   const validationError = useDateValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/DatePicker/shared.ts
+++ b/packages/material-ui-lab/src/DatePicker/shared.ts
@@ -1,5 +1,44 @@
-import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
+import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
+import {
+  ParseableDate,
+  defaultMinDate,
+  defaultMaxDate,
+} from '../internal/pickers/constants/prop-types';
+import {
+  useParsedDate,
+  OverrideParseableDateProps,
+} from '../internal/pickers/hooks/date-helpers-hooks';
+import { MuiPickersAdapter, useUtils } from '../internal/pickers/hooks/useUtils';
 import { CalendarPickerView } from '../CalendarPicker';
+import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
+import { DateValidationError, ValidationProps } from '../internal/pickers/hooks/useValidation';
+import { ExportedDateInputProps } from '../internal/pickers/PureDateInput';
+import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
+
+export type DatePickerView = 'year' | 'day' | 'month';
+export interface BaseDatePickerProps<TDate>
+  extends OverrideParseableDateProps<
+      TDate,
+      ExportedCalendarPickerProps<TDate>,
+      'minDate' | 'maxDate'
+    >,
+    BasePickerProps<ParseableDate<TDate>, TDate | null>,
+    ValidationProps<DateValidationError, ParseableDate<TDate>>,
+    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
+  /**
+   * First view to show.
+   */
+  openTo?: DatePickerView;
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DatePickerToolbar
+   */
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
+  /**
+   * Array of views to show.
+   */
+  views?: readonly DatePickerView[];
+}
 
 export const isYearOnlyView = (
   views: readonly CalendarPickerView[],
@@ -10,7 +49,7 @@ export const isYearAndMonthViews = (
 ): views is ReadonlyArray<'month' | 'year'> =>
   views.length === 2 && views.indexOf('month') !== -1 && views.indexOf('year') !== -1;
 
-export const getFormatAndMaskByViews = (
+const getFormatAndMaskByViews = (
   views: readonly CalendarPickerView[],
   utils: MuiPickersAdapter,
 ): { disableMaskedInput?: boolean; inputFormat: string; mask?: string } => {
@@ -33,3 +72,34 @@ export const getFormatAndMaskByViews = (
     inputFormat: utils.formats.keyboardDate,
   };
 };
+
+export type DefaultizedProps<Props> = Props & { inputFormat: string };
+
+export function useDatePickerDefaultizedProps<Props extends BaseDatePickerProps<unknown>>(
+  {
+    openTo = 'day',
+    views = ['year', 'day'],
+    minDate: minDateProp = defaultMinDate,
+    maxDate: maxDateProp = defaultMaxDate,
+    ...other
+  }: Props,
+  name: string,
+): DefaultizedProps<Props> {
+  const utils = useUtils();
+  const minDate = useParsedDate(minDateProp);
+  const maxDate = useParsedDate(maxDateProp);
+
+  // This is technically unsound if the type parameters appear in optional props.
+  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
+  return useThemeProps({
+    props: {
+      views,
+      openTo,
+      minDate,
+      maxDate,
+      ...getFormatAndMaskByViews(views, utils),
+      ...(other as Props),
+    },
+    name,
+  });
+}

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -1,147 +1,23 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
+import { MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
 import DateTimePickerToolbar from './DateTimePickerToolbar';
-import { ExportedClockPickerProps } from '../ClockPicker/ClockPicker';
 import {
   ResponsiveWrapper,
   ResponsiveWrapperProps,
 } from '../internal/pickers/wrappers/ResponsiveWrapper';
-import { pick12hOr24hFormat } from '../internal/pickers/text-field-helper';
-import {
-  useParsedDate,
-  OverrideParseableDateProps,
-} from '../internal/pickers/hooks/date-helpers-hooks';
-import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
-import {
-  DateTimeValidationError,
-  useDateTimeValidation,
-  ValidationProps,
-} from '../internal/pickers/hooks/useValidation';
-import {
-  ParseableDate,
-  defaultMinDate,
-  defaultMaxDate,
-} from '../internal/pickers/constants/prop-types';
+import { useDateTimeValidation } from '../internal/pickers/hooks/useValidation';
 import Picker from '../internal/pickers/Picker/Picker';
-import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
 import { parsePickerInputValue } from '../internal/pickers/date-utils';
 import { KeyboardDateInput } from '../internal/pickers/KeyboardDateInput';
-import { PureDateInput, ExportedDateInputProps } from '../internal/pickers/PureDateInput';
+import { PureDateInput } from '../internal/pickers/PureDateInput';
 import { usePickerState, PickerStateValueManager } from '../internal/pickers/hooks/usePickerState';
-import { DateTimePickerView } from './shared';
+import { BaseDateTimePickerProps, useDateTimePickerDefaultizedProps } from './shared';
 
 const valueManager: PickerStateValueManager<unknown, unknown> = {
   emptyValue: null,
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
-};
-
-export interface BaseDateTimePickerProps<TDate>
-  extends OverrideParseableDateProps<
-      TDate,
-      ExportedClockPickerProps<TDate> & ExportedCalendarPickerProps<TDate>,
-      'minDate' | 'maxDate' | 'minTime' | 'maxTime'
-    >,
-    BasePickerProps<ParseableDate<TDate>, TDate | null>,
-    ValidationProps<DateTimeValidationError, ParseableDate<TDate>>,
-    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
-  /**
-   * To show tabs.
-   */
-  hideTabs?: boolean;
-  /**
-   * Date tab icon.
-   */
-  dateRangeIcon?: React.ReactNode;
-  /**
-   * Time tab icon.
-   */
-  timeIcon?: React.ReactNode;
-  /**
-   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
-   */
-  minDateTime?: ParseableDate<TDate>;
-  /**
-   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
-   */
-  maxDateTime?: ParseableDate<TDate>;
-  /**
-   * First view to show.
-   */
-  openTo?: DateTimePickerView;
-  /**
-   * Component that will replace default toolbar renderer.
-   * @default DateTimePickerToolbar
-   */
-  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
-  /**
-   * Date format, that is displaying in toolbar.
-   */
-  toolbarFormat?: string;
-  /**
-   * Array of views to show.
-   */
-  views?: readonly DateTimePickerView[];
-}
-
-type InterceptedProps<Props> = Props & { inputFormat: string };
-
-function useInterceptProps<Props extends BaseDateTimePickerProps<unknown>>({
-  ampm,
-  inputFormat,
-  maxDate: __maxDate = defaultMaxDate,
-  maxDateTime: __maxDateTime,
-  maxTime: __maxTime,
-  minDate: __minDate = defaultMinDate,
-  minDateTime: __minDateTime,
-  minTime: __minTime,
-  openTo = 'day',
-  orientation = 'portrait',
-  views = ['year', 'day', 'hours', 'minutes'],
-  ...other
-}: Props): InterceptedProps<Props> {
-  const utils = useUtils();
-  const minTime = useParsedDate(__minTime);
-  const maxTime = useParsedDate(__maxTime);
-  const minDate = useParsedDate(__minDate);
-  const maxDate = useParsedDate(__maxDate);
-  const minDateTime = useParsedDate(__minDateTime);
-  const maxDateTime = useParsedDate(__maxDateTime);
-  const willUseAmPm = ampm ?? utils.is12HourCycleInCurrentLocale();
-
-  if (orientation !== 'portrait') {
-    throw new Error('We are not supporting custom orientation for DateTimePicker yet :(');
-  }
-
-  return {
-    openTo,
-    views,
-    ampm: willUseAmPm,
-    ampmInClock: true,
-    orientation,
-    showToolbar: true,
-    allowSameDateSelection: true,
-    minDate: minDateTime || minDate,
-    minTime: minDateTime || minTime,
-    maxDate: maxDateTime || maxDate,
-    maxTime: maxDateTime || maxTime,
-    disableIgnoringDatePartForTimeValidation: Boolean(minDateTime || maxDateTime),
-    acceptRegex: willUseAmPm ? /[\dap]/gi : /\d/gi,
-    mask: '__/__/____ __:__',
-    disableMaskedInput: willUseAmPm,
-    inputFormat: pick12hOr24hFormat(inputFormat, willUseAmPm, {
-      localized: utils.formats.keyboardDateTime,
-      '12h': utils.formats.keyboardDateTime12h,
-      '24h': utils.formats.keyboardDateTime24h,
-    }),
-    ...(other as Props),
-  };
-}
-
-export const dateTimePickerConfig = {
-  useInterceptProps,
 };
 
 export interface DateTimePickerProps<TDate = unknown>
@@ -167,14 +43,10 @@ const DateTimePicker = React.forwardRef(function DateTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as DateTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiDateTimePicker',
-  });
+  const props = useDateTimePickerDefaultizedProps(
+    inProps as DateTimePickerProps<unknown>,
+    'MuiDateTimePicker',
+  );
 
   const validationError = useDateTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/DateTimePicker/shared.ts
+++ b/packages/material-ui-lab/src/DateTimePicker/shared.ts
@@ -1,1 +1,128 @@
+import * as React from 'react';
+import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
+import { useUtils } from '../internal/pickers/hooks/useUtils';
+import { ExportedClockPickerProps } from '../ClockPicker/ClockPicker';
+import { pick12hOr24hFormat } from '../internal/pickers/text-field-helper';
+import {
+  useParsedDate,
+  OverrideParseableDateProps,
+} from '../internal/pickers/hooks/date-helpers-hooks';
+import { ExportedCalendarPickerProps } from '../CalendarPicker/CalendarPicker';
+import { DateTimeValidationError, ValidationProps } from '../internal/pickers/hooks/useValidation';
+import {
+  ParseableDate,
+  defaultMinDate,
+  defaultMaxDate,
+} from '../internal/pickers/constants/prop-types';
+import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
+import { ExportedDateInputProps } from '../internal/pickers/PureDateInput';
+
 export type DateTimePickerView = 'year' | 'day' | 'month' | 'hours' | 'minutes';
+
+export interface BaseDateTimePickerProps<TDate>
+  extends OverrideParseableDateProps<
+      TDate,
+      ExportedClockPickerProps<TDate> & ExportedCalendarPickerProps<TDate>,
+      'minDate' | 'maxDate' | 'minTime' | 'maxTime'
+    >,
+    BasePickerProps<ParseableDate<TDate>, TDate | null>,
+    ValidationProps<DateTimeValidationError, ParseableDate<TDate>>,
+    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
+  /**
+   * To show tabs.
+   */
+  hideTabs?: boolean;
+  /**
+   * Date tab icon.
+   */
+  dateRangeIcon?: React.ReactNode;
+  /**
+   * Time tab icon.
+   */
+  timeIcon?: React.ReactNode;
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
+  minDateTime?: ParseableDate<TDate>;
+  /**
+   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
+  maxDateTime?: ParseableDate<TDate>;
+  /**
+   * First view to show.
+   */
+  openTo?: DateTimePickerView;
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DateTimePickerToolbar
+   */
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat?: string;
+  /**
+   * Array of views to show.
+   */
+  views?: readonly DateTimePickerView[];
+}
+
+type DefaultizedProps<Props> = Props & { inputFormat: string };
+
+export function useDateTimePickerDefaultizedProps<Props extends BaseDateTimePickerProps<unknown>>(
+  {
+    ampm,
+    inputFormat,
+    maxDate: __maxDate = defaultMaxDate,
+    maxDateTime: __maxDateTime,
+    maxTime: __maxTime,
+    minDate: __minDate = defaultMinDate,
+    minDateTime: __minDateTime,
+    minTime: __minTime,
+    openTo = 'day',
+    orientation = 'portrait',
+    views = ['year', 'day', 'hours', 'minutes'],
+    ...other
+  }: Props,
+  name: string,
+): DefaultizedProps<Props> {
+  const utils = useUtils();
+  const minTime = useParsedDate(__minTime);
+  const maxTime = useParsedDate(__maxTime);
+  const minDate = useParsedDate(__minDate);
+  const maxDate = useParsedDate(__maxDate);
+  const minDateTime = useParsedDate(__minDateTime);
+  const maxDateTime = useParsedDate(__maxDateTime);
+  const willUseAmPm = ampm ?? utils.is12HourCycleInCurrentLocale();
+
+  if (orientation !== 'portrait') {
+    throw new Error('We are not supporting custom orientation for DateTimePicker yet :(');
+  }
+
+  return useThemeProps({
+    props: {
+      openTo,
+      views,
+      ampm: willUseAmPm,
+      ampmInClock: true,
+      orientation,
+      showToolbar: true,
+      allowSameDateSelection: true,
+      minDate: minDateTime || minDate,
+      minTime: minDateTime || minTime,
+      maxDate: maxDateTime || maxDate,
+      maxTime: maxDateTime || maxTime,
+      disableIgnoringDatePartForTimeValidation: Boolean(minDateTime || maxDateTime),
+      acceptRegex: willUseAmPm ? /[\dap]/gi : /\d/gi,
+      mask: '__/__/____ __:__',
+      disableMaskedInput: willUseAmPm,
+      inputFormat: pick12hOr24hFormat(inputFormat, willUseAmPm, {
+        localized: utils.formats.keyboardDateTime,
+        '12h': utils.formats.keyboardDateTime12h,
+        '24h': utils.formats.keyboardDateTime24h,
+      }),
+      ...(other as Props),
+    },
+    name,
+  });
+}

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { datePickerConfig, BaseDatePickerProps } from '../DatePicker/DatePicker';
+import { BaseDatePickerProps, useDatePickerDefaultizedProps } from '../DatePicker/shared';
 import DatePickerToolbar from '../DatePicker/DatePickerToolbar';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -16,8 +15,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = datePickerConfig;
 
 export interface DesktopDatePickerProps<TDate = unknown>
   extends BaseDatePickerProps<TDate>,
@@ -42,14 +39,10 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as DesktopDatePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiDesktopDatePicker',
-  });
+  const props = useDatePickerDefaultizedProps(
+    inProps as DesktopDatePickerProps<unknown>,
+    'MuiDesktopDatePicker',
+  );
 
   const validationError = useDateValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseDateTimePickerProps, dateTimePickerConfig } from '../DateTimePicker/DateTimePicker';
+import {
+  BaseDateTimePickerProps,
+  useDateTimePickerDefaultizedProps,
+} from '../DateTimePicker/shared';
 import DateTimePickerToolbar from '../DateTimePicker/DateTimePickerToolbar';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -16,8 +18,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = dateTimePickerConfig;
 
 export interface DesktopDateTimePickerProps<TDate = unknown>
   extends BaseDateTimePickerProps<TDate>,
@@ -42,14 +42,10 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as DesktopDateTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiDesktopDateTimePicker',
-  });
+  const props = useDateTimePickerDefaultizedProps(
+    inProps as DesktopDateTimePickerProps<unknown>,
+    'MuiDesktopDateTimePicker',
+  );
 
   const validationError = useDateTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
+import { BaseTimePickerProps, useTimePickerDefaultizedProps } from '../TimePicker/shared';
 import TimePickerToolbar from '../TimePicker/TimePickerToolbar';
 import DesktopWrapper, { DesktopWrapperProps } from '../internal/pickers/wrappers/DesktopWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -16,8 +15,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = timePickerConfig;
 
 export interface DesktopTimePickerProps<TDate = unknown>
   extends BaseTimePickerProps<TDate>,
@@ -42,14 +39,10 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as DesktopTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiDesktopTimePicker',
-  });
+  const props = useTimePickerDefaultizedProps(
+    inProps as DesktopTimePickerProps<unknown>,
+    'MuiDesktopTimePicker',
+  );
 
   const validationError = useTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseDatePickerProps, datePickerConfig } from '../DatePicker/DatePicker';
+import { BaseDatePickerProps, useDatePickerDefaultizedProps } from '../DatePicker/shared';
 import DatePickerToolbar from '../DatePicker/DatePickerToolbar';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -16,8 +15,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = datePickerConfig;
 
 export interface MobileDatePickerProps<TDate = unknown>
   extends BaseDatePickerProps<TDate>,
@@ -42,14 +39,10 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as MobileDatePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiMobileDatePicker',
-  });
+  const props = useDatePickerDefaultizedProps(
+    inProps as MobileDatePickerProps<unknown>,
+    'MuiMobileDatePicker',
+  );
 
   const validationError = useDateValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseDateTimePickerProps, dateTimePickerConfig } from '../DateTimePicker/DateTimePicker';
+import {
+  BaseDateTimePickerProps,
+  useDateTimePickerDefaultizedProps,
+} from '../DateTimePicker/shared';
 import DateTimePickerToolbar from '../DateTimePicker/DateTimePickerToolbar';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -16,8 +18,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = dateTimePickerConfig;
 
 export interface MobileDateTimePickerProps<TDate = unknown>
   extends BaseDateTimePickerProps<TDate>,
@@ -42,14 +42,10 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as MobileDateTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiMobileDateTimePicker',
-  });
+  const props = useDateTimePickerDefaultizedProps(
+    inProps as MobileDateTimePickerProps<unknown>,
+    'MuiMobileDateTimePicker',
+  );
 
   const validationError = useDateTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
+import { BaseTimePickerProps, useTimePickerDefaultizedProps } from '../TimePicker/shared';
 import TimePickerToolbar from '../TimePicker/TimePickerToolbar';
 import MobileWrapper, { MobileWrapperProps } from '../internal/pickers/wrappers/MobileWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -16,8 +15,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = timePickerConfig;
 
 export interface MobileTimePickerProps<TDate = unknown>
   extends BaseTimePickerProps<TDate>,
@@ -42,14 +39,10 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as MobileTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiMobileTimePicker',
-  });
+  const props = useTimePickerDefaultizedProps(
+    inProps as MobileTimePickerProps<unknown>,
+    'MuiMobileTimePicker',
+  );
 
   const validationError = useTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseDatePickerProps, datePickerConfig } from '../DatePicker/DatePicker';
+import { BaseDatePickerProps, useDatePickerDefaultizedProps } from '../DatePicker/shared';
 import DatePickerToolbar from '../DatePicker/DatePickerToolbar';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -15,8 +14,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = datePickerConfig;
 
 export interface StaticDatePickerProps<TDate = unknown> extends BaseDatePickerProps<TDate> {
   /**
@@ -45,14 +42,10 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as StaticDatePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiStaticDatePicker',
-  });
+  const props = useDatePickerDefaultizedProps(
+    inProps as StaticDatePickerProps<unknown>,
+    'MuiStaticDatePicker',
+  );
 
   const validationError = useDateValidation(props) !== null;
   const { pickerProps, inputProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseDateTimePickerProps, dateTimePickerConfig } from '../DateTimePicker/DateTimePicker';
+import {
+  BaseDateTimePickerProps,
+  useDateTimePickerDefaultizedProps,
+} from '../DateTimePicker/shared';
 import DateTimePickerToolbar from '../DateTimePicker/DateTimePickerToolbar';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -15,8 +17,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = dateTimePickerConfig;
 
 export interface StaticDateTimePickerProps<TDate = unknown> extends BaseDateTimePickerProps<TDate> {
   /**
@@ -45,14 +45,10 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as StaticDateTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiStaticDateTimePicker',
-  });
+  const props = useDateTimePickerDefaultizedProps(
+    inProps as StaticDateTimePickerProps<unknown>,
+    'MuiStaticDateTimePicker',
+  );
 
   const validationError = useDateTimeValidation(props) !== null;
   const { pickerProps, inputProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
-import { BaseTimePickerProps, timePickerConfig } from '../TimePicker/TimePicker';
+import { BaseTimePickerProps, useTimePickerDefaultizedProps } from '../TimePicker/shared';
 import TimePickerToolbar from '../TimePicker/TimePickerToolbar';
 import StaticWrapper, { StaticWrapperProps } from '../internal/pickers/wrappers/StaticWrapper';
 import Picker from '../internal/pickers/Picker/Picker';
@@ -15,8 +14,6 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils: MuiPickersAdapter, a: unknown, b: unknown) => utils.isEqual(a, b),
 };
-
-const { useInterceptProps } = timePickerConfig;
 
 export interface StaticTimePickerProps<TDate = unknown> extends BaseTimePickerProps<TDate> {
   /**
@@ -45,14 +42,10 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   // TODO: TDate needs to be instantiated at every usage.
-  const allProps = useInterceptProps(inProps as StaticTimePickerProps<unknown>);
-
-  // This is technically unsound if the type parameters appear in optional props.
-  // Optional props can be filled by `useThemeProps` with types that don't match the type parameters.
-  const props = useThemeProps({
-    props: allProps,
-    name: 'MuiStaticTimePicker',
-  });
+  const props = useTimePickerDefaultizedProps(
+    inProps as StaticTimePickerProps<unknown>,
+    'MuiStaticTimePicker',
+  );
 
   const validationError = useTimeValidation(props) !== null;
   const { pickerProps, inputProps } = usePickerState(props, valueManager);

--- a/packages/material-ui-lab/src/TimePicker/shared.tsx
+++ b/packages/material-ui-lab/src/TimePicker/shared.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
+import ClockIcon from '../internal/svg-icons/Clock';
+import { ParseableDate } from '../internal/pickers/constants/prop-types';
+import { ExportedClockPickerProps } from '../ClockPicker/ClockPicker';
+import { pick12hOr24hFormat } from '../internal/pickers/text-field-helper';
+import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
+import { TimeValidationError, ValidationProps } from '../internal/pickers/hooks/useValidation';
+import {
+  useParsedDate,
+  OverrideParseableDateProps,
+} from '../internal/pickers/hooks/date-helpers-hooks';
+import { BasePickerProps, ToolbarComponentProps } from '../internal/pickers/typings/BasePicker';
+import { ExportedDateInputProps } from '../internal/pickers/PureDateInput';
+
+export type TimePickerView = 'hours' | 'minutes' | 'seconds';
+
+export interface BaseTimePickerProps<TDate>
+  extends OverrideParseableDateProps<TDate, ExportedClockPickerProps<TDate>, 'minTime' | 'maxTime'>,
+    BasePickerProps<ParseableDate<TDate>, TDate | null>,
+    ValidationProps<TimeValidationError, ParseableDate<TDate>>,
+    ExportedDateInputProps<ParseableDate<TDate>, TDate | null> {
+  /**
+   * First view to show.
+   */
+  openTo?: TimePickerView;
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default TimePickerToolbar
+   */
+  ToolbarComponent?: React.JSXElementConstructor<ToolbarComponentProps>;
+  /**
+   * Array of views to show.
+   */
+  views?: readonly TimePickerView[];
+}
+
+function getTextFieldAriaText<TDate>(value: ParseableDate<TDate>, utils: MuiPickersAdapter) {
+  return value && utils.isValid(utils.date(value))
+    ? `Choose time, selected time is ${utils.format(utils.date(value), 'fullTime')}`
+    : 'Choose time';
+}
+
+type DefaultizedProps<Props> = Props & { inputFormat: string };
+export function useTimePickerDefaultizedProps<Props extends BaseTimePickerProps<unknown>>(
+  {
+    ampm,
+    inputFormat,
+    maxTime: __maxTime,
+    minTime: __minTime,
+    openTo = 'hours',
+    views = ['hours', 'minutes'],
+    ...other
+  }: Props,
+  name: string,
+): DefaultizedProps<Props> {
+  const utils = useUtils();
+
+  const minTime = useParsedDate(__minTime);
+  const maxTime = useParsedDate(__maxTime);
+  const willUseAmPm = ampm ?? utils.is12HourCycleInCurrentLocale();
+
+  return useThemeProps({
+    props: {
+      views,
+      openTo,
+      minTime,
+      maxTime,
+      ampm: willUseAmPm,
+      acceptRegex: willUseAmPm ? /[\dapAP]/gi : /\d/gi,
+      mask: '__:__',
+      disableMaskedInput: willUseAmPm,
+      getOpenDialogAriaText: getTextFieldAriaText,
+      openPickerIcon: <ClockIcon />,
+      inputFormat: pick12hOr24hFormat(inputFormat, willUseAmPm, {
+        localized: utils.formats.fullTime,
+        '12h': utils.formats.fullTime12h,
+        '24h': utils.formats.fullTime24h,
+      }),
+      ...(other as Props),
+    },
+    name,
+  });
+}


### PR DESCRIPTION
Removes the `*config` objects in favor of ES modules.

Will handle lint and other pickers later. Just want to get a look at bundle size. Edit: 
What I expected:
> StaticDatePicker | ▼ -55.7 kB (-25.29% ) | 165 kB | ▼ -16 kB (-22.65% ) | 54.7 kB
>-- | -- | -- | -- | --
>MobileDatePicker | ▼ -26.8 kB (-12.20% ) | 193 kB | ▼ -8.54 kB (-12.08% ) | 62.1 kB
>DesktopDatePicker | ▼ -25.5 kB (-11.62% ) | 194 kB | ▼ -5.9 kB (-8.35% ) | 64.7 kB
>@material-ui/lab | ▼ -210 B (-0.05% ) | 387 kB | ▲ +22 B (+0.02% ) | 116 kB
>DatePicker | ▼ -106 B (-0.05% ) | 220 kB | ▲ +106 B (+0.15% ) | 70.8 kB

