### PR TITLE
[docs] Normalize name use for state in pickers demo

### DIFF
--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.js
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.js
@@ -26,7 +26,7 @@ const maskMap = {
 
 export default function LocalizedDatePicker() {
   const [locale, setLocale] = React.useState('ru');
-  const [selectedDate, handleDateChange] = React.useState(new Date());
+  const [value, setValue] = React.useState(new Date());
 
   const selectLocale = (newLocale) => {
     setLocale(newLocale);
@@ -48,8 +48,8 @@ export default function LocalizedDatePicker() {
         </ToggleButtonGroup>
         <DatePicker
           mask={maskMap[locale]}
-          value={selectedDate}
-          onChange={(date) => handleDateChange(date)}
+          value={value}
+          onChange={(newValue) => setValue(newValue)}
           renderInput={(params) => <TextField {...params} />}
         />
       </div>

--- a/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/LocalizedDatePicker.tsx
@@ -26,7 +26,7 @@ const maskMap = {
 
 export default function LocalizedDatePicker() {
   const [locale, setLocale] = React.useState<keyof typeof maskMap>('ru');
-  const [selectedDate, handleDateChange] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Date | null>(new Date());
 
   const selectLocale = (newLocale: any) => {
     setLocale(newLocale);
@@ -48,8 +48,8 @@ export default function LocalizedDatePicker() {
         </ToggleButtonGroup>
         <DatePicker
           mask={maskMap[locale]}
-          value={selectedDate}
-          onChange={(date) => handleDateChange(date)}
+          value={value}
+          onChange={(newValue) => setValue(newValue)}
           renderInput={(params) => <TextField {...params} />}
         />
       </div>

--- a/docs/src/pages/components/date-picker/SubComponentsPickers.js
+++ b/docs/src/pages/components/date-picker/SubComponentsPickers.js
@@ -34,13 +34,13 @@ export default function SubComponentsPickers() {
         <CalendarPicker
           allowKeyboardControl={false}
           date={date}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newDate) => setDate(newDate)}
         />
         <MonthPicker
           date={date}
           minDate={minDate}
           maxDate={maxDate}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newDate) => setDate(newDate)}
         />
         <YearPicker
           className={yearPickerClasses.root}
@@ -48,7 +48,7 @@ export default function SubComponentsPickers() {
           isDateDisabled={() => false}
           minDate={minDate}
           maxDate={maxDate}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newDate) => setDate(newDate)}
         />
       </Box>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-picker/SubComponentsPickers.tsx
+++ b/docs/src/pages/components/date-picker/SubComponentsPickers.tsx
@@ -34,13 +34,13 @@ export default function SubComponentsPickers() {
         <CalendarPicker
           allowKeyboardControl={false}
           date={date}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newDate) => setDate(newDate)}
         />
         <MonthPicker
           date={date}
           minDate={minDate}
           maxDate={maxDate}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newDate) => setDate(newDate)}
         />
         <YearPicker
           className={yearPickerClasses.root}
@@ -48,7 +48,7 @@ export default function SubComponentsPickers() {
           isDateDisabled={() => false}
           minDate={minDate}
           maxDate={maxDate}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newDate) => setDate(newDate)}
         />
       </Box>
     </LocalizationProvider>

--- a/docs/src/pages/components/date-range-picker/CustomDateRangeInputs.js
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangeInputs.js
@@ -4,14 +4,14 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateRangePicker from '@material-ui/lab/DateRangePicker';
 
 export default function CustomDateRangeInputs() {
-  const [selectedDate, handleDateChange] = React.useState([null, null]);
+  const [value, setValue] = React.useState([null, null]);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DateRangePicker
         label="Advanced keyboard"
-        value={selectedDate}
-        onChange={(date) => handleDateChange(date)}
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
             <input ref={startProps.inputRef} {...startProps.inputProps} />

--- a/docs/src/pages/components/date-range-picker/CustomDateRangeInputs.tsx
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangeInputs.tsx
@@ -4,17 +4,14 @@ import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import DateRangePicker, { DateRange } from '@material-ui/lab/DateRangePicker';
 
 export default function CustomDateRangeInputs() {
-  const [selectedDate, handleDateChange] = React.useState<DateRange<Date>>([
-    null,
-    null,
-  ]);
+  const [value, setValue] = React.useState<DateRange<Date>>([null, null]);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DateRangePicker
         label="Advanced keyboard"
-        value={selectedDate}
-        onChange={(date) => handleDateChange(date)}
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
         renderInput={(startProps, endProps) => (
           <React.Fragment>
             <input

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function CustomDateRangePickerDay() {
   const classes = useStyles();
-  const [selectedDate, handleDateChange] = React.useState([null, null]);
+  const [value, setValue] = React.useState([null, null]);
 
   const renderWeekPickerDay = (date, dateRangePickerDayProps) => {
     return (
@@ -48,8 +48,8 @@ export default function CustomDateRangePickerDay() {
     <LocalizaitonProvider dateAdapter={AdapterDateFns}>
       <DateRangePicker
         label="date range"
-        value={selectedDate}
-        onChange={(date) => handleDateChange(date)}
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
         renderDay={renderWeekPickerDay}
         renderInput={(startProps, endProps) => (
           <React.Fragment>

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
@@ -31,10 +31,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function CustomDateRangePickerDay() {
   const classes = useStyles();
-  const [selectedDate, handleDateChange] = React.useState<DateRange<Date>>([
-    null,
-    null,
-  ]);
+  const [value, setValue] = React.useState<DateRange<Date>>([null, null]);
 
   const renderWeekPickerDay = (
     date: Date,
@@ -56,8 +53,8 @@ export default function CustomDateRangePickerDay() {
     <LocalizaitonProvider dateAdapter={AdapterDateFns}>
       <DateRangePicker
         label="date range"
-        value={selectedDate}
-        onChange={(date) => handleDateChange(date)}
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
         renderDay={renderWeekPickerDay}
         renderInput={(startProps, endProps) => (
           <React.Fragment>

--- a/docs/src/pages/components/pickers/MaterialUIPickers.js
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.js
@@ -8,12 +8,10 @@ import DesktopDatePicker from '@material-ui/lab/DesktopDatePicker';
 import MobileDatePicker from '@material-ui/lab/MobileDatePicker';
 
 export default function MaterialUIPickers() {
-  const [selectedDate, setSelectedDate] = React.useState(
-    new Date('2014-08-18T21:11:54'),
-  );
+  const [value, setValue] = React.useState(new Date('2014-08-18T21:11:54'));
 
-  const handleDateChange = (date) => {
-    setSelectedDate(date);
+  const handleChange = (newValue) => {
+    setValue(newValue);
   };
 
   return (
@@ -22,8 +20,8 @@ export default function MaterialUIPickers() {
         <DesktopDatePicker
           inputFormat="MM/dd/yyyy"
           label="Date picker desktop"
-          value={selectedDate}
-          onChange={handleDateChange}
+          value={value}
+          onChange={handleChange}
           renderInput={(params) => (
             <TextField
               id="date-picker-desktop"
@@ -39,8 +37,8 @@ export default function MaterialUIPickers() {
         <MobileDatePicker
           label="Date picker mobile"
           inputFormat="MM/dd/yyyy"
-          value={selectedDate}
-          onChange={handleDateChange}
+          value={value}
+          onChange={handleChange}
           renderInput={(params) => (
             <TextField
               id="date-picker-mobile"
@@ -55,8 +53,8 @@ export default function MaterialUIPickers() {
         />
         <TimePicker
           label="Time picker"
-          value={selectedDate}
-          onChange={handleDateChange}
+          value={value}
+          onChange={handleChange}
           renderInput={(params) => (
             <TextField margin="normal" {...params} variant="standard" />
           )}

--- a/docs/src/pages/components/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.tsx
@@ -8,12 +8,12 @@ import DesktopDatePicker from '@material-ui/lab/DesktopDatePicker';
 import MobileDatePicker from '@material-ui/lab/MobileDatePicker';
 
 export default function MaterialUIPickers() {
-  const [selectedDate, setSelectedDate] = React.useState<Date | null>(
+  const [value, setValue] = React.useState<Date | null>(
     new Date('2014-08-18T21:11:54'),
   );
 
-  const handleDateChange = (date: Date | null) => {
-    setSelectedDate(date);
+  const handleChange = (newValue: Date | null) => {
+    setValue(newValue);
   };
 
   return (
@@ -22,8 +22,8 @@ export default function MaterialUIPickers() {
         <DesktopDatePicker
           inputFormat="MM/dd/yyyy"
           label="Date picker desktop"
-          value={selectedDate}
-          onChange={handleDateChange}
+          value={value}
+          onChange={handleChange}
           renderInput={(params) => (
             <TextField
               id="date-picker-desktop"
@@ -39,8 +39,8 @@ export default function MaterialUIPickers() {
         <MobileDatePicker
           label="Date picker mobile"
           inputFormat="MM/dd/yyyy"
-          value={selectedDate}
-          onChange={handleDateChange}
+          value={value}
+          onChange={handleChange}
           renderInput={(params) => (
             <TextField
               id="date-picker-mobile"
@@ -55,8 +55,8 @@ export default function MaterialUIPickers() {
         />
         <TimePicker
           label="Time picker"
-          value={selectedDate}
-          onChange={handleDateChange}
+          value={value}
+          onChange={handleChange}
           renderInput={(params) => (
             <TextField margin="normal" {...params} variant="standard" />
           )}

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.js
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.js
@@ -20,7 +20,7 @@ const localeMap = {
 
 export default function LocalizedTimePicker() {
   const [locale, setLocale] = React.useState('ru');
-  const [selectedDate, handleDateChange] = React.useState(new Date());
+  const [value, setValue] = React.useState(new Date());
 
   const selectLocale = (newLocale) => {
     setLocale(newLocale);
@@ -34,8 +34,8 @@ export default function LocalizedTimePicker() {
           locale={localeMap[locale]}
         >
           <TimePicker
-            value={selectedDate}
-            onChange={(date) => handleDateChange(date)}
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             renderInput={(params) => <TextField {...params} />}
           />
           <ToggleButtonGroup value={locale} exclusive>

--- a/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
+++ b/docs/src/pages/components/time-picker/LocalizedTimePicker.tsx
@@ -20,7 +20,7 @@ const localeMap = {
 
 export default function LocalizedTimePicker() {
   const [locale, setLocale] = React.useState<keyof typeof localeMap>('ru');
-  const [selectedDate, handleDateChange] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Date | null>(new Date());
 
   const selectLocale = (newLocale: any) => {
     setLocale(newLocale);
@@ -34,8 +34,8 @@ export default function LocalizedTimePicker() {
           locale={localeMap[locale]}
         >
           <TimePicker
-            value={selectedDate}
-            onChange={(date) => handleDateChange(date)}
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             renderInput={(params) => <TextField {...params} />}
           />
           <ToggleButtonGroup value={locale} exclusive>

--- a/docs/src/pages/components/time-picker/SubComponentsTimePickers.js
+++ b/docs/src/pages/components/time-picker/SubComponentsTimePickers.js
@@ -11,7 +11,7 @@ export default function SubComponentsTimePickers() {
       <ClockPicker
         allowKeyboardControl={false}
         date={date}
-        onChange={(newValue) => setDate(newValue)}
+        onChange={(newDate) => setDate(newDate)}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/time-picker/SubComponentsTimePickers.tsx
+++ b/docs/src/pages/components/time-picker/SubComponentsTimePickers.tsx
@@ -11,7 +11,7 @@ export default function SubComponentsTimePickers() {
       <ClockPicker
         allowKeyboardControl={false}
         date={date}
-        onChange={(newValue) => setDate(newValue)}
+        onChange={(newDate) => setDate(newDate)}
       />
     </LocalizationProvider>
   );


### PR DESCRIPTION
A detail, apply the same convention as for the other components:

- name of the state = name of the prop
- name of the argument is prefixed with `new`