### PR TITLE
[Tooltip] Improve handling of small vs. touch screens

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -118,6 +118,7 @@ const TooltipTooltip = experimentalStyled(
     },
   },
 )(({ theme, styleProps }) => ({
+  /* Styles applied to the tooltip (label wrapper) element. */
   backgroundColor: alpha(theme.palette.grey[700], 0.92),
   borderRadius: theme.shape.borderRadius,
   color: theme.palette.common.white,
@@ -128,16 +129,19 @@ const TooltipTooltip = experimentalStyled(
   margin: 2,
   wordWrap: 'break-word',
   fontWeight: theme.typography.fontWeightMedium,
+  /* Styles applied to the tooltip (label wrapper) element if `arrow={true}`. */
   ...(styleProps.arrow && {
     position: 'relative',
     margin: 0,
   }),
+  /* Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch. */
   ...(styleProps.touch && {
     padding: '8px 16px',
     fontSize: theme.typography.pxToRem(14),
     lineHeight: `${round(16 / 14)}em`,
     fontWeight: theme.typography.fontWeightRegular,
   }),
+  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
   [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
     marginRight: '14px',
@@ -145,6 +149,7 @@ const TooltipTooltip = experimentalStyled(
       marginRight: '24px',
     }),
   },
+  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "right". */
   [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
     marginLeft: '14px',
@@ -152,6 +157,7 @@ const TooltipTooltip = experimentalStyled(
       marginLeft: '24px',
     }),
   },
+  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "top". */
   [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',
     marginBottom: '14px',
@@ -159,6 +165,7 @@ const TooltipTooltip = experimentalStyled(
       marginBottom: '24px',
     }),
   },
+  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "bottom". */
   [`.${tooltipClasses.popper}[data-popper-placement*="bottom"] &`]: {
     transformOrigin: 'center top',
     marginTop: '14px',

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -140,31 +140,31 @@ const TooltipTooltip = experimentalStyled(
   }),
   [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
-    marginRight: '24px',
-    [theme.breakpoints.up('sm')]: {
-      marginRight: '14px',
-    },
+    marginRight: '14px',
+    ...(styleProps.touch && {
+      marginRight: '24px',
+    }),
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
-    marginLeft: '24px',
-    [theme.breakpoints.up('sm')]: {
-      marginLeft: '14px',
-    },
+    marginLeft: '14px',
+    ...(styleProps.touch && {
+      marginLeft: '24px',
+    }),
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',
-    marginBottom: '24px',
-    [theme.breakpoints.up('sm')]: {
-      marginBottom: '14px',
-    },
+    marginBottom: '14px',
+    ...(styleProps.touch && {
+      marginBottom: '24px',
+    }),
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="bottom"] &`]: {
     transformOrigin: 'center top',
-    marginTop: '24px',
-    [theme.breakpoints.up('sm')]: {
-      marginTop: '14px',
-    },
+    marginTop: '14px',
+    ...(styleProps.touch && {
+      marginTop: '24px',
+    }),
   },
 }));
 

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -118,7 +118,6 @@ const TooltipTooltip = experimentalStyled(
     },
   },
 )(({ theme, styleProps }) => ({
-  /* Styles applied to the tooltip (label wrapper) element. */
   backgroundColor: alpha(theme.palette.grey[700], 0.92),
   borderRadius: theme.shape.borderRadius,
   color: theme.palette.common.white,
@@ -129,19 +128,16 @@ const TooltipTooltip = experimentalStyled(
   margin: 2,
   wordWrap: 'break-word',
   fontWeight: theme.typography.fontWeightMedium,
-  /* Styles applied to the tooltip (label wrapper) element if `arrow={true}`. */
   ...(styleProps.arrow && {
     position: 'relative',
     margin: 0,
   }),
-  /* Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch. */
   ...(styleProps.touch && {
     padding: '8px 16px',
     fontSize: theme.typography.pxToRem(14),
     lineHeight: `${round(16 / 14)}em`,
     fontWeight: theme.typography.fontWeightRegular,
   }),
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
   [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
     marginRight: '24px',
@@ -149,7 +145,6 @@ const TooltipTooltip = experimentalStyled(
       marginRight: '14px',
     },
   },
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "right". */
   [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
     marginLeft: '24px',
@@ -157,7 +152,6 @@ const TooltipTooltip = experimentalStyled(
       marginLeft: '14px',
     },
   },
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "top". */
   [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',
     marginBottom: '24px',
@@ -165,7 +159,6 @@ const TooltipTooltip = experimentalStyled(
       marginBottom: '14px',
     },
   },
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "bottom". */
   [`.${tooltipClasses.popper}[data-popper-placement*="bottom"] &`]: {
     transformOrigin: 'center top',
     marginTop: '24px',


### PR DESCRIPTION
Closes #23363

I gave a second look at the issue. Since my last proposal #23363, I have changed a bit my hypothesis and conclusion. At first, I thought that using the screen width to change the density of the tooltip would make the most sense, but I realized that with responsive font sizes, we do the opposite, we reduce the font size, we don't increase it. Also, these density visual changes seem to contribute to increasing the gap, which uses `styleProps.touch` too.