### PR TITLE
[core] Improve `react@experimental` compat

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -39,7 +39,13 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
 module.exports = {
   presets: [
     // backport of https://github.com/zeit/next.js/pull/9511
-    ['next/babel', { 'transform-runtime': { corejs: 2, version: transformRuntimeVersion } }],
+    [
+      'next/babel',
+      {
+        'preset-react': { runtime: 'automatic' },
+        'transform-runtime': { corejs: 2, version: transformRuntimeVersion },
+      },
+    ],
   ],
   plugins: [
     [

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -4,5 +4,5 @@ module.exports = {
   slow: 500,
   timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
-  require: [require.resolve('../utils/setupBabel')],
+  require: [require.resolve('../utils/setupBabelPlaywright')],
 };

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -92,7 +92,14 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('react-root'));
+const container = document.getElementById('react-root');
+const children = <App />;
+if (typeof ReactDOM.unstable_createRoot === 'function') {
+  const root = ReactDOM.unstable_createRoot(container);
+  root.render(children);
+} else {
+  ReactDOM.render(children, container);
+}
 
 window.DomTestingLibrary = DomTestingLibrary;
 window.elementToString = function elementToString(element) {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -93,6 +93,7 @@ describe('e2e', () => {
 
   async function renderFixture(fixturePath: string) {
     await page.goto(`${baseUrl}/e2e/${fixturePath}#no-dev`);
+    await page.waitForSelector('[data-testid="testcase"]:not([aria-busy="true"])');
   }
 
   before(async function beforeHook() {

--- a/test/regressions/.mocharc.js
+++ b/test/regressions/.mocharc.js
@@ -3,5 +3,5 @@ module.exports = {
   slow: 500,
   timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
-  require: [require.resolve('@babel/register')],
+  require: [require.resolve('../utils/setupBabelPlaywright')],
 };

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -320,4 +320,11 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('react-root'));
+const container = document.getElementById('react-root');
+const children = <App />;
+if (typeof ReactDOM.unstable_createRoot === 'function') {
+  const root = ReactDOM.unstable_createRoot(container);
+  root.render(children);
+} else {
+  ReactDOM.render(children, container);
+}

--- a/test/utils/initPlaywrightMatchers.ts
+++ b/test/utils/initPlaywrightMatchers.ts
@@ -41,7 +41,8 @@ chai.use((chaiAPI, utils) => {
 
     const { isFocused, stringifiedActiveElement, stringifiedElement } = await $element.evaluate(
       (element) => {
-        const activeElement = element.ownerDocument?.activeElement;
+        const activeElement =
+          element.ownerDocument !== null ? element.ownerDocument.activeElement : null;
         return {
           isFocused: activeElement === element,
           stringifiedElement: window.elementToString(element),

--- a/test/utils/setupBabelPlaywright.js
+++ b/test/utils/setupBabelPlaywright.js
@@ -1,0 +1,10 @@
+// In playwright we sometimes write functions that are executed in the browser environment.
+// Since we can't tell babel which parts of the code are executed in which environment we can only disable it entirely.
+// We're only stripping types and compiling ES6 to CommonJS modules which should be safe.
+
+require('@babel/register')({
+  configFile: false,
+  extensions: ['.js', '.ts', '.tsx'],
+  presets: [require.resolve('@babel/preset-typescript')],
+  plugins: [require.resolve('@babel/plugin-transform-modules-commonjs')],
+});


### PR DESCRIPTION
Cherry-picked some enhancements from https://github.com/mui-org/material-ui/pull/26107/files that are useful when testing `react@experimental`.

