### PR TITLE
[internal][pickers] Pass desktop wrapper props explicitly

### DIFF
--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -59,10 +59,11 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
 
   return (
     <DesktopWrapper
-      {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
+      PopperProps={PopperProps}
+      TransitionComponent={TransitionComponent}
     >
       <Picker
         {...pickerProps}

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -47,9 +47,14 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   const validationError = useDateValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
-  // Note that we are passing down all the value without spread.
-  // It saves us >1kb gzip and make any prop available automatically on any level down.
-  const { ToolbarComponent = DatePickerToolbar, value, onChange, ...other } = props;
+  const {
+    onChange,
+    PopperProps,
+    ToolbarComponent = DatePickerToolbar,
+    TransitionComponent,
+    value,
+    ...other
+  } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -104,6 +104,8 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
     inputFormat: passedInputFormat,
     minDate: minDateProp = defaultMinDate as TDate,
     maxDate: maxDateProp = defaultMaxDate as TDate,
+    PopperProps,
+    TransitionComponent,
     ...other
   } = props;
 
@@ -148,10 +150,11 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
 
   return (
     <DesktopTooltipWrapper
-      {...restProps}
       {...wrapperProps}
       DateInputProps={DateInputProps}
       KeyboardDateInputComponent={KeyboardDateInputComponent}
+      PopperProps={PopperProps}
+      TransitionComponent={TransitionComponent}
     >
       <DateRangePickerView<any>
         open={wrapperProps.open}

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -62,10 +62,11 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
 
   return (
     <DesktopWrapper
-      {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
+      PopperProps={PopperProps}
+      TransitionComponent={TransitionComponent}
     >
       <Picker
         {...pickerProps}

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -50,9 +50,14 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
   const validationError = useDateTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
-  // Note that we are passing down all the value without spread.
-  // It saves us >1kb gzip and make any prop available automatically on any level down.
-  const { ToolbarComponent = DateTimePickerToolbar, value, onChange, ...other } = props;
+  const {
+    onChange,
+    PopperProps,
+    ToolbarComponent = DateTimePickerToolbar,
+    TransitionComponent,
+    value,
+    ...other
+  } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -47,17 +47,23 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   const validationError = useTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
 
-  // Note that we are passing down all the value without spread.
-  // It saves us >1kb gzip and make any prop available automatically on any level down.
-  const { ToolbarComponent = TimePickerToolbar, value, onChange, ...other } = props;
+  const {
+    onChange,
+    PopperProps,
+    ToolbarComponent = TimePickerToolbar,
+    TransitionComponent,
+    value,
+    ...other
+  } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (
     <DesktopWrapper
-      {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
+      PopperProps={PopperProps}
+      TransitionComponent={TransitionComponent}
     >
       <Picker
         {...pickerProps}


### PR DESCRIPTION
Clears up where props goes. 

Minor step with the goal of removing the `ResponsiveWrapper`.