### PR TITLE
[pickers] Fix ref types

### DIFF
--- a/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/material-ui-lab/src/DatePicker/DatePicker.tsx
@@ -26,7 +26,7 @@ export interface DatePickerProps<TDate = unknown>
     ResponsiveWrapperProps {}
 
 type DatePickerComponent = (<TDate>(
-  props: DatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: DatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -25,7 +25,7 @@ export interface DateTimePickerProps<TDate = unknown>
     ResponsiveWrapperProps {}
 
 type DateTimePickerComponent = (<TDate>(
-  props: DateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: DateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -21,7 +21,7 @@ export interface DesktopDatePickerProps<TDate = unknown>
     DesktopWrapperProps {}
 
 type DesktopDatePickerComponent = (<TDate>(
-  props: DesktopDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: DesktopDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -24,7 +24,7 @@ export interface DesktopDateTimePickerProps<TDate = unknown>
     DesktopWrapperProps {}
 
 type DesktopDateTimePickerComponent = (<TDate>(
-  props: DesktopDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: DesktopDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -21,7 +21,7 @@ export interface DesktopTimePickerProps<TDate = unknown>
     DesktopWrapperProps {}
 
 type DesktopTimePickerComponent = (<TDate>(
-  props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -21,7 +21,7 @@ export interface MobileDatePickerProps<TDate = unknown>
     MobileWrapperProps {}
 
 type MobileDatePickerComponent = (<TDate>(
-  props: MobileDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: MobileDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -24,7 +24,7 @@ export interface MobileDateTimePickerProps<TDate = unknown>
     MobileWrapperProps {}
 
 type MobileDateTimePickerComponent = (<TDate>(
-  props: MobileDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: MobileDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -21,7 +21,7 @@ export interface MobileTimePickerProps<TDate = unknown>
     MobileWrapperProps {}
 
 type MobileTimePickerComponent = (<TDate>(
-  props: MobileTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: MobileTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -24,7 +24,7 @@ export interface StaticDatePickerProps<TDate = unknown> extends BaseDatePickerPr
 }
 
 type StaticDatePickerComponent = (<TDate>(
-  props: StaticDatePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: StaticDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -27,7 +27,7 @@ export interface StaticDateTimePickerProps<TDate = unknown> extends BaseDateTime
 }
 
 type StaticDateTimePickerComponent = (<TDate>(
-  props: StaticDateTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: StaticDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -24,7 +24,7 @@ export interface StaticTimePickerProps<TDate = unknown> extends BaseTimePickerPr
 }
 
 type StaticTimePickerComponent = (<TDate>(
-  props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -25,7 +25,7 @@ export interface TimePickerProps<TDate = unknown>
     ResponsiveWrapperProps {}
 
 type TimePickerComponent = (<TDate>(
-  props: TimePickerProps<TDate> & React.RefAttributes<HTMLInputElement>,
+  props: TimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
 ) => JSX.Element) & { propTypes?: any };
 
 /**


### PR DESCRIPTION
They were incorrectly typed as `HTMLInputElement` when it was `HTMLDivElement` at runtime. This affects `TimePicker`, `DatePicker`, `DateTimePicker` and their mobile and desktop variants.

The types were incorrectly casted. See `ref: React.Ref<HTMLDivElement>,`