### PR TITLE
[core] Update typings for theme's components

### DIFF
--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, StyleRules } from './withStyles';
+import { CSSProperties, CSSInterpolation } from './experimentalStyled';
 import { AccordionActionsClassKey } from '../AccordionActions';
 import { AccordionClassKey } from '../Accordion';
 import { AccordionDetailsClassKey } from '../AccordionDetails';
@@ -109,6 +109,10 @@ import { ToolbarClassKey } from '../Toolbar';
 import { TooltipClassKey } from '../Tooltip';
 import { TouchRippleClassKey } from '../ButtonBase/TouchRipple';
 import { TypographyClassKey } from '../Typography';
+
+export type StyleRules<
+ClassKey extends string = string
+> = Record<ClassKey, CSSInterpolation>;
 
 export type ComponentsOverrides = {
   [Name in keyof ComponentNameToClassKey]?: Partial<StyleRules<ComponentNameToClassKey[Name]>>;

--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -110,12 +110,15 @@ import { TooltipClassKey } from '../Tooltip';
 import { TouchRippleClassKey } from '../ButtonBase/TouchRipple';
 import { TypographyClassKey } from '../Typography';
 
-export type StyleRules<
-ClassKey extends string = string
-> = Record<ClassKey, CSSInterpolation>;
+export type OverridesStyleRules<ClassKey extends string = string> = Record<
+  ClassKey,
+  CSSInterpolation
+>;
 
 export type ComponentsOverrides = {
-  [Name in keyof ComponentNameToClassKey]?: Partial<StyleRules<ComponentNameToClassKey[Name]>>;
+  [Name in keyof ComponentNameToClassKey]?: Partial<
+    OverridesStyleRules<ComponentNameToClassKey[Name]>
+  >;
 } & {
   MuiCssBaseline?: CSSProperties | string;
 };

--- a/packages/material-ui/src/styles/variants.d.ts
+++ b/packages/material-ui/src/styles/variants.d.ts
@@ -1,17 +1,9 @@
-import { CSSProperties, CreateCSSProperties, PropsFunc } from '@material-ui/styles/withStyles';
+import { CSSInterpolation } from './experimentalStyled';
 import { ComponentsPropsList } from './props';
 
 export type ComponentsVariants = {
   [Name in keyof ComponentsPropsList]?: Array<{
     props: Partial<ComponentsPropsList[Name]>;
-    style: // JSS property bag
-    | CSSProperties
-      // JSS property bag where values are based on props
-      | CreateCSSProperties<Partial<ComponentsPropsList[Name]>>
-      // JSS property bag based on props
-      | PropsFunc<
-          Partial<ComponentsPropsList[Name]>,
-          CreateCSSProperties<Partial<ComponentsPropsList[Name]>>
-        >;
+    style: CSSInterpolation;
   }>;
 };


### PR DESCRIPTION
Updates the `theme.components.styleOverrides` and `theme.components.variants` to use the same typigns for the styles as the `experimentalStyled()`.