### PR TITLE
[docs] Remove `@material-ui/core/styles` from the styles pages

### DIFF
--- a/docs/src/pages/styles/advanced/GlobalCss.js
+++ b/docs/src/pages/styles/advanced/GlobalCss.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
   '@global': {

--- a/docs/src/pages/styles/advanced/GlobalCss.tsx
+++ b/docs/src/pages/styles/advanced/GlobalCss.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
   '@global': {

--- a/docs/src/pages/styles/advanced/HybridGlobalCss.js
+++ b/docs/src/pages/styles/advanced/HybridGlobalCss.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/styles/advanced/HybridGlobalCss.tsx
+++ b/docs/src/pages/styles/advanced/HybridGlobalCss.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/styles/advanced/ThemeNesting.js
+++ b/docs/src/pages/styles/advanced/ThemeNesting.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/docs/src/pages/styles/advanced/ThemeNesting.tsx
+++ b/docs/src/pages/styles/advanced/ThemeNesting.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, makeStyles } from '@material-ui/styles';
 
 interface MyTheme {
   background: string;

--- a/docs/src/pages/styles/advanced/Theming.js
+++ b/docs/src/pages/styles/advanced/Theming.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, makeStyles } from '@material-ui/styles';
 
 const themeInstance = {
   background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',

--- a/docs/src/pages/styles/advanced/Theming.tsx
+++ b/docs/src/pages/styles/advanced/Theming.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, makeStyles } from '@material-ui/styles';
 
 const themeInstance = {
   background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',

--- a/docs/src/pages/styles/advanced/UseTheme.js
+++ b/docs/src/pages/styles/advanced/UseTheme.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, useTheme } from '@material-ui/core/styles';
+import { ThemeProvider, useTheme } from '@material-ui/styles';
 
 function DeepChild() {
   const theme = useTheme();

--- a/docs/src/pages/styles/advanced/UseTheme.tsx
+++ b/docs/src/pages/styles/advanced/UseTheme.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, useTheme } from '@material-ui/core/styles';
+import { ThemeProvider, useTheme } from '@material-ui/styles';
 
 interface MyTheme {
   spacing: string;

--- a/docs/src/pages/styles/basics/AdaptingHOC.js
+++ b/docs/src/pages/styles/basics/AdaptingHOC.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 
 const styles = {

--- a/docs/src/pages/styles/basics/AdaptingHOC.tsx
+++ b/docs/src/pages/styles/basics/AdaptingHOC.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles, WithStyles } from '@material-ui/core/styles';
+import { withStyles, WithStyles } from '@material-ui/styles';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 
 const styles = {

--- a/docs/src/pages/styles/basics/AdaptingHook.js
+++ b/docs/src/pages/styles/basics/AdaptingHook.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles({

--- a/docs/src/pages/styles/basics/AdaptingHook.tsx
+++ b/docs/src/pages/styles/basics/AdaptingHook.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 import Button, { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
 
 interface Props {

--- a/docs/src/pages/styles/basics/HigherOrderComponent.js
+++ b/docs/src/pages/styles/basics/HigherOrderComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 
 const styles = {

--- a/docs/src/pages/styles/basics/HigherOrderComponent.tsx
+++ b/docs/src/pages/styles/basics/HigherOrderComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles, WithStyles } from '@material-ui/core/styles';
+import { withStyles, WithStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 
 const styles = {

--- a/docs/src/pages/styles/basics/Hook.js
+++ b/docs/src/pages/styles/basics/Hook.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles({

--- a/docs/src/pages/styles/basics/Hook.tsx
+++ b/docs/src/pages/styles/basics/Hook.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles({

--- a/docs/src/pages/styles/basics/NestedStylesHook.js
+++ b/docs/src/pages/styles/basics/NestedStylesHook.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/styles/basics/NestedStylesHook.tsx
+++ b/docs/src/pages/styles/basics/NestedStylesHook.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/styles/basics/StressTest.js
+++ b/docs/src/pages/styles/basics/StressTest.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider, useTheme, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, useTheme, makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles((theme) => ({
   root: (props) => ({

--- a/docs/src/pages/styles/basics/StressTest.tsx
+++ b/docs/src/pages/styles/basics/StressTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, useTheme, makeStyles } from '@material-ui/core/styles';
+import { ThemeProvider, useTheme, makeStyles } from '@material-ui/styles';
 
 interface MyTheme {
   color: string;


### PR DESCRIPTION
This PR updates the imports on the docs/styles pages to use only `@material-ui/styles`