### PR TITLE
[test] Add test for behavior when picker variant changes

### DIFF
--- a/test/regressions/fixtures/pickers/UncontrolledDateTimePicker.tsx
+++ b/test/regressions/fixtures/pickers/UncontrolledDateTimePicker.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import { TransitionProps } from '@material-ui/core/transitions';
+import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
+import DateTimePicker from '@material-ui/lab/DateTimePicker';
+
+const NoTransition = React.forwardRef(function NoTransition(
+  props: TransitionProps & { children?: React.ReactNode },
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const { children, in: inProp } = props;
+
+  if (!inProp) {
+    return null;
+  }
+  return (
+    <div ref={ref} tabIndex={-1}>
+      {children}
+    </div>
+  );
+});
+
+export default function UncontrolledDateTimePicker() {
+  const [mode, toggleMode] = React.useReducer(
+    (state) => (state === 'desktop' ? 'mobile' : 'desktop'),
+    'desktop',
+  );
+  React.useEffect(() => {
+    (window as any).muiTogglePickerMode = toggleMode;
+    return () => {
+      delete (window as any).muiTogglePickerMode;
+    };
+  }, []);
+  const desktopMediaQuery = '(pointer: fine)';
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DateTimePicker
+        // Simulating what would happen if the media query matches/not matches
+        // Simpler to implement than mocking window.matchMedia
+        desktopModeMediaQuery={mode === 'desktop' ? desktopMediaQuery : `not(${desktopMediaQuery})`}
+        onChange={() => {}}
+        renderInput={(params) => <TextField {...params} />}
+        TransitionComponent={NoTransition}
+        value={null}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -101,6 +101,29 @@ async function main() {
         await takeScreenshot({ testcase, route: '/regression-Rating/FocusVisibleRating3' });
       });
     });
+
+    describe('DateTimePicker', () => {
+      it('should handle change in pointer correctly', async () => {
+        const index = routes.findIndex(
+          (route) => route === '/regression-pickers/UncontrolledDateTimePicker',
+        );
+        await renderFixture(index);
+
+        await page.click('[aria-label="Choose date"]');
+        await page.click('[aria-label*="switch to year view"]');
+        await takeScreenshot({
+          testcase: await page.waitForSelector('[role="dialog"]'),
+          route: '/regression-pickers/UncontrolledDateTimePicker-desktop',
+        });
+        await page.evaluate(() => {
+          window.muiTogglePickerMode();
+        });
+        await takeScreenshot({
+          testcase: await page.waitForSelector('[role="dialog"]'),
+          route: '/regression-pickers/UncontrolledDateTimePicker-mobile',
+        });
+      });
+    });
   });
 
   run();


### PR DESCRIPTION
Helps with https://github.com/mui-org/material-ui/pull/26123

Right now I'm probably moving forward with https://github.com/mui-org/material-ui/pull/26123 even though it does regress in certain areas. Since the behavior is already fairly inconsistent (notice how the displayed view changes when switching to mobile i.e. it goes from year to calendar view) I feel safer just resetting entirely instead of only persisting some areas (e.g. `open` is persisted but not `view`).

Long term we can probably bring this back by using controlled/uncontrolled patterns. Short term people can restore the previous behavior by controlling `open`:

```tsx
function ResponsiveDateTimePicker() {
  const [open, setOpen] = React.useState(false);

	return <DateTimePicker open={open} onClose={() => setOpen(false)} onOpen={() => setOpen(true)} />
}
```