### PR TITLE
[useMediaQuery] Remove callback query and default options from theme

### DIFF
--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -43,20 +43,6 @@ function MyComponent() {
 
 {{"demo": "pages/components/use-media-query/ThemeHelper.js", "defaultCodeOpen": false}}
 
-Alternatively, you can use a callback function, accepting the theme as a first argument:
-
-```jsx
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-
-function MyComponent() {
-  const matches = useMediaQuery((theme) => theme.breakpoints.up('sm'));
-
-  return <span>{`theme.breakpoints.up('sm') matches: ${matches}`}</span>;
-}
-```
-
-⚠️ There is **no default** theme support, you have to inject it in a parent theme provider.
-
 ## Using JavaScript syntax
 
 You can use [json2mq](https://github.com/akiran/json2mq) to generate media query string from a JavaScript object.

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.d.ts
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.d.ts
@@ -16,7 +16,4 @@ export interface Options {
   ssrMatchMedia?: (query: string) => { matches: boolean };
 }
 
-export default function useMediaQuery<Theme = unknown>(
-  query: string | ((theme: Theme) => string),
-  options?: Options,
-): boolean;
+export default function useMediaQuery(query: string, options?: Options): boolean;

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -1,30 +1,8 @@
 import * as React from 'react';
-import { useTheme } from '@material-ui/private-theming';
-import getThemeProps from '../styles/getThemeProps';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
 export default function useMediaQuery(queryInput, options = {}) {
-  const theme = useTheme();
-  const props = getThemeProps({
-    theme,
-    name: 'MuiUseMediaQuery',
-    props: {},
-  });
-
-  if (process.env.NODE_ENV !== 'production') {
-    if (typeof queryInput === 'function' && theme === null) {
-      console.error(
-        [
-          'Material-UI: The `query` argument provided is invalid.',
-          'You are providing a function without a theme in the context.',
-          'One of the parent elements needs to use a ThemeProvider.',
-        ].join('\n'),
-      );
-    }
-  }
-
-  let query = typeof queryInput === 'function' ? queryInput(theme) : queryInput;
-  query = query.replace(/^@media( ?)/m, '');
+  const query = queryInput.replace(/^@media( ?)/m, '');
 
   // Wait for jsdom to support the match media feature.
   // All the browsers Material-UI support have this built-in.
@@ -38,10 +16,7 @@ export default function useMediaQuery(queryInput, options = {}) {
     matchMedia = supportMatchMedia ? window.matchMedia : null,
     noSsr = false,
     ssrMatchMedia = null,
-  } = {
-    ...props,
-    ...options,
-  };
+  } = options;
 
   const [match, setMatch] = React.useState(() => {
     if (noSsr && supportMatchMedia) {


### PR DESCRIPTION
Will not go forward in v5. Just want to see bundle impact.
> ▼ -570 B (-27.39% )

Given that `useMediaQuery` is targetted at non-Material-UI users it only makes sense to have a base implementation that has no relation to Material-UI.

That means:
1. No default options from the theme
    Can be implemented in userland via composition. It wasn't even documented in the useMediaQuery page
2. No query callback
    Problematic since unlike every other module in `/core` it has no default theme.
    For that reason it was never used in the docs so we might as well get rid of it.