### PR TITLE
[Table] Synchronize horizontal sticky header position with body

### DIFF
--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -118,7 +118,6 @@ const TableCellRoot = experimentalStyled(
   ...(styleProps.stickyHeader && {
     position: 'sticky',
     top: 0,
-    left: 0,
     zIndex: 2,
     backgroundColor: theme.palette.background.default,
   }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

HEAD:

https://next.material-ui.com/components/tables/#sticky-header

https://user-images.githubusercontent.com/4471489/117297334-60e61f00-ae76-11eb-8246-ef1e0611a3b2.mov

PR:

https://deploy-preview-26159--material-ui.netlify.app/components/tables/#sticky-header

https://user-images.githubusercontent.com/4471489/117297358-693e5a00-ae76-11eb-93db-9c3ff0305fce.mov

