### PR TITLE
[docs] Ensure TreeView demos don't overflow demo container

### DIFF
--- a/docs/src/pages/components/tree-view/ControlledTreeView.js
+++ b/docs/src/pages/components/tree-view/ControlledTreeView.js
@@ -31,7 +31,7 @@ export default function ControlledTreeView() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <Button onClick={handleExpandClick}>
           {expanded.length === 0 ? 'Expand all' : 'Collapse all'}

--- a/docs/src/pages/components/tree-view/ControlledTreeView.js
+++ b/docs/src/pages/components/tree-view/ControlledTreeView.js
@@ -31,7 +31,7 @@ export default function ControlledTreeView() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400 }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <Button onClick={handleExpandClick}>
           {expanded.length === 0 ? 'Expand all' : 'Collapse all'}

--- a/docs/src/pages/components/tree-view/ControlledTreeView.tsx
+++ b/docs/src/pages/components/tree-view/ControlledTreeView.tsx
@@ -31,7 +31,7 @@ export default function ControlledTreeView() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <Button onClick={handleExpandClick}>
           {expanded.length === 0 ? 'Expand all' : 'Collapse all'}

--- a/docs/src/pages/components/tree-view/ControlledTreeView.tsx
+++ b/docs/src/pages/components/tree-view/ControlledTreeView.tsx
@@ -31,7 +31,7 @@ export default function ControlledTreeView() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400 }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <Button onClick={handleExpandClick}>
           {expanded.length === 0 ? 'Expand all' : 'Collapse all'}

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.js
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.js
@@ -89,7 +89,7 @@ export default function CustomizedTreeView() {
       defaultCollapseIcon={<MinusSquare />}
       defaultExpandIcon={<PlusSquare />}
       defaultEndIcon={<CloseSquare />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <StyledTreeItem nodeId="1" label="Main">
         <StyledTreeItem nodeId="2" label="Hello" />

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.js
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.js
@@ -89,7 +89,7 @@ export default function CustomizedTreeView() {
       defaultCollapseIcon={<MinusSquare />}
       defaultExpandIcon={<PlusSquare />}
       defaultEndIcon={<CloseSquare />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <StyledTreeItem nodeId="1" label="Main">
         <StyledTreeItem nodeId="2" label="Hello" />

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.tsx
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.tsx
@@ -82,7 +82,7 @@ export default function CustomizedTreeView() {
       defaultCollapseIcon={<MinusSquare />}
       defaultExpandIcon={<PlusSquare />}
       defaultEndIcon={<CloseSquare />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <StyledTreeItem nodeId="1" label="Main">
         <StyledTreeItem nodeId="2" label="Hello" />

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.tsx
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.tsx
@@ -82,7 +82,7 @@ export default function CustomizedTreeView() {
       defaultCollapseIcon={<MinusSquare />}
       defaultExpandIcon={<PlusSquare />}
       defaultEndIcon={<CloseSquare />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <StyledTreeItem nodeId="1" label="Main">
         <StyledTreeItem nodeId="2" label="Hello" />

--- a/docs/src/pages/components/tree-view/DisabledTreeItems.js
+++ b/docs/src/pages/components/tree-view/DisabledTreeItems.js
@@ -14,7 +14,7 @@ export default function DisabledTreeItems() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400 }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
           control={

--- a/docs/src/pages/components/tree-view/DisabledTreeItems.js
+++ b/docs/src/pages/components/tree-view/DisabledTreeItems.js
@@ -14,7 +14,7 @@ export default function DisabledTreeItems() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
           control={

--- a/docs/src/pages/components/tree-view/DisabledTreeItems.tsx
+++ b/docs/src/pages/components/tree-view/DisabledTreeItems.tsx
@@ -14,7 +14,7 @@ export default function DisabledTreeItems() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400 }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
           control={

--- a/docs/src/pages/components/tree-view/DisabledTreeItems.tsx
+++ b/docs/src/pages/components/tree-view/DisabledTreeItems.tsx
@@ -14,7 +14,7 @@ export default function DisabledTreeItems() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}>
+    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
           control={

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -10,7 +10,7 @@ export default function FileSystemNavigator() {
       aria-label="file system navigator"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -10,7 +10,7 @@ export default function FileSystemNavigator() {
       aria-label="file system navigator"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
@@ -10,7 +10,7 @@ export default function FileSystemNavigator() {
       aria-label="file system navigator"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
@@ -10,7 +10,7 @@ export default function FileSystemNavigator() {
       aria-label="file system navigator"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/GmailTreeView.js
+++ b/docs/src/pages/components/tree-view/GmailTreeView.js
@@ -94,7 +94,7 @@ export default function GmailTreeView() {
       defaultCollapseIcon={<ArrowDropDownIcon />}
       defaultExpandIcon={<ArrowRightIcon />}
       defaultEndIcon={<div style={{ width: 24 }} />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <StyledTreeItem nodeId="1" labelText="All Mail" labelIcon={MailIcon} />
       <StyledTreeItem nodeId="2" labelText="Trash" labelIcon={DeleteIcon} />

--- a/docs/src/pages/components/tree-view/GmailTreeView.js
+++ b/docs/src/pages/components/tree-view/GmailTreeView.js
@@ -94,7 +94,7 @@ export default function GmailTreeView() {
       defaultCollapseIcon={<ArrowDropDownIcon />}
       defaultExpandIcon={<ArrowRightIcon />}
       defaultEndIcon={<div style={{ width: 24 }} />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <StyledTreeItem nodeId="1" labelText="All Mail" labelIcon={MailIcon} />
       <StyledTreeItem nodeId="2" labelText="Trash" labelIcon={DeleteIcon} />

--- a/docs/src/pages/components/tree-view/GmailTreeView.tsx
+++ b/docs/src/pages/components/tree-view/GmailTreeView.tsx
@@ -101,7 +101,7 @@ export default function GmailTreeView() {
       defaultCollapseIcon={<ArrowDropDownIcon />}
       defaultExpandIcon={<ArrowRightIcon />}
       defaultEndIcon={<div style={{ width: 24 }} />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <StyledTreeItem nodeId="1" labelText="All Mail" labelIcon={MailIcon} />
       <StyledTreeItem nodeId="2" labelText="Trash" labelIcon={DeleteIcon} />

--- a/docs/src/pages/components/tree-view/GmailTreeView.tsx
+++ b/docs/src/pages/components/tree-view/GmailTreeView.tsx
@@ -101,7 +101,7 @@ export default function GmailTreeView() {
       defaultCollapseIcon={<ArrowDropDownIcon />}
       defaultExpandIcon={<ArrowRightIcon />}
       defaultEndIcon={<div style={{ width: 24 }} />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <StyledTreeItem nodeId="1" labelText="All Mail" labelIcon={MailIcon} />
       <StyledTreeItem nodeId="2" labelText="Trash" labelIcon={DeleteIcon} />

--- a/docs/src/pages/components/tree-view/IconExpansionTreeView.js
+++ b/docs/src/pages/components/tree-view/IconExpansionTreeView.js
@@ -110,7 +110,7 @@ export default function IconExpansionTreeView() {
       aria-label="icon expansion"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <CustomTreeItem nodeId="1" label="Applications">
         <CustomTreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/IconExpansionTreeView.js
+++ b/docs/src/pages/components/tree-view/IconExpansionTreeView.js
@@ -110,7 +110,7 @@ export default function IconExpansionTreeView() {
       aria-label="icon expansion"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <CustomTreeItem nodeId="1" label="Applications">
         <CustomTreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/IconExpansionTreeView.tsx
+++ b/docs/src/pages/components/tree-view/IconExpansionTreeView.tsx
@@ -89,7 +89,7 @@ export default function IconExpansionTreeView() {
       aria-label="icon expansion"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <CustomTreeItem nodeId="1" label="Applications">
         <CustomTreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/IconExpansionTreeView.tsx
+++ b/docs/src/pages/components/tree-view/IconExpansionTreeView.tsx
@@ -89,7 +89,7 @@ export default function IconExpansionTreeView() {
       aria-label="icon expansion"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <CustomTreeItem nodeId="1" label="Applications">
         <CustomTreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/MultiSelectTreeView.js
+++ b/docs/src/pages/components/tree-view/MultiSelectTreeView.js
@@ -11,7 +11,7 @@ export default function MultiSelectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
       multiSelect
-      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/MultiSelectTreeView.js
+++ b/docs/src/pages/components/tree-view/MultiSelectTreeView.js
@@ -11,7 +11,7 @@ export default function MultiSelectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
       multiSelect
-      sx={{ height: 216, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/MultiSelectTreeView.tsx
+++ b/docs/src/pages/components/tree-view/MultiSelectTreeView.tsx
@@ -11,7 +11,7 @@ export default function MultiSelectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
       multiSelect
-      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/MultiSelectTreeView.tsx
+++ b/docs/src/pages/components/tree-view/MultiSelectTreeView.tsx
@@ -11,7 +11,7 @@ export default function MultiSelectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
       multiSelect
-      sx={{ height: 216, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       <TreeItem nodeId="1" label="Applications">
         <TreeItem nodeId="2" label="Calendar" />

--- a/docs/src/pages/components/tree-view/RichObjectTreeView.js
+++ b/docs/src/pages/components/tree-view/RichObjectTreeView.js
@@ -40,7 +40,7 @@ export default function RichObjectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpanded={['root']}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       {renderTree(data)}
     </TreeView>

--- a/docs/src/pages/components/tree-view/RichObjectTreeView.js
+++ b/docs/src/pages/components/tree-view/RichObjectTreeView.js
@@ -40,7 +40,7 @@ export default function RichObjectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpanded={['root']}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 110, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       {renderTree(data)}
     </TreeView>

--- a/docs/src/pages/components/tree-view/RichObjectTreeView.tsx
+++ b/docs/src/pages/components/tree-view/RichObjectTreeView.tsx
@@ -46,7 +46,7 @@ export default function RichObjectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpanded={['root']}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
+      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
     >
       {renderTree(data)}
     </TreeView>

--- a/docs/src/pages/components/tree-view/RichObjectTreeView.tsx
+++ b/docs/src/pages/components/tree-view/RichObjectTreeView.tsx
@@ -46,7 +46,7 @@ export default function RichObjectTreeView() {
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpanded={['root']}
       defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 110, flexGrow: 1, maxWidth: 400 }}
+      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflow: 'auto' }}
     >
       {renderTree(data)}
     </TreeView>


### PR DESCRIPTION
The [gmail clone treeview](https://6093d26ee081cf00074f9d5d--material-ui.netlify.app/components/tree-view#GmailTreeView) overflows its demo containers

Noticed on the gmail clone which now behaves like actual gmail (adds a scrollbar on overflow). Applied to all the other demos which can have the same issue on larger font sizes.

Before:
![Screenshot from 2021-05-06 14-42-54](https://user-images.githubusercontent.com/12292047/117301377-e370dd80-ae7a-11eb-9db5-97890c8562e7.png)

-- https://6093d26ee081cf00074f9d5d--material-ui.netlify.app/components/tree-view#GmailTreeView

After:

![Screenshot from 2021-05-06 14-43-22](https://user-images.githubusercontent.com/12292047/117301352-dbb13900-ae7a-11eb-90cc-77742014f599.png)

-- https://deploy-preview-26161--material-ui.netlify.app/components/tree-view/#GmailTreeView
