### PR TITLE
[theme] Remove `MuiThemeProvider` alias

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1512,6 +1512,15 @@ As the core components use emotion as a styled engine, the props used by emotion
   +import { jssPreset } from '@material-ui/styles';
   ```
 
+#### MuiThemeProvider
+
+- The `MuiThemeProvider` is no longer exported from `@material-ui/core/styles`. Use `ThemeProvider` instead.
+
+  ```diff
+  -import { MuiThemeProvider } from '@material-ui/core/styles';
+  +import { ThemeProvider } from '@material-ui/core/styles';
+  ```
+
 #### ServerStyleSheets
 
 - The `ServerStyleSheets` is no longer exported from `@material-ui/core/styles`. You should import it directly from `@material-ui/styles`.

--- a/framer/Material-UI.framerfx/code/ThemeProvider.tsx
+++ b/framer/Material-UI.framerfx/code/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { addPropertyControls, ControlType } from 'framer';
-import { MuiThemeProvider, createTheme } from '@material-ui/core/styles';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { parseColor } from './utils';
 
 interface Props {
@@ -40,9 +40,9 @@ export function Theme(props: Props): JSX.Element {
   });
 
   return (
-    <MuiThemeProvider theme={theme} {...other}>
+    <ThemeProvider theme={theme} {...other}>
       {children}
-    </MuiThemeProvider>
+    </ThemeProvider>
   );
 }
 

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -48,11 +48,7 @@ export {
   StyledComponentProps,
 } from './withStyles';
 export { default as experimentalStyled, CreateMUIStyled } from './experimentalStyled';
-export {
-  default as MuiThemeProvider,
-  default as ThemeProvider,
-  ThemeProviderProps,
-} from './ThemeProvider';
+export { default as ThemeProvider, ThemeProviderProps } from './ThemeProvider';
 export {
   createGenerateClassName,
   jssPreset,

--- a/packages/material-ui/src/styles/index.js
+++ b/packages/material-ui/src/styles/index.js
@@ -11,4 +11,4 @@ export { default as useTheme } from './useTheme';
 export { default as unstable_useThemeProps } from './useThemeProps';
 export { default as withStyles } from './withStyles';
 export { default as experimentalStyled } from './experimentalStyled';
-export { default as MuiThemeProvider, default as ThemeProvider } from './ThemeProvider';
+export { default as ThemeProvider } from './ThemeProvider';


### PR DESCRIPTION
### Breaking changes

- [theme] The `MuiThemeProvider` is no longer exported from `@material-ui/core/styles`. Use `ThemeProvider` instead.

  ```diff
  -import { MuiThemeProvider } from '@material-ui/core/styles';
  +import { ThemeProvider } from '@material-ui/core/styles';
  ```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012
