### PR TITLE
[core] Link to experimental size-comparison page

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -126,7 +126,9 @@ async function reportBundleSize() {
   await git(`fetch ${UPSTREAM_REMOTE}`);
   const mergeBaseCommit = await git(`merge-base HEAD ${UPSTREAM_REMOTE}/${upstreamRef}`);
 
-  const detailedComparisonUrl = `https://mui-dashboard.netlify.app/size-comparison?buildId=${azureBuildId}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number}`;
+  const detailedComparisonRoute = `/size-comparison?buildId=${azureBuildId}&baseRef=${danger.github.pr.base.ref}&baseCommit=${mergeBaseCommit}&prNumber=${danger.github.pr.number}`;
+  const detailedComparisonUrl = `https://mui-dashboard.netlify.app${detailedComparisonRoute}`;
+  const detailedComparisonUrlExperimental = `https://mui-maintainer-dashboard-remix.vercel.app/${detailedComparisonRoute}`;
 
   const comparison = await loadComparison(mergeBaseCommit, upstreamRef);
 
@@ -144,11 +146,13 @@ async function reportBundleSize() {
       markdown(importantChanges.join('\n'));
     }
 
-    const details = `[Details of bundle changes](${detailedComparisonUrl})`;
+    const details = `[Details of bundle changes](${detailedComparisonUrl}) ([experimental](${detailedComparisonUrlExperimental}))`;
 
     markdown(details);
   } else {
-    markdown(`[No bundle size changes](${detailedComparisonUrl})`);
+    markdown(
+      `[No bundle size changes](${detailedComparisonUrl}) ([experimental](${detailedComparisonUrlExperimental}))`,
+    );
   }
 }
 


### PR DESCRIPTION
The new page caches more aggressively so subsequent visits should be considerably faster (for the same commit obviously). On a cache-miss it's not clear though.

Since this uses caching, vercel and experimental tech (remix.run) it'll just live next to the stable page.