### PR TITLE
[Select][NativeSelect] Polish CSS classes

### DIFF
--- a/docs/pages/api-docs/native-select.json
+++ b/docs/pages/api-docs/native-select.json
@@ -18,12 +18,10 @@
   "name": "NativeSelect",
   "styles": {
     "classes": [
-      "root",
       "select",
       "filled",
       "outlined",
       "standard",
-      "selectMenu",
       "disabled",
       "icon",
       "iconOpen",

--- a/docs/pages/api-docs/native-select.json
+++ b/docs/pages/api-docs/native-select.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } },
+    "classes": { "type": { "name": "object" }, "default": "{}" },
     "IconComponent": { "type": { "name": "elementType" }, "default": "ArrowDropDownIcon" },
     "input": { "type": { "name": "element" }, "default": "<Input />" },
     "inputProps": { "type": { "name": "object" } },
@@ -18,6 +18,7 @@
   "name": "NativeSelect",
   "styles": {
     "classes": [
+      "root",
       "select",
       "filled",
       "outlined",

--- a/docs/pages/api-docs/select.json
+++ b/docs/pages/api-docs/select.json
@@ -33,12 +33,10 @@
   "name": "Select",
   "styles": {
     "classes": [
-      "root",
       "select",
       "filled",
       "outlined",
       "standard",
-      "selectMenu",
       "disabled",
       "icon",
       "iconOpen",

--- a/docs/pages/api-docs/select.json
+++ b/docs/pages/api-docs/select.json
@@ -33,6 +33,7 @@
   "name": "Select",
   "styles": {
     "classes": [
+      "root",
       "select",
       "filled",
       "outlined",

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1315,6 +1315,15 @@ As the core components use emotion as a styled engine, the props used by emotion
   />
   ```
 
+- Move the custom class on `input` to `select`. The `input` key is being applied on another element.
+
+  ```diff
+  <TablePagination
+  - classes={{ input: 'foo' }}
+  + classes={{ select: 'foo' }}
+  />
+  ```
+
 - Rename the `default` value of the `padding` prop to `normal`.
 
   ```diff

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1125,6 +1125,13 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Select label="Gender" />
   ```
 
+- Merge the `root` and `selectMenu` slots into `select`. Slots `root` and `selectMenu` are redundant and were removed.
+
+  ```diff
+  -<Select classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />
+  +<Select classes={{ select: 'class1 class2 class3' }} />
+  ```
+
 ### Skeleton
 
 - Move the component from the lab to the core. The component is now stable.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -956,6 +956,15 @@ As the core components use emotion as a styled engine, the props used by emotion
 - Remove `onRendered` prop.
   Depending on your use case either use a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) on the child element or an effect hook in the child component.
 
+### NativeSelect
+
+- Merge the `selectMenu` slot into `select`. Slot `selectMenu` was redundant. The `root` slot is no longer applied to the select, but to the root.
+
+  ```diff
+  -<NativeSelect classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />
+  +<NativeSelect classes={{ select: 'class1 class2 class3' }} />
+  ```
+
 ### OutlinedInput
 
 - Remove the `labelWidth` prop. The `label` prop now fulfills the same purpose, using CSS layout instead of JavaScript measurement to render the gap in the outlined.
@@ -1125,11 +1134,11 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Select label="Gender" />
   ```
 
-- Merge the `selectMenu` slot into `select`. Slot `selectMenu` was redundant. The `root` slot is no longer applied to the select, but to the input.
+- Merge the `selectMenu` slot into `select`. Slot `selectMenu` was redundant. The `root` slot is no longer applied to the select, but to the root.
 
   ```diff
   -<Select classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />
-  +<Select classes={{ root: 'class1', select: 'class2 class3' }} />
+  +<Select classes={{ select: 'class1 class2 class3' }} />
   ```
 
 ### Skeleton

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1125,11 +1125,11 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Select label="Gender" />
   ```
 
-- Merge the `root` and `selectMenu` slots into `select`. Slots `root` and `selectMenu` are redundant and were removed.
+- Merge the `selectMenu` slot into `select`. Slot `selectMenu` was redundant.
 
   ```diff
   -<Select classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />
-  +<Select classes={{ select: 'class1 class2 class3' }} />
+  +<Select classes={{ root: 'class1', select: 'class2 class3' }} />
   ```
 
 ### Skeleton

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1125,7 +1125,7 @@ As the core components use emotion as a styled engine, the props used by emotion
   +<Select label="Gender" />
   ```
 
-- Merge the `selectMenu` slot into `select`. Slot `selectMenu` was redundant.
+- Merge the `selectMenu` slot into `select`. Slot `selectMenu` was redundant. The `root` slot is no longer applied to the select, but to the input.
 
   ```diff
   -<Select classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />

--- a/docs/translations/api-docs/native-select/native-select.json
+++ b/docs/translations/api-docs/native-select/native-select.json
@@ -12,10 +12,6 @@
     "variant": "The variant to use."
   },
   "classDescriptions": {
-    "root": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the select component `root` class"
-    },
     "select": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the select component `select` class"
@@ -34,10 +30,6 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the select component",
       "conditions": "<code>variant=\"standard\"</code>"
-    },
-    "selectMenu": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the select component `selectMenu` class"
     },
     "disabled": {
       "description": "Pseudo-class applied to {{nodeName}}.",

--- a/docs/translations/api-docs/native-select/native-select.json
+++ b/docs/translations/api-docs/native-select/native-select.json
@@ -12,6 +12,7 @@
     "variant": "The variant to use."
   },
   "classDescriptions": {
+    "root": { "description": "Styles applied to the root element." },
     "select": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the select component `select` class"

--- a/docs/translations/api-docs/select/select.json
+++ b/docs/translations/api-docs/select/select.json
@@ -26,10 +26,6 @@
     "variant": "The variant to use."
   },
   "classDescriptions": {
-    "root": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the select component `root` class"
-    },
     "select": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the select component `select` class"
@@ -48,10 +44,6 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the select component",
       "conditions": "<code>variant=\"standard\"</code>"
-    },
-    "selectMenu": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the select component `selectMenu` class"
     },
     "disabled": {
       "description": "Pseudo-class applied to {{nodeName}}.",

--- a/docs/translations/api-docs/select/select.json
+++ b/docs/translations/api-docs/select/select.json
@@ -26,6 +26,7 @@
     "variant": "The variant to use."
   },
   "classDescriptions": {
+    "root": { "description": "Styles applied to the root element." },
     "select": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the select component `select` class"

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -15,6 +15,8 @@ export interface NativeSelectProps
    * Override or extend the styles applied to the component.
    */
   classes?: {
+    /** Styles applied to the root element. */
+    root?: string;
     /** Styles applied to the select component `select` class. */
     select?: string;
     /** Styles applied to the select component if `variant="filled"`. */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -13,6 +13,7 @@ export interface NativeSelectProps
   children?: React.ReactNode;
   /**
    * Override or extend the styles applied to the component.
+   * @default {}
    */
   classes?: {
     /** Styles applied to the root element. */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -15,8 +15,6 @@ export interface NativeSelectProps
    * Override or extend the styles applied to the component.
    */
   classes?: {
-    /** Styles applied to the select component `root` class. */
-    root?: string;
     /** Styles applied to the select component `select` class. */
     select?: string;
     /** Styles applied to the select component if `variant="filled"`. */
@@ -25,8 +23,6 @@ export interface NativeSelectProps
     outlined?: string;
     /** Styles applied to the select component if `variant="standard"`. */
     standard?: string;
-    /** Styles applied to the select component `selectMenu` class. */
-    selectMenu?: string;
     /** Pseudo-class applied to the select component `disabled` class. */
     disabled?: string;
     /** Styles applied to the icon component. */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -79,6 +79,7 @@ NativeSelect.propTypes /* remove-proptypes */ = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
+   * @default {}
    */
   classes: PropTypes.object,
   /**

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -1,12 +1,24 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import NativeSelectInput from './NativeSelectInput';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
 import Input from '../Input';
 import useThemeProps from '../styles/useThemeProps';
+import { getNativeSelectUtilityClasses } from './nativeSelectClasses';
+
+const useUtilityClasses = (styleProps) => {
+  const { classes } = styleProps;
+
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getNativeSelectUtilityClasses, classes);
+};
 
 const defaultInput = <Input />;
 /**
@@ -17,7 +29,7 @@ const NativeSelect = React.forwardRef(function NativeSelect(inProps, ref) {
   const {
     className,
     children,
-    classes,
+    classes: classesProp = {},
     IconComponent = ArrowDropDownIcon,
     input = defaultInput,
     inputProps,
@@ -32,13 +44,17 @@ const NativeSelect = React.forwardRef(function NativeSelect(inProps, ref) {
     states: ['variant'],
   });
 
+  const styleProps = { ...props, classes: classesProp };
+  const classes = useUtilityClasses(styleProps);
+  const { root, ...otherClasses } = classesProp;
+
   return React.cloneElement(input, {
     // Most of the logic is implemented in `NativeSelectInput`.
     // The `Select` component is a simple API wrapper to expose something better to play with.
     inputComponent: NativeSelectInput,
     inputProps: {
       children,
-      classes,
+      classes: otherClasses,
       IconComponent,
       variant: fcs.variant,
       type: undefined, // We render a select. We can ignore the type provided by the `Input`.
@@ -47,7 +63,7 @@ const NativeSelect = React.forwardRef(function NativeSelect(inProps, ref) {
     },
     ref,
     ...other,
-    className: clsx(className, input.props.className),
+    className: clsx(classes.root, input.props.className, className),
   });
 });
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -27,7 +27,7 @@ describe('<NativeSelect />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiNativeSelect',
-    skip: ['componentProp', 'componentsProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],
+    skip: ['componentProp', 'componentsProp', 'themeVariants', 'themeStyleOverrides'],
   }));
 
   it('should render a native select', () => {

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -62,7 +62,7 @@ describe('<NativeSelect />', () => {
 
   it('should provide the classes to the select component', () => {
     const { getByRole } = render(<NativeSelect {...defaultProps} />);
-    expect(getByRole('combobox')).to.have.class(classes.root);
+    expect(getByRole('combobox')).to.have.class(classes.select);
   });
 
   it('slots overrides should work', function test() {

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -11,7 +11,7 @@ const useUtilityClasses = (styleProps) => {
   const { classes, variant, disabled, open } = styleProps;
 
   const slots = {
-    root: ['root', 'select', variant, disabled && 'disabled'],
+    root: ['root', variant, disabled && 'disabled'],
     icon: ['icon', `icon${capitalize(variant)}`, open && 'iconOpen', disabled && 'disabled'],
   };
 
@@ -77,7 +77,6 @@ const NativeSelectRoot = experimentalStyled(
 
       return {
         ...styles.root,
-        ...styles.select,
         ...styles[styleProps.variant],
       };
     },

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -11,14 +11,14 @@ const useUtilityClasses = (styleProps) => {
   const { classes, variant, disabled, open } = styleProps;
 
   const slots = {
-    root: ['root', variant, disabled && 'disabled'],
+    select: ['select', variant, disabled && 'disabled'],
     icon: ['icon', `icon${capitalize(variant)}`, open && 'iconOpen', disabled && 'disabled'],
   };
 
   return composeClasses(slots, getNativeSelectUtilityClasses, classes);
 };
 
-export const nativeSelectRootStyles = ({ styleProps, theme }) => ({
+export const nativeSelectSelectStyles = ({ styleProps, theme }) => ({
   MozAppearance: 'none', // Reset
   WebkitAppearance: 'none', // Reset
   // When interacting quickly, the text can end up selected.
@@ -66,22 +66,22 @@ export const nativeSelectRootStyles = ({ styleProps, theme }) => ({
   }),
 });
 
-const NativeSelectRoot = experimentalStyled(
+const NativeSelectSelect = experimentalStyled(
   'select',
   {},
   {
     name: 'MuiNativeSelect',
-    slot: 'Root',
+    slot: 'Select',
     overridesResolver: (props, styles) => {
       const { styleProps } = props;
 
       return {
-        ...styles.root,
+        ...styles.select,
         ...styles[styleProps.variant],
       };
     },
   },
-)(nativeSelectRootStyles);
+)(nativeSelectSelectStyles);
 
 export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
   // We use a position absolute over a flexbox in order to forward the pointer events
@@ -137,9 +137,9 @@ const NativeSelectInput = React.forwardRef(function NativeSelectInput(props, ref
   const classes = useUtilityClasses(styleProps);
   return (
     <React.Fragment>
-      <NativeSelectRoot
+      <NativeSelectSelect
         styleProps={styleProps}
-        className={clsx(classes.root, className)}
+        className={clsx(classes.select, className)}
         disabled={disabled}
         ref={inputRef || ref}
         {...other}

--- a/packages/material-ui/src/NativeSelect/nativeSelectClasses.js
+++ b/packages/material-ui/src/NativeSelect/nativeSelectClasses.js
@@ -10,7 +10,6 @@ const nativeSelectClasses = generateUtilityClasses('MuiNativeSelect', [
   'filled',
   'outlined',
   'standard',
-  'selectMenu',
   'disabled',
   'icon',
   'iconOpen',

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -26,8 +26,6 @@ export interface SelectProps<T = unknown>
    * @default {}
    */
   classes?: {
-    /** Styles applied to the select component `root` class. */
-    root?: string;
     /** Styles applied to the select component `select` class. */
     select?: string;
     /** Styles applied to the select component if `variant="filled"`. */
@@ -36,8 +34,6 @@ export interface SelectProps<T = unknown>
     outlined?: string;
     /** Styles applied to the select component if `variant="standard"`. */
     standard?: string;
-    /** Styles applied to the select component `selectMenu` class. */
-    selectMenu?: string;
     /** Pseudo-class applied to the select component `disabled` class. */
     disabled?: string;
     /** Styles applied to the icon component. */

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -26,6 +26,8 @@ export interface SelectProps<T = unknown>
    * @default {}
    */
   classes?: {
+    /** Styles applied to the root element. */
+    root?: string;
     /** Styles applied to the select component `select` class. */
     select?: string;
     /** Styles applied to the select component if `variant="filled"`. */

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { deepmerge } from '@material-ui/utils';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import SelectInput from './SelectInput';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
@@ -11,6 +12,17 @@ import NativeSelectInput from '../NativeSelect/NativeSelectInput';
 import FilledInput from '../FilledInput';
 import OutlinedInput from '../OutlinedInput';
 import useThemeProps from '../styles/useThemeProps';
+import { getSelectUtilityClasses } from './selectClasses';
+
+const useUtilityClasses = (styleProps) => {
+  const { classes } = styleProps;
+
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getSelectUtilityClasses, classes);
+};
 
 const Select = React.forwardRef(function Select(inProps, ref) {
   const props = useThemeProps({ name: 'MuiSelect', props: inProps });
@@ -57,7 +69,9 @@ const Select = React.forwardRef(function Select(inProps, ref) {
       filled: <FilledInput />,
     }[variant];
 
-  const { root: rootClassName, ...otherClasses } = classesProp;
+  const styleProps = { ...props, classes: classesProp };
+  const classes = useUtilityClasses(styleProps);
+  const { root, ...otherClasses } = classesProp;
 
   return React.cloneElement(InputComponent, {
     // Most of the logic is implemented in `SelectInput`.
@@ -88,8 +102,7 @@ const Select = React.forwardRef(function Select(inProps, ref) {
     },
     ...(multiple && native && variant === 'outlined' ? { notched: true } : {}),
     ref,
-    classes: { root: rootClassName },
-    className: clsx(className, InputComponent.props.className),
+    className: clsx(classes.root, InputComponent.props.className, className),
     ...other,
   });
 });

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -17,7 +17,7 @@ const Select = React.forwardRef(function Select(inProps, ref) {
   const {
     autoWidth = false,
     children,
-    classes = {},
+    classes: classesProp = {},
     className,
     displayEmpty = false,
     IconComponent = ArrowDropDownIcon,
@@ -57,6 +57,8 @@ const Select = React.forwardRef(function Select(inProps, ref) {
       filled: <FilledInput />,
     }[variant];
 
+  const { root: rootClassName, ...otherClasses } = classesProp;
+
   return React.cloneElement(InputComponent, {
     // Most of the logic is implemented in `SelectInput`.
     // The `Select` component is a simple API wrapper to expose something better to play with.
@@ -81,11 +83,12 @@ const Select = React.forwardRef(function Select(inProps, ref) {
             SelectDisplayProps: { id, ...SelectDisplayProps },
           }),
       ...inputProps,
-      classes: inputProps ? deepmerge(classes, inputProps.classes) : classes,
+      classes: inputProps ? deepmerge(otherClasses, inputProps.classes) : otherClasses,
       ...(input ? input.props.inputProps : {}),
     },
     ...(multiple && native && variant === 'outlined' ? { notched: true } : {}),
     ref,
+    classes: { root: rootClassName },
     className: clsx(className, InputComponent.props.className),
     ...other,
   });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -39,12 +39,12 @@ describe('<Select />', () => {
       render(
         <Select
           inputProps={{
-            classes: { root: 'root' },
+            classes: { select: 'select' },
           }}
           value=""
         />,
       );
-      expect(document.querySelector(`.${classes.root}`)).to.have.class('root');
+      expect(document.querySelector(`.${classes.select}`)).to.have.class('select');
     });
   });
 

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -31,7 +31,7 @@ describe('<Select />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSelect',
-    skip: ['componentProp', 'componentsProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],
+    skip: ['componentProp', 'componentsProp', 'themeVariants', 'themeStyleOverrides'],
   }));
 
   describe('prop: inputProps', () => {

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -16,7 +16,7 @@ import { isFilled } from '../InputBase/utils';
 import experimentalStyled, { slotShouldForwardProp } from '../styles/experimentalStyled';
 import useForkRef from '../utils/useForkRef';
 import useControlled from '../utils/useControlled';
-import { getSelectUtilityClasses } from './selectClasses';
+import selectClasses, { getSelectUtilityClasses } from './selectClasses';
 
 const SelectSelect = experimentalStyled(
   'div',
@@ -27,14 +27,17 @@ const SelectSelect = experimentalStyled(
     overridesResolver: (props, styles) => {
       const { styleProps } = props;
       return {
-        ...styles.select,
-        ...styles[styleProps.variant],
+        // Win specificity over the input base
+        [`&.${selectClasses.select}`]: {
+          ...styles.select,
+          ...styles[styleProps.variant],
+        },
       };
     },
   },
 )(nativeSelectSelectStyles, {
   // Win specificity over the input base
-  '&': {
+  [`&.${selectClasses.select}`]: {
     height: 'auto', // Resets for multiple select with chips
     minHeight: '1.4375em', // Required for select\text-field height consistency
     textOverflow: 'ellipsis',

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -8,33 +8,33 @@ import { refType } from '@material-ui/utils';
 import ownerDocument from '../utils/ownerDocument';
 import capitalize from '../utils/capitalize';
 import Menu from '../Menu/Menu';
-import { nativeSelectRootStyles, nativeSelectIconStyles } from '../NativeSelect/NativeSelectInput';
+import {
+  nativeSelectSelectStyles,
+  nativeSelectIconStyles,
+} from '../NativeSelect/NativeSelectInput';
 import { isFilled } from '../InputBase/utils';
 import experimentalStyled, { slotShouldForwardProp } from '../styles/experimentalStyled';
 import useForkRef from '../utils/useForkRef';
 import useControlled from '../utils/useControlled';
-import selectClasses, { getSelectUtilityClasses } from './selectClasses';
+import { getSelectUtilityClasses } from './selectClasses';
 
-const SelectRoot = experimentalStyled(
+const SelectSelect = experimentalStyled(
   'div',
   {},
   {
     name: 'MuiSelect',
-    slot: 'Root',
+    slot: 'Select',
     overridesResolver: (props, styles) => {
       const { styleProps } = props;
       return {
-        [`&.${selectClasses.select}`]: {
-          ...styles.root,
-          ...styles.select,
-          ...styles[styleProps.variant],
-        },
+        ...styles.select,
+        ...styles[styleProps.variant],
       };
     },
   },
-)(nativeSelectRootStyles, {
+)(nativeSelectSelectStyles, {
   // Win specificity over the input base
-  [`&.${selectClasses.select}`]: {
+  [`&[role="button"]`]: {
     height: 'auto', // Resets for multiple select with chips
     minHeight: '1.4375em', // Required for select\text-field height consistency
     textOverflow: 'ellipsis',
@@ -96,7 +96,7 @@ const useUtilityClasses = (styleProps) => {
   const { classes, variant, disabled, open } = styleProps;
 
   const slots = {
-    root: ['root', 'select', variant, disabled && 'disabled'],
+    select: ['select', variant, disabled && 'disabled'],
     icon: ['icon', `icon${capitalize(variant)}`, open && 'iconOpen', disabled && 'disabled'],
     nativeInput: ['nativeInput'],
   };
@@ -457,7 +457,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   return (
     <React.Fragment>
-      <SelectRoot
+      <SelectSelect
         ref={handleDisplayRef}
         tabIndex={tabIndex}
         role="button"
@@ -473,7 +473,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         onFocus={onFocus}
         {...SelectDisplayProps}
         styleProps={styleProps}
-        className={clsx(classes.root, className, SelectDisplayProps.className)}
+        className={clsx(classes.select, className, SelectDisplayProps.className)}
         // The id is required for proper a11y
         id={buttonId}
       >
@@ -485,7 +485,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         ) : (
           display
         )}
-      </SelectRoot>
+      </SelectSelect>
       <SelectNativeInput
         value={Array.isArray(value) ? value.join(',') : value}
         name={name}

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -34,7 +34,7 @@ const SelectSelect = experimentalStyled(
   },
 )(nativeSelectSelectStyles, {
   // Win specificity over the input base
-  [`&[role="button"]`]: {
+  '&': {
     height: 'auto', // Resets for multiple select with chips
     minHeight: '1.4375em', // Required for select\text-field height consistency
     textOverflow: 'ellipsis',

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -25,10 +25,8 @@ const SelectRoot = experimentalStyled(
       const { styleProps } = props;
       return {
         [`&.${selectClasses.select}`]: {
-          // TODO v5: remove `root` and `selectMenu`
           ...styles.root,
           ...styles.select,
-          ...styles.selectMenu,
           ...styles[styleProps.variant],
         },
       };
@@ -36,7 +34,7 @@ const SelectRoot = experimentalStyled(
   },
 )(nativeSelectRootStyles, {
   // Win specificity over the input base
-  [`&.${selectClasses.selectMenu}`]: {
+  [`&.${selectClasses.select}`]: {
     height: 'auto', // Resets for multiple select with chips
     minHeight: '1.4375em', // Required for select\text-field height consistency
     textOverflow: 'ellipsis',
@@ -98,7 +96,7 @@ const useUtilityClasses = (styleProps) => {
   const { classes, variant, disabled, open } = styleProps;
 
   const slots = {
-    root: ['root', 'select', variant, disabled && 'disabled', 'selectMenu'],
+    root: ['root', 'select', variant, disabled && 'disabled'],
     icon: ['icon', `icon${capitalize(variant)}`, open && 'iconOpen', disabled && 'disabled'],
     nativeInput: ['nativeInput'],
   };

--- a/packages/material-ui/src/Select/selectClasses.js
+++ b/packages/material-ui/src/Select/selectClasses.js
@@ -10,7 +10,6 @@ const selectClasses = generateUtilityClasses('MuiSelect', [
   'filled',
   'outlined',
   'standard',
-  'selectMenu',
   'disabled',
   'focused',
   'icon',

--- a/packages/material-ui/src/Select/selectClasses.js
+++ b/packages/material-ui/src/Select/selectClasses.js
@@ -5,6 +5,7 @@ export function getSelectUtilityClasses(slot) {
 }
 
 const selectClasses = generateUtilityClasses('MuiSelect', [
+  'root',
   'select',
   'filled',
   'outlined',

--- a/packages/material-ui/src/Select/selectClasses.js
+++ b/packages/material-ui/src/Select/selectClasses.js
@@ -5,7 +5,6 @@ export function getSelectUtilityClasses(slot) {
 }
 
 const selectClasses = generateUtilityClasses('MuiSelect', [
-  'root',
   'select',
   'filled',
   'outlined',

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -103,7 +103,7 @@ const TablePaginationSelect = experimentalStyled(
   flexShrink: 0,
   marginRight: 32,
   marginLeft: 8,
-  [`& .${tablePaginationClasses.input}`]: {
+  [`& .${tablePaginationClasses.select}`]: {
     paddingLeft: 8,
     paddingRight: 24,
     textAlign: 'right',


### PR DESCRIPTION
### Breaking changes

- [Select] The `selectMenu` slot was merged into `select` because `selectMenu` slot was redundant. The `root` slot is no longer applied to the select, but to the root.

  ```diff
  -<Select classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />
  +<Select classes={{ root: 'class1', select: 'class2 class3' }} />
  ```

- [NativeSelect] The `selectMenu` slot was merged into `select` because `selectMenu` slot was redundant. The `root` slot is no longer applied to the select, but to the root.

  ```diff
  -<NativeSelect classes={{ root: 'class1', select: 'class2', selectMenu: 'class3' }} />
  +<NativeSelect classes={{ select: 'class1 class2 class3' }} />
  ```

- [TablePagination] The `classes.input` key was changed to be applied on another element. Use `classes.select` instead.

  ```diff
  <TablePagination
  - classes={{ input: 'foo' }}
  + classes={{ select: 'foo' }}
  />
  ```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012 
Closes #11646
Closes #25313

I couldn't understand very well the discussion that lead to this change. I found https://github.com/mui-org/material-ui/pull/25766#discussion_r614467435 about removing `root` and `select`. But the TODO in the code was to remove `selectMenu`. If it was not the specificity bug raised in #25763, we would only need to keep `root`.