### PR TITLE
[Grid] Remove unnecessary type exports

### DIFF
--- a/docs/src/pages/components/grid/InteractiveGrid.tsx
+++ b/docs/src/pages/components/grid/InteractiveGrid.tsx
@@ -23,7 +23,7 @@ type GridJustification =
   | 'space-around'
   | 'space-evenly';
 
-type Direction = Exclude<GridProps['direction'], undefined>
+type Direction = Exclude<GridProps['direction'], undefined>;
 
 export default function InteractiveGrid() {
   const [direction, setDirection] = React.useState<Direction>('row');

--- a/docs/src/pages/components/grid/InteractiveGrid.tsx
+++ b/docs/src/pages/components/grid/InteractiveGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Grid, { GridDirection } from '@material-ui/core/Grid';
+import Grid, { GridProps } from '@material-ui/core/Grid';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -23,8 +23,10 @@ type GridJustification =
   | 'space-around'
   | 'space-evenly';
 
+type Direction = Exclude<GridProps['direction'], undefined>
+
 export default function InteractiveGrid() {
-  const [direction, setDirection] = React.useState<GridDirection>('row');
+  const [direction, setDirection] = React.useState<Direction>('row');
   const [justifyContent, setJustifyContent] = React.useState<GridJustification>(
     'center',
   );
@@ -80,7 +82,7 @@ export default function InteractiveGrid() {
                   value={direction}
                   onChange={(event) => {
                     setDirection(
-                      (event.target as HTMLInputElement).value as GridDirection,
+                      (event.target as HTMLInputElement).value as Direction,
                     );
                   }}
                 >

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -846,7 +846,7 @@ As the core components use emotion as a styled engine, the props used by emotion
   + direction: GridProps['direction'];
   + spacing: GridProps['spacing'];
   + wrap: GridProps['wrap'];
-  + size: GridProps['xs'] & (string | number);
+  + size: Exclude<GridProps['xs'], boolean>;
   }
   ```
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -832,6 +832,24 @@ As the core components use emotion as a styled engine, the props used by emotion
   });
   ```
 
+- The auxiliary types `GridDirection`, `GridSpacing`, `GridWrap` and `GridSize` are not exported anymore. Instead, get them from `GridProps`.
+
+  ```diff
+  -import { GridDirection, GridSpacing, GridWrap, GridSize } from '@material-ui/core/Grid';
+  +import { GridProps } from '@material-ui/core/Grid';
+
+  interface Props {
+  - direction: GridDirection;
+  - spacing: GridSpacing;
+  - wrap: GridWrap;
+  - size: GridSize;
+  + direction: GridProps['direction'];
+  + spacing: GridProps['spacing'];
+  + wrap: GridProps['wrap'];
+  + size: GridProps['xs'] & (string | number);
+  }
+  ```
+
 ### GridList
 
 - Rename the `GridList` components to `ImageList` to align with the current Material Design naming.

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -3,12 +3,6 @@ import { SxProps, SystemProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
-
-type GridSpacing = number | string;
-
-type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
-
 type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type GridClassKey = keyof NonNullable<GridTypeMap['props']['classes']>;
@@ -83,7 +77,7 @@ export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
        * It is applied for all screen sizes.
        * @default 'row'
        */
-      direction?: GridDirection;
+      direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
       /**
        * If `true`, the component will have the flex *item* behavior.
        * You should be wrapping *items* with a *container*.
@@ -113,7 +107,7 @@ export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
        * It can only be used on a type `container` component.
        * @default 0
        */
-      spacing?: GridSpacing;
+      spacing?: string | number;
       /**
        * The system prop that allows defining system overrides as well as additional CSS styles.
        */
@@ -123,7 +117,7 @@ export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
        * It's applied for all screen sizes.
        * @default 'wrap'
        */
-      wrap?: GridWrap;
+      wrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
       /**
        * Defines the number of grids the component is going to use.
        * It's applied for the `xl` breakpoint and wider screens.

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -3,13 +3,13 @@ import { SxProps, SystemProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
-export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
-export type GridSpacing = number | string;
+type GridSpacing = number | string;
 
-export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
+type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
-export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type GridClassKey = keyof NonNullable<GridTypeMap['props']['classes']>;
 


### PR DESCRIPTION
### Breaking changes

- [Grid] Removed the export of the types `GridDirection`, `GridSpacing`, `GridWrap` and `GridSize`. Use `GridProps` to replace them:

  ```diff
  -import { GridDirection, GridSpacing, GridWrap, GridSize } from '@material-ui/core/Grid';
  +import { GridProps } from '@material-ui/core/Grid';

  interface Props {
  - direction: GridDirection;
  - spacing: GridSpacing;
  - wrap: GridWrap;
  - size: GridSize;
  + direction: GridProps['direction'];
  + spacing: GridProps['spacing'];
  + wrap: GridProps['wrap'];
  + size: Exclude<GridProps['xs'], boolean>;
  }
  ```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #20012