### PR TITLE
[ButtonBase] Omit aria-disabled if not disabled

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -295,7 +295,9 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     if (ComponentProp !== 'a' || !other.href) {
       buttonProps.role = 'button';
     }
-    buttonProps['aria-disabled'] = disabled;
+    if (disabled) {
+      buttonProps['aria-disabled'] = disabled;
+    }
   }
 
   const handleOwnRef = useForkRef(focusVisibleRef, buttonRef);

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -689,8 +689,16 @@ describe('<ButtonBase />', () => {
       expect(button).not.to.have.class(classes.focusVisible);
     });
 
-    it('should use aria attributes for other components', () => {
-      const { getByRole } = render(
+    it('should not use aria-disabled with button host', () => {
+      const { getByRole } = render(<ButtonBase disabled>Hello</ButtonBase>);
+      const button = getByRole('button');
+
+      expect(button).to.have.attribute('disabled');
+      expect(button).not.to.have.attribute('aria-disabled');
+    });
+
+    it('should use aria-disabled for other components', () => {
+      const { getByRole, setProps } = render(
         <ButtonBase component="span" disabled>
           Hello
         </ButtonBase>,
@@ -699,6 +707,9 @@ describe('<ButtonBase />', () => {
 
       expect(button).not.to.have.attribute('disabled');
       expect(button).to.have.attribute('aria-disabled', 'true');
+
+      setProps({ disabled: false });
+      expect(button).not.to.have.attribute('aria-disabled');
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Followed @oliviertassinari instructions on adding a check for the `aria-disabled` attribute.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Fixes: #25531 