### PR TITLE
[core] Batch small changes

### DIFF
--- a/benchmark/browser/scenarios/box-baseline/index.js
+++ b/benchmark/browser/scenarios/box-baseline/index.js
@@ -13,7 +13,7 @@ export default function BoxBaseline() {
             height: 200,
             borderWidth: '3px',
             borderColor: 'white',
-            ':hover': { backgroundColor: '#c51162' },
+            '&:hover': { backgroundColor: '#c51162' },
             '@media (min-width:0px)': { backgroundColor: '#3f51b5', borderStyle: 'dashed' },
             '@media (min-width:600px)': {
               backgroundColor: 'rgba(0, 0, 0, 0.87)',

--- a/benchmark/browser/scenarios/box-material-ui/index.js
+++ b/benchmark/browser/scenarios/box-material-ui/index.js
@@ -13,7 +13,7 @@ export default function SxPropBoxMaterialUI() {
             borderColor: 'white',
             backgroundColor: ['primary.main', 'text.primary', 'background.paper'],
             borderStyle: ['dashed', 'solid', 'dotted'],
-            ':hover': {
+            '&:hover': {
               backgroundColor: (theme) => theme.palette.secondary.dark,
             },
           }}

--- a/benchmark/browser/scenarios/box-theme-ui/index.js
+++ b/benchmark/browser/scenarios/box-theme-ui/index.js
@@ -27,7 +27,7 @@ export default function BoxThemeUI() {
             borderColor: 'white',
             backgroundColor: ['primary', 'text', 'background'],
             borderStyle: ['dashed', 'solid', 'dotted'],
-            ':hover': {
+            '&:hover': {
               backgroundColor: (t) => t.colors.text,
             },
           }}

--- a/benchmark/browser/scenarios/make-styles/index.js
+++ b/benchmark/browser/scenarios/make-styles/index.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles((theme) => ({
     height: 200,
     borderWidth: 3,
     borderColor: 'white',
-    ':hover': {
+    '&:hover': {
       backgroundColor: theme.palette.secondary.dark,
     },
     [theme.breakpoints.up('sm')]: {

--- a/docs/pages/performance/system.js
+++ b/docs/pages/performance/system.js
@@ -15,7 +15,7 @@ export default function SxPropBoxMaterialUI() {
             borderColor: 'white',
             backgroundColor: ['primary.main', 'text.primary', 'background.paper'],
             borderStyle: ['dashed', 'solid', 'dotted'],
-            ':hover': {
+            '&:hover': {
               backgroundColor: (theme) => theme.palette.secondary.dark,
             },
           }}

--- a/docs/src/pages/components/accordion/CustomizedAccordions.js
+++ b/docs/src/pages/components/accordion/CustomizedAccordions.js
@@ -24,7 +24,10 @@ const AccordionSummary = styled((props) => (
     {...props}
   />
 ))(({ theme }) => ({
-  backgroundColor: 'rgba(0, 0, 0, .03)',
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, .05)'
+      : 'rgba(0, 0, 0, .03)',
   flexDirection: 'row-reverse',
   '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
     transform: 'rotate(90deg)',

--- a/docs/src/pages/components/accordion/CustomizedAccordions.tsx
+++ b/docs/src/pages/components/accordion/CustomizedAccordions.tsx
@@ -26,7 +26,10 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
     {...props}
   />
 ))(({ theme }) => ({
-  backgroundColor: 'rgba(0, 0, 0, .03)',
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, .05)'
+      : 'rgba(0, 0, 0, .03)',
   flexDirection: 'row-reverse',
   '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
     transform: 'rotate(90deg)',

--- a/docs/src/pages/components/box/BoxSx.js
+++ b/docs/src/pages/components/box/BoxSx.js
@@ -8,7 +8,7 @@ export default function BoxSx() {
         width: 300,
         height: 300,
         bgcolor: 'primary.dark',
-        ':hover': {
+        '&:hover': {
           backgroundColor: 'primary.main',
           opacity: [0.9, 0.8, 0.7],
         },

--- a/docs/src/pages/components/box/BoxSx.tsx
+++ b/docs/src/pages/components/box/BoxSx.tsx
@@ -8,7 +8,7 @@ export default function BoxSx() {
         width: 300,
         height: 300,
         bgcolor: 'primary.dark',
-        ':hover': {
+        '&:hover': {
           backgroundColor: 'primary.main',
           opacity: [0.9, 0.8, 0.7],
         },

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
@@ -2,27 +2,34 @@ import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
 
-const Icon = styled('span')({
+const BpIcon = styled('span')(({ theme }) => ({
   borderRadius: 3,
   width: 16,
   height: 16,
-  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-  backgroundColor: '#f5f8fa',
-  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgb(16 22 26 / 40%)'
+      : 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa',
+  backgroundImage:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg,hsla(0,0%,100%,.05),hsla(0,0%,100%,0))'
+      : 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
   '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
   'input:hover ~ &': {
-    backgroundColor: '#ebf1f5',
+    backgroundColor: theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5',
   },
   'input:disabled ~ &': {
     boxShadow: 'none',
-    background: 'rgba(206,217,224,.5)',
+    background:
+      theme.palette.mode === 'dark' ? 'rgba(57,75,89,.5)' : 'rgba(206,217,224,.5)',
   },
-});
+}));
 
-const CheckedIcon = styled(Icon)({
+const BpCheckedIcon = styled(BpIcon)(({ theme }) => ({
   backgroundColor: '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&:before': {
@@ -38,10 +45,10 @@ const CheckedIcon = styled(Icon)({
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
-});
+}));
 
 // Inspired by blueprintjs
-function StyledCheckbox(props) {
+function BpCheckbox(props) {
   return (
     <Checkbox
       sx={{
@@ -49,8 +56,8 @@ function StyledCheckbox(props) {
       }}
       disableRipple
       color="default"
-      checkedIcon={<CheckedIcon />}
-      icon={<Icon />}
+      checkedIcon={<BpCheckedIcon />}
+      icon={<BpIcon />}
       inputProps={{ 'aria-label': 'Checkbox demo' }}
       {...props}
     />
@@ -60,9 +67,9 @@ function StyledCheckbox(props) {
 export default function CustomizedCheckbox() {
   return (
     <div>
-      <StyledCheckbox />
-      <StyledCheckbox defaultChecked />
-      <StyledCheckbox disabled />
+      <BpCheckbox />
+      <BpCheckbox defaultChecked />
+      <BpCheckbox disabled />
     </div>
   );
 }

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
@@ -29,7 +29,7 @@ const BpIcon = styled('span')(({ theme }) => ({
   },
 }));
 
-const BpCheckedIcon = styled(BpIcon)(({ theme }) => ({
+const BpCheckedIcon = styled(BpIcon)({
   backgroundColor: '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&:before': {
@@ -45,7 +45,7 @@ const BpCheckedIcon = styled(BpIcon)(({ theme }) => ({
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
-}));
+});
 
 // Inspired by blueprintjs
 function BpCheckbox(props) {

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
@@ -29,7 +29,7 @@ const BpIcon = styled('span')(({ theme }) => ({
   },
 }));
 
-const BpCheckedIcon = styled(BpIcon)(({ theme }) => ({
+const BpCheckedIcon = styled(BpIcon)({
   backgroundColor: '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&:before': {
@@ -45,7 +45,7 @@ const BpCheckedIcon = styled(BpIcon)(({ theme }) => ({
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
-}));
+});
 
 // Inspired by blueprintjs
 function BpCheckbox(props: CheckboxProps) {

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
@@ -2,27 +2,34 @@ import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 
-const Icon = styled('span')({
+const BpIcon = styled('span')(({ theme }) => ({
   borderRadius: 3,
   width: 16,
   height: 16,
-  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-  backgroundColor: '#f5f8fa',
-  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgb(16 22 26 / 40%)'
+      : 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa',
+  backgroundImage:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg,hsla(0,0%,100%,.05),hsla(0,0%,100%,0))'
+      : 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
   '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
   'input:hover ~ &': {
-    backgroundColor: '#ebf1f5',
+    backgroundColor: theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5',
   },
   'input:disabled ~ &': {
     boxShadow: 'none',
-    background: 'rgba(206,217,224,.5)',
+    background:
+      theme.palette.mode === 'dark' ? 'rgba(57,75,89,.5)' : 'rgba(206,217,224,.5)',
   },
-});
+}));
 
-const CheckedIcon = styled(Icon)({
+const BpCheckedIcon = styled(BpIcon)(({ theme }) => ({
   backgroundColor: '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&:before': {
@@ -38,10 +45,10 @@ const CheckedIcon = styled(Icon)({
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
   },
-});
+}));
 
 // Inspired by blueprintjs
-function StyledCheckbox(props: CheckboxProps) {
+function BpCheckbox(props: CheckboxProps) {
   return (
     <Checkbox
       sx={{
@@ -49,8 +56,8 @@ function StyledCheckbox(props: CheckboxProps) {
       }}
       disableRipple
       color="default"
-      checkedIcon={<CheckedIcon />}
-      icon={<Icon />}
+      checkedIcon={<BpCheckedIcon />}
+      icon={<BpIcon />}
       inputProps={{ 'aria-label': 'Checkbox demo' }}
       {...props}
     />
@@ -60,9 +67,9 @@ function StyledCheckbox(props: CheckboxProps) {
 export default function CustomizedCheckbox() {
   return (
     <div>
-      <StyledCheckbox />
-      <StyledCheckbox defaultChecked />
-      <StyledCheckbox disabled />
+      <BpCheckbox />
+      <BpCheckbox defaultChecked />
+      <BpCheckbox disabled />
     </div>
   );
 }

--- a/docs/src/pages/components/progress/CustomizedProgressBars.js
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.js
@@ -9,11 +9,11 @@ const BorderLinearProgress = withStyles((theme) => ({
     borderRadius: 5,
   },
   colorPrimary: {
-    backgroundColor: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
+    backgroundColor: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
   },
   bar: {
     borderRadius: 5,
-    backgroundColor: '#1a90ff',
+    backgroundColor: theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8',
   },
 }))(LinearProgress);
 
@@ -23,10 +23,10 @@ const useStylesFacebook = makeStyles((theme) => ({
     position: 'relative',
   },
   bottom: {
-    color: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
+    color: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
   },
   top: {
-    color: '#1a90ff',
+    color: theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8',
     animationDuration: '550ms',
     position: 'absolute',
     left: 0,

--- a/docs/src/pages/components/progress/CustomizedProgressBars.tsx
+++ b/docs/src/pages/components/progress/CustomizedProgressBars.tsx
@@ -11,11 +11,11 @@ const BorderLinearProgress = withStyles((theme: Theme) => ({
     borderRadius: 5,
   },
   colorPrimary: {
-    backgroundColor: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
+    backgroundColor: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
   },
   bar: {
     borderRadius: 5,
-    backgroundColor: '#1a90ff',
+    backgroundColor: theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8',
   },
 }))(LinearProgress);
 
@@ -25,10 +25,10 @@ const useStylesFacebook = makeStyles((theme: Theme) => ({
     position: 'relative',
   },
   bottom: {
-    color: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
+    color: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
   },
   top: {
-    color: '#1a90ff',
+    color: theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8',
     animationDuration: '550ms',
     position: 'absolute',
     left: 0,

--- a/docs/src/pages/components/radio-buttons/CustomizedRadios.js
+++ b/docs/src/pages/components/radio-buttons/CustomizedRadios.js
@@ -6,27 +6,34 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-const Icon = styled('span')({
+const BpIcon = styled('span')(({ theme }) => ({
   borderRadius: '50%',
   width: 16,
   height: 16,
-  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-  backgroundColor: '#f5f8fa',
-  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgb(16 22 26 / 40%)'
+      : 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa',
+  backgroundImage:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg,hsla(0,0%,100%,.05),hsla(0,0%,100%,0))'
+      : 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
   '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
   'input:hover ~ &': {
-    backgroundColor: '#ebf1f5',
+    backgroundColor: theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5',
   },
   'input:disabled ~ &': {
     boxShadow: 'none',
-    background: 'rgba(206,217,224,.5)',
+    background:
+      theme.palette.mode === 'dark' ? 'rgba(57,75,89,.5)' : 'rgba(206,217,224,.5)',
   },
-});
+}));
 
-const CheckedIcon = styled(Icon)({
+const BpCheckedIcon = styled(BpIcon)({
   backgroundColor: '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&:before': {
@@ -42,7 +49,7 @@ const CheckedIcon = styled(Icon)({
 });
 
 // Inspired by blueprintjs
-function StyledRadio(props) {
+function BpRadio(props) {
   return (
     <Radio
       sx={{
@@ -52,8 +59,8 @@ function StyledRadio(props) {
       }}
       disableRipple
       color="default"
-      checkedIcon={<CheckedIcon />}
-      icon={<Icon />}
+      checkedIcon={<BpCheckedIcon />}
+      icon={<BpIcon />}
       {...props}
     />
   );
@@ -64,13 +71,13 @@ export default function CustomizedRadios() {
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
       <RadioGroup defaultValue="female" aria-label="gender" name="customized-radios">
-        <FormControlLabel value="female" control={<StyledRadio />} label="Female" />
-        <FormControlLabel value="male" control={<StyledRadio />} label="Male" />
-        <FormControlLabel value="other" control={<StyledRadio />} label="Other" />
+        <FormControlLabel value="female" control={<BpRadio />} label="Female" />
+        <FormControlLabel value="male" control={<BpRadio />} label="Male" />
+        <FormControlLabel value="other" control={<BpRadio />} label="Other" />
         <FormControlLabel
           value="disabled"
           disabled
-          control={<StyledRadio />}
+          control={<BpRadio />}
           label="(Disabled option)"
         />
       </RadioGroup>

--- a/docs/src/pages/components/radio-buttons/CustomizedRadios.tsx
+++ b/docs/src/pages/components/radio-buttons/CustomizedRadios.tsx
@@ -6,27 +6,34 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-const Icon = styled('span')({
+const BpIcon = styled('span')(({ theme }) => ({
   borderRadius: '50%',
   width: 16,
   height: 16,
-  boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-  backgroundColor: '#f5f8fa',
-  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgb(16 22 26 / 40%)'
+      : 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa',
+  backgroundImage:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg,hsla(0,0%,100%,.05),hsla(0,0%,100%,0))'
+      : 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
   '.Mui-focusVisible &': {
     outline: '2px auto rgba(19,124,189,.6)',
     outlineOffset: 2,
   },
   'input:hover ~ &': {
-    backgroundColor: '#ebf1f5',
+    backgroundColor: theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5',
   },
   'input:disabled ~ &': {
     boxShadow: 'none',
-    background: 'rgba(206,217,224,.5)',
+    background:
+      theme.palette.mode === 'dark' ? 'rgba(57,75,89,.5)' : 'rgba(206,217,224,.5)',
   },
-});
+}));
 
-const CheckedIcon = styled(Icon)({
+const BpCheckedIcon = styled(BpIcon)({
   backgroundColor: '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&:before': {
@@ -42,7 +49,7 @@ const CheckedIcon = styled(Icon)({
 });
 
 // Inspired by blueprintjs
-function StyledRadio(props: RadioProps) {
+function BpRadio(props: RadioProps) {
   return (
     <Radio
       sx={{
@@ -52,8 +59,8 @@ function StyledRadio(props: RadioProps) {
       }}
       disableRipple
       color="default"
-      checkedIcon={<CheckedIcon />}
-      icon={<Icon />}
+      checkedIcon={<BpCheckedIcon />}
+      icon={<BpIcon />}
       {...props}
     />
   );
@@ -64,13 +71,13 @@ export default function CustomizedRadios() {
     <FormControl component="fieldset">
       <FormLabel component="legend">Gender</FormLabel>
       <RadioGroup defaultValue="female" aria-label="gender" name="customized-radios">
-        <FormControlLabel value="female" control={<StyledRadio />} label="Female" />
-        <FormControlLabel value="male" control={<StyledRadio />} label="Male" />
-        <FormControlLabel value="other" control={<StyledRadio />} label="Other" />
+        <FormControlLabel value="female" control={<BpRadio />} label="Female" />
+        <FormControlLabel value="male" control={<BpRadio />} label="Male" />
+        <FormControlLabel value="other" control={<BpRadio />} label="Other" />
         <FormControlLabel
           value="disabled"
           disabled
-          control={<StyledRadio />}
+          control={<BpRadio />}
           label="(Disabled option)"
         />
       </RadioGroup>

--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -4,18 +4,7 @@ import Slider, { SliderThumb } from '@material-ui/core/Slider';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
-
-const Root = styled('div')(
-  ({ theme }) => `
-  width: calc(300px + ${theme.spacing(6)});
-`,
-);
-
-const Separator = styled('div')(
-  ({ theme }) => `
-  height: ${theme.spacing(3)};
-`,
-);
+import Box from '@material-ui/core/Box';
 
 function ValueLabelComponent(props) {
   const { children, value } = props;
@@ -50,8 +39,8 @@ const marks = [
   },
 ];
 
-const IOSSlider = styled(Slider)({
-  color: '#3880ff',
+const IOSSlider = styled(Slider)(({ theme }) => ({
+  color: theme.palette.mode === 'dark' ? '#3880ff' : '#3880ff',
   height: 2,
   padding: '15px 0',
   '& .MuiSlider-thumb': {
@@ -75,7 +64,7 @@ const IOSSlider = styled(Slider)({
     top: -22,
     '& *': {
       background: 'transparent',
-      color: '#000',
+      color: theme.palette.mode === 'dark' ? '#fff' : '#000',
     },
   },
   '& .MuiSlider-track': {
@@ -96,7 +85,7 @@ const IOSSlider = styled(Slider)({
       backgroundColor: 'currentColor',
     },
   },
-});
+}));
 
 const PrettoSlider = styled(Slider)({
   color: '#52af77',
@@ -125,7 +114,7 @@ const PrettoSlider = styled(Slider)({
   },
 });
 
-const AirbnbSlider = styled(Slider)({
+const AirbnbSlider = styled(Slider)(({ theme }) => ({
   color: '#3a8589',
   height: 3,
   padding: '13px 0',
@@ -136,12 +125,7 @@ const AirbnbSlider = styled(Slider)({
     border: '1px solid currentColor',
     marginTop: -12,
     marginLeft: -13,
-    boxShadow: '#ebebeb 0 2px 2px',
-    '&:focus, &:hover, &.Mui-active': {
-      boxShadow: '#ccc 0 2px 3px 1px',
-    },
-    '& .bar': {
-      // display: inline-block !important;
+    '& .airbnb-bar': {
       height: 9,
       width: 1,
       backgroundColor: 'currentColor',
@@ -153,20 +137,20 @@ const AirbnbSlider = styled(Slider)({
     height: 3,
   },
   '& .MuiSlider-rail': {
-    color: '#d8d8d8',
-    opacity: 1,
+    color: theme.palette.mode === 'dark' ? '#bfbfbf' : '#d8d8d8',
+    opacity: theme.palette.mode === 'dark' ? undefined : 1,
     height: 3,
   },
-});
+}));
 
 function AirbnbThumbComponent(props) {
   const { children, ...other } = props;
   return (
     <SliderThumb {...other}>
       {children}
-      <span className="bar" />
-      <span className="bar" />
-      <span className="bar" />
+      <span className="airbnb-bar" />
+      <span className="airbnb-bar" />
+      <span className="airbnb-bar" />
     </SliderThumb>
   );
 }
@@ -177,7 +161,7 @@ AirbnbThumbComponent.propTypes = {
 
 export default function CustomizedSlider() {
   return (
-    <Root>
+    <Box sx={{ width: 320 }}>
       <Typography gutterBottom>iOS</Typography>
       <IOSSlider
         aria-label="ios slider"
@@ -185,14 +169,14 @@ export default function CustomizedSlider() {
         marks={marks}
         valueLabelDisplay="on"
       />
-      <Separator />
+      <Box sx={{ m: 3 }} />
       <Typography gutterBottom>pretto.fr</Typography>
       <PrettoSlider
         valueLabelDisplay="auto"
         aria-label="pretto slider"
         defaultValue={20}
       />
-      <Separator />
+      <Box sx={{ m: 3 }} />
       <Typography gutterBottom>Tooltip value label</Typography>
       <Slider
         valueLabelDisplay="auto"
@@ -202,13 +186,13 @@ export default function CustomizedSlider() {
         aria-label="custom thumb label"
         defaultValue={20}
       />
-      <Separator />
+      <Box sx={{ m: 3 }} />
       <Typography gutterBottom>Airbnb</Typography>
       <AirbnbSlider
         components={{ Thumb: AirbnbThumbComponent }}
         getAriaLabel={(index) => (index === 0 ? 'Minimum price' : 'Maximum price')}
         defaultValue={[20, 40]}
       />
-    </Root>
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -3,18 +3,7 @@ import Slider, { SliderThumb } from '@material-ui/core/Slider';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
-
-const Root = styled('div')(
-  ({ theme }) => `
-  width: calc(300px + ${theme.spacing(6)});
-`,
-);
-
-const Separator = styled('div')(
-  ({ theme }) => `
-  height: ${theme.spacing(3)};
-`,
-);
+import Box from '@material-ui/core/Box';
 
 interface Props {
   children: React.ReactElement;
@@ -49,8 +38,8 @@ const marks = [
   },
 ];
 
-const IOSSlider = styled(Slider)({
-  color: '#3880ff',
+const IOSSlider = styled(Slider)(({ theme }) => ({
+  color: theme.palette.mode === 'dark' ? '#3880ff' : '#3880ff',
   height: 2,
   padding: '15px 0',
   '& .MuiSlider-thumb': {
@@ -74,7 +63,7 @@ const IOSSlider = styled(Slider)({
     top: -22,
     '& *': {
       background: 'transparent',
-      color: '#000',
+      color: theme.palette.mode === 'dark' ? '#fff' : '#000',
     },
   },
   '& .MuiSlider-track': {
@@ -95,7 +84,7 @@ const IOSSlider = styled(Slider)({
       backgroundColor: 'currentColor',
     },
   },
-});
+}));
 
 const PrettoSlider = styled(Slider)({
   color: '#52af77',
@@ -124,7 +113,7 @@ const PrettoSlider = styled(Slider)({
   },
 });
 
-const AirbnbSlider = styled(Slider)({
+const AirbnbSlider = styled(Slider)(({ theme }) => ({
   color: '#3a8589',
   height: 3,
   padding: '13px 0',
@@ -135,12 +124,7 @@ const AirbnbSlider = styled(Slider)({
     border: '1px solid currentColor',
     marginTop: -12,
     marginLeft: -13,
-    boxShadow: '#ebebeb 0 2px 2px',
-    '&:focus, &:hover, &.Mui-active': {
-      boxShadow: '#ccc 0 2px 3px 1px',
-    },
-    '& .bar': {
-      // display: inline-block !important;
+    '& .airbnb-bar': {
       height: 9,
       width: 1,
       backgroundColor: 'currentColor',
@@ -152,11 +136,11 @@ const AirbnbSlider = styled(Slider)({
     height: 3,
   },
   '& .MuiSlider-rail': {
-    color: '#d8d8d8',
-    opacity: 1,
+    color: theme.palette.mode === 'dark' ? '#bfbfbf' : '#d8d8d8',
+    opacity: theme.palette.mode === 'dark' ? undefined : 1,
     height: 3,
   },
-});
+}));
 
 interface AirbnbThumbComponentProps extends React.HTMLAttributes<unknown> {}
 
@@ -165,16 +149,16 @@ function AirbnbThumbComponent(props: AirbnbThumbComponentProps) {
   return (
     <SliderThumb {...other}>
       {children}
-      <span className="bar" />
-      <span className="bar" />
-      <span className="bar" />
+      <span className="airbnb-bar" />
+      <span className="airbnb-bar" />
+      <span className="airbnb-bar" />
     </SliderThumb>
   );
 }
 
 export default function CustomizedSlider() {
   return (
-    <Root>
+    <Box sx={{ width: 320 }}>
       <Typography gutterBottom>iOS</Typography>
       <IOSSlider
         aria-label="ios slider"
@@ -182,14 +166,14 @@ export default function CustomizedSlider() {
         marks={marks}
         valueLabelDisplay="on"
       />
-      <Separator />
+      <Box sx={{ m: 3 }} />
       <Typography gutterBottom>pretto.fr</Typography>
       <PrettoSlider
         valueLabelDisplay="auto"
         aria-label="pretto slider"
         defaultValue={20}
       />
-      <Separator />
+      <Box sx={{ m: 3 }} />
       <Typography gutterBottom>Tooltip value label</Typography>
       <Slider
         valueLabelDisplay="auto"
@@ -199,13 +183,13 @@ export default function CustomizedSlider() {
         aria-label="custom thumb label"
         defaultValue={20}
       />
-      <Separator />
+      <Box sx={{ m: 3 }} />
       <Typography gutterBottom>Airbnb</Typography>
       <AirbnbSlider
         components={{ Thumb: AirbnbThumbComponent }}
         getAriaLabel={(index) => (index === 0 ? 'Minimum price' : 'Maximum price')}
         defaultValue={[20, 40]}
       />
-    </Root>
+    </Box>
   );
 }

--- a/docs/src/pages/components/steppers/CustomizedSteppers.js
+++ b/docs/src/pages/components/steppers/CustomizedSteppers.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
@@ -13,7 +13,7 @@ import StepConnector, {
   stepConnectorClasses,
 } from '@material-ui/core/StepConnector';
 
-const QontoConnector = styled(StepConnector)({
+const QontoConnector = styled(StepConnector)(({ theme }) => ({
   [`&.${stepConnectorClasses.alternativeLabel}`]: {
     top: 10,
     left: 'calc(-50% + 16px)',
@@ -30,14 +30,14 @@ const QontoConnector = styled(StepConnector)({
     },
   },
   [`& .${stepConnectorClasses.line}`]: {
-    borderColor: '#eaeaf0',
+    borderColor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : '#eaeaf0',
     borderTopWidth: 3,
     borderRadius: 1,
   },
-});
+}));
 
-const QontoStepIconRoot = styled('div')(({ styleProps = {} }) => ({
-  color: '#eaeaf0',
+const QontoStepIconRoot = styled('div')(({ theme, styleProps = {} }) => ({
+  color: theme.palette.mode === 'dark' ? theme.palette.grey[700] : '#eaeaf0',
   display: 'flex',
   height: 22,
   alignItems: 'center',
@@ -85,7 +85,7 @@ QontoStepIcon.propTypes = {
   completed: PropTypes.bool,
 };
 
-const ColorlibConnector = styled(StepConnector)({
+const ColorlibConnector = styled(StepConnector)(({ theme }) => ({
   [`&.${stepConnectorClasses.alternativeLabel}`]: {
     top: 22,
   },
@@ -104,13 +104,14 @@ const ColorlibConnector = styled(StepConnector)({
   [`& .${stepConnectorClasses.line}`]: {
     height: 3,
     border: 0,
-    backgroundColor: '#eaeaf0',
+    backgroundColor:
+      theme.palette.mode === 'dark' ? theme.palette.grey[800] : '#eaeaf0',
     borderRadius: 1,
   },
-});
+}));
 
-const ColorlibStepIconRoot = styled('div')(({ styleProps = {} }) => ({
-  backgroundColor: '#ccc',
+const ColorlibStepIconRoot = styled('div')(({ theme, styleProps = {} }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? theme.palette.grey[700] : '#ccc',
   zIndex: 1,
   color: '#fff',
   width: 50,
@@ -168,13 +169,8 @@ const steps = ['Select campaign settings', 'Create an ad group', 'Create an ad']
 
 export default function CustomizedSteppers() {
   return (
-    <Box sx={{ width: '100%' }}>
-      <Stepper
-        alternativeLabel
-        activeStep={1}
-        connector={<QontoConnector />}
-        sx={{ mb: 4 }}
-      >
+    <Stack sx={{ width: '100%' }} spacing={4}>
+      <Stepper alternativeLabel activeStep={1} connector={<QontoConnector />}>
         {steps.map((label) => (
           <Step key={label}>
             <StepLabel StepIconComponent={QontoStepIcon}>{label}</StepLabel>
@@ -188,6 +184,6 @@ export default function CustomizedSteppers() {
           </Step>
         ))}
       </Stepper>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/steppers/CustomizedSteppers.tsx
+++ b/docs/src/pages/components/steppers/CustomizedSteppers.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
@@ -13,7 +13,7 @@ import StepConnector, {
 } from '@material-ui/core/StepConnector';
 import { StepIconProps } from '@material-ui/core/StepIcon';
 
-const QontoConnector = styled(StepConnector)({
+const QontoConnector = styled(StepConnector)(({ theme }) => ({
   [`&.${stepConnectorClasses.alternativeLabel}`]: {
     top: 10,
     left: 'calc(-50% + 16px)',
@@ -30,14 +30,14 @@ const QontoConnector = styled(StepConnector)({
     },
   },
   [`& .${stepConnectorClasses.line}`]: {
-    borderColor: '#eaeaf0',
+    borderColor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : '#eaeaf0',
     borderTopWidth: 3,
     borderRadius: 1,
   },
-});
+}));
 
-const QontoStepIconRoot = styled('div')(({ styleProps = {} }) => ({
-  color: '#eaeaf0',
+const QontoStepIconRoot = styled('div')(({ theme, styleProps = {} }) => ({
+  color: theme.palette.mode === 'dark' ? theme.palette.grey[700] : '#eaeaf0',
   display: 'flex',
   height: 22,
   alignItems: 'center',
@@ -71,7 +71,7 @@ function QontoStepIcon(props: StepIconProps) {
   );
 }
 
-const ColorlibConnector = styled(StepConnector)({
+const ColorlibConnector = styled(StepConnector)(({ theme }) => ({
   [`&.${stepConnectorClasses.alternativeLabel}`]: {
     top: 22,
   },
@@ -90,13 +90,14 @@ const ColorlibConnector = styled(StepConnector)({
   [`& .${stepConnectorClasses.line}`]: {
     height: 3,
     border: 0,
-    backgroundColor: '#eaeaf0',
+    backgroundColor:
+      theme.palette.mode === 'dark' ? theme.palette.grey[800] : '#eaeaf0',
     borderRadius: 1,
   },
-});
+}));
 
-const ColorlibStepIconRoot = styled('div')(({ styleProps = {} }) => ({
-  backgroundColor: '#ccc',
+const ColorlibStepIconRoot = styled('div')(({ theme, styleProps = {} }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? theme.palette.grey[700] : '#ccc',
   zIndex: 1,
   color: '#fff',
   width: 50,
@@ -136,13 +137,8 @@ const steps = ['Select campaign settings', 'Create an ad group', 'Create an ad']
 
 export default function CustomizedSteppers() {
   return (
-    <Box sx={{ width: '100%' }}>
-      <Stepper
-        alternativeLabel
-        activeStep={1}
-        connector={<QontoConnector />}
-        sx={{ mb: 4 }}
-      >
+    <Stack sx={{ width: '100%' }} spacing={4}>
+      <Stepper alternativeLabel activeStep={1} connector={<QontoConnector />}>
         {steps.map((label) => (
           <Step key={label}>
             <StepLabel StepIconComponent={QontoStepIcon}>{label}</StepLabel>
@@ -156,6 +152,6 @@ export default function CustomizedSteppers() {
           </Step>
         ))}
       </Stepper>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/switches/CustomizedSwitches.js
+++ b/docs/src/pages/components/switches/CustomizedSwitches.js
@@ -6,7 +6,7 @@ import Switch from '@material-ui/core/Switch';
 import Stack from '@material-ui/core/Stack';
 import Typography from '@material-ui/core/Typography';
 
-const MaterialUISwitch = styled(Switch)({
+const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   width: 62,
   height: 34,
   padding: 7,
@@ -24,12 +24,12 @@ const MaterialUISwitch = styled(Switch)({
       },
       '& + .MuiSwitch-track': {
         opacity: 1,
-        backgroundColor: '#aab4be',
+        backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
       },
     },
   },
   '& .MuiSwitch-thumb': {
-    backgroundColor: '#001e3c',
+    backgroundColor: theme.palette.mode === 'dark' ? '#003892' : '#001e3c',
     width: 32,
     height: 32,
     '&:before': {
@@ -48,10 +48,10 @@ const MaterialUISwitch = styled(Switch)({
   },
   '& .MuiSwitch-track': {
     opacity: 1,
-    backgroundColor: '#aab4be',
+    backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
     borderRadius: 20 / 2,
   },
-});
+}));
 
 const Android12Switch = styled(Switch)(({ theme }) => ({
   padding: 8,
@@ -100,7 +100,7 @@ const IOSSwitch = styled((props) => (
       transform: 'translateX(16px)',
       color: '#fff',
       '& + .MuiSwitch-track': {
-        backgroundColor: '#65C466',
+        backgroundColor: theme.palette.mode === 'dark' ? '#2ECA45' : '#65C466',
         opacity: 1,
         border: 0,
       },
@@ -142,29 +142,39 @@ const AntSwitch = styled(Switch)(({ theme }) => ({
   height: 16,
   padding: 0,
   display: 'flex',
+  '&:active': {
+    '& .MuiSwitch-thumb': {
+      width: 15,
+    },
+    '& .MuiSwitch-switchBase.Mui-checked': {
+      transform: 'translateX(9px)',
+    },
+  },
   '& .MuiSwitch-switchBase': {
     padding: 2,
-    color: theme.palette.grey[500],
     '&.Mui-checked': {
       transform: 'translateX(12px)',
       color: '#fff',
       '& + .MuiSwitch-track': {
         opacity: 1,
-        backgroundColor: theme.palette.primary.main,
-        borderColor: theme.palette.primary.main,
+        backgroundColor: theme.palette.mode === 'dark' ? '#177ddc' : '#1890ff',
       },
     },
   },
   '& .MuiSwitch-thumb': {
+    boxShadow: '0 2px 4px 0 rgb(0 35 11 / 20%)',
     width: 12,
     height: 12,
-    boxShadow: 'none',
+    borderRadius: 6,
+    transition: theme.transitions.create(['width'], {
+      duration: 200,
+    }),
   },
   '& .MuiSwitch-track': {
-    border: `1px solid ${theme.palette.grey[500]}`,
     borderRadius: 16 / 2,
     opacity: 1,
-    backgroundColor: '#fff',
+    backgroundColor:
+      theme.palette.mode === 'dark' ? 'rgba(255,255,255,.35)' : 'rgba(0,0,0,.25)',
     boxSizing: 'border-box',
   },
 }));

--- a/docs/src/pages/components/switches/CustomizedSwitches.tsx
+++ b/docs/src/pages/components/switches/CustomizedSwitches.tsx
@@ -6,7 +6,7 @@ import Switch, { SwitchProps } from '@material-ui/core/Switch';
 import Stack from '@material-ui/core/Stack';
 import Typography from '@material-ui/core/Typography';
 
-const MaterialUISwitch = styled(Switch)({
+const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   width: 62,
   height: 34,
   padding: 7,
@@ -24,12 +24,12 @@ const MaterialUISwitch = styled(Switch)({
       },
       '& + .MuiSwitch-track': {
         opacity: 1,
-        backgroundColor: '#aab4be',
+        backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
       },
     },
   },
   '& .MuiSwitch-thumb': {
-    backgroundColor: '#001e3c',
+    backgroundColor: theme.palette.mode === 'dark' ? '#003892' : '#001e3c',
     width: 32,
     height: 32,
     '&:before': {
@@ -48,10 +48,10 @@ const MaterialUISwitch = styled(Switch)({
   },
   '& .MuiSwitch-track': {
     opacity: 1,
-    backgroundColor: '#aab4be',
+    backgroundColor: theme.palette.mode === 'dark' ? '#8796A5' : '#aab4be',
     borderRadius: 20 / 2,
   },
-});
+}));
 
 const Android12Switch = styled(Switch)(({ theme }) => ({
   padding: 8,
@@ -100,7 +100,7 @@ const IOSSwitch = styled((props: SwitchProps) => (
       transform: 'translateX(16px)',
       color: '#fff',
       '& + .MuiSwitch-track': {
-        backgroundColor: '#65C466',
+        backgroundColor: theme.palette.mode === 'dark' ? '#2ECA45' : '#65C466',
         opacity: 1,
         border: 0,
       },
@@ -142,29 +142,39 @@ const AntSwitch = styled(Switch)(({ theme }) => ({
   height: 16,
   padding: 0,
   display: 'flex',
+  '&:active': {
+    '& .MuiSwitch-thumb': {
+      width: 15,
+    },
+    '& .MuiSwitch-switchBase.Mui-checked': {
+      transform: 'translateX(9px)',
+    },
+  },
   '& .MuiSwitch-switchBase': {
     padding: 2,
-    color: theme.palette.grey[500],
     '&.Mui-checked': {
       transform: 'translateX(12px)',
       color: '#fff',
       '& + .MuiSwitch-track': {
         opacity: 1,
-        backgroundColor: theme.palette.primary.main,
-        borderColor: theme.palette.primary.main,
+        backgroundColor: theme.palette.mode === 'dark' ? '#177ddc' : '#1890ff',
       },
     },
   },
   '& .MuiSwitch-thumb': {
+    boxShadow: '0 2px 4px 0 rgb(0 35 11 / 20%)',
     width: 12,
     height: 12,
-    boxShadow: 'none',
+    borderRadius: 6,
+    transition: theme.transitions.create(['width'], {
+      duration: 200,
+    }),
   },
   '& .MuiSwitch-track': {
-    border: `1px solid ${theme.palette.grey[500]}`,
     borderRadius: 16 / 2,
     opacity: 1,
-    backgroundColor: '#fff',
+    backgroundColor:
+      theme.palette.mode === 'dark' ? 'rgba(255,255,255,.35)' : 'rgba(0,0,0,.25)',
     boxSizing: 'border-box',
   },
 }));

--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -92,6 +92,7 @@ Feel free to have as few or as many breakpoints as you want, naming them in what
 const theme = createTheme({
   breakpoints: {
     values: {
+      mobile: 0,
       tablet: 640,
       laptop: 1024,
       desktop: 1280,
@@ -112,7 +113,8 @@ declare module '@material-ui/core/styles' {
     md: false;
     lg: false;
     xl: false;
-    tablet: true; // adds the `tablet` breakpoint
+    mobile: true; // adds the `mobile` breakpoint
+    tablet: true;
     laptop: true;
     desktop: true;
   }

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -188,9 +188,12 @@ Cons:
 
 ### API tradeoff
 
-In previous versions, the system properties were supported as props on the `Box` component. From v5, however, the system provides a superset of CSS (supports all CSS properties/selectors in addition to custom ones), and is available in all components, so selectors cannot be efficiently mapped to props without potential naming conflicts. Instead, all system properties are available under one prop `sx`.
+Having the system under one prop (`sx`) helps to easily differentiate props defined for the sole purpose of CSS utilities, vs. those for component business logic.
+It's important for the **separation of concerns**.
+For instance, a `color` prop on a button impacts multiple states (hover, focus, etc.), not to be confused with the color CSS property.
 
-Additionally, having the system under one prop helps to easily differentiate props defined for the sole purpose of CSS utilities, vs. those for component business logic.
+Only the `Box`, `Stack`, `Typography`, and `Grid` components accept the system properties as _prop_ for the above reason.
+These components are designed to solve simple CSS problems, they are CSS component utilities.
 
 ## Usage
 

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -304,6 +304,7 @@ import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 const theme = createTheme({
   breakpoints: {
     values: {
+      mobile: 0,
       tablet: 640,
       laptop: 1024,
       desktop: 1280,
@@ -317,9 +318,8 @@ export default function CustomBreakpoints() {
       <Box
         sx={{
           width: {
-            tablet: 100,
+            mobile: 100,
             laptop: 300,
-            desktop: 500,
           },
         }}
       >

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -43,12 +43,13 @@ In general, you can expect the following release cycle:
 
 ## Release schedule
 
-| Date           | Version | Status   |
-| :------------- | :------ | :------- |
-| May 2018       | v1.0.0  | Released |
-| September 2018 | v3.0.0  | Released |
-| May 2019       | v4.0.0  | Released |
-| Q1 2021        | v5.0.0  | ⏳       |
+| Date               | Version     | Status           |
+| :----------------- | :---------- | :--------------- |
+| May 2018           | v1.0.0      | Released         |
+| September 2018     | v3.0.0      | Released         |
+| May 2019           | v4.0.0      | Released         |
+| July 1st, 2021      | v5.0.beta.0 | Work in progress |
+| September 1st, 2021 | v5.0.0      | ⏳               |
 
 You can follow the [milestones](https://github.com/mui-org/material-ui/milestones) for a more detailed overview.
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -43,11 +43,11 @@ In general, you can expect the following release cycle:
 
 ## Release schedule
 
-| Date               | Version     | Status           |
-| :----------------- | :---------- | :--------------- |
-| May 2018           | v1.0.0      | Released         |
-| September 2018     | v3.0.0      | Released         |
-| May 2019           | v4.0.0      | Released         |
+| Date                | Version     | Status           |
+| :------------------ | :---------- | :--------------- |
+| May 2018            | v1.0.0      | Released         |
+| September 2018      | v3.0.0      | Released         |
+| May 2019            | v4.0.0      | Released         |
 | July 1st, 2021      | v5.0.beta.0 | Work in progress |
 | September 1st, 2021 | v5.0.0      | ⏳               |
 

--- a/packages/material-ui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/material-ui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -117,7 +117,7 @@ describe('styleFunctionSx', () => {
       theme,
       sx: {
         background: 'rgb(0, 0, 255)',
-        ':hover': {
+        '&:hover': {
           backgroundColor: 'primary.main',
           opacity: {
             xs: 0.1,
@@ -135,7 +135,7 @@ describe('styleFunctionSx', () => {
 
     expect(result).to.deep.equal({
       background: 'rgb(0, 0, 255)',
-      ':hover': {
+      '&:hover': {
         backgroundColor: 'rgb(0, 0, 255)',
         '@media (min-width:0px)': {
           opacity: 0.1,

--- a/packages/material-ui/src/styles/createBreakpoints.test.js
+++ b/packages/material-ui/src/styles/createBreakpoints.test.js
@@ -5,6 +5,7 @@ describe('createBreakpoints', () => {
   const breakpoints = createBreakpoints({});
   const customBreakpoints = createBreakpoints({
     values: {
+      mobile: 0,
       tablet: 640,
       laptop: 1024,
       desktop: 1280,

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.ts
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.ts
@@ -9,7 +9,8 @@ declare module '@material-ui/core/styles' {
     md: false;
     lg: false;
     xl: false;
-    tablet: true; // adds the `tablet` breakpoint
+    mobile: true; // adds the `mobile` breakpoint
+    tablet: true;
     laptop: true;
     desktop: true;
   }
@@ -18,6 +19,7 @@ declare module '@material-ui/core/styles' {
 createTheme({
   breakpoints: {
     values: {
+      mobile: 0,
       tablet: 640,
       laptop: 1024,
       desktop: 1280,


### PR DESCRIPTION
- [styles] Include & for consistency 9051058: this remove confusion, helps predict what's the CSS selector.
- [docs] Release timeline, we will ship no matter what 15e311c: make public our plan. At this point, better to ship than delaying more.
- [docs] Add missing baseline breakpoint at 0px 46a2779: a follow-up on #26168
- [docs] Fix dark mode for Switch customization 78cfb62: I would actually be curious to check the GA report to get an idea of the % of the sessions that are in dark mode vs. light. I have also noticed that sometimes it's `theme.palette.mode === 'dark`, others `theme.palette.mode === 'light` 🤷‍♂️.
- [docs] Fix dark mode for Slider customization 4cbfb6a:
- [docs] Fix dark mode for checkbox customization bd6f341:
- [docs] Fix dark mode for radio customization ba01d69:
- [docs] Fix dark mode for stepper customization e22660a:
- [docs] Fix dark mode for progress customization 737e2cb:
- [docs] Fix dark mode for accordion customization 8ada0a1:
- [docs] Update outdated docs on sx vs. props cee2b0b: we changed this aspect after writing it.