### PR TITLE
[SelectField] new SelectField component

### DIFF
--- a/docs/pages/api-docs/select-field.js
+++ b/docs/pages/api-docs/select-field.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './select-field.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+Page.getInitialProps = () => {
+  const req = require.context(
+    'docs/translations/api-docs/select-field',
+    false,
+    /select-field.*.json$/,
+  );
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    descriptions,
+    pageContent: jsonPageContent,
+  };
+};

--- a/docs/pages/api-docs/select-field.json
+++ b/docs/pages/api-docs/select-field.json
@@ -1,0 +1,47 @@
+{
+  "props": {
+    "autoComplete": { "type": { "name": "string" } },
+    "autoFocus": { "type": { "name": "bool" } },
+    "classes": { "type": { "name": "object" } },
+    "color": {
+      "type": { "name": "enum", "description": "'primary'<br>&#124;&nbsp;'secondary'" },
+      "default": "'primary'"
+    },
+    "defaultValue": { "type": { "name": "any" } },
+    "disabled": { "type": { "name": "bool" } },
+    "error": { "type": { "name": "bool" } },
+    "FormHelperTextProps": { "type": { "name": "object" } },
+    "fullWidth": { "type": { "name": "bool" } },
+    "helperText": { "type": { "name": "node" } },
+    "id": { "type": { "name": "string" } },
+    "InputLabelProps": { "type": { "name": "object" } },
+    "inputProps": { "type": { "name": "object" } },
+    "InputProps": { "type": { "name": "object" } },
+    "inputRef": { "type": { "name": "custom", "description": "ref" } },
+    "label": { "type": { "name": "node" } },
+    "multiple": { "type": { "name": "bool" } },
+    "name": { "type": { "name": "string" } },
+    "native": { "type": { "name": "bool" } },
+    "placeholder": { "type": { "name": "string" } },
+    "required": { "type": { "name": "bool" } },
+    "SelectProps": { "type": { "name": "object" } },
+    "size": { "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" } },
+    "sx": { "type": { "name": "object" } },
+    "variant": {
+      "type": {
+        "name": "enum",
+        "description": "'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'"
+      },
+      "default": "'outlined'"
+    }
+  },
+  "name": "SelectField",
+  "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiSelectField" },
+  "spread": true,
+  "forwardsRefTo": "HTMLDivElement",
+  "filename": "/packages/material-ui/src/SelectField/SelectField.js",
+  "inheritance": { "component": "FormControl", "pathname": "/api/form-control/" },
+  "demos": "<ul><li><a href=\"/components/select-fields/\">Select Fields</a></li></ul>",
+  "styledComponent": true,
+  "cssComponent": false
+}

--- a/docs/pages/components/select-fields.js
+++ b/docs/pages/components/select-fields.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import { prepareMarkdown } from 'docs/src/modules/utils/parseMarkdown';
+
+const pageFilename = 'components/select-fields';
+const requireDemo = require.context('docs/src/pages/components/select-fields', false, /\.(js|tsx)$/);
+const requireRaw = require.context(
+  '!raw-loader!../../src/pages/components/select-fields',
+  false,
+  /\.(js|md|tsx)$/,
+);
+
+export default function Page({ demos, docs }) {
+  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+}
+
+Page.getInitialProps = () => {
+  const { demos, docs } = prepareMarkdown({ pageFilename, requireRaw });
+  return { demos, docs };
+};

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -67,6 +67,7 @@ const pages: readonly MuiPage[] = [
           { pathname: '/components/radio-buttons', title: 'Radio button' },
           { pathname: '/components/rating' },
           { pathname: '/components/selects', title: 'Select' },
+          { pathname: '/components/select-fields', title: 'Select Field' },
           { pathname: '/components/slider' },
           { pathname: '/components/switches', title: 'Switch' },
           { pathname: '/components/text-fields', title: 'Text field' },

--- a/docs/src/pages/components/select-fields/BasicSelectFields.js
+++ b/docs/src/pages/components/select-fields/BasicSelectFields.js
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function BasicSelectFields() {
+  const [currency, setCurrency] = React.useState('EUR');
+
+  const handleChange = (event) => {
+    setCurrency(event.target.value);
+  };
+
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& .MuiSelectField-root': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <div>
+        <SelectField
+          id="outlined-select-currency"
+          label="Select"
+          value={currency}
+          onChange={handleChange}
+          helperText="Please select your currency"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="outlined-select-currency-native"
+          label="Native select"
+          value={currency}
+          onChange={handleChange}
+          SelectProps={{
+            native: true,
+          }}
+          helperText="Please select your currency"
+        >
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          id="filled-select-currency"
+          label="Select"
+          value={currency}
+          onChange={handleChange}
+          helperText="Please select your currency"
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="filled-select-currency-native"
+          label="Native select"
+          value={currency}
+          onChange={handleChange}
+          SelectProps={{
+            native: true,
+          }}
+          helperText="Please select your currency"
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          id="standard-select-currency"
+          label="Select"
+          value={currency}
+          onChange={handleChange}
+          helperText="Please select your currency"
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="standard-select-currency-native"
+          label="Native select"
+          value={currency}
+          onChange={handleChange}
+          SelectProps={{
+            native: true,
+          }}
+          helperText="Please select your currency"
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>
+      </div>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/select-fields/BasicSelectFields.tsx
+++ b/docs/src/pages/components/select-fields/BasicSelectFields.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function BasicSelectFields() {
+  const [currency, setCurrency] = React.useState('EUR');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrency(event.target.value);
+  };
+
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& .MuiSelectField-root': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <div>
+        <SelectField
+          id="outlined-select-currency"
+          label="Select"
+          value={currency}
+          onChange={handleChange}
+          helperText="Please select your currency"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="outlined-select-currency-native"
+          label="Native select"
+          value={currency}
+          onChange={handleChange}
+          SelectProps={{
+            native: true,
+          }}
+          helperText="Please select your currency"
+        >
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          id="filled-select-currency"
+          label="Select"
+          value={currency}
+          onChange={handleChange}
+          helperText="Please select your currency"
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="filled-select-currency-native"
+          label="Native select"
+          value={currency}
+          onChange={handleChange}
+          SelectProps={{
+            native: true,
+          }}
+          helperText="Please select your currency"
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          id="standard-select-currency"
+          label="Select"
+          value={currency}
+          onChange={handleChange}
+          helperText="Please select your currency"
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="standard-select-currency-native"
+          label="Native select"
+          value={currency}
+          onChange={handleChange}
+          SelectProps={{
+            native: true,
+          }}
+          helperText="Please select your currency"
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>
+      </div>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/select-fields/FormPropsSelectFields.js
+++ b/docs/src/pages/components/select-fields/FormPropsSelectFields.js
@@ -1,0 +1,215 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function FormPropsSelectFields() {
+  const [currency, setCurrency] = React.useState('EUR');
+
+  const handleChange = (event) => {
+    setCurrency(event.target.value);
+  };
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& .MuiSelectField-root': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <div>
+        <SelectField
+          required
+          id="outlined-required"
+          label="Required"
+          value={currency}
+          onChange={handleChange}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          disabled
+          id="outlined-disabled"
+          label="Disabled"
+          value={currency}
+          onChange={handleChange}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="outlined-read-only-input"
+          label="Read Only"
+          value={currency}
+          onChange={handleChange}
+          InputProps={{
+            readOnly: true,
+          }}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="outlined-helperText"
+          label="Helper text"
+          defaultValue="Default Value"
+          helperText="Some important text"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          required
+          id="filled-required"
+          label="Required"
+          value={currency}
+          onChange={handleChange}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          disabled
+          id="filled-disabled"
+          label="Disabled"
+          value={currency}
+          onChange={handleChange}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="filled-read-only-input"
+          label="Read Only"
+          value={currency}
+          onChange={handleChange}
+          InputProps={{
+            readOnly: true,
+          }}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="filled-helperText"
+          label="Helper text"
+          defaultValue="Default Value"
+          helperText="Some important text"
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          required
+          id="standard-required"
+          label="Required"
+          value={currency}
+          onChange={handleChange}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          disabled
+          id="standard-disabled"
+          label="Disabled"
+          value={currency}
+          onChange={handleChange}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="standard-read-only-input"
+          label="Read Only"
+          value={currency}
+          onChange={handleChange}
+          InputProps={{
+            readOnly: true,
+          }}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="standard-helperText"
+          label="Helper text"
+          defaultValue="Default Value"
+          helperText="Some important text"
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/select-fields/FormPropsSelectFields.tsx
+++ b/docs/src/pages/components/select-fields/FormPropsSelectFields.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function FormPropsSelectFields() {
+  const [currency, setCurrency] = React.useState('EUR');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrency(event.target.value);
+  };
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& .MuiSelectField-root': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <div>
+        <SelectField
+          required
+          id="outlined-required"
+          label="Required"
+          value={currency}
+          onChange={handleChange}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          disabled
+          id="outlined-disabled"
+          label="Disabled"
+          value={currency}
+          onChange={handleChange}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="outlined-read-only-input"
+          label="Read Only"
+          value={currency}
+          onChange={handleChange}
+          InputProps={{
+            readOnly: true,
+          }}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="outlined-helperText"
+          label="Helper text"
+          defaultValue="Default Value"
+          helperText="Some important text"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          required
+          id="filled-required"
+          label="Required"
+          value={currency}
+          onChange={handleChange}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          disabled
+          id="filled-disabled"
+          label="Disabled"
+          value={currency}
+          onChange={handleChange}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="filled-read-only-input"
+          label="Read Only"
+          value={currency}
+          onChange={handleChange}
+          InputProps={{
+            readOnly: true,
+          }}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="filled-helperText"
+          label="Helper text"
+          defaultValue="Default Value"
+          helperText="Some important text"
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          required
+          id="standard-required"
+          label="Required"
+          value={currency}
+          onChange={handleChange}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          disabled
+          id="standard-disabled"
+          label="Disabled"
+          value={currency}
+          onChange={handleChange}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="standard-read-only-input"
+          label="Read Only"
+          value={currency}
+          onChange={handleChange}
+          InputProps={{
+            readOnly: true,
+          }}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          id="standard-helperText"
+          label="Helper text"
+          defaultValue="Default Value"
+          helperText="Some important text"
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/select-fields/MultipleSelectFields.js
+++ b/docs/src/pages/components/select-fields/MultipleSelectFields.js
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function MultipleSelectFields() {
+  const [currency, setCurrency] = React.useState([]);
+
+  const handleChange = (event) => {
+    setCurrency(event.target.value);
+  };
+
+  return (
+    <SelectField
+      id="outlined-select-currency"
+      label="Select"
+      multiple
+      value={currency}
+      onChange={handleChange}
+      helperText="Please select your currency"
+    >
+      {currencies.map((option) => (
+        <MenuItem key={option.value} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </SelectField>
+  );
+}

--- a/docs/src/pages/components/select-fields/MultipleSelectFields.tsx
+++ b/docs/src/pages/components/select-fields/MultipleSelectFields.tsx
@@ -22,10 +22,10 @@ const currencies = [
 ];
 
 export default function MultipleSelectFields() {
-  const [currency, setCurrency] = React.useState<string[]>([]);
+  const [selectedCurrencies, setSelectedCurrencies] = React.useState<string[]>([]);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setCurrency(event.target.value as string[]);
+    setSelectedCurrencies(event.target.value as string[]);
   };
 
   return (
@@ -33,7 +33,7 @@ export default function MultipleSelectFields() {
       id="outlined-select-currency"
       label="Select"
       multiple
-      value={currency}
+      value={selectedCurrencies}
       onChange={handleChange}
       helperText="Please select your currency"
     >

--- a/docs/src/pages/components/select-fields/MultipleSelectFields.tsx
+++ b/docs/src/pages/components/select-fields/MultipleSelectFields.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function MultipleSelectFields() {
+  const [currency, setCurrency] = React.useState<string[]>([]);
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setCurrency(event.target.value as string[]);
+  };
+
+  return (
+    <SelectField
+      id="outlined-select-currency"
+      label="Select"
+      multiple
+      value={currency}
+      onChange={handleChange}
+      helperText="Please select your currency"
+    >
+      {currencies.map((option) => (
+        <MenuItem key={option.value} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </SelectField>
+  );
+}

--- a/docs/src/pages/components/select-fields/NativeSelectField.js
+++ b/docs/src/pages/components/select-fields/NativeSelectField.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import SelectField from '@material-ui/core/SelectField';
-import MenuItem from '@material-ui/core/MenuItem';
 
 const currencies = [
   {
@@ -21,26 +20,26 @@ const currencies = [
   },
 ];
 
-export default function MultipleSelectFields() {
-  const [selectedCurrencies, setSelectedCurrencies] = React.useState([]);
+export default function NativeSelectField() {
+  const [currency, setCurrency] = React.useState('USD');
 
   const handleChange = (event) => {
-    setSelectedCurrencies(event.target.value);
+    setCurrency(event.target.value);
   };
 
   return (
     <SelectField
       id="outlined-select-currency"
-      label="Select"
-      multiple
-      value={selectedCurrencies}
+      label="Native Select"
+      native
+      value={currency}
       onChange={handleChange}
       helperText="Please select your currency"
     >
       {currencies.map((option) => (
-        <MenuItem key={option.value} value={option.value}>
+        <option key={option.value} value={option.value}>
           {option.label}
-        </MenuItem>
+        </option>
       ))}
     </SelectField>
   );

--- a/docs/src/pages/components/select-fields/NativeSelectField.tsx
+++ b/docs/src/pages/components/select-fields/NativeSelectField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import SelectField from '@material-ui/core/SelectField';
-import MenuItem from '@material-ui/core/MenuItem';
 
 const currencies = [
   {
@@ -21,26 +20,26 @@ const currencies = [
   },
 ];
 
-export default function MultipleSelectFields() {
-  const [selectedCurrencies, setSelectedCurrencies] = React.useState([]);
+export default function NativeSelectField() {
+  const [currency, setCurrency] = React.useState('USD');
 
-  const handleChange = (event) => {
-    setSelectedCurrencies(event.target.value);
+  const handleChange = (event: React.ChangeEvent<{ value: string }>) => {
+    setCurrency(event.target.value);
   };
 
   return (
     <SelectField
       id="outlined-select-currency"
-      label="Select"
-      multiple
-      value={selectedCurrencies}
+      label="Native Select"
+      native
+      value={currency}
       onChange={handleChange}
       helperText="Please select your currency"
     >
       {currencies.map((option) => (
-        <MenuItem key={option.value} value={option.value}>
+        <option key={option.value} value={option.value}>
           {option.label}
-        </MenuItem>
+        </option>
       ))}
     </SelectField>
   );

--- a/docs/src/pages/components/select-fields/ValidationSelectFields.js
+++ b/docs/src/pages/components/select-fields/ValidationSelectFields.js
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function ValidationSelectFields() {
+  const [currency, setCurrency] = React.useState('EUR');
+
+  const handleChange = (event) => {
+    setCurrency(event.target.value);
+  };
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& .MuiSelectField-root': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <div>
+        <SelectField
+          error
+          id="outlined-error"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          error
+          id="outlined-error-helper-text"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          helperText="Incorrect entry."
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          error
+          id="filled-error"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          error
+          id="filled-error-helper-text"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          helperText="Incorrect entry."
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          error
+          id="standard-error"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          error
+          id="standard-error-helper-text"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          helperText="Incorrect entry."
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/select-fields/ValidationSelectFields.tsx
+++ b/docs/src/pages/components/select-fields/ValidationSelectFields.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import SelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const currencies = [
+  {
+    value: 'USD',
+    label: '$',
+  },
+  {
+    value: 'EUR',
+    label: '€',
+  },
+  {
+    value: 'BTC',
+    label: '฿',
+  },
+  {
+    value: 'JPY',
+    label: '¥',
+  },
+];
+
+export default function ValidationSelectFields() {
+  const [currency, setCurrency] = React.useState('EUR');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrency(event.target.value);
+  };
+  return (
+    <Box
+      component="form"
+      sx={{
+        '& .MuiSelectField-root': { m: 1, width: '25ch' },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <div>
+        <SelectField
+          error
+          id="outlined-error"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          error
+          id="outlined-error-helper-text"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          helperText="Incorrect entry."
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          error
+          id="filled-error"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          error
+          id="filled-error-helper-text"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          helperText="Incorrect entry."
+          variant="filled"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+      <div>
+        <SelectField
+          error
+          id="standard-error"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+        <SelectField
+          error
+          id="standard-error-helper-text"
+          label="Error"
+          value={currency}
+          onChange={handleChange}
+          helperText="Incorrect entry."
+          variant="standard"
+        >
+          {currencies.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </SelectField>
+      </div>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/select-fields/select-fields.md
+++ b/docs/src/pages/components/select-fields/select-fields.md
@@ -1,0 +1,52 @@
+---
+title: Select Field React component
+components: FilledInput, FormControl, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, SelectField
+githubLabel: 'component: SelectField'
+materialDesign: https://material.io/components/select-fields
+---
+
+# Select Field
+
+<p class="description">Select fields let users choose an option.</p>
+
+Text fields allow users to choose an option from UI. They typically appear in forms and dialogs.
+
+{{"component": "modules/components/ComponentLinkHeader.js"}}
+
+## Basic SelectField
+
+The `SelectField` wrapper component is a complete form control including a label, select, and help text.
+
+It supports standard, outlined, and filled styling.
+
+{{"demo": "pages/components/select-fields/BasicSelectFields.js"}}
+
+**Note:** The standard variant of the `SelectField` is no longer documented in the [Material Design guidelines](https://material.io/)
+([here's why](https://medium.com/google-design/the-evolution-of-material-designs-text-fields-603688b3fe03)),
+but Material-UI will continue to support it.
+
+## Form props
+
+Standard form attributes are supported e.g. `required`, `disabled`, etc. as well as a `helperText` which is used to give context about a field's input, such as how the input will be used.
+
+{{"demo": "pages/components/select-fields/FormPropsSelectFields.js"}}
+
+## Validation
+
+The `error` prop toggles the error state.
+The `helperText` prop can then be used to provide feedback to the user about the error.
+
+{{"demo": "pages/components/select-fields/ValidationSelectFields.js"}}
+
+## Multiple selection
+
+The `Select` component can handle multiple selections. It's enabled with the `multiple` prop and `value` props must be an array of string.
+
+Like with the single selection, you can pull out the new value by accessing `event.target.value` in the `onChange` callback. It's always an array.
+
+{{"demo": "pages/components/select-fields/MultipleSelectFields.js"}}
+
+## Composition
+
+`SelectField` is compose of `FormControl`, `InputLabel`, `Select`, `FormHelperText` and 3 variants of InputComponent (`Input`, `OutlinedInput`, `FilledInput`). If you have a particular usecase that `SelectField` does not fit or it is hard to acheive the needs, take a look at [Select Documentation Page](/components/selects/#basic-select) for more control.
+

--- a/docs/src/pages/components/select-fields/select-fields.md
+++ b/docs/src/pages/components/select-fields/select-fields.md
@@ -38,6 +38,13 @@ The `helperText` prop can then be used to provide feedback to the user about the
 
 {{"demo": "pages/components/select-fields/ValidationSelectFields.js"}}
 
+## Native select
+
+As the user experience can be improved on mobile using the native select of the platform,
+we allow such pattern.
+
+{{"demo": "pages/components/select-fields/NativeSelectField.js"}}
+
 ## Multiple selection
 
 The `Select` component can handle multiple selections. It's enabled with the `multiple` prop and `value` props must be an array of string.
@@ -48,5 +55,5 @@ Like with the single selection, you can pull out the new value by accessing `eve
 
 ## Composition
 
-`SelectField` is compose of `FormControl`, `InputLabel`, `Select`, `FormHelperText` and 3 variants of InputComponent (`Input`, `OutlinedInput`, `FilledInput`). If you have a particular usecase that `SelectField` does not fit or it is hard to acheive the needs, take a look at [Select Documentation Page](/components/selects/#basic-select) for more control.
+`SelectField` is compose of `FormControl`, `InputLabel`, `Select`, `FormHelperText` and 3 variants of InputComponent (`Input`, `OutlinedInput`, `FilledInput`). If you have a particular use case that `SelectField` does not fit or it is hard to acheive the needs, take a look at [Select Documentation Page](/components/selects/#basic-select) for more control.
 

--- a/docs/src/pagesApi.js
+++ b/docs/src/pagesApi.js
@@ -106,6 +106,7 @@ module.exports = [
   { pathname: '/api-docs/rating' },
   { pathname: '/api-docs/scoped-css-baseline' },
   { pathname: '/api-docs/select' },
+  { pathname: '/api-docs/select-field' },
   { pathname: '/api-docs/skeleton' },
   { pathname: '/api-docs/slide' },
   { pathname: '/api-docs/slider' },

--- a/docs/translations/api-docs/select-field/select-field-de.json
+++ b/docs/translations/api-docs/select-field/select-field-de.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field-es.json
+++ b/docs/translations/api-docs/select-field/select-field-es.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field-fr.json
+++ b/docs/translations/api-docs/select-field/select-field-fr.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field-ja.json
+++ b/docs/translations/api-docs/select-field/select-field-ja.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field-pt.json
+++ b/docs/translations/api-docs/select-field/select-field-pt.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field-ru.json
+++ b/docs/translations/api-docs/select-field/select-field-ru.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field-zh.json
+++ b/docs/translations/api-docs/select-field/select-field-zh.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field.json
+++ b/docs/translations/api-docs/select-field/select-field.json
@@ -1,0 +1,31 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "autoComplete": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>.",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the label is displayed in an error state.",
+    "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "helperText": "The helper text content.",
+    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
+    "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
+    "inputRef": "Pass a ref to the <code>input</code> element.",
+    "label": "The label content.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "name": "Name attribute of the <code>input</code> element.",
+    "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
+    "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
+    "required": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required.",
+    "SelectProps": "Props applied to the <a href=\"/api/select/\"><code>Select</code></a> element.",
+    "size": "The size of the component.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details.",
+    "variant": "The variant to use."
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/packages/material-ui/src/FilledInput/FilledInput.d.ts
+++ b/packages/material-ui/src/FilledInput/FilledInput.d.ts
@@ -58,6 +58,7 @@ export type FilledInputClassKey = keyof NonNullable<FilledInputProps['classes']>
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -113,6 +113,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
  *
  * - [Checkboxes](https://material-ui.com/components/checkboxes/)
  * - [Radio Buttons](https://material-ui.com/components/radio-buttons/)
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Switches](https://material-ui.com/components/switches/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *

--- a/packages/material-ui/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.d.ts
@@ -72,6 +72,7 @@ export interface FormHelperTextTypeMap<P = {}, D extends React.ElementType = 'p'
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -52,6 +52,7 @@ export type InputClassKey = keyof NonNullable<InputProps['classes']>;
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
@@ -64,6 +64,7 @@ export interface InputAdornmentTypeMap<P = {}, D extends React.ElementType = 'di
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -253,6 +253,7 @@ export type InputBaseClassKey = keyof NonNullable<InputBaseProps['classes']>;
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -87,6 +87,7 @@ export type InputLabelClassKey = keyof NonNullable<InputLabelProps['classes']>;
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
@@ -60,6 +60,7 @@ export type OutlinedInputClassKey = keyof NonNullable<OutlinedInputProps['classe
  *
  * Demos:
  *
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
  * - [Text Fields](https://material-ui.com/components/text-fields/)
  *
  * API:

--- a/packages/material-ui/src/SelectField/SelectField.d.ts
+++ b/packages/material-ui/src/SelectField/SelectField.d.ts
@@ -99,6 +99,11 @@ export interface BaseSelectFieldProps<T>
    */
   label?: React.ReactNode;
   /**
+   * If `true`, the component uses a native `select` element.
+   * @default false
+   */
+   native?: boolean;
+  /**
    * If `true`, `value` must be an array and the menu will support multiple selections.
    * @default false
    */
@@ -120,7 +125,7 @@ export interface BaseSelectFieldProps<T>
   /**
    * Props applied to the [`Select`](/api/select/) element.
    */
-  SelectProps?: Partial<SelectProps>;
+  SelectProps?: Partial<Omit<SelectProps, 'native'>>;
   /**
    * The size of the component.
    */

--- a/packages/material-ui/src/SelectField/SelectField.d.ts
+++ b/packages/material-ui/src/SelectField/SelectField.d.ts
@@ -189,42 +189,10 @@ export type SelectFieldProps<T> =
 export type SelectFieldClassKey = keyof NonNullable<SelectFieldProps<unknown>['classes']>;
 
 /**
- * The `SelectField` is a convenience wrapper for the most common cases (80%).
- * It cannot be all things to all people, otherwise the API would grow out of control.
- *
- * ## Advanced Configuration
- *
- * It's important to understand that the text field is a simple abstraction
- * on top of the following components:
- *
- * *   [FormControl](https://material-ui.com/api/form-control/)
- * *   [InputLabel](https://material-ui.com/api/input-label/)
- * *   [Select](https://material-ui.com/api/select/)
- * *   [FilledInput](https://material-ui.com/api/filled-input/)
- * *   [OutlinedInput](https://material-ui.com/api/outlined-input/)
- * *   [Input](https://material-ui.com/api/input/)
- * *   [FormHelperText](https://material-ui.com/api/form-helper-text/)
- *
- * If you wish to alter the props applied to the `input` element, you can do so as follows:
- *
- * ```jsx
- * const inputProps = {
- *   step: 300,
- * };
- *
- * return <SelectField id="time" inputProps={inputProps} />;
- * ```
- *
- * For advanced cases, please look at the source of SelectField by clicking on the
- * "Edit this page" button above. Consider either:
- *
- * *   using the upper case props for passing values directly to the components
- * *   using the underlying components directly as shown in the demos
  *
  * Demos:
  *
  * - [Select Fields](https://material-ui.com/components/select-fields/)
- * - [Select](https://material-ui.com/components/selects/)
  *
  * API:
  *

--- a/packages/material-ui/src/SelectField/SelectField.d.ts
+++ b/packages/material-ui/src/SelectField/SelectField.d.ts
@@ -3,6 +3,7 @@ import { SxProps } from '@material-ui/system';
 import { OverridableStringUnion } from '@material-ui/types';
 import { InternalStandardProps as StandardProps } from '..';
 import { FormControlProps } from '../FormControl';
+import { SelectInputProps } from '../Select/SelectInput';
 import { FormHelperTextProps } from '../FormHelperText';
 import { InputBaseProps } from '../InputBase';
 import { InputProps as StandardInputProps } from '../Input';
@@ -15,12 +16,13 @@ import { Theme } from '../styles';
 export interface SelectFieldPropsColorOverrides {}
 export interface SelectFieldPropsSizeOverrides {}
 
-export interface BaseSelectFieldProps
+export interface BaseSelectFieldProps<T>
   extends StandardProps<
-    FormControlProps,
-    // event handlers are declared on derived interfaces
+      FormControlProps,
+      // event handlers are declared on derived interfaces
     'onChange' | 'onBlur' | 'onFocus' | 'defaultValue'
-  > {
+    >,
+    Pick<SelectInputProps<T>, 'value' | 'onChange' | 'onBlur'> {
   /**
    * This prop helps users to fill forms faster, especially on mobile devices.
    * The name can be confusing, as it's more like an autofill.
@@ -35,7 +37,7 @@ export interface BaseSelectFieldProps
   /**
    * @ignore
    */
-  children?: React.ReactNode;
+  children: React.ReactNode;
   /**
    * Override or extend the styles applied to the component.
    */
@@ -51,7 +53,7 @@ export interface BaseSelectFieldProps
   /**
    * The default value. Use when the component is not controlled.
    */
-  defaultValue?: unknown;
+  defaultValue?: T;
   /**
    * If `true`, the component is disabled.
    * @default false
@@ -97,15 +99,14 @@ export interface BaseSelectFieldProps
    */
   label?: React.ReactNode;
   /**
-   * If `true`, a `textarea` element is rendered instead of an input.
+   * If `true`, `value` must be an array and the menu will support multiple selections.
    * @default false
    */
-  multiline?: boolean;
+  multiple?: boolean;
   /**
    * Name attribute of the `input` element.
    */
   name?: string;
-  onBlur?: InputBaseProps['onBlur'];
   onFocus?: StandardInputProps['onFocus'];
   /**
    * The short hint displayed in the `input` before the user enters a value.
@@ -128,20 +129,9 @@ export interface BaseSelectFieldProps
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx?: SxProps<Theme>;
-  /**
-   * The value of the `input` element, required for a controlled component.
-   */
-  value?: unknown;
 }
 
-export interface StandardSelectFieldProps extends BaseSelectFieldProps {
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: StandardInputProps['onChange'];
+export interface StandardSelectFieldProps<T> extends BaseSelectFieldProps<T> {
   /**
    * The variant to use.
    * @default 'outlined'
@@ -156,14 +146,7 @@ export interface StandardSelectFieldProps extends BaseSelectFieldProps {
   InputProps?: Partial<StandardInputProps>;
 }
 
-export interface FilledSelectFieldProps extends BaseSelectFieldProps {
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: FilledInputProps['onChange'];
+export interface FilledSelectFieldProps<T> extends BaseSelectFieldProps<T> {
   /**
    * The variant to use.
    * @default 'outlined'
@@ -178,14 +161,7 @@ export interface FilledSelectFieldProps extends BaseSelectFieldProps {
   InputProps?: Partial<FilledInputProps>;
 }
 
-export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
-  /**
-   * Callback fired when the value is changed.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (string).
-   */
-  onChange?: OutlinedInputProps['onChange'];
+export interface OutlinedSelectFieldProps<T> extends BaseSelectFieldProps<T> {
   /**
    * The variant to use.
    * @default 'outlined'
@@ -200,9 +176,12 @@ export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
   InputProps?: Partial<OutlinedInputProps>;
 }
 
-export type SelectFieldProps = StandardSelectFieldProps | FilledSelectFieldProps | OutlinedSelectFieldProps;
+export type SelectFieldProps<T> =
+  | StandardSelectFieldProps<T>
+  | FilledSelectFieldProps<T>
+  | OutlinedSelectFieldProps<T>;
 
-export type SelectFieldClassKey = keyof NonNullable<SelectFieldProps['classes']>;
+export type SelectFieldClassKey = keyof NonNullable<SelectFieldProps<unknown>['classes']>;
 
 /**
  * The `SelectField` is a convenience wrapper for the most common cases (80%).
@@ -215,6 +194,7 @@ export type SelectFieldClassKey = keyof NonNullable<SelectFieldProps['classes']>
  *
  * *   [FormControl](https://material-ui.com/api/form-control/)
  * *   [InputLabel](https://material-ui.com/api/input-label/)
+ * *   [Select](https://material-ui.com/api/select/)
  * *   [FilledInput](https://material-ui.com/api/filled-input/)
  * *   [OutlinedInput](https://material-ui.com/api/outlined-input/)
  * *   [Input](https://material-ui.com/api/input/)
@@ -238,13 +218,12 @@ export type SelectFieldClassKey = keyof NonNullable<SelectFieldProps['classes']>
  *
  * Demos:
  *
- * - [Autocomplete](https://material-ui.com/components/autocomplete/)
- * - [Pickers](https://material-ui.com/components/pickers/)
- * - [Text Fields](https://material-ui.com/components/select-fields/)
+ * - [Select Fields](https://material-ui.com/components/select-fields/)
+ * - [Select](https://material-ui.com/components/selects/)
  *
  * API:
  *
  * - [SelectField API](https://material-ui.com/api/select-field/)
  * - inherits [FormControl API](https://material-ui.com/api/form-control/)
  */
-export default function SelectField(props: SelectFieldProps): JSX.Element;
+export default function SelectField<T>(props: SelectFieldProps<T>): JSX.Element;

--- a/packages/material-ui/src/SelectField/SelectField.d.ts
+++ b/packages/material-ui/src/SelectField/SelectField.d.ts
@@ -1,0 +1,250 @@
+import * as React from 'react';
+import { SxProps } from '@material-ui/system';
+import { OverridableStringUnion } from '@material-ui/types';
+import { InternalStandardProps as StandardProps } from '..';
+import { FormControlProps } from '../FormControl';
+import { FormHelperTextProps } from '../FormHelperText';
+import { InputBaseProps } from '../InputBase';
+import { InputProps as StandardInputProps } from '../Input';
+import { FilledInputProps } from '../FilledInput';
+import { OutlinedInputProps } from '../OutlinedInput';
+import { InputLabelProps } from '../InputLabel';
+import { SelectProps } from '../Select';
+import { Theme } from '../styles';
+
+export interface SelectFieldPropsColorOverrides {}
+export interface SelectFieldPropsSizeOverrides {}
+
+export interface BaseSelectFieldProps
+  extends StandardProps<
+    FormControlProps,
+    // event handlers are declared on derived interfaces
+    'onChange' | 'onBlur' | 'onFocus' | 'defaultValue'
+  > {
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete?: string;
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   * @default false
+   */
+  autoFocus?: boolean;
+  /**
+   * @ignore
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: {
+    /** Styles applied to the root element. */
+    root?: string;
+  };
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'primary'
+   */
+  color?: OverridableStringUnion<'primary' | 'secondary', SelectFieldPropsColorOverrides>;
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue?: unknown;
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the label is displayed in an error state.
+   * @default false
+   */
+  error?: boolean;
+  /**
+   * Props applied to the [`FormHelperText`](/api/form-helper-text/) element.
+   */
+  FormHelperTextProps?: Partial<FormHelperTextProps>;
+  /**
+   * If `true`, the input will take up the full width of its container.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * The helper text content.
+   */
+  helperText?: React.ReactNode;
+  /**
+   * The id of the `input` element.
+   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   */
+  id?: string;
+  /**
+   * Props applied to the [`InputLabel`](/api/input-label/) element.
+   */
+  InputLabelProps?: Partial<InputLabelProps>;
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps?: InputBaseProps['inputProps'];
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef?: React.Ref<any>;
+  /**
+   * The label content.
+   */
+  label?: React.ReactNode;
+  /**
+   * If `true`, a `textarea` element is rendered instead of an input.
+   * @default false
+   */
+  multiline?: boolean;
+  /**
+   * Name attribute of the `input` element.
+   */
+  name?: string;
+  onBlur?: InputBaseProps['onBlur'];
+  onFocus?: StandardInputProps['onFocus'];
+  /**
+   * The short hint displayed in the `input` before the user enters a value.
+   */
+  placeholder?: string;
+  /**
+   * If `true`, the label is displayed as required and the `input` element is required.
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * Props applied to the [`Select`](/api/select/) element.
+   */
+  SelectProps?: Partial<SelectProps>;
+  /**
+   * The size of the component.
+   */
+  size?: OverridableStringUnion<'small' | 'medium', SelectFieldPropsSizeOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The value of the `input` element, required for a controlled component.
+   */
+  value?: unknown;
+}
+
+export interface StandardSelectFieldProps extends BaseSelectFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: StandardInputProps['onChange'];
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant?: 'standard';
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/api/filled-input/),
+   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps?: Partial<StandardInputProps>;
+}
+
+export interface FilledSelectFieldProps extends BaseSelectFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: FilledInputProps['onChange'];
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: 'filled';
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/api/filled-input/),
+   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps?: Partial<FilledInputProps>;
+}
+
+export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: OutlinedInputProps['onChange'];
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: 'outlined';
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/api/filled-input/),
+   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps?: Partial<OutlinedInputProps>;
+}
+
+export type SelectFieldProps = StandardSelectFieldProps | FilledSelectFieldProps | OutlinedSelectFieldProps;
+
+export type SelectFieldClassKey = keyof NonNullable<SelectFieldProps['classes']>;
+
+/**
+ * The `SelectField` is a convenience wrapper for the most common cases (80%).
+ * It cannot be all things to all people, otherwise the API would grow out of control.
+ *
+ * ## Advanced Configuration
+ *
+ * It's important to understand that the text field is a simple abstraction
+ * on top of the following components:
+ *
+ * *   [FormControl](https://material-ui.com/api/form-control/)
+ * *   [InputLabel](https://material-ui.com/api/input-label/)
+ * *   [FilledInput](https://material-ui.com/api/filled-input/)
+ * *   [OutlinedInput](https://material-ui.com/api/outlined-input/)
+ * *   [Input](https://material-ui.com/api/input/)
+ * *   [FormHelperText](https://material-ui.com/api/form-helper-text/)
+ *
+ * If you wish to alter the props applied to the `input` element, you can do so as follows:
+ *
+ * ```jsx
+ * const inputProps = {
+ *   step: 300,
+ * };
+ *
+ * return <SelectField id="time" inputProps={inputProps} />;
+ * ```
+ *
+ * For advanced cases, please look at the source of SelectField by clicking on the
+ * "Edit this page" button above. Consider either:
+ *
+ * *   using the upper case props for passing values directly to the components
+ * *   using the underlying components directly as shown in the demos
+ *
+ * Demos:
+ *
+ * - [Autocomplete](https://material-ui.com/components/autocomplete/)
+ * - [Pickers](https://material-ui.com/components/pickers/)
+ * - [Text Fields](https://material-ui.com/components/select-fields/)
+ *
+ * API:
+ *
+ * - [SelectField API](https://material-ui.com/api/select-field/)
+ * - inherits [FormControl API](https://material-ui.com/api/form-control/)
+ */
+export default function SelectField(props: SelectFieldProps): JSX.Element;

--- a/packages/material-ui/src/SelectField/SelectField.js
+++ b/packages/material-ui/src/SelectField/SelectField.js
@@ -61,6 +61,7 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     InputProps,
     inputRef,
     label,
+    native = false,
     multiple = false,
     name,
     onBlur,
@@ -106,7 +107,7 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
       );
     }
   }
-  if (!SelectProps || !SelectProps.native) {
+  if (!native) {
     InputMore.id = undefined;
   }
   InputMore['aria-describedby'] = undefined;
@@ -134,6 +135,7 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
         id={id}
         labelId={inputLabelId}
         value={value}
+        native={native}
         multiple={multiple}
         input={
           <InputComponent

--- a/packages/material-ui/src/SelectField/SelectField.js
+++ b/packages/material-ui/src/SelectField/SelectField.js
@@ -269,6 +269,11 @@ SelectField.propTypes /* remove-proptypes */ = {
    */
   name: PropTypes.string,
   /**
+   * If `true`, the component uses a native `select` element.
+   * @default false
+   */
+  native: PropTypes.bool,
+  /**
    * @ignore
    */
   onBlur: PropTypes.func,

--- a/packages/material-ui/src/SelectField/SelectField.js
+++ b/packages/material-ui/src/SelectField/SelectField.js
@@ -61,7 +61,7 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     InputProps,
     inputRef,
     label,
-    multiline = false,
+    multiple = false,
     name,
     onBlur,
     onChange,
@@ -81,7 +81,7 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     disabled,
     error,
     fullWidth,
-    multiline,
+    multiple,
     required,
     variant,
   };
@@ -92,12 +92,37 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
   const inputLabelId = label && id ? `${id}-label` : undefined;
   const InputComponent = variantComponent[variant];
   const InputMore = {};
+  if (variant === 'outlined') {
+    if (InputLabelProps && typeof InputLabelProps.shrink !== 'undefined') {
+      InputMore.notched = InputLabelProps.shrink;
+    }
+    if (label) {
+      const displayRequired = InputLabelProps?.required ?? required;
+      InputMore.label = (
+        <React.Fragment>
+          {label}
+          {displayRequired && '\u00a0*'}
+        </React.Fragment>
+      );
+    }
+  }
   if (!SelectProps || !SelectProps.native) {
     InputMore.id = undefined;
   }
   InputMore['aria-describedby'] = undefined;
   return (
-    <SelectFieldRoot ref={ref} className={clsx(classes.root, className)} {...other}>
+    <SelectFieldRoot
+      className={clsx(classes.root, className)}
+      disabled={disabled}
+      error={error}
+      fullWidth={fullWidth}
+      ref={ref}
+      required={required}
+      color={color}
+      variant={variant}
+      styleProps={styleProps}
+      {...other}
+    >
       {label && (
         <InputLabel htmlFor={id} id={inputLabelId} {...InputLabelProps}>
           {label}
@@ -109,6 +134,7 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
         id={id}
         labelId={inputLabelId}
         value={value}
+        multiple={multiple}
         input={
           <InputComponent
             aria-describedby={helperTextId}
@@ -116,7 +142,6 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
             autoFocus={autoFocus}
             defaultValue={defaultValue}
             fullWidth={fullWidth}
-            multiline={multiline}
             name={name}
             value={value}
             id={id}
@@ -144,11 +169,145 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
   );
 });
 
-SelectField.propTypes = {
+SelectField.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   * @default false
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'primary'
+   */
+  color: PropTypes.oneOf(['primary', 'secondary']),
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue: PropTypes.any,
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the label is displayed in an error state.
+   * @default false
+   */
+  error: PropTypes.bool,
+  /**
+   * Props applied to the [`FormHelperText`](/api/form-helper-text/) element.
+   */
+  FormHelperTextProps: PropTypes.object,
+  /**
+   * If `true`, the input will take up the full width of its container.
+   * @default false
+   */
+  fullWidth: PropTypes.bool,
+  /**
+   * The helper text content.
+   */
+  helperText: PropTypes.node,
+  /**
+   * The id of the `input` element.
+   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   */
+  id: PropTypes.string,
+  /**
+   * Props applied to the [`InputLabel`](/api/input-label/) element.
+   */
+  InputLabelProps: PropTypes.object,
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/api/filled-input/),
+   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: refType,
+  /**
+   * The label content.
+   */
+  label: PropTypes.node,
+  /**
+   * If `true`, `value` must be an array and the menu will support multiple selections.
+   * @default false
+   */
+  multiple: PropTypes.bool,
+  /**
+   * Name attribute of the `input` element.
+   */
+  name: PropTypes.string,
+  /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onChange: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
+  /**
+   * The short hint displayed in the `input` before the user enters a value.
+   */
+  placeholder: PropTypes.string,
+  /**
+   * If `true`, the label is displayed as required and the `input` element is required.
+   * @default false
+   */
+  required: PropTypes.bool,
+  /**
+   * Props applied to the [`Select`](/api/select/) element.
+   */
+  SelectProps: PropTypes.object,
+  /**
+   * The size of the component.
+   */
+  size: PropTypes.oneOf(['medium', 'small']),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.object,
+  /**
+   * @ignore
+   */
+  value: PropTypes.any,
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
 };
 
 export default SelectField;

--- a/packages/material-ui/src/SelectField/SelectField.js
+++ b/packages/material-ui/src/SelectField/SelectField.js
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import { refType } from '@material-ui/utils';
+import experimentalStyled from '../styles/experimentalStyled';
+import useThemeProps from '../styles/useThemeProps';
+import Input from '../Input';
+import FilledInput from '../FilledInput';
+import OutlinedInput from '../OutlinedInput';
+import InputLabel from '../InputLabel';
+import FormControl from '../FormControl';
+import FormHelperText from '../FormHelperText';
+import Select from '../Select';
+import { getSelectFieldUtilityClasses } from './selectFieldClasses';
+
+const variantComponent = {
+  standard: Input,
+  filled: FilledInput,
+  outlined: OutlinedInput,
+};
+
+const useUtilityClasses = (styleProps) => {
+  const { classes } = styleProps;
+
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getSelectFieldUtilityClasses, classes);
+};
+
+const SelectFieldRoot = experimentalStyled(
+  FormControl,
+  {},
+  {
+    name: 'MuiSelectField',
+    slot: 'Root',
+    overridesResolver: (props, styles) => styles.root,
+  },
+)({});
+
+const SelectField = React.forwardRef(function SelectField(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSelectField' });
+
+  const {
+    autoComplete,
+    autoFocus = false,
+    children,
+    className,
+    color = 'primary',
+    defaultValue,
+    disabled = false,
+    error = false,
+    FormHelperTextProps,
+    fullWidth = false,
+    helperText,
+    id,
+    InputLabelProps,
+    inputProps,
+    InputProps,
+    inputRef,
+    label,
+    multiline = false,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    placeholder,
+    required = false,
+    SelectProps,
+    value,
+    variant = 'outlined',
+    ...other
+  } = props;
+
+  const styleProps = {
+    ...props,
+    autoFocus,
+    color,
+    disabled,
+    error,
+    fullWidth,
+    multiline,
+    required,
+    variant,
+  };
+
+  const classes = useUtilityClasses(styleProps);
+
+  const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
+  const inputLabelId = label && id ? `${id}-label` : undefined;
+  const InputComponent = variantComponent[variant];
+  const InputMore = {};
+  if (!SelectProps || !SelectProps.native) {
+    InputMore.id = undefined;
+  }
+  InputMore['aria-describedby'] = undefined;
+  return (
+    <SelectFieldRoot ref={ref} className={clsx(classes.root, className)} {...other}>
+      {label && (
+        <InputLabel htmlFor={id} id={inputLabelId} {...InputLabelProps}>
+          {label}
+        </InputLabel>
+      )}
+
+      <Select
+        aria-describedby={helperTextId}
+        id={id}
+        labelId={inputLabelId}
+        value={value}
+        input={
+          <InputComponent
+            aria-describedby={helperTextId}
+            autoComplete={autoComplete}
+            autoFocus={autoFocus}
+            defaultValue={defaultValue}
+            fullWidth={fullWidth}
+            multiline={multiline}
+            name={name}
+            value={value}
+            id={id}
+            inputRef={inputRef}
+            onBlur={onBlur}
+            onChange={onChange}
+            onFocus={onFocus}
+            placeholder={placeholder}
+            inputProps={inputProps}
+            {...InputMore}
+            {...InputProps}
+          />
+        }
+        {...SelectProps}
+      >
+        {children}
+      </Select>
+
+      {helperText && (
+        <FormHelperText id={helperTextId} {...FormHelperTextProps}>
+          {helperText}
+        </FormHelperText>
+      )}
+    </SelectFieldRoot>
+  );
+});
+
+SelectField.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+};
+
+export default SelectField;

--- a/packages/material-ui/src/SelectField/SelectField.test.js
+++ b/packages/material-ui/src/SelectField/SelectField.test.js
@@ -1,0 +1,224 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import FormControl from '@material-ui/core/FormControl';
+import MenuItem from '@material-ui/core/MenuItem';
+import SelectField, { selectFieldClasses as classes } from '@material-ui/core/SelectField';
+import { inputBaseClasses } from '@material-ui/core/InputBase';
+import { outlinedInputClasses } from '@material-ui/core/OutlinedInput';
+
+describe('<SelectField />', () => {
+  const mount = createMount();
+  const render = createClientRender();
+
+  describeConformanceV5(<SelectField variant="standard" value="" />, () => ({
+    classes,
+    inheritComponent: FormControl,
+    render,
+    mount,
+    muiName: 'MuiSelectField',
+    refInstanceof: window.HTMLDivElement,
+    testVariantProps: { variant: 'outlined' },
+    skip: ['componentProp', 'componentsProp'],
+  }));
+
+  describe('structure', () => {
+    it('should have an input as the only child', () => {
+      const { getAllByRole } = render(<SelectField value="" variant="standard" />);
+
+      expect(getAllByRole('textbox')).to.have.lengthOf(1);
+    });
+
+    it('should have comma separated value if multiple', () => {
+      const { getByRole } = render(
+        <SelectField variant="standard" multiple value={['foo', 'bar']} />,
+      );
+
+      expect(getByRole('textbox', { hidden: true })).to.have.value('foo,bar');
+    });
+
+    it('should forward the fullWidth prop to Input', () => {
+      const { getByTestId } = render(
+        <SelectField
+          value=""
+          variant="standard"
+          fullWidth
+          InputProps={{ 'data-testid': 'mui-input-base-root' }}
+        />,
+      );
+
+      expect(getByTestId('mui-input-base-root')).to.have.class(inputBaseClasses.fullWidth);
+    });
+  });
+
+  describe('with a label', () => {
+    it('should apply the className to the label', () => {
+      const { container } = render(
+        <SelectField
+          id="labelled"
+          label="Foo bar"
+          InputLabelProps={{ className: 'foo' }}
+          value=""
+          variant="standard"
+        />,
+      );
+
+      expect(container.querySelector('label')).to.have.class('foo');
+    });
+
+    ['', undefined].forEach((label) => {
+      it(`should not render empty (${label}) label element`, () => {
+        const { container } = render(
+          <SelectField id="labelled" label={label} value="" variant="standard" />,
+        );
+
+        expect(container.querySelector('label')).to.equal(null);
+      });
+    });
+  });
+
+  describe('with a helper text', () => {
+    it('should apply the className to the FormHelperText', () => {
+      const { getDescriptionOf, getByRole } = render(
+        <SelectField
+          id="aria-test"
+          helperText="Foo bar"
+          FormHelperTextProps={{ className: 'foo' }}
+          value=""
+          variant="standard"
+        />,
+      );
+
+      expect(getDescriptionOf(getByRole('button'))).to.have.class('foo');
+    });
+
+    it('should add accessibility labels to the input', () => {
+      const { getDescriptionOf, getByRole } = render(
+        <SelectField
+          id="aria-test"
+          helperText="Foo bar"
+          FormHelperTextProps={{ className: 'foo' }}
+          value=""
+          variant="standard"
+        />,
+      );
+
+      expect(getDescriptionOf(getByRole('button'))).to.have.text('Foo bar');
+    });
+  });
+
+  describe('with an outline', () => {
+    it('should set outline props', () => {
+      const { container, getAllByTestId } = render(
+        <SelectField
+          value=""
+          InputProps={{ classes: { notchedOutline: 'notch' } }}
+          label={<div data-testid="label">label</div>}
+          required
+        />,
+      );
+
+      const [, fakeLabel] = getAllByTestId('label');
+      const notch = container.querySelector('.notch legend');
+      expect(notch).to.contain(fakeLabel);
+      expect(notch).to.have.text('label\u00a0*');
+    });
+
+    it('should set shrink prop on outline from label', () => {
+      const { container } = render(
+        <SelectField value="" InputLabelProps={{ shrink: true }} classes={{}} />,
+      );
+
+      expect(container.querySelector('fieldset')).to.have.class(
+        outlinedInputClasses.notchedOutline,
+      );
+    });
+  });
+
+  describe('prop: InputProps', () => {
+    it('should apply additional props to the Input component', () => {
+      const { getByTestId } = render(
+        <SelectField
+          value=""
+          InputProps={{ 'data-testid': 'InputComponent' }}
+          variant="standard"
+        />,
+      );
+
+      expect(getByTestId('InputComponent')).not.to.equal(null);
+    });
+  });
+
+  describe('prop: select', () => {
+    it('can render a <select /> when `native`', () => {
+      const currencies = [
+        { value: 'USD', label: '$' },
+        { value: 'BTC', label: '฿' },
+      ];
+
+      const { container } = render(
+        <SelectField native variant="standard">
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>,
+      );
+
+      const select = container.querySelector('select');
+      expect(select).not.to.equal(null);
+      expect(select.options).to.have.lengthOf(2);
+    });
+
+    it('associates the label with the <select /> when `native={true}` and `id`', () => {
+      const { getByRole } = render(
+        <SelectField
+          label="Currency:"
+          id="labelled-select"
+          native
+          value="$"
+          variant="standard"
+        >
+          <option value="dollar">$</option>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox', { name: 'Currency:' })).to.have.property('value', 'dollar');
+    });
+
+    it('renders a combobox with the appropriate accessible name', () => {
+      const { getByRole } = render(
+        <SelectField id="my-select" label="Release: " value="stable" variant="standard">
+          <MenuItem value="alpha">Alpha</MenuItem>
+          <MenuItem value="beta">Beta</MenuItem>
+          <MenuItem value="stable">Stable</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('button')).toHaveAccessibleName('Release: Stable');
+    });
+
+    it('creates an input[hidden] that has no accessible properties', () => {
+      const { container } = render(
+        <SelectField id="my-select" label="Release: " value="stable" variant="standard">
+          <MenuItem value="stable">Stable</MenuItem>
+        </SelectField>,
+      );
+
+      const input = container.querySelector('input[aria-hidden]');
+      expect(input).not.to.have.attribute('id');
+      expect(input).not.to.have.attribute('aria-describedby');
+    });
+
+    it('renders a combobox with the appropriate accessible description', () => {
+      const { getByRole } = render(
+        <SelectField id="aria-test" helperText="Foo bar" value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('button')).toHaveAccessibleDescription('Foo bar');
+    });
+  });
+});

--- a/packages/material-ui/src/SelectField/index.d.ts
+++ b/packages/material-ui/src/SelectField/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './SelectField';
+export * from './SelectField';
+
+export { default as selectFieldClasses } from './selectFieldClasses';
+export * from './selectFieldClasses';

--- a/packages/material-ui/src/SelectField/index.js
+++ b/packages/material-ui/src/SelectField/index.js
@@ -1,0 +1,4 @@
+export { default } from './SelectField';
+
+export { default as selectFieldClasses } from './selectFieldClasses';
+export * from './selectFieldClasses';

--- a/packages/material-ui/src/SelectField/selectFieldClasses.d.ts
+++ b/packages/material-ui/src/SelectField/selectFieldClasses.d.ts
@@ -1,0 +1,7 @@
+import { SelectFieldClassKey } from './SelectField';
+
+declare const selectFieldClasses: Record<SelectFieldClassKey, string>;
+
+export function getSelectFieldUtilityClass(slot: string): string;
+
+export default selectFieldClasses;

--- a/packages/material-ui/src/SelectField/selectFieldClasses.js
+++ b/packages/material-ui/src/SelectField/selectFieldClasses.js
@@ -1,0 +1,9 @@
+import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unstyled';
+
+export function getSelectFieldUtilityClasses(slot) {
+  return generateUtilityClass('MuiSelectField', slot);
+}
+
+const selectClasses = generateUtilityClasses('MuiSelectField', ['root']);
+
+export default selectClasses;

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -333,6 +333,9 @@ export * from './ScopedCssBaseline';
 export { default as Select } from './Select';
 export * from './Select';
 
+export { default as SelectField } from './SelectField';
+export * from './SelectField';
+
 export { default as Skeleton } from './Skeleton';
 export * from './Skeleton';
 

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -266,6 +266,9 @@ export * from './ScopedCssBaseline';
 export { default as Select } from './Select';
 export * from './Select';
 
+export { default as SelectField } from './SelectField';
+export * from './SelectField';
+
 export { default as Skeleton } from './Skeleton';
 export * from './Skeleton';
 

--- a/packages/material-ui/src/styles/components.d.ts
+++ b/packages/material-ui/src/styles/components.d.ts
@@ -323,6 +323,10 @@ export interface Components {
     defaultProps?: ComponentsProps['MuiSelect'];
     styleOverrides?: ComponentsOverrides['MuiSelect'];
   };
+  MuiSelectField?: {
+    defaultProps?: ComponentsProps['MuiSelectField'];
+    styleOverrides?: ComponentsOverrides['MuiSelectField'];
+  };
   MuiSkeleton?: {
     defaultProps?: ComponentsProps['MuiSkeleton'];
     styleOverrides?: ComponentsOverrides['MuiSkeleton'];

--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -75,6 +75,7 @@ import { RadioClassKey } from '../Radio';
 import { RatingClassKey } from '../Rating';
 import { ScopedCssBaselineClassKey } from '../ScopedCssBaseline';
 import { SelectClassKey } from '../Select';
+import { SelectFieldClassKey } from '../SelectField';
 import { SkeletonClassKey } from '../Skeleton';
 import { SliderClassKey } from '../Slider';
 import { SnackbarClassKey } from '../Snackbar';
@@ -200,6 +201,7 @@ export interface ComponentNameToClassKey {
   MuiRating: RatingClassKey;
   MuiScopedCssBaseline: ScopedCssBaselineClassKey;
   MuiSelect: SelectClassKey;
+  MuiSelectField: SelectFieldClassKey;
   MuiSkeleton: SkeletonClassKey;
   MuiSlider: SliderClassKey;
   MuiSnackbar: SnackbarClassKey;

--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -78,6 +78,7 @@ import { RadioProps } from '../Radio';
 import { RatingProps } from '../Rating';
 import { ScopedCssBaselineProps } from '../ScopedCssBaseline';
 import { SelectProps } from '../Select';
+import { SelectFieldProps } from '../SelectField';
 import { SkeletonProps } from '../Skeleton';
 import { SliderProps } from '../Slider';
 import { SnackbarContentProps } from '../SnackbarContent';
@@ -198,6 +199,7 @@ export interface ComponentsPropsList {
   MuiRating: RatingProps;
   MuiScopedCssBaseline: ScopedCssBaselineProps;
   MuiSelect: SelectProps;
+  MuiSelectField: SelectFieldProps;
   MuiSkeleton: SkeletonProps;
   MuiSlider: SliderProps;
   MuiSnackbar: SnackbarProps;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
this PR is the first part to fix #21782

Summary of this PR
- create new component `SelectField` to separate select from `TextField` (detail is in the issue above)
- type `value` `onChange` follow `Select` component pattern (use generic since value can be string or array)
- expose `multiple`, `native` at the top of `SelectField` for ease of use.
```js
<SelectField
  native
  multiple
  // I think this is better than SelectProps={{ native: true, multiple: true }}
  ...
>
  ...
</SelectField>
```

I feel `SelectField` has a better API than using `select` in TextField. @oliviertassinari

For removing `select` from `TextField` (breaking change), I think it can be another followup PR?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
