### PR TITLE
rating(docs)  fixed  labelText issue in Customized rating now it will show hover feedback text like done in https://material-ui.com/components/rating/#hover-feedback.

### DIFF
--- a/docs/src/pages/components/rating/CustomizedRating.js
+++ b/docs/src/pages/components/rating/CustomizedRating.js
@@ -16,6 +16,8 @@ const StyledRating = styled(Rating)({
 });
 
 export default function CustomizedRating() {
+  const [value, setValue] = React.useState(2);
+  const [hover, setHover] = React.useState(-1);
   return (
     <Box
       sx={{
@@ -23,14 +25,31 @@ export default function CustomizedRating() {
       }}
     >
       <Typography component="legend">Custom icon and color</Typography>
-      <StyledRating
-        name="customized-color"
-        defaultValue={2}
-        getLabelText={(value) => `${value} Heart${value !== 1 ? 's' : ''}`}
-        precision={0.5}
-        icon={<FavoriteIcon fontSize="inherit" />}
-        emptyIcon={<FavoriteBorderIcon fontSize="inherit" />}
-      />
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <StyledRating
+          name="customized-color"
+          value={value}
+          onChange={(event, newValue) => {
+            setValue(newValue);
+          }}
+          onChangeActive={(event, newHover) => {
+            setHover(newHover);
+          }}
+          precision={0.5}
+          icon={<FavoriteIcon fontSize="inherit" />}
+          emptyIcon={<FavoriteBorderIcon fontSize="inherit" />}
+        />
+        {value !== null && (
+          <Box sx={{ ml: 2 }}>
+            {hover !== -1 ? hover : value} Heart{value !== 1 ? 's' : ''}
+          </Box>
+        )}
+      </Box>
       <Typography component="legend">10 stars</Typography>
       <Rating name="customized-10" defaultValue={2} max={10} />
     </Box>

--- a/docs/src/pages/components/rating/CustomizedRating.tsx
+++ b/docs/src/pages/components/rating/CustomizedRating.tsx
@@ -16,6 +16,8 @@ const StyledRating = styled(Rating)({
 });
 
 export default function CustomizedRating() {
+  const [value, setValue] = React.useState<number | null>(2);
+  const [hover, setHover] = React.useState(-1);
   return (
     <Box
       sx={{
@@ -23,14 +25,31 @@ export default function CustomizedRating() {
       }}
     >
       <Typography component="legend">Custom icon and color</Typography>
-      <StyledRating
-        name="customized-color"
-        defaultValue={2}
-        getLabelText={(value: number) => `${value} Heart${value !== 1 ? 's' : ''}`}
-        precision={0.5}
-        icon={<FavoriteIcon fontSize="inherit" />}
-        emptyIcon={<FavoriteBorderIcon fontSize="inherit" />}
-      />
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <StyledRating
+          name="customized-color"
+          value={value}
+          onChange={(event, newValue) => {
+            setValue(newValue);
+          }}
+          onChangeActive={(event, newHover) => {
+            setHover(newHover);
+          }}
+          precision={0.5}
+          icon={<FavoriteIcon fontSize="inherit" />}
+          emptyIcon={<FavoriteBorderIcon fontSize="inherit" />}
+        />
+        {value !== null && (
+          <Box sx={{ ml: 2 }}>
+            {hover !== -1 ? hover : value} Heart{value !== 1 ? 's' : ''}
+          </Box>
+        )}
+      </Box>
       <Typography component="legend">10 stars</Typography>
       <Rating name="customized-10" defaultValue={2} max={10} />
     </Box>


### PR DESCRIPTION
issue [#21018](https://github.com/mui-org/material-ui/issues/21018)

<img width="312" alt="Screenshot 2021-05-09 232526" src="https://user-images.githubusercontent.com/64005315/117582090-e17a7900-b11d-11eb-8350-158118058c68.png">
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
