### PR TITLE
[NProgressBar] Fix invalid ARIA and HTML

### DIFF
--- a/packages/material-ui-docs/src/NProgressBar/NProgressBar.js
+++ b/packages/material-ui-docs/src/NProgressBar/NProgressBar.js
@@ -6,10 +6,11 @@ import NoSsr from '@material-ui/core/NoSsr';
 import { exactProp } from '@material-ui/utils';
 
 NProgress.configure({
+  barSelector: '.nprogress-bar',
   template: `
-    <div class="nprogress-bar" role="bar">
-      <dt></dt>
-      <dd></dd>
+    <div class="nprogress-bar" role="progressbar">
+      <div></div>
+      <div></div>
     </div>
   `,
 });
@@ -42,7 +43,7 @@ const styles = (theme) => {
           right: 0,
           height: 2,
         },
-        '& dd, & dt': {
+        '& > div': {
           position: 'absolute',
           top: 0,
           height: 2,
@@ -50,13 +51,13 @@ const styles = (theme) => {
           borderRadius: '100%',
           animation: 'mui-nprogress-pulse 2s ease-out 0s infinite',
         },
-        '& dd': {
+        '& > div:first-child': {
           opacity: 0.6,
           width: 20,
           right: 0,
           clip: 'rect(-6px,22px,14px,10px)',
         },
-        '& dt': {
+        '& > div:last-child': {
           opacity: 0.6,
           width: 180,
           right: -80,


### PR DESCRIPTION
1. Use `progressbar` as a role instead of `bar` (which is not a valid role)
1. Use `div` and pseudo selectors instead of `dt` and `dd` which is invalid markup 

I understand that there's ongoing work to promote this component to core but in its current state it's blocking automated a11y trests. This fix should be propagated to `@material-ui/docs` anyway.