### PR TITLE
[slider] Center value label for disabled slider

### DIFF
--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -127,9 +127,10 @@ If you need to perform 30 re-renders per second or more, we recommend disabling 
 }
 ```
 
-### IE11
+### IE 11
 
-The circular progress component animation on IE11 is degraded. The stroke dash animation is not working (equivalent to `disableShrink`) and the circular animation wobbles.
+The circular progress component animation on IE 11 is degraded.
+The stroke dash animation is not working (equivalent to `disableShrink`) and the circular animation wobbles.
 You can solve the latter with:
 
 ```css

--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -60,7 +60,6 @@ const IOSSlider = styled(Slider)(({ theme }) => ({
     },
   },
   '& .MuiSlider-valueLabel': {
-    left: 'calc(-50% + 12px)',
     top: -22,
     '& *': {
       background: 'transparent',
@@ -100,9 +99,6 @@ const PrettoSlider = styled(Slider)({
     '&:focus, &:hover, &.Mui-active': {
       boxShadow: 'inherit',
     },
-  },
-  '& .MuiSlider-valueLabel': {
-    left: 'calc(-50% + 4px)',
   },
   '& .MuiSlider-track': {
     height: 8,

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -59,7 +59,6 @@ const IOSSlider = styled(Slider)(({ theme }) => ({
     },
   },
   '& .MuiSlider-valueLabel': {
-    left: 'calc(-50% + 12px)',
     top: -22,
     '& *': {
       background: 'transparent',
@@ -99,9 +98,6 @@ const PrettoSlider = styled(Slider)({
     '&:focus, &:hover, &.Mui-active': {
       boxShadow: 'inherit',
     },
-  },
-  '& .MuiSlider-valueLabel': {
-    left: 'calc(-50% + 4px)',
   },
   '& .MuiSlider-track': {
     height: 8,

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -148,8 +148,8 @@ However, you need to make sure that:
 ### IE 11
 
 The slider's value label is not centered in IE 11.
-The alignement is not handled to make customizations easier with the lastest browser.
-You can solve the latter with:
+The alignement is not handled to make customizations easier with the lastest browsers.
+You can solve the issue with:
 
 ```css
 .MuiSlider-valueLabel {

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -142,3 +142,17 @@ However, you need to make sure that:
 - Each thumb has a user-friendly text for its current value.
   This is not required if the value matches the semantics of the label.
   You can change the name with the `getAriaValueText` or `aria-valuetext` prop.
+
+## Limitations
+
+### IE 11
+
+The slider's value label is not centered in IE 11.
+The alignement is not handled to make customizations easier with the lastest browser.
+You can solve the latter with:
+
+```css
+.MuiSlider-valueLabel {
+  left: calc(-50% - 4px);
+}
+```

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -255,8 +255,6 @@ export const SliderValueLabel = experimentalStyled(
     overridesResolver: (props, styles) => styles.valueLabel,
   },
 )(({ theme }) => ({
-  // IE 11 centering bug, to remove from the customization demos once no longer supported
-  left: 'calc(-50% - 4px)',
   [`&.${sliderClasses.valueLabelOpen}`]: {
     transform: 'scale(1) translateY(-10px)',
   },

--- a/test/regressions/fixtures/Slider/SimpleDisabledSlider.js
+++ b/test/regressions/fixtures/Slider/SimpleDisabledSlider.js
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import Slider from '@material-ui/core/Slider';
+
+export default function SimpleDisabledSlider() {
+  return (
+    <div style={{ width: 300, padding: 50 }}>
+      <Slider defaultValue={30} valueLabelDisplay="on" disabled />
+    </div>
+  );
+}

--- a/test/regressions/fixtures/Slider/SimpleDisabledSlider.js
+++ b/test/regressions/fixtures/Slider/SimpleDisabledSlider.js
@@ -3,7 +3,7 @@ import Slider from '@material-ui/core/Slider';
 
 export default function SimpleDisabledSlider() {
   return (
-    <div style={{ width: 300, padding: 50 }}>
+    <div style={{ width: 300, paddingTop: 50 }}>
       <Slider defaultValue={30} valueLabelDisplay="on" disabled />
     </div>
   );


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR correctly centers a value label for a disabled slider, resolving [this issue](https://github.com/mui-org/material-ui/issues/19329), by removing a fix for IE 11. It also removes the same fix from the customized slider demos and adds a simple test for a disabled slider with an active value label. 

Closes #19329

<img width="225" alt="Screenshot 2021-05-15 at 14 14 00" src="https://user-images.githubusercontent.com/3165635/118360442-d72a0600-b587-11eb-88d5-1806ef9d2c33.png">

```jsx
<Slider
  color="success"
  value={value}
  step={10}
  marks
  valueLabelDisplay="auto"
  onChange={handleChange}
  aria-labelledby="continuous-slider"
/>
```