### PR TITLE
[pickers] Migrate StaticWrapper to emotion

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/wrappers/StaticWrapper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/wrappers/StaticWrapper.tsx
@@ -1,19 +1,7 @@
 import * as React from 'react';
-import { WithStyles, withStyles, MuiStyles, StyleRules } from '@material-ui/core/styles';
+import { experimentalStyled as styled } from '@material-ui/core/styles';
 import { DIALOG_WIDTH } from '../constants/dimensions';
 import { WrapperVariantContext, IsStaticVariantContext } from './WrapperVariantContext';
-
-type StaticWrapperClassKey = 'root';
-
-const styles: MuiStyles<StaticWrapperClassKey> = (theme): StyleRules<StaticWrapperClassKey> => ({
-  root: {
-    overflow: 'hidden',
-    minWidth: DIALOG_WIDTH,
-    display: 'flex',
-    flexDirection: 'column',
-    backgroundColor: theme.palette.background.paper,
-  },
-});
 
 export interface StaticWrapperProps {
   children?: React.ReactNode;
@@ -23,18 +11,30 @@ export interface StaticWrapperProps {
   displayStaticWrapperAs: 'desktop' | 'mobile';
 }
 
-function StaticWrapper(props: StaticWrapperProps & WithStyles<typeof styles>) {
-  const { classes, displayStaticWrapperAs, children } = props;
+const StaticWrapperRoot = styled(
+  'div',
+  {},
+  { skipSx: true },
+)(({ theme }) => ({
+  overflow: 'hidden',
+  minWidth: DIALOG_WIDTH,
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: theme.palette.background.paper,
+}));
+
+function StaticWrapper(props: StaticWrapperProps) {
+  const { displayStaticWrapperAs, children } = props;
 
   const isStatic = true;
 
   return (
     <IsStaticVariantContext.Provider value={isStatic}>
       <WrapperVariantContext.Provider value={displayStaticWrapperAs}>
-        <div className={classes.root}>{children}</div>
+        <StaticWrapperRoot>{children}</StaticWrapperRoot>
       </WrapperVariantContext.Provider>
     </IsStaticVariantContext.Provider>
   );
 }
 
-export default withStyles(styles, { name: 'MuiPickersStaticWrapper' })(StaticWrapper);
+export default StaticWrapper;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This is an internal component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
