### PR TITLE
[slider] Fix support for non primary colors

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -62,20 +62,19 @@ export const SliderRoot = experimentalStyled(
   position: 'relative',
   cursor: 'pointer',
   touchAction: 'none',
-  color: theme.palette.primary.main,
+  color: theme.palette[styleProps.color].main,
   WebkitTapHighlightColor: 'transparent',
-  ...(styleProps.color === 'secondary' && {
-    color: theme.palette.secondary.main,
-  }),
-  [`&.${sliderClasses.disabled}`]: {
-    pointerEvents: 'none',
-    cursor: 'default',
-    color: theme.palette.grey[400],
-  },
   ...(styleProps.orientation === 'vertical' && {
     width: 2,
     height: '100%',
     padding: '0 13px',
+  }),
+  ...(styleProps.marked && {
+    marginBottom: 20,
+    ...(styleProps.orientation === 'vertical' && {
+      marginBottom: 'auto',
+      marginRight: 20,
+    }),
   }),
   // The primary input mechanism of the device includes a pointing device of limited accuracy.
   '@media (pointer: coarse)': {
@@ -88,13 +87,16 @@ export const SliderRoot = experimentalStyled(
   '@media print': {
     colorAdjust: 'exact',
   },
-  ...(styleProps.marked && {
-    marginBottom: 20,
-    ...(styleProps.orientation === 'vertical' && {
-      marginBottom: 'auto',
-      marginRight: 20,
-    }),
-  }),
+  [`&.${sliderClasses.disabled}`]: {
+    pointerEvents: 'none',
+    cursor: 'default',
+    color: theme.palette.grey[400],
+  },
+  [`&.${sliderClasses.dragging}`]: {
+    [`& .${sliderClasses.thumb}, & .${sliderClasses.track}`]: {
+      transition: 'none',
+    },
+  },
   [`& .${sliderClasses.valueLabelCircle}`]: {
     display: 'flex',
     alignItems: 'center',
@@ -107,16 +109,8 @@ export const SliderRoot = experimentalStyled(
   },
   [`& .${sliderClasses.valueLabelLabel}`]: {
     color: theme.palette[styleProps.color].contrastText,
-    ...(styleProps.color === 'secondary' && {
-      color: theme.palette.secondary.contrastText,
-    }),
     transform: 'rotate(45deg)',
     textAlign: 'center',
-  },
-  [`&.${sliderClasses.dragging}`]: {
-    [`& .${sliderClasses.thumb}, & .${sliderClasses.track}`]: {
-      transition: 'none',
-    },
   },
 }));
 
@@ -168,8 +162,8 @@ export const SliderTrack = experimentalStyled(
     backgroundColor:
       // Same logic as the LinearProgress track color
       theme.palette.mode === 'light'
-        ? lighten(theme.palette.primary.main, 0.62)
-        : darken(theme.palette.primary.main, 0.5),
+        ? lighten(theme.palette[styleProps.color].main, 0.62)
+        : darken(theme.palette[styleProps.color].main, 0.5),
   }),
 }));
 
@@ -203,6 +197,10 @@ export const SliderThumb = experimentalStyled(
   transition: theme.transitions.create(['box-shadow', 'left'], {
     duration: theme.transitions.duration.shortest,
   }),
+  ...(styleProps.orientation === 'vertical' && {
+    marginLeft: -5,
+    marginBottom: -6,
+  }),
   '&::after': {
     position: 'absolute',
     content: '""',
@@ -214,13 +212,13 @@ export const SliderThumb = experimentalStyled(
     bottom: -15,
   },
   [`&:hover, &.${sliderClasses.focusVisible}`]: {
-    boxShadow: `0px 0px 0px 8px ${alpha(theme.palette.primary.main, 0.16)}`,
+    boxShadow: `0px 0px 0px 8px ${alpha(theme.palette[styleProps.color].main, 0.16)}`,
     '@media (hover: none)': {
       boxShadow: 'none',
     },
   },
   [`&.${sliderClasses.active}`]: {
-    boxShadow: `0px 0px 0px 14px ${alpha(theme.palette.primary.main, 0.16)}`,
+    boxShadow: `0px 0px 0px 14px ${alpha(theme.palette[styleProps.color].main, 0.16)}`,
   },
   [`&.${sliderClasses.disabled}`]: {
     width: 8,
@@ -235,18 +233,6 @@ export const SliderThumb = experimentalStyled(
       boxShadow: 'none',
     },
   },
-  ...(styleProps.orientation === 'vertical' && {
-    marginLeft: -5,
-    marginBottom: -6,
-  }),
-  ...(styleProps.color === 'secondary' && {
-    [`&:hover, &.${sliderClasses.focusVisible}`]: {
-      boxShadow: `0px 0px 0px 8px ${alpha(theme.palette.secondary.main, 0.16)}`,
-    },
-    [`&.${sliderClasses.active}`]: {
-      boxShadow: `0px 0px 0px 14px ${alpha(theme.palette.secondary.main, 0.16)}`,
-    },
-  }),
 }));
 
 export const SliderValueLabel = experimentalStyled(
@@ -421,6 +407,12 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
           ...componentsProps.thumb,
           ...(shouldSpreadStyleProps(components.Thumb) && {
             styleProps: { ...componentsProps.thumb?.styleProps, color },
+          }),
+        },
+        track: {
+          ...componentsProps.track,
+          ...(shouldSpreadStyleProps(components.Track) && {
+            styleProps: { ...componentsProps.track?.styleProps, color },
           }),
         },
       }}

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -107,6 +107,9 @@ export const SliderRoot = experimentalStyled(
   },
   [`& .${sliderClasses.valueLabelLabel}`]: {
     color: theme.palette.primary.contrastText,
+    ...(styleProps.color === 'secondary' && {
+      color: theme.palette.secondary.contrastText,
+    }),
     transform: 'rotate(45deg)',
     textAlign: 'center',
   },

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -106,7 +106,7 @@ export const SliderRoot = experimentalStyled(
     transform: 'rotate(-45deg)',
   },
   [`& .${sliderClasses.valueLabelLabel}`]: {
-    color: theme.palette.primary.contrastText,
+    color: theme.palette[styleProps.color].contrastText,
     ...(styleProps.color === 'secondary' && {
       color: theme.palette.secondary.contrastText,
     }),


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR styles a slider value label with the appropriate text color. It addresses 

Closes #26270 

Preview: https://deploy-preview-26285--material-ui.netlify.app/components/slider/