### PR TITLE
[core] Fix NotchedOutlineProps type

### DIFF
--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.d.ts
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.d.ts
@@ -7,6 +7,7 @@ export interface NotchedOutlineProps
   error?: boolean;
   focused?: boolean;
   notched: boolean;
+  label?: React.ReactNode;
 }
 
 export type NotchedOutlineClassKey = keyof NonNullable<NotchedOutlineProps['classes']>;

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.d.ts
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.d.ts
@@ -6,8 +6,8 @@ export interface NotchedOutlineProps
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;
-  notched: boolean;
   label?: React.ReactNode;
+  notched: boolean;
 }
 
 export type NotchedOutlineClassKey = keyof NonNullable<NotchedOutlineProps['classes']>;


### PR DESCRIPTION
If using NotchedOutline as a direct import TypeScript reported compilation error because label was missing from the NotchedOutlineProps types.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
