### PR TITLE
[core] Include human readable target in the browserstack build

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,8 +5,12 @@ const CI = Boolean(process.env.CI);
 
 let build = `material-ui local ${new Date().toISOString()}`;
 
-if (process.env.CIRCLE_BUILD_URL) {
-  build = process.env.CIRCLE_BUILD_URL;
+if (process.env.CIRCLECI) {
+  const buildPrefix =
+    process.env.CIRCLE_PR_NUMBER !== undefined
+      ? `#${process.env.CIRCLE_PR_NUMBER}`
+      : process.env.CIRCLE_BRANCH;
+  build = `${buildPrefix}: ${process.env.CIRCLE_BUILD_URL}`;
 }
 
 const browserStack = {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -8,7 +8,7 @@ let build = `material-ui local ${new Date().toISOString()}`;
 if (process.env.CIRCLECI) {
   const buildPrefix =
     process.env.CIRCLE_PR_NUMBER !== undefined
-      ? `#${process.env.CIRCLE_PR_NUMBER}`
+      ? process.env.CIRCLE_PR_NUMBER
       : process.env.CIRCLE_BRANCH;
   build = `${buildPrefix}: ${process.env.CIRCLE_BUILD_URL}`;
 }


### PR DESCRIPTION
For example, `next:  https://circleci.com/gh/mui-org/material-ui/252223` or `12345: https://circleci.com/gh/mui-org/material-ui/252223`

Prefixing the pr number with `#` does not work: https://github.com/mui-org/material-ui/pull/26322#discussion_r633067960