### PR TITLE
[docs] Simplify demos slider

### DIFF
--- a/docs/src/pages/components/slider/ColorSlider.js
+++ b/docs/src/pages/components/slider/ColorSlider.js
@@ -6,18 +6,14 @@ function valuetext(value) {
   return `${value}°C`;
 }
 
-export default function DiscreteSliderSteps() {
+export default function ColorSlider() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
-        aria-label="Small steps"
-        defaultValue={0.00000005}
+        aria-label="Temperature"
+        defaultValue={30}
         getAriaValueText={valuetext}
-        step={0.00000001}
-        marks
-        min={-0.00000005}
-        max={0.0000001}
-        valueLabelDisplay="auto"
+        color="secondary"
       />
     </Box>
   );

--- a/docs/src/pages/components/slider/ColorSlider.tsx
+++ b/docs/src/pages/components/slider/ColorSlider.tsx
@@ -2,22 +2,18 @@ import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import Slider from '@material-ui/core/Slider';
 
-function valuetext(value) {
+function valuetext(value: number) {
   return `${value}°C`;
 }
 
-export default function DiscreteSliderSteps() {
+export default function ColorSlider() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
-        aria-label="Small steps"
-        defaultValue={0.00000005}
+        aria-label="Temperature"
+        defaultValue={30}
         getAriaValueText={valuetext}
-        step={0.00000001}
-        marks
-        min={-0.00000005}
-        max={0.0000001}
-        valueLabelDisplay="auto"
+        color="secondary"
       />
     </Box>
   );

--- a/docs/src/pages/components/slider/ContinuousSlider.js
+++ b/docs/src/pages/components/slider/ContinuousSlider.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
+import Stack from '@material-ui/core/Stack';
 import Slider from '@material-ui/core/Slider';
 import VolumeDown from '@material-ui/icons/VolumeDown';
 import VolumeUp from '@material-ui/icons/VolumeUp';
@@ -15,28 +14,12 @@ export default function ContinuousSlider() {
 
   return (
     <Box sx={{ width: 200 }}>
-      <Typography id="continuous-slider" gutterBottom>
-        Volume
-      </Typography>
-      <Grid container spacing={2} alignItems="center">
-        <Grid item>
-          <VolumeDown />
-        </Grid>
-        <Grid item xs>
-          <Slider
-            value={value}
-            onChange={handleChange}
-            aria-labelledby="continuous-slider"
-          />
-        </Grid>
-        <Grid item>
-          <VolumeUp />
-        </Grid>
-      </Grid>
-      <Typography id="disabled-slider" gutterBottom>
-        Disabled slider
-      </Typography>
-      <Slider disabled defaultValue={30} aria-labelledby="disabled-slider" />
+      <Stack spacing={2} direction="row" sx={{ mb: 1 }}>
+        <VolumeDown />
+        <Slider aria-label="Volume" value={value} onChange={handleChange} />
+        <VolumeUp />
+      </Stack>
+      <Slider disabled defaultValue={30} aria-label="Disabled slider" />
     </Box>
   );
 }

--- a/docs/src/pages/components/slider/ContinuousSlider.tsx
+++ b/docs/src/pages/components/slider/ContinuousSlider.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
+import Stack from '@material-ui/core/Stack';
 import Slider from '@material-ui/core/Slider';
 import VolumeDown from '@material-ui/icons/VolumeDown';
 import VolumeUp from '@material-ui/icons/VolumeUp';
@@ -15,28 +14,12 @@ export default function ContinuousSlider() {
 
   return (
     <Box sx={{ width: 200 }}>
-      <Typography id="continuous-slider" gutterBottom>
-        Volume
-      </Typography>
-      <Grid container spacing={2} alignItems="center">
-        <Grid item>
-          <VolumeDown />
-        </Grid>
-        <Grid item xs>
-          <Slider
-            value={value}
-            onChange={handleChange}
-            aria-labelledby="continuous-slider"
-          />
-        </Grid>
-        <Grid item>
-          <VolumeUp />
-        </Grid>
-      </Grid>
-      <Typography id="disabled-slider" gutterBottom>
-        Disabled slider
-      </Typography>
-      <Slider disabled defaultValue={30} aria-labelledby="disabled-slider" />
+      <Stack spacing={2} direction="row" sx={{ mb: 1 }}>
+        <VolumeDown />
+        <Slider aria-label="Volume" value={value} onChange={handleChange} />
+        <VolumeUp />
+      </Stack>
+      <Slider disabled defaultValue={30} aria-label="Disabled slider" />
     </Box>
   );
 }

--- a/docs/src/pages/components/slider/DiscreteSlider.js
+++ b/docs/src/pages/components/slider/DiscreteSlider.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value) {
@@ -10,33 +9,17 @@ function valuetext(value) {
 export default function DiscreteSlider() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider" gutterBottom>
-        Temperature
-      </Typography>
       <Slider
+        aria-label="Temperature"
         defaultValue={30}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider"
         valueLabelDisplay="auto"
         step={10}
         marks
         min={10}
         max={110}
       />
-      <Typography id="discrete-slider-disabled" gutterBottom>
-        Disabled
-      </Typography>
-      <Slider
-        defaultValue={30}
-        getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-disabled"
-        valueLabelDisplay="auto"
-        step={10}
-        marks
-        min={10}
-        max={110}
-        disabled
-      />
+      <Slider defaultValue={30} step={10} marks min={10} max={110} disabled />
     </Box>
   );
 }

--- a/docs/src/pages/components/slider/DiscreteSlider.tsx
+++ b/docs/src/pages/components/slider/DiscreteSlider.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value: number) {
@@ -10,33 +9,17 @@ function valuetext(value: number) {
 export default function DiscreteSlider() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider" gutterBottom>
-        Temperature
-      </Typography>
       <Slider
+        aria-label="Temperature"
         defaultValue={30}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider"
         valueLabelDisplay="auto"
         step={10}
         marks
         min={10}
         max={110}
       />
-      <Typography id="discrete-slider-disabled" gutterBottom>
-        Disabled
-      </Typography>
-      <Slider
-        defaultValue={30}
-        getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-disabled"
-        valueLabelDisplay="auto"
-        step={10}
-        marks
-        min={10}
-        max={110}
-        disabled
-      />
+      <Slider defaultValue={30} step={10} marks min={10} max={110} disabled />
     </Box>
   );
 }

--- a/docs/src/pages/components/slider/DiscreteSliderLabel.js
+++ b/docs/src/pages/components/slider/DiscreteSliderLabel.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 const marks = [
@@ -26,16 +25,13 @@ function valuetext(value) {
   return `${value}°C`;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderLabel() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-always" gutterBottom>
-        Always visible
-      </Typography>
       <Slider
+        aria-label="Always visible"
         defaultValue={80}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-always"
         step={10}
         marks={marks}
         valueLabelDisplay="on"

--- a/docs/src/pages/components/slider/DiscreteSliderLabel.tsx
+++ b/docs/src/pages/components/slider/DiscreteSliderLabel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 const marks = [
@@ -26,16 +25,13 @@ function valuetext(value: number) {
   return `${value}°C`;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderLabel() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-always" gutterBottom>
-        Always visible
-      </Typography>
       <Slider
+        aria-label="Always visible"
         defaultValue={80}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-always"
         step={10}
         marks={marks}
         valueLabelDisplay="on"

--- a/docs/src/pages/components/slider/DiscreteSliderMarks.js
+++ b/docs/src/pages/components/slider/DiscreteSliderMarks.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 const marks = [
@@ -26,16 +25,13 @@ function valuetext(value) {
   return `${value}°C`;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderMarks() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-custom" gutterBottom>
-        Custom marks
-      </Typography>
       <Slider
+        aria-label="Custom marks"
         defaultValue={20}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-custom"
         step={10}
         valueLabelDisplay="auto"
         marks={marks}

--- a/docs/src/pages/components/slider/DiscreteSliderMarks.tsx
+++ b/docs/src/pages/components/slider/DiscreteSliderMarks.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 const marks = [
@@ -26,16 +25,13 @@ function valuetext(value: number) {
   return `${value}°C`;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderMarks() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-custom" gutterBottom>
-        Custom marks
-      </Typography>
       <Slider
+        aria-label="Custom marks"
         defaultValue={20}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-custom"
         step={10}
         valueLabelDisplay="auto"
         marks={marks}

--- a/docs/src/pages/components/slider/DiscreteSliderSteps.tsx
+++ b/docs/src/pages/components/slider/DiscreteSliderSteps.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value: number) {
   return `${value}°C`;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderSteps() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-small-steps" gutterBottom>
-        Small steps
-      </Typography>
       <Slider
+        aria-label="Small steps"
         defaultValue={0.00000005}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-small-steps"
         step={0.00000001}
         marks
         min={-0.00000005}

--- a/docs/src/pages/components/slider/DiscreteSliderValues.js
+++ b/docs/src/pages/components/slider/DiscreteSliderValues.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 const marks = [
@@ -30,17 +29,14 @@ function valueLabelFormat(value) {
   return marks.findIndex((mark) => mark.value === value) + 1;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderValues() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-restrict" gutterBottom>
-        Restricted values
-      </Typography>
       <Slider
+        aria-label="Restricted values"
         defaultValue={20}
         valueLabelFormat={valueLabelFormat}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-restrict"
         step={null}
         valueLabelDisplay="auto"
         marks={marks}

--- a/docs/src/pages/components/slider/DiscreteSliderValues.tsx
+++ b/docs/src/pages/components/slider/DiscreteSliderValues.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 const marks = [
@@ -30,17 +29,14 @@ function valueLabelFormat(value: number) {
   return marks.findIndex((mark) => mark.value === value) + 1;
 }
 
-export default function DiscreteSlider() {
+export default function DiscreteSliderValues() {
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="discrete-slider-restrict" gutterBottom>
-        Restricted values
-      </Typography>
       <Slider
+        aria-label="Restricted values"
         defaultValue={20}
         valueLabelFormat={valueLabelFormat}
         getAriaValueText={valuetext}
-        aria-labelledby="discrete-slider-restrict"
         step={null}
         valueLabelDisplay="auto"
         marks={marks}

--- a/docs/src/pages/components/slider/MinimumDistanceSlider.js
+++ b/docs/src/pages/components/slider/MinimumDistanceSlider.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value) {
@@ -46,25 +45,19 @@ export default function MinimumDistanceSlider() {
 
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="minimum-distance-demo" gutterBottom>
-        Minimum distance
-      </Typography>
       <Slider
+        aria-label="Minimum distance"
         value={value1}
         onChange={handleChange1}
         valueLabelDisplay="auto"
-        aria-labelledby="minimum-distance-demo"
         getAriaValueText={valuetext}
         disableSwap
       />
-      <Typography id="minimum-distance-shift-demo" gutterBottom>
-        Minimum distance shift
-      </Typography>
       <Slider
+        aria-label="Minimum distance shift"
         value={value2}
         onChange={handleChange2}
         valueLabelDisplay="auto"
-        aria-labelledby="minimum-distance-shift-demo"
         getAriaValueText={valuetext}
         disableSwap
       />

--- a/docs/src/pages/components/slider/MinimumDistanceSlider.js
+++ b/docs/src/pages/components/slider/MinimumDistanceSlider.js
@@ -46,7 +46,7 @@ export default function MinimumDistanceSlider() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
-        aria-label="Minimum distance"
+        getAriaLabel={() => 'Minimum distance'}
         value={value1}
         onChange={handleChange1}
         valueLabelDisplay="auto"
@@ -54,7 +54,7 @@ export default function MinimumDistanceSlider() {
         disableSwap
       />
       <Slider
-        aria-label="Minimum distance shift"
+        getAriaLabel={() => 'Minimum distance shift'}
         value={value2}
         onChange={handleChange2}
         valueLabelDisplay="auto"

--- a/docs/src/pages/components/slider/MinimumDistanceSlider.tsx
+++ b/docs/src/pages/components/slider/MinimumDistanceSlider.tsx
@@ -54,7 +54,7 @@ export default function MinimumDistanceSlider() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
-        aria-label="Minimum distance"
+        getAriaLabel={() => 'Minimum distance'}
         value={value1}
         onChange={handleChange1}
         valueLabelDisplay="auto"
@@ -62,7 +62,7 @@ export default function MinimumDistanceSlider() {
         disableSwap
       />
       <Slider
-        aria-label="Minimum distance shift"
+        getAriaLabel={() => 'Minimum distance shift'}
         value={value2}
         onChange={handleChange2}
         valueLabelDisplay="auto"

--- a/docs/src/pages/components/slider/MinimumDistanceSlider.tsx
+++ b/docs/src/pages/components/slider/MinimumDistanceSlider.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value: number) {
@@ -54,25 +53,19 @@ export default function MinimumDistanceSlider() {
 
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="minimum-distance-demo" gutterBottom>
-        Minimum distance
-      </Typography>
       <Slider
+        aria-label="Minimum distance"
         value={value1}
         onChange={handleChange1}
         valueLabelDisplay="auto"
-        aria-labelledby="minimum-distance-demo"
         getAriaValueText={valuetext}
         disableSwap
       />
-      <Typography id="minimum-distance-shift-demo" gutterBottom>
-        Minimum distance shift
-      </Typography>
       <Slider
+        aria-label="Minimum distance shift"
         value={value2}
         onChange={handleChange2}
         valueLabelDisplay="auto"
-        aria-labelledby="minimum-distance-shift-demo"
         getAriaValueText={valuetext}
         disableSwap
       />

--- a/docs/src/pages/components/slider/RangeSlider.js
+++ b/docs/src/pages/components/slider/RangeSlider.js
@@ -16,7 +16,7 @@ export default function RangeSlider() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
-        aria-label="Temperature range"
+        getAriaLabel={() => 'Temperature range'}
         value={value}
         onChange={handleChange}
         valueLabelDisplay="auto"

--- a/docs/src/pages/components/slider/RangeSlider.js
+++ b/docs/src/pages/components/slider/RangeSlider.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value) {
@@ -16,14 +15,11 @@ export default function RangeSlider() {
 
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="range-slider-demo" gutterBottom>
-        Temperature range
-      </Typography>
       <Slider
+        aria-label="Temperature range"
         value={value}
         onChange={handleChange}
         valueLabelDisplay="auto"
-        aria-labelledby="range-slider-demo"
         getAriaValueText={valuetext}
       />
     </Box>

--- a/docs/src/pages/components/slider/RangeSlider.tsx
+++ b/docs/src/pages/components/slider/RangeSlider.tsx
@@ -16,7 +16,7 @@ export default function RangeSlider() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
-        aria-label="Temperature range"
+        getAriaLabel={() => 'Temperature range'}
         value={value}
         onChange={handleChange}
         valueLabelDisplay="auto"

--- a/docs/src/pages/components/slider/RangeSlider.tsx
+++ b/docs/src/pages/components/slider/RangeSlider.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value: number) {
@@ -16,14 +15,11 @@ export default function RangeSlider() {
 
   return (
     <Box sx={{ width: 300 }}>
-      <Typography id="range-slider-demo" gutterBottom>
-        Temperature range
-      </Typography>
       <Slider
+        aria-label="Temperature range"
         value={value}
         onChange={handleChange}
         valueLabelDisplay="auto"
-        aria-labelledby="range-slider-demo"
         getAriaValueText={valuetext}
       />
     </Box>

--- a/docs/src/pages/components/slider/UnstyledSlider.js
+++ b/docs/src/pages/components/slider/UnstyledSlider.js
@@ -3,9 +3,10 @@ import { experimentalStyled as styled, alpha } from '@material-ui/core/styles';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
 import Box from '@material-ui/core/Box';
 
-const StyledSlider = styled(SliderUnstyled)`
-  color: black;
-  height: 2px;
+const StyledSlider = styled(SliderUnstyled)(
+  ({ theme }) => `
+  color: ${theme.palette.primary.main};
+  height: 4px;
   width: 100%;
   padding: 13px 0;
   display: inline-block;
@@ -13,13 +14,17 @@ const StyledSlider = styled(SliderUnstyled)`
   cursor: pointer;
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
+  opacity: 0.75;
+  &:hover {
+    opacity: 1;
+  }
 
   & .MuiSlider-rail {
     display: block;
     position: absolute;
     width: 100%;
-    height: 2px;
-    border-radius: 1px;
+    height: 4px;
+    border-radius: 2px;
     background-color: currentColor;
     opacity: 0.38;
   }
@@ -27,46 +32,34 @@ const StyledSlider = styled(SliderUnstyled)`
   & .MuiSlider-track {
     display: block;
     position: absolute;
-    height: 2px;
-    border-radius: 1px;
+    height: 4px;
+    border-radius: 2px;
     background-color: currentColor;
   }
 
   & .MuiSlider-thumb {
     position: absolute;
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
     margin-left: -6px;
     margin-top: -5px;
     box-sizing: border-box;
     border-radius: 50%;
     outline: 0;
-    background-color: currentColor;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-
-    &::after {
-      position: absolute;
-      content: '';
-      border-radius: 50%;
-      left: -15px;
-      top: -15px;
-      right: -15px;
-      bottom: -15px;
-    }
+    border: 2px solid currentColor;
+    background-color: ${theme.palette.getContrastText(theme.palette.primary.main)};
 
     :hover,
     &.Mui-focusVisible {
-      box-shadow: 0 0 0 8px ${alpha('#000', 0.16)};
+      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.15)};
     }
 
     &.Mui-active {
-      box-shadow: 0 0 0 14px ${alpha('#000', 0.16)};
+      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.3)};
     }
   }
-`;
+`,
+);
 
 export default function UnstyledSlider() {
   return (

--- a/docs/src/pages/components/slider/UnstyledSlider.tsx
+++ b/docs/src/pages/components/slider/UnstyledSlider.tsx
@@ -3,9 +3,10 @@ import { experimentalStyled as styled, alpha } from '@material-ui/core/styles';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
 import Box from '@material-ui/core/Box';
 
-const StyledSlider = styled(SliderUnstyled)`
-  color: black;
-  height: 2px;
+const StyledSlider = styled(SliderUnstyled)(
+  ({ theme }) => `
+  color: ${theme.palette.primary.main};
+  height: 4px;
   width: 100%;
   padding: 13px 0;
   display: inline-block;
@@ -13,13 +14,17 @@ const StyledSlider = styled(SliderUnstyled)`
   cursor: pointer;
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
+  opacity: 0.75;
+  &:hover {
+    opacity: 1;
+  }
 
   & .MuiSlider-rail {
     display: block;
     position: absolute;
     width: 100%;
-    height: 2px;
-    border-radius: 1px;
+    height: 4px;
+    border-radius: 2px;
     background-color: currentColor;
     opacity: 0.38;
   }
@@ -27,46 +32,34 @@ const StyledSlider = styled(SliderUnstyled)`
   & .MuiSlider-track {
     display: block;
     position: absolute;
-    height: 2px;
-    border-radius: 1px;
+    height: 4px;
+    border-radius: 2px;
     background-color: currentColor;
   }
 
   & .MuiSlider-thumb {
     position: absolute;
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
     margin-left: -6px;
     margin-top: -5px;
     box-sizing: border-box;
     border-radius: 50%;
     outline: 0;
-    background-color: currentColor;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-
-    &::after {
-      position: absolute;
-      content: '';
-      border-radius: 50%;
-      left: -15px;
-      top: -15px;
-      right: -15px;
-      bottom: -15px;
-    }
+    border: 2px solid currentColor;
+    background-color: ${theme.palette.getContrastText(theme.palette.primary.main)};
 
     :hover,
     &.Mui-focusVisible {
-      box-shadow: 0 0 0 8px ${alpha('#000', 0.16)};
+      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.15)};
     }
 
     &.Mui-active {
-      box-shadow: 0 0 0 14px ${alpha('#000', 0.16)};
+      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.3)};
     }
   }
-`;
+`,
+);
 
 export default function UnstyledSlider() {
   return (

--- a/docs/src/pages/components/slider/VerticalAccessibleSlider.js
+++ b/docs/src/pages/components/slider/VerticalAccessibleSlider.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 export default function VerticalSlider() {
@@ -11,23 +10,18 @@ export default function VerticalSlider() {
   }
 
   return (
-    <React.Fragment>
-      <Typography id="vertical-accessible-slider" gutterBottom>
-        Temperature
-      </Typography>
-      <Box sx={{ height: 300 }}>
-        <Slider
-          sx={{
-            '& input[type="range"]': {
-              WebkitAppearance: 'slider-vertical',
-            },
-          }}
-          orientation="vertical"
-          defaultValue={30}
-          aria-labelledby="vertical-accessible-slider"
-          onKeyDown={preventHorizontalKeyboardNavigation}
-        />
-      </Box>
-    </React.Fragment>
+    <Box sx={{ height: 300 }}>
+      <Slider
+        sx={{
+          '& input[type="range"]': {
+            WebkitAppearance: 'slider-vertical',
+          },
+        }}
+        orientation="vertical"
+        defaultValue={30}
+        aria-label="Temperature"
+        onKeyDown={preventHorizontalKeyboardNavigation}
+      />
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider/VerticalAccessibleSlider.tsx
+++ b/docs/src/pages/components/slider/VerticalAccessibleSlider.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 export default function VerticalSlider() {
@@ -11,23 +10,18 @@ export default function VerticalSlider() {
   }
 
   return (
-    <React.Fragment>
-      <Typography id="vertical-accessible-slider" gutterBottom>
-        Temperature
-      </Typography>
-      <Box sx={{ height: 300 }}>
-        <Slider
-          sx={{
-            '& input[type="range"]': {
-              WebkitAppearance: 'slider-vertical',
-            },
-          }}
-          orientation="vertical"
-          defaultValue={30}
-          aria-labelledby="vertical-accessible-slider"
-          onKeyDown={preventHorizontalKeyboardNavigation}
-        />
-      </Box>
-    </React.Fragment>
+    <Box sx={{ height: 300 }}>
+      <Slider
+        sx={{
+          '& input[type="range"]': {
+            WebkitAppearance: 'slider-vertical',
+          },
+        }}
+        orientation="vertical"
+        defaultValue={30}
+        aria-label="Temperature"
+        onKeyDown={preventHorizontalKeyboardNavigation}
+      />
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider/VerticalSlider.js
+++ b/docs/src/pages/components/slider/VerticalSlider.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value) {
@@ -28,32 +27,26 @@ const marks = [
 
 export default function VerticalSlider() {
   return (
-    <React.Fragment>
-      <Typography id="vertical-slider" gutterBottom>
-        Temperature
-      </Typography>
-      <Box sx={{ height: 300 }}>
-        <Slider
-          orientation="vertical"
-          getAriaValueText={valuetext}
-          defaultValue={30}
-          aria-labelledby="vertical-slider"
-        />
-        <Slider
-          disabled
-          orientation="vertical"
-          getAriaValueText={valuetext}
-          defaultValue={30}
-          aria-labelledby="vertical-slider"
-        />
-        <Slider
-          orientation="vertical"
-          defaultValue={[20, 37]}
-          aria-labelledby="vertical-slider"
-          getAriaValueText={valuetext}
-          marks={marks}
-        />
-      </Box>
-    </React.Fragment>
+    <Box sx={{ height: 300 }}>
+      <Slider
+        aria-label="Temperature"
+        orientation="vertical"
+        getAriaValueText={valuetext}
+        defaultValue={30}
+      />
+      <Slider
+        aria-label="Temperature"
+        orientation="vertical"
+        defaultValue={30}
+        disabled
+      />
+      <Slider
+        aria-label="Temperature"
+        orientation="vertical"
+        getAriaValueText={valuetext}
+        defaultValue={[20, 37]}
+        marks={marks}
+      />
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider/VerticalSlider.js
+++ b/docs/src/pages/components/slider/VerticalSlider.js
@@ -41,7 +41,7 @@ export default function VerticalSlider() {
         disabled
       />
       <Slider
-        aria-label="Temperature"
+        getAriaLabel={() => 'Temperature'}
         orientation="vertical"
         getAriaValueText={valuetext}
         defaultValue={[20, 37]}

--- a/docs/src/pages/components/slider/VerticalSlider.tsx
+++ b/docs/src/pages/components/slider/VerticalSlider.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
 
 function valuetext(value: number) {
@@ -28,32 +27,26 @@ const marks = [
 
 export default function VerticalSlider() {
   return (
-    <React.Fragment>
-      <Typography id="vertical-slider" gutterBottom>
-        Temperature
-      </Typography>
-      <Box sx={{ height: 300 }}>
-        <Slider
-          orientation="vertical"
-          getAriaValueText={valuetext}
-          defaultValue={30}
-          aria-labelledby="vertical-slider"
-        />
-        <Slider
-          disabled
-          orientation="vertical"
-          getAriaValueText={valuetext}
-          defaultValue={30}
-          aria-labelledby="vertical-slider"
-        />
-        <Slider
-          orientation="vertical"
-          defaultValue={[20, 37]}
-          aria-labelledby="vertical-slider"
-          getAriaValueText={valuetext}
-          marks={marks}
-        />
-      </Box>
-    </React.Fragment>
+    <Box sx={{ height: 300 }}>
+      <Slider
+        aria-label="Temperature"
+        orientation="vertical"
+        getAriaValueText={valuetext}
+        defaultValue={30}
+      />
+      <Slider
+        aria-label="Temperature"
+        orientation="vertical"
+        defaultValue={30}
+        disabled
+      />
+      <Slider
+        aria-label="Temperature"
+        orientation="vertical"
+        getAriaValueText={valuetext}
+        defaultValue={[20, 37]}
+        marks={marks}
+      />
+    </Box>
   );
 }

--- a/docs/src/pages/components/slider/VerticalSlider.tsx
+++ b/docs/src/pages/components/slider/VerticalSlider.tsx
@@ -41,7 +41,7 @@ export default function VerticalSlider() {
         disabled
       />
       <Slider
-        aria-label="Temperature"
+        getAriaLabel={() => 'Temperature'}
         orientation="vertical"
         getAriaValueText={valuetext}
         defaultValue={[20, 37]}

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -25,8 +25,6 @@ Continuous sliders allow users to select a value along a subjective range.
 ## Discrete sliders
 
 Discrete sliders can be adjusted to a specific value by referencing its value indicator.
-By order of demos:
-
 You can generate a mark for each step with `marks={true}`.
 
 {{"demo": "pages/components/slider/DiscreteSlider.js"}}
@@ -74,6 +72,10 @@ If you want the range to shift when reaching minimum distance, you can utilize t
 In this example, an input allows a discrete value to be set.
 
 {{"demo": "pages/components/slider/InputSlider.js"}}
+
+## Color
+
+{{"demo": "pages/components/slider/ColorSlider.js"}}
 
 ## Customized sliders
 


### PR DESCRIPTION
A follow-up on #26285

- Shorten the demo and remove distractions
- Add color demo
- Update the unstyled demo to match Ant Design / Fluent UI pattern.

Preview https://deploy-preview-26324--material-ui.netlify.app/components/slider/ 