### PR TITLE
[Container] Fix support for custom breakpoints

### DIFF
--- a/docs/pages/api-docs/container.json
+++ b/docs/pages/api-docs/container.json
@@ -7,7 +7,7 @@
     "maxWidth": {
       "type": {
         "name": "union",
-        "description": "'lg'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;'xs'<br>&#124;&nbsp;false<br>&#124;&nbsp;string"
+        "description": "'xs'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'lg'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;false<br>&#124;&nbsp;string"
       },
       "default": "'lg'"
     },

--- a/docs/pages/api-docs/container.json
+++ b/docs/pages/api-docs/container.json
@@ -6,8 +6,8 @@
     "fixed": { "type": { "name": "bool" } },
     "maxWidth": {
       "type": {
-        "name": "enum",
-        "description": "'lg'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;'xs'<br>&#124;&nbsp;false"
+        "name": "union",
+        "description": "'lg'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;'xs'<br>&#124;&nbsp;false<br>&#124;&nbsp;string"
       },
       "default": "'lg'"
     },

--- a/packages/material-ui/src/Container/Container.d.ts
+++ b/packages/material-ui/src/Container/Container.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { SxProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { Breakpoints } from '../styles/createBreakpoints';
 import { ContainerClasses } from './containerClasses';
 
 export interface ContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
@@ -30,7 +31,7 @@ export interface ContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * Set to `false` to disable `maxWidth`.
      * @default 'lg'
      */
-    maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
+    maxWidth?: Breakpoints | false;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Container/Container.d.ts
+++ b/packages/material-ui/src/Container/Container.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SxProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
-import { Breakpoints } from '../styles/createBreakpoints';
+import { Breakpoint } from '../styles/createBreakpoints';
 import { ContainerClasses } from './containerClasses';
 
 export interface ContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
@@ -31,7 +31,7 @@ export interface ContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * Set to `false` to disable `maxWidth`.
      * @default 'lg'
      */
-    maxWidth?: Breakpoints | false;
+    maxWidth?: Breakpoint | false;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -155,7 +155,10 @@ Container.propTypes /* remove-proptypes */ = {
    * Set to `false` to disable `maxWidth`.
    * @default 'lg'
    */
-  maxWidth: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs', false]),
+  maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOf([
+    'lg', 'md', 'sm', 'xl', 'xs',
+    false
+  ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -156,8 +156,12 @@ Container.propTypes /* remove-proptypes */ = {
    * @default 'lg'
    */
   maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOf([
-    'lg', 'md', 'sm', 'xl', 'xs',
-    false
+    'lg',
+    'md',
+    'sm',
+    'xl',
+    'xs',
+    false,
   ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -156,7 +156,7 @@ Container.propTypes /* remove-proptypes */ = {
    * @default 'lg'
    */
   maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']),
+    PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs', false]),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -156,7 +156,7 @@ Container.propTypes /* remove-proptypes */ = {
    * @default 'lg'
    */
   maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs', false]),
+    PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -155,13 +155,9 @@ Container.propTypes /* remove-proptypes */ = {
    * Set to `false` to disable `maxWidth`.
    * @default 'lg'
    */
-  maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOf([
-    'lg',
-    'md',
-    'sm',
-    'xl',
-    'xs',
-    false,
+  maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs']),
+    PropTypes.string,
   ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.tsx
@@ -1,4 +1,6 @@
-import { createTheme } from '@material-ui/core/styles';
+import * as React from 'react';
+import Container from '@material-ui/core/Container';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
 // testing docs/src/pages/customization/breakpoints/breakpoints.md
 
@@ -16,7 +18,7 @@ declare module '@material-ui/core/styles' {
   }
 }
 
-createTheme({
+const theme = createTheme({
   breakpoints: {
     values: {
       mobile: 0,
@@ -25,4 +27,20 @@ createTheme({
       desktop: 1280,
     },
   },
+  components: {
+    MuiContainer: {
+      defaultProps: {
+        maxWidth: 'laptop',
+      },
+    },
+  },
 });
+
+function MyContainer() {
+  return (
+    <ThemeProvider theme={theme}>
+      hello
+      <Container maxWidth="tablet">yooo</Container>
+    </ThemeProvider>
+  );
+}

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.tsconfig.json
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../../../../tsconfig",
-  "files": ["breakpointsOverrides.spec.ts"]
+  "files": ["breakpointsOverrides.spec.tsx"]
 }


### PR DESCRIPTION
With this PR I'm fixing the Container component when you define custom breakpoints.

Used the patch code by @oliviertassinari in this fix #21745

Also, run tests & try it in my own project. Everything working 💯 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
