### PR TITLE
[Dialog] Fix support for custom breakpoints

### DIFF
--- a/docs/pages/api-docs/dialog.json
+++ b/docs/pages/api-docs/dialog.json
@@ -11,8 +11,8 @@
     "fullWidth": { "type": { "name": "bool" } },
     "maxWidth": {
       "type": {
-        "name": "enum",
-        "description": "'lg'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;'xs'<br>&#124;&nbsp;false"
+        "name": "union",
+        "description": "'xs'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'lg'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;false<br>&#124;&nbsp;string"
       },
       "default": "'sm'"
     },

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -5,6 +5,7 @@ import { PaperProps } from '../Paper';
 import { ModalProps } from '../Modal';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
 import { DialogClasses } from './dialogClasses';
+import { Breakpoint } from '../styles/createBreakpoints';
 
 export interface DialogProps
   extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, 'children'> {
@@ -47,7 +48,7 @@ export interface DialogProps
    * Set to `false` to disable `maxWidth`.
    * @default 'sm'
    */
-  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
+  maxWidth?: Breakpoint | false;
   /**
    * Callback fired when the backdrop is clicked.
    */

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -347,7 +347,10 @@ Dialog.propTypes /* remove-proptypes */ = {
    * Set to `false` to disable `maxWidth`.
    * @default 'sm'
    */
-  maxWidth: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs', false]),
+  maxWidth: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
+    PropTypes.string,
+  ]),
   /**
    * Callback fired when the backdrop is clicked.
    */

--- a/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.tsx
+++ b/packages/material-ui/test/typescript/moduleAugmentation/breakpointsOverrides.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Container from '@material-ui/core/Container';
+import Dialog from '@material-ui/core/Dialog';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
 // testing docs/src/pages/customization/breakpoints/breakpoints.md
@@ -41,6 +42,9 @@ function MyContainer() {
     <ThemeProvider theme={theme}>
       hello
       <Container maxWidth="tablet">yooo</Container>
+      <Dialog open maxWidth="tablet">
+        <div />
+      </Dialog>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Update Dialog typings to accept custom breakpoints on `maxWidth` by using `Breakpoint` utility.

Tests run with `yarn test` and `yarn proptypes`

Closes #26330 