### PR TITLE
[docs] Persist copied state indefinitely or until the user moves their cursor

### DIFF
--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -241,13 +241,13 @@ const DialogDetails = React.memo(function DialogDetails(props) {
 
   const handleClick = (tooltip) => async (event) => {
     await copy(event.currentTarget.textContent);
-    const setOpen = tooltip === 1 ? setCopied1 : setCopied2;
+    const setCopied = tooltip === 1 ? setCopied1 : setCopied2;
     const timeout = tooltip === 1 ? timeout1 : timeout2;
 
-    setOpen(true);
+    setCopied(true);
     clearTimeout(timeout.current);
     timeout.current = setTimeout(() => {
-      setOpen(false);
+      setCopied(false);
     }, 2000);
   };
 

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -30,7 +30,7 @@ import synonyms from './synonyms';
 if (process.env.NODE_ENV !== 'production') {
   Object.keys(synonyms).forEach((icon) => {
     if (!mui[icon]) {
-      throw new Error(`The icon ${icon} no longer exists.`);
+      console.warn(`The icon ${icon} no longer exists. Remove it from \`synonyms\``);
     }
   });
 }

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -96,7 +96,7 @@ function selectNode(node) {
   selection.addRange(range);
 }
 
-let Icons = (props) => {
+const Icons = React.memo(function Icons(props) {
   const { icons, classes, handleOpenClick } = props;
 
   const handleIconClick = (icon) => () => {
@@ -144,14 +144,13 @@ let Icons = (props) => {
       })}
     </div>
   );
-};
+});
 
 Icons.propTypes = {
   classes: PropTypes.object.isRequired,
   handleOpenClick: PropTypes.func.isRequired,
   icons: PropTypes.array.isRequired,
 };
-Icons = React.memo(Icons);
 
 const useDialogStyles = makeStyles(
   (theme) => ({
@@ -230,7 +229,7 @@ const useDialogStyles = makeStyles(
   { defaultTheme },
 );
 
-let DialogDetails = (props) => {
+const DialogDetails = React.memo(function DialogDetails(props) {
   const classes = useDialogStyles();
   const { open, selectedIcon, handleClose } = props;
 
@@ -380,14 +379,13 @@ let DialogDetails = (props) => {
       )}
     </Dialog>
   );
-};
+});
 
 DialogDetails.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
   selectedIcon: PropTypes.object,
 };
-DialogDetails = React.memo(DialogDetails);
 
 const useStyles = makeStyles(
   (theme) => ({

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -492,21 +492,9 @@ export default function SearchIcons() {
     setOpen(false);
   }, []);
 
-  const isMounted = React.useRef(false);
-  React.useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-
   const handleChange = React.useMemo(
     () =>
       debounce((value) => {
-        if (!isMounted.current) {
-          return;
-        }
-
         if (value === '') {
           setKeys(null);
         } else {
@@ -527,6 +515,12 @@ export default function SearchIcons() {
       }, 220),
     [],
   );
+
+  React.useEffect(() => {
+    return () => {
+      handleChange.cancel();
+    };
+  }, [handleChange]);
 
   const icons = React.useMemo(
     () =>

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -240,19 +240,15 @@ const DialogDetails = React.memo(function DialogDetails(props) {
   const timeout2 = React.useRef();
 
   const handleClick = (tooltip) => async (event) => {
-    try {
-      await copy(event.currentTarget.textContent);
-      const setOpen = tooltip === 1 ? setCopied1 : setCopied2;
-      const timeout = tooltip === 1 ? timeout1 : timeout2;
+    await copy(event.currentTarget.textContent);
+    const setOpen = tooltip === 1 ? setCopied1 : setCopied2;
+    const timeout = tooltip === 1 ? timeout1 : timeout2;
 
-      setOpen(true);
-      clearTimeout(timeout.current);
-      timeout.current = setTimeout(() => {
-        setOpen(false);
-      }, 2000);
-    } finally {
-      // Ok
-    }
+    setOpen(true);
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
+      setOpen(false);
+    }, 2000);
   };
 
   React.useEffect(() => {

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -235,30 +235,14 @@ const DialogDetails = React.memo(function DialogDetails(props) {
 
   const t = useTranslate();
   const [copied1, setCopied1] = React.useState(false);
-  const timeout1 = React.useRef();
   const [copied2, setCopied2] = React.useState(false);
-  const timeout2 = React.useRef();
 
   const handleClick = (tooltip) => async (event) => {
     await copy(event.currentTarget.textContent);
     const setCopied = tooltip === 1 ? setCopied1 : setCopied2;
-    const timeout = tooltip === 1 ? timeout1 : timeout2;
 
     setCopied(true);
-    clearTimeout(timeout.current);
-    timeout.current = setTimeout(() => {
-      setCopied(false);
-    }, 2000);
   };
-
-  React.useEffect(() => {
-    return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      clearTimeout(timeout1.current);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      clearTimeout(timeout2.current);
-    };
-  }, []);
 
   return (
     <Dialog
@@ -274,6 +258,9 @@ const DialogDetails = React.memo(function DialogDetails(props) {
             <Tooltip
               placement="right"
               title={copied1 ? t('copied') : t('clickToCopy')}
+              TransitionProps={{
+                onExited: () => setCopied1(false),
+              }}
             >
               <Typography
                 component="h2"
@@ -286,7 +273,11 @@ const DialogDetails = React.memo(function DialogDetails(props) {
               </Typography>
             </Tooltip>
           </DialogTitle>
-          <Tooltip placement="top" title={copied2 ? t('copied') : t('clickToCopy')}>
+          <Tooltip
+            placement="top"
+            title={copied2 ? t('copied') : t('clickToCopy')}
+            TransitionProps={{ onExited: () => setCopied2(false) }}
+          >
             <HighlightedCode
               className={classes.markdown}
               onClick={handleClick(2)}

--- a/docs/src/pages/components/material-icons/synonyms.js
+++ b/docs/src/pages/components/material-icons/synonyms.js
@@ -213,7 +213,6 @@ const synonyms = {
   Duo: 'call chat conference device video',
   Dvr: 'laptop monitor',
   DynamicFeed: 'live refresh update',
-  Eco: 'environment green leaf',
   EditLocation: 'gps map pin write',
   Eject: 'arrow player remove triangle up',
   Elderly: 'old',


### PR DESCRIPTION
Preview: https://deploy-preview-26336--material-ui.netlify.app/components/material-icons/

The timeout always felt weird since the copied state doesn't actually change after N seconds. I feel like capturing the user intention by clearing when the cursor moves (i.e. the tooltip disappears) is the better UX here.

Included a bunch of refactorings to the page that stood out to me. Only b524eeafd0cc8d3943acdd75d9b8ba31b559885d changes user observable behavior. Review by commit is advised.