### PR TITLE
[core] Remove `@material-ui/styles` dependencies from declaration files too

### DIFF
--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -49,12 +49,6 @@ export {
 } from './withStyles';
 export { default as experimentalStyled, CreateMUIStyled, CSSObject } from './experimentalStyled';
 export { default as ThemeProvider } from './ThemeProvider';
-export {
-  createGenerateClassName,
-  jssPreset,
-  ServerStyleSheets,
-  StylesProvider,
-} from '@material-ui/styles';
 export { ComponentsProps } from './props';
 export { ComponentsVariants } from './variants';
 export { ComponentsOverrides } from './overrides';


### PR DESCRIPTION
Leftover from https://github.com/mui-org/material-ui/pull/26100