### PR TITLE
[core] Leverage CircleCI workspaces for jobs after checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,15 @@ jobs:
       - persist_to_workspace:
           root: /tmp/
           paths:
+            # sync with `workspaces` in workroot package.json
             - './material-ui/node_modules'
+            - './material-ui/benchmark/node_modules'
+            - './material-ui/packages/*/node_modules'
+            - './material-ui/docs/node_modules'
+            - './material-ui/docs/packages/*/node_modules'
+            - './material-ui/framer/node_modules'
+            - './material-ui/test/node_modules'
+            # Keep path in sync with "PLAYWRIGHT_BROWSERS_PATH"
             - './pw-browsers'
 
   test_unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp/
           paths:
-            - './material-ui/**/node_modules'
+            - './material-ui/node_modules'
             - './pw-browsers'
 
   test_unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - install_js
+      - install_js:
+          browsers: true
       - when:
           # Install can be "dirty" when running with non-default versions of React
           condition:
@@ -126,11 +127,18 @@ jobs:
             - run:
                 name: Check for duplicated packages
                 command: yarn deduplicate
+      - persist_to_workspace:
+          root: /tmp/
+          paths:
+            - './material-ui/**/node_modules'
+            - './pw-browsers'
+
   test_unit:
     <<: *defaults
     steps:
       - checkout
-      - install_js
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: Tests fake browser
           command: yarn test:coverage:ci
@@ -179,7 +187,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - install_js
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: Eslint
           command: yarn lint:ci
@@ -193,7 +202,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - install_js
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: '`yarn prettier` changes committed?'
           command: yarn prettier check-changed
@@ -230,7 +240,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - install_js
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: Transpile TypeScript demos
           command: yarn docs:typescript:formatted
@@ -327,8 +338,8 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js:
-          browsers: true
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: Tests real browsers
           command: yarn test:karma
@@ -344,8 +355,8 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js:
-          browsers: true
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: yarn test:e2e
           command: yarn test:e2e
@@ -390,8 +401,8 @@ jobs:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js:
-          browsers: true
+      - attach_workspace:
+          at: /tmp/
       - run:
           name: Run visual regression tests
           command: xvfb-run yarn test:regressions


### PR DESCRIPTION
Instead of cache+yarn we now persist and attach the whole workspace.

On a normal run this has no effect (persisting 50s + attaching 10s vs cache+yarn 60s). However, failures  due to flakyness are going to be a lot faster since they only have to attach the workspace. So on these "restart from failed" runs we save 50s.

Will try this out starting next week if accepted and see how this affects CI perf. 