### PR TITLE
[ClockPicker] Rework keyboard implementation

### DIFF
--- a/docs/pages/api-docs/clock-picker.json
+++ b/docs/pages/api-docs/clock-picker.json
@@ -2,9 +2,9 @@
   "props": {
     "date": { "type": { "name": "any" }, "required": true },
     "onChange": { "type": { "name": "func" }, "required": true },
-    "allowKeyboardControl": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "components": {
       "type": {
         "name": "shape",
@@ -15,7 +15,7 @@
     "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getHoursClockNumberText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -40,7 +40,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -32,7 +32,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/desktop-time-picker.json
+++ b/docs/pages/api-docs/desktop-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowKeyboardControl": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
@@ -20,7 +19,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -36,7 +36,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/mobile-time-picker.json
+++ b/docs/pages/api-docs/mobile-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowKeyboardControl": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "cancelText": { "type": { "name": "node" }, "default": "\"CANCEL\"" },
@@ -24,7 +23,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -36,7 +36,7 @@
     },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/static-time-picker.json
+++ b/docs/pages/api-docs/static-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowKeyboardControl": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
@@ -24,7 +23,7 @@
     },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/time-picker.json
+++ b/docs/pages/api-docs/time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowKeyboardControl": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "cancelText": { "type": { "name": "node" }, "default": "\"CANCEL\"" },
@@ -28,7 +27,7 @@
     "disableOpenPicker": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },
-      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate,\n  adapter: MuiPickersAdapter<TDate>,\n) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`"
+      "default": "<TDate extends any>(\n  view: ClockView,\n  time: TDate | null,\n  adapter: MuiPickersAdapter<TDate>,\n) =>\n  `Select ${view}. ${\n    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`\n  }`"
     },
     "getOpenDialogAriaText": {
       "type": { "name": "func" },

--- a/docs/src/pages/components/time-picker/SubComponentsTimePickers.js
+++ b/docs/src/pages/components/time-picker/SubComponentsTimePickers.js
@@ -8,11 +8,7 @@ export default function SubComponentsTimePickers() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <ClockPicker
-        allowKeyboardControl={false}
-        date={date}
-        onChange={(newDate) => setDate(newDate)}
-      />
+      <ClockPicker date={date} onChange={(newDate) => setDate(newDate)} />
     </LocalizationProvider>
   );
 }

--- a/docs/src/pages/components/time-picker/SubComponentsTimePickers.tsx
+++ b/docs/src/pages/components/time-picker/SubComponentsTimePickers.tsx
@@ -8,11 +8,7 @@ export default function SubComponentsTimePickers() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <ClockPicker
-        allowKeyboardControl={false}
-        date={date}
-        onChange={(newDate) => setDate(newDate)}
-      />
+      <ClockPicker date={date} onChange={(newDate) => setDate(newDate)} />
     </LocalizationProvider>
   );
 }

--- a/docs/translations/api-docs/clock-picker/clock-picker.json
+++ b/docs/translations/api-docs/clock-picker/clock-picker.json
@@ -1,9 +1,9 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "Set to <code>true</code> if focus should be moved to clock picker.",
     "components": "The components used for each slot. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "date": "Selected date @DateIOType.",

--- a/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
+++ b/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/mobile-time-picker/mobile-time-picker.json
+++ b/docs/translations/api-docs/mobile-time-picker/mobile-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/static-time-picker/static-time-picker.json
+++ b/docs/translations/api-docs/static-time-picker/static-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/time-picker/time-picker.json
+++ b/docs/translations/api-docs/time-picker/time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowKeyboardControl": "Enables keyboard listener for moving between days in calendar. Defaults to <code>true</code> unless the <code>ClockPicker</code> is used inside a <code>Static*</code> picker component.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -140,14 +140,14 @@ function Clock<TDate>(props: ClockProps<TDate>) {
     onChange(newValue, isFinish);
   };
 
-  const setTime = (event: any, isFinish: PickerSelectionState) => {
-    let { offsetX, offsetY } = event;
+  const setTime = (event: MouseEvent | React.TouchEvent, isFinish: PickerSelectionState) => {
+    let { offsetX, offsetY } = event as MouseEvent;
 
-    if (typeof offsetX === 'undefined') {
-      const rect = event.target.getBoundingClientRect();
+    if (offsetX === undefined) {
+      const rect = ((event as React.TouchEvent).target as HTMLElement).getBoundingClientRect();
 
-      offsetX = event.changedTouches[0].clientX - rect.left;
-      offsetY = event.changedTouches[0].clientY - rect.top;
+      offsetX = (event as React.TouchEvent).changedTouches[0].clientX - rect.left;
+      offsetY = (event as React.TouchEvent).changedTouches[0].clientY - rect.top;
     }
 
     const newSelectedValue =
@@ -171,14 +171,8 @@ function Clock<TDate>(props: ClockProps<TDate>) {
   };
 
   const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    // MouseEvent.which is deprecated, but MouseEvent.buttons is not supported in Safari
-    const isButtonPressed =
-      // tslint:disable-next-line deprecation
-      typeof event.buttons === 'undefined' ? event.nativeEvent.which === 1 : event.buttons === 1;
-
-    if (isButtonPressed) {
+    // event.buttons & PRIMARY_MOUSE_BUTTON
+    if (event.buttons > 0) {
       setTime(event.nativeEvent, 'shallow');
     }
   };

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -2,24 +2,25 @@ import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { experimentalStyled as styled } from '@material-ui/core/styles';
+import { unstable_useEnhancedEffect as useEnhancedEffect } from '@material-ui/utils';
 import ClockPointer from './ClockPointer';
 import { useUtils, MuiPickersAdapter } from '../internal/pickers/hooks/useUtils';
-import { useGlobalKeyDown, keycode } from '../internal/pickers/hooks/useKeyDown';
-import {
-  WrapperVariantContext,
-  IsStaticVariantContext,
-} from '../internal/pickers/wrappers/WrapperVariantContext';
+import { WrapperVariantContext } from '../internal/pickers/wrappers/WrapperVariantContext';
 import { PickerSelectionState } from '../internal/pickers/hooks/usePickerState';
 import { useMeridiemMode } from '../internal/pickers/hooks/date-helpers-hooks';
 import { ClockView, getHours, getMinutes } from './shared';
 
 export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
-  allowKeyboardControl?: boolean;
   ampm: boolean;
   ampmInClock: boolean;
+  autoFocus?: boolean;
   children: readonly React.ReactNode[];
   date: TDate | null;
-  getClockLabelText: (view: ClockView, time: TDate, adapter: MuiPickersAdapter<TDate>) => string;
+  getClockLabelText: (
+    view: ClockView,
+    time: TDate | null,
+    adapter: MuiPickersAdapter<TDate>,
+  ) => string;
   isTimeDisabled: (timeValue: number, type: ClockView) => boolean;
   minutesStep?: number;
   onChange: (value: number, isFinish?: PickerSelectionState) => void;
@@ -106,9 +107,9 @@ const ClockPmButton = styled(IconButton, { skipSx: true })(({ theme, styleProps 
  */
 function Clock<TDate>(props: ClockProps<TDate>) {
   const {
-    allowKeyboardControl,
     ampm,
     ampmInClock,
+    autoFocus,
     children,
     date,
     getClockLabelText,
@@ -125,7 +126,6 @@ function Clock<TDate>(props: ClockProps<TDate>) {
   const styleProps = { ...props };
 
   const utils = useUtils<TDate>();
-  const isStatic = React.useContext(IsStaticVariantContext);
   const wrapperVariant = React.useContext(WrapperVariantContext);
   const isMoving = React.useRef(false);
 
@@ -194,20 +194,51 @@ function Clock<TDate>(props: ClockProps<TDate>) {
   }, [type, value]);
 
   const keyboardControlStep = type === 'minutes' ? minutesStep : 1;
-  useGlobalKeyDown(Boolean(allowKeyboardControl ?? !isStatic) && !isMoving.current, {
-    [keycode.Home]: () => handleValueChange(0, 'partial'), // annulate both hours and minutes
-    [keycode.End]: () => handleValueChange(type === 'minutes' ? 59 : 23, 'partial'),
-    [keycode.ArrowUp]: () => handleValueChange(value + keyboardControlStep, 'partial'),
-    [keycode.ArrowDown]: () => handleValueChange(value - keyboardControlStep, 'partial'),
-  });
+
+  const listboxRef = React.useRef<HTMLDivElement>(null);
+  // Since this is rendered when a Popper is opened we can't use passive effects.
+  // Focusing in passive effects in Popper causes scroll jump.
+  useEnhancedEffect(() => {
+    if (autoFocus) {
+      // The ref not being resolved would be a bug in Material-UI.
+      listboxRef.current!.focus();
+    }
+  }, [autoFocus]);
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    // TODO: Why this early exit?
+    if (isMoving.current) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'Home':
+        // annulate both hours and minutes
+        handleValueChange(0, 'partial');
+        event.preventDefault();
+        break;
+      case 'End':
+        handleValueChange(type === 'minutes' ? 59 : 23, 'partial');
+        event.preventDefault();
+        break;
+      case 'ArrowUp':
+        handleValueChange(value + keyboardControlStep, 'partial');
+        event.preventDefault();
+        break;
+      case 'ArrowDown':
+        handleValueChange(value - keyboardControlStep, 'partial');
+        event.preventDefault();
+        break;
+      default:
+      // do nothing
+    }
+  };
 
   return (
     <ClockRoot>
       <ClockClock>
         <ClockSquareMask
-          role="menu"
           data-mui-test="clock"
-          tabIndex={0}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
           onMouseUp={handleMouseUp}
@@ -222,13 +253,19 @@ function Clock<TDate>(props: ClockProps<TDate>) {
                 value={value}
                 isInner={isPointerInner}
                 hasSelected={hasSelected}
-                aria-live="polite"
-                aria-label={getClockLabelText(type, date, utils)}
               />
             )}
           </React.Fragment>
         )}
-        {children}
+        <div
+          aria-label={getClockLabelText(type, date, utils)}
+          ref={listboxRef}
+          role="listbox"
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+        >
+          {children}
+        </div>
       </ClockClock>
       {ampm && (wrapperVariant === 'desktop' || ampmInClock) && (
         <React.Fragment>

--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -109,7 +109,7 @@ function Clock<TDate>(props: ClockProps<TDate>) {
     allowKeyboardControl,
     ampm,
     ampmInClock,
-    children: numbersElementsArray,
+    children,
     date,
     getClockLabelText,
     handleMeridiemChange,
@@ -234,7 +234,7 @@ function Clock<TDate>(props: ClockProps<TDate>) {
             )}
           </React.Fragment>
         )}
-        {numbersElementsArray}
+        {children}
       </ClockClock>
       {ampm && (wrapperVariant === 'desktop' || ampmInClock) && (
         <React.Fragment>

--- a/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
@@ -5,7 +5,6 @@ import { generateUtilityClasses } from '@material-ui/unstyled';
 import { CLOCK_WIDTH, CLOCK_HOUR_WIDTH } from './shared';
 
 export interface ClockNumberProps extends React.HTMLAttributes<HTMLSpanElement> {
-  // TODO: spread to a `span`. What are the implications (generic role etc.)
   'aria-label': string;
   disabled: boolean;
   index: number;

--- a/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockNumber.tsx
@@ -64,6 +64,9 @@ function ClockNumber(props: ClockNumberProps) {
         },
         className,
       )}
+      aria-disabled={disabled ? true : undefined}
+      aria-selected={selected ? true : undefined}
+      role="option"
       style={{
         transform: `translate(${x}px, ${y + (CLOCK_WIDTH - CLOCK_HOUR_WIDTH) / 2}px`,
       }}

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
@@ -1,36 +1,140 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformance, fireTouchChangedEvent } from 'test/utils';
-import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
+import { describeConformance, fireEvent, fireTouchChangedEvent, screen } from 'test/utils';
 import ClockPicker from '@material-ui/lab/ClockPicker';
 import {
   adapterToUse,
-  AdapterClassToUse,
+  createPickerMount,
   createPickerRender,
   getByMuiTest,
 } from '../internal/pickers/test-utils';
 
 describe('<ClockPicker />', () => {
-  const mount = createMount();
+  const mount = createPickerMount();
   const render = createPickerRender();
-
-  const localizedMount = (node: React.ReactNode) => {
-    return mount(
-      <LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>,
-    );
-  };
 
   describeConformance(<ClockPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
     classes: {},
     inheritComponent: 'div',
-    mount: localizedMount,
+    mount,
     refInstanceof: window.HTMLDivElement,
     // cannot test reactTestRenderer because of required context
     skip: ['componentProp', 'propsSpread', 'reactTestRenderer'],
   }));
 
-  context('Time validation on touch ', () => {
+  it('renders a listbox with a name', () => {
+    render(<ClockPicker date={null} onChange={() => {}} />);
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toHaveAccessibleName('Select hours. No time selected');
+  });
+
+  it('has a name depending on the `date`', () => {
+    render(<ClockPicker date={adapterToUse.date('2019-01-01T04:20:00.000')} onChange={() => {}} />);
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toHaveAccessibleName('Select hours. Selected time is 4:20 AM');
+  });
+
+  it('can be autofocused on mount', () => {
+    render(<ClockPicker autoFocus date={null} onChange={() => {}} />);
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toHaveFocus();
+  });
+
+  it('selects the current date on mount', () => {
+    render(<ClockPicker date={adapterToUse.date('2019-01-01T04:20:00.000')} onChange={() => {}} />);
+
+    const selectedOption = screen.getByRole('option', { selected: true });
+    expect(selectedOption).toHaveAccessibleName('4 hours');
+  });
+
+  it('selects the first hour on Home press', () => {
+    const handleChange = spy();
+    render(
+      <ClockPicker
+        autoFocus
+        date={adapterToUse.date('2019-01-01T04:20:00.000')}
+        onChange={handleChange}
+      />,
+    );
+    const listbox = screen.getByRole('listbox');
+
+    fireEvent.keyDown(listbox, { key: 'Home' });
+
+    expect(handleChange.callCount).to.equal(1);
+    const [newDate, reason] = handleChange.firstCall.args;
+    // TODO: Can't find the GH issue regarding this
+    // expect(newDate).toEqualDateTime(adapterToUse.date('2019-01-01T00:20:00.000'));
+    // but the year, mont, day is different
+    expect(adapterToUse.getHours(newDate)).to.equal(0);
+    expect(adapterToUse.getMinutes(newDate)).to.equal(20);
+    expect(reason).to.equal('partial');
+  });
+
+  it('selects the last hour on End press', () => {
+    const handleChange = spy();
+    render(
+      <ClockPicker
+        autoFocus
+        date={adapterToUse.date('2019-01-01T04:20:00.000')}
+        onChange={handleChange}
+      />,
+    );
+    const listbox = screen.getByRole('listbox');
+
+    fireEvent.keyDown(listbox, { key: 'End' });
+
+    expect(handleChange.callCount).to.equal(1);
+    const [newDate, reason] = handleChange.firstCall.args;
+    expect(adapterToUse.getHours(newDate)).to.equal(23);
+    expect(adapterToUse.getMinutes(newDate)).to.equal(20);
+    expect(reason).to.equal('partial');
+  });
+
+  it('selects the next hour on ArrowUp press', () => {
+    const handleChange = spy();
+    render(
+      <ClockPicker
+        autoFocus
+        date={adapterToUse.date('2019-01-01T04:20:00.000')}
+        onChange={handleChange}
+      />,
+    );
+    const listbox = screen.getByRole('listbox');
+
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+
+    expect(handleChange.callCount).to.equal(1);
+    const [newDate, reason] = handleChange.firstCall.args;
+    expect(adapterToUse.getHours(newDate)).to.equal(5);
+    expect(adapterToUse.getMinutes(newDate)).to.equal(20);
+    expect(reason).to.equal('partial');
+  });
+
+  it('selects the previous hour on ArrowDown press', () => {
+    const handleChange = spy();
+    render(
+      <ClockPicker
+        autoFocus
+        date={adapterToUse.date('2019-01-01T04:20:00.000')}
+        onChange={handleChange}
+      />,
+    );
+    const listbox = screen.getByRole('listbox');
+
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+
+    expect(handleChange.callCount).to.equal(1);
+    const [newDate, reason] = handleChange.firstCall.args;
+    expect(adapterToUse.getHours(newDate)).to.equal(3);
+    expect(adapterToUse.getMinutes(newDate)).to.equal(20);
+    expect(reason).to.equal('partial');
+  });
+
+  describe('Time validation on touch ', () => {
     before(function beforeHook() {
       if (typeof window.Touch === 'undefined' || typeof window.TouchEvent === 'undefined') {
         this.skip();

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
@@ -44,6 +44,17 @@ describe('<ClockPicker />', () => {
     expect(listbox).toHaveFocus();
   });
 
+  it('stays focused when the view changes', () => {
+    const { setProps } = render(
+      <ClockPicker autoFocus date={null} onChange={() => {}} view="hours" />,
+    );
+
+    setProps({ view: 'minutes' });
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toHaveFocus();
+  });
+
   it('selects the current date on mount', () => {
     render(<ClockPicker date={adapterToUse.date('2019-01-01T04:20:00.000')} onChange={() => {}} />);
 

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -36,9 +36,12 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText?: (
     view: ClockView,
@@ -350,11 +353,6 @@ ClockPicker.propTypes /* remove-proptypes */ = {
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */
@@ -364,6 +362,10 @@ ClockPicker.propTypes /* remove-proptypes */ = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
+  /**
+   * Set to `true` if focus should be moved to clock picker.
+   */
+  autoFocus: PropTypes.bool,
   /**
    * @ignore
    */
@@ -395,9 +397,12 @@ ClockPicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.tsx
@@ -33,11 +33,6 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
    */
   ampmInClock?: boolean;
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl?: boolean;
-  /**
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
@@ -45,10 +40,18 @@ export interface ExportedClockPickerProps<TDate> extends TimeValidationProps<TDa
    *   adapter: MuiPickersAdapter<TDate>,
    * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
    */
-  getClockLabelText?: (view: ClockView, time: TDate, adapter: MuiPickersAdapter<TDate>) => string;
+  getClockLabelText?: (
+    view: ClockView,
+    time: TDate | null,
+    adapter: MuiPickersAdapter<TDate>,
+  ) => string;
 }
 
 export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate> {
+  /**
+   * Set to `true` if focus should be moved to clock picker.
+   */
+  autoFocus?: boolean;
   /**
    * The components used for each slot.
    * Either a string to use a HTML element or a component.
@@ -119,9 +122,12 @@ export const styles: MuiStyles<'arrowSwitcher'> = {
 
 const defaultGetClockLabelText = <TDate extends any>(
   view: ClockView,
-  time: TDate,
+  time: TDate | null,
   adapter: MuiPickersAdapter<TDate>,
-) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`;
+) =>
+  `Select ${view}. ${
+    time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+  }`;
 
 const defaultGetMinutesClockNumberText = (minutes: string) => `${minutes} minutes`;
 
@@ -137,9 +143,9 @@ const defaultGetSecondsClockNumberText = (seconds: string) => `${seconds} second
  */
 function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof styles>) {
   const {
-    allowKeyboardControl,
     ampm = false,
     ampmInClock = false,
+    autoFocus,
     classes,
     components,
     componentsProps,
@@ -322,13 +328,13 @@ function ClockPicker<TDate>(props: ClockPickerProps<TDate> & WithStyles<typeof s
       )}
 
       <Clock<TDate>
+        autoFocus={autoFocus}
         date={date}
         ampmInClock={ampmInClock}
         type={view}
         ampm={ampm}
         getClockLabelText={getClockLabelText}
         minutesStep={minutesStep}
-        allowKeyboardControl={allowKeyboardControl}
         isTimeDisabled={isTimeDisabled}
         meridiemMode={meridiemMode}
         handleMeridiemChange={handleMeridiemChange}

--- a/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -203,9 +203,12 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -184,9 +184,12 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -87,11 +87,6 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */
@@ -137,9 +132,12 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -197,9 +197,12 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -81,11 +81,6 @@ MobileTimePicker.propTypes /* remove-proptypes */ = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */
@@ -150,9 +145,12 @@ MobileTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -183,9 +183,12 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -83,11 +83,6 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */
@@ -134,9 +129,12 @@ StaticTimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.tsx
@@ -84,11 +84,6 @@ TimePicker.propTypes /* remove-proptypes */ = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * Enables keyboard listener for moving between days in calendar.
-   * Defaults to `true` unless the `ClockPicker` is used inside a `Static*` picker component.
-   */
-  allowKeyboardControl: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */
@@ -159,9 +154,12 @@ TimePicker.propTypes /* remove-proptypes */ = {
    * Accessible text that helps user to understand which time and view is selected.
    * @default <TDate extends any>(
    *   view: ClockView,
-   *   time: TDate,
+   *   time: TDate | null,
    *   adapter: MuiPickersAdapter<TDate>,
-   * ) => `Select ${view}. Selected time is ${adapter.format(time, 'fullTime')}`
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
    */
   getClockLabelText: PropTypes.func,
   /**

--- a/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -164,6 +164,7 @@ function Picker({
             {isTimePickerView(openView) && (
               <ClockPicker
                 {...other}
+                autoFocus
                 date={date}
                 view={openView}
                 onChange={handleChangeAndOpenNext}


### PR DESCRIPTION
**BREAKING CHANGE**

Removes `allowKeyboardControl` from `ClockPicker` (and `TimePicker` and variants)

Part of https://github.com/mui-org/material-ui/issues/25481

1. removes `allowKeyboardControl` from `ClockPicker` (and `TimePicker` and variants)
1. autofocus clock when the time picker is opened
1. allows keyboard access of clock picker in static mode
1. rework a11y tree
   I don't know what the pattern was before i.e. I've never seen menu + a separate aria-live that announces the value before. Now the clock is implemented as a listbox where the hours are options. 

Preview: https://deploy-preview-26400--material-ui.netlify.app/components/time-picker

Follow-up: 
- [ ] active descendant of the listbox
- [ ] focus indicator