### PR TITLE
Add $ to animation name

### DIFF
--- a/docs/src/pages/components/avatars/BadgeAvatars.tsx
+++ b/docs/src/pages/components/avatars/BadgeAvatars.tsx
@@ -16,7 +16,7 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
       width: '100%',
       height: '100%',
       borderRadius: '50%',
-      animation: 'ripple 1.2s infinite ease-in-out',
+      animation: '$ripple 1.2s infinite ease-in-out',
       border: '1px solid currentColor',
       content: '""',
     },


### PR DESCRIPTION
Example didn't show the $ before ripple under animation.  It's required for keyframes to work properly.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
