### PR TITLE
[test] setProps from createPickerRender should set props on the rendered element

### DIFF
--- a/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
@@ -51,12 +51,15 @@ export function createPickerRender({
 }: PickerRenderOptions & import('test/utils').RenderOptions = {}) {
   const clientRender = createClientRender(renderOptions);
 
-  return (node: React.ReactNode) =>
-    clientRender(
+  function Wrapper({ children }: { children?: React.ReactNode }) {
+    return (
       <LocalizationProvider locale={locale} dateAdapter={AdapterClassToUse}>
-        {node}
-      </LocalizationProvider>,
+        {children}
+      </LocalizationProvider>
     );
+  }
+
+  return (node: React.ReactElement) => clientRender(node, { wrapper: Wrapper });
 }
 
 export const queryByMuiTest = queryHelpers.queryByAttribute.bind(null, 'data-mui-test');


### PR DESCRIPTION
Previously `setProps` from `createPickerRender` would set props on the provider. This was suprising to me and probably not what we want generally.
