### PR TITLE
[test] Fix prop-type warning

### DIFF
--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -192,7 +192,7 @@ describe('<InputAdornment />', () => {
   it('applies a size small class inside <FormControl size="small" />', () => {
     const { getByTestId } = render(
       <FormControl size="small">
-        <InputAdornment placement="start" data-testid="root">
+        <InputAdornment position="start" data-testid="root">
           $
         </InputAdornment>
       </FormControl>,
@@ -204,7 +204,7 @@ describe('<InputAdornment />', () => {
   it('applies a hiddenLabel class inside <FormControl hiddenLabel />', () => {
     const { getByTestId } = render(
       <FormControl hiddenLabel>
-        <InputAdornment placement="start" data-testid="root">
+        <InputAdornment position="start" data-testid="root">
           $
         </InputAdornment>
       </FormControl>,


### PR DESCRIPTION
Noticed in the CI log of #26428.

<img width="944" alt="Screenshot 2021-05-23 at 15 30 24" src="https://user-images.githubusercontent.com/3165635/119262509-d58dbd00-bbdb-11eb-933c-d72489b57c04.png">

The CI doesn't fail for them, for some reason.