### PR TITLE
[core] Fix peer dependencies declaration with yarn v2

### DIFF
--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -36,8 +36,7 @@
   "peerDependencies": {
     "@material-ui/core": "^5.0.0-alpha.1",
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -42,7 +42,8 @@
     "dayjs": "^1.8.17",
     "luxon": "^1.21.3",
     "moment": "^2.24.0",
-    "react": "^17.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -39,8 +39,7 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
This is a follow-up on the lead given in https://github.com/mui-org/material-ui/issues/20012#issuecomment-844724225. I have created a new project with **yarn v2** and vite, using the date picker. It yields two resolution issues:

<img width="1152" alt="Screenshot 2021-05-23 at 16 03 23" src="https://user-images.githubusercontent.com/3165635/119263747-99109000-bbe0-11eb-9a38-0aa01068c3c0.png">

I have pushed:

- 5353bd6 to solve the first error. The system doesn't need react-dom, so it won't complain in the lab that depends on it.
- 180ac23 to solve the second error. react-transition-group depends on react-dom, we need to declare it.
- dc28ce4 bonus