### PR TITLE
[core] Batch small changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/3.material-design.md
+++ b/.github/ISSUE_TEMPLATE/3.material-design.md
@@ -1,0 +1,5 @@
+---
+name: Material design issue
+about: An issue with one of our components regarding the Material design guidelines.
+labels: 'status: needs triage, material design system'
+---

--- a/.github/ISSUE_TEMPLATE/3.material-design.md
+++ b/.github/ISSUE_TEMPLATE/3.material-design.md
@@ -1,5 +1,0 @@
----
-name: Material design issue
-about: An issue with one of our components regarding the Material design guidelines.
-labels: 'status: needs triage, material design system'
----

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -67,7 +67,7 @@ const inHouseAds = [
     link: 'https://material-ui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-templates',
     img: '/static/ads-in-house/themes-2.jpg',
     description:
-      '<b>Premium Templates</b>. Start your project with the best templates for admins, dashboards and more.',
+      '<b>Premium Templates</b>. Start your project with the best templates for admins, dashboards, and more.',
   },
   {
     name: 'themes',

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Router, { useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { createTheme } from '@material-ui/core/styles';
 import { withStyles } from '@material-ui/styles';
 import NProgress from 'nprogress';
@@ -52,18 +52,6 @@ function NextNProgressBar() {
 
   return <NProgressBar />;
 }
-
-Router.events.onRouteChangeStart = () => {
-  NProgress.start();
-};
-
-Router.events.onRouteChangeComplete = () => {
-  NProgress.done();
-};
-
-Router.events.onRouteChangeError = () => {
-  NProgress.done();
-};
 
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
 function DeferredAppSearch() {

--- a/docs/src/pages/components/modal/ModalUnstyled.js
+++ b/docs/src/pages/components/modal/ModalUnstyled.js
@@ -54,9 +54,7 @@ export default function ModalUnstyledDemo() {
       >
         <Box sx={style}>
           <h2 id="unstyled-modal-title">Text in a modal</h2>
-          <p id="unstyled-modal-description">
-            Aliquid amet deserunt earum eos nihil officia porro, quasi quibusdam!
-          </p>
+          <p id="unstyled-modal-description">Aliquid amet deserunt earum!</p>
         </Box>
       </StyledModal>
     </div>

--- a/docs/src/pages/components/modal/ModalUnstyled.tsx
+++ b/docs/src/pages/components/modal/ModalUnstyled.tsx
@@ -54,9 +54,7 @@ export default function ModalUnstyledDemo() {
       >
         <Box sx={style}>
           <h2 id="unstyled-modal-title">Text in a modal</h2>
-          <p id="unstyled-modal-description">
-            Aliquid amet deserunt earum eos nihil officia porro, quasi quibusdam!
-          </p>
+          <p id="unstyled-modal-description">Aliquid amet deserunt earum!</p>
         </Box>
       </StyledModal>
     </div>

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -18,7 +18,6 @@ The `Modal` offers important features:
 - ♿️ It properly manages focus; moving to the modal content,
   and keeping it there until the modal is closed.
 - ♿️ Adds the appropriate ARIA roles automatically.
-- 📦 [5 kB gzipped](/size-snapshot).
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
@@ -41,6 +40,8 @@ Modal is a lower-level construct that is leveraged by the following components:
 Notice that you can disable the outline (often blue or gold) with the `outline: 0` CSS property.
 
 ## Unstyled
+
+- 📦 [4.7 kB gzipped](https://bundlephobia.com/result?p=@material-ui/unstyled@next)
 
 The modal also comes with an unstyled version.
 It's ideal for doing heavy customizations and minimizing bundle size.

--- a/docs/src/pages/components/portal/portal.md
+++ b/docs/src/pages/components/portal/portal.md
@@ -8,8 +8,6 @@ githubLabel: 'component: Portal'
 
 <p class="description">The portal component renders its children into a new "subtree" outside of current DOM hierarchy.</p>
 
-- 📦 [1.3 kB gzipped](/size-snapshot)
-
 The children of the portal component will be appended to the `container` specified.
 The component is used internally by the [`Modal`](/components/modal/) and [`Popper`](/components/popper/) components.
 
@@ -25,6 +23,8 @@ React [doesn't support](https://github.com/facebook/react/issues/13097) the [`cr
 You have to wait for the client-side hydration to see the children.
 
 ## Unstyled
+
+- 📦 [970 B gzipped](https://bundlephobia.com/result?p=@material-ui/unstyled@next)
 
 As the component does not have any styles, it also comes with the unstyled package.
 

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -12,8 +12,6 @@ waiAria: https://www.w3.org/TR/wai-aria-practices/#slider
 
 Sliders reflect a range of values along a bar, from which users may select a single value. They are ideal for adjusting settings such as volume, brightness, or applying image filters.
 
-- 📦 [22 kB gzipped](/size-snapshot) (but only +8 kB when used together with other Material-UI components).
-
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Continuous sliders
@@ -123,6 +121,10 @@ Increasing _x_ by one increases the represented value by factor _2_.
 {{"demo": "pages/components/slider/NonLinearSlider.js"}}
 
 ## Unstyled
+
+<!-- #default-branch-switch -->
+
+- 📦 [5.6 kB gzipped](https://bundlephobia.com/result?p=@material-ui/unstyled@next)
 
 The slider also comes with an unstyled version.
 It's ideal for doing heavy customizations and minimizing bundle size.

--- a/docs/src/pages/components/toggle-button/ToggleButtons.js
+++ b/docs/src/pages/components/toggle-button/ToggleButtons.js
@@ -19,7 +19,6 @@ export default function ToggleButtons() {
       exclusive
       onChange={handleAlignment}
       aria-label="text alignment"
-      fullWidth
     >
       <ToggleButton value="left" aria-label="left aligned">
         <FormatAlignLeftIcon />

--- a/docs/src/pages/components/toggle-button/ToggleButtons.tsx
+++ b/docs/src/pages/components/toggle-button/ToggleButtons.tsx
@@ -22,7 +22,6 @@ export default function ToggleButtons() {
       exclusive
       onChange={handleAlignment}
       aria-label="text alignment"
-      fullWidth
     >
       <ToggleButton value="left" aria-label="left aligned">
         <FormatAlignLeftIcon />

--- a/docs/src/pages/components/trap-focus/trap-focus.md
+++ b/docs/src/pages/components/trap-focus/trap-focus.md
@@ -13,9 +13,6 @@ This is useful when implementing overlays such as modal dialogs, which should no
 
 When `open={true}` the trap is enabled, and pressing <kbd class="key">Tab</kbd> or <kbd><kbd  class="key">Shift</kbd>+<kbd class="key">Tab</kbd></kbd> will rotate focus within the inner focusable elements of the component.
 
-- 📦 [1.5 kB gzipped](https://material-ui.com/size-snapshot).
-- ⚛️ Support portals
-
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 > ⚠️ The component is experimental and unstable.
@@ -25,6 +22,8 @@ When `open={true}` the trap is enabled, and pressing <kbd class="key">Tab</kbd> 
 {{"demo": "pages/components/trap-focus/BasicTrapFocus.js"}}
 
 ## Unstyled
+
+- 📦 [2.0 kB gzipped](https://bundlephobia.com/result?p=@material-ui/unstyled@next)
 
 As the component does not have any styles, it also comes with the unstyled package.
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -342,14 +342,14 @@ const theme = createTheme({
   >
   ```
 
-- Replace `css` prop with `sx` to avoid collision with styled-components & emotion CSS props.
+- Replace `css` prop with `sx` to avoid collision with styled-components & emotion `css` prop.
 
-```diff
--<Box css={{ color: 'primary.main' }} />
-+<Box sx={{ color: 'primary.main' }} />
-```
+  ```diff
+  -<Box css={{ color: 'primary.main' }} />
+  +<Box sx={{ color: 'primary.main' }} />
+  ```
 
-> Note that the system grid function wasn't documented in v4.
+  > Note that the system grid function wasn't documented in v4.
 
 ### Core components
 


### PR DESCRIPTION
- [docs] Use Oxford comma convention ed2454c
- [docs] Fix v5 migration css prop fe56dc1
- [docs] The bundle size resonates more for unstyled 0288b8e
- [docs] Fix broken ToggleButtons demo 2547aed311: Fix display of https://next.material-ui.com/components/toggle-button/#exclusive-selection.
- [docs] Remove unused code 417e3a3: A follow-up on #26233. cc @eps1lon for review
- ~[core] Remove issue template that is almost never used: f347ed5. From what I understand, the last time the issue template was used is #21902. 10 months ago. It seems safe to remove it.~