### PR TITLE
[test] Catch broken demo

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -25,8 +25,9 @@ const styles = (theme) => ({
   },
   root: {
     backgroundColor: theme.palette.background.default,
-    display: 'inline-block',
     padding: theme.spacing(1),
+    display: 'flex',
+    justifyContent: 'center',
   },
 });
 


### PR DESCRIPTION
Leverage the learnings from https://github.com/mui-org/material-ui-x/pull/1692.

My hope is that it will catch this broken demo:  https://next.material-ui.com/components/toggle-button/#exclusive-selection. It currently renders as:

<img width="677" alt="Screenshot 2021-05-23 at 17 18 27" src="https://user-images.githubusercontent.com/3165635/119266392-ed207200-bbea-11eb-9654-67f0517b626a.png">
