### PR TITLE
[test] Flush scheduled effects before user event returns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   react-dist-tag:
     description: The dist-tag of react to be used
     type: string
-    default: next
+    default: stable
   workflow:
     description: The name of the workflow to run
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   react-dist-tag:
     description: The dist-tag of react to be used
     type: string
-    default: stable
+    default: next
   workflow:
     description: The name of the workflow to run
     type: string

--- a/test/utils/userEvent.ts
+++ b/test/utils/userEvent.ts
@@ -1,5 +1,5 @@
 import { click, mouseDown, mouseUp } from './fireDiscreteEvent';
-import { fireEvent } from './createClientRender';
+import { act, fireEvent } from './createClientRender';
 
 export function touch(target: Element): void {
   fireEvent.touchStart(target);
@@ -10,4 +10,6 @@ export function mousePress(target: Element): void {
   mouseDown(target);
   mouseUp(target);
   click(target);
+  // Flush scheduled effects
+  act(() => {});
 }


### PR DESCRIPTION
Otherwise it wouldn't behave the same as using `fireEvent.click`. `react@next` started failing due to not flushing the scheduled effects.