### PR TITLE
[Tabs] Update `min` & `max` width and remove `minWidth` media query

### DIFF
--- a/docs/src/pages/components/tabs/TabsWrappedLabel.js
+++ b/docs/src/pages/components/tabs/TabsWrappedLabel.js
@@ -19,7 +19,7 @@ export default function TabsWrappedLabel() {
       >
         <Tab
           value="one"
-          label="New Arrivals in the Longest Text of Nonfiction"
+          label="New Arrivals in the Longest Text of Nonfiction that should appear in the next line"
           wrapped
         />
         <Tab value="two" label="Item Two" />

--- a/docs/src/pages/components/tabs/TabsWrappedLabel.tsx
+++ b/docs/src/pages/components/tabs/TabsWrappedLabel.tsx
@@ -19,7 +19,7 @@ export default function TabsWrappedLabel() {
       >
         <Tab
           value="one"
-          label="New Arrivals in the Longest Text of Nonfiction"
+          label="New Arrivals in the Longest Text of Nonfiction that should appear in the next line"
           wrapped
         />
         <Tab value="two" label="Item Two" />

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1437,6 +1437,9 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
   +<Tabs scrollButtons={false} />
   ```
 
+- Tab `minWidth` changed from `72px` => `90px` (without media-query) according to [material-design spec](https://material.io/components/tabs#specs)
+- Tab `maxWidth` changed from `264px` => `360px` according to [material-design spec](https://material.io/components/tabs#specs)
+
 ### TextField
 
 - Change the default variant from `standard` to `outlined`. Standard has been removed from the Material Design Guidelines.

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -50,7 +50,7 @@ const TabRoot = experimentalStyled(ButtonBase, {
   position: 'relative',
   minHeight: 48,
   flexShrink: 0,
-  padding: '6px 12px',
+  padding: '12px 16px',
   overflow: 'hidden',
   whiteSpace: 'normal',
   textAlign: 'center',
@@ -119,6 +119,7 @@ const TabWrapper = experimentalStyled('span', {
   justifyContent: 'center',
   width: '100%',
   flexDirection: 'column',
+  lineHeight: 1.25,
 });
 
 const Tab = React.forwardRef(function Tab(inProps, ref) {

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -59,6 +59,7 @@ const TabRoot = experimentalStyled(ButtonBase, {
     styleProps.label && {
       minHeight: 72,
       paddingTop: 9,
+      paddingBottom: 9,
       [`& .${tabClasses.wrapper} > *:first-child`]: {
         marginBottom: 6,
       },

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -45,8 +45,8 @@ const TabRoot = experimentalStyled(ButtonBase, {
 })(({ theme, styleProps }) => ({
   /* Styles applied to the root element. */
   ...theme.typography.button,
-  maxWidth: 264,
-  minWidth: 72,
+  maxWidth: 360,
+  minWidth: 90,
   position: 'relative',
   minHeight: 48,
   flexShrink: 0,
@@ -54,9 +54,6 @@ const TabRoot = experimentalStyled(ButtonBase, {
   overflow: 'hidden',
   whiteSpace: 'normal',
   textAlign: 'center',
-  [theme.breakpoints.up('sm')]: {
-    minWidth: 160,
-  },
   /* Styles applied to the root element if both `icon` and `label` are provided. */
   ...(styleProps.icon &&
     styleProps.label && {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #15824

The change follow [material design spec](https://material.io/components/tabs#specs)

- [x] added to migration v5 docs (Tabs section)
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-26458--material-ui.netlify.app/components/tabs/