### PR TITLE
[docs] Prepare for data grid auto-generated docs

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -127,6 +127,9 @@ const styles = (theme) => ({
       '& .required': {
         color: theme.palette.type === 'light' ? '#006500' : '#a5ffa5',
       },
+      '& .optional': {
+        color: theme.palette.type === 'light' ? '#080065' : '#a5b3ff',
+      },
       '& .prop-type': {
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
         color: theme.palette.type === 'light' ? '#932981' : '#ffb6ec',

--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -161,7 +161,19 @@ const pages = [
     pathname: '/api-docs',
     children: [
       ...findPages[0].children,
-      ...[{ pathname: '/api-docs/data-grid' }, { pathname: '/api-docs/x-grid' }],
+      {
+        pathname: '/api-docs/data-grid',
+        title: 'Data Grid',
+        children: [
+          { pathname: '/api-docs/data-grid', title: 'API Reference' },
+          { pathname: '/api-docs/data-grid/data-grid' },
+          { pathname: '/api-docs/data-grid/x-grid' },
+          { pathname: '/api-docs/data-grid/grid-api', title: 'GridApi' },
+          { pathname: '/api-docs/data-grid/grid-col-def', title: 'GridColDef' },
+          { pathname: '/api-docs/data-grid/grid-cell-params', title: 'GridCellParams' },
+          { pathname: '/api-docs/data-grid/grid-row-params', title: 'GridRowParams' },
+        ],
+      },
     ].sort((a, b) =>
       a.pathname.replace('/api-docs/', '').localeCompare(b.pathname.replace('/api-docs/', '')),
     ),

--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -166,8 +166,8 @@ const pages = [
         title: 'Data Grid',
         children: [
           { pathname: '/api-docs/data-grid', title: 'API Reference' },
-          { pathname: '/api-docs/data-grid/data-grid' },
-          { pathname: '/api-docs/data-grid/x-grid' },
+          { pathname: '/api-docs/data-grid/data-grid', title: 'DataGrid' },
+          { pathname: '/api-docs/data-grid/x-grid', title: 'XGrid' },
           { pathname: '/api-docs/data-grid/grid-api', title: 'GridApi' },
           { pathname: '/api-docs/data-grid/grid-col-def', title: 'GridColDef' },
           { pathname: '/api-docs/data-grid/grid-cell-params', title: 'GridCellParams' },


### PR DESCRIPTION
### ⚠WARNING⚠

Once merged this PR, sync with @mui-org/x before doing the push to the docs repo. This is to prevent dead links since existing pages were moved.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related to https://github.com/mui-org/material-ui-x/pull/1529

- 8e42f12 - adds paths for new API pages 
- 642cc69 - adds a class name to be used on optional properties:

<img src="https://user-images.githubusercontent.com/42154031/119905794-45c17900-bf23-11eb-9cc8-d50d5518f974.png" width="370" />

Preview https://deploy-preview-1529--material-ui-x.netlify.app/api/data-grid/data-grid/