### PR TITLE
[docs] Add warning about git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
+# Enable via `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+# DO NOT ENABLE THIS CONFIG GLOBALLY
+# OTHERWISE git-blame WILL CRASH IN ANY REPOSITORY WITHOUT SUCH A FILE
+
 # changes to prettier config
 5dc1cbca1055c8440ae8c02fffbad7e6a1e2674e
 ef96151de118fe2560682bdedf130e69739082ea


### PR DESCRIPTION
Previously recommended a global config but that crashes git-blame in any repository without such a file.