### PR TITLE
[utils] Convert useId to TypeScript

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/Clock.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/Clock.tsx
@@ -26,8 +26,9 @@ export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
   onChange: (value: number, isFinish?: PickerSelectionState) => void;
   /**
    * DOM id that the selected option should have
+   * Should only be `undefined` on the server
    */
-  selectedId: string;
+  selectedId: string | undefined;
   type: ClockView;
   value: number;
 }

--- a/packages/material-ui-lab/src/ClockPicker/ClockNumbers.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockNumbers.tsx
@@ -11,8 +11,9 @@ interface GetHourNumbersOptions {
   onChange: (value: number, isFinish?: PickerSelectionState) => void;
   /**
    * DOM id that the selected option should have
+   * Should only be `undefined` on the server
    */
-  selectedId: string;
+  selectedId: string | undefined;
   utils: MuiPickersAdapter;
 }
 

--- a/packages/material-ui-utils/src/useId.d.ts
+++ b/packages/material-ui-utils/src/useId.d.ts
@@ -1,1 +1,0 @@
-export default function useId(idOverride?: string): string;

--- a/packages/material-ui-utils/src/useId.ts
+++ b/packages/material-ui-utils/src/useId.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default function useId(idOverride) {
+export default function useId(idOverride?: string): string | undefined {
   const [defaultId, setDefaultId] = React.useState(idOverride);
   const id = idOverride || defaultId;
   React.useEffect(() => {


### PR DESCRIPTION
The typings are currently incorrect (they return a non-nullable string when it is in fact always null on the server). Cherry-pick from https://github.com/mui-org/material-ui/pull/26489