### PR TITLE
[Tooltip] Finish exiting once started

### DIFF
--- a/docs/pages/api-docs/tooltip.json
+++ b/docs/pages/api-docs/tooltip.json
@@ -38,6 +38,7 @@
       "popper",
       "popperInteractive",
       "popperArrow",
+      "popperClose",
       "tooltip",
       "tooltipArrow",
       "arrow",

--- a/docs/translations/api-docs/tooltip/tooltip.json
+++ b/docs/translations/api-docs/tooltip/tooltip.json
@@ -42,6 +42,11 @@
       "nodeName": "the Popper component",
       "conditions": "<code>arrow={true}</code>"
     },
+    "popperClose": {
+      "description": "Styles applied to {{nodeName}} unless {{conditions}}.",
+      "nodeName": "the Popper component",
+      "conditions": "the tooltip is open"
+    },
     "tooltip": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the tooltip (label wrapper) element"

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -47,15 +47,19 @@ const TooltipPopper = experimentalStyled(Popper, {
       ...styles.popper,
       ...(!styleProps.disableInteractive && styles.popperInteractive),
       ...(styleProps.arrow && styles.popperArrow),
+      ...(!styleProps.open && styles.popperClose),
     };
   },
-})(({ theme, styleProps }) => ({
+})(({ theme, styleProps, open }) => ({
   /* Styles applied to the Popper element. */
   zIndex: theme.zIndex.tooltip,
   pointerEvents: 'none', // disable jss-rtl plugin
   /* Styles applied to the Popper component unless `disableInteractive={true}`. */
   ...(!styleProps.disableInteractive && {
     pointerEvents: 'auto',
+  }),
+  ...(!open && {
+    pointerEvents: 'none',
   }),
   /* Styles applied to the Popper element if `arrow={true}`. */
   ...(styleProps.arrow && {

--- a/packages/material-ui/src/Tooltip/tooltipClasses.ts
+++ b/packages/material-ui/src/Tooltip/tooltipClasses.ts
@@ -7,6 +7,8 @@ export interface TooltipClasses {
   popperInteractive: string;
   /** Styles applied to the Popper component if `arrow={true}`. */
   popperArrow: string;
+  /** Styles applied to the Popper component unless the tooltip is open. */
+  popperClose: string;
   /** Styles applied to the tooltip (label wrapper) element. */
   tooltip: string;
   /** Styles applied to the tooltip (label wrapper) element if `arrow={true}`. */
@@ -35,6 +37,7 @@ const tooltipClasses: TooltipClasses = generateUtilityClasses('MuiTooltip', [
   'popper',
   'popperInteractive',
   'popperArrow',
+  'popperClose',
   'tooltip',
   'tooltipArrow',
   'touch',


### PR DESCRIPTION
Previously the Tooltip could re-open during exit transitions. This could create flickering tooltips e.g. https://github.com/mui-org/material-ui/issues/26416. It's probably best to finish exiting before you can open a Tooltip again

Closes https://github.com/mui-org/material-ui/issues/26416
Note that the repro still needs adjustment: 

```diff
 )(({ theme }) => ({
   [`& .${tooltipClasses.tooltip}`]: {
     backgroundColor: "#f5f5f9",
     color: "rgba(0, 0, 0, 0.87)",
     maxWidth: "none",
     padding: `${theme.spacing(1.5)} ${theme.spacing(1.5)}`,
     boxShadow: theme.shadows[10],
-    pointerEvents: "auto"
   },
   [`& .${tooltipClasses.arrow}`]: {
     color: "#f5f5f9"
   }
 }));
```
--- https://codesandbox.io/s/nervous-perlman-k0pq5