### PR TITLE
[docs] Multiple select demos moving when selecting values

### DIFF
--- a/docs/src/pages/components/selects/MultipleSelect.js
+++ b/docs/src/pages/components/selects/MultipleSelect.js
@@ -49,7 +49,7 @@ export default function MultipleSelect() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300 }}>
+      <FormControl sx={{ m: 1, width: 300 }}>
         <InputLabel id="demo-multiple-name-label">Name</InputLabel>
         <Select
           labelId="demo-multiple-name-label"

--- a/docs/src/pages/components/selects/MultipleSelect.tsx
+++ b/docs/src/pages/components/selects/MultipleSelect.tsx
@@ -49,7 +49,7 @@ export default function MultipleSelect() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300 }}>
+      <FormControl sx={{ m: 1, width: 300 }}>
         <InputLabel id="demo-multiple-name-label">Name</InputLabel>
         <Select
           labelId="demo-multiple-name-label"

--- a/docs/src/pages/components/selects/MultipleSelectCheckmarks.js
+++ b/docs/src/pages/components/selects/MultipleSelectCheckmarks.js
@@ -40,7 +40,7 @@ export default function MultipleSelectCheckmarks() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300 }}>
+      <FormControl sx={{ m: 1, width: 300 }}>
         <InputLabel id="demo-multiple-checkbox-label">Tag</InputLabel>
         <Select
           labelId="demo-multiple-checkbox-label"

--- a/docs/src/pages/components/selects/MultipleSelectCheckmarks.tsx
+++ b/docs/src/pages/components/selects/MultipleSelectCheckmarks.tsx
@@ -40,7 +40,7 @@ export default function MultipleSelectCheckmarks() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300 }}>
+      <FormControl sx={{ m: 1, width: 300 }}>
         <InputLabel id="demo-multiple-checkbox-label">Tag</InputLabel>
         <Select
           labelId="demo-multiple-checkbox-label"

--- a/docs/src/pages/components/selects/MultipleSelectChip.js
+++ b/docs/src/pages/components/selects/MultipleSelectChip.js
@@ -51,7 +51,7 @@ export default function MultipleSelectChip() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300 }}>
+      <FormControl sx={{ m: 1, width: 300 }}>
         <InputLabel id="demo-multiple-chip-label">Chip</InputLabel>
         <Select
           labelId="demo-multiple-chip-label"

--- a/docs/src/pages/components/selects/MultipleSelectChip.tsx
+++ b/docs/src/pages/components/selects/MultipleSelectChip.tsx
@@ -51,7 +51,7 @@ export default function MultipleSelectChip() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300 }}>
+      <FormControl sx={{ m: 1, width: 300 }}>
         <InputLabel id="demo-multiple-chip-label">Chip</InputLabel>
         <Select
           labelId="demo-multiple-chip-label"

--- a/docs/src/pages/components/selects/MultipleSelectPlaceholder.js
+++ b/docs/src/pages/components/selects/MultipleSelectPlaceholder.js
@@ -48,7 +48,7 @@ export default function MultipleSelectPlaceholder() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300, mt: 3 }}>
+      <FormControl sx={{ m: 1, width: 300, mt: 3 }}>
         <Select
           multiple
           displayEmpty

--- a/docs/src/pages/components/selects/MultipleSelectPlaceholder.tsx
+++ b/docs/src/pages/components/selects/MultipleSelectPlaceholder.tsx
@@ -48,7 +48,7 @@ export default function MultipleSelectPlaceholder() {
 
   return (
     <div>
-      <FormControl sx={{ m: 1, minWidth: 120, maxWidth: 300, mt: 3 }}>
+      <FormControl sx={{ m: 1, width: 300, mt: 3 }}>
         <Select
           multiple
           displayEmpty


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When selecting different values for multiple select the width of select changed. This PR solves it by setting the width to `300px` for multiple selects in demos. 

Closes: #19245

Preview: https://deploy-preview-26539--material-ui.netlify.app/components/selects/#multiple-select