### PR TITLE
[docs] `Rating` `value` is nullable in `onChange`

### DIFF
--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -207,6 +207,10 @@ function resolveType(type: NonNullable<doctrine.Tag['type']>): string {
     return 'void';
   }
 
+  if (type.type === 'NullLiteral') {
+    return 'null';
+  }
+
   if (type.type === 'TypeApplication') {
     const arrayTypeName = resolveType(type.applications[0]);
     return `${arrayTypeName}[]`;

--- a/docs/translations/api-docs/rating/rating.json
+++ b/docs/translations/api-docs/rating/rating.json
@@ -12,7 +12,7 @@
     "IconContainerComponent": "The component containing the icon.",
     "max": "Maximum rating.",
     "name": "The name attribute of the radio <code>input</code> elements. This input <code>name</code> should be unique within the page. Being unique within a form is insufficient since the <code>name</code> is used to generated IDs.",
-    "onChange": "Callback fired when the value changes.<br><br><strong>Signature:</strong><br><code>function(event: object, value: number) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>value:</em> The new value.",
+    "onChange": "Callback fired when the value changes.<br><br><strong>Signature:</strong><br><code>function(event: object, value: number \\| null) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>value:</em> The new value.",
     "onChangeActive": "Callback function that is fired when the hover state changes.<br><br><strong>Signature:</strong><br><code>function(event: object, value: number) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>value:</em> The new value.",
     "precision": "The minimum increment value change allowed.",
     "readOnly": "Removes all hover effects and pointer events.",

--- a/packages/material-ui/src/Rating/Rating.d.ts
+++ b/packages/material-ui/src/Rating/Rating.d.ts
@@ -80,7 +80,7 @@ export interface RatingProps
   /**
    * Callback fired when the value changes.
    * @param {object} event The event source of the callback.
-   * @param {number} value The new value.
+   * @param {number|null} value The new value.
    */
   onChange?: (event: React.SyntheticEvent, value: number | null) => void;
   /**

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -637,7 +637,7 @@ Rating.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when the value changes.
    * @param {object} event The event source of the callback.
-   * @param {number} value The new value.
+   * @param {number|null} value The new value.
    */
   onChange: PropTypes.func,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [o] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The previous PR I created somehow got closed immediately after I reverted my previous change.  Please look at this PR instead.

@eps1lon you told me to look at material-ui/packages/material-ui/src/Rating/Rating.d.ts Line 82, but I think you meant I might take a look of a different line of Rating.d.ts.  I couldn't understand when I looked an line 82.

Put in null in onChange in Rating, and also put in handling NullLiteral in auto generation of the descriptions of a function and its parameters.

Closes #26497
