### PR TITLE
[AppBar] Fix background color on dark mode

### DIFF
--- a/docs/pages/api-docs/app-bar.json
+++ b/docs/pages/api-docs/app-bar.json
@@ -9,6 +9,7 @@
       },
       "default": "'primary'"
     },
+    "enableColorOnDark": { "type": { "name": "bool" } },
     "position": {
       "type": {
         "name": "enum",

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -113,9 +113,8 @@ const styles = (theme) => ({
     },
   },
   appBar: {
-    color: theme.palette.mode === 'light' ? null : '#fff',
-    backgroundColor: theme.palette.mode === 'light' ? null : theme.palette.background.level2,
     transition: theme.transitions.create('width'),
+    boxShadow: theme.shadows[4],
   },
   language: {
     margin: theme.spacing(0, 0.5, 0, 1),
@@ -203,7 +202,7 @@ function AppFrame(props) {
         {t('appFrame.skipToContent')}
       </MuiLink>
       <MarkdownLinks />
-      <AppBar className={appBarClassName}>
+      <AppBar elevation={8} className={appBarClassName}>
         <Toolbar>
           <IconButton
             edge="start"

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -114,7 +114,6 @@ const styles = (theme) => ({
   },
   appBar: {
     transition: theme.transitions.create('width'),
-    boxShadow: theme.shadows[4],
   },
   language: {
     margin: theme.spacing(0, 0.5, 0, 1),
@@ -202,7 +201,7 @@ function AppFrame(props) {
         {t('appFrame.skipToContent')}
       </MuiLink>
       <MarkdownLinks />
-      <AppBar elevation={8} className={appBarClassName}>
+      <AppBar className={appBarClassName}>
         <Toolbar>
           <IconButton
             edge="start"

--- a/docs/src/pages/components/app-bar/app-bar.md
+++ b/docs/src/pages/components/app-bar/app-bar.md
@@ -136,3 +136,27 @@ function HideOnScroll(props) {
   );
 }
 ```
+
+## Enable Color on Dark
+
+From v5 onward, `color` prop has no effect on dark mode according to [material design spec](https://material.io/design/color/dark-theme.html). You can opt out by passing `enableColorOnDark` prop.
+
+```jsx
+// Specific element via prop
+<AppBar enableColorOnDark />
+
+// Affect all AppBars via theme
+<ThemeProvider
+  theme={createTheme({
+    components: {
+      MuiAppBar: {
+        defaultProps: {
+          enableColorOnDark: true,
+        },
+      },
+    },
+  })}
+>
+  <AppBar />
+</ThemeProvider>
+```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -362,7 +362,7 @@ As the core components use emotion as their style engine, the props used by emot
 ### AppBar
 
 - [AppBar] Remove z-index when position static and relative. This avoids the creation of a stacking context and rendering issues.
-- `color` has no effect in dark mode by default due to [material design spec](https://material.io/design/color/dark-theme.html). Use `enableColorOnDark` to opt out from this behaviour.
+- The `color` prop has no longer any effect in dark mode. The app bar uses the background color required by the elevation to follow the [Material Design guidelines](https://material.io/design/color/dark-theme.html). Use `enableColorOnDark` to restore the behavior of v4.
 
   ```jsx
   <AppBar enableColorOnDark />

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -363,7 +363,7 @@ As the core components use emotion as their style engine, the props used by emot
 
 - [AppBar] Remove z-index when position static and relative. This avoids the creation of a stacking context and rendering issues.
 - `color` has no effect in dark mode by default due to [material design spec](https://material.io/design/color/dark-theme.html). Use `enableColorOnDark` to opt out from this behaviour.
-  
+
   ```jsx
   <AppBar enableColorOnDark />
   ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -362,6 +362,11 @@ As the core components use emotion as their style engine, the props used by emot
 ### AppBar
 
 - [AppBar] Remove z-index when position static and relative. This avoids the creation of a stacking context and rendering issues.
+- `color` has no effect in dark mode by default due to [material design spec](https://material.io/design/color/dark-theme.html). Use `enableColorOnDark` to opt out from this behaviour.
+  
+  ```jsx
+  <AppBar enableColorOnDark />
+  ```
 
 ### Alert
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -361,7 +361,7 @@ As the core components use emotion as their style engine, the props used by emot
 
 ### AppBar
 
-- [AppBar] Remove z-index when position static and relative. This avoids the creation of a stacking context and rendering issues.
+- Remove z-index when position static and relative. This avoids the creation of a stacking context and rendering issues.
 - The `color` prop has no longer any effect in dark mode. The app bar uses the background color required by the elevation to follow the [Material Design guidelines](https://material.io/design/color/dark-theme.html). Use `enableColorOnDark` to restore the behavior of v4.
 
   ```jsx

--- a/docs/translations/api-docs/app-bar/app-bar.json
+++ b/docs/translations/api-docs/app-bar/app-bar.json
@@ -4,6 +4,7 @@
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "enableColorOnDark": "If true, the <code>color</code> prop is applied in dark mode.",
     "position": "The positioning type. The behavior of the different options is described <a href=\"https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning\">in the MDN web docs</a>. Note: <code>sticky</code> is not universally supported and will fall back to <code>static</code> when unavailable.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/basics/#the-sx-prop\">`sx` page</a> for more details."
   },

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -21,16 +21,16 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
        */
       color?: OverridableStringUnion<PropTypes.Color | 'transparent', AppBarPropsColorOverrides>;
       /**
+       * If true, the `color` prop is applied in dark mode
+       */
+      enableColorOnDark?: boolean;
+      /**
        * The positioning type. The behavior of the different options is described
        * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
        * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.
        * @default 'fixed'
        */
       position?: 'fixed' | 'absolute' | 'sticky' | 'static' | 'relative';
-      /**
-       * If true, the `color` prop does not have effect in dark mode
-       */
-      skipColorOnDark?: boolean;
       /**
        * The system prop that allows defining system overrides as well as additional CSS styles.
        */

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -21,7 +21,7 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
        */
       color?: OverridableStringUnion<PropTypes.Color | 'transparent', AppBarPropsColorOverrides>;
       /**
-       * If true, the `color` prop is applied in dark mode
+       * If true, the `color` prop is applied in dark mode.
        */
       enableColorOnDark?: boolean;
       /**

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -28,6 +28,10 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
        */
       position?: 'fixed' | 'absolute' | 'sticky' | 'static' | 'relative';
       /**
+       * If true, the `color` prop does not have effect in dark mode
+       */
+      skipColorOnDark?: boolean;
+      /**
        * The system prop that allows defining system overrides as well as additional CSS styles.
        */
       sx?: SxProps<Theme>;

--- a/packages/material-ui/src/AppBar/AppBar.d.ts
+++ b/packages/material-ui/src/AppBar/AppBar.d.ts
@@ -22,6 +22,7 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
       color?: OverridableStringUnion<PropTypes.Color | 'transparent', AppBarPropsColorOverrides>;
       /**
        * If true, the `color` prop is applied in dark mode.
+       * @default false
        */
       enableColorOnDark?: boolean;
       /**

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -172,7 +172,7 @@ AppBar.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
-   * If true, the `color` prop is applied in dark mode
+   * If true, the `color` prop is applied in dark mode.
    */
   enableColorOnDark: PropTypes.bool,
   /**

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -173,6 +173,7 @@ AppBar.propTypes /* remove-proptypes */ = {
   ]),
   /**
    * If true, the `color` prop is applied in dark mode.
+   * @default false
    */
   enableColorOnDark: PropTypes.bool,
   /**

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -100,17 +100,28 @@ const AppBarRoot = experimentalStyled(Paper, {
       backgroundColor: 'transparent',
       color: 'inherit',
     }),
+    ...(styleProps.skipColorOnDark && {
+      backgroundColor: null,
+      color: null,
+    }),
   };
 });
 
 const AppBar = React.forwardRef(function AppBar(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiAppBar' });
-  const { className, color = 'primary', position = 'fixed', ...other } = props;
+  const {
+    className,
+    color = 'primary',
+    position = 'fixed',
+    skipColorOnDark = true,
+    ...other
+  } = props;
 
   const styleProps = {
     ...props,
     color,
     position,
+    skipColorOnDark,
   };
 
   const classes = useUtilityClasses(styleProps);
@@ -166,6 +177,10 @@ AppBar.propTypes /* remove-proptypes */ = {
    * @default 'fixed'
    */
   position: PropTypes.oneOf(['absolute', 'fixed', 'relative', 'static', 'sticky']),
+  /**
+   * If true, the `color` prop does not have effect in dark mode
+   */
+  skipColorOnDark: PropTypes.bool,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -100,10 +100,11 @@ const AppBarRoot = experimentalStyled(Paper, {
       backgroundColor: 'transparent',
       color: 'inherit',
     }),
-    ...(styleProps.skipColorOnDark && {
-      backgroundColor: null,
-      color: null,
-    }),
+    ...(theme.palette.mode === 'dark' &&
+      styleProps.skipColorOnDark && {
+        backgroundColor: null,
+        color: null,
+      }),
   };
 });
 

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -101,7 +101,7 @@ const AppBarRoot = experimentalStyled(Paper, {
       color: 'inherit',
     }),
     ...(theme.palette.mode === 'dark' &&
-      styleProps.skipColorOnDark && {
+      !styleProps.enableColorOnDark && {
         backgroundColor: null,
         color: null,
       }),
@@ -114,7 +114,7 @@ const AppBar = React.forwardRef(function AppBar(inProps, ref) {
     className,
     color = 'primary',
     position = 'fixed',
-    skipColorOnDark = true,
+    enableColorOnDark = false,
     ...other
   } = props;
 
@@ -122,7 +122,7 @@ const AppBar = React.forwardRef(function AppBar(inProps, ref) {
     ...props,
     color,
     position,
-    skipColorOnDark,
+    enableColorOnDark,
   };
 
   const classes = useUtilityClasses(styleProps);
@@ -172,16 +172,16 @@ AppBar.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
+   * If true, the `color` prop is applied in dark mode
+   */
+  enableColorOnDark: PropTypes.bool,
+  /**
    * The positioning type. The behavior of the different options is described
    * [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
    * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.
    * @default 'fixed'
    */
   position: PropTypes.oneOf(['absolute', 'fixed', 'relative', 'static', 'sticky']),
-  /**
-   * If true, the `color` prop does not have effect in dark mode
-   */
-  skipColorOnDark: PropTypes.bool,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -113,8 +113,8 @@ const AppBar = React.forwardRef(function AppBar(inProps, ref) {
   const {
     className,
     color = 'primary',
-    position = 'fixed',
     enableColorOnDark = false,
+    position = 'fixed',
     ...other
   } = props;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #18308

Preview https://deploy-preview-26545--material-ui.netlify.app/components/app-bar/

The case of AppBar is special because the specified color should be enabled only in `light` mode. I propose the fix by adding another flag (naming can be discussed) to neglect the color prop in dark mode. This approach works great because `AppBar` inherit `Paper` which support elevation already. The flag is `true` by default (consider breaking change) due to the [material design spec](https://material.io/design/color/dark-theme.html)

Even bottom appbar also use elevation https://material.io/design/color/dark-theme.html#custom-application

### Default Behavior
```jsx
<AppBar color="primary" /> // color has no effect in dark mode
```

### Enable for specific component (opt out via prop)
```jsx
<AppBar color="primary" enableColorOnDark />
```

### Enable globally (opt out via theme)
```js
createTheme({
  components: {
    MuiAppBar: {
      defaultProps: {
        enableColorOnDark: true,
      }
    }
  }
})
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
