### PR TITLE
[Box] Fix runtime error when using styled-components without ThemeProvider

### DIFF
--- a/packages/material-ui-system/src/createBox.js
+++ b/packages/material-ui-system/src/createBox.js
@@ -4,13 +4,13 @@ import clsx from 'clsx';
 import styled, { ThemeContext } from '@material-ui/styled-engine';
 import styleFunctionSx, { extendSxProp } from './styleFunctionSx';
 
-function isEmpty(obj) {
+function isObjectEmpty(obj) {
   return Object.keys(obj).length === 0;
 }
 
 const useTheme = (defaultTheme) => {
   const contextTheme = React.useContext(ThemeContext);
-  return !contextTheme || isEmpty(contextTheme) ? defaultTheme : contextTheme;
+  return !contextTheme || isObjectEmpty(contextTheme) ? defaultTheme : contextTheme;
 };
 
 export default function createBox(defaultTheme = {}) {

--- a/packages/material-ui-system/src/createBox.js
+++ b/packages/material-ui-system/src/createBox.js
@@ -10,7 +10,7 @@ function isEmpty(obj) {
 
 const useTheme = (defaultTheme) => {
   const contextTheme = React.useContext(ThemeContext);
-  return isEmpty(contextTheme) ? defaultTheme : contextTheme;
+  return (!contextTheme || isEmpty(contextTheme)) ? defaultTheme : contextTheme;
 };
 
 export default function createBox(defaultTheme = {}) {

--- a/packages/material-ui-system/src/createBox.js
+++ b/packages/material-ui-system/src/createBox.js
@@ -10,7 +10,7 @@ function isEmpty(obj) {
 
 const useTheme = (defaultTheme) => {
   const contextTheme = React.useContext(ThemeContext);
-  return (!contextTheme || isEmpty(contextTheme)) ? defaultTheme : contextTheme;
+  return !contextTheme || isEmpty(contextTheme) ? defaultTheme : contextTheme;
 };
 
 export default function createBox(defaultTheme = {}) {


### PR DESCRIPTION
FIxing an issue foind while testing out `styled-components` usage with the new `Box` component. 

Before:
https://codesandbox.io/s/wizardly-dew-9m8p8?file=/src/index.js

Now:
https://codesandbox.io/s/condescending-nightingale-mdc80?file=/package.json
