### PR TITLE
[docs] Improve migration guide for `@material-ui/styles`

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1834,10 +1834,10 @@ If you are using the utilities from `@material-ui/styles` together with the `@ma
 
 As `@material-ui/styles` is no longer part of `@material-ui/core/styles`, you need to add a module augmentation for the `DefaultTheme`.
 
-  ```diff
-  import { Theme } from '@material-ui/core/styles';
+```diff
+import { Theme } from '@material-ui/core/styles';
 
-  declare module '@material-ui/styles' {
-    interface DefaultTheme extends Theme {}
-  }
-  ```
+declare module '@material-ui/styles' {
+  interface DefaultTheme extends Theme {}
+}
+```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1829,3 +1829,15 @@ If you are using the utilities from `@material-ui/styles` together with the `@ma
 -import { ThemeProvider } from '@material-ui/styles';
 +import { ThemeProvider } from '@material-ui/core/styles';
 ```
+
+#### Default theme (TypeScript)
+
+As `@material-ui/styles` is no longer part of `@material-ui/core/styles`, you need to add a module augmentation for the `DefaultTheme`.
+
+  ```diff
+  import { Theme } from '@material-ui/core/styles';
+
+  declare module '@material-ui/styles' {
+    interface DefaultTheme extends Theme {}
+  }
+  ```

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1832,7 +1832,7 @@ If you are using the utilities from `@material-ui/styles` together with the `@ma
 
 #### Default theme (TypeScript)
 
-As `@material-ui/styles` is no longer part of `@material-ui/core/styles`, you need to add a module augmentation for the `DefaultTheme`.
+The `@material-ui/styles` package is no longer part of `@material-ui/core/styles`. If you are using `@material-ui/styles` together with `@material-ui/core` you need to add a module augmentation for the `DefaultTheme`.
 
 ```ts
 import { Theme } from '@material-ui/core/styles';

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1834,7 +1834,7 @@ If you are using the utilities from `@material-ui/styles` together with the `@ma
 
 As `@material-ui/styles` is no longer part of `@material-ui/core/styles`, you need to add a module augmentation for the `DefaultTheme`.
 
-```diff
+```ts
 import { Theme } from '@material-ui/core/styles';
 
 declare module '@material-ui/styles' {


### PR DESCRIPTION
Developers that still use `makeStyles` and `withStyles`, now need to use the utils exported from `@material-ui/styles`. However, if these are used together with `@material-ui/core`, they no longer have the `DefaultTheme` as the correct one. They need to use module augmentation to achieve this.