### PR TITLE
[Popover] Fix PaperProps.ref breaking positioning

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -121,7 +121,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     ...other
   } = props;
   const paperRef = React.useRef();
-  const handleRef = useForkRef(paperRef, PaperProps.ref);
+  const handlePaperRef = useForkRef(paperRef, PaperProps.ref);
 
   const styleProps = {
     ...props,
@@ -372,7 +372,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
         <PopoverPaper
           elevation={elevation}
           {...PaperProps}
-          ref={handleRef}
+          ref={handlePaperRef}
           className={clsx(classes.paper, PaperProps.className)}
         >
           {children}

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -14,6 +14,7 @@ import useThemeProps from '../styles/useThemeProps';
 import debounce from '../utils/debounce';
 import ownerDocument from '../utils/ownerDocument';
 import ownerWindow from '../utils/ownerWindow';
+import useForkRef from '../utils/useForkRef';
 import Grow from '../Grow';
 import Modal from '../Modal';
 import Paper from '../Paper';
@@ -120,6 +121,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     ...other
   } = props;
   const paperRef = React.useRef();
+  const handleRef = useForkRef(paperRef, PaperProps.ref);
 
   const styleProps = {
     ...props,
@@ -369,8 +371,8 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       >
         <PopoverPaper
           elevation={elevation}
-          ref={paperRef}
           {...PaperProps}
+          ref={handleRef}
           className={clsx(classes.paper, PaperProps.className)}
         >
           {children}

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -254,6 +254,26 @@ describe('<Popover />', () => {
     });
   });
 
+  describe('PaperProps.ref', () => {
+    it('should position popover correctly', () => {
+      const handleEntering = spy();
+      mount(
+        <Popover
+          {...defaultProps}
+          open
+          PaperProps={{ 'data-testid': 'Popover', ref: () => null }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+          TransitionProps={{ onEntering: handleEntering }}
+        >
+          <div />
+        </Popover>,
+      );
+
+      const element = handleEntering.args[0][0];
+      expect(element.style.top === '16px' && element.style.left === '16px').to.equal(true);
+    });
+  });
+
   describe('transition lifecycle', () => {
     describe('handleEntering(element)', () => {
       it('should set the inline styles for the enter phase', () => {
@@ -296,7 +316,7 @@ describe('<Popover />', () => {
     let expectPopover;
 
     before(() => {
-      openPopover = (anchorOrigin, mockPaperRef) => {
+      openPopover = (anchorOrigin) => {
         if (!anchorEl) {
           anchorEl = document.createElement('div');
         }
@@ -316,10 +336,6 @@ describe('<Popover />', () => {
         });
         document.body.appendChild(anchorEl);
 
-        const PaperProps = mockPaperRef
-          ? { 'data-testid': 'Popover', ref: () => null }
-          : { 'data-testid': 'Popover' }
-
         return new Promise((resolve) => {
           const component = (
             <Popover
@@ -327,7 +343,7 @@ describe('<Popover />', () => {
               anchorEl={anchorEl}
               anchorOrigin={anchorOrigin}
               transitionDuration={0}
-              PaperProps={{...PaperProps}}
+              PaperProps={{ 'data-testid': 'Popover' }}
               TransitionProps={{
                 onEntered: () => {
                   popoverEl = document.querySelector('[data-testid="Popover"]');
@@ -358,14 +374,6 @@ describe('<Popover />', () => {
 
     it('should be positioned over the top left of the anchor', async () => {
       await openPopover({ vertical: 'top', horizontal: 'left' });
-      const anchorRect = anchorEl.getBoundingClientRect();
-      const expectedTop = anchorRect.top <= 16 ? 16 : anchorRect.top;
-      const expectedLeft = anchorRect.left <= 16 ? 16 : anchorRect.left;
-      expectPopover(expectedTop, expectedLeft);
-    });
-
-    it('should be positioned over the top left of the anchor even when `PaperProps.ref` is passed as prop', async () => {
-      await openPopover({ vertical: 'top', horizontal: 'left' }, true);
       const anchorRect = anchorEl.getBoundingClientRect();
       const expectedTop = anchorRect.top <= 16 ? 16 : anchorRect.top;
       const expectedLeft = anchorRect.left <= 16 ? 16 : anchorRect.left;

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -296,7 +296,7 @@ describe('<Popover />', () => {
     let expectPopover;
 
     before(() => {
-      openPopover = (anchorOrigin) => {
+      openPopover = (anchorOrigin, mockPaperRef) => {
         if (!anchorEl) {
           anchorEl = document.createElement('div');
         }
@@ -316,6 +316,10 @@ describe('<Popover />', () => {
         });
         document.body.appendChild(anchorEl);
 
+        const PaperProps = mockPaperRef
+          ? { 'data-testid': 'Popover', ref: () => null }
+          : { 'data-testid': 'Popover' }
+
         return new Promise((resolve) => {
           const component = (
             <Popover
@@ -323,7 +327,7 @@ describe('<Popover />', () => {
               anchorEl={anchorEl}
               anchorOrigin={anchorOrigin}
               transitionDuration={0}
-              PaperProps={{ 'data-testid': 'Popover' }}
+              PaperProps={{...PaperProps}}
               TransitionProps={{
                 onEntered: () => {
                   popoverEl = document.querySelector('[data-testid="Popover"]');
@@ -354,6 +358,14 @@ describe('<Popover />', () => {
 
     it('should be positioned over the top left of the anchor', async () => {
       await openPopover({ vertical: 'top', horizontal: 'left' });
+      const anchorRect = anchorEl.getBoundingClientRect();
+      const expectedTop = anchorRect.top <= 16 ? 16 : anchorRect.top;
+      const expectedLeft = anchorRect.left <= 16 ? 16 : anchorRect.left;
+      expectPopover(expectedTop, expectedLeft);
+    });
+
+    it('should be positioned over the top left of the anchor even when `PaperProps.ref` is passed as prop', async () => {
+      await openPopover({ vertical: 'top', horizontal: 'left' }, true);
       const anchorRect = anchorEl.getBoundingClientRect();
       const expectedTop = anchorRect.top <= 16 ? 16 : anchorRect.top;
       const expectedLeft = anchorRect.left <= 16 ? 16 : anchorRect.left;

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -257,20 +257,17 @@ describe('<Popover />', () => {
   describe('PaperProps.ref', () => {
     it('should position popover correctly', () => {
       const handleEntering = spy();
-      mount(
+      render(
         <Popover
           {...defaultProps}
           open
           PaperProps={{ 'data-testid': 'Popover', ref: () => null }}
-          anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
           TransitionProps={{ onEntering: handleEntering }}
         >
           <div />
         </Popover>,
       );
-
-      const element = handleEntering.args[0][0];
-      expect(element.style.top === '16px' && element.style.left === '16px').to.equal(true);
+      expect(handleEntering.args[0][0]).toHaveInlineStyle({ top: '16px', left: '16px' });
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #26538

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixed by making use of `useForkRef` utility as described in the issue comments.