### PR TITLE
[Select] Fix custom font size centering arrow

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -84,7 +84,7 @@ export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
   // to the input and to support wrapping tags..
   position: 'absolute',
   right: 0,
-  top: 'calc(50% - 12px)', // Center vertically
+  top: 'calc(50% - .5em)', // Center vertically
   pointerEvents: 'none', // Don't block pointer events on the select under the icon.
   color: theme.palette.action.active,
   [`&.${nativeSelectClasses.disabled}`]: {

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -84,7 +84,7 @@ export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
   // to the input and to support wrapping tags..
   position: 'absolute',
   right: 0,
-  top: 'calc(50% - .5em)', // Center vertically
+  top: 'calc(50% - .5em)', // Center vertically, height is 1em
   pointerEvents: 'none', // Don't block pointer events on the select under the icon.
   color: theme.palette.action.active,
   [`&.${nativeSelectClasses.disabled}`]: {


### PR DESCRIPTION
Modifying the calc in order to center the select arrow vertically when the font size is changed [#26401}

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #26401