### PR TITLE
[ButtonBase] Consider as a link with a custom component and `to` prop

### DIFF
--- a/docs/src/pages/guides/routing/ButtonDemo.js
+++ b/docs/src/pages/guides/routing/ButtonDemo.js
@@ -1,16 +1,10 @@
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
 
-function preventDefault(event) {
-  event.preventDefault();
-}
-
 export default function ButtonDemo() {
   return (
-    <div role="presentation" onClick={preventDefault}>
-      <Button href="/" variant="contained">
-        Link
-      </Button>
-    </div>
+    <Button href="/" variant="contained">
+      Link
+    </Button>
   );
 }

--- a/docs/src/pages/guides/routing/ButtonDemo.js
+++ b/docs/src/pages/guides/routing/ButtonDemo.js
@@ -1,15 +1,16 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const preventDefault = (event) => event.preventDefault();
+function preventDefault(event) {
+  event.preventDefault();
+}
 
 export default function ButtonDemo() {
   return (
-    <Box role="presentation" onClick={preventDefault}>
+    <div role="presentation" onClick={preventDefault}>
       <Button href="/" variant="contained">
         Link
       </Button>
-    </Box>
+    </div>
   );
 }

--- a/docs/src/pages/guides/routing/ButtonDemo.tsx
+++ b/docs/src/pages/guides/routing/ButtonDemo.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 
-const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
+function preventDefault(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+  event.preventDefault();
+}
 
 export default function ButtonDemo() {
   return (
-    <Box role="presentation" onClick={preventDefault}>
+    <div role="presentation" onClick={preventDefault}>
       <Button href="/" variant="contained">
         Link
       </Button>
-    </Box>
+    </div>
   );
 }

--- a/docs/src/pages/guides/routing/ButtonDemo.tsx
+++ b/docs/src/pages/guides/routing/ButtonDemo.tsx
@@ -1,16 +1,10 @@
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
 
-function preventDefault(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
-  event.preventDefault();
-}
-
 export default function ButtonDemo() {
   return (
-    <div role="presentation" onClick={preventDefault}>
-      <Button href="/" variant="contained">
-        Link
-      </Button>
-    </div>
+    <Button href="/" variant="contained">
+      Link
+    </Button>
   );
 }

--- a/docs/src/pages/guides/routing/ButtonRouter.js
+++ b/docs/src/pages/guides/routing/ButtonRouter.js
@@ -4,7 +4,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 
 const LinkBehavior = React.forwardRef((props, ref) => (
-  <RouterLink ref={ref} to="/getting-started/installation/" {...props} />
+  <RouterLink ref={ref} to="/" {...props} role={undefined} />
 ));
 
 export default function ButtonRouter() {
@@ -15,7 +15,7 @@ export default function ButtonRouter() {
           With prop forwarding
         </Button>
         <br />
-        <Button component={LinkBehavior}>Without prop forwarding</Button>
+        <Button component={LinkBehavior}>With inlining</Button>
       </Router>
     </div>
   );

--- a/docs/src/pages/guides/routing/ButtonRouter.tsx
+++ b/docs/src/pages/guides/routing/ButtonRouter.tsx
@@ -4,9 +4,7 @@ import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-d
 import Button from '@material-ui/core/Button';
 
 const LinkBehavior = React.forwardRef<any, Omit<RouterLinkProps, 'to'>>(
-  (props, ref) => (
-    <RouterLink ref={ref} to="/getting-started/installation/" {...props} />
-  ),
+  (props, ref) => <RouterLink ref={ref} to="/" {...props} role={undefined} />,
 );
 
 export default function ButtonRouter() {
@@ -17,7 +15,7 @@ export default function ButtonRouter() {
           With prop forwarding
         </Button>
         <br />
-        <Button component={LinkBehavior}>Without prop forwarding</Button>
+        <Button component={LinkBehavior}>With inlining</Button>
       </Router>
     </div>
   );

--- a/docs/src/pages/guides/routing/LinkDemo.js
+++ b/docs/src/pages/guides/routing/LinkDemo.js
@@ -2,11 +2,13 @@ import * as React from 'react';
 import Link from '@material-ui/core/Link';
 import Box from '@material-ui/core/Box';
 
-const preventDefault = (event) => event.preventDefault();
+function preventDefault(event) {
+  event.preventDefault();
+}
 
 export default function LinkDemo() {
   return (
-    <Box sx={{ typography: 'body1' }} role="presentation" onClick={preventDefault}>
+    <Box sx={{ typography: 'body1' }} onClick={preventDefault}>
       <Link href="/">Link</Link>
     </Box>
   );

--- a/docs/src/pages/guides/routing/LinkDemo.js
+++ b/docs/src/pages/guides/routing/LinkDemo.js
@@ -2,13 +2,9 @@ import * as React from 'react';
 import Link from '@material-ui/core/Link';
 import Box from '@material-ui/core/Box';
 
-function preventDefault(event) {
-  event.preventDefault();
-}
-
 export default function LinkDemo() {
   return (
-    <Box sx={{ typography: 'body1' }} onClick={preventDefault}>
+    <Box sx={{ typography: 'body1' }}>
       <Link href="/">Link</Link>
     </Box>
   );

--- a/docs/src/pages/guides/routing/LinkDemo.tsx
+++ b/docs/src/pages/guides/routing/LinkDemo.tsx
@@ -2,11 +2,13 @@ import * as React from 'react';
 import Link from '@material-ui/core/Link';
 import Box from '@material-ui/core/Box';
 
-const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
+function preventDefault(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+  event.preventDefault();
+}
 
 export default function LinkDemo() {
   return (
-    <Box sx={{ typography: 'body1' }} role="presentation" onClick={preventDefault}>
+    <Box sx={{ typography: 'body1' }} onClick={preventDefault}>
       <Link href="/">Link</Link>
     </Box>
   );

--- a/docs/src/pages/guides/routing/LinkDemo.tsx
+++ b/docs/src/pages/guides/routing/LinkDemo.tsx
@@ -2,13 +2,9 @@ import * as React from 'react';
 import Link from '@material-ui/core/Link';
 import Box from '@material-ui/core/Box';
 
-function preventDefault(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
-  event.preventDefault();
-}
-
 export default function LinkDemo() {
   return (
-    <Box sx={{ typography: 'body1' }} onClick={preventDefault}>
+    <Box sx={{ typography: 'body1' }}>
       <Link href="/">Link</Link>
     </Box>
   );

--- a/docs/src/pages/guides/routing/ListRouter.js
+++ b/docs/src/pages/guides/routing/ListRouter.js
@@ -19,7 +19,7 @@ function ListItemLink(props) {
   const renderLink = React.useMemo(
     () =>
       React.forwardRef(function Link(itemProps, ref) {
-        return <RouterLink to={to} ref={ref} {...itemProps} />;
+        return <RouterLink to={to} ref={ref} {...itemProps} role={undefined} />;
       }),
     [to],
   );

--- a/docs/src/pages/guides/routing/ListRouter.tsx
+++ b/docs/src/pages/guides/routing/ListRouter.tsx
@@ -27,7 +27,7 @@ function ListItemLink(props: ListItemLinkProps) {
         itemProps,
         ref,
       ) {
-        return <RouterLink to={to} ref={ref} {...itemProps} />;
+        return <RouterLink to={to} ref={ref} {...itemProps} role={undefined} />;
       }),
     [to],
   );

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -73,7 +73,7 @@ You can apply the same strategy with all the components: BottomNavigation, Card,
 
 **Note**: The button base component adds the `role="button"` attribute when it identifies the intent to render a button without a native `<button>` element.
 This can create issues when rendering a link.
-If you are not using one of the `href`, `to`, or `componnet="a"` props, you need to **shallow the role** attribute.
+If you are not using one of the `href`, `to`, or `component="a"` props, you need to **shallow the role** attribute.
 It's why `role={undefined}` is set in the above demo.
 
 ```jsx

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -63,6 +63,10 @@ You can learn more about this prop in the [composition guide](/guides/compositio
 Here are a few demos with [react-router](https://github.com/ReactTraining/react-router).
 You can apply the same strategy with all the components: BottomNavigation, Card, etc.
 
+**Note**: When the `component` prop is used on the `ButtonBase` and not indicators are
+given that a link is rendered, a `role="button"` prop is provided by the `ButtonBase` to the component.
+You need to swallow this attribute if you are rendering a link, e.g. with `role={undefined}`.
+
 ### Link
 
 {{"demo": "pages/guides/routing/LinkRouter.js"}}

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -73,8 +73,8 @@ You can apply the same strategy with all the components: BottomNavigation, Card,
 
 **Note**: The button base component adds the `role="button"` attribute when it identifies the intent to render a button without a native `<button>` element.
 This can create issues when rendering a link.
-If you are not using one of the `href`, `to`, or `component="a"` props, you need to **swallow the role** attribute.
-It's why `role={undefined}` is set in the above demo.
+If you are not using one of the `href`, `to`, or `component="a"` props, you need to override the `role` attribute.
+The above demo achieves this by setting `role={undefined}` **after** the spread props.
 
 ```jsx
 const LinkBehavior = React.forwardRef((props, ref) => (

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -73,7 +73,7 @@ You can apply the same strategy with all the components: BottomNavigation, Card,
 
 **Note**: The button base component adds the `role="button"` attribute when it identifies the intent to render a button without a native `<button>` element.
 This can create issues when rendering a link.
-If you are not using one of the `href`, `to`, or `component="a"` props, you need to **shallow the role** attribute.
+If you are not using one of the `href`, `to`, or `component="a"` props, you need to **swallow the role** attribute.
 It's why `role={undefined}` is set in the above demo.
 
 ```jsx

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -63,9 +63,9 @@ You can learn more about this prop in the [composition guide](/guides/compositio
 Here are a few demos with [react-router](https://github.com/ReactTraining/react-router).
 You can apply the same strategy with all the components: BottomNavigation, Card, etc.
 
-**Note**: When the `component` prop is used on the `ButtonBase` and not indicators are
+**Note**: When the `component` prop is used on the `ButtonBase` and no indicators are
 given that a link is rendered, a `role="button"` prop is provided by the `ButtonBase` to the component.
-You need to swallow this attribute if you are rendering a link, e.g. with `role={undefined}`.
+You need to override this attribute if you are rendering a link, e.g. with `role={undefined}`.
 
 ### Link
 

--- a/docs/src/pages/guides/routing/routing.md
+++ b/docs/src/pages/guides/routing/routing.md
@@ -58,26 +58,33 @@ const theme = createTheme({
 ## `component` prop
 
 You can achieve the integration with third-party routing libraries with the `component` prop.
-You can learn more about this prop in the [composition guide](/guides/composition/#component-prop).
+You can learn more about this prop in the [**composition guide**](/guides/composition/#component-prop).
+
+### Link
 
 Here are a few demos with [react-router](https://github.com/ReactTraining/react-router).
 You can apply the same strategy with all the components: BottomNavigation, Card, etc.
 
-**Note**: When the `component` prop is used on the `ButtonBase` and no indicators are
-given that a link is rendered, a `role="button"` prop is provided by the `ButtonBase` to the component.
-You need to override this attribute if you are rendering a link, e.g. with `role={undefined}`.
-
-### Link
-
 {{"demo": "pages/guides/routing/LinkRouter.js"}}
-
-### Tabs
-
-{{"demo": "pages/guides/routing/TabsRouter.js", "defaultCodeOpen": false}}
 
 ### Button
 
 {{"demo": "pages/guides/routing/ButtonRouter.js"}}
+
+**Note**: The button base component adds the `role="button"` attribute when it identifies the intent to render a button without a native `<button>` element.
+This can create issues when rendering a link.
+If you are not using one of the `href`, `to`, or `componnet="a"` props, you need to **shallow the role** attribute.
+It's why `role={undefined}` is set in the above demo.
+
+```jsx
+const LinkBehavior = React.forwardRef((props, ref) => (
+  <RouterLink ref={ref} to="/" {...props} role={undefined} />
+));
+```
+
+### Tabs
+
+{{"demo": "pages/guides/routing/TabsRouter.js", "defaultCodeOpen": false}}
 
 ### List
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -283,7 +283,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
 
   let ComponentProp = component;
 
-  if (ComponentProp === 'button' && other.href) {
+  if (ComponentProp === 'button' && (other.href || other.to)) {
     ComponentProp = LinkComponent;
   }
 
@@ -292,7 +292,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     buttonProps.type = type === undefined ? 'button' : type;
     buttonProps.disabled = disabled;
   } else {
-    if (!other.href) {
+    if (!other.href && !other.to) {
       buttonProps.role = 'button';
     }
     if (disabled) {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -143,6 +143,7 @@ describe('<ButtonBase />', () => {
       });
 
       const { container } = render(
+        // @ts-expect-error missing types in CustomLink
         <ButtonBase component={CustomLink} href="https://google.com">
           Hello
         </ButtonBase>,
@@ -156,14 +157,17 @@ describe('<ButtonBase />', () => {
 
     it('should not add role="button" if custom component and to are used', () => {
       const CustomLink = React.forwardRef((props, ref) => {
+        // @ts-expect-error missing types in CustomLink
+        const { to, ...other } = props
         return (
-          <a data-testid="customLink" ref={ref} {...props}>
+          <a data-testid="customLink" ref={ref} {...other} href={to}>
             {props.children}
           </a>
         );
       });
 
       const { container } = render(
+        // @ts-expect-error missing types in CustomLink
         <ButtonBase component={CustomLink} to="https://google.com">
           Hello
         </ButtonBase>,

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -133,7 +133,7 @@ describe('<ButtonBase />', () => {
       expect(button).not.to.have.attribute('type');
     });
 
-    it('should not add role="button" if custom LinkComponent and href are used', () => {
+    it('should not add role="button" if custom component and href are used', () => {
       const CustomLink = React.forwardRef((props, ref) => {
         return (
           <a data-testid="customLink" ref={ref} {...props}>
@@ -143,7 +143,7 @@ describe('<ButtonBase />', () => {
       });
 
       const { container } = render(
-        <ButtonBase LinkComponent={CustomLink} href="https://google.com">
+        <ButtonBase component={CustomLink} href="https://google.com">
           Hello
         </ButtonBase>,
       );
@@ -151,6 +151,24 @@ describe('<ButtonBase />', () => {
       expect(button).to.have.property('nodeName', 'A');
       expect(button).to.have.attribute('data-testid', 'customLink');
       expect(button).to.have.attribute('href', 'https://google.com');
+      expect(button).not.to.have.attribute('role', 'button');
+    });
+
+    it('should not add role="button" if custom component and to are used', () => {
+      const CustomLink = React.forwardRef((props, ref) => {
+        return (
+          <a data-testid="customLink" ref={ref} {...props}>
+            {props.children}
+          </a>
+        );
+      });
+
+      const { container } = render(
+        <ButtonBase component={CustomLink} to="https://google.com">
+          Hello
+        </ButtonBase>,
+      );
+      const button = container.firstChild;
       expect(button).not.to.have.attribute('role', 'button');
     });
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -158,7 +158,7 @@ describe('<ButtonBase />', () => {
     it('should not add role="button" if custom component and to are used', () => {
       const CustomLink = React.forwardRef((props, ref) => {
         // @ts-expect-error missing types in CustomLink
-        const { to, ...other } = props
+        const { to, ...other } = props;
         return (
           <a data-testid="customLink" ref={ref} {...other} href={to}>
             {props.children}


### PR DESCRIPTION
`<ButtonBase component={CustomComponent} to="/some/value" />` will no longer pass `role="button"` to `CustomComponent`.

Fixes #26453 by improving the documentation and the component's logic:

- The prop name `to` is frequently used by routing libraries to provide the location to navigate to. Developers find it in react-router and reach-router, by the same authors. We now handle the existent of the prop as a heuristic to remove the role="button" attribute provided on the `component` prop. We assume that the final host will be a `<a>` element. This fixes the first example of this demo: https://next.material-ui.com/guides/routing/#button
- The second example of https://next.material-ui.com/guides/routing/#button requires extra care as the ButtonBase receives no information about the final intent. It assumes it will render a button, e.g. with a `<div>` host element.
- We update the documentation to make the two previous points clear for the developers.

Preview: https://deploy-preview-26576--material-ui.netlify.app/guides/routing/#button