### PR TITLE
Missing Package

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -8,6 +8,7 @@
     "@emotion/styled": "latest",
     "@emotion/server": "latest",
     "@material-ui/core": "next",
+     "@material-ui/styles": "^4.11.4",
     "clsx": "latest",
     "next": "latest",
     "prop-types": "latest",


### PR DESCRIPTION
_document.js import this package, but it is not installed. I think there is no v5 for **@material-ui/styles** yet ya?

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
