### PR TITLE
[Rating] onChangeActive shouldn't be fired on blur/focus

### DIFF
--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -357,10 +357,6 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
       hover: prev.hover,
       focus: newFocus,
     }));
-
-    if (onChangeActive && focus !== newFocus) {
-      onChangeActive(event, newFocus);
-    }
   };
 
   const handleBlur = (event) => {
@@ -378,10 +374,6 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
       hover: prev.hover,
       focus: newFocus,
     }));
-
-    if (onChangeActive && focus !== newFocus) {
-      onChangeActive(event, newFocus);
-    }
   };
 
   const [emptyValueFocused, setEmptyValueFocused] = React.useState(false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #26573