### PR TITLE
@material-ui/styles dependency missing

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -8,6 +8,7 @@
     "@emotion/styled": "latest",
     "@emotion/server": "latest",
     "@material-ui/core": "next",
+    "@material-ui/styles": "latest",
     "clsx": "latest",
     "next": "latest",
     "prop-types": "latest",


### PR DESCRIPTION
This example app requires **@material-ui/styles** to run with both yarn and npm after initial download

> Dependency is listed in `_document.tsx` **line 5** import `{ ServerStyleSheets } from '@material-ui/styles'`

The dependency was not listed in `package.json` and wouldn't run until installed.
This pull request resolves this issue and allows the app to run on initial clone & install.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
