### PR TITLE
[Radio][Checkbox] Don't forward `color` to DOM elements

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -98,7 +98,6 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
   return (
     <CheckboxRoot
       type="checkbox"
-      color={color}
       inputProps={{
         'data-indeterminate': indeterminate,
         ...inputProps,

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -100,7 +100,6 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
 
   return (
     <RadioRoot
-      color={color}
       type="radio"
       icon={React.cloneElement(defaultIcon, { fontSize: size === 'small' ? 'small' : 'medium' })}
       checkedIcon={React.cloneElement(defaultCheckedIcon, {


### PR DESCRIPTION
Fix regression from #26460, see the latest commit on HEAD: https://validator.w3.org/nu/?doc=https%3A%2F%2F60bcae09a9d7c90007682486--material-ui.netlify.app%2Fcomponents%2Fcheckboxes%2F to reproduce the error.


![image](https://user-images.githubusercontent.com/18292247/120928769-525a8400-c710-11eb-964d-ee9ea96b8072.png)

This is the error from `Checkbox`. 

![image](https://user-images.githubusercontent.com/18292247/120928800-77e78d80-c710-11eb-9534-7b408fa76518.png)

@oliviertassinari @mnajdova in case I miss anything else.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
