### PR TITLE
[ClickAwayListener] Update test case to reflect expected vs. actual

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -191,7 +191,7 @@ describe('<ClickAwayListener />', () => {
       });
     });
 
-    it('should be called if an element is interleaved between mousedown and mouseup', () => {
+    it('should not be called if an element is interleaved between mousedown and mouseup with trigger on click', () => {
       /**
        * @param {Element} element
        * @returns {Element[]}
@@ -256,6 +256,7 @@ describe('<ClickAwayListener />', () => {
       fireDiscreteEvent.mouseUp(mouseUpTarget);
       fireDiscreteEvent.click(clickTarget);
 
+      // TODO fix, should be 0
       expect(onClickAway.callCount).to.equal(1);
     });
   });


### PR DESCRIPTION
A follow-up on #25903 to adjust what we expect vs. what's we have.

The "why" on the expected behavior is based on a simple UX hypothesis: In the worse case (unexpected behavior), it's better to have users perform two inputs (two clicks) to trigger two actions (open + clickaway) **than** one input that triggers two actions. In the former case, the interface feels slow, in the latter, the interface feels broken.

As far as I know, no arguments have been made so far to defend that the current behavior is expected. @m4theushw's exploration, [feedback](https://github.com/mui-org/material-ui/issues/25578#issuecomment-828357974) from the community, and my exploration seem to support the direction taken in this PR: the current behavior is KO.