### PR TITLE
[test] Make tests oblivious to StrictMode

### DIFF
--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { spy, useFakeTimers } from 'sinon';
+import { useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
 import {
   createMount,
@@ -44,17 +44,15 @@ describe('<Popper />', () => {
 
   describe('prop: placement', () => {
     it('should have top placement', () => {
-      const renderSpy = spy();
       render(
         <Popper {...defaultProps} placement="top">
           {({ placement }) => {
-            renderSpy(placement);
-            return null;
+            return <span data-testid="renderSpy" data-placement={placement} />;
           }}
         </Popper>,
       );
-      expect(renderSpy.callCount).to.equal(2); // strict mode renders twice
-      expect(renderSpy.args[0][0]).to.equal('top');
+
+      expect(screen.getByTestId('renderSpy')).to.have.attribute('data-placement', 'top');
     });
 
     [

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -280,7 +280,7 @@ describe('<TextareaAutosize />', () => {
           scrollHeight: 100,
           lineHeight: () => {
             index += 1;
-            return 15 + index;
+            return index;
           },
         });
 

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -249,7 +249,7 @@ function clientRender(
     container,
     emotionCache,
     hydrate,
-    strict = true,
+    strict = false,
     profiler,
     wrapper: InnerWrapper = React.Fragment,
   } = configuration;

--- a/test/utils/createClientRender.tsx
+++ b/test/utils/createClientRender.tsx
@@ -249,7 +249,7 @@ function clientRender(
     container,
     emotionCache,
     hydrate,
-    strict = false,
+    strict = true,
     profiler,
     wrapper: InnerWrapper = React.Fragment,
   } = configuration;

--- a/test/utils/mochaHooks.test.js
+++ b/test/utils/mochaHooks.test.js
@@ -46,7 +46,8 @@ describe('mochaHooks', () => {
 
     describe('dedupes missing act() warnings by component', () => {
       const mochaHooks = createMochaHooks(Mocha);
-      const render = createClientRender();
+      // missing act warnings only happen in StrictMode
+      const render = createClientRender({ strict: true });
 
       beforeEach(function beforeEachHook() {
         mochaHooks.beforeAll.forEach((beforeAllMochaHook) => {


### PR DESCRIPTION
This allows us to run the test suite with different defauls for StrictMode.

Might be that we have to run some tests without StrictMode for some time until we're compatible with concurrent React.
