### PR TITLE
[test] Bundling fixtures should not override source build with published build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,11 +422,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture node-esm
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: |
@@ -449,11 +450,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture next-webpack4
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: yarn start
@@ -472,11 +474,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture next-webpack5
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: yarn start
@@ -495,11 +498,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture create-react-app
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: yarn start
@@ -518,11 +522,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture snowpack
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: yarn start
@@ -541,11 +546,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture vite
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: yarn start
@@ -564,11 +570,12 @@ jobs:
       - run:
           name: Prepare fixture
           command: |
-            node ../../scripts/useBuildFromSource.js .
             node ../../scripts/createFixture esbuild
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            node ../../scripts/useBuildFromSource.js .
       - run:
           name: Test fixture
           command: |

--- a/test/bundling/README.md
+++ b/test/bundling/README.md
@@ -11,15 +11,16 @@ The created file might need some manual adjustment since not every edge case is 
 1. Use the node version you want to use (e.g. `nvm use 14.0.0`)
 1. Prepare the package.json
    - to test a Pull Request
-     - checkout branch
-     - `yarn`
-     - `yarn lerna run build --scope "@material-ui/*"`
-     - `cd` to fixture
-     - `node ../../scripts/useBuildFromSource.js .`
+     1. checkout branch
+     1. `yarn`
+     1. `yarn lerna run build --scope "@material-ui/*"`
+     1. `cd` to fixture
+     1. `yarn install`
+     1. `node ../../scripts/useBuildFromSource.js .`
    - to test a published npm dist tag (e.g. `latest` or `next`) on npm
-     - adjust the dependencies in the package.json accordingly
-1. `cd` to fixture
-1. `yarn install`
+     1. `cd` to fixture
+     1. adjust the dependencies in the package.json accordingly
+     1. `yarn install`
 1. `yarn start` should exit with 0
 
 ### In CI


### PR DESCRIPTION
`useBuildFromSource` was always overridden by `yarn install`. We need to install first before we portal the build from source.

bundling pipeline should fail without https://github.com/mui-org/material-ui/pull/26656#issuecomment-857082885: https://app.circleci.com/pipelines/github/mui-org/material-ui/43159/workflows/d5eccc95-2c13-4974-b370-ad3bfdfa52b3

Good news: It's only `next`. All other meta frameworks are unaffected.