### PR TITLE
[List] Add ListItemButton export to index

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -267,6 +267,9 @@ export * from './ListItem';
 export { default as ListItemAvatar } from './ListItemAvatar';
 export * from './ListItemAvatar';
 
+export { default as ListItemButton } from './ListItemButton';
+export * from './ListItemButton';
+
 export { default as ListItemIcon } from './ListItemIcon';
 export * from './ListItemIcon';
 

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -200,6 +200,9 @@ export * from './ListItem';
 export { default as ListItemAvatar } from './ListItemAvatar';
 export * from './ListItemAvatar';
 
+export { default as ListItemButton } from './ListItemButton';
+export * from './ListItemButton';
+
 export { default as ListItemIcon } from './ListItemIcon';
 export * from './ListItemIcon';
 


### PR DESCRIPTION
close #26660 

Add ListItemButton as export in packages/material-ui/src/index.js and packages/material-ui/src/index.d.ts files

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
