### PR TITLE
[system] Fix support of custom shape in createTheme

### DIFF
--- a/packages/material-ui-system/src/createTheme/createTheme.js
+++ b/packages/material-ui-system/src/createTheme/createTheme.js
@@ -22,7 +22,7 @@ function createTheme(options = {}, ...args) {
       components: {}, // Inject component definitions.
       palette: { mode: 'light', ...paletteInput },
       spacing,
-      shape: { ...shape, shapeInput },
+      shape: { ...shape, ...shapeInput },
     },
     other,
   );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56271/121388829-b4e79600-c943-11eb-9b86-88c4f6ad4133.png)

Looks like a spread operator is missing.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
