### PR TITLE
[test] Count profiler renders not passive effects

### DIFF
--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -2,10 +2,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { act, createClientRender, createServerRender } from 'test/utils';
+import { act, createClientRender, createServerRender, screen, RenderCounter } from 'test/utils';
 import mediaQuery from 'css-mediaquery';
 import { expect } from 'chai';
-import { spy, stub } from 'sinon';
+import { stub } from 'sinon';
 
 function createMatchMedia(width, ref) {
   const listeners = [];
@@ -42,24 +42,17 @@ describe('useMediaQuery', () => {
   });
 
   const render = createClientRender();
-  let values;
-
-  beforeEach(() => {
-    values = spy();
-  });
 
   describe('without feature', () => {
     it('should work without window.matchMedia available', () => {
       expect(typeof window.matchMedia).to.equal('undefined');
-      const ref = React.createRef();
-      const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:100px)');
-        return <span ref={ref}>{`${matches}`}</span>;
+        return <span data-testid="matches">{`${matches}`}</span>;
       };
 
       render(<Test />);
-      expect(text()).to.equal('false');
+      expect(screen.getByTestId('matches').textContent).to.equal('false');
     });
   });
 
@@ -87,153 +80,175 @@ describe('useMediaQuery', () => {
 
     describe('option: defaultMatches', () => {
       it('should be false by default', () => {
-        const ref = React.createRef();
-        const text = () => ref.current.textContent;
+        const getRenderCountRef = React.createRef();
         const Test = () => {
           const matches = useMediaQuery('(min-width:2000px)');
-          React.useEffect(() => values(matches));
-          return <span ref={ref}>{`${matches}`}</span>;
+          return (
+            <RenderCounter ref={getRenderCountRef}>
+              <span data-testid="matches">{`${matches}`}</span>
+            </RenderCounter>
+          );
         };
 
         render(<Test />);
-        expect(text()).to.equal('false');
-        expect(values.callCount).to.equal(1);
+        expect(screen.getByTestId('matches').textContent).to.equal('false');
+        expect(getRenderCountRef.current()).to.equal(1);
       });
 
       it('should take the option into account', () => {
-        const ref = React.createRef();
-        const text = () => ref.current.textContent;
+        const getRenderCountRef = React.createRef();
         const Test = () => {
           const matches = useMediaQuery('(min-width:2000px)', {
             defaultMatches: true,
           });
-          React.useEffect(() => values(matches));
-          return <span ref={ref}>{`${matches}`}</span>;
+          return (
+            <RenderCounter ref={getRenderCountRef}>
+              <span data-testid="matches">{`${matches}`}</span>
+            </RenderCounter>
+          );
         };
 
         render(<Test />);
-        expect(text()).to.equal('false');
-        expect(values.callCount).to.equal(2);
+        expect(screen.getByTestId('matches').textContent).to.equal('false');
+        expect(getRenderCountRef.current()).to.equal(2);
       });
     });
 
     describe('option: noSsr', () => {
       it('should render once if the default value match the expectation', () => {
-        const ref = React.createRef();
-        const text = () => ref.current.textContent;
+        const getRenderCountRef = React.createRef();
         const Test = () => {
           const matches = useMediaQuery('(min-width:2000px)', {
             defaultMatches: false,
           });
-          React.useEffect(() => values(matches));
-          return <span ref={ref}>{`${matches}`}</span>;
+
+          return (
+            <RenderCounter ref={getRenderCountRef}>
+              <span data-testid="matches">{`${matches}`}</span>
+            </RenderCounter>
+          );
         };
 
         render(<Test />);
-        expect(text()).to.equal('false');
-        expect(values.callCount).to.equal(1);
+        expect(screen.getByTestId('matches').textContent).to.equal('false');
+        expect(getRenderCountRef.current()).to.equal(1);
       });
 
       it('should render twice if the default value does not match the expectation', () => {
-        const ref = React.createRef();
-        const text = () => ref.current.textContent;
+        const getRenderCountRef = React.createRef();
         const Test = () => {
           const matches = useMediaQuery('(min-width:2000px)', {
             defaultMatches: true,
           });
-          React.useEffect(() => values(matches));
-          return <span ref={ref}>{`${matches}`}</span>;
+
+          return (
+            <RenderCounter ref={getRenderCountRef}>
+              <span data-testid="matches">{`${matches}`}</span>
+            </RenderCounter>
+          );
         };
 
         render(<Test />);
-        expect(text()).to.equal('false');
-        expect(values.callCount).to.equal(2);
+        expect(screen.getByTestId('matches').textContent).to.equal('false');
+        expect(getRenderCountRef.current()).to.equal(2);
       });
 
       it('should render once if the default value does not match the expectation', () => {
-        const ref = React.createRef();
-        const text = () => ref.current.textContent;
+        const getRenderCountRef = React.createRef();
         const Test = () => {
           const matches = useMediaQuery('(min-width:2000px)', {
             defaultMatches: true,
             noSsr: true,
           });
-          React.useEffect(() => values(matches));
-          return <span ref={ref}>{`${matches}`}</span>;
+
+          return (
+            <RenderCounter ref={getRenderCountRef}>
+              <span data-testid="matches">{`${matches}`}</span>
+            </RenderCounter>
+          );
         };
 
         render(<Test />);
-        expect(text()).to.equal('false');
-        expect(values.callCount).to.equal(1);
+        expect(screen.getByTestId('matches').textContent).to.equal('false');
+        expect(getRenderCountRef.current()).to.equal(1);
       });
     });
 
     it('should try to reconcile each time', () => {
-      const ref = React.createRef();
-      const text = () => ref.current.textContent;
+      const getRenderCountRef = React.createRef();
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
-        React.useEffect(() => values(matches));
-        return <span ref={ref}>{`${matches}`}</span>;
+
+        return (
+          <RenderCounter ref={getRenderCountRef}>
+            <span data-testid="matches">{`${matches}`}</span>
+          </RenderCounter>
+        );
       };
 
       const { unmount } = render(<Test />);
-      expect(text()).to.equal('false');
-      expect(values.callCount).to.equal(2);
+      expect(screen.getByTestId('matches').textContent).to.equal('false');
+      expect(getRenderCountRef.current()).to.equal(2);
 
       unmount();
 
       render(<Test />);
-      expect(text()).to.equal('false');
-      expect(values.callCount).to.equal(4);
+      expect(screen.getByTestId('matches').textContent).to.equal('false');
+      expect(getRenderCountRef.current()).to.equal(2);
     });
 
     it('should be able to change the query dynamically', () => {
-      const ref = React.createRef();
-      const text = () => ref.current.textContent;
+      const getRenderCountRef = React.createRef();
       const Test = (props) => {
         const matches = useMediaQuery(props.query, {
           defaultMatches: true,
         });
-        React.useEffect(() => values(matches));
-        return <span ref={ref}>{`${matches}`}</span>;
+
+        return (
+          <RenderCounter ref={getRenderCountRef}>
+            <span data-testid="matches">{`${matches}`}</span>
+          </RenderCounter>
+        );
       };
       Test.propTypes = {
         query: PropTypes.string.isRequired,
       };
 
       const { setProps } = render(<Test query="(min-width:2000px)" />);
-      expect(text()).to.equal('false');
-      expect(values.callCount).to.equal(2);
+      expect(screen.getByTestId('matches').textContent).to.equal('false');
+      expect(getRenderCountRef.current()).to.equal(2);
       setProps({ query: '(min-width:100px)' });
-      expect(text()).to.equal('true');
-      expect(values.callCount).to.equal(4);
+      expect(screen.getByTestId('matches').textContent).to.equal('true');
+      expect(getRenderCountRef.current()).to.equal(4);
     });
 
     it('should observe the media query', () => {
-      const ref = React.createRef();
-      const text = () => ref.current.textContent;
+      const getRenderCountRef = React.createRef();
       const Test = (props) => {
         const matches = useMediaQuery(props.query);
-        React.useEffect(() => values(matches));
-        return <span ref={ref}>{`${matches}`}</span>;
+
+        return (
+          <RenderCounter ref={getRenderCountRef}>
+            <span data-testid="matches">{`${matches}`}</span>
+          </RenderCounter>
+        );
       };
       Test.propTypes = {
         query: PropTypes.string.isRequired,
       };
 
       render(<Test query="(min-width:2000px)" />);
-      expect(values.callCount).to.equal(1);
-      expect(text()).to.equal('false');
+      expect(getRenderCountRef.current()).to.equal(1);
+      expect(screen.getByTestId('matches').textContent).to.equal('false');
 
       act(() => {
         matchMediaInstances[0].instance.matches = true;
         matchMediaInstances[0].listeners[0]();
       });
-      expect(text()).to.equal('true');
-      expect(values.callCount).to.equal(2);
+      expect(screen.getByTestId('matches').textContent).to.equal('true');
+      expect(getRenderCountRef.current()).to.equal(2);
     });
   });
 
@@ -243,11 +258,10 @@ describe('useMediaQuery', () => {
     it('should use the ssr match media ponyfill', () => {
       let markup;
       expect(() => {
-        const ref = React.createRef();
         function MyComponent() {
           const matches = useMediaQuery('(min-width:2000px)');
-          values(matches);
-          return <span ref={ref}>{`${matches}`}</span>;
+
+          return <span>{`${matches}`}</span>;
         }
 
         const Test = () => {
@@ -270,7 +284,6 @@ describe('useMediaQuery', () => {
       }).toErrorDev(['Warning: useLayoutEffect does nothing on the server']);
 
       expect(markup.text()).to.equal('true');
-      expect(values.callCount).to.equal(1);
     });
   });
 

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -1,88 +1,80 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { spy } from 'sinon';
-import { act, createClientRender } from 'test/utils';
+import { act, createClientRender, RenderCounter, screen } from 'test/utils';
 import useScrollTrigger from '@material-ui/core/useScrollTrigger';
 import Container from '@material-ui/core/Container';
 import Box from '@material-ui/core/Box';
 
 describe('useScrollTrigger', () => {
   const render = createClientRender();
-  let values;
-
-  beforeEach(() => {
-    values = spy();
-  });
-
-  const triggerRef = React.createRef();
-  const containerRef = React.createRef(); // Get the scroll container's parent
-  const getContainer = () => containerRef.current.children[0]; // Get the scroll container
-  const getTriggerValue = () => triggerRef.current.textContent; // Retrieve the trigger value
-
-  function Test(props) {
-    const { customContainer, ...other } = props;
-    const [container, setContainer] = React.useState();
-    const trigger = useScrollTrigger({ ...other, target: container });
-
-    React.useEffect(() => {
-      values(trigger);
-    });
-
-    return (
-      <React.Fragment>
-        <span ref={triggerRef}>{`${trigger}`}</span>
-        <div ref={containerRef}>
-          <Container ref={customContainer ? setContainer : null}>
-            <Box sx={{ my: 2 }}>Custom container</Box>
-          </Container>
-        </div>
-      </React.Fragment>
-    );
-  }
-
-  Test.propTypes = {
-    customContainer: PropTypes.bool,
-  };
 
   describe('defaultTrigger', () => {
     it('should be false by default', () => {
+      const getRenderCountRef = React.createRef();
       const TestDefault = () => {
         const trigger = useScrollTrigger();
-        React.useEffect(() => {
-          values(trigger);
-        });
-        return <span ref={triggerRef}>{`${trigger}`}</span>;
+        return (
+          <RenderCounter ref={getRenderCountRef}>
+            <span data-testid="trigger">{`${trigger}`}</span>
+          </RenderCounter>
+        );
       };
 
       render(<TestDefault />);
-      expect(getTriggerValue()).to.equal('false');
-      expect(values.callCount).to.equal(1);
+
+      expect(screen.getByTestId('trigger').textContent).to.equal('false');
+      expect(getRenderCountRef.current()).to.equal(1);
     });
 
     it('should be false by default when using ref', () => {
+      const getRenderCountRef = React.createRef();
+      const triggerRef = React.createRef();
       const TestDefaultWithRef = () => {
         const [container, setContainer] = React.useState();
         const trigger = useScrollTrigger({
           target: container,
         });
-        React.useEffect(() => {
-          values(trigger);
-        });
         return (
-          <React.Fragment>
+          <RenderCounter ref={getRenderCountRef}>
             <span ref={triggerRef}>{`${trigger}`}</span>
             <span ref={setContainer} />
-          </React.Fragment>
+          </RenderCounter>
         );
       };
       render(<TestDefaultWithRef />);
-      expect(getTriggerValue()).to.equal('false');
-      expect(values.callCount).to.equal(2);
+      expect(triggerRef.current.textContent).to.equal('false');
+      expect(getRenderCountRef.current()).to.equal(2);
     });
   });
 
   describe('scroll', () => {
+    const triggerRef = React.createRef();
+    const containerRef = React.createRef(); // Get the scroll container's parent
+    const getContainer = () => containerRef.current.children[0]; // Get the scroll container
+    const getTriggerValue = () => triggerRef.current.textContent; // Retrieve the trigger value
+
+    function Test(props) {
+      const { customContainer, ...other } = props;
+      const [container, setContainer] = React.useState();
+      const trigger = useScrollTrigger({ ...other, target: container });
+
+      return (
+        <React.Fragment>
+          <span ref={triggerRef}>{`${trigger}`}</span>
+          <div ref={containerRef}>
+            <Container ref={customContainer ? setContainer : null}>
+              <Box sx={{ my: 2 }}>Custom container</Box>
+            </Container>
+          </div>
+        </React.Fragment>
+      );
+    }
+
+    Test.propTypes = {
+      customContainer: PropTypes.bool,
+    };
+
     before(function beforeHook() {
       // Only run the test on node.
       if (!/jsdom/.test(window.navigator.userAgent)) {

--- a/test/utils/components.js
+++ b/test/utils/components.js
@@ -39,7 +39,7 @@ export class ErrorBoundary extends React.Component {
 /**
  * Allows counting how many times the owner of `RenderCounter` rendered.
  * @example <RenderCounter ref={getRenderCountRef}>...</RenderCounter>
- *          getRenderCountRef.current === 2
+ *          getRenderCountRef.current() === 2
  * @type {import('react').JSXElementConstructor<{children: import('react').ReactNode} & import('react').RefAttributes<() => number>>}
  */
 export const RenderCounter = React.forwardRef(function RenderCounter({ children }, ref) {

--- a/test/utils/components.js
+++ b/test/utils/components.js
@@ -40,7 +40,7 @@ export class ErrorBoundary extends React.Component {
  * Allows counting how many times the owner of `RenderCounter` rendered.
  * @example <RenderCounter ref={getRenderCountRef}>...</RenderCounter>
  *          getRenderCountRef.current === 2
- * @type {import('react').JSXElementConstructor<{children: import('react').ReactNode} & import('react').RefAttributes<number>>}
+ * @type {import('react').JSXElementConstructor<{children: import('react').ReactNode} & import('react').RefAttributes<() => number>>}
  */
 export const RenderCounter = React.forwardRef(function RenderCounter({ children }, ref) {
   const getRenderCountRef = React.useRef(0);

--- a/test/utils/components.js
+++ b/test/utils/components.js
@@ -6,8 +6,6 @@ import PropTypes from 'prop-types';
  * @example <ErrorBoundary ref={errorRef}><MyComponent /></ErrorBoundary>;
  *          expect(errorRef.current.errors).to.have.lenght(0);
  */
-// enforce a single file for test related components
-// eslint-disable-next-line import/prefer-default-export
 export class ErrorBoundary extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -37,3 +35,29 @@ export class ErrorBoundary extends React.Component {
     return this.props.children;
   }
 }
+
+/**
+ * Allows counting how many times the owner of `RenderCounter` rendered.
+ * @example <RenderCounter ref={getRenderCountRef}>...</RenderCounter>
+ *          getRenderCountRef.current === 2
+ * @type {import('react').JSXElementConstructor<{children: import('react').ReactNode} & import('react').RefAttributes<number>>}
+ */
+export const RenderCounter = React.forwardRef(function RenderCounter({ children }, ref) {
+  const getRenderCountRef = React.useRef(0);
+  React.useImperativeHandle(ref, () => () => getRenderCountRef.current);
+
+  return (
+    <React.Profiler
+      id="render-counter"
+      onRender={() => {
+        getRenderCountRef.current += 1;
+      }}
+    >
+      {children}
+    </React.Profiler>
+  );
+});
+
+RenderCounter.propTypes = {
+  children: PropTypes.node,
+};


### PR DESCRIPTION
Uses `React.Profiler` instead of `useEffect` to count commits (implementation in https://github.com/eps1lon/material-ui/blob/af74ef1e9fcbbc40d23b0fd6f05fb05fac42689e/test/utils/components.js#L45-L63). `useEffect` will have slightly different semantics in React 18. See https://github.com/reactwg/react-18/discussions/18 for more context.

/cc @oliviertassinari and @dtassone. I think one of you asked me a while back how to test render count.