### PR TITLE
[test] Run e2e test with React 18 on a schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,7 +686,7 @@ workflows:
           react-dist-tag: next
       - test_regressions:
           react-dist-tag: next
-      - test_regressions:
+      - test_e2e:
           react-dist-tag: next
   typescript-next:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,6 +634,7 @@ workflows:
           requires:
             - checkout
       - test_e2e:
+          react-dist-tag: next
           requires:
             - checkout
   bundling:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,7 +634,6 @@ workflows:
           requires:
             - checkout
       - test_e2e:
-          react-dist-tag: next
           requires:
             - checkout
   bundling:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,8 @@ workflows:
           react-dist-tag: next
       - test_regressions:
           react-dist-tag: next
+      - test_regressions:
+          react-dist-tag: next
   typescript-next:
     triggers:
       - schedule:


### PR DESCRIPTION
Adds `test_e2e` to our `react-next` workflow