### PR TITLE
[system] Remove `theme` & `isRtl` from `useThemeProps`

### DIFF
--- a/docs/src/pages/customization/palette/Palette.js
+++ b/docs/src/pages/customization/palette/Palette.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { createTheme } from '@material-ui/core/styles';
-import { ThemeProvider } from '@material-ui/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { purple } from '@material-ui/core/colors';
 import Button from '@material-ui/core/Button';
 

--- a/docs/src/pages/customization/palette/Palette.tsx
+++ b/docs/src/pages/customization/palette/Palette.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { createTheme } from '@material-ui/core/styles';
-import { ThemeProvider } from '@material-ui/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { purple } from '@material-ui/core/colors';
 import Button from '@material-ui/core/Button';
 

--- a/packages/material-ui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/material-ui-lab/src/LoadingButton/LoadingButton.js
@@ -31,12 +31,7 @@ const useUtilityClasses = (styleProps) => {
 
 // TODO use `import { rootShouldForwardProp } from '../styles/styled';` once move to core
 const rootShouldForwardProp = (prop) =>
-  prop !== 'styleProps' &&
-  prop !== 'theme' &&
-  prop !== 'isRtl' &&
-  prop !== 'sx' &&
-  prop !== 'as' &&
-  prop !== 'classes';
+  prop !== 'styleProps' && prop !== 'theme' && prop !== 'sx' && prop !== 'as' && prop !== 'classes';
 const LoadingButtonRoot = styled(Button, {
   shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes',
   name: 'MuiLoadingButton',

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -83,7 +83,7 @@ const TreeView = React.forwardRef(function TreeView(inProps, ref) {
     selected: selectedProp,
     ...other
   } = props;
-  // use the `isRtl` from the props after the buildAPI script support it
+
   const theme = useTheme();
   const isRtl = theme.direction === 'rtl';
 

--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -53,7 +53,7 @@ const variantsResolver = (props, styles, theme, name) => {
 };
 
 export const shouldForwardProp = (prop) =>
-  prop !== 'styleProps' && prop !== 'theme' && prop !== 'isRtl' && prop !== 'sx' && prop !== 'as';
+  prop !== 'styleProps' && prop !== 'theme' && prop !== 'sx' && prop !== 'as';
 
 export const systemDefaultTheme = createTheme();
 

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -133,7 +133,6 @@ export { default as shape } from './createTheme/shape';
 export * from './createTheme/shape';
 
 export { default as unstable_useThemeProps } from './useThemeProps';
-export { getThemeProps as unstable_getThemeProps } from './useThemeProps';
 
 export { default as useTheme } from './useTheme';
 export * from './useTheme';

--- a/packages/material-ui-system/src/index.js
+++ b/packages/material-ui-system/src/index.js
@@ -34,6 +34,5 @@ export { default as createTheme } from './createTheme';
 export { default as createBreakpoints } from './createTheme/createBreakpoints';
 export { default as shape } from './createTheme/shape';
 export { default as unstable_useThemeProps } from './useThemeProps';
-export { getThemeProps as unstable_getThemeProps } from './useThemeProps';
 export { default as useTheme } from './useTheme';
 export * from './colorManipulator';

--- a/packages/material-ui-system/src/useThemeProps/index.d.ts
+++ b/packages/material-ui-system/src/useThemeProps/index.d.ts
@@ -1,4 +1,2 @@
 export { default } from './useThemeProps';
 export * from './useThemeProps';
-
-export { default as getThemeProps } from './getThemeProps';

--- a/packages/material-ui-system/src/useThemeProps/index.js
+++ b/packages/material-ui-system/src/useThemeProps/index.js
@@ -1,2 +1,1 @@
 export { default } from './useThemeProps';
-export { default as getThemeProps } from './getThemeProps';

--- a/packages/material-ui-system/src/useThemeProps/useThemeProps.d.ts
+++ b/packages/material-ui-system/src/useThemeProps/useThemeProps.d.ts
@@ -8,17 +8,8 @@ export type ThemedProps<Theme, Name extends keyof any> = Theme extends {
   ? Props
   : {};
 
-export interface AdditionalThemeProps<Theme> {
-  isRtl: boolean;
-  theme: Theme;
-}
-
 export default function useThemeProps<
   Theme extends ThemeWithProps,
   Props,
   Name extends keyof any,
->(params: {
-  props: Props;
-  name: Name;
-  defaultTheme?: Theme;
-}): Props & ThemedProps<Theme, Name> & AdditionalThemeProps<Theme>;
+>(params: { props: Props; name: Name; defaultTheme?: Theme }): Props & ThemedProps<Theme, Name>;

--- a/packages/material-ui-system/src/useThemeProps/useThemeProps.js
+++ b/packages/material-ui-system/src/useThemeProps/useThemeProps.js
@@ -2,13 +2,7 @@ import getThemeProps from './getThemeProps';
 import useTheme from '../useTheme';
 
 export default function useThemeProps({ props, name, defaultTheme }) {
-  const contextTheme = useTheme(defaultTheme);
-  const more = getThemeProps({ theme: contextTheme, name, props });
-  const theme = more.theme || contextTheme;
-
-  return {
-    theme,
-    isRtl: theme.direction === 'rtl',
-    ...more,
-  };
+  const theme = useTheme(defaultTheme);
+  const mergedProps = getThemeProps({ theme, name, props });
+  return { ...mergedProps };
 }

--- a/packages/material-ui-system/src/useThemeProps/useThemeProps.js
+++ b/packages/material-ui-system/src/useThemeProps/useThemeProps.js
@@ -4,5 +4,5 @@ import useTheme from '../useTheme';
 export default function useThemeProps({ props, name, defaultTheme }) {
   const theme = useTheme(defaultTheme);
   const mergedProps = getThemeProps({ theme, name, props });
-  return { ...mergedProps };
+  return mergedProps;
 }

--- a/packages/material-ui-system/src/useThemeProps/useThemeProps.spec.ts
+++ b/packages/material-ui-system/src/useThemeProps/useThemeProps.spec.ts
@@ -21,10 +21,6 @@ function ThemedComponent() {
     name: 'MuiSlider',
   });
 
-  // additional props are valid
-  expectType<boolean, typeof props.isRtl>(props.isRtl);
-  expectType<Theme, typeof props.theme>(props.theme);
-
   // component's props are valid
   // Only existence of props is relevant here not type.
   props.track;

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.js
@@ -214,8 +214,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
     isRtl = false,
     components = {},
     componentsProps = {},
-    /* eslint-disable-next-line react/prop-types */
-    theme,
     ...other
   } = props;
 
@@ -642,7 +640,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
       {...(!isHostComponent(Root) && {
         as: component,
         styleProps: { ...styleProps, ...rootProps.styleProps },
-        theme,
       })}
       {...other}
       className={clsx(classes.root, rootProps.className, className)}
@@ -651,7 +648,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
         {...railProps}
         {...(!isHostComponent(Rail) && {
           styleProps: { ...styleProps, ...railProps.styleProps },
-          theme,
         })}
         className={clsx(classes.rail, railProps.className)}
       />
@@ -659,7 +655,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
         {...trackProps}
         {...(!isHostComponent(Track) && {
           styleProps: { ...styleProps, ...trackProps.styleProps },
-          theme,
         })}
         className={clsx(classes.track, trackProps.className)}
         style={{ ...trackStyle, ...trackProps.style }}
@@ -690,7 +685,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
               {...markProps}
               {...(!isHostComponent(Mark) && {
                 styleProps: { ...styleProps, ...markProps.styleProps, markActive },
-                theme,
               })}
               style={{ ...style, ...markProps.style }}
               className={clsx(classes.mark, markProps.className, {
@@ -708,7 +702,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                     ...markLabelProps.styleProps,
                     markLabelActive: markActive,
                   },
-                  theme,
                 })}
                 style={{ ...style, ...markLabelProps.style }}
                 className={clsx(classes.markLabel, markLabelProps.className, {
@@ -744,7 +737,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
               className={clsx(classes.valueLabel, valueLabelProps.className)}
               {...(!isHostComponent(ValueLabel) && {
                 styleProps: { ...styleProps, ...valueLabelProps.styleProps },
-                theme,
               })}
             >
               <Thumb
@@ -758,7 +750,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                 })}
                 {...(!isHostComponent(Thumb) && {
                   styleProps: { ...styleProps, ...thumbProps.styleProps },
-                  theme,
                 })}
                 style={{
                   ...style,

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -190,7 +190,7 @@ const BadgeBadge = styled('span', {
 }));
 
 const Badge = React.forwardRef(function Badge(inProps, ref) {
-  const { isRtl, ...props } = useThemeProps({ props: inProps, name: 'MuiBadge' });
+  const props = useThemeProps({ props: inProps, name: 'MuiBadge' });
   const {
     components = {},
     componentsProps = {},

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -8,6 +8,7 @@ import formControlState from '../FormControl/formControlState';
 import FormControlContext, { useFormControl } from '../FormControl/FormControlContext';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
+import useTheme from '../styles/useTheme';
 import capitalize from '../utils/capitalize';
 import useForkRef from '../utils/useForkRef';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
@@ -255,12 +256,10 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
     startAdornment,
     type = 'text',
     value: valueProp,
-    /* eslint-disable-next-line react/prop-types */
-    isRtl,
-    /* eslint-disable-next-line react/prop-types */
-    theme,
     ...other
   } = props;
+
+  const theme = useTheme();
 
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -8,6 +8,7 @@ import MenuList from '../MenuList';
 import Paper from '../Paper';
 import Popover from '../Popover';
 import styled, { rootShouldForwardProp } from '../styles/styled';
+import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import { getMenuUtilityClass } from './menuClasses';
 
@@ -63,7 +64,7 @@ const MenuMenuList = styled(MenuList, {
 });
 
 const Menu = React.forwardRef(function Menu(inProps, ref) {
-  const { isRtl, theme, ...props } = useThemeProps({ props: inProps, name: 'MuiMenu' });
+  const props = useThemeProps({ props: inProps, name: 'MuiMenu' });
 
   const {
     autoFocus = true,
@@ -80,6 +81,9 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
     variant = 'selectedMenu',
     ...other
   } = props;
+
+  const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
 
   const styleProps = {
     ...props,

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -248,6 +248,10 @@ Menu.propTypes /* remove-proptypes */ = {
    */
   open: PropTypes.bool.isRequired,
   /**
+   * @ignore
+   */
+  PaperProps: PropTypes.object,
+  /**
    * `classes` prop applied to the [`Popover`](/api/popover/) element.
    */
   PopoverClasses: PropTypes.object,

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -73,7 +73,6 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
     MenuListProps = {},
     onClose,
     open,
-    // eslint-disable-next-line react/prop-types
     PaperProps = {},
     PopoverClasses,
     transitionDuration = 'auto',

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -11,6 +11,7 @@ import SliderUnstyled, {
 import { alpha, lighten, darken } from '@material-ui/system';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
+import useTheme from '../styles/useTheme';
 import capitalize from '../utils/capitalize';
 
 export const sliderClasses = {
@@ -358,6 +359,10 @@ const shouldSpreadStyleProps = (Component) => {
 
 const Slider = React.forwardRef(function Slider(inputProps, ref) {
   const props = useThemeProps({ props: inputProps, name: 'MuiSlider' });
+
+  const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
+
   const { components = {}, componentsProps = {}, color = 'primary', ...other } = props;
 
   const styleProps = { ...props, color };
@@ -367,6 +372,8 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
   return (
     <SliderUnstyled
       {...other}
+      isRtl={isRtl}
+      theme={theme}
       components={{
         Root: SliderRoot,
         Rail: SliderRail,

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -373,7 +373,6 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
     <SliderUnstyled
       {...other}
       isRtl={isRtl}
-      theme={theme}
       components={{
         Root: SliderRoot,
         Rail: SliderRail,

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { elementTypeAcceptingRef } from '@material-ui/utils';
-import { unstable_getThemeProps as getThemeProps } from '@material-ui/system';
+import { unstable_useThemeProps as useThemeProps } from '@material-ui/system';
 import Drawer, { getAnchor, isHorizontal } from '../Drawer/Drawer';
 import ownerDocument from '../utils/ownerDocument';
 import ownerWindow from '../utils/ownerWindow';
@@ -134,8 +134,8 @@ const iOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigato
 const transitionDurationDefault = { enter: duration.enteringScreen, exit: duration.leavingScreen };
 
 const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) {
+  const props = useThemeProps({ name: 'MuiSwipeableDrawer', props: inProps });
   const theme = useTheme();
-  const props = getThemeProps({ name: 'MuiSwipeableDrawer', props: inProps, theme });
   const {
     anchor = 'left',
     disableBackdropTransition = false,

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.js
@@ -6,6 +6,7 @@ import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import ButtonBase from '../ButtonBase';
+import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
 import tabScrollButtonClasses, { getTabScrollButtonUtilityClass } from './tabScrollButtonClasses';

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.js
@@ -53,8 +53,10 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(inProps, ref) 
   const props = useThemeProps({ props: inProps, name: 'MuiTabScrollButton' });
   const { className, direction, orientation, disabled, ...other } = props;
 
-  // TODO: convert to simple assignment after the type error in defaultPropsHandler.js:60:6 is fixed
-  const styleProps = { ...props };
+  const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
+
+  const styleProps = { isRtl, ...props };
 
   const classes = useUtilityClasses(styleProps);
 

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -674,6 +674,10 @@ Tooltip.propTypes /* remove-proptypes */ = {
    */
   classes: PropTypes.object,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * Set to `true` if the `title` acts as an accessible description.
    * By default the `title` acts as an accessible label for the child.
    * @default false

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -5,6 +5,7 @@ import { elementAcceptingRef } from '@material-ui/utils';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import { alpha } from '@material-ui/system';
 import styled from '../styles/styled';
+import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import Grow from '../Grow';
@@ -212,7 +213,7 @@ function composeEventHandler(handler, eventHandler) {
 }
 
 const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
-  const { theme, isRtl, ...props } = useThemeProps({ props: inProps, name: 'MuiTooltip' });
+  const props = useThemeProps({ props: inProps, name: 'MuiTooltip' });
   const {
     arrow = false,
     children,
@@ -240,6 +241,8 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     TransitionProps,
     ...other
   } = props;
+
+  const theme = useTheme();
 
   const [childNode, setChildNode] = React.useState();
   const [arrowRef, setArrowRef] = React.useState(null);

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -89,7 +89,7 @@ const transformDeprecatedColors = (color) => {
 const Typography = React.forwardRef(function Typography(inProps, ref) {
   const themeProps = useThemeProps({ props: inProps, name: 'MuiTypography' });
   const color = transformDeprecatedColors(themeProps.color);
-  const props = extendSxProp(themeProps);
+  const props = extendSxProp({ ...themeProps, color });
 
   const {
     align = 'inherit',

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -88,7 +88,7 @@ const transformDeprecatedColors = (color) => {
 
 const Typography = React.forwardRef(function Typography(inProps, ref) {
   const themeProps = useThemeProps({ props: inProps, name: 'MuiTypography' });
-  themeProps.color = transformDeprecatedColors(themeProps.color);
+  const color = transformDeprecatedColors(themeProps.color);
   const props = extendSxProp(themeProps);
 
   const {
@@ -106,6 +106,7 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
   const styleProps = {
     ...props,
     align,
+    color,
     className,
     component,
     gutterBottom,

--- a/packages/material-ui/src/styles/useThemeProps.d.ts
+++ b/packages/material-ui/src/styles/useThemeProps.d.ts
@@ -10,16 +10,8 @@ export type ThemedProps<Theme, Name extends keyof any> = Theme extends {
   ? Props
   : {};
 
-export interface AdditionalThemeProps<Theme> {
-  isRtl: boolean;
-  theme: Theme;
-}
-
 export default function useThemeProps<
   Theme extends ThemeWithProps,
   Props,
   Name extends keyof any,
->(params: {
-  props: Props;
-  name: Name;
-}): Props & ThemedProps<Theme, Name> & AdditionalThemeProps<Theme>;
+>(params: { props: Props; name: Name }): Props & ThemedProps<Theme, Name>;

--- a/packages/material-ui/src/styles/useThemeProps.spec.ts
+++ b/packages/material-ui/src/styles/useThemeProps.spec.ts
@@ -1,16 +1,11 @@
 import { Theme, unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
 import { SliderProps } from '@material-ui/core/Slider';
-import { expectType } from '@material-ui/types';
 
 function ThemedComponent() {
   const props = useThemeProps<Theme, SliderProps, 'MuiSlider'>({
     props: { color: 'primary' },
     name: 'MuiSlider',
   });
-
-  // additional props are valid
-  expectType<boolean, typeof props.isRtl>(props.isRtl);
-  expectType<Theme, typeof props.theme>(props.theme);
 
   // component's props are valid
   // Only existence of props is relevant here not type.

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { useTheme } from '@material-ui/private-theming';
-import { unstable_getThemeProps as getThemeProps } from '@material-ui/system';
+import { unstable_useThemeProps as useThemeProps } from '@material-ui/system';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
 export default function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();
-  const props = getThemeProps({
-    theme,
-    name: 'MuiUseMediaQuery',
-    props: {},
-  });
+  // eslint-disable-next-line material-ui/mui-name-matches-component-name
+  const props = useThemeProps({ name: 'MuiUseMediaQuery', props: {} });
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof queryInput === 'function' && theme === null) {


### PR DESCRIPTION
**BREAKING CHANGE**

The `isRtl` and `theme` props are no longer added by the `useThemeProps` hook. You can use the `useTheme` hook for this.

```diff
-import { unstable_useThemeProps as useThemeProps } from '@material-ui/core/styles';
+import { unstable_useThemeProps as useThemeProps, useTheme } from '@material-ui/core/styles';

 const Component = (inProps) => {
-  const { isRtl, theme, ...props } = useThemeProps({ props: inProps, name: 'MuiComponent' });
+  const props = useThemeProps({ props: inProps, name: 'MuiComponent' });

+  const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
 //.. rest of the code
}
```