### PR TITLE
[core] Monitore size of key system modules

### DIFF
--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -76,6 +76,14 @@ async function getWebpackEntries() {
       path: 'packages/material-ui-system/build/esm/index.js',
     },
     {
+      name: 'createBox',
+      path: 'packages/material-ui-system/build/esm/createBox.js',
+    },
+    {
+      name: 'createStyled',
+      path: 'packages/material-ui-system/build/esm/createStyled.js',
+    },
+    {
       name: '@material-ui/core/styles/createTheme',
       path: 'packages/material-ui/build/styles/createTheme.js',
     },


### PR DESCRIPTION
A follow-up on https://github.com/mui-org/material-ui/pull/26668#issuecomment-858048319, as we plan to add more modules to the system package. It should help monitor the size of its two main modules, simplifying the problem by removing tree-shaking from the equation.