### PR TITLE
[docs] Move custom theme to frame

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -85,6 +85,9 @@ const styles = (theme) => ({
   },
   root: {
     display: 'flex',
+    ...(theme.palette.mode === 'dark' && {
+      backgroundColor: '#222',
+    }),
   },
   grow: {
     flex: '1 1 auto',

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -86,7 +86,7 @@ const styles = (theme) => ({
   root: {
     display: 'flex',
     ...(theme.palette.mode === 'dark' && {
-      backgroundColor: '#222',
+      backgroundColor: theme.palette.grey[900],
     }),
   },
   grow: {

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -224,10 +224,6 @@ export function ThemeProvider(props) {
       languageMap[userLanguage],
     );
 
-    if (paletteMode === 'dark') {
-      nextTheme.palette.background.default = '#222';
-    }
-
     return nextTheme;
   }, [dense, direction, paletteColors, paletteMode, spacing, userLanguage]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #22112

I still want to keep `#222` as background because I think this

![image](https://user-images.githubusercontent.com/18292247/121840804-35711280-cd07-11eb-8c4d-8b4759de0c5d.png)

is better than

![image](https://user-images.githubusercontent.com/18292247/121840825-46218880-cd07-11eb-9038-2178e233773b.png)

So I move the color to frame instead. I don't think this will confuse the people because the body still contain default background color. @oliviertassinari what do you think?


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
