### PR TITLE
[IconButton] Add size `large` and update styles

### DIFF
--- a/docs/pages/api-docs/icon-button.json
+++ b/docs/pages/api-docs/icon-button.json
@@ -22,7 +22,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },
@@ -39,6 +39,8 @@
       "colorSecondary",
       "disabled",
       "sizeSmall",
+      "sizeMedium",
+      "sizeLarge",
       "label"
     ],
     "globalClasses": { "disabled": "Mui-disabled" },

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -273,7 +273,7 @@ function AppFrame(props) {
             </Menu>
           </NoSsr>
           <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-            <IconButton color="inherit" onClick={handleSettingsDrawerOpen}>
+            <IconButton color="inherit" size="large" onClick={handleSettingsDrawerOpen}>
               <SettingsIcon />
             </IconButton>
           </Tooltip>
@@ -285,6 +285,7 @@ function AppFrame(props) {
               href={process.env.SOURCE_CODE_REPO}
               data-ga-event-category="header"
               data-ga-event-action="github"
+              size="large"
             >
               <GitHubIcon />
             </IconButton>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -203,6 +203,7 @@ function AppFrame(props) {
       <AppBar className={appBarClassName}>
         <Toolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label={t('appFrame.openDrawer')}

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -56,6 +56,7 @@ const useDemoToolbarStyles = makeStyles(
           height: theme.spacing(6),
         },
         justifyContent: 'space-between',
+        alignItems: 'center',
       },
       toggleButtonGroup: {
         margin: '8px 0',

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -480,6 +480,7 @@ export default function DemoToolbar(props) {
             placement="bottom"
           >
             <IconButton
+              size="large"
               aria-controls={openDemoSource ? demoSourceId : null}
               data-ga-event-category="demo"
               data-ga-event-label={demoOptions.demo}
@@ -498,6 +499,7 @@ export default function DemoToolbar(props) {
               placement="bottom"
             >
               <IconButton
+                size="large"
                 data-ga-event-category="demo"
                 data-ga-event-label={demoOptions.demo}
                 data-ga-event-action="codesandbox"
@@ -510,6 +512,7 @@ export default function DemoToolbar(props) {
           )}
           <Tooltip classes={{ popper: classes.tooltip }} title={t('copySource')} placement="bottom">
             <IconButton
+              size="large"
               data-ga-event-category="demo"
               data-ga-event-label={demoOptions.demo}
               data-ga-event-action="copy"
@@ -521,6 +524,7 @@ export default function DemoToolbar(props) {
           </Tooltip>
           <Tooltip classes={{ popper: classes.tooltip }} title={t('resetFocus')} placement="bottom">
             <IconButton
+              size="large"
               data-ga-event-category="demo"
               data-ga-event-label={demoOptions.demo}
               data-ga-event-action="reset-focus"
@@ -532,6 +536,7 @@ export default function DemoToolbar(props) {
           </Tooltip>
           <Tooltip classes={{ popper: classes.tooltip }} title={t('resetDemo')} placement="bottom">
             <IconButton
+              size="large"
               aria-controls={demoId}
               data-ga-event-category="demo"
               data-ga-event-label={demoOptions.demo}
@@ -543,6 +548,7 @@ export default function DemoToolbar(props) {
             </IconButton>
           </Tooltip>
           <IconButton
+            size="large"
             onClick={handleMoreClick}
             aria-label={t('seeMore')}
             aria-owns={anchorEl ? 'demo-menu-more' : undefined}

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -137,6 +137,7 @@ export default function Notifications() {
       >
         <IconButton
           color="inherit"
+          size="large"
           ref={anchorRef}
           aria-controls={open ? 'notifications-popup' : undefined}
           aria-haspopup="true"

--- a/docs/src/pages/components/app-bar/BottomAppBar.js
+++ b/docs/src/pages/components/app-bar/BottomAppBar.js
@@ -112,7 +112,7 @@ export default function BottomAppBar() {
       </Paper>
       <AppBar position="fixed" color="primary" sx={{ top: 'auto', bottom: 0 }}>
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="open drawer">
+          <IconButton color="inherit" aria-label="open drawer">
             <MenuIcon />
           </IconButton>
           <StyledFab color="secondary" aria-label="add">
@@ -122,7 +122,7 @@ export default function BottomAppBar() {
           <IconButton color="inherit">
             <SearchIcon />
           </IconButton>
-          <IconButton edge="end" color="inherit">
+          <IconButton color="inherit">
             <MoreIcon />
           </IconButton>
         </Toolbar>

--- a/docs/src/pages/components/app-bar/BottomAppBar.tsx
+++ b/docs/src/pages/components/app-bar/BottomAppBar.tsx
@@ -110,7 +110,7 @@ export default function BottomAppBar() {
       </Paper>
       <AppBar position="fixed" color="primary" sx={{ top: 'auto', bottom: 0 }}>
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="open drawer">
+          <IconButton color="inherit" aria-label="open drawer">
             <MenuIcon />
           </IconButton>
           <StyledFab color="secondary" aria-label="add">
@@ -120,7 +120,7 @@ export default function BottomAppBar() {
           <IconButton color="inherit">
             <SearchIcon />
           </IconButton>
-          <IconButton edge="end" color="inherit">
+          <IconButton color="inherit">
             <MoreIcon />
           </IconButton>
         </Toolbar>

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -12,7 +12,13 @@ export default function ButtonAppBar() {
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -12,7 +12,13 @@ export default function ButtonAppBar() {
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>

--- a/docs/src/pages/components/app-bar/MenuAppBar.js
+++ b/docs/src/pages/components/app-bar/MenuAppBar.js
@@ -44,7 +44,13 @@ export default function MenuAppBar() {
       </FormGroup>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
@@ -53,6 +59,7 @@ export default function MenuAppBar() {
           {auth && (
             <div>
               <IconButton
+                size="large"
                 aria-label="account of current user"
                 aria-controls="menu-appbar"
                 aria-haspopup="true"

--- a/docs/src/pages/components/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/components/app-bar/MenuAppBar.tsx
@@ -44,7 +44,13 @@ export default function MenuAppBar() {
       </FormGroup>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
@@ -53,6 +59,7 @@ export default function MenuAppBar() {
           {auth && (
             <div>
               <IconButton
+                size="large"
                 aria-label="account of current user"
                 aria-controls="menu-appbar"
                 aria-haspopup="true"

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
@@ -120,7 +120,7 @@ export default function PrimarySearchAppBar() {
       onClose={handleMobileMenuClose}
     >
       <MenuItem>
-        <IconButton aria-label="show 4 new mails" color="inherit">
+        <IconButton size="large" aria-label="show 4 new mails" color="inherit">
           <Badge badgeContent={4} color="secondary">
             <MailIcon />
           </Badge>
@@ -128,7 +128,11 @@ export default function PrimarySearchAppBar() {
         <p>Messages</p>
       </MenuItem>
       <MenuItem>
-        <IconButton aria-label="show 11 new notifications" color="inherit">
+        <IconButton
+          size="large"
+          aria-label="show 11 new notifications"
+          color="inherit"
+        >
           <Badge badgeContent={11} color="secondary">
             <NotificationsIcon />
           </Badge>
@@ -137,6 +141,7 @@ export default function PrimarySearchAppBar() {
       </MenuItem>
       <MenuItem onClick={handleProfileMenuOpen}>
         <IconButton
+          size="large"
           aria-label="account of current user"
           aria-controls="primary-search-account-menu"
           aria-haspopup="true"
@@ -154,6 +159,7 @@ export default function PrimarySearchAppBar() {
       <AppBar position="static">
         <Toolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"
@@ -180,17 +186,22 @@ export default function PrimarySearchAppBar() {
           </Search>
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
-            <IconButton aria-label="show 4 new mails" color="inherit">
+            <IconButton size="large" aria-label="show 4 new mails" color="inherit">
               <Badge badgeContent={4} color="secondary">
                 <MailIcon />
               </Badge>
             </IconButton>
-            <IconButton aria-label="show 17 new notifications" color="inherit">
+            <IconButton
+              size="large"
+              aria-label="show 17 new notifications"
+              color="inherit"
+            >
               <Badge badgeContent={17} color="secondary">
                 <NotificationsIcon />
               </Badge>
             </IconButton>
             <IconButton
+              size="large"
               edge="end"
               aria-label="account of current user"
               aria-controls={menuId}
@@ -203,6 +214,7 @@ export default function PrimarySearchAppBar() {
           </Box>
           <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
             <IconButton
+              size="large"
               aria-label="show more"
               aria-controls={mobileMenuId}
               aria-haspopup="true"

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
@@ -121,7 +121,7 @@ export default function PrimarySearchAppBar() {
       onClose={handleMobileMenuClose}
     >
       <MenuItem>
-        <IconButton aria-label="show 4 new mails" color="inherit">
+        <IconButton size="large" aria-label="show 4 new mails" color="inherit">
           <Badge badgeContent={4} color="secondary">
             <MailIcon />
           </Badge>
@@ -129,7 +129,11 @@ export default function PrimarySearchAppBar() {
         <p>Messages</p>
       </MenuItem>
       <MenuItem>
-        <IconButton aria-label="show 11 new notifications" color="inherit">
+        <IconButton
+          size="large"
+          aria-label="show 11 new notifications"
+          color="inherit"
+        >
           <Badge badgeContent={11} color="secondary">
             <NotificationsIcon />
           </Badge>
@@ -138,6 +142,7 @@ export default function PrimarySearchAppBar() {
       </MenuItem>
       <MenuItem onClick={handleProfileMenuOpen}>
         <IconButton
+          size="large"
           aria-label="account of current user"
           aria-controls="primary-search-account-menu"
           aria-haspopup="true"
@@ -155,6 +160,7 @@ export default function PrimarySearchAppBar() {
       <AppBar position="static">
         <Toolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"
@@ -181,17 +187,22 @@ export default function PrimarySearchAppBar() {
           </Search>
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
-            <IconButton aria-label="show 4 new mails" color="inherit">
+            <IconButton size="large" aria-label="show 4 new mails" color="inherit">
               <Badge badgeContent={4} color="secondary">
                 <MailIcon />
               </Badge>
             </IconButton>
-            <IconButton aria-label="show 17 new notifications" color="inherit">
+            <IconButton
+              size="large"
+              aria-label="show 17 new notifications"
+              color="inherit"
+            >
               <Badge badgeContent={17} color="secondary">
                 <NotificationsIcon />
               </Badge>
             </IconButton>
             <IconButton
+              size="large"
               edge="end"
               aria-label="account of current user"
               aria-controls={menuId}
@@ -204,6 +215,7 @@ export default function PrimarySearchAppBar() {
           </Box>
           <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
             <IconButton
+              size="large"
               aria-label="show more"
               aria-controls={mobileMenuId}
               aria-haspopup="true"

--- a/docs/src/pages/components/app-bar/ProminentAppBar.js
+++ b/docs/src/pages/components/app-bar/ProminentAppBar.js
@@ -25,6 +25,7 @@ export default function ProminentAppBar() {
       <AppBar position="static">
         <StyledToolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"
@@ -40,10 +41,15 @@ export default function ProminentAppBar() {
           >
             Material-UI
           </Typography>
-          <IconButton aria-label="search" color="inherit">
+          <IconButton size="large" aria-label="search" color="inherit">
             <SearchIcon />
           </IconButton>
-          <IconButton aria-label="display more actions" edge="end" color="inherit">
+          <IconButton
+            size="large"
+            aria-label="display more actions"
+            edge="end"
+            color="inherit"
+          >
             <MoreIcon />
           </IconButton>
         </StyledToolbar>

--- a/docs/src/pages/components/app-bar/ProminentAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ProminentAppBar.tsx
@@ -25,6 +25,7 @@ export default function ProminentAppBar() {
       <AppBar position="static">
         <StyledToolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"
@@ -40,10 +41,15 @@ export default function ProminentAppBar() {
           >
             Material-UI
           </Typography>
-          <IconButton aria-label="search" color="inherit">
+          <IconButton size="large" aria-label="search" color="inherit">
             <SearchIcon />
           </IconButton>
-          <IconButton aria-label="display more actions" edge="end" color="inherit">
+          <IconButton
+            size="large"
+            aria-label="display more actions"
+            edge="end"
+            color="inherit"
+          >
             <MoreIcon />
           </IconButton>
         </StyledToolbar>

--- a/docs/src/pages/components/app-bar/SearchAppBar.js
+++ b/docs/src/pages/components/app-bar/SearchAppBar.js
@@ -57,6 +57,7 @@ export default function SearchAppBar() {
       <AppBar position="static">
         <Toolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"

--- a/docs/src/pages/components/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/SearchAppBar.tsx
@@ -57,6 +57,7 @@ export default function SearchAppBar() {
       <AppBar position="static">
         <Toolbar>
           <IconButton
+            size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"

--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
-import IconButton from '@material-ui/core/IconButton';
-import DeleteIcon from '@material-ui/icons/Delete';
-import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
 export default function ButtonSizes() {
   return (
@@ -34,26 +31,6 @@ export default function ButtonSizes() {
         <Button variant="contained" size="large">
           Large
         </Button>
-      </div>
-      <div>
-        <IconButton aria-label="delete" size="small">
-          <ArrowDownwardIcon fontSize="inherit" />
-        </IconButton>
-        <IconButton aria-label="delete">
-          <DeleteIcon fontSize="small" />
-        </IconButton>
-        <IconButton aria-label="delete">
-          <DeleteIcon />
-        </IconButton>
-        <IconButton aria-label="delete" size="large">
-          <DeleteIcon />
-        </IconButton>
-        <IconButton aria-label="delete" size="large">
-          <DeleteIcon fontSize="inherit" />
-        </IconButton>
-        <IconButton aria-label="delete">
-          <DeleteIcon fontSize="large" />
-        </IconButton>
       </div>
     </Box>
   );

--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -45,6 +45,12 @@ export default function ButtonSizes() {
         <IconButton aria-label="delete">
           <DeleteIcon />
         </IconButton>
+        <IconButton aria-label="delete" size="large">
+          <DeleteIcon />
+        </IconButton>
+        <IconButton aria-label="delete" size="large">
+          <DeleteIcon fontSize="inherit" />
+        </IconButton>
         <IconButton aria-label="delete">
           <DeleteIcon fontSize="large" />
         </IconButton>

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
-import IconButton from '@material-ui/core/IconButton';
-import DeleteIcon from '@material-ui/icons/Delete';
-import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
 export default function ButtonSizes() {
   return (
@@ -34,26 +31,6 @@ export default function ButtonSizes() {
         <Button variant="contained" size="large">
           Large
         </Button>
-      </div>
-      <div>
-        <IconButton aria-label="delete" size="small">
-          <ArrowDownwardIcon fontSize="inherit" />
-        </IconButton>
-        <IconButton aria-label="delete">
-          <DeleteIcon fontSize="small" />
-        </IconButton>
-        <IconButton aria-label="delete">
-          <DeleteIcon />
-        </IconButton>
-        <IconButton aria-label="delete" size="large">
-          <DeleteIcon />
-        </IconButton>
-        <IconButton aria-label="delete" size="large">
-          <DeleteIcon fontSize="inherit" />
-        </IconButton>
-        <IconButton aria-label="delete">
-          <DeleteIcon fontSize="large" />
-        </IconButton>
       </div>
     </Box>
   );

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -45,6 +45,12 @@ export default function ButtonSizes() {
         <IconButton aria-label="delete">
           <DeleteIcon />
         </IconButton>
+        <IconButton aria-label="delete" size="large">
+          <DeleteIcon />
+        </IconButton>
+        <IconButton aria-label="delete" size="large">
+          <DeleteIcon fontSize="inherit" />
+        </IconButton>
         <IconButton aria-label="delete">
           <DeleteIcon fontSize="large" />
         </IconButton>

--- a/docs/src/pages/components/buttons/IconButtonSizes.js
+++ b/docs/src/pages/components/buttons/IconButtonSizes.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+export default function IconButtonSizes() {
+  return (
+    <Box sx={{ '& button': { m: 1 } }}>
+      <IconButton aria-label="delete" size="small">
+        <DeleteIcon fontSize="inherit" />
+      </IconButton>
+      <IconButton aria-label="delete" size="small">
+        <DeleteIcon fontSize="small" />
+      </IconButton>
+      <IconButton aria-label="delete" size="large">
+        <DeleteIcon />
+      </IconButton>
+      <IconButton aria-label="delete" size="large">
+        <DeleteIcon fontSize="inherit" />
+      </IconButton>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/buttons/IconButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/IconButtonSizes.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+export default function IconButtonSizes() {
+  return (
+    <Box sx={{ '& button': { m: 1 } }}>
+      <IconButton aria-label="delete" size="small">
+        <DeleteIcon fontSize="inherit" />
+      </IconButton>
+      <IconButton aria-label="delete" size="small">
+        <DeleteIcon fontSize="small" />
+      </IconButton>
+      <IconButton aria-label="delete" size="large">
+        <DeleteIcon />
+      </IconButton>
+      <IconButton aria-label="delete" size="large">
+        <DeleteIcon fontSize="inherit" />
+      </IconButton>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/buttons/buttons.md
+++ b/docs/src/pages/components/buttons/buttons.md
@@ -103,6 +103,12 @@ deselected, such as adding or removing a star to an item.
 
 {{"demo": "pages/components/buttons/IconButtons.js"}}
 
+### Sizes
+
+For larger or smaller icon buttons, use the `size` prop.
+
+{{"demo": "pages/components/buttons/IconButtonSizes.js"}}
+
 ## Customized buttons
 
 Here are some examples of customizing the component. You can learn more about this in the

--- a/docs/src/pages/components/lists/CustomizedList.js
+++ b/docs/src/pages/components/lists/CustomizedList.js
@@ -91,6 +91,7 @@ export default function CustomizedList() {
               </ListItemButton>
               <Tooltip title="Project Settings">
                 <IconButton
+                  size="large"
                   sx={{
                     '& svg': {
                       color: 'rgba(255,255,255,0.8)',

--- a/docs/src/pages/components/lists/CustomizedList.tsx
+++ b/docs/src/pages/components/lists/CustomizedList.tsx
@@ -91,6 +91,7 @@ export default function CustomizedList() {
               </ListItemButton>
               <Tooltip title="Project Settings">
                 <IconButton
+                  size="large"
                   sx={{
                     '& svg': {
                       color: 'rgba(255,255,255,0.8)',

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -979,7 +979,7 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
 
 ### IconButton
 
-- The default size's padding is reduced to `8px` which make default IconButton size of `40px`. To get the old default size (`48px`), use `size="large"`.
+- The default size's padding is reduced to `8px` which makes the default IconButton size of `40px`. To get the old default size (`48px`), use `size="large"`. The change was done to better match Google's products when Material Design stopped documenting the icon button pattern.
 
   ```diff
   - <IconButton>

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -970,11 +970,20 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
 ### Icon
 
 - The default value of `fontSize` was changed from `default` to `medium` for consistency.
-  In the unlikey event that you were using the value `default`, the prop can be removed:
+  In the unlikely event that you were using the value `default`, the prop can be removed:
 
   ```diff
   -<Icon fontSize="default">icon-name</Icon>
   +<Icon>icon-name</Icon>
+  ```
+
+### IconButton
+
+- The default size's padding is reduced to `8px` which make default IconButton size of `40px`. To get the old default size (`48px`), use `size="large"`.
+
+  ```diff
+  - <IconButton>
+  + <IconButton size="large">
   ```
 
 ### Menu

--- a/docs/translations/api-docs/icon-button/icon-button.json
+++ b/docs/translations/api-docs/icon-button/icon-button.json
@@ -48,6 +48,16 @@
       "nodeName": "the root element",
       "conditions": "<code>size=\"small\"</code>"
     },
+    "sizeMedium": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"medium\"</code>"
+    },
+    "sizeLarge": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"large\"</code>"
+    },
     "label": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the children container element"

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -54,7 +54,7 @@ export type IconButtonTypeMap<
      * `small` is equivalent to the dense button styling.
      * @default 'medium'
      */
-    size?: OverridableStringUnion<'small' | 'medium', IconButtonPropsSizeOverrides>;
+    size?: OverridableStringUnion<'small' | 'medium' | 'large', IconButtonPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -46,7 +46,7 @@ const IconButtonRoot = styled(ButtonBase, {
     textAlign: 'center',
     flex: '0 0 auto',
     fontSize: theme.typography.pxToRem(24),
-    padding: 12,
+    padding: 8,
     borderRadius: '50%',
     overflow: 'visible', // Explicitly set the default value to solve a bug on IE11.
     color: theme.palette.action.active,
@@ -98,8 +98,13 @@ const IconButtonRoot = styled(ButtonBase, {
     }),
     /* Styles applied to the root element if `size="small"`. */
     ...(styleProps.size === 'small' && {
-      padding: 3,
+      padding: 6,
       fontSize: theme.typography.pxToRem(18),
+    }),
+    /* Styles applied to the root element if `size="small"`. */
+    ...(styleProps.size === 'large' && {
+      padding: 12,
+      fontSize: theme.typography.pxToRem(28),
     }),
     /* Styles applied to the root element if `disabled={true}`. */
     [`&.${iconButtonClasses.disabled}`]: {
@@ -239,7 +244,7 @@ IconButton.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -98,7 +98,7 @@ const IconButtonRoot = styled(ButtonBase, {
     }),
     /* Styles applied to the root element if `size="small"`. */
     ...(styleProps.size === 'small' && {
-      padding: 6,
+      padding: 5,
       fontSize: theme.typography.pxToRem(18),
     }),
     /* Styles applied to the root element if `size="small"`. */

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -70,8 +70,12 @@ describe('<IconButton />', () => {
       root = render(<IconButton size="medium">book</IconButton>).container.firstChild;
       expect(root).not.to.have.class(classes.sizeSmall);
 
+      root = render(<IconButton size="large">book</IconButton>).container.firstChild;
+      expect(root).to.have.class(classes.sizeLarge);
+
       root = render(<IconButton>book</IconButton>).container.firstChild;
       expect(root).not.to.have.class(classes.sizeSmall);
+      expect(root).not.to.have.class(classes.sizeLarge);
     });
   });
 

--- a/packages/material-ui/src/IconButton/iconButtonClasses.ts
+++ b/packages/material-ui/src/IconButton/iconButtonClasses.ts
@@ -17,6 +17,10 @@ export interface IconButtonClasses {
   disabled: string;
   /** Styles applied to the root element if `size="small"`. */
   sizeSmall: string;
+  /** Styles applied to the root element if `size="medium"`. */
+  sizeMedium: string;
+  /** Styles applied to the root element if `size="large"`. */
+  sizeLarge: string;
   /** Styles applied to the children container element. */
   label: string;
 }
@@ -37,6 +41,7 @@ const iconButtonClasses: IconButtonClasses = generateUtilityClasses('MuiIconButt
   'edgeEnd',
   'sizeSmall',
   'sizeMedium',
+  'sizeLarge',
   'label',
 ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**BREAKING CHANGE**

- The default size's padding is reduced to `8px` which makes the default IconButton size of `40px`. To get the old default size (`48px`), use `size="large"`. The change was done to better match Google's products when Material Design stopped documenting the icon button pattern.

  ```diff
  - <IconButton>
  + <IconButton size="large">
  ```

---

close #24045

🔗 https://deploy-preview-26748--material-ui.netlify.app/

- add size `large`
- update padding on `small` and `medium` size
- update `ButtonSizes` demo to include `<IconButton size="large">`
- add to `migration-v4.md` about breaking change

One thing I notice, should `label` be removed from `IconButton` same as #26666 

|                       | inherit | small[20px] | medium[24px] (default) | large[35px] |
|-----------------------|---------|-------|------------------|-------|
| small[5px > 18px]     | 28px    | 30px  | 36px             | 47px  |
| medium[8px] (default) | -       | 36px  | 40px             | 51px  |
| large[12px > 28px]           | 52px       | 44px  | 48px             | 59px  |



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
