### PR TITLE
[useId] Reduce likelyhood of collisions

### DIFF
--- a/packages/material-ui-utils/src/useId.ts
+++ b/packages/material-ui-utils/src/useId.ts
@@ -8,7 +8,7 @@ export default function useId(idOverride?: string): string | undefined {
       // Fallback to this default id when possible.
       // Use the random value for client-side rendering only.
       // We can't use it server-side.
-      setDefaultId(`mui-${Math.round(Math.random() * 1e5)}`);
+      setDefaultId(`mui-${Math.round(Math.random() * 1e9)}`);
     }
   }, [defaultId]);
   return id;


### PR DESCRIPTION
We're not sending these IDs over the wire anyway so all the bytes we can safe are the ones used for writing out the multiplier (currently 3 bytes).

We go from 1:25 Million to 1:25 Quintillion. I'm buying all the lottery tickets there are if I hit that chance before `useOpaqueIdentifier` is released. Edit: It's not that unlikely for most cases considering the [birthday problem](https://en.wikipedia.org/wiki/Birthday_problem).

Reduces likelyhood of test failures such as https://app.circleci.com/pipelines/github/mui-org/material-ui/43396/workflows/9085d613-22fa-4e90-b3a6-6e5fcd4eafbe/jobs/260663