### PR TITLE
[ButtonBase] Derive state on render instead of in layout effects

### DIFF
--- a/packages/material-ui/src/ButtonBase/Ripple.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import useEventCallback from '../utils/useEventCallback';
-import useEnhancedEffect from '../utils/useEnhancedEffect';
 
 /**
  * @ignore - internal component.
@@ -38,12 +37,11 @@ function Ripple(props) {
   });
 
   const handleExited = useEventCallback(onExited);
-  // Ripple is used for user feedback (e.g. click or press) so we want to apply styles with the highest priority
-  useEnhancedEffect(() => {
+  if (!inProp && !leaving) {
+    setLeaving(true);
+  }
+  React.useEffect(() => {
     if (!inProp) {
-      // react-transition-group#onExit
-      setLeaving(true);
-
       // react-transition-group#onExited
       const timeoutId = setTimeout(handleExited, timeout);
       return () => {

--- a/packages/material-ui/src/ButtonBase/Ripple.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import useEventCallback from '../utils/useEventCallback';
 
 /**
  * @ignore - internal component.
@@ -15,7 +14,7 @@ function Ripple(props) {
     rippleY,
     rippleSize,
     in: inProp,
-    onExited = () => {},
+    onExited,
     timeout,
   } = props;
   const [leaving, setLeaving] = React.useState(false);
@@ -36,20 +35,19 @@ function Ripple(props) {
     [classes.childPulsate]: pulsate,
   });
 
-  const handleExited = useEventCallback(onExited);
   if (!inProp && !leaving) {
     setLeaving(true);
   }
   React.useEffect(() => {
-    if (!inProp) {
+    if (!inProp && onExited != null) {
       // react-transition-group#onExited
-      const timeoutId = setTimeout(handleExited, timeout);
+      const timeoutId = setTimeout(onExited, timeout);
       return () => {
         clearTimeout(timeoutId);
       };
     }
     return undefined;
-  }, [handleExited, inProp, timeout]);
+  }, [onExited, inProp, timeout]);
 
   return (
     <span className={rippleClassName} style={rippleStyles}>


### PR DESCRIPTION
Gets rid of all layout effects in `ButtonBase`. That way passive effects in a parent aren't flushed anymore just because the ButtonBase used a layout effect.

This was the main offender:
```js
// Ripple is used for user feedback (e.g. click or press) so we want to apply styles with the highest priority
useEnhancedEffect(() => {
  if (!inProp) setLeaving(true)
}, [inProp]);  
```

Preview: https://deploy-preview-26762--material-ui.netlify.app/components/buttons/