### PR TITLE
[System] - In object breakpoints, reorder to follow size order

### DIFF
--- a/packages/material-ui-system/src/breakpoints.js
+++ b/packages/material-ui-system/src/breakpoints.js
@@ -35,7 +35,20 @@ export function handleBreakpoints(props, propValue, styleFromPropValue) {
 
   if (typeof propValue === 'object') {
     const themeBreakpoints = props.theme.breakpoints || defaultBreakpoints;
-    return Object.keys(propValue).reduce((acc, breakpoint) => {
+
+    const keys = Object.keys(propValue).sort((first, second) => {
+      if (themeBreakpoints[first] < themeBreakpoints[second]) {
+        return -1;
+      }
+
+      if (themeBreakpoints[first] > themeBreakpoints[second]) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+    return keys.reduce((acc, breakpoint) => {
       acc[themeBreakpoints.up(breakpoint)] = styleFromPropValue(propValue[breakpoint]);
       return acc;
     }, {});

--- a/packages/material-ui-system/src/breakpoints.test.js
+++ b/packages/material-ui-system/src/breakpoints.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import breakpoints from './breakpoints';
+import breakpoints, { handleBreakpoints } from './breakpoints';
 import style from './style';
 
 const textColor = style({
@@ -24,6 +24,36 @@ describe('breakpoints', () => {
       color: 'red',
       '@media (min-width:600px)': {
         color: 'blue',
+      },
+    });
+  });
+});
+
+describe('handleBreakpoints', () => {
+  it('should reorder breakpoint following size', () => {
+    const styleFromPropValue = (value) => ({ padding: value });
+
+    expect(
+      handleBreakpoints(
+        {
+          theme: {},
+        },
+        {
+          md: 12,
+          xs: 8,
+          sm: 10,
+        },
+        styleFromPropValue,
+      ),
+    ).to.deep.equal({
+      '@media (min-width:0px)': {
+        padding: 8,
+      },
+      '@media (min-width:600px)': {
+        padding: 10,
+      },
+      '@media (min-width:960px)': {
+        padding: 12,
       },
     });
   });


### PR DESCRIPTION
When you use an prop as object, following the breakpoint approach, if the object do not follow the size order:

`p={{ md: .., sm: ..., xs: ... }}`

It won't work, since the priority comes right to left.

An example could be found here: https://codesandbox.io/s/keys-order-mui-v8qjb?file=/src/App.js

Just open the sandbox and resize the browser panel, you will see that yellow box never changes the padding.

This is an bug dectected after use eslint sort-keys rule: https://eslint.org/docs/rules/sort-keys 

