### PR TITLE
[docs] Fix small PT typo fix: inciar -> iniciar

### DIFF
--- a/docs/src/pages/components/css-baseline/css-baseline-pt.md
+++ b/docs/src/pages/components/css-baseline/css-baseline-pt.md
@@ -5,7 +5,7 @@ githubLabel: 'component: CssBaseline'
 
 # CSS Baseline
 
-<p class="description">Material-UI oferece um componente CSS Base a fim de inciar uma elegante, consistente e simples base para construção de aplicativos.</p>
+<p class="description">Material-UI oferece um componente CSS Base a fim de iniciar uma elegante, consistente e simples base para construção de aplicativos.</p>
 
 [A paleta](/system/palette/) com funções de estilo.
 


### PR DESCRIPTION
Just a small typo fix here: https://material-ui.com/pt/components/css-baseline/. It says `inciar`, but the correct spelling is `iniciar`. That's all! Great work with Material UI, guys!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
