### PR TITLE
[docs] Explain "inherited props" better in the props table

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -284,6 +284,8 @@ import { ${componentName} } from '${source}';`}
           </React.Fragment>
         )}
         <Heading hash="props" />
+        <span dangerouslySetInnerHTML={{ __html: spreadHint }} />
+        <br />
         <PropsTable componentProps={componentProps} propDescriptions={propDescriptions} />
         <br />
         {cssComponent && (
@@ -298,8 +300,6 @@ import { ${componentName} } from '${source}';`}
           </React.Fragment>
         )}
         <span dangerouslySetInnerHTML={{ __html: refHint }} />
-        <br />
-        <span dangerouslySetInnerHTML={{ __html: spreadHint }} />
         {inheritance && (
           <React.Fragment>
             <Heading hash="inheritance" level="h3" />

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -284,8 +284,7 @@ import { ${componentName} } from '${source}';`}
           </React.Fragment>
         )}
         <Heading hash="props" />
-        <span dangerouslySetInnerHTML={{ __html: spreadHint }} />
-        <br />
+        <p dangerouslySetInnerHTML={{ __html: spreadHint }} />
         <PropsTable componentProps={componentProps} propDescriptions={propDescriptions} />
         <br />
         {cssComponent && (

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -22,7 +22,7 @@
     "refNotHeld": "The component cannot hold a ref.",
     "refRootElement": "The <code>ref</code> is forwarded to the root element.",
     "ruleName": "Rule name",
-    "spreadHint": "Any other props supplied will be provided to the root element ({{spreadHintElement}}).",
+    "spreadHint": "Props of the {{spreadHintElement}} are also available.",
     "styleOverrides": "The name <code>{{componentStyles.name}}</code> can be used when providing <a href=\"/customization/globals/#default-props\">default props</a> or <a href=\"/customization/globals/#css\">style overrides</a> in the theme.",
     "type": "Type"
   },

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -13,7 +13,7 @@
     "inheritanceDescription": "While not explicitly documented above, the props of the <a href=\"{{pathname}}\">{{component}}</a> component{{suffix}} are also available on {{componentName}}. You can take advantage of this to <a href=\"/guides/api/#spread\">target nested components</a>.",
     "inheritanceSuffixTransition": " from react-transition-group",
     "name": "Name",
-    "nativeElement": "native element",
+    "nativeElement": "native",
     "overrideStyles": "You can override the style of the component using one of these customization options:\n",
     "overrideStylesJss": "<ul>\n<li>With a rule name of the <a href=\"/customization/components/#overriding-styles-with-classes\"><code>classes</code> object prop</a>.</li>\n<li>With a <a href=\"/customization/components/#overriding-styles-with-global-class-names\">global class name</a>.</li>\n<li>With a theme and an <a href=\"/customization/globals/#css\"><code>styleOverrides</code> property</a>.</li>\n</ul>\nIf that isn't sufficient, you can check the <a href=\"{{URL}}\">implementation of the component</a> for more detail.",
     "overrideStylesStyledComponent": "<ul>\n<li>With a <a href=\"/guides/interoperability/#global-css\">global class name</a>.</li>\n<li>With a rule name as part of the component's <a href=\"/customization/theme-components/#global-style-overrides\"><code>styleOverrides</code> property</a> in a custom theme.</li>\n</ul>",
@@ -22,7 +22,7 @@
     "refNotHeld": "The component cannot hold a ref.",
     "refRootElement": "The <code>ref</code> is forwarded to the root element.",
     "ruleName": "Rule name",
-    "spreadHint": "Props of the {{spreadHintElement}} are also available.",
+    "spreadHint": "Props of the {{spreadHintElement}} component are also available.",
     "styleOverrides": "The name <code>{{componentStyles.name}}</code> can be used when providing <a href=\"/customization/globals/#default-props\">default props</a> or <a href=\"/customization/globals/#css\">style overrides</a> in the theme.",
     "type": "Type"
   },


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/26752

1. Move spread hint to the top of the table to make it harder to miss
1. Explain it more in terms what the dev wants
    They're probably not interested what happens with excess props but rather what props are available.

Preview: https://deploy-preview-26778--material-ui.netlify.app/api/text-field/