### PR TITLE
[docs] Improve notification color

### DIFF
--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -145,7 +145,7 @@ export default function Notifications() {
           data-ga-event-action="toggleNotifications"
         >
           <Badge
-            color="secondary"
+            color="error"
             badgeContent={
               messageList
                 ? messageList.reduce(


### PR DESCRIPTION
Reverting the color of the notification to be red. It has bigger contrast, and it is usually the color used for notifications.

**Previously**

![image](https://user-images.githubusercontent.com/4512430/122260379-7d449500-ced3-11eb-8b35-c18dccce23a4.png)

**Now**

![image](https://user-images.githubusercontent.com/4512430/122260317-68680180-ced3-11eb-9e40-8f84ff116f4e.png)


