### PR TITLE
[Dialog] Automatically label by its DialogTitle

### DIFF
--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
@@ -95,9 +95,9 @@ export default function FreeSoloCreateOptionDialog() {
         freeSolo
         renderInput={(params) => <TextField {...params} label="Free solo dialog" />}
       />
-      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+      <Dialog open={open} onClose={handleClose}>
         <form onSubmit={handleSubmit}>
-          <DialogTitle id="form-dialog-title">Add a new film</DialogTitle>
+          <DialogTitle>Add a new film</DialogTitle>
           <DialogContent>
             <DialogContentText>
               Did you miss any film in our list? Please, add it!

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
@@ -93,9 +93,9 @@ export default function FreeSoloCreateOptionDialog() {
         freeSolo
         renderInput={(params) => <TextField {...params} label="Free solo dialog" />}
       />
-      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+      <Dialog open={open} onClose={handleClose}>
         <form onSubmit={handleSubmit}>
-          <DialogTitle id="form-dialog-title">Add a new film</DialogTitle>
+          <DialogTitle>Add a new film</DialogTitle>
           <DialogContent>
             <DialogContentText>
               Did you miss any film in our list? Please, add it!

--- a/docs/src/pages/components/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/components/dialogs/AlertDialogSlide.js
@@ -32,12 +32,9 @@ export default function AlertDialogSlide() {
         TransitionComponent={Transition}
         keepMounted
         onClose={handleClose}
-        aria-labelledby="alert-dialog-slide-title"
         aria-describedby="alert-dialog-slide-description"
       >
-        <DialogTitle id="alert-dialog-slide-title">
-          {"Use Google's location service?"}
-        </DialogTitle>
+        <DialogTitle>{"Use Google's location service?"}</DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-slide-description">
             Let Google help apps determine location. This means sending anonymous

--- a/docs/src/pages/components/dialogs/AlertDialogSlide.tsx
+++ b/docs/src/pages/components/dialogs/AlertDialogSlide.tsx
@@ -38,12 +38,9 @@ export default function AlertDialogSlide() {
         TransitionComponent={Transition}
         keepMounted
         onClose={handleClose}
-        aria-labelledby="alert-dialog-slide-title"
         aria-describedby="alert-dialog-slide-description"
       >
-        <DialogTitle id="alert-dialog-slide-title">
-          {"Use Google's location service?"}
-        </DialogTitle>
+        <DialogTitle>{"Use Google's location service?"}</DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-slide-description">
             Let Google help apps determine location. This means sending anonymous

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.js
@@ -64,11 +64,10 @@ function ConfirmationDialogRaw(props) {
       sx={{ '& .MuiDialog-paper': { width: '80%', maxHeight: 435 } }}
       maxWidth="xs"
       TransitionProps={{ onEntering: handleEntering }}
-      aria-labelledby="confirmation-dialog-title"
       open={open}
       {...other}
     >
-      <DialogTitle id="confirmation-dialog-title">Phone Ringtone</DialogTitle>
+      <DialogTitle>Phone Ringtone</DialogTitle>
       <DialogContent dividers>
         <RadioGroup
           ref={radioGroupRef}

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
@@ -71,11 +71,10 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
       sx={{ '& .MuiDialog-paper': { width: '80%', maxHeight: 435 } }}
       maxWidth="xs"
       TransitionProps={{ onEntering: handleEntering }}
-      aria-labelledby="confirmation-dialog-title"
       open={open}
       {...other}
     >
-      <DialogTitle id="confirmation-dialog-title">Phone Ringtone</DialogTitle>
+      <DialogTitle>Phone Ringtone</DialogTitle>
       <DialogContent dividers>
         <RadioGroup
           ref={radioGroupRef}

--- a/docs/src/pages/components/dialogs/FormDialog.js
+++ b/docs/src/pages/components/dialogs/FormDialog.js
@@ -23,8 +23,8 @@ export default function FormDialog() {
       <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
-      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-        <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Subscribe</DialogTitle>
         <DialogContent>
           <DialogContentText>
             To subscribe to this website, please enter your email address here. We

--- a/docs/src/pages/components/dialogs/FormDialog.tsx
+++ b/docs/src/pages/components/dialogs/FormDialog.tsx
@@ -23,8 +23,8 @@ export default function FormDialog() {
       <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
-      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-        <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Subscribe</DialogTitle>
         <DialogContent>
           <DialogContentText>
             To subscribe to this website, please enter your email address here. We

--- a/docs/src/pages/components/dialogs/MaxWidthDialog.js
+++ b/docs/src/pages/components/dialogs/MaxWidthDialog.js
@@ -44,9 +44,8 @@ export default function MaxWidthDialog() {
         maxWidth={maxWidth}
         open={open}
         onClose={handleClose}
-        aria-labelledby="max-width-dialog-title"
       >
-        <DialogTitle id="max-width-dialog-title">Optional sizes</DialogTitle>
+        <DialogTitle>Optional sizes</DialogTitle>
         <DialogContent>
           <DialogContentText>
             You can set my maximum width and whether to adapt or not.

--- a/docs/src/pages/components/dialogs/MaxWidthDialog.tsx
+++ b/docs/src/pages/components/dialogs/MaxWidthDialog.tsx
@@ -44,9 +44,8 @@ export default function MaxWidthDialog() {
         maxWidth={maxWidth}
         open={open}
         onClose={handleClose}
-        aria-labelledby="max-width-dialog-title"
       >
-        <DialogTitle id="max-width-dialog-title">Optional sizes</DialogTitle>
+        <DialogTitle>Optional sizes</DialogTitle>
         <DialogContent>
           <DialogContentText>
             You can set my maximum width and whether to adapt or not.

--- a/docs/src/pages/components/dialogs/SimpleDialog.js
+++ b/docs/src/pages/components/dialogs/SimpleDialog.js
@@ -27,8 +27,8 @@ function SimpleDialog(props) {
   };
 
   return (
-    <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
-      <DialogTitle id="simple-dialog-title">Set backup account</DialogTitle>
+    <Dialog onClose={handleClose} open={open}>
+      <DialogTitle>Set backup account</DialogTitle>
       <List sx={{ pt: 0 }}>
         {emails.map((email) => (
           <ListItem button onClick={() => handleListItemClick(email)} key={email}>

--- a/docs/src/pages/components/dialogs/SimpleDialog.tsx
+++ b/docs/src/pages/components/dialogs/SimpleDialog.tsx
@@ -32,8 +32,8 @@ function SimpleDialog(props: SimpleDialogProps) {
   };
 
   return (
-    <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
-      <DialogTitle id="simple-dialog-title">Set backup account</DialogTitle>
+    <Dialog onClose={handleClose} open={open}>
+      <DialogTitle>Set backup account</DialogTitle>
       <List sx={{ pt: 0 }}>
         {emails.map((email) => (
           <ListItem button onClick={() => handleListItemClick(email)} key={email}>

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -245,13 +245,7 @@ const DialogDetails = React.memo(function DialogDetails(props) {
   };
 
   return (
-    <Dialog
-      fullWidth
-      maxWidth="sm"
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="icon-dialog-title"
-    >
+    <Dialog fullWidth maxWidth="sm" open={open} onClose={handleClose}>
       {selectedIcon ? (
         <React.Fragment>
           <DialogTitle disableTypography>
@@ -266,7 +260,6 @@ const DialogDetails = React.memo(function DialogDetails(props) {
                 component="h2"
                 variant="h6"
                 className={classes.title}
-                id="icon-dialog-title"
                 onClick={handleClick(1)}
               >
                 {selectedIcon.importName}

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import { unstable_useId as useId } from '@material-ui/utils';
 import capitalize from '../utils/capitalize';
 import Modal from '../Modal';
 import Fade from '../Fade';
@@ -10,6 +11,7 @@ import Paper from '../Paper';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
 import dialogClasses, { getDialogUtilityClass } from './dialogClasses';
+import DialogContext from './DialogContext';
 import Backdrop from '../Backdrop';
 
 const DialogBackdrop = styled(Backdrop, {
@@ -170,7 +172,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiDialog' });
   const {
     'aria-describedby': ariaDescribedby,
-    'aria-labelledby': ariaLabelledby,
+    'aria-labelledby': ariaLabelledbyProp,
     BackdropComponent,
     BackdropProps,
     children,
@@ -225,6 +227,11 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
     }
   };
 
+  const ariaLabelledby = useId(ariaLabelledbyProp);
+  const dialogContextValue = React.useMemo(() => {
+    return { titleId: ariaLabelledby };
+  }, [ariaLabelledby]);
+
   return (
     <DialogRoot
       className={clsx(classes.root, className)}
@@ -267,7 +274,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
             className={clsx(classes.paper, PaperProps.className)}
             styleProps={styleProps}
           >
-            {children}
+            <DialogContext.Provider value={dialogContextValue}>{children}</DialogContext.Provider>
           </DialogPaper>
         </DialogContainer>
       </TransitionComponent>

--- a/packages/material-ui/src/Dialog/DialogContext.ts
+++ b/packages/material-ui/src/Dialog/DialogContext.ts
@@ -6,4 +6,8 @@ interface DialogContextValue {
 
 const DialogContext = createContext<DialogContextValue>({});
 
+if (process.env.NODE_ENV !== 'production') {
+  DialogContext.displayName = 'DialogContext';
+}
+
 export default DialogContext;

--- a/packages/material-ui/src/Dialog/DialogContext.ts
+++ b/packages/material-ui/src/Dialog/DialogContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+interface DialogContextValue {
+  titleId?: string;
+}
+
+const DialogContext = createContext<DialogContextValue>({});
+
+export default DialogContext;

--- a/packages/material-ui/src/DialogTitle/DialogTitle.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.js
@@ -6,6 +6,7 @@ import Typography from '../Typography';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import { getDialogTitleUtilityClass } from './dialogTitleClasses';
+import DialogContext from '../Dialog/DialogContext';
 
 const useUtilityClasses = (styleProps) => {
   const { classes } = styleProps;
@@ -32,9 +33,11 @@ const DialogTitle = React.forwardRef(function DialogTitle(inProps, ref) {
     name: 'MuiDialogTitle',
   });
 
-  const { className, ...other } = props;
+  const { className, id: idProp, ...other } = props;
   const styleProps = props;
   const classes = useUtilityClasses(styleProps);
+
+  const { titleId: id = idProp } = React.useContext(DialogContext);
 
   return (
     <DialogTitleRoot
@@ -43,6 +46,7 @@ const DialogTitle = React.forwardRef(function DialogTitle(inProps, ref) {
       styleProps={styleProps}
       ref={ref}
       variant="h6"
+      id={id}
       {...other}
     />
   );

--- a/packages/material-ui/src/DialogTitle/DialogTitle.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.js
@@ -70,6 +70,10 @@ DialogTitle.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * @ignore
+   */
+  id: PropTypes.string,
+  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.object,

--- a/packages/material-ui/test/integration/DialogIntegration.test.js
+++ b/packages/material-ui/test/integration/DialogIntegration.test.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { createClientRender, screen } from 'test/utils';
+
+describe('<Dialog /> integration', () => {
+  const render = createClientRender();
+
+  it('is automatically labelled by its DialogTitle', () => {
+    render(
+      <Dialog open>
+        <DialogTitle>Set backup account</DialogTitle>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Set backup account');
+  });
+});

--- a/packages/material-ui/test/integration/DialogIntegration.test.js
+++ b/packages/material-ui/test/integration/DialogIntegration.test.js
@@ -16,4 +16,16 @@ describe('<Dialog /> integration', () => {
 
     expect(screen.getByRole('dialog')).toHaveAccessibleName('Set backup account');
   });
+
+  it('can be manually labelled', () => {
+    render(
+      <Dialog open aria-labelledby="dialog-title">
+        <DialogTitle id="dialog-title">Set backup account</DialogTitle>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAccessibleName('Set backup account');
+    expect(dialog).to.have.attr('aria-labelledby', 'dialog-title');
+  });
 });


### PR DESCRIPTION
Removes the need to manually wire up Dialog and DialogTitle

Instead of 
```js
<Dialog aria-labelledby={id}>
  <DialogTitle id={id} />
</Dialog>
```
you can write
```js
<Dialog>
  <DialogTitle />
</Dialog>
```
instead which automatically labels the `role="dialog"` with the contents of `DialogTitle`.