### PR TITLE
[core] Fix running Framer's prettier under pwsh

### DIFF
--- a/framer/package.json
+++ b/framer/package.json
@@ -21,7 +21,7 @@
     "build": "yarn build:core && yarn build:styles && yarn prettier",
     "build:core": "cross-env BABEL_ENV=development babel-node --config-file ../babel.config.js ./scripts/buildFramer.js ../packages/material-ui/src ./Material-UI.framerfx/code",
     "build:styles": "cross-env BABEL_ENV=development babel-node --config-file ../babel.config.js ./scripts/buildFramer.js ../packages/material-ui-styles/src ./Material-UI.framerfx/code",
-    "prettier": "prettier --write --config ../prettier.config.js './**/*.{js,tsx}'",
+    "prettier": "prettier --write --config ../prettier.config.js ./**/*.{js,tsx}",
     "typescript": "tsc -p tsconfig.json"
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Running `yarn framer:build` under PowerShell 7 on Windows throws an error:
`[error] No files matching the pattern were found: "'./**/*.{js,tsx}'".`

This is caused by apostrophes around the file pattern in `prettier` task.