### PR TITLE
[core] Assume no document.all at runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -33,9 +33,6 @@ module.exports = function getBabelConfig(api) {
     [
       '@babel/preset-env',
       {
-        assumptions: {
-          noDocumentAll: true,
-        },
         bugfixes: true,
         browserslistEnv: process.env.BABEL_ENV || process.env.NODE_ENV,
         debug: process.env.MUI_BUILD_VERBOSE === 'true',
@@ -99,6 +96,9 @@ module.exports = function getBabelConfig(api) {
   }
 
   return {
+    assumptions: {
+      noDocumentAll: true,
+    },
     presets,
     plugins,
     ignore: [/@babel[\\|/]runtime/], // Fix a Windows issue.

--- a/babel.config.js
+++ b/babel.config.js
@@ -33,6 +33,9 @@ module.exports = function getBabelConfig(api) {
     [
       '@babel/preset-env',
       {
+        assumptions: {
+          noDocumentAll: true,
+        },
         bugfixes: true,
         browserslistEnv: process.env.BABEL_ENV || process.env.NODE_ENV,
         debug: process.env.MUI_BUILD_VERBOSE === 'true',

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -37,9 +37,10 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
 );
 
 module.exports = {
-  assumptions: {
-    noDocumentAll: true,
-  },
+  // TODO: Enable once nextjs uses babel 7.13
+  // assumptions: {
+  //   noDocumentAll: true,
+  // },
   presets: [
     // backport of https://github.com/zeit/next.js/pull/9511
     [

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -42,6 +42,11 @@ module.exports = {
     [
       'next/babel',
       {
+        'preset-env': {
+          assumptions: {
+            noDocumentAll: true,
+          },
+        },
         'preset-react': { runtime: 'automatic' },
         'transform-runtime': { corejs: 2, version: transformRuntimeVersion },
       },

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -37,16 +37,14 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
 );
 
 module.exports = {
+  assumptions: {
+    noDocumentAll: true,
+  },
   presets: [
     // backport of https://github.com/zeit/next.js/pull/9511
     [
       'next/babel',
       {
-        'preset-env': {
-          assumptions: {
-            noDocumentAll: true,
-          },
-        },
         'preset-react': { runtime: 'automatic' },
         'transform-runtime': { corejs: 2, version: transformRuntimeVersion },
       },


### PR DESCRIPTION
We've been a bit hesitant to adopt nullish coalescing (`prop ?? defaultValue`) and optional chaining (`Props?.onChange`) due to the [heavy transpilation cost](https://babeljs.io/repl#?browsers=chrome%2040&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=A4Jw9sAED82QJgUwGYEMCuAbALgNVZuogNwBQACuMAM7QB0YAdgMIAWqjA5iUA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.14.6&externalPlugins=%40babel%2Fplugin-transform-react-constant-elements%407.13.10).

However, we can make some assumptions that allow [lighter transpilation](https://babeljs.io/repl#?browsers=chrome%2040&build=&builtIns=false&corejs=3.6&spec=false&loose=true&code_lz=A4Jw9sAED82QJgUwGYEMCuAbALgNVZuogNwBQACuMAM7QB0YAdgMIAWqjA5iUA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.14.6&externalPlugins=%40babel%2Fplugin-transform-react-constant-elements%407.13.10);

Will translate the other `loose` transpilations to [`assumptions`](https://babeljs.io/docs/en/assumptions) as well but in a follow-up to make sure these don't affect bundle size.