### PR TITLE
[Drawer] Remove incorrect transition handler props

### DIFF
--- a/packages/material-ui/src/Drawer/Drawer.d.ts
+++ b/packages/material-ui/src/Drawer/Drawer.d.ts
@@ -4,11 +4,10 @@ import { InternalStandardProps as StandardProps, Theme } from '..';
 import { ModalProps } from '../Modal';
 import { SlideProps } from '../Slide';
 import { PaperProps } from '../Paper';
-import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
+import { TransitionProps } from '../transitions/transition';
 import { DrawerClasses } from './drawerClasses';
 
-export interface DrawerProps
-  extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, 'open' | 'children'> {
+export interface DrawerProps extends StandardProps<ModalProps, 'open' | 'children'> {
   /**
    * Side from which the drawer will appear.
    * @default 'left'


### PR DESCRIPTION
Previously `<Drawer onEntered={() => {}} />` passed type-checking even though `onEntered` had no effect on runtime. Only `<Drawer SlideProps={{ onEntered: () => {} }} />` or `<Drawer BackdropProps={{ onEntered: () => {} }} />` has an effect at runtime.