### PR TITLE
[Modal] Type BackdropProps according to styled version

### DIFF
--- a/docs/pages/api-docs/dialog.json
+++ b/docs/pages/api-docs/dialog.json
@@ -3,7 +3,7 @@
     "open": { "type": { "name": "bool" }, "required": true },
     "aria-describedby": { "type": { "name": "string" } },
     "aria-labelledby": { "type": { "name": "string" } },
-    "BackdropComponent": { "type": { "name": "elementType" } },
+    "BackdropComponent": { "type": { "name": "elementType" }, "default": "Backdrop" },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "disableEscapeKeyDown": { "type": { "name": "bool" } },

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -290,6 +290,7 @@ Dialog.propTypes /* remove-proptypes */ = {
   'aria-labelledby': PropTypes.string,
   /**
    * A backdrop component. This prop enables custom backdrop rendering.
+   * @default Backdrop
    */
   BackdropComponent: PropTypes.elementType,
   /**

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { SxProps } from '@material-ui/system';
+import { OverrideProps } from '@material-ui/types';
 import {
   ExtendModalUnstyledTypeMap,
   ExtendModalUnstyled,
-  ModalUnstyledProps,
 } from '@material-ui/unstyled/ModalUnstyled';
 import { Theme } from '../styles';
 import { BackdropProps } from '../Backdrop';
@@ -63,6 +63,6 @@ export const modalClasses: ModalClasses;
 export type ModalProps<
   D extends React.ElementType = ModalTypeMap['defaultComponent'],
   P = {},
-> = ModalUnstyledProps<D, P>;
+> = OverrideProps<ModalTypeMap<D, P>, D>;
 
 export default Modal;

--- a/packages/material-ui/src/Modal/Modal.spec.tsx
+++ b/packages/material-ui/src/Modal/Modal.spec.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import Modal, { ModalProps } from '@material-ui/core/Modal';
+
+const backdropProps: ModalProps['BackdropProps'] = {
+  onEntered: () => console.log('entered'),
+};
+
+<Modal open BackdropProps={{ onEntered: () => console.log('entered') }}>
+  <div />
+</Modal>;


### PR DESCRIPTION
Previously `ModalProps` pointed to the unstyled modal props. So e.g. `let backdropProps: ModalProps['BackdropProps'] = {  onEntered: () ==> console.log('entered') }` failed type checking even though it was valid when directly passed to `<Modal />`.