### PR TITLE
[TextField] Prevent `hiddenLabel` from spreading to DOM

### DIFF
--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -185,7 +185,7 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     inputComponent = 'input',
     multiline = false,
     type = 'text',
-    hiddenLabel, // declare here to prevent leaking to DOM
+    hiddenLabel, // declare here to prevent spreading to DOM
     ...other
   } = props;
 

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -185,7 +185,6 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     inputComponent = 'input',
     multiline = false,
     type = 'text',
-    hiddenLabel = false,
     ...other
   } = props;
 
@@ -194,7 +193,6 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     fullWidth,
     inputComponent,
     multiline,
-    hiddenLabel,
     type,
   };
 

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -185,6 +185,7 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     inputComponent = 'input',
     multiline = false,
     type = 'text',
+    hiddenLabel = false,
     ...other
   } = props;
 
@@ -193,6 +194,7 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     fullWidth,
     inputComponent,
     multiline,
+    hiddenLabel,
     type,
   };
 

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -185,6 +185,7 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     inputComponent = 'input',
     multiline = false,
     type = 'text',
+    hiddenLabel, // declare here to prevent leaking to DOM
     ...other
   } = props;
 

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -482,6 +482,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
   const Input = components.Input || InputBaseComponent;
   inputProps = { ...inputProps, ...componentsProps.input };
 
+  delete other.hiddenLabel; // prevent hiddenLabel leak to DOM
   return (
     <React.Fragment>
       <GlobalStyles

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -482,7 +482,6 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
   const Input = components.Input || InputBaseComponent;
   inputProps = { ...inputProps, ...componentsProps.input };
 
-  delete other.hiddenLabel; // prevent hiddenLabel leak to DOM
   return (
     <React.Fragment>
       <GlobalStyles


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**reproduce** https://codesandbox.io/s/basictextfields-material-demo-forked-hmhf6?file=/demo.tsx

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
