### PR TITLE
[docs] Make mobile picker more consistent with Its behavior

### DIFF
--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.js
@@ -10,6 +10,8 @@ import Stack from '@material-ui/core/Stack';
 export default function ResponsiveDatePickers() {
   const [value, setValue] = React.useState(new Date());
 
+  const [previousValue, setPreviousValue] = React.useState(new Date());
+
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <Stack spacing={3}>
@@ -18,6 +20,15 @@ export default function ResponsiveDatePickers() {
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
+          }}
+          onAccept={(acceptValue) => {
+            setValue(acceptValue);
+          }}
+          onClose={() => {
+            setValue(previousValue);
+          }}
+          onOpen={() => {
+            setPreviousValue(value);
           }}
           renderInput={(params) => <TextField {...params} />}
         />

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
@@ -10,6 +10,8 @@ import Stack from '@material-ui/core/Stack';
 export default function ResponsiveDatePickers() {
   const [value, setValue] = React.useState<Date | null>(new Date());
 
+  const [previousValue, setPreviousValue] = React.useState<Date | null>(new Date());
+
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <Stack spacing={3}>
@@ -18,6 +20,15 @@ export default function ResponsiveDatePickers() {
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
+          }}
+          onAccept={(acceptValue) => {
+            setValue(acceptValue);
+          }}
+          onClose={() => {
+            setValue(previousValue)
+          }}
+          onOpen={() => {
+            setPreviousValue(value);
           }}
           renderInput={(params) => <TextField {...params} />}
         />

--- a/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
+++ b/docs/src/pages/components/date-picker/ResponsiveDatePickers.tsx
@@ -25,7 +25,7 @@ export default function ResponsiveDatePickers() {
             setValue(acceptValue);
           }}
           onClose={() => {
-            setValue(previousValue)
+            setValue(previousValue);
           }}
           onOpen={() => {
             setPreviousValue(value);

--- a/docs/src/pages/components/pickers/MaterialUIPickers.js
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.js
@@ -10,6 +10,8 @@ import MobileDatePicker from '@material-ui/lab/MobileDatePicker';
 export default function MaterialUIPickers() {
   const [value, setValue] = React.useState(new Date('2014-08-18T21:11:54'));
 
+  const [previousValue, setPreviousValue] = React.useState(value);
+
   const handleChange = (newValue) => {
     setValue(newValue);
   };
@@ -29,6 +31,15 @@ export default function MaterialUIPickers() {
           inputFormat="MM/dd/yyyy"
           value={value}
           onChange={handleChange}
+          onAccept={(accpetValue) => {
+            setValue(accpetValue)
+          }}
+          onClose={() => {
+            setValue(previousValue)
+          }}
+          onOpen={() => {
+            setPreviousValue(value)
+          }}
           renderInput={(params) => <TextField {...params} />}
         />
         <TimePicker

--- a/docs/src/pages/components/pickers/MaterialUIPickers.js
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.js
@@ -32,13 +32,13 @@ export default function MaterialUIPickers() {
           value={value}
           onChange={handleChange}
           onAccept={(accpetValue) => {
-            setValue(accpetValue)
+            setValue(accpetValue);
           }}
           onClose={() => {
-            setValue(previousValue)
+            setValue(previousValue);
           }}
           onOpen={() => {
-            setPreviousValue(value)
+            setPreviousValue(value);
           }}
           renderInput={(params) => <TextField {...params} />}
         />

--- a/docs/src/pages/components/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.tsx
@@ -11,6 +11,7 @@ export default function MaterialUIPickers() {
   const [value, setValue] = React.useState<Date | null>(
     new Date('2014-08-18T21:11:54'),
   );
+  const [previousValue, setPreviousValue] = React.useState<Date | null>(value);
 
   const handleChange = (newValue: Date | null) => {
     setValue(newValue);
@@ -31,6 +32,15 @@ export default function MaterialUIPickers() {
           inputFormat="MM/dd/yyyy"
           value={value}
           onChange={handleChange}
+          onAccept={(accpetValue) => {
+            setValue(accpetValue)
+          }}
+          onClose={() => {
+            setValue(previousValue)
+          }}
+          onOpen={() => {
+            setPreviousValue(value)
+          }}
           renderInput={(params) => <TextField {...params} />}
         />
         <TimePicker

--- a/docs/src/pages/components/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/components/pickers/MaterialUIPickers.tsx
@@ -33,13 +33,13 @@ export default function MaterialUIPickers() {
           value={value}
           onChange={handleChange}
           onAccept={(accpetValue) => {
-            setValue(accpetValue)
+            setValue(accpetValue);
           }}
           onClose={() => {
-            setValue(previousValue)
+            setValue(previousValue);
           }}
           onOpen={() => {
-            setPreviousValue(value)
+            setPreviousValue(value);
           }}
           renderInput={(params) => <TextField {...params} />}
         />


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Improve the usage of [MobileDatePicker](https://next.material-ui.com/components/date-picker/#responsiveness) in [Responsive](https://next.material-ui.com/components/date-picker/#responsiveness) and [Introduction](https://next.material-ui.com/components/pickers/#react-components).

Since `MobileDatePicker` has **cancel** and  **accept** behavior by default, It should be handled more properly. The current behavior is when user cancel the dialog, but the date keeps changing by `onChange`.