### PR TITLE
[DatePicker] Remove helper text default value

### DIFF
--- a/docs/src/pages/components/date-picker/HelperText.js
+++ b/docs/src/pages/components/date-picker/HelperText.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
+import DatePicker from '@material-ui/lab/DatePicker';
+
+export default function HelperText() {
+  const [value, setValue] = React.useState(null);
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DatePicker
+        label="Helper text example"
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy"/>}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/src/pages/components/date-picker/HelperText.js
+++ b/docs/src/pages/components/date-picker/HelperText.js
@@ -15,7 +15,7 @@ export default function HelperText() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy"/>}
+        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/HelperText.js
+++ b/docs/src/pages/components/date-picker/HelperText.js
@@ -15,7 +15,9 @@ export default function HelperText() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy" />}
+        renderInput={(params) => (
+          <TextField {...params} helperText={params?.inputProps?.placeholder} />
+        )}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/HelperText.tsx
+++ b/docs/src/pages/components/date-picker/HelperText.tsx
@@ -15,7 +15,7 @@ export default function HelperText() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy"/>}
+        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy" />}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/HelperText.tsx
+++ b/docs/src/pages/components/date-picker/HelperText.tsx
@@ -15,7 +15,9 @@ export default function HelperText() {
         onChange={(newValue) => {
           setValue(newValue);
         }}
-        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy" />}
+        renderInput={(params) => (
+          <TextField {...params} helperText={params?.inputProps?.placeholder} />
+        )}
       />
     </LocalizationProvider>
   );

--- a/docs/src/pages/components/date-picker/HelperText.tsx
+++ b/docs/src/pages/components/date-picker/HelperText.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
+import DatePicker from '@material-ui/lab/DatePicker';
+
+export default function HelperText() {
+  const [value, setValue] = React.useState<Date | null>(null);
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DatePicker
+        label="Helper text example"
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        renderInput={(params) => <TextField {...params} helperText="mm/dd/yyyy"/>}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/src/pages/components/date-picker/date-picker.md
+++ b/docs/src/pages/components/date-picker/date-picker.md
@@ -41,12 +41,6 @@ The date picker is rendered as a modal dialog on mobile, and a textbox with a po
 
 {{"demo": "pages/components/date-picker/BasicDatePicker.js"}}
 
-## Helper text
-
-It's possible to show a message to give more information about the type of date.
-
-{{"demo": "pages/components/date-picker/HelperText.js"}}
-
 ## Static mode
 
 It's possible to render any date picker without the modal/popover and text field. This can be helpful when building custom popover/modal containers.
@@ -119,3 +113,9 @@ You can take advantage of the [PickersDay](/api/pickers-day/) component.
 Sometimes it may be necessary to display additional info right in the calendar. Here's an example of prefetching and displaying server-side data using the `onMonthChange`, `loading`, and `renderDay` props.
 
 {{"demo": "pages/components/date-picker/ServerRequestDatePicker.js"}}
+
+## Helper text
+
+You can show a helper text with the date format accepted.
+
+{{"demo": "pages/components/date-picker/HelperText.js"}}

--- a/docs/src/pages/components/date-picker/date-picker.md
+++ b/docs/src/pages/components/date-picker/date-picker.md
@@ -41,6 +41,12 @@ The date picker is rendered as a modal dialog on mobile, and a textbox with a po
 
 {{"demo": "pages/components/date-picker/BasicDatePicker.js"}}
 
+## Helper text
+
+It's possible to show a message to give more information about the type of date.
+
+{{"demo": "pages/components/date-picker/HelperText.js"}}
+
 ## Static mode
 
 It's possible to render any date picker without the modal/popover and text field. This can be helpful when building custom popover/modal containers.

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -94,7 +94,7 @@ describe('<DesktopDatePicker /> keyboard interactions', () => {
         <TestKeyboardDatePicker
           mask="____"
           inputFormat="yyyy"
-          renderInput={(params) => <TextField {...params} id="test" />}
+          renderInput={(params) => <TextField {...params} id="test" helperText="yyyy" />}
         />,
       );
 

--- a/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -94,7 +94,9 @@ describe('<DesktopDatePicker /> keyboard interactions', () => {
         <TestKeyboardDatePicker
           mask="____"
           inputFormat="yyyy"
-          renderInput={(params) => <TextField {...params} id="test" helperText="yyyy" />}
+          renderInput={(params) => (
+            <TextField {...params} id="test" helperText={params?.inputProps?.placeholder} />
+          )}
         />,
       );
 

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -105,7 +105,6 @@ export function useMaskedInput({
     label,
     disabled,
     error: validationError,
-    helperText: formatHelperText,
     inputProps: {
       ...inputStateArgs,
       disabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I removed the default value to the helperText, and put an example in docs, to show how to use it. 

Closes #23533 

Preview: https://deploy-preview-26866--material-ui.netlify.app/components/date-picker/#helper-text