### PR TITLE
[docs] Add extend-props page

### DIFF
--- a/docs/pages/guides/extend-props.js
+++ b/docs/pages/guides/extend-props.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import { prepareMarkdown } from 'docs/src/modules/utils/parseMarkdown';
+
+const pageFilename = 'guides/extend-props';
+const requireDemo = require.context('docs/src/pages/guides/extend-props', false, /\.(js|tsx)$/);
+const requireRaw = require.context(
+  '!raw-loader!../../src/pages/guides/extend-props',
+  false,
+  /\.(js|md|tsx)$/,
+);
+
+export default function Page({ demos, docs }) {
+  return <MarkdownDocs demos={demos} docs={docs} requireDemo={requireDemo} />;
+}
+
+Page.getInitialProps = () => {
+  const { demos, docs } = prepareMarkdown({ pageFilename, requireRaw });
+  return { demos, docs };
+};

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -277,6 +277,7 @@ const pages: readonly MuiPage[] = [
     children: [
       { pathname: '/guides/api', title: 'API Design Approach' },
       { pathname: '/guides/typescript', title: 'TypeScript' },
+      { pathname: '/guides/extend-props', title: 'Extend Props' },
       { pathname: '/guides/interoperability', title: 'Style Library Interoperability' },
       { pathname: '/guides/styled-engine' },
       { pathname: '/guides/minimizing-bundle-size' },

--- a/docs/src/pages/guides/extend-props/TintedChip.js
+++ b/docs/src/pages/guides/extend-props/TintedChip.js
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { ThemeProvider, createTheme, alpha } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import Chip from '@material-ui/core/Chip';
+
+let theme = createTheme();
+
+const colors = ['primary', 'secondary'];
+
+theme = createTheme({
+  components: {
+    MuiChip: {
+      variants: colors.map((color) => ({
+        props: { variant: 'tinted', color },
+        style: {
+          backgroundColor: alpha(theme.palette[color].main, 0.12),
+          color: theme.palette[color].main,
+        },
+      })),
+    },
+  },
+});
+
+export default function TintedChip() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Chip label="Primary" variant="tinted" color="primary" />
+        <Chip label="Secondary" variant="tinted" color="secondary" />
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/docs/src/pages/guides/extend-props/TintedChip.js
+++ b/docs/src/pages/guides/extend-props/TintedChip.js
@@ -1,22 +1,48 @@
 import * as React from 'react';
 import { ThemeProvider, createTheme, alpha } from '@material-ui/core/styles';
+import { blueGrey } from '@material-ui/core/colors';
 import Box from '@material-ui/core/Box';
 import Chip from '@material-ui/core/Chip';
+import Stack from '@material-ui/core/Stack';
 
 let theme = createTheme();
 
-const colors = ['primary', 'secondary'];
+const colors = ['primary', 'secondary', 'blueGrey'];
 
 theme = createTheme({
+  palette: {
+    blueGrey: {
+      main: blueGrey[700],
+      light: blueGrey[400],
+      dark: blueGrey[900],
+      contrastText: '#fff',
+    },
+  },
   components: {
     MuiChip: {
-      variants: colors.map((color) => ({
-        props: { variant: 'tinted', color },
-        style: {
-          backgroundColor: alpha(theme.palette[color].main, 0.12),
-          color: theme.palette[color].main,
+      variants: [
+        ...colors.map((color) => ({
+          props: { variant: 'tinted', color },
+          style: {
+            backgroundColor: alpha(
+              color === 'blueGrey' ? blueGrey[500] : theme.palette[color].main,
+              0.12,
+            ),
+            color: color === 'blueGrey' ? blueGrey[500] : theme.palette[color].main,
+            fontWeight: 500,
+          },
+        })),
+        {
+          props: { size: 'large' },
+          style: {
+            height: 40,
+            borderRadius: 20,
+            fontSize: '1rem',
+            fontWeight: 'bold',
+            letterSpacing: 0,
+          },
         },
-      })),
+      ],
     },
   },
 });
@@ -25,8 +51,18 @@ export default function TintedChip() {
   return (
     <ThemeProvider theme={theme}>
       <Box sx={{ display: 'flex', gap: 2 }}>
-        <Chip label="Primary" variant="tinted" color="primary" />
-        <Chip label="Secondary" variant="tinted" color="secondary" />
+        <Stack spacing={2} alignItems="center">
+          <Chip label="Primary" variant="tinted" color="primary" />
+          <Chip label="Primary" variant="tinted" color="primary" size="large" />
+        </Stack>
+        <Stack spacing={2} alignItems="center">
+          <Chip label="Secondary" variant="tinted" color="secondary" />
+          <Chip label="Secondary" variant="tinted" color="secondary" size="large" />
+        </Stack>
+        <Stack spacing={2} alignItems="center">
+          <Chip label="Secondary" variant="tinted" color="blueGrey" />
+          <Chip label="Secondary" variant="tinted" color="blueGrey" size="large" />
+        </Stack>
       </Box>
     </ThemeProvider>
   );

--- a/docs/src/pages/guides/extend-props/TintedChip.tsx
+++ b/docs/src/pages/guides/extend-props/TintedChip.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import {
+  ThemeProvider,
+  createTheme,
+  alpha,
+  SimplePaletteColorOptions,
+} from '@material-ui/core/styles';
+import { blueGrey } from '@material-ui/core/colors';
+import Box from '@material-ui/core/Box';
+import Chip from '@material-ui/core/Chip';
+import Stack from '@material-ui/core/Stack';
+
+declare module '@material-ui/core/styles' {
+  interface Palette {
+    blueGrey: SimplePaletteColorOptions;
+  }
+  interface PaletteOptions {
+    blueGrey: SimplePaletteColorOptions;
+  }
+}
+
+declare module '@material-ui/core/Chip' {
+  interface ChipPropsVariantOverrides {
+    tinted: true;
+  }
+
+  interface ChipPropsColorOverrides {
+    blueGrey: true;
+  }
+
+  interface ChipPropsSizeOverrides {
+    large: true;
+  }
+}
+
+let theme = createTheme();
+
+const colors = ['primary', 'secondary', 'blueGrey'] as const;
+
+theme = createTheme({
+  palette: {
+    blueGrey: {
+      main: blueGrey[700],
+      light: blueGrey[400],
+      dark: blueGrey[900],
+      contrastText: '#fff',
+    },
+  },
+  components: {
+    MuiChip: {
+      variants: [
+        ...colors.map((color) => ({
+          props: { variant: 'tinted' as const, color },
+          style: {
+            backgroundColor: alpha(
+              color === 'blueGrey' ? blueGrey[500] : theme.palette[color].main,
+              0.12,
+            ),
+            color: color === 'blueGrey' ? blueGrey[500] : theme.palette[color].main,
+            fontWeight: 500,
+          },
+        })),
+        {
+          props: { size: 'large' },
+          style: {
+            height: 40,
+            borderRadius: 20,
+            fontSize: '1rem',
+            fontWeight: 'bold',
+            letterSpacing: 0,
+          },
+        },
+      ],
+    },
+  },
+});
+
+export default function TintedChip() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Stack spacing={2} alignItems="center">
+          <Chip label="Primary" variant="tinted" color="primary" />
+          <Chip label="Primary" variant="tinted" color="primary" size="large" />
+        </Stack>
+        <Stack spacing={2} alignItems="center">
+          <Chip label="Secondary" variant="tinted" color="secondary" />
+          <Chip label="Secondary" variant="tinted" color="secondary" size="large" />
+        </Stack>
+        <Stack spacing={2} alignItems="center">
+          <Chip label="Secondary" variant="tinted" color="blueGrey" />
+          <Chip label="Secondary" variant="tinted" color="blueGrey" size="large" />
+        </Stack>
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/docs/src/pages/guides/extend-props/extend-props.md
+++ b/docs/src/pages/guides/extend-props/extend-props.md
@@ -88,7 +88,7 @@ theme = createTheme({
     },
   },
   // ...components
-})
+});
 ```
 
 Next, extend the `color` and `size` of `Chip`.
@@ -136,5 +136,3 @@ theme = createTheme({
 Let's take a look at the result!
 
 {{"demo": "pages/guides/extend-props/TintedChip.js"}}
-
-

--- a/docs/src/pages/guides/extend-props/extend-props.md
+++ b/docs/src/pages/guides/extend-props/extend-props.md
@@ -1,0 +1,140 @@
+# Extend Props
+
+<p class="description">You can add more colors, sizes, variants to components and apply across the application.</p>
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
+It can be done by adding new variant to component theme. Let's add new variant called `tinted` to `Chip`.
+
+```tsx
+// themeSetup.ts or the file contains application theme
+
+import { ThemeProvider, createTheme, alpha } from '@material-ui/core/styles';
+
+let theme = createTheme();
+
+theme = createTheme({
+  components: {
+    MuiChip: {
+      variants: [
+        {
+          props: { variant: 'tinted', color: 'primary' },
+          style: {
+            backgroundColor: alpha(theme.palette.primary.main, 0.12),
+            color: theme.palette.primary.main,
+            fontWeight: 500,
+          },
+        }
+      ],
+    },
+  },
+});
+
+function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Chip variant="tinted" color="primary" label="Tinted Primary">
+    </ThemeProvider>
+  )
+}
+```
+
+As a result `<Chip variant="tinted" color="primary" />` will display light primary background. See the [full demo](/guides/extend-props/#tinted-chip-variant) at the bottom of the page.
+
+> For **Typescript** project, you need to extend the props via module augmentation.
+
+```ts
+// themeSetup.ts
+
+declare module '@material-ui/core/Chip' {
+  interface ChipPropsVariantOverrides {
+    tinted: true;
+  }
+}
+```
+
+Let's take a step further and extending `color`, `size` to `Chip` component. For color, we need to extend the color palette for the new color.
+
+```tsx
+// themeSetup.ts
+
+import {
+  ThemeProvider,
+  createTheme,
+  alpha,
+  SimplePaletteColorOptions,
+} from '@material-ui/core/styles';
+
+declare module '@material-ui/core/styles' {
+  interface Palette {
+    blueGrey: SimplePaletteColorOptions;
+  }
+  interface PaletteOptions {
+    blueGrey: SimplePaletteColorOptions;
+  }
+}
+```
+
+This will allow us to create the theme with `blueGrey` color key without typescript error, also it is type-safe when accessing `theme.palette.blueGrey` in other places.
+
+```tsx
+theme = createTheme({
+  palette: {
+    blueGrey: {
+      main: blueGrey[700],
+      light: blueGrey[400],
+      dark: blueGrey[900],
+      contrastText: '#fff',
+    },
+  },
+  // ...components
+})
+```
+
+Next, extend the `color` and `size` of `Chip`.
+
+```tsx
+// themeSetup.ts
+
+declare module '@material-ui/core/Chip' {
+  interface ChipPropsVariantOverrides {
+    tinted: true;
+  }
+
+  interface ChipPropsColorOverrides {
+    blueGrey: true;
+  }
+
+  interface ChipPropsSizeOverrides {
+    large: true;
+  }
+}
+
+theme = createTheme({
+  components: {
+    MuiChip: {
+      variants: [
+        // ...tinted variant
+        {
+          props: { size: 'large' },
+          style: {
+            height: 40,
+            borderRadius: 20,
+            fontSize: '1rem',
+            fontWeight: 'bold',
+            letterSpacing: 0,
+          },
+        },
+      ],
+    },
+  },
+});
+```
+
+## Tinted chip variant
+
+Let's take a look at the result!
+
+{{"demo": "pages/guides/extend-props/TintedChip.js"}}
+
+

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -298,6 +298,7 @@
     "/customization/styled": "styled",
     "/guides": "How To Guides",
     "/guides/typescript": "TypeScript",
+    "/guides/extend-props": "Extend Props",
     "/guides/interoperability": "Style Library Interoperability",
     "/guides/styled-engine": "Styled Engine",
     "/guides/minimizing-bundle-size": "Minimizing Bundle Size",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I cannot find the docs explaining about how to extend component variant, so I added it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-26867--material-ui.netlify.app/guides/extend-props/