### PR TITLE
[docs] Update unstyled demos to not depend on `@material-ui/core`

### DIFF
--- a/docs/src/pages/components/badges/UnstyledBadge.js
+++ b/docs/src/pages/components/badges/UnstyledBadge.js
@@ -73,7 +73,7 @@ function BadgeContent() {
 export default function UnstyledBadge() {
   return (
     <Box
-      sx={{ '& > :not(style) + :not(style)': { ml: (theme) => theme.spacing(4) } }}
+      sx={{ '& > :not(style) + :not(style)': { ml: 4 } }}
     >
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />

--- a/docs/src/pages/components/badges/UnstyledBadge.js
+++ b/docs/src/pages/components/badges/UnstyledBadge.js
@@ -72,9 +72,7 @@ function BadgeContent() {
 
 export default function UnstyledBadge() {
   return (
-    <Box
-      sx={{ '& > :not(style) + :not(style)': { ml: 4 } }}
-    >
+    <Box sx={{ '& > :not(style) + :not(style)': { ml: 4 } }}>
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />
       </StyledBadge>

--- a/docs/src/pages/components/badges/UnstyledBadge.js
+++ b/docs/src/pages/components/badges/UnstyledBadge.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled, Box } from '@material-ui/system';
 import BadgeUnstyled from '@material-ui/unstyled/BadgeUnstyled';
-import Box from '@material-ui/core/Box';
-import Stack from '@material-ui/core/Stack';
 
 const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
@@ -74,13 +72,15 @@ function BadgeContent() {
 
 export default function UnstyledBadge() {
   return (
-    <Stack spacing={4} direction="row">
+    <Box
+      sx={{ '& > :not(style) + :not(style)': { ml: (theme) => theme.spacing(4) } }}
+    >
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />
       </StyledBadge>
       <StyledBadge badgeContent={5} variant="dot" overlap="circular">
         <BadgeContent />
       </StyledBadge>
-    </Stack>
+    </Box>
   );
 }

--- a/docs/src/pages/components/badges/UnstyledBadge.tsx
+++ b/docs/src/pages/components/badges/UnstyledBadge.tsx
@@ -73,7 +73,7 @@ function BadgeContent() {
 export default function UnstyledBadge() {
   return (
     <Box
-      sx={{ '& > :not(style) + :not(style)': { ml: (theme) => theme.spacing(4) } }}
+      sx={{ '& > :not(style) + :not(style)': { ml: 4 } }}
     >
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />

--- a/docs/src/pages/components/badges/UnstyledBadge.tsx
+++ b/docs/src/pages/components/badges/UnstyledBadge.tsx
@@ -72,9 +72,7 @@ function BadgeContent() {
 
 export default function UnstyledBadge() {
   return (
-    <Box
-      sx={{ '& > :not(style) + :not(style)': { ml: 4 } }}
-    >
+    <Box sx={{ '& > :not(style) + :not(style)': { ml: 4 } }}>
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />
       </StyledBadge>

--- a/docs/src/pages/components/badges/UnstyledBadge.tsx
+++ b/docs/src/pages/components/badges/UnstyledBadge.tsx
@@ -72,7 +72,9 @@ function BadgeContent() {
 
 export default function UnstyledBadge() {
   return (
-    <Box sx={{ '& > :not(style) + :not(style)': { ml: (theme) => theme.spacing(4) } }}>
+    <Box
+      sx={{ '& > :not(style) + :not(style)': { ml: (theme) => theme.spacing(4) } }}
+    >
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />
       </StyledBadge>

--- a/docs/src/pages/components/badges/UnstyledBadge.tsx
+++ b/docs/src/pages/components/badges/UnstyledBadge.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled, Box } from '@material-ui/system';
 import BadgeUnstyled from '@material-ui/unstyled/BadgeUnstyled';
-import Box from '@material-ui/core/Box';
-import Stack from '@material-ui/core/Stack';
 
 const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
@@ -74,13 +72,13 @@ function BadgeContent() {
 
 export default function UnstyledBadge() {
   return (
-    <Stack spacing={4} direction="row">
+    <Box sx={{ '& > :not(style) + :not(style)': { ml: (theme) => theme.spacing(4) } }}>
       <StyledBadge badgeContent={5} overlap="circular">
         <BadgeContent />
       </StyledBadge>
       <StyledBadge badgeContent={5} variant="dot" overlap="circular">
         <BadgeContent />
       </StyledBadge>
-    </Stack>
+    </Box>
   );
 }

--- a/docs/src/pages/components/modal/ModalUnstyled.js
+++ b/docs/src/pages/components/modal/ModalUnstyled.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
+import { styled, Box } from '@material-ui/system';
 import ModalUnstyled from '@material-ui/unstyled/ModalUnstyled';
 
 const StyledModal = styled(ModalUnstyled)`

--- a/docs/src/pages/components/modal/ModalUnstyled.tsx
+++ b/docs/src/pages/components/modal/ModalUnstyled.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
+import { styled, Box } from '@material-ui/system';
 import ModalUnstyled from '@material-ui/unstyled/ModalUnstyled';
 
 const StyledModal = styled(ModalUnstyled)`

--- a/docs/src/pages/components/slider/UnstyledSlider.js
+++ b/docs/src/pages/components/slider/UnstyledSlider.js
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { styled, alpha } from '@material-ui/core/styles';
+import { styled, alpha, Box } from '@material-ui/system';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
-import Box from '@material-ui/core/Box';
 
 const StyledSlider = styled(SliderUnstyled)(
   ({ theme }) => `
-  color: ${theme.palette.primary.main};
+  color: #1976d2;
   height: 4px;
   width: 100%;
   padding: 13px 0;
@@ -47,15 +46,15 @@ const StyledSlider = styled(SliderUnstyled)(
     border-radius: 50%;
     outline: 0;
     border: 2px solid currentColor;
-    background-color: ${theme.palette.getContrastText(theme.palette.primary.main)};
+    background-color: white;
 
     :hover,
     &.Mui-focusVisible {
-      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.15)};
+      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.15)};
     }
 
     &.Mui-active {
-      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.3)};
+      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.3)};
     }
   }
 `,

--- a/docs/src/pages/components/slider/UnstyledSlider.js
+++ b/docs/src/pages/components/slider/UnstyledSlider.js
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { styled, alpha, Box } from '@material-ui/system';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
 
-const StyledSlider = styled(SliderUnstyled)(
-  ({ theme }) => `
+const StyledSlider = styled(SliderUnstyled)`
   color: #1976d2;
   height: 4px;
   width: 100%;
@@ -57,8 +56,7 @@ const StyledSlider = styled(SliderUnstyled)(
       box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.3)};
     }
   }
-`,
-);
+`;
 
 export default function UnstyledSlider() {
   return (

--- a/docs/src/pages/components/slider/UnstyledSlider.js
+++ b/docs/src/pages/components/slider/UnstyledSlider.js
@@ -13,6 +13,7 @@ const StyledSlider = styled(SliderUnstyled)`
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
   opacity: 0.75;
+
   &:hover {
     opacity: 1;
   }

--- a/docs/src/pages/components/slider/UnstyledSlider.js
+++ b/docs/src/pages/components/slider/UnstyledSlider.js
@@ -46,7 +46,7 @@ const StyledSlider = styled(SliderUnstyled)(
     border-radius: 50%;
     outline: 0;
     border: 2px solid currentColor;
-    background-color: white;
+    background-color: #fff;
 
     :hover,
     &.Mui-focusVisible {

--- a/docs/src/pages/components/slider/UnstyledSlider.js
+++ b/docs/src/pages/components/slider/UnstyledSlider.js
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { styled, alpha, Box } from '@material-ui/system';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
 
-const StyledSlider = styled(SliderUnstyled)`
-  color: #1976d2;
+const StyledSlider = styled(SliderUnstyled)(
+  ({ theme }) => `
+  color: ${theme.palette.mode === 'light' ? '#1976d2' : '#90caf9'};
   height: 4px;
   width: 100%;
   padding: 13px 0;
@@ -13,7 +14,6 @@ const StyledSlider = styled(SliderUnstyled)`
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
   opacity: 0.75;
-
   &:hover {
     opacity: 1;
   }
@@ -50,14 +50,21 @@ const StyledSlider = styled(SliderUnstyled)`
 
     :hover,
     &.Mui-focusVisible {
-      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.15)};
+      box-shadow: 0 0 0 0.25rem ${alpha(
+        theme.palette.mode === 'light' ? '#1976d2' : '#90caf9',
+        0.15,
+      )};
     }
 
     &.Mui-active {
-      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.3)};
+      box-shadow: 0 0 0 0.25rem ${alpha(
+        theme.palette.mode === 'light' ? '#1976d2' : '#90caf9',
+        0.3,
+      )};
     }
   }
-`;
+`,
+);
 
 export default function UnstyledSlider() {
   return (

--- a/docs/src/pages/components/slider/UnstyledSlider.tsx
+++ b/docs/src/pages/components/slider/UnstyledSlider.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { styled, alpha } from '@material-ui/core/styles';
+import { styled, alpha, Box } from '@material-ui/system';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
-import Box from '@material-ui/core/Box';
 
 const StyledSlider = styled(SliderUnstyled)(
   ({ theme }) => `
-  color: ${theme.palette.primary.main};
+  color: #1976d2;
   height: 4px;
   width: 100%;
   padding: 13px 0;
@@ -47,15 +46,15 @@ const StyledSlider = styled(SliderUnstyled)(
     border-radius: 50%;
     outline: 0;
     border: 2px solid currentColor;
-    background-color: ${theme.palette.getContrastText(theme.palette.primary.main)};
+    background-color: white;
 
     :hover,
     &.Mui-focusVisible {
-      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.15)};
+      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.15)};
     }
 
     &.Mui-active {
-      box-shadow: 0 0 0 0.25rem ${alpha(theme.palette.primary.main, 0.3)};
+      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.3)};
     }
   }
 `,

--- a/docs/src/pages/components/slider/UnstyledSlider.tsx
+++ b/docs/src/pages/components/slider/UnstyledSlider.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { styled, alpha, Box } from '@material-ui/system';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
 
-const StyledSlider = styled(SliderUnstyled)(
-  ({ theme }) => `
+const StyledSlider = styled(SliderUnstyled)`
   color: #1976d2;
   height: 4px;
   width: 100%;
@@ -57,8 +56,7 @@ const StyledSlider = styled(SliderUnstyled)(
       box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.3)};
     }
   }
-`,
-);
+`;
 
 export default function UnstyledSlider() {
   return (

--- a/docs/src/pages/components/slider/UnstyledSlider.tsx
+++ b/docs/src/pages/components/slider/UnstyledSlider.tsx
@@ -13,6 +13,7 @@ const StyledSlider = styled(SliderUnstyled)`
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
   opacity: 0.75;
+
   &:hover {
     opacity: 1;
   }

--- a/docs/src/pages/components/slider/UnstyledSlider.tsx
+++ b/docs/src/pages/components/slider/UnstyledSlider.tsx
@@ -46,7 +46,7 @@ const StyledSlider = styled(SliderUnstyled)(
     border-radius: 50%;
     outline: 0;
     border: 2px solid currentColor;
-    background-color: white;
+    background-color: #fff;
 
     :hover,
     &.Mui-focusVisible {

--- a/docs/src/pages/components/slider/UnstyledSlider.tsx
+++ b/docs/src/pages/components/slider/UnstyledSlider.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { styled, alpha, Box } from '@material-ui/system';
 import SliderUnstyled from '@material-ui/unstyled/SliderUnstyled';
 
-const StyledSlider = styled(SliderUnstyled)`
-  color: #1976d2;
+const StyledSlider = styled(SliderUnstyled)(
+  ({ theme }) => `
+  color: ${theme.palette.mode === 'light' ? '#1976d2' : '#90caf9'};
   height: 4px;
   width: 100%;
   padding: 13px 0;
@@ -13,7 +14,6 @@ const StyledSlider = styled(SliderUnstyled)`
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
   opacity: 0.75;
-
   &:hover {
     opacity: 1;
   }
@@ -50,14 +50,21 @@ const StyledSlider = styled(SliderUnstyled)`
 
     :hover,
     &.Mui-focusVisible {
-      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.15)};
+      box-shadow: 0 0 0 0.25rem ${alpha(
+        theme.palette.mode === 'light' ? '#1976d2' : '#90caf9',
+        0.15,
+      )};
     }
 
     &.Mui-active {
-      box-shadow: 0 0 0 0.25rem ${alpha('#1976d2', 0.3)};
+      box-shadow: 0 0 0 0.25rem ${alpha(
+        theme.palette.mode === 'light' ? '#1976d2' : '#90caf9',
+        0.3,
+      )};
     }
   }
-`;
+`,
+);
 
 export default function UnstyledSlider() {
   return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-26869--material-ui.netlify.app/components/slider/#unstyled