### PR TITLE
[Stepper] Fix support for no connectors

### DIFF
--- a/packages/material-ui/src/Stepper/Stepper.d.ts
+++ b/packages/material-ui/src/Stepper/Stepper.d.ts
@@ -32,7 +32,7 @@ export interface StepperProps extends StandardProps<PaperProps> {
    * An element to be placed between each step.
    * @default <StepConnector />
    */
-  connector?: React.ReactElement<any, any>;
+  connector?: React.ReactElement<any, any> | null;
   /**
    * If set the `Stepper` will not assist in controlling steps for linear flow.
    * @default false

--- a/packages/material-ui/src/Stepper/Stepper.test.tsx
+++ b/packages/material-ui/src/Stepper/Stepper.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
-import { stepIconClasses } from '@material-ui/core/StepIcon';
 import Step, { StepProps, stepClasses } from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import StepConnector, { stepConnectorClasses } from '@material-ui/core/StepConnector';

--- a/packages/material-ui/src/Stepper/Stepper.test.tsx
+++ b/packages/material-ui/src/Stepper/Stepper.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
-import Step, { stepClasses } from '@material-ui/core/Step';
+import { stepIconClasses } from '@material-ui/core/StepIcon';
+import Step, { StepProps, stepClasses } from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import StepConnector, { stepConnectorClasses } from '@material-ui/core/StepConnector';
 import StepContent, { stepContentClasses } from '@material-ui/core/StepContent';
@@ -113,7 +114,7 @@ describe('<Stepper />', () => {
     });
 
     it('passes index down correctly when rendering children containing arrays', () => {
-      const CustomStep = ({ index }) => <div data-index={index} data-testid="step" />;
+      const CustomStep = ({ index }: StepProps) => <div data-index={index} data-testid="step" />;
 
       const { getAllByTestId } = render(
         <Stepper nonLinear>
@@ -239,17 +240,23 @@ describe('<Stepper />', () => {
   it('should be able to force a state', () => {
     const { container } = render(
       <Stepper>
-        <Step />
-        <Step active />
-        <Step />
+        <Step>
+          <StepLabel>one</StepLabel>
+        </Step>
+        <Step active>
+          <StepLabel>two</StepLabel>
+        </Step>
+        <Step>
+          <StepLabel>tree</StepLabel>
+        </Step>
       </Stepper>,
     );
 
-    const steps = container.querySelectorAll(`.${stepClasses.root}`);
+    const steps = container.querySelectorAll(`.${stepIconClasses.root}`);
 
-    expect(steps[0]).not.to.have.class(stepClasses.active);
-    expect(steps[1]).not.to.have.class(stepClasses.active);
-    expect(steps[2]).not.to.have.class(stepClasses.active);
+    expect(steps[0]).to.have.class(stepIconClasses.active);
+    expect(steps[1]).to.have.class(stepIconClasses.active);
+    expect(steps[2]).not.to.have.class(stepIconClasses.active);
   });
 
   it('should hide the last connector', () => {

--- a/packages/material-ui/src/Stepper/Stepper.test.tsx
+++ b/packages/material-ui/src/Stepper/Stepper.test.tsx
@@ -237,28 +237,6 @@ describe('<Stepper />', () => {
     expect(steps).to.have.length(1);
   });
 
-  it('should be able to force a state', () => {
-    const { container } = render(
-      <Stepper>
-        <Step>
-          <StepLabel>one</StepLabel>
-        </Step>
-        <Step active>
-          <StepLabel>two</StepLabel>
-        </Step>
-        <Step>
-          <StepLabel>tree</StepLabel>
-        </Step>
-      </Stepper>,
-    );
-
-    const steps = container.querySelectorAll(`.${stepIconClasses.root}`);
-
-    expect(steps[0]).to.have.class(stepIconClasses.active);
-    expect(steps[1]).to.have.class(stepIconClasses.active);
-    expect(steps[2]).not.to.have.class(stepIconClasses.active);
-  });
-
   it('should hide the last connector', () => {
     const { container } = render(
       <Stepper orientation="vertical">


### PR DESCRIPTION
The purpose of this PR is to allow to set a null stepper connector in TS. It works in JS. Perhaps there's another way to acomplish this, please let me know..

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
