### PR TITLE
[ToggleButtonGroup] Removes `:not` selector; improves CSS specificity

### DIFF
--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -54,15 +54,14 @@ const ToggleButtonGroupRoot = styled('div', {
   [`& .${toggleButtonGroupClasses.grouped}`]: {
     /* Styles applied to the children if `orientation="horizontal"`. */
     borderRadius: 0,
+
     ...(styleProps.orientation === 'horizontal'
       ? {
-          borderLeft: '1px solid transparent',
           marginLeft: -1,
-          [`&:first-of-type', &.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
-            {
-              marginLeft: 0,
-            },
+          borderLeft: '1px solid transparent',
           '&:first-of-type': {
+            marginLeft: 0,
+            borderLeftColor: 'rgba(0, 0, 0, 0.12)',
             borderTopLeftRadius: theme.shape.borderRadius,
             borderBottomLeftRadius: theme.shape.borderRadius,
           },
@@ -73,17 +72,16 @@ const ToggleButtonGroupRoot = styled('div', {
           [`&.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
             {
               borderLeft: 0,
+              marginLeft: 0,
             },
         }
       : {
           /* Styles applied to the children if `orientation="vertical"`. */
-          borderTop: '1px solid transparent',
           marginTop: -1,
-          [`&:first-of-type, &.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
-            {
-              marginTop: 0,
-            },
+          borderTop: '1px solid transparent',
           '&:first-of-type': {
+            marginTop: 0,
+            borderTopColor: 'rgba(0, 0, 0, 0.12)',
             borderTopLeftRadius: theme.shape.borderRadius,
             borderTopRightRadius: theme.shape.borderRadius,
           },
@@ -94,6 +92,7 @@ const ToggleButtonGroupRoot = styled('div', {
           [`&.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
             {
               borderTop: 0,
+              marginTop: 0,
             },
         }),
   },

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -54,7 +54,6 @@ const ToggleButtonGroupRoot = styled('div', {
   [`& .${toggleButtonGroupClasses.grouped}`]: {
     /* Styles applied to the children if `orientation="horizontal"`. */
     borderRadius: 0,
-
     ...(styleProps.orientation === 'horizontal'
       ? {
           marginLeft: -1,
@@ -66,21 +65,17 @@ const ToggleButtonGroupRoot = styled('div', {
             borderBottomLeftRadius: theme.shape.borderRadius,
           },
           '&:last-of-type': {
+            borderLeft: 0,
+            marginLeft: 0,
             borderTopRightRadius: theme.shape.borderRadius,
             borderBottomRightRadius: theme.shape.borderRadius,
           },
-          [`&.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
-            {
-              borderLeft: 0,
-              marginLeft: 0,
-            },
         }
       : {
           /* Styles applied to the children if `orientation="vertical"`. */
           marginTop: -1,
           borderTop: '1px solid transparent',
           '&:first-of-type': {
-            marginTop: 0,
             borderTopColor: 'rgba(0, 0, 0, 0.12)',
             borderTopLeftRadius: theme.shape.borderRadius,
             borderTopRightRadius: theme.shape.borderRadius,
@@ -88,12 +83,8 @@ const ToggleButtonGroupRoot = styled('div', {
           '&:last-of-type': {
             borderBottomLeftRadius: theme.shape.borderRadius,
             borderBottomRightRadius: theme.shape.borderRadius,
+            borderTop: 0,
           },
-          [`&.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
-            {
-              borderTop: 0,
-              marginTop: 0,
-            },
         }),
   },
 }));

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -53,40 +53,47 @@ const ToggleButtonGroupRoot = styled('div', {
   /* Styles applied to the children. */
   [`& .${toggleButtonGroupClasses.grouped}`]: {
     /* Styles applied to the children if `orientation="horizontal"`. */
+    borderRadius: 0,
     ...(styleProps.orientation === 'horizontal'
       ? {
-          '&:not(:first-of-type)': {
-            marginLeft: -1,
-            borderLeft: '1px solid transparent',
-            borderTopLeftRadius: 0,
-            borderBottomLeftRadius: 0,
+          borderLeft: '1px solid transparent',
+          marginLeft: -1,
+          [`&:first-of-type', &.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
+            {
+              marginLeft: 0,
+            },
+          '&:first-of-type': {
+            borderTopLeftRadius: theme.shape.borderRadius,
+            borderBottomLeftRadius: theme.shape.borderRadius,
           },
-          '&:not(:last-of-type)': {
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0,
+          '&:last-of-type': {
+            borderTopRightRadius: theme.shape.borderRadius,
+            borderBottomRightRadius: theme.shape.borderRadius,
           },
           [`&.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
             {
               borderLeft: 0,
-              marginLeft: 0,
             },
         }
       : {
           /* Styles applied to the children if `orientation="vertical"`. */
-          '&:not(:first-of-type)': {
-            marginTop: -1,
-            borderTop: '1px solid transparent',
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
+          borderTop: '1px solid transparent',
+          marginTop: -1,
+          [`&:first-of-type, &.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
+            {
+              marginTop: 0,
+            },
+          '&:first-of-type': {
+            borderTopLeftRadius: theme.shape.borderRadius,
+            borderTopRightRadius: theme.shape.borderRadius,
           },
-          '&:not(:last-of-type)': {
-            borderBottomLeftRadius: 0,
-            borderBottomRightRadius: 0,
+          '&:last-of-type': {
+            borderBottomLeftRadius: theme.shape.borderRadius,
+            borderBottomRightRadius: theme.shape.borderRadius,
           },
           [`&.${toggleButtonGroupClasses.selected} + .${toggleButtonGroupClasses.grouped}.${toggleButtonGroupClasses.selected}`]:
             {
               borderTop: 0,
-              marginTop: 0,
             },
         }),
   },


### PR DESCRIPTION
Removes `:not` selector, which improves CSS specificity
- This allows dependents to override CSS defaults more easily.

🙏  🙂 

--- 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
