### PR TITLE
[BottomNavigation] Remove `wrapper` from BottomNavigationAction

### DIFF
--- a/docs/pages/api-docs/bottom-navigation-action.json
+++ b/docs/pages/api-docs/bottom-navigation-action.json
@@ -10,7 +10,7 @@
   },
   "name": "BottomNavigationAction",
   "styles": {
-    "classes": ["root", "selected", "iconOnly", "wrapper", "label"],
+    "classes": ["root", "selected", "iconOnly", "label"],
     "globalClasses": { "selected": "Mui-selected" },
     "name": "MuiBottomNavigationAction"
   },

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -547,9 +547,7 @@ You can use the [`moved-lab-modules` codemod](https://github.com/mui-org/materia
   +<BottomNavigation onChange={(event: React.SyntheticEvent) => {}} />
   ```
 
-### BottomNavigationAction
-
-- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).
+- Remove the `span` element that wraps the children. Remove the `wrapper` classKey too. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).
 
   ```diff
   <button class="MuiBottomNavigationAction-root">

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -547,7 +547,9 @@ You can use the [`moved-lab-modules` codemod](https://github.com/mui-org/materia
   +<BottomNavigation onChange={(event: React.SyntheticEvent) => {}} />
   ```
 
-- Remove the `span` element that wraps the children. Remove the `wrapper` classKey too. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).
+### BottomNavigationAction
+
+- Remove the `span` element that wraps the children. Remove the `wrapper` classKey too. More details about [this change](https://github.com/mui-org/material-ui/pull/26923).
 
   ```diff
   <button class="MuiBottomNavigationAction-root">

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -547,6 +547,21 @@ You can use the [`moved-lab-modules` codemod](https://github.com/mui-org/materia
   +<BottomNavigation onChange={(event: React.SyntheticEvent) => {}} />
   ```
 
+### BottomNavigationAction
+
+- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).
+
+  ```diff
+  <button class="MuiBottomNavigationAction-root">
+  - <span class="MuiBottomNavigationAction-wrapper">
+      {icon}
+      <span class="MuiBottomNavigationAction-label">
+        {label}
+      </span>
+  - </span>
+  </button>
+  ```
+
 ### Box
 
 - The `borderRadius` system prop value transformation has been changed. If it receives a number, it multiplies this value with the `theme.shape.borderRadius` value. Use a string to provide an explicit `px` value.

--- a/docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json
+++ b/docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json
@@ -21,10 +21,6 @@
       "nodeName": "the root element",
       "conditions": "<code>showLabel={false}</code> and not selected"
     },
-    "wrapper": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the span element that wraps the icon and label"
-    },
     "label": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the label's span element"

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -15,7 +15,6 @@ const useUtilityClasses = (styleProps) => {
 
   const slots = {
     root: ['root', !showLabel && !selected && 'iconOnly', selected && 'selected'],
-    wrapper: ['wrapper'],
     label: ['label', !showLabel && !selected && 'iconOnly', selected && 'selected'],
   };
 
@@ -42,6 +41,7 @@ const BottomNavigationActionRoot = styled(ButtonBase, {
   minWidth: 80,
   maxWidth: 168,
   color: theme.palette.text.secondary,
+  flexDirection: 'column',
   flex: '1',
   ...(!styleProps.showLabel &&
     !styleProps.selected && {
@@ -52,19 +52,6 @@ const BottomNavigationActionRoot = styled(ButtonBase, {
     color: theme.palette.primary.main,
   },
 }));
-
-const BottomNavigationActionWrapper = styled('span', {
-  name: 'MuiBottomNavigationAction',
-  slot: 'Wrapper',
-  overridesResolver: (props, styles) => styles.wrapper,
-})({
-  /* Styles applied to the span element that wraps the icon and label. */
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '100%',
-  flexDirection: 'column',
-});
 
 const BottomNavigationActionLabel = styled('span', {
   name: 'MuiBottomNavigationAction',
@@ -175,12 +162,10 @@ const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(
       styleProps={styleProps}
       {...other}
     >
-      <BottomNavigationActionWrapper className={classes.wrapper} styleProps={styleProps}>
-        {icon}
-        <BottomNavigationActionLabel className={classes.label} styleProps={styleProps}>
-          {label}
-        </BottomNavigationActionLabel>
-      </BottomNavigationActionWrapper>
+      {icon}
+      <BottomNavigationActionLabel className={classes.label} styleProps={styleProps}>
+        {label}
+      </BottomNavigationActionLabel>
     </BottomNavigationActionRoot>
   );
 });

--- a/packages/material-ui/src/BottomNavigationAction/bottomNavigationActionClasses.ts
+++ b/packages/material-ui/src/BottomNavigationAction/bottomNavigationActionClasses.ts
@@ -7,8 +7,6 @@ export interface BottomNavigationActionClasses {
   selected: string;
   /** Pseudo-class applied to the root element if `showLabel={false}` and not selected. */
   iconOnly: string;
-  /** Styles applied to the span element that wraps the icon and label. */
-  wrapper: string;
   /** Styles applied to the label's span element. */
   label: string;
 }
@@ -21,7 +19,7 @@ export function getBottomNavigationActionUtilityClass(slot: string): string {
 
 const bottomNavigationActionClasses: BottomNavigationActionClasses = generateUtilityClasses(
   'MuiBottomNavigationAction',
-  ['root', 'iconOnly', 'selected', 'wrapper', 'label'],
+  ['root', 'iconOnly', 'selected', 'label'],
 );
 
 export default bottomNavigationActionClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**BREAKING CHANGE**

- [BottomNavigation] Remove wrapper from BottomNavigationAction (#26923) @siriwatknp 

  `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).

  ```diff
  <button class="MuiBottomNavigationAction-root">
  - <span class="MuiBottomNavigationAction-wrapper">
      {icon}
      <span class="MuiBottomNavigationAction-label">
        {label}
      </span>
  - </span>
  </button>
  ```

---

**WHY the wrapper is removed**
`button > span > children` exists as a workaround for flex container bug on button BUT not anymore, so this PR remove the span.

- ✅ Chrome 83+ (latest 90)
- ✅ Safari 11+ (latest 14)
- ✅ Edge
- ✅ Firefox 63 (latest 89)

https://github.com/philipwalton/flexbugs#flexbug-9

---

fix one of breaking changes #20012.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-26923--material-ui.netlify.app/components/bottom-navigation/