### PR TITLE
[Tabs] Remove unnecessary `wrapper` from Tab

### DIFF
--- a/docs/pages/api-docs/tab.json
+++ b/docs/pages/api-docs/tab.json
@@ -22,8 +22,7 @@
       "selected",
       "disabled",
       "fullWidth",
-      "wrapped",
-      "wrapper"
+      "wrapped"
     ],
     "globalClasses": { "selected": "Mui-selected", "disabled": "Mui-disabled" },
     "name": "MuiTab"

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1583,8 +1583,20 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
   +<Tabs scrollButtons={false} />
   ```
 
+### Tab
+
 - Tab `minWidth` changed from `72px` => `90px` (without media-query) according to [material-design spec](https://material.io/components/tabs#specs)
 - Tab `maxWidth` changed from `264px` => `360px` according to [material-design spec](https://material.io/components/tabs#specs)
+- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).
+
+  ```diff
+  <button class="MuiTab-root">
+  - <span class="MuiTab-wrapper">
+      {icon}
+      {label}
+  - </span>
+  </button>
+  ```
 
 ### TextField
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1587,7 +1587,7 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
 
 - Tab `minWidth` changed from `72px` => `90px` (without media-query) according to [material-design spec](https://material.io/components/tabs#specs)
 - Tab `maxWidth` changed from `264px` => `360px` according to [material-design spec](https://material.io/components/tabs#specs)
-- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).
+- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26926).
 
   ```diff
   <button class="MuiTab-root">

--- a/docs/translations/api-docs/tab/tab.json
+++ b/docs/translations/api-docs/tab/tab.json
@@ -53,10 +53,6 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>wrapped={true}</code>"
-    },
-    "wrapper": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the `icon` and `label`'s wrapper element"
     }
   }
 }

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -22,7 +22,6 @@ const useUtilityClasses = (styleProps) => {
       selected && 'selected',
       disabled && 'disabled',
     ],
-    wrapper: ['wrapper'],
   };
 
   return composeClasses(slots, getTabUtilityClass, classes);
@@ -54,13 +53,15 @@ const TabRoot = styled(ButtonBase, {
   overflow: 'hidden',
   whiteSpace: 'normal',
   textAlign: 'center',
+  flexDirection: 'column',
+  lineHeight: 1.25,
   /* Styles applied to the root element if both `icon` and `label` are provided. */
   ...(styleProps.icon &&
     styleProps.label && {
       minHeight: 72,
       paddingTop: 9,
       paddingBottom: 9,
-      [`& .${tabClasses.wrapper} > *:first-child`]: {
+      [`& > *:first-child`]: {
         marginBottom: 6,
       },
     }),
@@ -105,23 +106,8 @@ const TabRoot = styled(ButtonBase, {
   /* Styles applied to the root element if `wrapped={true}`. */
   ...(styleProps.wrapped && {
     fontSize: theme.typography.pxToRem(12),
-    lineHeight: 1.5,
   }),
 }));
-
-const TabWrapper = styled('span', {
-  name: 'MuiTab',
-  slot: 'Wrapper',
-  overridesResolver: (props, styles) => styles.wrapper,
-})({
-  /* Styles applied to the `icon` and `label`'s wrapper element. */
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '100%',
-  flexDirection: 'column',
-  lineHeight: 1.25,
-});
 
 const Tab = React.forwardRef(function Tab(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiTab' });
@@ -197,10 +183,8 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
       tabIndex={selected ? 0 : -1}
       {...other}
     >
-      <TabWrapper className={classes.wrapper} styleProps={styleProps}>
-        {icon}
-        {label}
-      </TabWrapper>
+      {icon}
+      {label}
       {indicator}
     </TabRoot>
   );

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -15,7 +15,6 @@ describe('<Tab />', () => {
     render,
     mount,
     muiName: 'MuiTab',
-    testDeepOverrides: { slotName: 'wrapper', slotClassName: classes.wrapper },
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp', 'componentsProp'],

--- a/packages/material-ui/src/Tab/tabClasses.ts
+++ b/packages/material-ui/src/Tab/tabClasses.ts
@@ -19,8 +19,6 @@ export interface TabClasses {
   fullWidth: string;
   /** Styles applied to the root element if `wrapped={true}`. */
   wrapped: string;
-  /** Styles applied to the `icon` and `label`'s wrapper element. */
-  wrapper: string;
 }
 
 export type TabClassKey = keyof TabClasses;
@@ -39,7 +37,6 @@ const tabClasses: TabClasses = generateUtilityClasses('MuiTab', [
   'disabled',
   'fullWidth',
   'wrapped',
-  'wrapper',
 ]);
 
 export default tabClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**BREAKING CHANGE**

- [Tabs] Remove unnecessary wrapper from Tab (#26926) @siriwatknp 

  `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/26666).

  ```diff
  <button class="MuiTab-root">
  - <span class="MuiTab-wrapper">
      {icon}
      {label}
  - </span>
  </button>
  ```
---

**WHY the wrapper is removed**
`button > span > children` exists as a workaround for flex container bug on button BUT not anymore, so this PR remove the span.

- ✅ Chrome 83+ (latest 90)
- ✅ Safari 11+ (latest 14)
- ✅ Edge
- ✅ Firefox 63 (latest 89)

https://github.com/philipwalton/flexbugs#flexbug-9

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-26926--material-ui.netlify.app/components/tabs/#icon-tabs