### PR TITLE
[typescript] Disallow spreading TransitionHandlerProps

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -3,11 +3,10 @@ import { SxProps, Breakpoint } from '@material-ui/system';
 import { InternalStandardProps as StandardProps, Theme } from '..';
 import { PaperProps } from '../Paper';
 import { ModalProps } from '../Modal';
-import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
+import { TransitionProps } from '../transitions/transition';
 import { DialogClasses } from './dialogClasses';
 
-export interface DialogProps
-  extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, 'children'> {
+export interface DialogProps extends StandardProps<ModalProps, 'children'> {
   /**
    * The id(s) of the element(s) that describe the dialog.
    */

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -4,10 +4,10 @@ import { InternalStandardProps as StandardProps } from '..';
 import { PopoverProps } from '../Popover';
 import { MenuListProps } from '../MenuList';
 import { Theme } from '../styles';
-import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
+import { TransitionProps } from '../transitions/transition';
 import { MenuClasses } from './menuClasses';
 
-export interface MenuProps extends StandardProps<PopoverProps & Partial<TransitionHandlerProps>> {
+export interface MenuProps extends StandardProps<PopoverProps> {
   /**
    * An HTML element, or a function that returns one.
    * It's used to set the position of the menu.

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -4,7 +4,7 @@ import { InternalStandardProps as StandardProps } from '..';
 import { PaperProps } from '../Paper';
 import { ModalProps } from '../Modal';
 import { Theme } from '../styles';
-import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
+import { TransitionProps } from '../transitions/transition';
 import { PopoverClasses } from './popoverClasses';
 
 export interface PopoverOrigin {
@@ -19,8 +19,7 @@ export interface PopoverPosition {
 
 export type PopoverReference = 'anchorEl' | 'anchorPosition' | 'none';
 
-export interface PopoverProps
-  extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, 'children'> {
+export interface PopoverProps extends StandardProps<ModalProps, 'children'> {
   /**
    * A ref for imperative actions.
    * It currently only supports updatePosition() action.

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -3,7 +3,7 @@ import { SxProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '..';
 import { SnackbarContentProps } from '../SnackbarContent';
-import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
+import { TransitionProps } from '../transitions/transition';
 import { ClickAwayListenerProps } from '../ClickAwayListener';
 import { SnackbarClasses } from './snackbarClasses';
 
@@ -14,8 +14,7 @@ export interface SnackbarOrigin {
 
 export type SnackbarCloseReason = 'timeout' | 'clickaway';
 
-export interface SnackbarProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>> {
+export interface SnackbarProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>> {
   /**
    * The action to display. It renders after the message, at the end of the snackbar.
    */

--- a/packages/material-ui/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.d.ts
@@ -3,17 +3,14 @@ import { SxProps } from '@material-ui/system';
 import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '..';
 import { FabProps } from '../Fab';
-import { TransitionHandlerProps, TransitionProps } from '../transitions';
+import { TransitionProps } from '../transitions';
 import { SpeedDialClasses } from './speedDialClasses';
 
 export type CloseReason = 'toggle' | 'blur' | 'mouseLeave' | 'escapeKeyDown';
 export type OpenReason = 'toggle' | 'focus' | 'mouseEnter';
 
 export interface SpeedDialProps
-  extends StandardProps<
-    React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
-    'children'
-  > {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'children'> {
   /**
    * SpeedDialActions to display when the SpeedDial is `open`.
    */


### PR DESCRIPTION
Applying the same fix as https://github.com/mui-org/material-ui/pull/26835 to all incorrect usages of `TransitionHandlerProps`.