### PR TITLE
[core] Fix tests on Windows

### DIFF
--- a/packages/material-ui-codemod/src/util/readFile.js
+++ b/packages/material-ui-codemod/src/util/readFile.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import { EOL } from 'os';
+
+export default function readFile(filePath) {
+  const fileContents = fs.readFileSync(filePath, 'utf8').toString();
+  if (EOL !== '\n') {
+    return fileContents.replace(/\n/g, EOL);
+  }
+
+  return fileContents;
+}

--- a/packages/material-ui-codemod/src/v0.15.0/import-path.test.js
+++ b/packages/material-ui-codemod/src/v0.15.0/import-path.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./import-path.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v0.15.0/import-path.test.js
+++ b/packages/material-ui-codemod/src/v0.15.0/import-path.test.js
@@ -3,13 +3,14 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './import-path';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str.replace(/^\s+|\s+$/, '');
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./import-path.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v1.0.0/color-imports.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/color-imports.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./color-imports.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v1.0.0/color-imports.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/color-imports.test.js
@@ -3,13 +3,14 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './color-imports';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str.replace(/^\s+|\s+$/, '');
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./color-imports.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v1.0.0/import-path.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/import-path.test.js
@@ -3,13 +3,14 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './import-path';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str ? str.replace(/^\s+|\s+$/, '') : '';
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -23,7 +24,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./import-path.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +35,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./import-path.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v1.0.0/import-path.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/import-path.test.js
@@ -23,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./import-path.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +34,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./import-path.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./svg-icon-imports.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.test.js
@@ -3,13 +3,14 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './svg-icon-imports';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str.replace(/^\s+|\s+$/, '');
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./svg-icon-imports.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test.js
@@ -23,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./optimal-imports.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +34,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./optimal-imports.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/optimal-imports.test.js
@@ -3,13 +3,14 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './optimal-imports';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str ? str.replace(/^\s+|\s+$/, '') : '';
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -23,7 +24,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./optimal-imports.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +35,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./optimal-imports.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -23,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./theme-spacing-api.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('update theme spacing API for destructured', () => {
@@ -33,7 +33,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./theme-spacing-api.test/expected_destructured.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -4,13 +4,14 @@ import { EOL } from 'os';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-spacing-api';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str.replace(/^\s+|\s+$/, '').replace(/\r*\n/g, EOL);
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -23,7 +24,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./theme-spacing-api.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('update theme spacing API for destructured', () => {
@@ -33,7 +34,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./theme-spacing-api.test/expected_destructured.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test.js
@@ -3,13 +3,14 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './top-level-imports';
+import readFile from '../util/readFile';
 
 function trim(str) {
   return str ? str.replace(/^\s+|\s+$/, '') : '';
 }
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -26,7 +27,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./top-level-imports.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -40,7 +41,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./top-level-imports.test/expected.js');
-        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/top-level-imports.test.js
@@ -26,7 +26,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./top-level-imports.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -40,7 +40,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./top-level-imports.test/expected.js');
-        expect(trim(actual)).to.equal(trim(expected), 'The transformed version should be correct');
+        expect(trim(actual.replace(/\r\n/g, '\n'))).to.equal(trim(expected), 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/autocomplete-rename-closeicon.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/autocomplete-rename-closeicon.test.js
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./autocomplete-rename-closeicon.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/autocomplete-rename-closeicon.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/autocomplete-rename-closeicon.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './autocomplete-rename-closeicon';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./autocomplete-rename-closeicon.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/avatar-circle-circular.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/avatar-circle-circular.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./avatar-circle-circular.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./avatar-circle-circular.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/avatar-circle-circular.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/avatar-circle-circular.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './avatar-circle-circular';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./avatar-circle-circular.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./avatar-circle-circular.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/badge-overlap-value.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/badge-overlap-value.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './badge-overlap-value';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./badge-overlap-value.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./badge-overlap-value.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/badge-overlap-value.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/badge-overlap-value.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./badge-overlap-value.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./badge-overlap-value.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/box-borderradius-values.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/box-borderradius-values.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-borderradius-values';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-borderradius-values.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/box-borderradius-values.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/box-borderradius-values.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-borderradius-values.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/box-rename-gap.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/box-rename-gap.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-rename-gap';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-rename-gap.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-rename-gap.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/box-rename-gap.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/box-rename-gap.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-rename-gap.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-rename-gap.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/box-sx-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/box-sx-prop.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-sx-prop';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-sx-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-sx-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/box-sx-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/box-sx-prop.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-sx-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./box-sx-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/button-color-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/button-color-prop.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./button-color-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./button-color-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/button-color-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/button-color-prop.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './button-color-prop';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./button-color-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./button-color-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/chip-variant-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/chip-variant-prop.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./chip-variant-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./chip-variant-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/chip-variant-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/chip-variant-prop.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './chip-variant-prop';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./chip-variant-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./chip-variant-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/circularprogress-variant.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/circularprogress-variant.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./circularprogress-variant.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./circularprogress-variant.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/circularprogress-variant.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/circularprogress-variant.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './circularprogress-variant';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./circularprogress-variant.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./circularprogress-variant.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/collapse-rename-collapsedheight.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/collapse-rename-collapsedheight.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./collapse-rename-collapsedheight.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./collapse-rename-collapsedheight.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/collapse-rename-collapsedheight.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/collapse-rename-collapsedheight.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './collapse-rename-collapsedheight';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./collapse-rename-collapsedheight.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./collapse-rename-collapsedheight.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/component-rename-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/component-rename-prop.test.js
@@ -21,7 +21,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./component-rename-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +34,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./component-rename-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/component-rename-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/component-rename-prop.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './component-rename-prop';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -21,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./component-rename-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +35,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./component-rename-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/fade-rename-alpha.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/fade-rename-alpha.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./fade-rename-alpha.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./fade-rename-alpha.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should not modify local functions', () => {
@@ -50,7 +50,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./fade-rename-alpha.test/unmodified.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/fade-rename-alpha.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/fade-rename-alpha.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './fade-rename-alpha';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./fade-rename-alpha.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./fade-rename-alpha.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should not modify local functions', () => {
@@ -50,7 +51,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./fade-rename-alpha.test/unmodified.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/grid-justify-justifycontent.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/grid-justify-justifycontent.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './grid-justify-justifycontent';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./grid-justify-justifycontent.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./grid-justify-justifycontent.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/grid-justify-justifycontent.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/grid-justify-justifycontent.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./grid-justify-justifycontent.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./grid-justify-justifycontent.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/moved-lab-modules.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/moved-lab-modules.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './moved-lab-modules';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./moved-lab-modules.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +37,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./moved-lab-modules.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/moved-lab-modules.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/moved-lab-modules.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./moved-lab-modules.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -36,7 +36,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./moved-lab-modules.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/theme-breakpoints.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/theme-breakpoints.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-breakpoints';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./theme-breakpoints.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/theme-breakpoints.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/theme-breakpoints.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./theme-breakpoints.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/theme-spacing.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/theme-spacing.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-spacing';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {

--- a/packages/material-ui-codemod/src/v5.0.0/use-transitionprops.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/use-transitionprops.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './use-transitionprops';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -21,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./use-transitionprops.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +35,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./use-transitionprops.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/use-transitionprops.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/use-transitionprops.test.js
@@ -21,7 +21,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./use-transitionprops.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
 
       it('should be idempotent', () => {
@@ -34,7 +34,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./use-transitionprops.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/variant-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/variant-prop.test.js
@@ -3,9 +3,10 @@ import path from 'path';
 import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './variant-prop';
+import readFile from '../util/readFile';
 
 function read(fileName) {
-  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+  return readFile(path.join(__dirname, fileName));
 }
 
 describe('@material-ui/codemod', () => {
@@ -22,7 +23,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./variant-prop.test/expected.js');
-        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-codemod/src/v5.0.0/variant-prop.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/variant-prop.test.js
@@ -22,7 +22,7 @@ describe('@material-ui/codemod', () => {
         );
 
         const expected = read('./variant-prop.test/expected.js');
-        expect(actual).to.equal(expected, 'The transformed version should be correct');
+        expect(actual.replace(/\r\n/g, '\n')).to.equal(expected, 'The transformed version should be correct');
       });
     });
   });

--- a/packages/material-ui-envinfo/envinfo.test.js
+++ b/packages/material-ui-envinfo/envinfo.test.js
@@ -2,6 +2,8 @@ const { expect } = require('chai');
 const { execFileSync } = require('child_process');
 const path = require('path');
 
+const isRunningOnWindows = process.platform === 'win32';
+
 describe('@material-ui/envinfo', () => {
   const packagePath = __dirname;
   before(function beforeHook() {
@@ -12,15 +14,22 @@ describe('@material-ui/envinfo', () => {
 
     // Building might take some time
     this.timeout(10000);
-    execFileSync('yarn', ['build'], { cwd: packagePath, stdio: 'pipe' });
+    execFileSync(isRunningOnWindows ? 'yarn.cmd' : 'yarn', ['build'], {
+      cwd: packagePath,
+      stdio: 'pipe',
+    });
   });
 
   function execEnvinfo(args) {
     const buildPath = path.resolve(packagePath, 'build');
-    return execFileSync('npx', ['--package', buildPath, 'envinfo', ...args], {
-      encoding: 'utf-8',
-      stdio: 'pipe',
-    });
+    return execFileSync(
+      isRunningOnWindows ? 'npx.cmd' : 'npx',
+      ['--package', buildPath, 'envinfo', ...args],
+      {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      },
+    );
   }
 
   it('includes info about the environment relevant to Material-UI', function test() {

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -36,6 +36,15 @@ const blacklistedIcons = [
 }, []);
 
 /**
+ * Converts directory separators to slashes, so the path can be used in fast-glob.
+ * @param {string} pathToNormalize
+ * @returns
+ */
+function normalizePath(pathToNormalize) {
+  return pathToNormalize.replace(/\\/g, '/');
+}
+
+/**
  * Return Pascal-Cased component name.
  * @param {string} destPath
  * @returns {string} class name
@@ -52,7 +61,7 @@ export function getComponentName(destPath) {
 }
 
 async function generateIndex(options) {
-  const files = await globAsync(path.join(options.outputDir, '*.js'));
+  const files = await globAsync(normalizePath(path.join(options.outputDir, '*.js')));
   const index = files
     .map((file) => {
       const typename = path.basename(file).replace('.js', '');
@@ -267,7 +276,7 @@ export async function handler(options) {
   await fse.ensureDir(options.outputDir);
 
   const [svgPaths, template] = await Promise.all([
-    globAsync(path.join(options.svgDir, options.glob)),
+    globAsync(normalizePath(path.join(options.svgDir, options.glob))),
     fse.readFile(path.join(__dirname, 'templateSvgIcon.js'), {
       encoding: 'utf8',
     }),
@@ -288,9 +297,9 @@ export async function handler(options) {
   queue.push(svgPaths);
   await queue.wait({ empty: true });
 
-  let legacyFiles = await globAsync(path.join(__dirname, '/legacy', '*.js'));
+  let legacyFiles = await globAsync(normalizePath(path.join(__dirname, '/legacy', '*.js')));
   legacyFiles = legacyFiles.map((file) => path.basename(file));
-  let generatedFiles = await globAsync(path.join(options.outputDir, '*.js'));
+  let generatedFiles = await globAsync(normalizePath(path.join(options.outputDir, '*.js')));
   generatedFiles = generatedFiles.map((file) => path.basename(file));
 
   const duplicatedIconsLegacy = intersection(legacyFiles, generatedFiles);

--- a/packages/material-ui-utils/macros/MuiError.macro.js
+++ b/packages/material-ui-utils/macros/MuiError.macro.js
@@ -141,9 +141,9 @@ function muiError({ references, babel, config, source }) {
           '@material-ui/utils',
         );
       } else {
-        const normalizedRelativeImport = path.normalize(
-          source.replace('../macros/MuiError.macro', './formatMuiErrorMessage'),
-        );
+        const normalizedRelativeImport = path
+          .normalize(source.replace('../macros/MuiError.macro', './formatMuiErrorMessage'))
+          .replace(/\\/g, '/');
         // 'formatMuiErrorMessage' implies './formatMuiErrorMessage' for fs paths but not for import specifiers.
         const formatMuiErrorMessageImportSource = normalizedRelativeImport.startsWith('.')
           ? normalizedRelativeImport


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Running `yarn test` on Windows causes several tests to fail. Mostly these are codemod tests that expect LF but are receiving CRLF when codemods are executed on Windows.

In other case the builder from material-ui-icons passes a path to fast-glob without ensuring it contains forward slashes as separators (fast-glob does not support backslashes).