### PR TITLE
[codemod] Improve DX when using the package

### DIFF
--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -48,7 +48,7 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
+You can find more details about the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
 
 #### `avatar-circle-circular`
 

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -12,8 +12,8 @@ This repository contains a collection of codemod scripts based for use with
 
 - Make the codemod locally available `npm install -D @material-ui/codemod@next` <!-- #default-branch-switch -->
 - Make jscodeshift globally available `npm install -g jscodeshift`
-- Run the codemod: `jscodeshift --extensions js,ts,jsx,tsx --parser tsx <path-to-codemod-script> <path-to-source>`
-  - Applies the transform script specified in `<path-to-codemod-script>` recursively to `<path-to-source>`.
+- Run the codemod: `jscodeshift --extensions js,ts,jsx,tsx --parser tsx <path-to-codemod-script> <path>`
+  - Applies the transform script specified in `<path-to-codemod-script>` recursively to the sources in `<path>`.
   - Use the `-d` option for a dry-run and use `-p` to print the output for comparison.
 
 ## Included scripts
@@ -45,7 +45,7 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js  <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -68,7 +68,6 @@ jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
 
-
 #### `button-color-prop`
 
 Removes the outdated `color` prop values.

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -33,7 +33,7 @@ A generic codemod to rename any component prop.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/component-rename-prop.js --component=Grid --from=prop --to=newProp <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/component-rename-prop.js --component=Grid --from=prop --to=newProp <path>
 ```
 
 #### `autocomplete-rename-closeicon`
@@ -46,7 +46,7 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/autocomplete-rename-closeicon.js  <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js  <path>
 ```
 
 #### `avatar-circle-circular`
@@ -61,7 +61,7 @@ Updates the Avatar `variant` value and classes key from 'circle' to 'circular'.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/avatar-circle-circular.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
 ```
 
 #### `box-borderradius-values`
@@ -76,7 +76,7 @@ Updates the Box API from separate system props to `sx`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/box-borderradius-values.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
 ```
 
 #### `button-color-prop`
@@ -91,7 +91,7 @@ Removes the outdated `color` prop values.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/button-color-prop.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
 ```
 
 #### `box-rename-gap`
@@ -108,7 +108,7 @@ Renames the Box `grid*Gap` props.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/box-rename-gap.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
 ```
 
 #### `badge-overlap-value`
@@ -139,7 +139,7 @@ Renames the badge's props.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/badge-overlap-value.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
 ```
 
 #### `chip-variant-prop`
@@ -152,7 +152,7 @@ Removes the Chip `variant` prop if the value is `"default"`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/chip-variant-prop.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
 ```
 
 #### `circularprogress-variant`
@@ -165,7 +165,7 @@ Rename the CircularPress `static` variant to `determinate`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/circularprogress-variant.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
 ```
 
 #### `collapse-rename-collapsedheight`
@@ -180,7 +180,7 @@ Rename the CircularPress `static` variant to `determinate`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/collapse-rename-collapsedheight.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
 ```
 
 #### `fade-rename-alpha`
@@ -196,7 +196,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/fade-rename-alpha.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
 ```
 
 #### `grid-justify-justifycontent`
@@ -209,7 +209,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/grid-justify-justifycontent.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
 ```
 
 #### `moved-lab-modules`
@@ -229,7 +229,7 @@ or
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/moved-lab-modules.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
 ```
 
 #### `variant-prop`
@@ -261,7 +261,7 @@ The diff should look like this:
 This codemod is **non-idempotent** (`variant="standard"` would be added on a subsequent run, where `variant="outlined"` was removed), so it should only be run once against any particular codebase.
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/variant-prop.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
 ```
 
 #### `theme-breakpoints`
@@ -276,7 +276,7 @@ Updates breakpoint values to match new logic.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/theme-breakpoints.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
 ```
 
 #### `use-transitionprops`
@@ -303,7 +303,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/use-transitionprops.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
 ```
 
 #### `theme-spacing`
@@ -318,7 +318,7 @@ Removes the 'px' suffix from some template strings.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/theme-spacing.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-spacing.js <path>
 ```
 
 Note that if there are calculations using `theme.spacing()`, these will need to be resolved manually. Consider using CSS calc:
@@ -341,7 +341,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v4.0.0/theme-spacing-api.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/theme-spacing-api.js <path>
 ```
 
 This codemod tries to perform a basic expression simplification which can be improved for expressions that use more than one operation.
@@ -366,7 +366,7 @@ Converts all `@material-ui/core` imports more than 1 level deep to the optimal f
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v4.0.0/optimal-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/optimal-imports.js <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -382,7 +382,7 @@ Converts all `@material-ui/core` submodule imports to the root module:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v4.0.0/top-level-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/top-level-imports.js <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -401,7 +401,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v1.0.0/import-path.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/import-path.js <path>
 ```
 
 **Notice**: if you are migrating from pre-v1.0, and your imports use `material-ui`, you will need to manually find and replace all references to `material-ui` in your code to `@material-ui/core`. E.g.:
@@ -426,7 +426,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v1.0.0/color-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/color-imports.js <path>
 ```
 
 **additional options**
@@ -448,7 +448,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v1.0.0/svg-icon-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/svg-icon-imports.js <path>
 ```
 
 ### v0.15.0
@@ -465,12 +465,12 @@ The diff should look like this:
 +import FlatButton from 'material-ui/src/FlatButton';
 
 // From npm
--import RaisedButton from 'material-ui/lib/raised-button';
+-import RaisedButton from 'material-ui/node/raised-button';
 +import RaisedButton from 'material-ui/RaisedButton';
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v0.15.0/import-path.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v0.15.0/import-path.js <path>
 ```
 
 ### Recast Options

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -496,7 +496,7 @@ The diff should look like this:
 +import FlatButton from 'material-ui/src/FlatButton';
 
 // From npm
--import RaisedButton from 'material-ui/node/raised-button';
+-import RaisedButton from 'material-ui/lib/raised-button';
 +import RaisedButton from 'material-ui/RaisedButton';
 ```
 

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -6,10 +6,10 @@
 [![npm downloads](https://img.shields.io/npm/dm/@material-ui/codemod.svg?style=flat-square)](https://www.npmjs.com/package/@material-ui/codemod)
 
 This repository contains a collection of codemod scripts based for use with
-[JSCodeshift](https://github.com/facebook/jscodeshift) that help update Material-UI
+[jscodeshift](https://github.com/facebook/jscodeshift) that help update Material-UI
 APIs.
 
-## Setup & Run
+## Setup & run
 
 - `npm install -D @material-ui/codemod@next` <!-- #default-branch-switch -->
 - `npx jscodeshift -t <path-to-codemod-script> <path>`
@@ -17,7 +17,7 @@ APIs.
   - Use the `-d` option for a dry-run and use `-p` to print the output for comparison.
   - Use the `--extensions tsx --parser tsx` options to convert TypeScript source code.
 
-## Included Scripts
+## Included scripts
 
 ### v5.0.0
 
@@ -41,8 +41,8 @@ npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@materia
 Renames `fade` style utility import and calls from `fade` to `alpha`.
 
 ```diff
--<Grid justify="left">Item</Grid>
-+<Grid item justifyContent="left">Item</Grid>
+-<Autocomplete closeIcon={defaultClearIcon} />
++<Autocomplete clearIcon={defaultClearIcon} />
 ```
 
 ```sh
@@ -71,8 +71,8 @@ Updates the Box API from separate system props to `sx`.
 ```diff
 -<Box borderRadius="borderRadius">
 -<Box borderRadius={16}>
--<Box borderRadius={1}>
--<Box borderRadius="16px">
++<Box borderRadius={1}>
++<Box borderRadius="16px">
 ```
 
 ```sh
@@ -81,7 +81,7 @@ npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@materia
 
 #### `button-color-prop`
 
-Removes the Chip `variant` prop if the value is `"default"`.
+Removes the outdated `color` prop values.
 
 ```diff
 -<Button color="primary">
@@ -113,7 +113,7 @@ npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@materia
 
 #### `badge-overlap-value`
 
-Renames the Box `grid*Gap` props.
+Renames the badge's props.
 
 ```diff
 -<Badge overlap="circle">
@@ -240,19 +240,25 @@ The diff should look like this:
 ```diff
 -<TextField value="Standard" />
 -<TextField value="Outlined" variant="outlined" />
--<Select value="Standard" />
--<Select value="Outlined" variant="outlined" />
--<FormControl value="Standard" />
--<FormControl value="Outlined" variant="outlined" />
 +<TextField value="Standard" variant="standard" />
 +<TextField value="Outlined" />
+```
+
+```diff
+-<Select value="Standard" />
+-<Select value="Outlined" variant="outlined" />
 +<Select value="Standard" variant="standard" />
 +<Select value="Outlined" />
+```
+
+```diff
+-<FormControl value="Standard" />
+-<FormControl value="Outlined" variant="outlined" />
 +<FormControl value="Standard" variant="standard" />
 +<FormControl value="Outlined" />
 ```
 
-This codemod is **non-idempotent** (`variant="standard"` would be added on a subsequent run, where `variant="outlined"` was removed), so should only be run once against any particular codebase.
+This codemod is **non-idempotent** (`variant="standard"` would be added on a subsequent run, where `variant="outlined"` was removed), so it should only be run once against any particular codebase.
 
 ```sh
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/lib/v5.0.0/variant-prop.js <path>
@@ -275,7 +281,7 @@ npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@materia
 
 #### `use-transitionprops`
 
-Updates Dialog, Menu, Popover and Snackbar to use the `TransitionProps` prop to replace the `onEnter*` and `onExit*` props.
+Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to replace the `onEnter*` and `onExit*` props.
 
 ```diff
 <Dialog
@@ -305,11 +311,10 @@ npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@materia
 Removes the 'px' suffix from some template strings.
 
 ```diff
-`${theme.spacing(2)}px`
-`${theme.spacing(2)}px ${theme.spacing(4)}px`
-`${theme.spacing(2)}`
-`${theme.spacing(2)} ${theme.spacing(4)}`
-
+-`${theme.spacing(2)}px`
+-`${theme.spacing(2)}px ${theme.spacing(4)}px`
++`${theme.spacing(2)}`
++`${theme.spacing(2)} ${theme.spacing(4)}`
 ```
 
 ```sh
@@ -318,9 +323,9 @@ npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@materia
 
 Note that if there are calculations using `theme.spacing()`, these will need to be resolved manually. Consider using CSS calc:
 
-```
--`${theme.spacing(2) - 1}px`
-+`calc(${theme.spacing(2)} - 1px)`
+```diff
+-width: `${theme.spacing(2) - 1}px`,
++widith: `calc(${theme.spacing(2)} - 1px)`,
 ```
 
 ### v4.0.0

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -11,11 +11,11 @@ APIs.
 
 ## Setup & run
 
-- `npm install -D @material-ui/codemod@next` <!-- #default-branch-switch -->
-- `npx jscodeshift -t <path-to-codemod-script> <path>`
-  - Applies the transform script specified in `<path-to-codemod-script>` recursively to `<path>`.
+- Make the codemod locally available `npm install -D @material-ui/codemod@next` <!-- #default-branch-switch -->
+- Make jscodeshift globally available `npm install -g jscodeshift`
+- Run the codemod: `jscodeshift --extensions js,ts,jsx,tsx --parser tsx <path-to-codemod-script> <path-to-source>`
+  - Applies the transform script specified in `<path-to-codemod-script>` recursively to `<path-to-source>`.
   - Use the `-d` option for a dry-run and use `-p` to print the output for comparison.
-  - Use the `--extensions tsx --parser tsx` options to convert TypeScript source code.
 
 ## Included scripts
 
@@ -33,7 +33,7 @@ A generic codemod to rename any component prop.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/component-rename-prop.js --component=Grid --from=prop --to=newProp <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/component-rename-prop.js --component=Grid --from=prop --to=newProp <path>
 ```
 
 #### `autocomplete-rename-closeicon`
@@ -46,7 +46,7 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js  <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js  <path>
 ```
 
 #### `avatar-circle-circular`
@@ -61,7 +61,7 @@ Updates the Avatar `variant` value and classes key from 'circle' to 'circular'.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
 ```
 
 #### `box-borderradius-values`
@@ -76,7 +76,7 @@ Updates the Box API from separate system props to `sx`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
 ```
 
 #### `button-color-prop`
@@ -91,7 +91,7 @@ Removes the outdated `color` prop values.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
 ```
 
 #### `box-rename-gap`
@@ -108,7 +108,7 @@ Renames the Box `grid*Gap` props.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
 ```
 
 #### `badge-overlap-value`
@@ -139,7 +139,7 @@ Renames the badge's props.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
 ```
 
 #### `chip-variant-prop`
@@ -152,7 +152,7 @@ Removes the Chip `variant` prop if the value is `"default"`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
 ```
 
 #### `circularprogress-variant`
@@ -165,7 +165,7 @@ Rename the CircularPress `static` variant to `determinate`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
 ```
 
 #### `collapse-rename-collapsedheight`
@@ -180,7 +180,7 @@ Rename the CircularPress `static` variant to `determinate`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
 ```
 
 #### `fade-rename-alpha`
@@ -196,7 +196,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
 ```
 
 #### `grid-justify-justifycontent`
@@ -209,7 +209,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
 ```
 
 #### `moved-lab-modules`
@@ -229,7 +229,7 @@ or
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
 ```
 
 #### `variant-prop`
@@ -261,7 +261,7 @@ The diff should look like this:
 This codemod is **non-idempotent** (`variant="standard"` would be added on a subsequent run, where `variant="outlined"` was removed), so it should only be run once against any particular codebase.
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
 ```
 
 #### `theme-breakpoints`
@@ -276,7 +276,7 @@ Updates breakpoint values to match new logic.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
 ```
 
 #### `use-transitionprops`
@@ -303,7 +303,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
 ```
 
 #### `theme-spacing`
@@ -318,7 +318,7 @@ Removes the 'px' suffix from some template strings.
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-spacing.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-spacing.js <path>
 ```
 
 Note that if there are calculations using `theme.spacing()`, these will need to be resolved manually. Consider using CSS calc:
@@ -341,7 +341,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/theme-spacing-api.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/theme-spacing-api.js <path>
 ```
 
 This codemod tries to perform a basic expression simplification which can be improved for expressions that use more than one operation.
@@ -366,7 +366,7 @@ Converts all `@material-ui/core` imports more than 1 level deep to the optimal f
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/optimal-imports.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/optimal-imports.js <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -382,7 +382,7 @@ Converts all `@material-ui/core` submodule imports to the root module:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/top-level-imports.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/top-level-imports.js <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -401,7 +401,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/import-path.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/import-path.js <path>
 ```
 
 **Notice**: if you are migrating from pre-v1.0, and your imports use `material-ui`, you will need to manually find and replace all references to `material-ui` in your code to `@material-ui/core`. E.g.:
@@ -426,13 +426,13 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/color-imports.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/color-imports.js <path>
 ```
 
 **additional options**
 
 ```
-npx jscodeshift -t <color-imports.js> <path> --importPath='mui/styles/colors' --targetPath='mui/colors'
+jscodeshift -t <color-imports.js> <path> --importPath='mui/styles/colors' --targetPath='mui/colors'
 ```
 
 #### `svg-icon-imports`
@@ -448,7 +448,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/svg-icon-imports.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/svg-icon-imports.js <path>
 ```
 
 ### v0.15.0
@@ -470,7 +470,7 @@ The diff should look like this:
 ```
 
 ```sh
-npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v0.15.0/import-path.js <path>
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v0.15.0/import-path.js <path>
 ```
 
 ### Recast Options
@@ -479,5 +479,5 @@ Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through the `printOptions` command line argument:
 
 ```sh
-npx jscodeshift -t transform.js <path> --printOptions='{"quote": "double", "trailingComma": false}'
+jscodeshift -t transform.js <path> --printOptions='{"quote": "double", "trailingComma": false}'
 ```

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -47,7 +47,7 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js <path>
 ```
 
-You can find more details about the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
 
 #### `avatar-circle-circular`
 
@@ -64,7 +64,7 @@ Updates the Avatar `variant` value and classes key from 'circle' to 'circular'.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
 
 #### `button-color-prop`
 
@@ -81,7 +81,7 @@ Removes the outdated `color` prop values.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#button).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#button).
 
 #### `box-borderradius-values`
 
@@ -98,7 +98,7 @@ Updates the Box API from separate system props to `sx`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
 
 #### `box-rename-gap`
 
@@ -117,7 +117,7 @@ Renames the Box `grid*Gap` props.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
 
 #### `badge-overlap-value`
 
@@ -150,7 +150,7 @@ Renames the badge's props.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#badge).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#badge).
 
 #### `chip-variant-prop`
 
@@ -165,7 +165,7 @@ Removes the Chip `variant` prop if the value is `"default"`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#chip).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#chip).
 
 #### `circularprogress-variant`
 
@@ -180,7 +180,7 @@ Rename the CircularPress `static` variant to `determinate`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#circularprogress).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#circularprogress).
 
 #### `collapse-rename-collapsedheight`
 
@@ -197,7 +197,7 @@ Rename the CircularPress `static` variant to `determinate`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#collapse).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#collapse).
 
 #### `fade-rename-alpha`
 
@@ -215,7 +215,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#styles).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#styles).
 
 #### `grid-justify-justifycontent`
 
@@ -230,7 +230,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#grid).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#grid).
 
 #### `moved-lab-modules`
 
@@ -252,7 +252,7 @@ or
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#skeleton).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#skeleton).
 
 #### `variant-prop`
 
@@ -286,7 +286,7 @@ This codemod is **non-idempotent** (`variant="standard"` would be added on a sub
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#textfield).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#textfield).
 
 #### `use-transitionprops`
 
@@ -315,7 +315,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](/guides/migration-v4/#dialog).
+You can find more details about this breaking change in [the migration guide](/guides/migration-v4/#dialog).
 
 #### `theme-breakpoints`
 
@@ -332,7 +332,7 @@ Updates breakpoint values to match new logic.
 npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
 
 #### `theme-spacing`
 
@@ -356,7 +356,7 @@ Note that if there are calculations using `theme.spacing()`, these will need to 
 +widith: `calc(${theme.spacing(2)} - 1px)`,
 ```
 
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
 
 ### v4.0.0
 

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -10,9 +10,8 @@ This repository contains a collection of codemod scripts based for use with
 
 ## Setup & run
 
-- Make the codemod locally available `npm install -D @material-ui/codemod@next` <!-- #default-branch-switch -->
-- Make jscodeshift globally available `npm install -g jscodeshift`
-- Run the codemod: `jscodeshift --extensions js,ts,jsx,tsx --parser tsx <path-to-codemod-script> <path>`
+- `npm install -D @material-ui/codemod@next` <!-- #default-branch-switch -->
+- Run the codemod: `npx npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx <path-to-codemod-script> <path>`
   - Applies the transform script specified in `<path-to-codemod-script>` recursively to the sources in `<path>`.
   - Use the `-d` option for a dry-run and use `-p` to print the output for comparison.
 
@@ -32,7 +31,7 @@ A generic codemod to rename any component prop.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/component-rename-prop.js --component=Grid --from=prop --to=newProp <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/component-rename-prop.js --component=Grid --from=prop --to=newProp <path>
 ```
 
 #### `autocomplete-rename-closeicon`
@@ -45,7 +44,7 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js <path>
 ```
 
 You can find more details about the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
@@ -62,7 +61,7 @@ Updates the Avatar `variant` value and classes key from 'circle' to 'circular'.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
@@ -79,7 +78,7 @@ Removes the outdated `color` prop values.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#button).
@@ -96,7 +95,7 @@ Updates the Box API from separate system props to `sx`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
@@ -115,7 +114,7 @@ Renames the Box `grid*Gap` props.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
@@ -148,7 +147,7 @@ Renames the badge's props.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#badge).
@@ -163,7 +162,7 @@ Removes the Chip `variant` prop if the value is `"default"`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#chip).
@@ -178,7 +177,7 @@ Rename the CircularPress `static` variant to `determinate`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#circularprogress).
@@ -195,7 +194,7 @@ Rename the CircularPress `static` variant to `determinate`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#collapse).
@@ -213,7 +212,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#styles).
@@ -228,7 +227,7 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#grid).
@@ -250,7 +249,7 @@ or
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#skeleton).
@@ -284,7 +283,7 @@ The diff should look like this:
 This codemod is **non-idempotent** (`variant="standard"` would be added on a subsequent run, where `variant="outlined"` was removed), so it should only be run once against any particular codebase.
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#textfield).
@@ -313,7 +312,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](/guides/migration-v4/#dialog).
@@ -330,7 +329,7 @@ Updates breakpoint values to match new logic.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
@@ -347,7 +346,7 @@ Removes the 'px' suffix from some template strings.
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-spacing.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-spacing.js <path>
 ```
 
 Note that if there are calculations using `theme.spacing()`, these will need to be resolved manually. Consider using CSS calc:
@@ -372,7 +371,7 @@ The diff should look like this:
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/theme-spacing-api.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/theme-spacing-api.js <path>
 ```
 
 This codemod tries to perform a basic expression simplification which can be improved for expressions that use more than one operation.
@@ -397,7 +396,7 @@ Converts all `@material-ui/core` imports more than 1 level deep to the optimal f
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/optimal-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/optimal-imports.js <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -413,7 +412,7 @@ Converts all `@material-ui/core` submodule imports to the root module:
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/top-level-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v4.0.0/top-level-imports.js <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -432,7 +431,7 @@ The diff should look like this:
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/import-path.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/import-path.js <path>
 ```
 
 **Notice**: if you are migrating from pre-v1.0, and your imports use `material-ui`, you will need to manually find and replace all references to `material-ui` in your code to `@material-ui/core`. E.g.:
@@ -457,7 +456,7 @@ The diff should look like this:
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/color-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/color-imports.js <path>
 ```
 
 **additional options**
@@ -479,7 +478,7 @@ The diff should look like this:
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/svg-icon-imports.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v1.0.0/svg-icon-imports.js <path>
 ```
 
 ### v0.15.0
@@ -501,7 +500,7 @@ The diff should look like this:
 ```
 
 ```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v0.15.0/import-path.js <path>
+npx jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v0.15.0/import-path.js <path>
 ```
 
 ### Recast Options
@@ -510,5 +509,5 @@ Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through the `printOptions` command line argument:
 
 ```sh
-jscodeshift -t transform.js <path> --printOptions='{"quote": "double", "trailingComma": false}'
+npx jscodeshift -t transform.js <path> --printOptions='{"quote": "double", "trailingComma": false}'
 ```

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -49,6 +49,8 @@ Renames `fade` style utility import and calls from `fade` to `alpha`.
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/autocomplete-rename-closeicon.js  <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
+
 #### `avatar-circle-circular`
 
 Updates the Avatar `variant` value and classes key from 'circle' to 'circular'.
@@ -63,6 +65,8 @@ Updates the Avatar `variant` value and classes key from 'circle' to 'circular'.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/avatar-circle-circular.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
 
 #### `box-borderradius-values`
 
@@ -79,6 +83,8 @@ Updates the Box API from separate system props to `sx`.
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
+
 #### `button-color-prop`
 
 Removes the outdated `color` prop values.
@@ -93,6 +99,8 @@ Removes the outdated `color` prop values.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/button-color-prop.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#button).
 
 #### `box-rename-gap`
 
@@ -110,6 +118,8 @@ Renames the Box `grid*Gap` props.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-rename-gap.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
 
 #### `badge-overlap-value`
 
@@ -142,6 +152,8 @@ Renames the badge's props.
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/badge-overlap-value.js <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#badge).
+
 #### `chip-variant-prop`
 
 Removes the Chip `variant` prop if the value is `"default"`.
@@ -155,6 +167,8 @@ Removes the Chip `variant` prop if the value is `"default"`.
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/chip-variant-prop.js <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#chip).
+
 #### `circularprogress-variant`
 
 Rename the CircularPress `static` variant to `determinate`.
@@ -167,6 +181,8 @@ Rename the CircularPress `static` variant to `determinate`.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/circularprogress-variant.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#circularprogress).
 
 #### `collapse-rename-collapsedheight`
 
@@ -182,6 +198,8 @@ Rename the CircularPress `static` variant to `determinate`.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/collapse-rename-collapsedheight.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#collapse).
 
 #### `fade-rename-alpha`
 
@@ -199,6 +217,8 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/fade-rename-alpha.js <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#styles).
+
 #### `grid-justify-justifycontent`
 
 Renames `fade` style utility import and calls frpm `fade` to `alpha`.
@@ -211,6 +231,8 @@ Renames `fade` style utility import and calls frpm `fade` to `alpha`.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/grid-justify-justifycontent.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#grid).
 
 #### `moved-lab-modules`
 
@@ -231,6 +253,8 @@ or
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/moved-lab-modules.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#skeleton).
 
 #### `variant-prop`
 
@@ -264,6 +288,8 @@ This codemod is **non-idempotent** (`variant="standard"` would be added on a sub
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/variant-prop.js <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#textfield).
+
 #### `theme-breakpoints`
 
 Updates breakpoint values to match new logic.
@@ -278,6 +304,8 @@ Updates breakpoint values to match new logic.
 ```sh
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
 
 #### `use-transitionprops`
 
@@ -306,6 +334,8 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/use-transitionprops.js <path>
 ```
 
+You can find more details of the breaking changes in [the migration guide](/guides/migration-v4/#dialog).
+
 #### `theme-spacing`
 
 Removes the 'px' suffix from some template strings.
@@ -327,6 +357,8 @@ Note that if there are calculations using `theme.spacing()`, these will need to 
 -width: `${theme.spacing(2) - 1}px`,
 +widith: `calc(${theme.spacing(2)} - 1px)`,
 ```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
 
 ### v4.0.0
 

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -6,8 +6,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/@material-ui/codemod.svg?style=flat-square)](https://www.npmjs.com/package/@material-ui/codemod)
 
 This repository contains a collection of codemod scripts based for use with
-[jscodeshift](https://github.com/facebook/jscodeshift) that help update Material-UI
-APIs.
+[jscodeshift](https://github.com/facebook/jscodeshift) that help update Material-UI APIs.
 
 ## Setup & run
 

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -68,22 +68,6 @@ jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
 
-#### `box-borderradius-values`
-
-Updates the Box API from separate system props to `sx`.
-
-```diff
--<Box borderRadius="borderRadius">
--<Box borderRadius={16}>
-+<Box borderRadius={1}>
-+<Box borderRadius="16px">
-```
-
-```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
-```
-
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
 
 #### `button-color-prop`
 
@@ -101,6 +85,23 @@ jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui
 ```
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#button).
+
+#### `box-borderradius-values`
+
+Updates the Box API from separate system props to `sx`.
+
+```diff
+-<Box borderRadius="borderRadius">
+-<Box borderRadius={16}>
++<Box borderRadius={1}>
++<Box borderRadius="16px">
+```
+
+```sh
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/box-borderradius-values.js <path>
+```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
 
 #### `box-rename-gap`
 
@@ -290,23 +291,6 @@ jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui
 
 You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#textfield).
 
-#### `theme-breakpoints`
-
-Updates breakpoint values to match new logic.
-
-```diff
--theme.breakpoints.down('sm')
--theme.breakpoints.between('sm', 'md')
-+theme.breakpoints.down('md')
-+theme.breakpoints.between('sm', 'lg')
-```
-
-```sh
-jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
-```
-
-You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
-
 #### `use-transitionprops`
 
 Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to replace the `onEnter*` and `onExit*` props.
@@ -335,6 +319,23 @@ jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui
 ```
 
 You can find more details of the breaking changes in [the migration guide](/guides/migration-v4/#dialog).
+
+#### `theme-breakpoints`
+
+Updates breakpoint values to match new logic.
+
+```diff
+-theme.breakpoints.down('sm')
+-theme.breakpoints.between('sm', 'md')
++theme.breakpoints.down('md')
++theme.breakpoints.between('sm', 'lg')
+```
+
+```sh
+jscodeshift --extensions js,ts,jsx,tsx --parser tsx -t node_modules/@material-ui/codemod/node/v5.0.0/theme-breakpoints.js <path>
+```
+
+You can find more details of the breaking changes in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
 
 #### `theme-spacing`
 


### PR DESCRIPTION
This is a follow-up on #26932. I had already noticed the issues, but seeing the PR made me trigger a time allocation slot. This is fixing the frustrations I had when trying to leverage the package for [material-ui-store](https://github.com/mui-org/material-ui-store).

The change:

1. The formatting of the page is off
3. The `/lib` folder do no longer exists. https://unpkg.com/browse/@material-ui/codemod@next/
4. Give up on npx. It's both slow, It reinstall each time, adding +8s of run. It's also **not working**: https://github.com/facebook/jscodeshift/issues/441. In my case:

<img width="789" alt="Capture d’écran 2021-06-24 à 15 43 56" src="https://user-images.githubusercontent.com/3165635/123273548-07f44800-d503-11eb-994e-f29cfaa3266d.png">

5. Crosslink between codemod and migration guide
6. Better sort asc, group related codemodes
