### PR TITLE
[Radio] Fix `defaultValue` to match the other value types 

### DIFF
--- a/docs/pages/api-docs/radio-group.json
+++ b/docs/pages/api-docs/radio-group.json
@@ -1,12 +1,7 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "defaultValue": {
-      "type": {
-        "name": "union",
-        "description": "Array&lt;string&gt;<br>&#124;&nbsp;number<br>&#124;&nbsp;string"
-      }
-    },
+    "defaultValue": { "type": { "name": "any" } },
     "name": { "type": { "name": "string" } },
     "onChange": { "type": { "name": "func" } },
     "value": { "type": { "name": "any" } }

--- a/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
@@ -5,7 +5,7 @@ export interface RadioGroupProps extends Omit<FormGroupProps, 'onChange'> {
   /**
    * The default value. Use when the component is not controlled.
    */
-  defaultValue?: FormGroupProps['defaultValue'];
+  defaultValue?: any;
   /**
    * The name used to reference the value of the control.
    * If you don't provide this prop, it falls back to a randomly generated name.

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -76,11 +76,7 @@ RadioGroup.propTypes /* remove-proptypes */ = {
   /**
    * The default value. Use when the component is not controlled.
    */
-  defaultValue: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+  defaultValue: PropTypes.any,
   /**
    * The name used to reference the value of the control.
    * If you don't provide this prop, it falls back to a randomly generated name.

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -12,16 +12,17 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
     // eslint-disable-next-line react/prop-types
     actions,
     children,
+    defaultValue,
     name: nameProp,
-    value: valueProp,
     onChange,
+    value: valueProp,
     ...other
   } = props;
   const rootRef = React.useRef(null);
 
   const [value, setValueState] = useControlled({
     controlled: valueProp,
-    default: props.defaultValue,
+    default: defaultValue,
     name: 'RadioGroup',
   });
 


### PR DESCRIPTION
Complementary to #26772, it fixes a simple inconsistency I have noticed looking at #26772. We want to have the same type for RadioGroup.defaultValue, RadioGroup.value, and Radio.value.