### PR TITLE
[test] Add a default mount implementation to conformance tests

### DIFF
--- a/packages/material-ui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.test.tsx
+++ b/packages/material-ui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.test.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import CalendarPickerSkeleton, {
   calendarPickerSkeletonClasses as classes,
 } from '@material-ui/lab/CalendarPickerSkeleton';
 
 describe('<CalendarPickerSkeleton />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CalendarPickerSkeleton />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiCalendarPickerSkeleton',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'refForwarding', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/material-ui-lab/src/LoadingButton/LoadingButton.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5, screen } from 'test/utils';
+import { createClientRender, describeConformanceV5, screen } from 'test/utils';
 import { expect } from 'chai';
 import Button from '@material-ui/core/Button';
 import LoadingButton, { loadingButtonClasses as classes } from '@material-ui/lab/LoadingButton';
 
 describe('<LoadingButton />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<LoadingButton>Conformance?</LoadingButton>, () => ({
     classes,
     inheritComponent: Button,
     render,
-    mount,
     muiName: 'MuiLoadingButton',
     testVariantProps: { loading: true },
     refInstanceof: window.HTMLButtonElement,

--- a/packages/material-ui-lab/src/Timeline/Timeline.test.tsx
+++ b/packages/material-ui-lab/src/Timeline/Timeline.test.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Timeline, { timelineClasses as classes } from '@material-ui/lab/Timeline';
 
 describe('<Timeline />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<Timeline />, () => ({
     classes,
     inheritComponent: 'ul',
-    mount,
     render,
     muiName: 'MuiTimeline',
     refInstanceof: window.HTMLUListElement,

--- a/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.test.js
+++ b/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TimelineConnector, {
   timelineConnectorClasses as classes,
 } from '@material-ui/lab/TimelineConnector';
 
 describe('<TimelineConnector />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TimelineConnector />, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     muiName: 'MuiTimelineConnector',
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Typography from '@material-ui/core/Typography';
 import Timeline from '@material-ui/lab/Timeline';
 import TimelineItem from '@material-ui/lab/TimelineItem';
@@ -10,13 +10,11 @@ import TimelineContent, {
 
 describe('<TimelineContent />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TimelineContent />, () => ({
     classes,
     inheritComponent: Typography,
     render,
-    mount,
     muiName: 'MuiTimelineContent',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TimelineDot, { timelineDotClasses as classes } from '@material-ui/lab/TimelineDot';
 
 describe('<TimelineDot />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TimelineDot />, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     muiName: 'MuiTimelineDot',
     refInstanceof: window.HTMLSpanElement,
     testVariantProps: { color: 'secondary', variant: 'outlined' },

--- a/packages/material-ui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/material-ui-lab/src/TimelineItem/TimelineItem.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TimelineItem, { timelineItemClasses as classes } from '@material-ui/lab/TimelineItem';
 
 describe('<TimelineItem />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TimelineItem />, () => ({
     classes,
     inheritComponent: 'li',
     render,
-    mount,
     muiName: 'MuiTimelineItem',
     refInstanceof: window.HTMLLIElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Typography from '@material-ui/core/Typography';
 import Timeline from '@material-ui/lab/Timeline';
 import TimelineItem from '@material-ui/lab/TimelineItem';
@@ -10,13 +10,11 @@ import TimelineOppositeContent, {
 
 describe('<TimelineOppositeContent />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TimelineOppositeContent />, () => ({
     classes,
     inheritComponent: Typography,
     render,
-    mount,
     muiName: 'MuiTimelineOppositeContent',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.test.js
+++ b/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TimelineSeparator, {
   timelineSeparatorClasses as classes,
 } from '@material-ui/lab/TimelineSeparator';
 
 describe('<TimelineSeparator />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TimelineSeparator />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiTimelineSeparator',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { spy } from 'sinon';
 import {
-  createMount,
   describeConformanceV5,
   act,
   createEvent,
@@ -15,13 +14,11 @@ import TreeView from '@material-ui/lab/TreeView';
 import TreeItem, { treeItemClasses as classes } from '@material-ui/lab/TreeItem';
 
 describe('<TreeItem />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<TreeItem nodeId="one" label="one" />, () => ({
     classes,
     inheritComponent: 'li',
-    mount,
     render,
     muiName: 'MuiTreeItem',
     refInstanceof: window.HTMLLIElement,

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -8,21 +8,18 @@ import {
   fireEvent,
   screen,
   describeConformanceV5,
-  createMount,
 } from 'test/utils';
 import Portal from '@material-ui/core/Portal';
 import TreeView, { treeViewClasses as classes } from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
 
 describe('<TreeView />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<TreeView />, () => ({
     classes,
     inheritComponent: 'ul',
     render,
-    mount,
     refInstanceof: window.HTMLUListElement,
     muiName: 'MuiTreeView',
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui-system/src/Box/Box.test.js
+++ b/packages/material-ui-system/src/Box/Box.test.js
@@ -1,15 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Box from '@material-ui/core/Box';
 
 describe('<Box />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<Box />, () => ({
     render,
-    mount,
     inheritComponent: 'div',
     skip: [
       'componentProp',

--- a/packages/material-ui-unstyled/src/BackdropUnstyled/BackdropUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/BackdropUnstyled/BackdropUnstyled.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformance } from 'test/utils';
+import { createClientRender, describeConformance } from 'test/utils';
 import BackdropUnstyled, {
   backdropUnstyledClasses as classes,
 } from '@material-ui/unstyled/BackdropUnstyled';
 
 describe('<BackdropUnstyled />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(
@@ -17,7 +16,6 @@ describe('<BackdropUnstyled />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'div',
     }),

--- a/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/BadgeUnstyled/BadgeUnstyled.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformance } from 'test/utils';
+import { createClientRender, describeConformance } from 'test/utils';
 import BadgeUnstyled, {
   badgeUnstyledClasses as classes,
 } from '@material-ui/unstyled/BadgeUnstyled';
 
 describe('<BadgeUnstyled />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(
@@ -17,7 +16,6 @@ describe('<BadgeUnstyled />', () => {
       classes,
       inheritComponent: 'span',
       render,
-      mount,
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
     }),

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ModalUnstyled, {
   modalUnstyledClasses as classes,
 } from '@material-ui/unstyled/ModalUnstyled';
 
 describe('<ModalUnstyled />', () => {
-  const mount = createMount();
   const render = createClientRender();
   let savedBodyStyle;
 
@@ -26,7 +25,6 @@ describe('<ModalUnstyled />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       refInstanceof: window.HTMLDivElement,
       skip: [
         'rootClass', // portal, can't determin the root

--- a/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/material-ui-unstyled/src/SliderUnstyled/SliderUnstyled.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformance, screen } from 'test/utils';
+import { createClientRender, describeConformance, screen } from 'test/utils';
 import SliderUnstyled, {
   sliderUnstyledClasses as classes,
 } from '@material-ui/unstyled/SliderUnstyled';
@@ -12,14 +12,12 @@ describe('<SliderUnstyled />', () => {
     }
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(<SliderUnstyled value={0} />, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     refInstanceof: window.HTMLSpanElement,
     testComponentPropWith: 'span',
   }));

--- a/packages/material-ui/src/Accordion/Accordion.test.js
+++ b/packages/material-ui/src/Accordion/Accordion.test.js
@@ -2,21 +2,20 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, createClientRender, fireEvent } from 'test/utils';
 import Accordion, { accordionClasses as classes } from '@material-ui/core/Accordion';
 import Paper from '@material-ui/core/Paper';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 
 describe('<Accordion />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const minimalChildren = [<AccordionSummary key="header">Header</AccordionSummary>];
 
   describeConformanceV5(<Accordion>{minimalChildren}</Accordion>, () => ({
     classes,
     inheritComponent: Paper,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordion',
     testVariantProps: { variant: 'rounded' },

--- a/packages/material-ui/src/AccordionActions/AccordionActions.test.js
+++ b/packages/material-ui/src/AccordionActions/AccordionActions.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import AccordionActions, {
   accordionActionsClasses as classes,
 } from '@material-ui/core/AccordionActions';
 
 describe('<AccordionActions />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<AccordionActions>Conformance</AccordionActions>, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordionActions',
     testVariantProps: { disableSpacing: true },

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import AccordionDetails, {
   accordionDetailsClasses as classes,
 } from '@material-ui/core/AccordionDetails';
 
 describe('<AccordionDetails />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<AccordionDetails>Conformance</AccordionDetails>, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordionDetails',
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import AccordionSummary, {
   accordionSummaryClasses as classes,
 } from '@material-ui/core/AccordionSummary';
@@ -10,13 +10,11 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<AccordionSummary />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<AccordionSummary />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordionSummary',
     testVariantProps: { disabled: true },

--- a/packages/material-ui/src/Alert/Alert.test.js
+++ b/packages/material-ui/src/Alert/Alert.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Alert, { alertClasses as classes } from '@material-ui/core/Alert';
 import Paper from '@material-ui/core/Paper';
 
 describe('<Alert />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Alert />, () => ({
     classes,
     inheritComponent: Paper,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAlert',
     testVariantProps: { variant: 'standard', color: 'success' },

--- a/packages/material-ui/src/AlertTitle/AlertTitle.test.js
+++ b/packages/material-ui/src/AlertTitle/AlertTitle.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import AlertTitle, { alertTitleClasses as classes } from '@material-ui/core/AlertTitle';
 
 describe('<AlertTitle />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<AlertTitle />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiAlertTitle',
     refInstanceof: window.HTMLDivElement,
     testStateOverrides: { styleKey: 'root' },

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5, screen } from 'test/utils';
+import { createClientRender, describeConformanceV5, screen } from 'test/utils';
 import AppBar, { appBarClasses as classes } from '@material-ui/core/AppBar';
 import Paper from '@material-ui/core/Paper';
 
 describe('<AppBar />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<AppBar>Conformance?</AppBar>, () => ({
     classes,
     inheritComponent: Paper,
     render,
-    mount,
     muiName: 'MuiAppBar',
     refInstanceof: window.HTMLElement,
     testVariantProps: { position: 'relative' },

--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import {
-  createMount,
-  describeConformanceV5,
-  act,
-  createClientRender,
-  fireEvent,
-  screen,
-} from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent, screen } from 'test/utils';
 import { spy } from 'sinon';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
@@ -35,7 +28,6 @@ function checkHighlightIs(listbox, expected) {
 
 describe('<Autocomplete />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
@@ -43,7 +35,6 @@ describe('<Autocomplete />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiAutocomplete',
       testVariantProps: { variant: 'foo' },
       testDeepOverrides: { slotName: 'endAdornment', slotClassName: classes.endAdornment },

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, fireEvent, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, fireEvent, describeConformanceV5 } from 'test/utils';
 import { spy } from 'sinon';
 import Avatar, { avatarClasses as classes } from '@material-ui/core/Avatar';
 import CancelIcon from '../internal/svg-icons/Cancel';
 
 describe('<Avatar />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Avatar />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
     muiName: 'MuiAvatar',

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import Avatar from '@material-ui/core/Avatar';
 import AvatarGroup, { avatarGroupClasses as classes } from '@material-ui/core/AvatarGroup';
 
 describe('<AvatarGroup />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <AvatarGroup>
@@ -16,7 +15,6 @@ describe('<AvatarGroup />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiAvatarGroup',
       refInstanceof: window.HTMLDivElement,
       testVariantProps: { max: 10, spacing: 'small', variant: 'square' },

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount, createClientRender, describeConformanceV5, act } from 'test/utils';
+import { createClientRender, describeConformanceV5, act } from 'test/utils';
 import Backdrop, { backdropClasses as classes } from '@material-ui/core/Backdrop';
 import Fade from '@material-ui/core/Fade';
 
 describe('<Backdrop />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Backdrop open />, () => ({
     classes,
     inheritComponent: Fade,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiBackdrop',
     testVariantProps: { invisible: true },

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { BadgeUnstyled } from '@material-ui/unstyled';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Badge, { badgeClasses as classes } from '@material-ui/core/Badge';
 
 function findBadge(container) {
@@ -10,7 +10,7 @@ function findBadge(container) {
 
 describe('<Badge />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const defaultProps = {
     children: (
       <div className="unique" data-testid="children">
@@ -28,7 +28,6 @@ describe('<Badge />', () => {
       classes,
       inheritComponent: BadgeUnstyled,
       render,
-      mount,
       refInstanceof: window.HTMLSpanElement,
       muiName: 'MuiBadge',
       testVariantProps: { color: 'secondary', variant: 'dot' },

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, createClientRender, fireEvent } from 'test/utils';
 import BottomNavigation, {
   bottomNavigationClasses as classes,
 } from '@material-ui/core/BottomNavigation';
@@ -12,7 +12,7 @@ import Icon from '@material-ui/core/Icon';
 
 describe('<BottomNavigation />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const icon = <Icon>restore</Icon>;
   const getBottomNavigation = (container) => container.firstChild;
 
@@ -24,7 +24,6 @@ describe('<BottomNavigation />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiBottomNavigation',
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'span',

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import {
-  createMount,
-  describeConformanceV5,
-  createClientRender,
-  within,
-  fireEvent,
-} from 'test/utils';
+import { describeConformanceV5, createClientRender, within, fireEvent } from 'test/utils';
 import BottomNavigationAction, {
   bottomNavigationActionClasses as classes,
 } from '@material-ui/core/BottomNavigationAction';
@@ -15,13 +9,11 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<BottomNavigationAction />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<BottomNavigationAction />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiBottomNavigationAction',
     refInstanceof: window.HTMLButtonElement,
     testVariantProps: { showLabel: true },

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Box from '@material-ui/core/Box';
 
 describe('<Box />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<Box />, () => ({
     render,
-    mount,
     inheritComponent: 'div',
     skip: [
       'componentProp',

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender, screen } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, screen } from 'test/utils';
 import Breadcrumbs, { breadcrumbsClasses as classes } from '@material-ui/core/Breadcrumbs';
 
 describe('<Breadcrumbs />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Breadcrumbs>Conformance?</Breadcrumbs>, () => ({
     classes,
     inheritComponent: 'nav',
     render,
-    mount,
     muiName: 'MuiBreadcrumbs',
     refInstanceof: window.HTMLElement,
     testComponentPropWith: 'div',

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import {
-  createMount,
   describeConformanceV5,
   act,
   createClientRender,
@@ -13,13 +12,11 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<Button />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Button startIcon="icon">Conformance?</Button>, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     refInstanceof: window.HTMLButtonElement,
     muiName: 'MuiButton',
     testDeepOverrides: { slotName: 'startIcon', slotClassName: classes.startIcon },

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
-  createMount,
   describeConformanceV5,
   act,
   createClientRender,
@@ -19,10 +18,6 @@ import ButtonBase, { buttonBaseClasses as classes } from '@material-ui/core/Butt
 
 describe('<ButtonBase />', () => {
   const render = createClientRender();
-  /**
-   * @type {ReturnType<typeof createMount>}
-   */
-  const mount = createMount();
 
   // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14156632/
   let canFireDragEvents = true;
@@ -42,7 +37,6 @@ describe('<ButtonBase />', () => {
     classes,
     inheritComponent: 'button',
     render,
-    mount,
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'a',
     muiName: 'MuiButtonBase',

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
+import { describeConformanceV5, act, createClientRender } from 'test/utils';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
 const cb = () => {};
 
 describe('<TouchRipple />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   /**
    * @param {object} other props to spread to TouchRipple
@@ -47,7 +46,6 @@ describe('<TouchRipple />', () => {
     classes: {},
     inheritComponent: 'span',
     render,
-    mount,
     refInstanceof: Object,
     muiName: 'MuiTouchRipple',
     skip: [

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ButtonGroup, { buttonGroupClasses as classes } from '@material-ui/core/ButtonGroup';
 import Button from '@material-ui/core/Button';
 
 describe('<ButtonGroup />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <ButtonGroup>
@@ -16,7 +15,6 @@ describe('<ButtonGroup />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'span',
       muiName: 'MuiButtonGroup',

--- a/packages/material-ui/src/Card/Card.test.tsx
+++ b/packages/material-ui/src/Card/Card.test.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Card, { cardClasses as classes } from '@material-ui/core/Card';
 import Paper from '@material-ui/core/Paper';
 
 describe('<Card />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Card />, () => ({
     classes,
     inheritComponent: Paper,
     render,
-    mount,
     muiName: 'MuiCard',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { raised: true },

--- a/packages/material-ui/src/CardActionArea/CardActionArea.test.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import CardActionArea, { cardActionAreaClasses as classes } from '@material-ui/core/CardActionArea';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<CardActionArea />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CardActionArea />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiCardActionArea',
     testDeepOverrides: { slotName: 'focusHighlight', slotClassName: classes.focusHighlight },
     testVariantProps: { variant: 'foo' },

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import CardActions, { cardActionsClasses as classes } from '@material-ui/core/CardActions';
 
 describe('<CardActions />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CardActions />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiCardActions',
     testVariantProps: { disableSpacing: true },

--- a/packages/material-ui/src/CardContent/CardContent.test.js
+++ b/packages/material-ui/src/CardContent/CardContent.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import CardContent, { cardContentClasses as classes } from '@material-ui/core/CardContent';
 
 describe('<CardContent />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CardContent />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiCardContent',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/CardHeader/CardHeader.test.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import { typographyClasses } from '@material-ui/core/Typography';
 import CardHeader, { cardHeaderClasses as classes } from '@material-ui/core/CardHeader';
 
 describe('<CardHeader />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CardHeader />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiCardHeader',
     refInstanceof: window.HTMLDivElement,
     testDeepOverrides: { slotName: 'content', slotClassName: classes.content },

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import CardMedia, { cardMediaClasses as classes } from '@material-ui/core/CardMedia';
 
 describe('<CardMedia />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CardMedia image="/fake.png" />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiCardMedia',
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -1,20 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
+import { describeConformanceV5, act, createClientRender } from 'test/utils';
 import Checkbox, { checkboxClasses as classes } from '@material-ui/core/Checkbox';
 import FormControl from '@material-ui/core/FormControl';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<Checkbox />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Checkbox checked />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiCheckbox',
     testVariantProps: { variant: 'foo' },
     testStateOverrides: { prop: 'color', value: 'secondary', styleKey: 'colorSecondary' },

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
-  createMount,
   describeConformanceV5,
   act,
   createClientRender,
@@ -17,13 +16,11 @@ import CheckBox from '../internal/svg-icons/CheckBox';
 
 describe('<Chip />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Chip />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiChip',
     testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
     testVariantProps: { variant: 'outlined' },

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import CircularProgress, {
   circularProgressClasses as classes,
 } from '@material-ui/core/CircularProgress';
 
 describe('<CircularProgress />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<CircularProgress />, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     muiName: 'MuiCircularProgress',
     testDeepOverrides: { slotName: 'circle', slotClassName: classes.circle },
     testVariantProps: { variant: 'determinate' },

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Collapse, { collapseClasses as classes } from '@material-ui/core/Collapse';
 
 describe('<Collapse />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const defaultProps = {
     in: true,
     children: <div />,
@@ -18,7 +18,6 @@ describe('<Collapse />', () => {
     classes,
     inheritComponent: Transition,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiCollapse',
     testVariantProps: { orientation: 'horizontal' },

--- a/packages/material-ui/src/Container/Container.test.js
+++ b/packages/material-ui/src/Container/Container.test.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import Container, { containerClasses as classes } from '@material-ui/core/Container';
 
 describe('<Container />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const defaultProps = {
     children: <div />,
   };
@@ -14,7 +14,6 @@ describe('<Container />', () => {
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLElement,
     muiName: 'MuiContainer',
     skip: ['componentsProp'],

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import {
-  createMount,
-  describeConformanceV5,
-  act,
-  createClientRender,
-  fireEvent,
-  screen,
-} from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent, screen } from 'test/utils';
 import Modal from '@material-ui/core/Modal';
 import Dialog, { dialogClasses as classes } from '@material-ui/core/Dialog';
 
@@ -48,7 +41,6 @@ describe('<Dialog />', () => {
     clock.restore();
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(
@@ -60,7 +52,6 @@ describe('<Dialog />', () => {
       inheritComponent: Modal,
       muiName: 'MuiDialog',
       render,
-      mount,
       testVariantProps: { variant: 'foo' },
       testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },
       refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/DialogActions/DialogActions.test.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import DialogActions, { dialogActionsClasses as classes } from '@material-ui/core/DialogActions';
 
 describe('<DialogActions />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<DialogActions />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiDialogActions',
     testVariantProps: { disableSpacing: true },

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import DialogContent, { dialogContentClasses as classes } from '@material-ui/core/DialogContent';
 
 describe('<DialogContent />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<DialogContent />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiDialogContent',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { dividers: true },

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
-import { createClientRender, describeConformanceV5, createMount } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Typography from '@material-ui/core/Typography';
 import DialogContentText, {
   dialogContentTextClasses as classes,
 } from '@material-ui/core/DialogContentText';
 
 describe('<DialogContentText />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<DialogContentText>foo</DialogContentText>, () => ({
     classes,
     inheritComponent: Typography,
     render,
-    mount,
     muiName: 'MuiDialogContentText',
     refInstanceof: window.HTMLParagraphElement,
     skip: ['componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import DialogTitle, { dialogTitleClasses as classes } from '@material-ui/core/DialogTitle';
 
 describe('<DialogTitle />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<DialogTitle>foo</DialogTitle>, () => ({
     classes,
     inheritComponent: 'h2',
     render,
-    mount,
     muiName: 'MuiDialogTitle',
     refInstanceof: window.HTMLHeadingElement,
     testVariantProps: { 'data-color': 'red' },

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import Divider, { dividerClasses as classes } from '@material-ui/core/Divider';
 
 describe('<Divider />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Divider />, () => ({
     classes,
     inheritComponent: 'hr',
     render,
-    mount,
     muiName: 'MuiDivider',
     refInstanceof: window.HTMLHRElement,
     testComponentPropWith: 'div',

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { useFakeTimers, spy } from 'sinon';
-import { act, createMount, createClientRender, describeConformanceV5, screen } from 'test/utils';
+import { act, createClientRender, describeConformanceV5, screen } from 'test/utils';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Drawer, { drawerClasses as classes } from '@material-ui/core/Drawer';
 import { getAnchor, isHorizontal } from './Drawer';
@@ -19,7 +19,6 @@ describe('<Drawer />', () => {
   });
 
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <Drawer open disablePortal>
@@ -29,7 +28,6 @@ describe('<Drawer />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiDrawer',
       testVariantProps: { variant: 'persistent' },
       testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import {
   describeConformanceV5,
   createClientRender,
-  createMount,
   createServerRender,
   act,
   fireEvent,
@@ -14,13 +13,11 @@ import Icon from '@material-ui/core/Icon';
 
 describe('<Fab />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Fab>Conformance?</Fab>, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiFab',
     testVariantProps: { variant: 'extended' },
     testDeepOverrides: { slotName: 'label', slotClassName: classes.label },

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createClientRender, createMount, describeConformance } from 'test/utils';
+import { createClientRender, describeConformance } from 'test/utils';
 import { Transition } from 'react-transition-group';
 import Fade from '@material-ui/core/Fade';
 
 describe('<Fade />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   const defaultProps = {
     in: true,
@@ -17,7 +16,6 @@ describe('<Fade />', () => {
   describeConformance(<Fade {...defaultProps} />, () => ({
     classes: {},
     inheritComponent: Transition,
-    mount,
     refInstanceof: window.HTMLDivElement,
     skip: [
       'componentProp',

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import FilledInput, { filledInputClasses as classes } from '@material-ui/core/FilledInput';
 import InputBase from '@material-ui/core/InputBase';
 
 describe('<FilledInput />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<FilledInput open />, () => ({
     classes,
     inheritComponent: InputBase,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiFilledInput',
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
+import { describeConformanceV5, act, createClientRender } from 'test/utils';
 import FormControl, { formControlClasses as classes } from '@material-ui/core/FormControl';
 import Input from '@material-ui/core/Input';
 import Select from '@material-ui/core/Select';
@@ -9,7 +9,6 @@ import useFormControl from './useFormControl';
 
 describe('<FormControl />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   function TestComponent(props) {
     const context = useFormControl();
@@ -23,7 +22,6 @@ describe('<FormControl />', () => {
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'fieldset',
     muiName: 'MuiFormControl',

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import FormControlLabel, {
   formControlLabelClasses as classes,
 } from '@material-ui/core/FormControlLabel';
@@ -10,13 +10,11 @@ import Typography from '@material-ui/core/Typography';
 
 describe('<FormControlLabel />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<FormControlLabel label="Pizza" control={<Checkbox />} />, () => ({
     classes,
     inheritComponent: 'label',
     render,
-    mount,
     muiName: 'MuiFormControlLabel',
     testVariantProps: { disabled: true },
     refInstanceof: window.HTMLLabelElement,

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import FormGroup, { formGroupClasses as classes } from '@material-ui/core/FormGroup';
 
 describe('<FormGroup />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<FormGroup />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiFormGroup',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { row: true },

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import FormHelperText, { formHelperTextClasses as classes } from '@material-ui/core/FormHelperText';
 import FormControl from '@material-ui/core/FormControl';
 
 describe('<FormHelperText />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<FormHelperText />, () => ({
     classes,
     inheritComponent: 'p',
     render,
-    mount,
     refInstanceof: window.HTMLParagraphElement,
     testComponentPropWith: 'div',
     muiName: 'MuiFormHelperText',

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
+import { describeConformanceV5, act, createClientRender } from 'test/utils';
 import FormLabel, { formLabelClasses as classes } from '@material-ui/core/FormLabel';
 import FormControl, { useFormControl } from '@material-ui/core/FormControl';
 import { hexToRgb } from '@material-ui/core/styles';
@@ -9,13 +9,11 @@ import defaultTheme from '../styles/defaultTheme';
 
 describe('<FormLabel />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<FormLabel />, () => ({
     classes,
     inheritComponent: 'label',
     render,
-    mount,
     refInstanceof: window.HTMLLabelElement,
     testComponentPropWith: 'div',
     muiName: 'MuiFormLabel',

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender, screen } from 'test/utils';
+import { describeConformanceV5, createClientRender, screen } from 'test/utils';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import defaultTheme from '@material-ui/core/styles/defaultTheme';
 import Grid, { gridClasses as classes } from '@material-ui/core/Grid';
@@ -8,13 +8,11 @@ import { generateRowGap, generateColumnGap } from './Grid';
 
 describe('<Grid />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Grid />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiGrid',
     testVariantProps: { container: true, spacing: 5 },

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 // use act from test/utils/createClientRender once we drop createMount from this test
-import { createClientRender, createMount, describeConformance } from 'test/utils';
+import { createClientRender, describeConformance } from 'test/utils';
 import { act } from 'react-dom/test-utils';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
@@ -11,7 +11,7 @@ import useForkRef from '../utils/useForkRef';
 
 describe('<Grow />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const defaultProps = {
     in: true,
     children: <div />,
@@ -24,7 +24,6 @@ describe('<Grow />', () => {
     () => ({
       classes: {},
       inheritComponent: Transition,
-      mount,
       refInstanceof: window.HTMLDivElement,
       skip: [
         'componentProp',

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-// use act from test/utils/createClientRender once we drop createMount from this test
-import { createClientRender, describeConformance } from 'test/utils';
-import { act } from 'react-dom/test-utils';
+import { act, createClientRender, describeConformance } from 'test/utils';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Grow from '@material-ui/core/Grow';

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Icon, { iconClasses as classes } from '@material-ui/core/Icon';
 
 describe('<Icon />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Icon>account_circle</Icon>, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     muiName: 'MuiIcon',
     refInstanceof: window.HTMLSpanElement,
     testComponentPropWith: 'div',

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -1,20 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import IconButton, { iconButtonClasses as classes } from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<IconButton />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<IconButton>book</IconButton>, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     refInstanceof: window.HTMLButtonElement,
     muiName: 'MuiIconButton',
     testVariantProps: { edge: 'end', disabled: true },

--- a/packages/material-ui/src/ImageList/ImageList.test.js
+++ b/packages/material-ui/src/ImageList/ImageList.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ImageList, { imageListClasses as classes } from '@material-ui/core/ImageList';
 
 const itemsData = [
@@ -18,7 +18,6 @@ const itemsData = [
 
 describe('<ImageList />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <ImageList>
@@ -28,7 +27,6 @@ describe('<ImageList />', () => {
       classes,
       inheritComponent: 'ul',
       render,
-      mount,
       refInstanceof: window.HTMLUListElement,
       testComponentPropWith: 'li',
       muiName: 'MuiImageList',

--- a/packages/material-ui/src/ImageListItem/ImageListItem.test.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.test.js
@@ -1,18 +1,16 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ImageList from '@material-ui/core/ImageList';
 import ImageListItem, { imageListItemClasses as classes } from '@material-ui/core/ImageListItem';
 
 describe('<ImageListItem />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ImageListItem />, () => ({
     classes,
     inheritComponent: 'li',
     render,
-    mount,
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'div',
     muiName: 'MuiImageListItem',

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.test.js
@@ -1,19 +1,17 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ImageListItemBar, {
   imageListItemBarClasses as classes,
 } from '@material-ui/core/ImageListItemBar';
 
 describe('<ImageListItemBar />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ImageListItemBar title="conform?" />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiImageListItemBar',
     testDeepOverrides: { slotName: 'titleWrap', slotClassName: classes.titleWrap },

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import InputBase from '@material-ui/core/InputBase';
 import Input, { inputClasses as classes } from '@material-ui/core/Input';
 
 describe('<Input />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Input />, () => ({
     classes,
     inheritComponent: InputBase,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiInput',
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import { typographyClasses } from '@material-ui/core/Typography';
 import InputAdornment, { inputAdornmentClasses as classes } from '@material-ui/core/InputAdornment';
 import TextField from '@material-ui/core/TextField';
@@ -8,13 +8,11 @@ import FormControl from '@material-ui/core/FormControl';
 import Input from '@material-ui/core/Input';
 
 describe('<InputAdornment />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<InputAdornment position="start">foo</InputAdornment>, () => ({
     classes,
     inheritComponent: 'div',
-    mount,
     render,
     muiName: 'MuiInputAdornment',
     testVariantProps: { color: 'primary' },

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import FormControl, { useFormControl } from '@material-ui/core/FormControl';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import TextField from '@material-ui/core/TextField';
@@ -11,13 +11,11 @@ import InputBase, { inputBaseClasses as classes } from '@material-ui/core/InputB
 
 describe('<InputBase />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<InputBase />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiInputBase',
     testVariantProps: { size: 'small' },

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
+import { describeConformanceV5, act, createClientRender } from 'test/utils';
 import FormControl from '@material-ui/core/FormControl';
 import Input from '@material-ui/core/Input';
 import FormLabel from '@material-ui/core/FormLabel';
@@ -9,13 +9,11 @@ import InputLabel, { inputLabelClasses as classes } from '@material-ui/core/Inpu
 
 describe('<InputLabel />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<InputLabel>Foo</InputLabel>, () => ({
     classes,
     inheritComponent: FormLabel,
     render,
-    mount,
     refInstanceof: window.HTMLLabelElement,
     muiName: 'MuiInputLabel',
     testVariantProps: { size: 'small' },

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, screen, describeConformanceV5 } from 'test/utils';
+import { createClientRender, screen, describeConformanceV5 } from 'test/utils';
 import LinearProgress, { linearProgressClasses as classes } from '@material-ui/core/LinearProgress';
 
 describe('<LinearProgress />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<LinearProgress />, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     muiName: 'MuiLinearProgress',
     testDeepOverrides: { slotName: 'bar', slotClassName: classes.bar },
     testVariantProps: { variant: 'determinate', value: 25 },

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, act, createClientRender, fireEvent, describeConformanceV5 } from 'test/utils';
+import { act, createClientRender, fireEvent, describeConformanceV5 } from 'test/utils';
 import Link, { linkClasses as classes } from '@material-ui/core/Link';
 import Typography, { typographyClasses } from '@material-ui/core/Typography';
 
@@ -15,13 +15,11 @@ function focusVisible(element) {
 
 describe('<Link />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Link href="/">Home</Link>, () => ({
     classes,
     inheritComponent: Typography,
     render,
-    mount,
     muiName: 'MuiLink',
     refInstanceof: window.HTMLAnchorElement,
     testVariantProps: { color: 'secondary', variant: 'h1' },

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import ListSubheader, { listSubheaderClasses } from '@material-ui/core/ListSubheader';
 import ListItem, { listItemClasses } from '@material-ui/core/ListItem';
 import List, { listClasses as classes } from '@material-ui/core/List';
 
 describe('<List />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<List />, () => ({
     classes,
     inheritComponent: 'ul',
     render,
-    mount,
     muiName: 'MuiList',
     refInstanceof: window.HTMLUListElement,
     testVariantProps: { disablePadding: true },

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import {
-  createMount,
-  describeConformanceV5,
-  act,
-  createClientRender,
-  fireEvent,
-  queries,
-} from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent, queries } from 'test/utils';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
@@ -21,13 +14,11 @@ const NoContent = React.forwardRef(() => {
 
 describe('<ListItem />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ListItem />, () => ({
     classes,
     inheritComponent: 'li',
     render,
-    mount,
     refInstanceof: window.HTMLLIElement,
     muiName: 'MuiListItem',
     testVariantProps: { dense: true },

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ListItemAvatar, { listItemAvatarClasses as classes } from '@material-ui/core/ListItemAvatar';
 
 describe('<ListItemAvatar />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <ListItemAvatar>
@@ -14,7 +13,6 @@ describe('<ListItemAvatar />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiListItemAvatar',
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/ListItemButton/ListItemButton.test.js
+++ b/packages/material-ui/src/ListItemButton/ListItemButton.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import ListItemButton, { listItemButtonClasses as classes } from '@material-ui/core/ListItemButton';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ListContext from '../List/ListContext';
 
 describe('<ListItemButton />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ListItemButton />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'a',
     muiName: 'MuiListItemButton',

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ListItemIcon, { listItemIconClasses as classes } from '@material-ui/core/ListItemIcon';
 
 describe('<ListItemIcon />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <ListItemIcon>
@@ -14,7 +13,6 @@ describe('<ListItemIcon />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiListItemIcon',
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemSecondaryAction, {
   listItemSecondaryActionClasses as classes,
@@ -8,12 +8,10 @@ import ListItemSecondaryAction, {
 
 describe('<ListItemSecondaryAction />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ListItemSecondaryAction />, () => ({
     classes,
     inheritComponent: 'div',
-    mount,
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiListItemSecondaryAction',

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Typography, { typographyClasses } from '@material-ui/core/Typography';
 import ListItemText, { listItemTextClasses as classes } from '@material-ui/core/ListItemText';
 
 describe('<ListItemText />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ListItemText>Conformance?</ListItemText>, () => ({
     classes,
     inheritComponent: 'div',
-    mount,
     render,
     muiName: 'MuiListItemText',
     testVariantProps: { inset: true },

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import ListSubheader, { listSubheaderClasses as classes } from '@material-ui/core/ListSubheader';
 
 describe('<ListSubheader />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ListSubheader />, () => ({
     classes,
     inheritComponent: 'li',
     render,
-    mount,
     muiName: 'MuiListSubheader',
     refInstanceof: window.HTMLLIElement,
     testVariantProps: { disableGutters: true },

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { spy, useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import {
-  createMount,
-  createClientRender,
-  describeConformanceV5,
-  screen,
-  fireEvent,
-} from 'test/utils';
+import { createClientRender, describeConformanceV5, screen, fireEvent } from 'test/utils';
 import Menu, { menuClasses as classes } from '@material-ui/core/Menu';
 import Popover from '@material-ui/core/Popover';
 
@@ -23,14 +17,12 @@ describe('<Menu />', () => {
     clock.restore();
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<Menu anchorEl={() => document.createElement('div')} open />, () => ({
     classes,
     inheritComponent: Popover,
     render,
-    mount,
     muiName: 'MuiMenu',
     refInstanceof: window.HTMLDivElement,
     testDeepOverrides: { slotName: 'list', slotClassName: classes.list },

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -1,26 +1,18 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  createMount,
-  describeConformanceV5,
-  createClientRender,
-  fireEvent,
-  screen,
-} from 'test/utils';
+import { describeConformanceV5, createClientRender, fireEvent, screen } from 'test/utils';
 import MenuItem, { menuItemClasses as classes } from '@material-ui/core/MenuItem';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ListContext from '../List/ListContext';
 
 describe('<MenuItem />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<MenuItem />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'a',
     muiName: 'MuiMenuItem',

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { createMount, describeConformance, createClientRender } from 'test/utils';
+import { describeConformance, createClientRender } from 'test/utils';
 import MenuList from '@material-ui/core/MenuList';
 import List from '@material-ui/core/List';
 import getScrollbarSize from '../utils/getScrollbarSize';
@@ -17,13 +17,11 @@ function setStyleWidthForJsdomOrBrowser(style, width) {
 }
 
 describe('<MenuList />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(<MenuList />, () => ({
     classes: {},
     inheritComponent: List,
-    mount,
     refInstanceof: window.HTMLUListElement,
     skip: ['componentProp'],
   }));

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5, screen } from 'test/utils';
+import { createClientRender, describeConformanceV5, screen } from 'test/utils';
 import Paper, { paperClasses } from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
 import MobileStepper, { mobileStepperClasses as classes } from '@material-ui/core/MobileStepper';
@@ -8,7 +8,6 @@ import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 
 describe('<MobileStepper />', () => {
-  const mount = createMount();
   const render = createClientRender();
   const defaultProps = {
     steps: 2,
@@ -29,7 +28,6 @@ describe('<MobileStepper />', () => {
   describeConformanceV5(<MobileStepper {...defaultProps} />, () => ({
     classes,
     inheritComponent: Paper,
-    mount,
     render,
     muiName: 'MuiMobileStepper',
     testVariantProps: { variant: 'progress' },

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -8,7 +8,6 @@ import {
   createClientRender,
   fireEvent,
   within,
-  createMount,
   describeConformanceV5,
   screen,
 } from 'test/utils';
@@ -18,7 +17,7 @@ import Modal, { modalClasses as classes } from '@material-ui/core/Modal';
 
 describe('<Modal />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   let savedBodyStyle;
 
   before(() => {
@@ -37,7 +36,6 @@ describe('<Modal />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiModal',
       refInstanceof: window.HTMLDivElement,
       testVariantProps: { hideBackdrop: true },

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createTheme, ThemeProvider, styled } from '@material-ui/core/styles';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import NativeSelect, { nativeSelectClasses as classes } from '@material-ui/core/NativeSelect';
 import Input, { inputClasses } from '@material-ui/core/Input';
 
 describe('<NativeSelect />', () => {
-  const mount = createMount();
   const render = createClientRender();
   const defaultProps = {
     input: <Input />,
@@ -23,7 +22,6 @@ describe('<NativeSelect />', () => {
   describeConformanceV5(<NativeSelect {...defaultProps} />, () => ({
     classes,
     inheritComponent: Input,
-    mount,
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiNativeSelect',

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import OutlinedInput, { outlinedInputClasses as classes } from '@material-ui/core/OutlinedInput';
 import InputBase from '@material-ui/core/InputBase';
 
 describe('<OutlinedInput />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<OutlinedInput />, () => ({
     classes,
     inheritComponent: InputBase,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiOutlinedInput',
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },

--- a/packages/material-ui/src/Pagination/Pagination.test.js
+++ b/packages/material-ui/src/Pagination/Pagination.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Pagination, { paginationClasses as classes } from '@material-ui/core/Pagination';
 
 describe('<Pagination />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Pagination />, () => ({
     classes,
     inheritComponent: 'nav',
     render,
-    mount,
     muiName: 'MuiPagination',
     refInstanceof: window.HTMLElement,
     testDeepOverrides: { slotName: 'ul', slotClassName: classes.ul },

--- a/packages/material-ui/src/PaginationItem/PaginationItem.test.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import PaginationItem, { paginationItemClasses as classes } from '@material-ui/core/PaginationItem';
 
 describe('<PaginationItem />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<PaginationItem />, () => ({
     classes,
     inheritComponent: 'button',
     render,
-    mount,
     muiName: 'MuiPaginationItem',
     refInstanceof: window.HTMLButtonElement,
     testVariantProps: { variant: 'foo' },

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Paper, { paperClasses as classes } from '@material-ui/core/Paper';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
 describe('<Paper />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Paper />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiPaper',
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'header',

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -2,20 +2,12 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
-import {
-  createMount,
-  describeConformance,
-  act,
-  createClientRender,
-  fireEvent,
-  screen,
-} from 'test/utils';
+import { describeConformance, act, createClientRender, fireEvent, screen } from 'test/utils';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import Grow from '@material-ui/core/Grow';
 import Popper from '@material-ui/core/Popper';
 
 describe('<Popper />', () => {
-  const mount = createMount();
   let rtlTheme;
   const render = createClientRender();
   const defaultProps = {
@@ -33,7 +25,6 @@ describe('<Popper />', () => {
   describeConformance(<Popper {...defaultProps} />, () => ({
     classes: {},
     inheritComponent: 'div',
-    mount,
     refInstanceof: window.HTMLDivElement,
     skip: [
       'componentProp',

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import Radio, { radioClasses as classes } from '@material-ui/core/Radio';
 import FormControl from '@material-ui/core/FormControl';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<Radio />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Radio />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiRadio',
     testVariantProps: { color: 'secondary' },
     refInstanceof: window.HTMLSpanElement,

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -2,19 +2,17 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { createMount, describeConformance, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import FormGroup from '@material-ui/core/FormGroup';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup, { useRadioGroup } from '@material-ui/core/RadioGroup';
 
 describe('<RadioGroup />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(<RadioGroup value="" />, () => ({
     classes: {},
     inheritComponent: FormGroup,
-    mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
   }));

--- a/packages/material-ui/src/Rating/Rating.test.js
+++ b/packages/material-ui/src/Rating/Rating.test.js
@@ -1,24 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub, spy } from 'sinon';
-import {
-  act,
-  createMount,
-  describeConformanceV5,
-  createClientRender,
-  fireEvent,
-  screen,
-} from 'test/utils';
+import { act, describeConformanceV5, createClientRender, fireEvent, screen } from 'test/utils';
 import Rating, { ratingClasses as classes } from '@material-ui/core/Rating';
 
 describe('<Rating />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<Rating />, () => ({
     classes,
     inheritComponent: 'span',
-    mount,
     render,
     muiName: 'MuiRating',
     testVariantProps: { variant: 'foo' },

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import ScopedCssBaseline, {
   scopedCssBaselineClasses as classes,
 } from '@material-ui/core/ScopedCssBaseline';
 
 describe('<ScopedCssBaseline />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ScopedCssBaseline />, () => ({
     classes,
     inheritComponent: 'div',
-    mount,
     render,
     muiName: 'MuiScopedCssBaseline',
     refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import {
-  createMount,
   describeConformanceV5,
   ErrorBoundary,
   act,
@@ -30,14 +29,13 @@ describe('<Select />', () => {
   afterEach(() => {
     clock.restore();
   });
-  const mount = createMount();
+
   const render = createClientRender();
 
   describeConformanceV5(<Select value="" />, () => ({
     classes,
     inheritComponent: OutlinedInput,
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSelect',
     skip: ['componentProp', 'componentsProp', 'themeVariants', 'themeStyleOverrides'],

--- a/packages/material-ui/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui/src/Skeleton/Skeleton.test.js
@@ -1,17 +1,15 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Skeleton, { skeletonClasses as classes } from '@material-ui/core/Skeleton';
 
 describe('<Skeleton />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Skeleton />, () => ({
     classes,
     inheritComponent: 'span',
     render,
-    mount,
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSkeleton',
     testVariantProps: { variant: 'circular', animation: 'wave' },

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createClientRender, createMount, describeConformance } from 'test/utils';
+import { createClientRender, describeConformance } from 'test/utils';
 import { createTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 import Slide from '@material-ui/core/Slide';
@@ -10,7 +10,7 @@ import { useForkRef } from '../utils';
 
 describe('<Slide />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   const defaultProps = {
     in: true,
     children: <div id="testChild" />,
@@ -24,7 +24,6 @@ describe('<Slide />', () => {
     () => ({
       classes: {},
       inheritComponent: Transition,
-      mount,
       refInstanceof: window.HTMLDivElement,
       skip: [
         'componentProp',

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -2,14 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';
 import { expect } from 'chai';
-import {
-  createMount,
-  describeConformanceV5,
-  act,
-  createClientRender,
-  fireEvent,
-  screen,
-} from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent, screen } from 'test/utils';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { SliderUnstyled } from '@material-ui/unstyled';
 import Slider, { sliderClasses as classes } from '@material-ui/core/Slider';
@@ -35,13 +28,11 @@ describe('<Slider />', () => {
   });
 
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Slider value={0} />, () => ({
     classes,
     inheritComponent: SliderUnstyled,
     render,
-    mount,
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSlider',
     testDeepOverrides: { slotName: 'thumb', slotClassName: classes.thumb },

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import Snackbar, { snackbarClasses as classes } from '@material-ui/core/Snackbar';
 
 describe('<Snackbar />', () => {
@@ -16,8 +16,6 @@ describe('<Snackbar />', () => {
   afterEach(() => {
     clock.restore();
   });
-
-  const mount = createMount();
 
   const clientRender = createClientRender();
   /**
@@ -40,7 +38,6 @@ describe('<Snackbar />', () => {
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSnackbar',
     skip: [

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Paper from '@material-ui/core/Paper';
 import SnackbarContent, {
   snackbarContentClasses as classes,
@@ -8,13 +8,11 @@ import SnackbarContent, {
 
 describe('<SnackbarContent />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<SnackbarContent message="conform?" />, () => ({
     classes,
     inheritComponent: Paper,
     render,
-    mount,
     muiName: 'MuiSnackbarContent',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import {
-  createMount,
   createClientRender,
   act,
   fireEvent,
@@ -26,7 +25,6 @@ describe('<SpeedDial />', () => {
     clock.restore();
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   const icon = <Icon>font_icon</Icon>;
@@ -40,7 +38,6 @@ describe('<SpeedDial />', () => {
   describeConformanceV5(<SpeedDial {...defaultProps} />, () => ({
     classes,
     inheritComponent: 'div',
-    mount,
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSpeedDial',

--- a/packages/material-ui/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import { useFakeTimers } from 'sinon';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -19,7 +19,6 @@ describe('<SpeedDialAction />', () => {
     clock.restore();
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(
@@ -27,7 +26,6 @@ describe('<SpeedDialAction />', () => {
     () => ({
       classes,
       inheritComponent: Tooltip,
-      mount,
       render,
       refInstanceof: window.HTMLButtonElement,
       muiName: 'MuiSpeedDialAction',

--- a/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Icon from '@material-ui/core/Icon';
 import SpeedDialIcon, { speedDialIconClasses as classes } from '@material-ui/core/SpeedDialIcon';
 
 describe('<SpeedDialIcon />', () => {
-  const mount = createMount();
   const render = createClientRender();
   const icon = <Icon>font_icon</Icon>;
 
   describeConformanceV5(<SpeedDialIcon />, () => ({
     classes,
     inheritComponent: 'span',
-    mount,
     render,
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSpeedDialIcon',

--- a/packages/material-ui/src/Stack/Stack.test.js
+++ b/packages/material-ui/src/Stack/Stack.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Stack from '@material-ui/core/Stack';
 import { createTheme } from '@material-ui/core/styles';
 import defaultTheme from '@material-ui/core/styles/defaultTheme';
@@ -8,12 +8,10 @@ import { style } from './Stack';
 
 describe('<Stack />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Stack />, () => ({
     render,
     inheritComponent: 'div',
-    mount,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiStack',
     skip: ['componentProp', 'componentsProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Step, { stepClasses as classes } from '@material-ui/core/Step';
 import Stepper from '@material-ui/core/Stepper';
 import StepLabel, { stepLabelClasses } from '@material-ui/core/StepLabel';
@@ -8,13 +8,11 @@ import StepButton, { stepButtonClasses } from '@material-ui/core/StepButton';
 
 describe('<Step />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Step />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiStep',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import { fireEvent } from '@testing-library/dom';
 import StepButton, { stepButtonClasses as classes } from '@material-ui/core/StepButton';
 import Step from '@material-ui/core/Step';
@@ -12,12 +12,9 @@ describe('<StepButton />', () => {
   const render = createClientRender();
 
   describe('internals', () => {
-    const mount = createMount();
-
     describeConformanceV5(<StepButton />, () => ({
       classes,
       inheritComponent: ButtonBase,
-      mount,
       muiName: 'MuiStepButton',
       refInstanceof: window.HTMLButtonElement,
       render,

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepConnector, { stepConnectorClasses as classes } from '@material-ui/core/StepConnector';
 
 describe('<StepConnector />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<StepConnector />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiStepConnector',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp', 'themeVariants'],

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import StepIcon, { stepIconClasses as classes } from '@material-ui/core/StepIcon';
 
 describe('<StepIcon />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<StepIcon icon={1} />, () => ({
     classes,
     inheritComponent: 'svg',
     render,
-    mount,
     muiName: 'MuiStepIcon',
     testVariantProps: { completed: true },
     refInstanceof: window.SVGSVGElement,

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Typography from '@material-ui/core/Typography';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
@@ -8,14 +8,12 @@ import { stepIconClasses as iconClasses } from '@material-ui/core/StepIcon';
 import StepLabel, { stepLabelClasses as classes } from '@material-ui/core/StepLabel';
 
 describe('<StepLabel />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<StepLabel />, () => ({
     classes,
     inheritComponent: 'span',
     muiName: 'MuiStepLabel',
-    mount,
     render,
     refInstanceof: window.HTMLSpanElement,
     testVariantProps: { error: true },

--- a/packages/material-ui/src/Stepper/Stepper.test.tsx
+++ b/packages/material-ui/src/Stepper/Stepper.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Step, { StepProps, stepClasses } from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import StepConnector, { stepConnectorClasses } from '@material-ui/core/StepConnector';
@@ -8,7 +8,6 @@ import StepContent, { stepContentClasses } from '@material-ui/core/StepContent';
 import Stepper, { stepperClasses as classes } from '@material-ui/core/Stepper';
 
 describe('<Stepper />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(
@@ -19,7 +18,6 @@ describe('<Stepper />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
       muiName: 'MuiStepper',
       refInstanceof: window.HTMLDivElement,
       testVariantProps: { variant: 'foo' },

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import SvgIcon, { svgIconClasses as classes } from '@material-ui/core/SvgIcon';
 
 describe('<SvgIcon />', () => {
   const render = createClientRender();
-  const mount = createMount();
+
   let path;
 
   before(() => {
@@ -20,7 +20,6 @@ describe('<SvgIcon />', () => {
       classes,
       inheritComponent: 'svg',
       render,
-      mount,
       muiName: 'MuiSvgIcon',
       refInstanceof: window.SVGSVGElement,
       testComponentPropWith: (props) => (

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import {
-  createMount,
-  fireEvent,
-  createClientRender,
-  describeConformance,
-  screen,
-} from 'test/utils';
+import { fireEvent, createClientRender, describeConformance, screen } from 'test/utils';
 import PropTypes, { checkPropTypes } from 'prop-types';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import Drawer, { drawerClasses } from '@material-ui/core/Drawer';
@@ -75,13 +69,11 @@ describe('<SwipeableDrawer />', () => {
     clock.restore();
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />, () => ({
     classes: {},
     inheritComponent: Drawer,
-    mount,
     refInstanceof: window.HTMLDivElement,
     skip: [
       'componentProp',

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import Switch, { switchClasses as classes } from '@material-ui/core/Switch';
 import FormControl from '@material-ui/core/FormControl';
 
 describe('<Switch />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Switch />, () => ({
     classes,
     render,
-    mount,
     muiName: 'MuiSwitch',
     testDeepOverrides: { slotName: 'track', slotClassName: classes.track },
     refInstanceof: window.HTMLSpanElement,

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformanceV5, act, createClientRender, fireEvent } from 'test/utils';
 import Tab, { tabClasses as classes } from '@material-ui/core/Tab';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<Tab />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Tab textColor="inherit" />, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiTab',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLButtonElement,

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TabScrollButton, {
   tabScrollButtonClasses as classes,
 } from '@material-ui/core/TabScrollButton';
@@ -11,13 +11,11 @@ describe('<TabScrollButton />', () => {
     orientation: 'horizontal',
   };
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TabScrollButton {...defaultProps} />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiTabScrollButton',
     testVariantProps: { orientation: 'vertical' },
     refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Table, { tableClasses as classes } from '@material-ui/core/Table';
 import TableContext from './TableContext';
 
 describe('<Table />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <Table>
@@ -16,7 +15,6 @@ describe('<Table />', () => {
       classes,
       inheritComponent: 'table',
       render,
-      mount,
       muiName: 'MuiTable',
       testVariantProps: { variant: 'foo' },
       refInstanceof: window.HTMLTableElement,

--- a/packages/material-ui/src/TableContainer/TableContainer.test.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TableContainer, { tableContainerClasses as classes } from '@material-ui/core/TableContainer';
 
 describe('<TableContainer />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<TableContainer />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiTableContainer',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import SortIcon from '@material-ui/icons/Sort';
 import TableSortLabel, { tableSortLabelClasses as classes } from '@material-ui/core/TableSortLabel';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<TableSortLabel />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<TableSortLabel />, () => ({
     classes,
     inheritComponent: ButtonBase,
-    mount,
     render,
     muiName: 'MuiTableSortLabel',
     testVariantProps: { variant: 'foo' },

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import {
-  createMount,
   describeConformanceV5,
   act,
   createClientRender,
@@ -43,7 +42,6 @@ describe('<Tabs />', () => {
   // tests mocking getBoundingClientRect prevent mocha to exit
   const isJSDOM = navigator.userAgent === 'node.js';
 
-  const mount = createMount();
   const render = createClientRender();
 
   before(function beforeHook() {
@@ -61,7 +59,6 @@ describe('<Tabs />', () => {
   describeConformanceV5(<Tabs value={0} />, () => ({
     classes,
     inheritComponent: 'div',
-    mount,
     render,
     muiName: 'MuiTabs',
     refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import FormControl from '@material-ui/core/FormControl';
 import { inputBaseClasses } from '@material-ui/core/InputBase';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -8,14 +8,12 @@ import { outlinedInputClasses } from '@material-ui/core/OutlinedInput';
 import TextField, { textFieldClasses as classes } from '@material-ui/core/TextField';
 
 describe('<TextField />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<TextField variant="standard" />, () => ({
     classes,
     inheritComponent: FormControl,
     render,
-    mount,
     muiName: 'MuiTextField',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { variant: 'outlined' },

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub, useFakeTimers } from 'sinon';
-import { createMount, describeConformance, act, createClientRender, fireEvent } from 'test/utils';
+import { describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import TextareaAutosize from '@material-ui/core/TextareaAutosize';
 
 describe('<TextareaAutosize />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformance(<TextareaAutosize />, () => ({
     inheritComponent: 'textarea',
-    mount,
     refInstanceof: window.HTMLTextAreaElement,
     skip: ['rootClass', 'componentProp'],
   }));

--- a/packages/material-ui/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.test.js
@@ -1,24 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  createClientRender,
-  createMount,
-  describeConformanceV5,
-  createServerRender,
-} from 'test/utils';
+import { createClientRender, describeConformanceV5, createServerRender } from 'test/utils';
 import ToggleButton, { toggleButtonClasses as classes } from '@material-ui/core/ToggleButton';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
 describe('<ToggleButton />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ToggleButton value="X">Hello, World!</ToggleButton>, () => ({
     classes,
     inheritComponent: ButtonBase,
     render,
-    mount,
     muiName: 'MuiToggleButton',
     testVariantProps: { variant: 'foo' },
     testDeepOverrides: { slotName: 'label', slotClassName: classes.label },

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender } from 'test/utils';
 import ToggleButtonGroup, {
   toggleButtonGroupClasses as classes,
 } from '@material-ui/core/ToggleButtonGroup';
@@ -9,13 +9,11 @@ import ToggleButton from '@material-ui/core/ToggleButton';
 
 describe('<ToggleButtonGroup />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<ToggleButtonGroup />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiToggleButtonGroup',
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp', 'componentsProp'],

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Toolbar, { toolbarClasses as classes } from '@material-ui/core/Toolbar';
 
 describe('<Toolbar />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<Toolbar />, () => ({
     classes,
     inheritComponent: 'div',
     render,
-    mount,
     muiName: 'MuiToolbar',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { variant: 'foo' },

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import {
-  createMount,
   describeConformanceV5,
   act,
   createClientRender,
@@ -45,7 +44,6 @@ describe('<Tooltip />', () => {
     });
   });
 
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(
@@ -56,7 +54,6 @@ describe('<Tooltip />', () => {
       classes,
       inheritComponent: 'button',
       render,
-      mount,
       muiName: 'MuiTooltip',
       refInstanceof: window.HTMLButtonElement,
       testRootOverrides: { slotName: 'popper', slotClassName: classes.popper },

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -1,21 +1,16 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import Typography, { typographyClasses as classes } from '@material-ui/core/Typography';
 
 describe('<Typography />', () => {
   const render = createClientRender();
-  /**
-   * @type {ReturnType<typeof createMount>}
-   */
-  const mount = createMount();
 
   describeConformanceV5(<Typography />, () => ({
     classes,
     inheritComponent: 'p',
     render,
-    mount,
     refInstanceof: window.HTMLParagraphElement,
     muiName: 'MuiTypography',
     testVariantProps: { variant: 'dot' },

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createMount, describeConformance, createClientRender } from 'test/utils';
+import { describeConformance, createClientRender } from 'test/utils';
 import { Transition } from 'react-transition-group';
 import Zoom from '@material-ui/core/Zoom';
 
 describe('<Zoom />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformance(
     <Zoom in>
@@ -16,7 +15,6 @@ describe('<Zoom />', () => {
     () => ({
       classes: {},
       inheritComponent: Transition,
-      mount,
       refInstanceof: window.HTMLDivElement,
       skip: [
         'componentProp',

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, act, createClientRender } from 'test/utils';
+import { describeConformanceV5, act, createClientRender } from 'test/utils';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import ButtonBase from '../ButtonBase';
@@ -9,7 +9,6 @@ import classes from './switchBaseClasses';
 
 describe('<SwitchBase />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(
     <SwitchBase checkedIcon="checked" icon="unchecked" type="checkbox" />,
@@ -17,7 +16,6 @@ describe('<SwitchBase />', () => {
       classes,
       inheritComponent: ButtonBase,
       render,
-      mount,
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
       testVariantProps: { disabled: true },

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -2,6 +2,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import createMount from './createMount';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 
 /**
@@ -202,7 +203,7 @@ const fullSuite = {
  * @property {() => void} [after]
  * @property {Record<string, string>} classes - `classes` of the component provided by `@material-ui/styles`
  * @property {import('react').ElementType} [inheritComponent] - The element type that receives spread props or `undefined` if props are not spread.
- * @property {(node: React.ReactNode) => import('enzyme').ReactWrapper} mount - Should be a return value from createMount
+ * @property {(node: React.ReactNode) => import('enzyme').ReactWrapper} [mount] - By default uses enzyme to mount the component in StrictMode. If you need to wrap the node, pass a custom mount implementation.
  * @property {Array<keyof typeof fullSuite>} [only] - If specified only run the tests listed
  * @property {any} refInstanceof - `ref` will be an instanceof this constructor.
  * @property {Array<keyof typeof fullSuite>} [skip] - Skip the specified tests
@@ -216,15 +217,28 @@ const fullSuite = {
  * @param {() => ConformanceOptions} getOptions
  */
 export default function describeConformance(minimalElement, getOptions) {
-  const { after: runAfterHook = () => {}, only = Object.keys(fullSuite), skip = [] } = getOptions();
   describe('Material-UI component API', () => {
+    const {
+      after: runAfterHook = () => {},
+      mount = createMount(),
+      only = Object.keys(fullSuite),
+      skip = [],
+    } = getOptions();
+
     after(runAfterHook);
+
+    function getTestOptions() {
+      return {
+        ...getOptions(),
+        mount,
+      };
+    }
 
     Object.keys(fullSuite)
       .filter((testKey) => only.indexOf(testKey) !== -1 && skip.indexOf(testKey) === -1)
       .forEach((testKey) => {
         const test = fullSuite[testKey];
-        test(minimalElement, getOptions);
+        test(minimalElement, getTestOptions);
       });
   });
 }

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -11,13 +11,14 @@ import {
   testReactTestRenderer,
   testRootClass,
 } from './describeConformance';
+import createMount from './createMount';
 
 /**
  * @typedef {Object} ConformanceOptions
  * @property {() => void} [after]
  * @property {object} classes - `classes` of the component provided by `@material-ui/styled-engine`
  * @property {import('react').ElementType} [inheritComponent] - The element type that receives spread props or `undefined` if props are not spread.
- * @property {(node: React.ReactNode) => import('enzyme').ReactWrapper} mount - Should be a return value from createMount
+ * @property {(node: React.ReactNode) => import('enzyme').ReactWrapper} [mount] - Should be a return value from createMount
  * @property {string} muiName
  * @property {(node: React.ReactElement) => import('./createClientRender').MuiRenderResult} [render] - Should be a return value from createClientRender
  * @property {Array<keyof typeof fullSuite>} [only] - If specified only run the tests listed
@@ -355,18 +356,30 @@ const fullSuite = {
  * @param {() => ConformanceOptions} getOptions
  */
 export default function describeConformanceV5(minimalElement, getOptions) {
-  const { after: runAfterHook = () => {}, only = Object.keys(fullSuite), skip = [] } = getOptions();
-
-  const filteredTests = Object.keys(fullSuite).filter(
-    (testKey) => only.indexOf(testKey) !== -1 && skip.indexOf(testKey) === -1,
-  );
-
   describe('Material-UI component API', () => {
+    const {
+      after: runAfterHook = () => {},
+      mount = createMount(),
+      only = Object.keys(fullSuite),
+      skip = [],
+    } = getOptions();
+
+    const filteredTests = Object.keys(fullSuite).filter(
+      (testKey) => only.indexOf(testKey) !== -1 && skip.indexOf(testKey) === -1,
+    );
+
     after(runAfterHook);
+
+    function getTestOptions() {
+      return {
+        ...getOptions(),
+        mount,
+      };
+    }
 
     filteredTests.forEach((testKey) => {
       const test = fullSuite[testKey];
-      test(minimalElement, getOptions);
+      test(minimalElement, getTestOptions);
     });
   });
 }


### PR DESCRIPTION
Allows us to remove usage of enzyme in most tests i.e. we remove the choice between enzyme and testing-library from most tests.

The goal is to make it straight forward to grep whether a tests needs enzyme (just search for `createMount`. `mount` is a bit too generic. Removing it from most tests is just better overall since it's one less concept people are confronted when reading a test.

Follow-up:
- [x] Remove `createMount` where just need `createPickerMount` (https://github.com/mui-org/material-ui/pull/26951)
- [ ] Remove `createMount` call from tests that just need a wrapper component 
- [x] Remove remaining `mount` usages where possible (https://github.com/mui-org/material-ui/pull/26951)