### PR TITLE
[test] Use createPickerMount where appropriate

### DIFF
--- a/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.test.tsx
@@ -1,25 +1,24 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, fireEvent, screen, describeConformanceV5 } from 'test/utils';
-import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
-import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import { fireEvent, screen, describeConformanceV5 } from 'test/utils';
 import CalendarPicker, { calendarPickerClasses as classes } from '@material-ui/lab/CalendarPicker';
-import { adapterToUse, createPickerRender, getAllByMuiTest } from '../internal/pickers/test-utils';
+import {
+  adapterToUse,
+  createPickerMount,
+  createPickerRender,
+  getAllByMuiTest,
+} from '../internal/pickers/test-utils';
 
 describe('<CalendarPicker />', () => {
-  const mount = createMount();
+  const mount = createPickerMount();
   const render = createPickerRender({ strict: false });
-
-  const localizedMount = (node: React.ReactNode) => {
-    return mount(<LocalizationProvider dateAdapter={AdapterDateFns}>{node}</LocalizationProvider>);
-  };
 
   describeConformanceV5(<CalendarPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
     classes,
     inheritComponent: 'div',
     render,
     muiName: 'MuiCalendarPicker',
-    mount: localizedMount,
+    mount,
     refInstanceof: window.HTMLDivElement,
     // cannot test reactTestRenderer because of required context
     skip: [

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
-import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
+import { describeConformanceV5 } from 'test/utils';
 import DateRangePickerDay, {
   dateRangePickerDayClasses as classes,
 } from '@material-ui/lab/DateRangePickerDay';
-import { adapterToUse, AdapterClassToUse } from '../internal/pickers/test-utils';
+import {
+  adapterToUse,
+  createPickerMount,
+  createPickerRender,
+} from '../internal/pickers/test-utils';
 
 describe('<DateRangePickerDay />', () => {
-  const mount = createMount();
-  const render = createClientRender();
-
-  const localizedMount = (node: React.ReactNode) => {
-    return mount(
-      <LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>,
-    );
-  };
+  const mount = createPickerMount();
+  const render = createPickerRender();
 
   describeConformanceV5(
     <DateRangePickerDay
@@ -33,9 +30,8 @@ describe('<DateRangePickerDay />', () => {
       classes,
       inheritComponent: 'button',
       muiName: 'MuiDateRangePickerDay',
-      render: (node: React.ReactNode) =>
-        render(<LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>),
-      mount: localizedMount,
+      render,
+      mount,
       refInstanceof: window.HTMLButtonElement,
       // cannot test reactTestRenderer because of required context
       skip: [

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { createMount, fireEvent, screen, describeConformanceV5 } from 'test/utils';
-import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
-import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import { fireEvent, screen, describeConformanceV5 } from 'test/utils';
 import MonthPicker, { monthPickerClasses as classes } from '@material-ui/lab/MonthPicker';
-import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
+import {
+  adapterToUse,
+  createPickerMount,
+  createPickerRender,
+} from '../internal/pickers/test-utils';
 
 describe('<MonthPicker />', () => {
-  const mount = createMount();
+  const mount = createPickerMount();
   const render = createPickerRender();
-
-  const localizedMount = (node: React.ReactNode) => {
-    return mount(<LocalizationProvider dateAdapter={AdapterDateFns}>{node}</LocalizationProvider>);
-  };
 
   describeConformanceV5(
     <MonthPicker
@@ -26,7 +24,7 @@ describe('<MonthPicker />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount: localizedMount,
+      mount,
       muiName: 'MuiMonthPicker',
       refInstanceof: window.HTMLDivElement,
       // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { createMount, fireEvent, screen, describeConformanceV5 } from 'test/utils';
-import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
-import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import { fireEvent, screen, describeConformanceV5 } from 'test/utils';
 import YearPicker, { yearPickerClasses as classes } from '@material-ui/lab/YearPicker';
-import { adapterToUse, createPickerRender } from '../internal/pickers/test-utils';
+import {
+  adapterToUse,
+  createPickerMount,
+  createPickerRender,
+} from '../internal/pickers/test-utils';
 
 describe('<YearPicker />', () => {
-  const mount = createMount();
+  const mount = createPickerMount();
   const render = createPickerRender();
-
-  const localizedMount = (node: React.ReactNode) => {
-    return mount(<LocalizationProvider dateAdapter={AdapterDateFns}>{node}</LocalizationProvider>);
-  };
 
   describeConformanceV5(
     <YearPicker
@@ -26,7 +24,7 @@ describe('<YearPicker />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
-      mount: localizedMount,
+      mount,
       render,
       muiName: 'MuiYearPicker',
       refInstanceof: window.HTMLDivElement,


### PR DESCRIPTION
`createPickerMount` is already an abstraction around
```js
const localizedMount = (node: React.ReactNode) => {
  return mount(<LocalizationProvider dateAdapter={AdapterDateFns}>{node}</LocalizationProvider>);
};
```