### PR TITLE
[test] Convert NativeSelectInput tests to testing-library

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -30,7 +30,7 @@ export interface NativeSelectProps
   /**
    * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes">Attributes</a> applied to the `select` element.
    */
-  inputProps?: NativeSelectInputProps;
+  inputProps?: Partial<NativeSelectInputProps>;
   /**
    * Callback fired when a menu item is selected.
    *

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
@@ -4,7 +4,7 @@ import { Theme } from '..';
 
 export interface NativeSelectInputProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   disabled?: boolean;
-  IconComponent?: React.ElementType;
+  IconComponent: React.ElementType;
   inputRef?: React.Ref<HTMLSelectElement>;
   variant?: 'standard' | 'outlined' | 'filled';
   sx?: SxProps<Theme>;

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -1,32 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createMount, describeConformanceV5, createClientRender } from 'test/utils';
+import { describeConformanceV5, createClientRender, fireEvent } from 'test/utils';
 import NativeSelectInput from './NativeSelectInput';
 
 describe('<NativeSelectInput />', () => {
-  const mount = createMount();
   const render = createClientRender();
-  const defaultProps = {
-    classes: { select: 'select' },
-    onChange: () => {},
-    value: 10,
-    IconComponent: 'div',
-    children: [
-      <option key={1} value={10}>
-        Ten
-      </option>,
-      <option key={2} value={20}>
-        Twenty
-      </option>,
-      <option key={3} value={30}>
-        Thirty
-      </option>,
-    ],
-  };
 
-  describeConformanceV5(<NativeSelectInput {...defaultProps} onChange={() => {}} />, () => ({
-    mount,
+  describeConformanceV5(<NativeSelectInput IconComponent="div" />, () => ({
     only: ['refForwarding'],
     refInstanceof: window.HTMLSelectElement,
     muiName: 'MuiNativeSelectInput',
@@ -34,7 +15,7 @@ describe('<NativeSelectInput />', () => {
 
   it('should render a native select', () => {
     const { container } = render(
-      <NativeSelectInput {...defaultProps}>
+      <NativeSelectInput IconComponent="div" onChange={() => {}} value={10}>
         <option value={10}>Ten</option>
         <option value={20}>Twenty</option>
         <option value={30}>Thirty</option>
@@ -46,27 +27,24 @@ describe('<NativeSelectInput />', () => {
 
   it('should respond to update event', () => {
     const handleChange = spy();
-    const wrapper = mount(
-      <NativeSelectInput {...defaultProps} onChange={handleChange}>
+    render(
+      <NativeSelectInput defaultValue={10} IconComponent="div" onChange={handleChange}>
         <option value={10}>Ten</option>
         <option value={20}>Twenty</option>
         <option value={30}>Thirty</option>
       </NativeSelectInput>,
     );
 
-    wrapper.find('select').simulate('change', { target: { value: 20 } });
+    fireEvent.change(document.querySelector('select'), { target: { value: 20 } });
+
     expect(handleChange.callCount).to.equal(1);
-    expect(handleChange.args[0][0].target.value).to.equal(20);
+    expect(handleChange.args[0][0].target.value).to.equal('20');
   });
 
   it('should apply outlined class', () => {
     const outlined = 'outlined';
     const { container } = render(
-      <NativeSelectInput
-        {...defaultProps}
-        variant="outlined"
-        classes={{ ...defaultProps.classes, outlined }}
-      />,
+      <NativeSelectInput IconComponent="div" variant="outlined" classes={{ outlined }} />,
     );
 
     expect(container.firstChild).to.have.class(outlined);
@@ -75,11 +53,7 @@ describe('<NativeSelectInput />', () => {
   it('should apply filled class', () => {
     const filled = 'filled';
     const { container } = render(
-      <NativeSelectInput
-        {...defaultProps}
-        variant="filled"
-        classes={{ ...defaultProps.classes, filled }}
-      />,
+      <NativeSelectInput IconComponent="div" variant="filled" classes={{ filled }} />,
     );
 
     expect(container.firstChild).to.have.class(filled);


### PR DESCRIPTION
Based on https://github.com/mui-org/material-ui/pull/26949 ([diff](https://github.com/eps1lon/material-ui/compare/test/hide-enzyme...eps1lon:test/NativeSelectInput/testing-library))

Part of https://github.com/mui-org/material-ui/issues/22911

Last tests where we can switch from enzyme. The remaining test need enzyme. Not converting the JSS tests since I consider them legacy at this point and don't want them to block React 18 efforts in case JSS has  issues with concurrent rendering. 