### PR TITLE
[docs] Remove link that points to v4 blog post

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -17,7 +17,7 @@ We'll do our best to keep things easy to follow, and as sequential as possible, 
 ## Why you should migrate
 
 This documentation page covers the _how_ of migrating from v4 to v5.
-The _why_ is covered in the [release blog post on Medium](https://medium.com/material-ui/material-ui-v4-is-out-4b7587d1e701).
+The _why_ will be covered in an upcoming blog post on Medium.
 
 ## Updating your dependencies
 


### PR DESCRIPTION
To increase accuracy of docs, this PR removes a link that points to v4 medium post and replaces it with note that there will be an upcoming post on Medium covering the _why_ of upgrading.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
