### PR TITLE
[core] Batch small changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ Big thanks to the 18 contributors who made this release possible. Here are some 
 
   <a href="https://next.material-ui.com/components/slider/#continuous-sliders"><img width="247" alt="" src="https://user-images.githubusercontent.com/3165635/121884800-a8808600-cd13-11eb-8cdf-e25de8f1ba73.png" style="margin: auto"></a>
 
-- 💡 `IconButton` now supports 3 sizes (`small, medium, large`). [See demo](/components/buttons/#sizes-2).
+- 💡 `IconButton` now supports 3 sizes (`small, medium, large`). [See demo](https://next.material-ui.com/components/buttons/#sizes-2).
 - ♿️ We have improved the default style of the `Link` to be more accessible (#26145) @ahmed-28
 
   <a href="https://next.material-ui.com/components/links/"><img width="543" alt="" src="https://user-images.githubusercontent.com/3165635/123097983-ef1b6200-d430-11eb-97da-b491fba5df49.png"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2338,7 +2338,7 @@ Big thanks to the 23 contributors who made this release possible. Here are some 
 ### Docs
 
 - <!-- 86 --> [examples] Patch preact example not working (#24616)
-- <!-- 78 --> [docs] Add missing newline in component JSDOC (#24610) @eps1lon
+- <!-- 78 --> [docs] Add missing newline in component JSDoc (#24610) @eps1lon
 - <!-- 70 --> [docs] Add API of picker components (#24497) @eps1lon
 - <!-- 63 --> [examples] Add `locale` prop to the Nextjs Link component (#24596) @CyanoFresh
 - <!-- 52 --> [docs] List required props first in /api/* (#24526) @eps1lon
@@ -4791,7 +4791,7 @@ Here are some highlights ✨:
 - [docs] Add 'size' prop to ToggleButton API docs (#22052) @zenje
 - [docs] Add ClassKeys migration description for Renaming API (#22061) @kodai3
 - [docs] Add a label to the TreeView demos (#21900) @joshwooding
-- [docs] Add missing JSDOC for various props (#22005) @eps1lon
+- [docs] Add missing JSDoc for various props (#22005) @eps1lon
 - [docs] Add the services that support MUI in readme (#22137) @naineet
 - [docs] Add trailingSlash: true (#22008) @oliviertassinari
 - [docs] Add visibility to TypeScript examples (#22013) @esemeniuc
@@ -5930,7 +5930,7 @@ Here are some highlights ✨:
 - [Tooltip] Fix TextField integration (#20252) @ShehryarShoukat96
 - [Tooltip] Remove superfluous argument in handleBlur call (#20271) @CptWesley
 - [TypeScript] Enable module augmentation of CommonColors (#20212) @eps1lon
-- [TypeScript] Add JSDOC to ListItem TypeScript props (#20171) @eps1lon
+- [TypeScript] Add JSDoc to ListItem TypeScript props (#20171) @eps1lon
 - [TypeScript] Fix Checkbox and Radio type propType (#20293) @eps1lon
 - [TypeScript] Fix incorrect typings regarding transition components a… (#20306) @eps1lon
 - [TypeScript] Link to demos and API in IntelliSense (#20078) @eps1lon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ on _Details_ to find out more about them.
 
 ### Updating the component API documentation
 
-The component API in the component `propTypes` and under `docs/pages/api-docs` is auto-generated from the [JSDOC](https://jsdoc.app/about-getting-started.html) in the TypeScript declarations.
+The component API in the component `propTypes` and under `docs/pages/api-docs` is auto-generated from the [JSDoc](https://jsdoc.app/about-getting-started.html) in the TypeScript declarations.
 Be sure to update the documentation in the corresponding `.d.ts` files (e.g. `packages/material-ui/src/Button/Button.d.ts` for `<Button>`) and the run:
 
 ```sh

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -119,7 +119,6 @@ const externs = [
  * @property {string} hash
  * @property {number} level
  * @property {string} text
- *
  * @param {object} context
  * @param {Record<string, string>} context.headingHashes - WILL BE MUTATED
  * @param {TableOfContentsEntry[]} context.toc - WILL BE MUTATED

--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -60,7 +60,7 @@ function BrandingHero() {
   return (
     <Container>
       <Typography variant="h1" align="center" sx={{ mt: 9, mx: 'auto' }}>
-        {"We're are making building "}
+        {"We're making building "}
         <Box component="span" sx={{ display: { xs: 'none', md: 'block' } }} />
         UIs more <UnderlinedText>accessible</UnderlinedText>
       </Typography>

--- a/docs/pages/branding/mui-x.tsx
+++ b/docs/pages/branding/mui-x.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';

--- a/docs/pages/company/lead-designer.js
+++ b/docs/pages/company/lead-designer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
 import {
   demos,

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -175,14 +175,14 @@ function createDescribeableProp(
 
     if (shouldHaveDefaultAnnotation) {
       throw new Error(
-        `JSDOC @default annotation not found. Add \`@default ${defaultValue.value}\` to the JSDOC of this prop.`,
+        `JSDoc @default annotation not found. Add \`@default ${defaultValue.value}\` to the JSDoc of this prop.`,
       );
     }
   } else if (jsdocDefaultValue !== undefined) {
     // `defaultValue` can't be undefined or we would've thrown earlier.
     if (jsdocDefaultValue.value !== defaultValue!.value) {
       throw new Error(
-        `Expected JSDOC @default annotation for prop '${propName}' of "${jsdocDefaultValue.value}" to equal runtime default value of "${defaultValue?.value}"`,
+        `Expected JSDoc @default annotation for prop '${propName}' of "${jsdocDefaultValue.value}" to equal runtime default value of "${defaultValue?.value}"`,
       );
     }
   }
@@ -437,7 +437,7 @@ async function annotateComponentDefinition(context: {
           const bindingId = babelPath.node.declaration.name;
           const binding = babelPath.scope.bindings[bindingId];
 
-          // The JSDOC MUST be located at the declaration
+          // The JSDoc MUST be located at the declaration
           if (babel.types.isFunctionDeclaration(binding.path.node)) {
             // For function declarations the binding is equal to the declaration
             // /**

--- a/docs/scripts/helpers.js
+++ b/docs/scripts/helpers.js
@@ -26,7 +26,6 @@ function fixLineEndings(source, target) {
 
 /**
  * Converts styled or regular component d.ts file to unstyled d.ts
- *
  * @param {string} filename - the file of the styled or regular mui component
  */
 function getUnstyledFilename(filename, definitionFile = false) {

--- a/docs/src/modules/branding/BrandingFooter.tsx
+++ b/docs/src/modules/branding/BrandingFooter.tsx
@@ -59,12 +59,12 @@ export default function BrandingFooter() {
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/x">
+                    <Link color="inherit" variant="body2" href="/branding/x/">
                       Material-UI X
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/pricing">
+                    <Link color="inherit" variant="body2" href="/branding/pricing/">
                       {t1('Pricing')}
                     </Link>
                   </li>
@@ -105,37 +105,37 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t1('Library')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/getting-started/templates">
+                    <Link color="inherit" variant="body2" href="/getting-started/templates/">
                       {t1('Free templates')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/components/material-icons">
+                    <Link color="inherit" variant="body2" href="/components/material-icons/">
                       {t1('Material Icons')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/components/box">
+                    <Link color="inherit" variant="body2" href="/components/box/">
                       {t1('Components')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/api/accordion">
+                    <Link color="inherit" variant="body2" href="/api/accordion/">
                       {t1('Components API')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/system/basics">
+                    <Link color="inherit" variant="body2" href="/system/basics/">
                       {t1('System')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/customization/theming">
+                    <Link color="inherit" variant="body2" href="/customization/theming/">
                       {t1('Customization')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/guides/api">
+                    <Link color="inherit" variant="body2" href="/guides/api/">
                       {t1('How To Guides')}
                     </Link>
                   </li>
@@ -145,7 +145,7 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t1('Explore')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/getting-started/installation">
+                    <Link color="inherit" variant="body2" href="/getting-started/installation/">
                       {t1('Docs')}
                     </Link>
                   </li>
@@ -155,22 +155,22 @@ export default function BrandingFooter() {
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/showcase">
+                    <Link color="inherit" variant="body2" href="/discover-more/showcase/">
                       {t1('Showcase')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/related-projects">
+                    <Link color="inherit" variant="body2" href="/discover-more/related-projects/">
                       {t1('Related Projects')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/roadmap">
+                    <Link color="inherit" variant="body2" href="/discover-more/roadmap/">
                       {t1('Roadmap')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/languages">
+                    <Link color="inherit" variant="body2" href="/discover-more/languages/">
                       {t1('Languages')}
                     </Link>
                   </li>
@@ -178,17 +178,17 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t('footerCompany')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/company/about">
+                    <Link color="inherit" variant="body2" href="/company/about/">
                       {t1('About')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/company/contact">
+                    <Link color="inherit" variant="body2" href="/company/contact/">
                       {t1('Contact Us')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/company/jobs">
+                    <Link color="inherit" variant="body2" href="/company/jobs/">
                       {t1('Jobs')}
                     </Link>
                   </li>

--- a/docs/src/modules/branding/BrandingFooter.tsx
+++ b/docs/src/modules/branding/BrandingFooter.tsx
@@ -54,22 +54,32 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t1('Products')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/">
                       Material-UI
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/branding/x/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/branding/x/">
                       Material-UI X
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/branding/pricing/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/branding/pricing/"
+                    >
                       {t1('Pricing')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="https://material-ui.com/store/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="https://material-ui.com/store/"
+                    >
                       {t1('Store')}
                     </Link>
                   </li>
@@ -79,6 +89,7 @@ export default function BrandingFooter() {
                   <li>
                     <Link
                       color="inherit"
+                      underline="hover"
                       variant="body2"
                       href="https://github.com/mui-org/material-ui"
                     >
@@ -86,13 +97,19 @@ export default function BrandingFooter() {
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="https://twitter.com/MaterialUI">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="https://twitter.com/MaterialUI"
+                    >
                       Twitter
                     </Link>
                   </li>
                   <li>
                     <Link
                       color="inherit"
+                      underline="hover"
                       variant="body2"
                       href="https://stackoverflow.com/questions/tagged/material-ui"
                     >
@@ -105,37 +122,52 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t1('Library')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/getting-started/templates/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/getting-started/templates/"
+                    >
                       {t1('Free templates')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/components/material-icons/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/components/material-icons/"
+                    >
                       {t1('Material Icons')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/components/box/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/components/box/">
                       {t1('Components')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/api/accordion/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/api/accordion/">
                       {t1('Components API')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/system/basics/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/system/basics/">
                       {t1('System')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/customization/theming/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/customization/theming/"
+                    >
                       {t1('Customization')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/guides/api/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/guides/api/">
                       {t1('How To Guides')}
                     </Link>
                   </li>
@@ -145,32 +177,62 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t1('Explore')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/getting-started/installation/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/getting-started/installation/"
+                    >
                       {t1('Docs')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="https://medium.com/material-ui">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="https://medium.com/material-ui"
+                    >
                       {t1('Blog')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/showcase/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/discover-more/showcase/"
+                    >
                       {t1('Showcase')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/related-projects/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/discover-more/related-projects/"
+                    >
                       {t1('Related Projects')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/roadmap/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/discover-more/roadmap/"
+                    >
                       {t1('Roadmap')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/discover-more/languages/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/discover-more/languages/"
+                    >
                       {t1('Languages')}
                     </Link>
                   </li>
@@ -178,17 +240,22 @@ export default function BrandingFooter() {
                 <Typography component="h3">{t('footerCompany')}</Typography>
                 <ul>
                   <li>
-                    <Link color="inherit" variant="body2" href="/company/about/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/company/about/">
                       {t1('About')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/company/contact/">
+                    <Link
+                      color="inherit"
+                      underline="hover"
+                      variant="body2"
+                      href="/company/contact/"
+                    >
                       {t1('Contact Us')}
                     </Link>
                   </li>
                   <li>
-                    <Link color="inherit" variant="body2" href="/company/jobs/">
+                    <Link color="inherit" underline="hover" variant="body2" href="/company/jobs/">
                       {t1('Jobs')}
                     </Link>
                   </li>
@@ -240,7 +307,8 @@ export default function BrandingFooter() {
             replacement={{
               versionNumber: (
                 <Link
-                  color="inherit"
+                  color="text.primary"
+                  underline="hover"
                   href={`https://material-ui.com${languagePrefix}/versions/`}
                   aria-label={`v${process.env.LIB_VERSION}. View versions page.`}
                 >
@@ -249,7 +317,8 @@ export default function BrandingFooter() {
               ),
               license: (
                 <Link
-                  color="inherit"
+                  color="text.primary"
+                  underline="hover"
                   href={`https://github.com/mui-org/material-ui/blob/v${process.env.LIB_VERSION}/LICENSE`}
                 >
                   {t('license')}

--- a/docs/src/modules/branding/BrandingFooter.tsx
+++ b/docs/src/modules/branding/BrandingFooter.tsx
@@ -198,7 +198,7 @@ export default function BrandingFooter() {
                 <BrandingNewsletter />
                 <Typography
                   sx={{ mt: 1, mb: 3 }}
-                  color="textSecondary"
+                  color="text.secondary"
                   variant="body3"
                   component="div"
                 >
@@ -235,7 +235,7 @@ export default function BrandingFooter() {
             </Grid>
           </Grid>
         </Grid>
-        <Typography sx={{ mt: { xs: 4, sm: 5, md: 4 } }} color="textSecondary" variant="body3">
+        <Typography sx={{ mt: { xs: 4, sm: 5, md: 4 } }} color="text.secondary" variant="body3">
           <Interpolate
             replacement={{
               versionNumber: (

--- a/docs/src/modules/branding/BrandingHeader.tsx
+++ b/docs/src/modules/branding/BrandingHeader.tsx
@@ -26,7 +26,7 @@ const links = (
         color="inherit"
         underline="none"
         activeClassName="Mui-active"
-        href="/branding/mui-x"
+        href="/branding/mui-x/"
       >
         {t1('Material-UI X')}
       </Link>
@@ -37,7 +37,7 @@ const links = (
         color="inherit"
         underline="none"
         activeClassName="Mui-active"
-        href="/branding/pricing"
+        href="/branding/pricing/"
       >
         {t1('Pricing')}
       </Link>
@@ -48,7 +48,7 @@ const links = (
         color="inherit"
         underline="none"
         activeClassName="Mui-active"
-        href="/getting-started/templates"
+        href="/getting-started/templates/"
       >
         {t1('Templates')}
       </Link>
@@ -59,7 +59,7 @@ const links = (
         color="inherit"
         underline="none"
         activeClassName="Mui-active"
-        href="/branding/about"
+        href="/branding/about/"
       >
         {t1('About Us')}
       </Link>

--- a/docs/src/modules/branding/BrandingRoot.tsx
+++ b/docs/src/modules/branding/BrandingRoot.tsx
@@ -331,6 +331,11 @@ theme = createTheme(theme, {
         },
       },
     },
+    MuiLink: {
+      defaultProps: {
+        underline: 'hover',
+      },
+    },
   },
 });
 

--- a/docs/src/modules/branding/BrandingRoot.tsx
+++ b/docs/src/modules/branding/BrandingRoot.tsx
@@ -331,11 +331,6 @@ theme = createTheme(theme, {
         },
       },
     },
-    MuiLink: {
-      defaultProps: {
-        underline: 'hover',
-      },
-    },
   },
 });
 

--- a/docs/src/modules/branding/ComparisonTable.tsx
+++ b/docs/src/modules/branding/ComparisonTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { styled, alpha, useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Table from '@material-ui/core/Table';

--- a/docs/src/modules/components/AppFooter.js
+++ b/docs/src/modules/components/AppFooter.js
@@ -84,7 +84,7 @@ function AppFooter(props) {
             <Grid item xs={12} sm={3}>
               <div className={classes.logo}>
                 <img src="/static/logo_raw.svg" alt="" />
-                <Link variant="body1" color="inherit" href="/">
+                <Link underline="hover" variant="body1" color="inherit" href="/">
                   Material-UI
                 </Link>
               </div>
@@ -98,13 +98,19 @@ function AppFooter(props) {
                   <Link
                     color="inherit"
                     variant="body2"
+                    underline="hover"
                     href="https://github.com/mui-org/material-ui"
                   >
                     GitHub
                   </Link>
                 </li>
                 <li>
-                  <Link color="inherit" variant="body2" href="https://twitter.com/MaterialUI">
+                  <Link
+                    underline="hover"
+                    color="inherit"
+                    variant="body2"
+                    href="https://twitter.com/MaterialUI"
+                  >
                     Twitter
                   </Link>
                 </li>
@@ -112,13 +118,19 @@ function AppFooter(props) {
                   <Link
                     color="inherit"
                     variant="body2"
+                    underline="hover"
                     href="https://stackoverflow.com/questions/tagged/material-ui"
                   >
                     StackOverflow
                   </Link>
                 </li>
                 <li>
-                  <Link color="inherit" variant="body2" href="/discover-more/team/">
+                  <Link
+                    underline="hover"
+                    color="inherit"
+                    variant="body2"
+                    href="/discover-more/team/"
+                  >
                     {t('pages./discover-more/team')}
                   </Link>
                 </li>
@@ -130,17 +142,32 @@ function AppFooter(props) {
               </Typography>
               <ul>
                 <li>
-                  <Link color="inherit" variant="body2" href="/getting-started/support/">
+                  <Link
+                    underline="hover"
+                    color="inherit"
+                    variant="body2"
+                    href="/getting-started/support/"
+                  >
                     {t('pages./getting-started/support')}
                   </Link>
                 </li>
                 <li>
-                  <Link color="inherit" variant="body2" href="https://medium.com/material-ui/">
+                  <Link
+                    underline="hover"
+                    color="inherit"
+                    variant="body2"
+                    href="https://medium.com/material-ui/"
+                  >
                     {t('blogTitle')}
                   </Link>
                 </li>
                 <li>
-                  <Link color="inherit" variant="body2" href="/components/material-icons/">
+                  <Link
+                    underline="hover"
+                    color="inherit"
+                    variant="body2"
+                    href="/components/material-icons/"
+                  >
                     {t('pages./components/material-icons')}
                   </Link>
                 </li>
@@ -152,20 +179,20 @@ function AppFooter(props) {
               </Typography>
               <ul>
                 <li>
-                  <Link color="inherit" variant="body2" href="/company/about/">
+                  <Link underline="hover" color="inherit" variant="body2" href="/company/about/">
                     About
                   </Link>
                 </li>
                 <li>
-                  <Link color="inherit" variant="body2" href="/company/contact/">
+                  <Link underline="hover" color="inherit" variant="body2" href="/company/contact/">
                     Contact Us
                   </Link>
                 </li>
                 <li className={classes.careers}>
-                  <Link color="inherit" variant="body2" href="/company/careers/">
+                  <Link underline="hover" color="inherit" variant="body2" href="/company/careers/">
                     Careers
                   </Link>
-                  <Link color="inherit" variant="body2" href="/company/careers/">
+                  <Link underline="hover" color="inherit" variant="body2" href="/company/careers/">
                     <Badge>hiring</Badge>
                   </Link>
                 </li>
@@ -177,7 +204,8 @@ function AppFooter(props) {
               replacement={{
                 versionNumber: (
                   <Link
-                    color="inherit"
+                    color="text.primary"
+                    underline="hover"
                     href={`https://material-ui.com${languagePrefix}/versions/`}
                     aria-label={`v${process.env.LIB_VERSION}. View versions page.`}
                   >
@@ -186,7 +214,8 @@ function AppFooter(props) {
                 ),
                 license: (
                   <Link
-                    color="inherit"
+                    color="text.primary"
+                    underline="hover"
                     href={`https://github.com/mui-org/material-ui/blob/v${process.env.LIB_VERSION}/LICENSE`}
                   >
                     {t('license')}

--- a/docs/src/modules/components/AppFooter.js
+++ b/docs/src/modules/components/AppFooter.js
@@ -204,8 +204,7 @@ function AppFooter(props) {
               replacement={{
                 versionNumber: (
                   <Link
-                    color="text.primary"
-                    underline="hover"
+                    color="inherit"
                     href={`https://material-ui.com${languagePrefix}/versions/`}
                     aria-label={`v${process.env.LIB_VERSION}. View versions page.`}
                   >
@@ -214,8 +213,7 @@ function AppFooter(props) {
                 ),
                 license: (
                   <Link
-                    color="text.primary"
-                    underline="hover"
+                    color="inherit"
                     href={`https://github.com/mui-org/material-ui/blob/v${process.env.LIB_VERSION}/LICENSE`}
                   >
                     {t('license')}

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -160,12 +160,20 @@ function AppNavDrawer(props) {
       <React.Fragment>
         <div className={classes.toolbarIe11}>
           <div className={classes.toolbar}>
-            <Link className={classes.title} href="/" onClick={onClose} variant="h6" color="inherit">
+            <Link
+              className={classes.title}
+              href="/"
+              underline="hover"
+              onClick={onClose}
+              variant="h6"
+              color="inherit"
+            >
               Material-UI
             </Link>
             {process.env.LIB_VERSION ? (
               <Link
                 color="text.secondary"
+                underline="hover"
                 variant="caption"
                 href={`https://material-ui.com${languagePrefix}/versions/`}
                 onClick={onClose}

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -134,17 +134,16 @@ const useStyles = makeStyles(
       },
     },
     code: {
-      display: 'none',
       padding: 0,
       marginBottom: theme.spacing(1),
-      marginRight: 0,
+      marginTop: theme.spacing(2),
       [theme.breakpoints.up('sm')]: {
-        display: 'block',
+        marginTop: theme.spacing(0),
       },
       '& pre': {
         overflow: 'auto',
         lineHeight: 1.5,
-        margin: '0 !important',
+        margin: '0 auto',
         maxHeight: 'min(68vh, 1000px)',
       },
     },

--- a/docs/src/modules/utils/defaultPropsHandler.js
+++ b/docs/src/modules/utils/defaultPropsHandler.js
@@ -69,7 +69,6 @@ function getDefaultValue(propertyPath, importer) {
 }
 
 /**
- *
  * @param {import('doctrine').Annotation} jsdoc
  * @return {{ value: string } | undefined}
  */

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
@@ -121,7 +121,7 @@ export default function PrimarySearchAppBar() {
     >
       <MenuItem>
         <IconButton size="large" aria-label="show 4 new mails" color="inherit">
-          <Badge badgeContent={4} color="secondary">
+          <Badge badgeContent={4} color="error">
             <MailIcon />
           </Badge>
         </IconButton>
@@ -130,10 +130,10 @@ export default function PrimarySearchAppBar() {
       <MenuItem>
         <IconButton
           size="large"
-          aria-label="show 11 new notifications"
+          aria-label="show 17 new notifications"
           color="inherit"
         >
-          <Badge badgeContent={11} color="secondary">
+          <Badge badgeContent={17} color="error">
             <NotificationsIcon />
           </Badge>
         </IconButton>
@@ -187,7 +187,7 @@ export default function PrimarySearchAppBar() {
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             <IconButton size="large" aria-label="show 4 new mails" color="inherit">
-              <Badge badgeContent={4} color="secondary">
+              <Badge badgeContent={4} color="error">
                 <MailIcon />
               </Badge>
             </IconButton>
@@ -196,7 +196,7 @@ export default function PrimarySearchAppBar() {
               aria-label="show 17 new notifications"
               color="inherit"
             >
-              <Badge badgeContent={17} color="secondary">
+              <Badge badgeContent={17} color="error">
                 <NotificationsIcon />
               </Badge>
             </IconButton>

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
@@ -122,7 +122,7 @@ export default function PrimarySearchAppBar() {
     >
       <MenuItem>
         <IconButton size="large" aria-label="show 4 new mails" color="inherit">
-          <Badge badgeContent={4} color="secondary">
+          <Badge badgeContent={4} color="error">
             <MailIcon />
           </Badge>
         </IconButton>
@@ -131,10 +131,10 @@ export default function PrimarySearchAppBar() {
       <MenuItem>
         <IconButton
           size="large"
-          aria-label="show 11 new notifications"
+          aria-label="show 17 new notifications"
           color="inherit"
         >
-          <Badge badgeContent={11} color="secondary">
+          <Badge badgeContent={17} color="error">
             <NotificationsIcon />
           </Badge>
         </IconButton>
@@ -188,7 +188,7 @@ export default function PrimarySearchAppBar() {
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             <IconButton size="large" aria-label="show 4 new mails" color="inherit">
-              <Badge badgeContent={4} color="secondary">
+              <Badge badgeContent={4} color="error">
                 <MailIcon />
               </Badge>
             </IconButton>
@@ -197,7 +197,7 @@ export default function PrimarySearchAppBar() {
               aria-label="show 17 new notifications"
               color="inherit"
             >
-              <Badge badgeContent={17} color="secondary">
+              <Badge badgeContent={17} color="error">
                 <NotificationsIcon />
               </Badge>
             </IconButton>

--- a/docs/src/pages/components/badges/AccessibleBadges.js
+++ b/docs/src/pages/components/badges/AccessibleBadges.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
 import MailIcon from '@material-ui/icons/Mail';

--- a/docs/src/pages/components/badges/AccessibleBadges.tsx
+++ b/docs/src/pages/components/badges/AccessibleBadges.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
 import MailIcon from '@material-ui/icons/Mail';

--- a/docs/src/pages/components/buttons/ColorButtons.js
+++ b/docs/src/pages/components/buttons/ColorButtons.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import Button from '@material-ui/core/Button';
 
 export default function ColorButtons() {
   return (
-    <Box sx={{ '& > :not(style)': { m: 1 } }}>
+    <Stack direction="row" spacing={2}>
       <Button color="secondary">Secondary</Button>
       <Button variant="contained" color="success">
         Success
@@ -12,6 +12,6 @@ export default function ColorButtons() {
       <Button variant="outlined" color="error">
         Error
       </Button>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/ColorButtons.tsx
+++ b/docs/src/pages/components/buttons/ColorButtons.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import Button from '@material-ui/core/Button';
 
 export default function ColorButtons() {
   return (
-    <Box sx={{ '& > :not(style)': { m: 1 } }}>
+    <Stack direction="row" spacing={2}>
       <Button color="secondary">Secondary</Button>
       <Button variant="contained" color="success">
         Success
@@ -12,6 +12,6 @@ export default function ColorButtons() {
       <Button variant="outlined" color="error">
         Error
       </Button>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -4,7 +4,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function ContainedButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button variant="contained">Contained</Button>
       <Button variant="contained" disabled>
         Disabled

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -4,7 +4,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function ContainedButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button variant="contained">Contained</Button>
       <Button variant="contained" disabled>
         Disabled

--- a/docs/src/pages/components/buttons/IconButtonColors.js
+++ b/docs/src/pages/components/buttons/IconButtonColors.js
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import IconButton from '@material-ui/core/IconButton';
 import Fingerprint from '@material-ui/icons/Fingerprint';
 
 export default function IconButtonColors() {
   return (
-    <Box sx={{ '& button': { m: 1 } }}>
+    <Stack direction="row" spacing={1}>
       <IconButton aria-label="fingerprint" color="secondary">
         <Fingerprint />
       </IconButton>
       <IconButton aria-label="fingerprint" color="success">
         <Fingerprint />
       </IconButton>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtonColors.js
+++ b/docs/src/pages/components/buttons/IconButtonColors.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import Fingerprint from '@material-ui/icons/Fingerprint';

--- a/docs/src/pages/components/buttons/IconButtonColors.tsx
+++ b/docs/src/pages/components/buttons/IconButtonColors.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import IconButton from '@material-ui/core/IconButton';
 import Fingerprint from '@material-ui/icons/Fingerprint';
 
 export default function IconButtonColors() {
   return (
-    <Box sx={{ '& button': { m: 1 } }}>
+    <Stack direction="row" spacing={1}>
       <IconButton aria-label="fingerprint" color="secondary">
         <Fingerprint />
       </IconButton>
       <IconButton aria-label="fingerprint" color="success">
         <Fingerprint />
       </IconButton>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtonColors.tsx
+++ b/docs/src/pages/components/buttons/IconButtonColors.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import Fingerprint from '@material-ui/icons/Fingerprint';

--- a/docs/src/pages/components/buttons/IconButtonSizes.js
+++ b/docs/src/pages/components/buttons/IconButtonSizes.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 
 export default function IconButtonSizes() {
   return (
-    <Box sx={{ '& button': { m: 1 } }}>
+    <Stack direction="row" alignItems="center" spacing={1}>
       <IconButton aria-label="delete" size="small">
         <DeleteIcon fontSize="inherit" />
       </IconButton>
@@ -18,6 +18,6 @@ export default function IconButtonSizes() {
       <IconButton aria-label="delete" size="large">
         <DeleteIcon fontSize="inherit" />
       </IconButton>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtonSizes.js
+++ b/docs/src/pages/components/buttons/IconButtonSizes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';

--- a/docs/src/pages/components/buttons/IconButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/IconButtonSizes.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
+import Stack from '@material-ui/core/Stack';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 
 export default function IconButtonSizes() {
   return (
-    <Box sx={{ '& button': { m: 1 } }}>
+    <Stack direction="row" alignItems="center" spacing={1}>
       <IconButton aria-label="delete" size="small">
         <DeleteIcon fontSize="inherit" />
       </IconButton>
@@ -18,6 +18,6 @@ export default function IconButtonSizes() {
       <IconButton aria-label="delete" size="large">
         <DeleteIcon fontSize="inherit" />
       </IconButton>
-    </Box>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/IconButtonSizes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';

--- a/docs/src/pages/components/buttons/IconButtons.js
+++ b/docs/src/pages/components/buttons/IconButtons.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
+import Stack from '@material-ui/core/Stack';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 
 export default function IconButtons() {
   return (
-    <div>
+    <Stack direction="row" spacing={1}>
       <IconButton aria-label="delete">
         <DeleteIcon />
       </IconButton>
@@ -19,6 +20,6 @@ export default function IconButtons() {
       <IconButton color="primary" aria-label="add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
-    </div>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/IconButtons.tsx
+++ b/docs/src/pages/components/buttons/IconButtons.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
+import Stack from '@material-ui/core/Stack';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 
 export default function IconButtons() {
   return (
-    <div>
+    <Stack direction="row" spacing={1}>
       <IconButton aria-label="delete">
         <DeleteIcon />
       </IconButton>
@@ -19,6 +20,6 @@ export default function IconButtons() {
       <IconButton color="primary" aria-label="add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
-    </div>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -6,7 +6,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function IconLabelButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button variant="outlined" startIcon={<DeleteIcon />}>
         Delete
       </Button>

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -6,7 +6,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function IconLabelButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button variant="outlined" startIcon={<DeleteIcon />}>
         Delete
       </Button>

--- a/docs/src/pages/components/buttons/LoadingButtons.js
+++ b/docs/src/pages/components/buttons/LoadingButtons.js
@@ -5,7 +5,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function LoadingButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <LoadingButton loading variant="outlined">
         Submit
       </LoadingButton>

--- a/docs/src/pages/components/buttons/LoadingButtons.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtons.tsx
@@ -5,7 +5,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function LoadingButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <LoadingButton loading variant="outlined">
         Submit
       </LoadingButton>

--- a/docs/src/pages/components/buttons/OutlinedButtons.js
+++ b/docs/src/pages/components/buttons/OutlinedButtons.js
@@ -4,7 +4,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function OutlinedButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button variant="outlined">Primary</Button>
       <Button variant="outlined" disabled>
         Disabled

--- a/docs/src/pages/components/buttons/OutlinedButtons.tsx
+++ b/docs/src/pages/components/buttons/OutlinedButtons.tsx
@@ -4,7 +4,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function OutlinedButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button variant="outlined">Primary</Button>
       <Button variant="outlined" disabled>
         Disabled

--- a/docs/src/pages/components/buttons/TextButtons.js
+++ b/docs/src/pages/components/buttons/TextButtons.js
@@ -4,7 +4,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function TextButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button>Primary</Button>
       <Button disabled>Disabled</Button>
       <Button href="#text-buttons">Link</Button>

--- a/docs/src/pages/components/buttons/TextButtons.tsx
+++ b/docs/src/pages/components/buttons/TextButtons.tsx
@@ -4,7 +4,7 @@ import Stack from '@material-ui/core/Stack';
 
 export default function TextButtons() {
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={2}>
       <Button>Primary</Button>
       <Button disabled>Disabled</Button>
       <Button href="#text-buttons">Link</Button>

--- a/docs/src/pages/components/buttons/UploadButtons.js
+++ b/docs/src/pages/components/buttons/UploadButtons.js
@@ -11,7 +11,7 @@ const Input = styled('input')({
 
 export default function UploadButtons() {
   return (
-    <Stack direction="row" alignItems="center" spacing={1}>
+    <Stack direction="row" alignItems="center" spacing={2}>
       <label htmlFor="contained-button-file">
         <Input accept="image/*" id="contained-button-file" multiple type="file" />
         <Button variant="contained" component="span">

--- a/docs/src/pages/components/buttons/UploadButtons.tsx
+++ b/docs/src/pages/components/buttons/UploadButtons.tsx
@@ -11,7 +11,7 @@ const Input = styled('input')({
 
 export default function UploadButtons() {
   return (
-    <Stack direction="row" alignItems="center" spacing={1}>
+    <Stack direction="row" alignItems="center" spacing={2}>
       <label htmlFor="contained-button-file">
         <Input accept="image/*" id="contained-button-file" multiple type="file" />
         <Button variant="contained" component="span">

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -57,6 +57,13 @@ The prop is converted into a CSS property using the [`theme.spacing()`](/customi
 
 {{"demo": "pages/components/grid/SpacingGrid.js", "bg": true}}
 
+### Row & column spacing
+
+The `rowSpacing` and `columnSpacing` props allow for specifying the row and column gaps independently.
+It's similar to the `row-gap` and `column-gap` properties of [CSS Grid](/system/grid/#row-gap-amp-column-gap).
+
+{{"demo": "pages/components/grid/RowAndColumnSpacing.js", "bg": true}}
+
 ## Responsive values
 
 You can switch the props' value based on the active breakpoint.
@@ -81,13 +88,6 @@ Responsive values is supported by:
 >   <Grid item xs={2} />
 > </Grid>
 > ```
-
-### Row & column spacing
-
-The `rowSpacing` and `columnSpacing` props allow for specifying the row and column gaps independently.
-It's similar to the `row-gap` and `column-gap` properties of [CSS Grid](/system/grid/#row-gap-amp-column-gap).
-
-{{"demo": "pages/components/grid/RowAndColumnSpacing.js", "bg": true}}
 
 ## Interactive
 

--- a/docs/src/pages/components/slider/MusicPlayerSlider.js
+++ b/docs/src/pages/components/slider/MusicPlayerSlider.js
@@ -101,7 +101,7 @@ export default function MusicPlayerSlider() {
             />
           </CoverImage>
           <Box sx={{ ml: 1.5, minWidth: 0 }}>
-            <Typography variant="caption" color="textSecondary" fontWeight={500}>
+            <Typography variant="caption" color="text.secondary" fontWeight={500}>
               Jun Pulse
             </Typography>
             <Typography noWrap>

--- a/docs/src/pages/components/slider/MusicPlayerSlider.tsx
+++ b/docs/src/pages/components/slider/MusicPlayerSlider.tsx
@@ -101,7 +101,7 @@ export default function MusicPlayerSlider() {
             />
           </CoverImage>
           <Box sx={{ ml: 1.5, minWidth: 0 }}>
-            <Typography variant="caption" color="textSecondary" fontWeight={500}>
+            <Typography variant="caption" color="text.secondary" fontWeight={500}>
               Jun Pulse
             </Typography>
             <Typography noWrap>

--- a/docs/src/pages/components/slider/SliderSizes.js
+++ b/docs/src/pages/components/slider/SliderSizes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Box from '@material-ui/core/Box';
 import Slider from '@material-ui/core/Slider';

--- a/docs/src/pages/components/slider/SliderSizes.tsx
+++ b/docs/src/pages/components/slider/SliderSizes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Box from '@material-ui/core/Box';
 import Slider from '@material-ui/core/Slider';

--- a/docs/src/pages/components/text-fields/FullWidthTextField.js
+++ b/docs/src/pages/components/text-fields/FullWidthTextField.js
@@ -10,7 +10,7 @@ export default function FullWidthTextField() {
         maxWidth: '100%',
       }}
     >
-      <TextField fullWidth label={'fullWidth'} id="fullWidth" />
+      <TextField fullWidth label="fullWidth" id="fullWidth" />
     </Box>
   );
 }

--- a/docs/src/pages/components/text-fields/FullWidthTextField.tsx
+++ b/docs/src/pages/components/text-fields/FullWidthTextField.tsx
@@ -10,7 +10,7 @@ export default function FullWidthTextField() {
         maxWidth: '100%',
       }}
     >
-      <TextField fullWidth label={'fullWidth'} id="fullWidth" />
+      <TextField fullWidth label="fullWidth" id="fullWidth" />
     </Box>
   );
 }

--- a/docs/src/pages/customization/palette/DarkTheme.js
+++ b/docs/src/pages/customization/palette/DarkTheme.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
 import {
   styled,
   ThemeProvider,
@@ -105,13 +106,13 @@ export default function DarkTheme() {
   // Note that if you intend to use two or more themes at the same time on your site,
   // you need to wrap them with a single ThemeProvider at the root (not like in this example).
   return (
-    <div style={{ width: '100%' }}>
+    <Box sx={{ width: '100%' }}>
       <ThemeProvider theme={darkTheme}>
         <Demo />
       </ThemeProvider>
       <ThemeProvider theme={lightTheme}>
         <Demo />
       </ThemeProvider>
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/customization/palette/Intentions.js
+++ b/docs/src/pages/customization/palette/Intentions.js
@@ -100,15 +100,15 @@ function IntentionsInner() {
 }
 
 export default function Intentions() {
+  const theme = useTheme();
+
   return (
     <ThemeProvider
-      theme={(outerTheme) =>
-        createTheme({
-          palette: {
-            mode: outerTheme.palette.mode,
-          },
-        })
-      }
+      theme={createTheme({
+        palette: {
+          mode: theme.palette.mode,
+        },
+      })}
     >
       <IntentionsInner />
     </ThemeProvider>

--- a/docs/src/pages/customization/palette/Intentions.js
+++ b/docs/src/pages/customization/palette/Intentions.js
@@ -99,11 +99,17 @@ function IntentionsInner() {
   );
 }
 
-const defaultTheme = createTheme();
-
 export default function Intentions() {
   return (
-    <ThemeProvider theme={defaultTheme}>
+    <ThemeProvider
+      theme={(outerTheme) =>
+        createTheme({
+          palette: {
+            mode: outerTheme.palette.mode,
+          },
+        })
+      }
+    >
       <IntentionsInner />
     </ThemeProvider>
   );

--- a/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/PickersPopper.tsx
@@ -55,7 +55,6 @@ function clickedRootScrollbar(event: MouseEvent, doc: Document) {
 /**
  * Based on @material-ui/core/ClickAwayListener without the customization.
  * We can probably strip away even more since children won't be portaled.
- *
  * @param onClickAway
  * @param onClick
  * @param onTouchStart

--- a/packages/material-ui-utils/macros/MuiError.macro.js
+++ b/packages/material-ui-utils/macros/MuiError.macro.js
@@ -15,7 +15,6 @@ function invertObject(object) {
  * Supported imports:
  * 1. bare specifier e.g. `'@material-ui/utils/macros/MuiError.macro'`
  * 2. relative import from `packages/material-ui-utils/src` e.g. `'../macros/MuiError.macro'`
- *
  * @param {import('babel-plugin-macros').MacroParams} param0
  */
 function muiError({ references, babel, config, source }) {

--- a/packages/material-ui-utils/src/integerPropType.test.js
+++ b/packages/material-ui-utils/src/integerPropType.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { integerPropType } from '@material-ui/utils';

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -182,10 +182,10 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
   const {
     disableUnderline,
     fullWidth = false,
+    hiddenLabel, // declare here to prevent spreading to DOM
     inputComponent = 'input',
     multiline = false,
     type = 'text',
-    hiddenLabel, // declare here to prevent spreading to DOM
     ...other
   } = props;
 

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -51,7 +51,7 @@ export type BaseProps<M extends OverridableTypeMap> =
 /**
  * Props that are valid for material-ui components.
  */
-// each component declares it's classes in a separate interface for proper JSDOC.
+// each component declares it's classes in a separate interface for proper JSDoc.
 export interface CommonProps extends StyledComponentProps<never> {
   className?: string;
   style?: React.CSSProperties;

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -117,12 +117,12 @@ const StepLabel = React.forwardRef(function StepLabel(inProps, ref) {
   const {
     children,
     className,
+    componentsProps = {},
     error = false,
     icon: iconProp,
     optional,
     StepIconComponent: StepIconComponentProp,
     StepIconProps,
-    componentsProps = {},
     ...other
   } = props;
 

--- a/packages/material-ui/src/colors/colors.spec.tsx
+++ b/packages/material-ui/src/colors/colors.spec.tsx
@@ -8,7 +8,7 @@ type KeysEquivalent<T, U> = keyof T extends keyof U
 
 function colorTypeMatches(variants: keyof Color) {
   // Checking that each color has the exact shape as Color
-  // we don't use the Color type for these to provide JSDOC for each color
+  // we don't use the Color type for these to provide JSDoc for each color
   // in which we preview the color
   const amber: KeysEquivalent<Color, typeof colors.amber> = true;
   const blue: KeysEquivalent<Color, typeof colors.blue> = true;

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -26,13 +26,13 @@ export type StandardProps<
  *
  * Internal helper type for conform (describeConformance) components
  * However, we don't declare classes on this type.
- * It is recommended to declare them manually with an interface so that each class can have a separate JSDOC.
+ * It is recommended to declare them manually with an interface so that each class can have a separate JSDoc.
  */
 export type InternalStandardProps<C, Removals extends keyof C = never> = DistributiveOmit<
   C,
   'classes' | Removals
 > &
-  // each component declares it's classes in a separate interface for proper JSDOC
+  // each component declares it's classes in a separate interface for proper JSDoc
   StyledComponentProps<never> & {
     ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
     // TODO: Remove implicit props. Up to each component.

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -3,7 +3,6 @@ import { Theme } from './createTheme';
 
 /**
  * Custom styled utility that has a default MUI theme.
- *
  * @param tag HTML tag or component that should serve as base.
  * @param options Styled options for the created component.
  * @returns React component that has styles attached to it.

--- a/scripts/buildColorTypes.js
+++ b/scripts/buildColorTypes.js
@@ -60,7 +60,7 @@ function buildColorPreviews(name, variants) {
 /**
  * The goal is to have a preview of the actual color and the color string in IntelliSense
  * We create for each color an svg that is filled with that color and reference
- * that svg in the corresponding JSDOC.
+ * that svg in the corresponding JSDoc.
  * Since we use https://material-ui.com as a reference changes are only visible
  * after release
  */

--- a/scripts/buildTypes.js
+++ b/scripts/buildTypes.js
@@ -10,9 +10,7 @@ const exec = promisify(childProcess.exec);
 
 /**
  * Fixes a wrong import path caused by https://github.com/microsoft/TypeScript/issues/39117
- *
  * @remarks Paths are hardcoded since it is unclear if all these broken import paths target "public paths".
- *
  * @param {string} importPath - POSIX path
  */
 function rewriteImportPath(importPath) {

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -113,8 +113,8 @@ const transitionCallbacks = [
 ];
 /**
  * These are components that use props implemented by external components.
- * Those props have their own JSDOC which we don't want to emit in our docs
- * but do want them to have JSDOC in IntelliSense
+ * Those props have their own JSDoc which we don't want to emit in our docs
+ * but do want them to have JSDoc in IntelliSense
  * TODO: In the future we want to ignore external docs on the initial load anyway
  * since they will be fetched dynamically.
  */

--- a/scripts/releaseChangelog.js
+++ b/scripts/releaseChangelog.js
@@ -28,7 +28,6 @@ function parseTags(commitMessage) {
 }
 
 /**
- *
  * @param {Octokit.ReposCompareCommitsResponseCommitsItem} commitsItem
  */
 function filterCommit(commitsItem) {

--- a/test/bundling/scripts/createFixture.js
+++ b/test/bundling/scripts/createFixture.js
@@ -9,7 +9,6 @@ import { URL } from 'url';
  */
 
 /**
- *
  * @param {URL} destinationUrl
  * @param {string} templateSource
  * @param {Record<string, string>} templateValues

--- a/test/utils/components.js
+++ b/test/utils/components.js
@@ -37,7 +37,8 @@ export class ErrorBoundary extends React.Component {
 }
 
 /**
- * Allows counting how many times the owner of `RenderCounter` rendered.
+ * Allows counting how many times the owner of `RenderCounter` rendered or
+ * a component within the RenderCounter tree "commits" an update.
  * @example <RenderCounter ref={getRenderCountRef}>...</RenderCounter>
  *          getRenderCountRef.current() === 2
  * @type {import('react').JSXElementConstructor<{children: import('react').ReactNode} & import('react').RefAttributes<() => number>>}

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -92,7 +92,6 @@ export function testComponentProp(element, getOptions) {
 
 /**
  * Material-UI components can spread additional props to a documented component.
- *
  * @param {React.ReactElement} element
  * @param {() => ConformanceOptions} getOptions
  */


### PR DESCRIPTION
- [core] JSDOC -> JSDoc f33ba3f: This seems to be the official name: https://en.wikipedia.org/wiki/JSDoc.
- sort props asc ad69034: a small detail.
- [website] Fix small mistakes in the branding 4c0c751: Fix 404 link, fix design regression with link.
- [website] Fix Link underline aesthetic regressions a0b62ee: In a couple of use cases, the link behavior is implicit and doesn't need the underline to be explicit.
- [docs] Fix demo in dark mode ba0434d: Open https://next.material-ui.com/customization/palette/#default-values and turn on dark mode.
- [core] Sort props asc ab2c468: a small detail.
- [core] Apply @tag convention da29091: a convention we have been using so far.
- [docs] Improve notification color b5308fc: Same as #26796. It displays funny https://next.material-ui.com/components/app-bar/#app-bar-with-a-primary-search-field.
- [docs] Remove outdated API fa98959: textSecondary -> text.secondary cc @siriwatknp.
- [core] Update import of React to match convention 066eda3: a small detail
- [docs] Apply quotes convention df57b19: a small detail
- [docs] Use the same spacing between the demos 766bd15 4ab4c91: I have noticed that the button demos felt inconsistent. I have updated the set to use 16px for buttons and 8px for icon buttons.
- [docs] Fix header inversion 9d543bf: The headers were no longer in the logical order. I suspect a merge conflict.
- [docs] Dispaly code previews on mobile 5e05cf0: The new behavior:

<img width="363" alt="Capture d’écran 2021-06-27 à 01 02 55" src="https://user-images.githubusercontent.com/3165635/123527875-72fc7500-d6e3-11eb-9ea3-475f875921f4.png">

- [test] Polish RenderCounter description 39cab97: A follow up on https://github.com/mui-org/material-ui/pull/26678#discussion_r650399515
- [docs] Apply FIXME 3c82ad2: From https://github.com/mui-org/material-ui/pull/26774/files#r659238100

I have noticed more opportunities, but the others need to be in dedicated PRs.