### PR TITLE
[docs] Fix demo paths in windows

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -188,8 +188,7 @@ module.exports = {
 
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
-    // FIXME: Revert before merging
-    if (process.env.PULL_REQUEST === 'false' && !l10nPRInNetlify && !vercelDeploy) {
+    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify && !vercelDeploy) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -188,7 +188,8 @@ module.exports = {
 
     // We want to speed-up the build of pull requests.
     // For crowdin PRs we want to build all locales for testing.
-    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify && !vercelDeploy) {
+    // FIXME: Revert before merging
+    if (process.env.PULL_REQUEST === 'false' && !l10nPRInNetlify && !vercelDeploy) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -241,7 +241,7 @@ function createRender(context) {
 /**
  * @param {object} config
  * @param {() => string} config.requireRaw - returnvalue of require.context
- * @param {string} config.pageFilename - filename relative to nextjs pages directory
+ * @param {string} config.pageFilename - posix filename relative to nextjs pages directory
  */
 function prepareMarkdown(config) {
   const { pageFilename, requireRaw } = config;


### PR DESCRIPTION
The import paths are currently more complicated than they need to. Ideally the `{{"demo":"demo/path"}}` syntax would just use import paths that are valid in JS as well. Right now they neither work with regular JS import nor webpack because they all start with `pages/`.

We can fix this another time though.