### PR TITLE
[docs] Update Autocomplete example data source

### DIFF
--- a/docs/src/pages/components/autocomplete/Asynchronous.tsx
+++ b/docs/src/pages/components/autocomplete/Asynchronous.tsx
@@ -1,4 +1,4 @@
-// *https://www.registers.service.gov.uk/registers/country/use-the-api*
+// *https://restcountries.eu/*
 import fetch from 'cross-fetch';
 import React from 'react';
 import TextField from '@material-ui/core/TextField';
@@ -28,12 +28,12 @@ export default function Asynchronous() {
     }
 
     (async () => {
-      const response = await fetch('https://country.register.gov.uk/records.json?page-size=5000');
+      const response = await fetch('https://restcountries.eu/rest/v2/all');
       await sleep(1e3); // For demo purposes.
       const countries = await response.json();
 
       if (active) {
-        setOptions(Object.keys(countries).map((key) => countries[key].item[0]) as CountryType[]);
+        setOptions(countries.map( (country) => { return {name: country.name} }) as CountryType[]);
       }
     })();
 


### PR DESCRIPTION
The previous data source at https://www.registers.service.gov.uk has been deprecated on the 15th of March 2021 as per official communication at https://data.gov.uk/dataset/a8f488fd-eaea-4176-92b0-6d0437b4d121/historical-gov-uk-registers

I am suggesting to use https://restcountries.eu because it is free, and there are a few well known companies using it.

I have updated the code snippets to process and show the results.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
