### PR TITLE
[test] Only allow wrapping enzyme mount not creating

### DIFF
--- a/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/CalendarPicker.test.tsx
@@ -4,13 +4,12 @@ import { fireEvent, screen, describeConformanceV5 } from 'test/utils';
 import CalendarPicker, { calendarPickerClasses as classes } from '@material-ui/lab/CalendarPicker';
 import {
   adapterToUse,
-  createPickerMount,
+  wrapPickerMount,
   createPickerRender,
   getAllByMuiTest,
 } from '../internal/pickers/test-utils';
 
 describe('<CalendarPicker />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender({ strict: false });
 
   describeConformanceV5(<CalendarPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
@@ -18,7 +17,7 @@ describe('<CalendarPicker />', () => {
     inheritComponent: 'div',
     render,
     muiName: 'MuiCalendarPicker',
-    mount,
+    wrapMount: wrapPickerMount,
     refInstanceof: window.HTMLDivElement,
     // cannot test reactTestRenderer because of required context
     skip: [

--- a/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/material-ui-lab/src/ClockPicker/ClockPicker.test.tsx
@@ -11,13 +11,12 @@ import {
 import ClockPicker, { clockPickerClasses as classes } from '@material-ui/lab/ClockPicker';
 import {
   adapterToUse,
-  createPickerMount,
+  wrapPickerMount,
   createPickerRender,
   getByMuiTest,
 } from '../internal/pickers/test-utils';
 
 describe('<ClockPicker />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformanceV5(
@@ -25,7 +24,7 @@ describe('<ClockPicker />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
-      mount,
+      wrapMount: wrapPickerMount,
       render,
       refInstanceof: window.HTMLDivElement,
       muiName: 'MuiClockPicker',

--- a/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePicker/DateRangePicker.test.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import DateRangePicker from '@material-ui/lab/DateRangePicker';
 import { describeConformance } from 'test/utils';
-import { createPickerMount, createPickerRender } from '../internal/pickers/test-utils';
+import { createPickerRender, wrapPickerMount } from '../internal/pickers/test-utils';
 
 describe('<DateRangePicker />', () => {
   const render = createPickerRender();
-  const mount = createPickerMount();
 
   describeConformance(
     <DateRangePicker
@@ -16,7 +15,7 @@ describe('<DateRangePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),

--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -3,14 +3,9 @@ import { describeConformanceV5 } from 'test/utils';
 import DateRangePickerDay, {
   dateRangePickerDayClasses as classes,
 } from '@material-ui/lab/DateRangePickerDay';
-import {
-  adapterToUse,
-  createPickerMount,
-  createPickerRender,
-} from '../internal/pickers/test-utils';
+import { adapterToUse, wrapPickerMount, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<DateRangePickerDay />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformanceV5(
@@ -31,7 +26,7 @@ describe('<DateRangePickerDay />', () => {
       inheritComponent: 'button',
       muiName: 'MuiDateRangePickerDay',
       render,
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLButtonElement,
       // cannot test reactTestRenderer because of required context
       skip: [

--- a/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -7,7 +7,7 @@ import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import { DateRange } from '@material-ui/lab/DateRangePicker';
 import DesktopDateRangePicker from '@material-ui/lab/DesktopDateRangePicker';
 import {
-  createPickerMount,
+  wrapPickerMount,
   createPickerRender,
   FakeTransitionComponent,
   adapterToUse,
@@ -24,7 +24,6 @@ const defaultRangeRenderInput = (startProps: TextFieldProps, endProps: TextField
 
 describe('<DesktopDateRangePicker />', () => {
   const render = createPickerRender({ strict: false });
-  const mount = createPickerMount();
 
   before(function beforeHook() {
     if (!/jsdom/.test(window.navigator.userAgent)) {
@@ -41,7 +40,7 @@ describe('<DesktopDateRangePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),

--- a/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -6,11 +6,7 @@ import { act, describeConformance, fireEvent, screen, userEvent } from 'test/uti
 import { TransitionProps } from '@material-ui/core/transitions';
 import { TimePickerProps } from '@material-ui/lab/TimePicker';
 import DesktopTimePicker from '@material-ui/lab/DesktopTimePicker';
-import {
-  createPickerMount,
-  createPickerRender,
-  adapterToUse,
-} from '../internal/pickers/test-utils';
+import { wrapPickerMount, createPickerRender, adapterToUse } from '../internal/pickers/test-utils';
 
 describe('<DesktopTimePicker />', () => {
   let clock: ReturnType<typeof useFakeTimers>;
@@ -23,7 +19,6 @@ describe('<DesktopTimePicker />', () => {
   });
 
   const render = createPickerRender();
-  const mount = createPickerMount();
 
   describeConformance(
     <DesktopTimePicker
@@ -33,7 +28,7 @@ describe('<DesktopTimePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),

--- a/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import MobileDateRangePicker from '@material-ui/lab/MobileDateRangePicker';
 import { describeConformance } from 'test/utils';
-import { createPickerMount, createPickerRender } from '../internal/pickers/test-utils';
+import { wrapPickerMount, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<MobileDateRangePicker />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformance(
@@ -16,7 +15,7 @@ describe('<MobileDateRangePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),

--- a/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/MobileTimePicker/MobileTimePicker.test.tsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { describeConformance, fireEvent, fireTouchChangedEvent } from 'test/utils';
 import MobileTimePicker from '@material-ui/lab/MobileTimePicker';
 import {
-  createPickerMount,
+  wrapPickerMount,
   createPickerRender,
   adapterToUse,
   getByMuiTest,
@@ -29,7 +29,6 @@ function createMouseEventWithOffsets(
 
 describe('<MobileTimePicker />', () => {
   const render = createPickerRender();
-  const mount = createPickerMount();
 
   describeConformance(
     <MobileTimePicker
@@ -39,7 +38,7 @@ describe('<MobileTimePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),

--- a/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
+++ b/packages/material-ui-lab/src/MonthPicker/MonthPicker.test.tsx
@@ -3,14 +3,9 @@ import { spy } from 'sinon';
 import { expect } from 'chai';
 import { fireEvent, screen, describeConformanceV5 } from 'test/utils';
 import MonthPicker, { monthPickerClasses as classes } from '@material-ui/lab/MonthPicker';
-import {
-  adapterToUse,
-  createPickerMount,
-  createPickerRender,
-} from '../internal/pickers/test-utils';
+import { adapterToUse, wrapPickerMount, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<MonthPicker />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformanceV5(
@@ -24,7 +19,7 @@ describe('<MonthPicker />', () => {
       classes,
       inheritComponent: 'div',
       render,
-      mount,
+      wrapMount: wrapPickerMount,
       muiName: 'MuiMonthPicker',
       refInstanceof: window.HTMLDivElement,
       // cannot test reactTestRenderer because of required context

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
@@ -3,14 +3,9 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { describeConformanceV5, fireEvent, screen } from 'test/utils';
 import PickersDay, { pickersDayClasses as classes } from '@material-ui/lab/PickersDay';
-import {
-  adapterToUse,
-  createPickerMount,
-  createPickerRender,
-} from '../internal/pickers/test-utils';
+import { adapterToUse, wrapPickerMount, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<PickersDay />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformanceV5(
@@ -24,7 +19,7 @@ describe('<PickersDay />', () => {
       classes,
       inheritComponent: 'button',
       render,
-      mount,
+      wrapMount: wrapPickerMount,
       muiName: 'MuiPickersDay',
       refInstanceof: window.HTMLButtonElement,
       testVariantProps: { variant: 'disableMargin' },

--- a/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/material-ui-lab/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -6,7 +6,7 @@ import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import StaticDateRangePicker from '@material-ui/lab/StaticDateRangePicker';
 import { describeConformance } from 'test/utils';
 import {
-  createPickerMount,
+  wrapPickerMount,
   createPickerRender,
   adapterToUse,
   getAllByMuiTest,
@@ -28,7 +28,6 @@ describe('<StaticDateRangePicker />', () => {
     clock.restore();
   });
 
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformance(
@@ -39,7 +38,7 @@ describe('<StaticDateRangePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: undefined,
       skip: [
         'componentProp',

--- a/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/material-ui-lab/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import { describeConformance } from 'test/utils';
 import StaticTimePicker from './StaticTimePicker';
-import { createPickerMount } from '../internal/pickers/test-utils';
+import { wrapPickerMount } from '../internal/pickers/test-utils';
 
 describe('<StaticTimePicker />', () => {
-  const mount = createPickerMount();
-
   describeConformance(
     <StaticTimePicker
       onChange={() => {}}
@@ -15,7 +13,7 @@ describe('<StaticTimePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: undefined,
       skip: [
         'componentProp',

--- a/packages/material-ui-lab/src/TabList/TabList.test.js
+++ b/packages/material-ui-lab/src/TabList/TabList.test.js
@@ -1,24 +1,14 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformance } from 'test/utils';
+import { createClientRender, describeConformance } from 'test/utils';
 import Tab from '@material-ui/core/Tab';
 import Tabs, { tabsClasses as classes } from '@material-ui/core/Tabs';
 import TabList from './TabList';
 import TabContext from '../TabContext';
 
 describe('<TabList />', () => {
-  const mount = createMount();
   const render = createClientRender();
-
-  /**
-   *
-   * @param {React.ReactNode} node
-   */
-  function mountInContext(node) {
-    const wrapper = mount(<TabContext value="0">{node}</TabContext>);
-    return wrapper.childAt(0);
-  }
 
   describeConformance(<TabList />, () => ({
     // @ts-expect-error https://github.com/microsoft/TypeScript/issues/15300
@@ -28,7 +18,10 @@ describe('<TabList />', () => {
      * @param {React.ReactNode} node
      */
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
-    mount: mountInContext,
+    wrapMount: (mount) => (node) => {
+      const wrapper = mount(<TabContext value="0">{node}</TabContext>);
+      return wrapper.childAt(0);
+    },
     refInstanceof: window.HTMLDivElement,
     // TODO: no idea why reactTestRenderer fails
     skip: ['reactTestRenderer'],

--- a/packages/material-ui-lab/src/TabPanel/TabPanel.test.tsx
+++ b/packages/material-ui-lab/src/TabPanel/TabPanel.test.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TabPanel, { tabPanelClasses as classes } from '@material-ui/lab/TabPanel';
 import TabContext from '../TabContext';
 
 describe('<TabPanel />', () => {
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(<TabPanel value="0" />, () => ({
     classes,
     inheritComponent: 'div',
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
-    mount: (node) => mount(<TabContext value="0">{node}</TabContext>),
+    wrapMount: (mount) => (node) => mount(<TabContext value="0">{node}</TabContext>),
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiTabPanel',
     skip: [

--- a/packages/material-ui-lab/src/TimePicker/TimePicker.test.tsx
+++ b/packages/material-ui-lab/src/TimePicker/TimePicker.test.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
 import { describeConformance } from 'test/utils';
 import TimePicker from './TimePicker';
-import { createPickerMount } from '../internal/pickers/test-utils';
+import { wrapPickerMount } from '../internal/pickers/test-utils';
 
 describe('<TimePicker />', () => {
-  const mount = createPickerMount();
-
   describeConformance(
     <TimePicker
       onChange={() => {}}
@@ -15,7 +13,7 @@ describe('<TimePicker />', () => {
     />,
     () => ({
       classes: {},
-      mount,
+      wrapMount: wrapPickerMount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp', 'mergeClassName', 'propsSpread', 'rootClass', 'reactTestRenderer'],
     }),

--- a/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
+++ b/packages/material-ui-lab/src/YearPicker/YearPicker.test.tsx
@@ -3,14 +3,9 @@ import { spy } from 'sinon';
 import { expect } from 'chai';
 import { fireEvent, screen, describeConformanceV5 } from 'test/utils';
 import YearPicker, { yearPickerClasses as classes } from '@material-ui/lab/YearPicker';
-import {
-  adapterToUse,
-  createPickerMount,
-  createPickerRender,
-} from '../internal/pickers/test-utils';
+import { adapterToUse, wrapPickerMount, createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<YearPicker />', () => {
-  const mount = createPickerMount();
   const render = createPickerRender();
 
   describeConformanceV5(
@@ -24,7 +19,7 @@ describe('<YearPicker />', () => {
     () => ({
       classes,
       inheritComponent: 'div',
-      mount,
+      wrapMount: wrapPickerMount,
       render,
       muiName: 'MuiYearPicker',
       refInstanceof: window.HTMLDivElement,

--- a/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
+++ b/packages/material-ui-lab/src/internal/pickers/test-utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { parseISO } from 'date-fns';
-import { createClientRender, createMount, fireEvent, screen } from 'test/utils';
+import { createClientRender, fireEvent, screen } from 'test/utils';
 import { queryHelpers, Matcher, MatcherOptions } from '@testing-library/react/pure';
 import { TransitionProps } from '@material-ui/core/transitions';
 import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
@@ -38,9 +38,7 @@ interface PickerRenderOptions {
   locale?: string | object;
 }
 
-export function createPickerMount(options: { strict?: boolean } = {}) {
-  const mount = createMount(options);
-
+export function wrapPickerMount(mount: (node: React.ReactNode) => import('enzyme').ReactWrapper) {
   return (node: React.ReactNode) =>
     mount(<LocalizationProvider dateAdapter={AdapterClassToUse}>{node}</LocalizationProvider>);
 }

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -52,7 +52,6 @@ describe('<Popover />', () => {
     classes,
     inheritComponent: Modal,
     render,
-    mount,
     muiName: 'MuiPopover',
     refInstanceof: window.HTMLDivElement,
     testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import { collapseClasses } from '@material-ui/core/Collapse';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
@@ -8,12 +8,11 @@ import StepContent, { stepContentClasses as classes } from '@material-ui/core/St
 
 describe('<StepContent />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   describeConformanceV5(<StepContent />, () => ({
     classes,
     inheritComponent: 'div',
-    mount: (node) => {
+    wrapMount: (mount) => (node) => {
       const wrapper = mount(
         <Stepper orientation="vertical">
           <Step>{node}</Step>

--- a/packages/material-ui/src/TableBody/TableBody.test.js
+++ b/packages/material-ui/src/TableBody/TableBody.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TableBody, { tableBodyClasses as classes } from '@material-ui/core/TableBody';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 
 describe('<TableBody />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   function renderInTable(node) {
     return render(<table>{node}</table>);
@@ -15,7 +14,7 @@ describe('<TableBody />', () => {
   describeConformanceV5(<TableBody />, () => ({
     classes,
     inheritComponent: 'tbody',
-    mount: (node) => {
+    wrapMount: (mount) => (node) => {
       const wrapper = mount(<table>{node}</table>);
       return wrapper.find('table').childAt(0);
     },

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender, createMount, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TableCell, { tableCellClasses as classes } from '@material-ui/core/TableCell';
 
 describe('<TableCell />', () => {
   const render = createClientRender();
-  const mount = createMount();
   function renderInTable(node) {
     return render(
       <table>
@@ -29,7 +28,7 @@ describe('<TableCell />', () => {
       );
       return { container: container.firstChild.firstChild.firstChild, ...other };
     },
-    mount: (node) => {
+    wrapMount: (mount) => (node) => {
       const wrapper = mount(
         <table>
           <tbody>

--- a/packages/material-ui/src/TableFooter/TableFooter.test.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TableFooter, { tableFooterClasses as classes } from '@material-ui/core/TableFooter';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 
 describe('<TableFooter />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   function renderInTable(node) {
     return render(<table>{node}</table>);
@@ -19,7 +18,7 @@ describe('<TableFooter />', () => {
       const { container, ...other } = render(<table>{node}</table>);
       return { container: container.firstChild, ...other };
     },
-    mount: (node) => {
+    wrapMount: (mount) => (node) => {
       const wrapper = mount(<table>{node}</table>);
       return wrapper.find('table').childAt(0);
     },

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TableHead, { tableHeadClasses as classes } from '@material-ui/core/TableHead';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
 
 describe('<TableHead />', () => {
-  const mount = createMount();
   const render = createClientRender();
   function renderInTable(node) {
     return render(<table>{node}</table>);
@@ -14,7 +13,7 @@ describe('<TableHead />', () => {
   describeConformanceV5(<TableHead />, () => ({
     classes,
     inheritComponent: 'thead',
-    mount: (node) => {
+    wrapMount: (mount) => (node) => {
       const wrapper = mount(<table>{node}</table>);
       return wrapper.find('table').childAt(0);
     },

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { createMount, describeConformanceV5, fireEvent, createClientRender } from 'test/utils';
+import { describeConformanceV5, fireEvent, createClientRender } from 'test/utils';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
@@ -12,7 +12,6 @@ import TablePagination, {
 
 describe('<TablePagination />', () => {
   const noop = () => {};
-  const mount = createMount();
   const render = createClientRender();
 
   describeConformanceV5(
@@ -30,7 +29,7 @@ describe('<TablePagination />', () => {
         );
         return { container: container.firstChild.firstChild.firstChild, ...other };
       },
-      mount: (node) => {
+      wrapMount: (mount) => (node) => {
         const wrapper = mount(
           <table>
             <tbody>

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createClientRender, describeConformanceV5 } from 'test/utils';
+import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TableRow, { tableRowClasses as classes } from '@material-ui/core/TableRow';
 
 describe('<TableRow />', () => {
   const render = createClientRender();
-  const mount = createMount();
 
   function renderInTable(node) {
     return render(
@@ -26,7 +25,7 @@ describe('<TableRow />', () => {
       );
       return { container: container.firstChild.firstChild, ...other };
     },
-    mount: (node) => {
+    wrapMount: (mount) => (node) => {
       const wrapper = mount(
         <table>
           <tbody>{node}</tbody>

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -203,11 +203,11 @@ const fullSuite = {
  * @property {() => void} [after]
  * @property {Record<string, string>} classes - `classes` of the component provided by `@material-ui/styles`
  * @property {import('react').ElementType} [inheritComponent] - The element type that receives spread props or `undefined` if props are not spread.
- * @property {(node: React.ReactNode) => import('enzyme').ReactWrapper} [mount] - By default uses enzyme to mount the component in StrictMode. If you need to wrap the node, pass a custom mount implementation.
  * @property {Array<keyof typeof fullSuite>} [only] - If specified only run the tests listed
  * @property {any} refInstanceof - `ref` will be an instanceof this constructor.
  * @property {Array<keyof typeof fullSuite>} [skip] - Skip the specified tests
  * @property {string} [testComponentPropWith] - The host component that should be rendered instead.
+ * @property {(mount: (node: React.ReactNode) => import('enzyme').ReactWrapper) => (node: React.ReactNode) => import('enzyme').ReactWrapper} [wrapMount] - You can use this option to mount the component with enzyme in a WrapperComponent. Make sure the returned node corresponds to the input node and not the wrapper component.
  */
 
 /**
@@ -220,10 +220,13 @@ export default function describeConformance(minimalElement, getOptions) {
   describe('Material-UI component API', () => {
     const {
       after: runAfterHook = () => {},
-      mount = createMount(),
       only = Object.keys(fullSuite),
       skip = [],
+      wrapMount = (mount) => mount,
     } = getOptions();
+
+    const baseMount = createMount();
+    const mount = wrapMount(baseMount);
 
     after(runAfterHook);
 

--- a/test/utils/describeConformanceV5.js
+++ b/test/utils/describeConformanceV5.js
@@ -18,7 +18,6 @@ import createMount from './createMount';
  * @property {() => void} [after]
  * @property {object} classes - `classes` of the component provided by `@material-ui/styled-engine`
  * @property {import('react').ElementType} [inheritComponent] - The element type that receives spread props or `undefined` if props are not spread.
- * @property {(node: React.ReactNode) => import('enzyme').ReactWrapper} [mount] - Should be a return value from createMount
  * @property {string} muiName
  * @property {(node: React.ReactElement) => import('./createClientRender').MuiRenderResult} [render] - Should be a return value from createClientRender
  * @property {Array<keyof typeof fullSuite>} [only] - If specified only run the tests listed
@@ -28,6 +27,7 @@ import createMount from './createMount';
  * @property {{ slotName: string, slotClassName: string }} [testDeepOverrides]
  * @property {{ prop?: string, value?: any, styleKey: string }} [testStateOverrides]
  * @property {object} [testVariantProps]
+ * @property {(mount: (node: React.ReactNode) => import('enzyme').ReactWrapper) => (node: React.ReactNode) => import('enzyme').ReactWrapper} [wrapMount] - You can use this option to mount the component with enzyme in a WrapperComponent. Make sure the returned node corresponds to the input node and not the wrapper component.
  */
 
 function throwMissingPropError(field) {
@@ -359,14 +359,17 @@ export default function describeConformanceV5(minimalElement, getOptions) {
   describe('Material-UI component API', () => {
     const {
       after: runAfterHook = () => {},
-      mount = createMount(),
       only = Object.keys(fullSuite),
       skip = [],
+      wrapMount,
     } = getOptions();
 
     const filteredTests = Object.keys(fullSuite).filter(
       (testKey) => only.indexOf(testKey) !== -1 && skip.indexOf(testKey) === -1,
     );
+
+    const baseMount = createMount();
+    const mount = wrapMount !== undefined ? wrapMount(baseMount) : baseMount;
 
     after(runAfterHook);
 


### PR DESCRIPTION
This way we know that if we actually create a mount implementation in a test suite, at least one test is using enzyme.

Follow-up to https://github.com/mui-org/material-ui/pull/26949