### PR TITLE
[Theme] fix `createTransitions` types

### DIFF
--- a/packages/material-ui/src/styles/createTransitions.d.ts
+++ b/packages/material-ui/src/styles/createTransitions.d.ts
@@ -49,3 +49,8 @@ export interface Transitions {
   create: typeof create;
   getAutoHeightDuration: typeof getAutoHeightDuration;
 }
+
+export default function createTransitions(inputTransitions?: {
+  easing?: Partial<Easing>;
+  duration?: Partial<Duration>;
+}): Transitions;

--- a/packages/material-ui/src/styles/createTransitions.js
+++ b/packages/material-ui/src/styles/createTransitions.js
@@ -43,7 +43,7 @@ function getAutoHeightDuration(height) {
   return Math.round((4 + 15 * constant ** 0.25 + constant / 5) * 10);
 }
 
-export default function createTransitions(inputTransitions) {
+export default function createTransitions(inputTransitions = {}) {
   const mergedEasing = {
     ...easing,
     ...inputTransitions.easing,

--- a/packages/material-ui/src/styles/createTransitions.spec.ts
+++ b/packages/material-ui/src/styles/createTransitions.spec.ts
@@ -1,0 +1,5 @@
+import createTransitions from './createTransitions';
+
+createTransitions();
+createTransitions({ easing: { easeInOut: 'cubic-bezier(0.4, 0, 0.2, 1)' } });
+createTransitions({ duration: { short: 250 } });

--- a/packages/material-ui/src/styles/createTransitions.spec.ts
+++ b/packages/material-ui/src/styles/createTransitions.spec.ts
@@ -1,5 +1,8 @@
-import createTransitions from './createTransitions';
+import { createTheme, Theme } from '@material-ui/core/styles';
 
-createTransitions();
-createTransitions({ easing: { easeInOut: 'cubic-bezier(0.4, 0, 0.2, 1)' } });
-createTransitions({ duration: { short: 250 } });
+{
+  const transitions = createTheme().transitions;
+  transitions.create('all');
+  transitions.create('all', { easing: 'cubic-bezier(0.4, 0, 0.2, 1)' });
+  transitions.create('all', { duration: 250 });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Context**
Found this issue when doing codemod migration in some project that `createTransitions` has no default export. I also check that `createTypography`, and other `create...` contains `export default` type. So this PR do the same for `createTransitions`.

**Changes**
- add `default export function createTransitions` to `.d.ts`
- add `createTransitions.spec.ts`
- support `createTransitions()` (no need to pass `{}`)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
