### PR TITLE
[docs] Use actual link to paperbase

### DIFF
--- a/docs/src/pages/premium-themes/.eslintrc.js
+++ b/docs/src/pages/premium-themes/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  rules: {
-    'jsx-a11y/anchor-is-valid': 'off',
-    'react/prop-types': 'off',
-  },
-};

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -38,7 +38,7 @@ function Header(props) {
             <Grid item xs />
             <Grid item>
               <Link
-                href="#"
+                href="https://docs.paperbase.app/"
                 variant="body2"
                 sx={{
                   textDecoration: 'none',
@@ -47,6 +47,8 @@ function Header(props) {
                     color: 'common.white',
                   },
                 }}
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Go to docs
               </Link>

--- a/docs/src/pages/premium-themes/paperbase/Header.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Header.tsx
@@ -41,7 +41,7 @@ export default function Header(props: HeaderProps) {
             <Grid item xs />
             <Grid item>
               <Link
-                href="#"
+                href="https://docs.paperbase.app/"
                 variant="body2"
                 sx={{
                   textDecoration: 'none',
@@ -50,6 +50,8 @@ export default function Header(props: HeaderProps) {
                     color: 'common.white',
                   },
                 }}
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Go to docs
               </Link>


### PR DESCRIPTION
Use an actual link in the template instead of a dummy. Dummy components are just confusing in demos. We might as well use an image instead. And it's also confusing since one doesn't know what this link is for without a proper `href`.