### PR TITLE
[docs] Use custom markdown loader for landing page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,8 @@ module.exports = {
     'import/named': 'off',
     // Missing yarn workspace support
     'import/no-extraneous-dependencies': 'off',
+    // The code is already coupled to webpack. Prefer explicit coupling.
+    'import/no-webpack-loader-syntax': 'off',
 
     // doesn't work?
     'jsx-a11y/label-has-associated-control': [
@@ -229,9 +231,6 @@ module.exports = {
     {
       files: ['docs/pages/**/*.js'],
       rules: {
-        // The code is already coupled to webpack.
-        'import/no-webpack-loader-syntax': 'off',
-
         'react/prop-types': 'off',
       },
     },

--- a/docs/packages/markdown/index.js
+++ b/docs/packages/markdown/index.js
@@ -1,0 +1,3 @@
+const { getHeaders, renderInline } = require('./parseMarkdown');
+
+module.exports = { getHeaders, renderInline };

--- a/docs/packages/markdown/index.js
+++ b/docs/packages/markdown/index.js
@@ -1,3 +1,3 @@
-const { getHeaders, renderInline } = require('./parseMarkdown');
+const { createRender, getHeaders, renderInline } = require('./parseMarkdown');
 
-module.exports = { getHeaders, renderInline };
+module.exports = { createRender, getHeaders, renderInline };

--- a/docs/packages/markdown/package.json
+++ b/docs/packages/markdown/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.1",
   "private": true,
   "type": "commonjs",
-  "main": "./parseMarkdown.js",
+  "main": "./index.js",
   "exports": {
-    ".": "./parseMarkdown.js",
+    ".": "./index.js",
     "./loader": "./loader.js",
     "./prism": "./prism.js"
   },

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -7,9 +7,7 @@ import Container from '@material-ui/core/Container';
 import Steps from 'docs/src/pages/landing/Steps';
 import Themes from 'docs/src/pages/landing/Themes';
 import QuickWord from 'docs/src/pages/landing/QuickWord';
-import Sponsors, {
-  getInitialProps as getInitialSponsorsProps,
-} from 'docs/src/pages/landing/Sponsors';
+import Sponsors from 'docs/src/pages/landing/Sponsors';
 import Users from 'docs/src/pages/landing/Users';
 import Quotes from 'docs/src/pages/landing/Quotes';
 import Pro from 'docs/src/pages/landing/Pro';
@@ -86,15 +84,7 @@ const Social = styled('div')(({ theme }) => ({
   },
 }));
 
-interface LandingPageProps {
-  sponsorsProps: {
-    docs: object;
-  };
-}
-
-export default function LandingPage(props: LandingPageProps) {
-  const { sponsorsProps } = props;
-
+export default function LandingPage() {
   React.useEffect(() => {
     loadDependencies();
   }, []);
@@ -160,7 +150,7 @@ export default function LandingPage(props: LandingPageProps) {
           <QuickWord />
           <Steps />
           <Themes />
-          <Sponsors {...sponsorsProps} />
+          <Sponsors />
           <Quotes />
           <Users />
         </main>
@@ -189,9 +179,3 @@ export default function LandingPage(props: LandingPageProps) {
     </AppFrame>
   );
 }
-
-LandingPage.getInitialProps = async () => {
-  return {
-    sponsorsProps: await getInitialSponsorsProps(),
-  };
-};

--- a/docs/src/modules/utils/mapApiPageTranslations.js
+++ b/docs/src/modules/utils/mapApiPageTranslations.js
@@ -1,4 +1,4 @@
-import { createRender } from '@material-ui/markdown/parseMarkdown';
+import { createRender } from '@material-ui/markdown';
 
 const notEnglishJsonRegExp = /-([a-z]{2})\.json$/;
 

--- a/docs/src/pages/landing/Sponsors.js
+++ b/docs/src/pages/landing/Sponsors.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import NoSsr from '@material-ui/core/NoSsr';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import Container from '@material-ui/core/Container';
 import Divider from '@material-ui/core/Divider';
-import { prepareMarkdown } from '@material-ui/markdown/parseMarkdown';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
+import { docs } from '!@material-ui/markdown/loader!./backers.md';
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -28,7 +27,7 @@ const useStyles = makeStyles(
   { name: 'Sponsors' },
 );
 
-export default function Sponsors({ docs }) {
+export default function Sponsors() {
   const classes = useStyles();
   const userLanguage = useUserLanguage();
   const { rendered } = docs[userLanguage];
@@ -51,18 +50,4 @@ export default function Sponsors({ docs }) {
       </NoSsr>
     </div>
   );
-}
-
-Sponsors.propTypes = {
-  docs: PropTypes.object.isRequired,
-};
-
-const requireRaw = require.context('./', false, /\.md$/);
-
-export async function getInitialProps() {
-  const { docs } = prepareMarkdown({
-    pageFilename: '/',
-    requireRaw,
-  });
-  return { docs };
 }


### PR DESCRIPTION
On 3G:
1s faster LCP
.5s faster visually complete

Preview: https://60ded7131d29f000078293ea--material-ui.netlify.app/
webpagetest comparison: https://www.webpagetest.org/video/compare.php?tests=210702_BiDcP4_2cd4ae910ce48056696f0c9380ed0731%2C210702_AiDc1H_9c8e1753971838289020ba4efb8e776d&thumbSize=200&ival=500&end=visual

`yarn docs:build` changes
```diff
Page                                                           Size     First Load JS
-┌ λ /                                                          42.6 kB         328 kB
+┌ λ /                                                          23.9 kB         309 kB
```