### PR TITLE
[theme] Add missing MuiRating types to components.d.ts

### DIFF
--- a/packages/material-ui/src/styles/components.d.ts
+++ b/packages/material-ui/src/styles/components.d.ts
@@ -320,6 +320,10 @@ export interface Components {
     defaultProps?: ComponentsProps['MuiRadio'];
     styleOverrides?: ComponentsOverrides['MuiRadio'];
   };
+  MuiRating?: {
+    defaultProps?: ComponentsProps['MuiRating'];
+    styleOverrides?: ComponentsOverrides['MuiRating'];
+  };
   MuiScopedCssBaseline?: {
     defaultProps?: ComponentsProps['MuiScopedCssBaseline'];
     styleOverrides?: ComponentsOverrides['MuiScopedCssBaseline'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

fixes #27056 