### PR TITLE
[ToggleButton] Remove unnecessary span

### DIFF
--- a/docs/pages/api-docs/toggle-button.json
+++ b/docs/pages/api-docs/toggle-button.json
@@ -33,7 +33,6 @@
       "standard",
       "primary",
       "secondary",
-      "label",
       "sizeSmall",
       "sizeMedium",
       "sizeLarge"

--- a/docs/pages/api-docs/toggle-button.json
+++ b/docs/pages/api-docs/toggle-button.json
@@ -6,7 +6,7 @@
     "color": {
       "type": {
         "name": "union",
-        "description": "'standard'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+        "description": "'standard'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
     },

--- a/docs/pages/api-docs/toggle-button.json
+++ b/docs/pages/api-docs/toggle-button.json
@@ -6,7 +6,7 @@
     "color": {
       "type": {
         "name": "union",
-        "description": "'standard'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
+        "description": "'standard'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
     },

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1713,6 +1713,16 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
 
   You can use the [`moved-lab-modules` codemod](https://github.com/mui-org/material-ui/tree/HEAD/packages/material-ui-codemod#moved-lab-modules) for automatic migration.
 
+- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/27111).
+
+  ```diff
+  <button class="MuiToggleButton-root">
+  - <span class="MuiToggleButton-label">
+      {children}
+  - </span>
+  </button>
+  ```
+
 ### Tooltip
 
 - Tooltips are now interactive by default.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1713,7 +1713,7 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
 
   You can use the [`moved-lab-modules` codemod](https://github.com/mui-org/material-ui/tree/HEAD/packages/material-ui-codemod#moved-lab-modules) for automatic migration.
 
-- `span` element that wraps children has been removed. `wrapper` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/27111).
+- `span` element that wraps children has been removed. `label` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/27111).
 
   ```diff
   <button class="MuiToggleButton-root">

--- a/docs/translations/api-docs/toggle-button/toggle-button.json
+++ b/docs/translations/api-docs/toggle-button/toggle-button.json
@@ -40,10 +40,6 @@
       "nodeName": "the root element",
       "conditions": "<code>color=\"secondary\"</code>"
     },
-    "label": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the `label` wrapper element"
-    },
     "sizeSmall": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
@@ -24,7 +24,7 @@ export type ToggleButtonTypeMap<
      * The color of the button when it is in an active state.
      * @default 'standard'
      */
-    color?: 'standard' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+    color?: 'standard' | 'primary' | 'secondary';
     /**
      * If `true`, the component is disabled.
      * @default false

--- a/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
@@ -24,7 +24,7 @@ export type ToggleButtonTypeMap<
      * The color of the button when it is in an active state.
      * @default 'standard'
      */
-    color?: 'standard' | 'primary' | 'secondary';
+    color?: 'standard' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
     /**
      * If `true`, the component is disabled.
      * @default false

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -22,7 +22,6 @@ const useUtilityClasses = (styleProps) => {
       `size${capitalize(size)}`,
       color,
     ],
-    label: ['label'],
   };
 
   return composeClasses(slots, getToggleButtonUtilityClass, classes);
@@ -36,91 +35,58 @@ const ToggleButtonRoot = styled(ButtonBase, {
 
     return [styles.root, styles[`size${capitalize(styleProps.size)}`]];
   },
-})(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
-  ...theme.typography.button,
-  borderRadius: theme.shape.borderRadius,
-  padding: 11,
-  border: `1px solid ${theme.palette.divider}`,
-  color: theme.palette.action.active,
-  /* Styles applied to the root element if `fullWidth={true}`. */
-  ...(styleProps.fullWidth && {
-    width: '100%',
-  }),
-  [`&.${toggleButtonClasses.disabled}`]: {
-    color: theme.palette.action.disabled,
-    border: `1px solid ${theme.palette.action.disabledBackground}`,
-  },
-  '&:hover': {
-    textDecoration: 'none',
-    // Reset on mouse devices
-    backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.hoverOpacity),
-    '@media (hover: none)': {
-      backgroundColor: 'transparent',
+})(({ theme, styleProps }) => {
+  const selectedColor =
+    styleProps.color === 'standard'
+      ? theme.palette.text.primary
+      : theme.palette[styleProps.color].main;
+  return {
+    ...theme.typography.button,
+    borderRadius: theme.shape.borderRadius,
+    padding: 11,
+    border: `1px solid ${theme.palette.divider}`,
+    color: theme.palette.action.active,
+    /* Styles applied to the root element if `fullWidth={true}`. */
+    ...(styleProps.fullWidth && {
+      width: '100%',
+    }),
+    [`&.${toggleButtonClasses.disabled}`]: {
+      color: theme.palette.action.disabled,
+      border: `1px solid ${theme.palette.action.disabledBackground}`,
     },
-  },
-  /* Styles applied to the root element if `color="standard"`. */
-  ...(styleProps.color === 'standard' && {
+    '&:hover': {
+      textDecoration: 'none',
+      // Reset on mouse devices
+      backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.hoverOpacity),
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
     [`&.${toggleButtonClasses.selected}`]: {
-      color: theme.palette.text.primary,
-      backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.selectedOpacity),
+      color: selectedColor,
+      backgroundColor: alpha(selectedColor, theme.palette.action.selectedOpacity),
       '&:hover': {
         backgroundColor: alpha(
-          theme.palette.text.primary,
+          selectedColor,
           theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
         ),
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
-          backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.selectedOpacity),
+          backgroundColor: alpha(selectedColor, theme.palette.action.selectedOpacity),
         },
       },
     },
-  }),
-  /* Styles applied to the root element if `color!="standard"`. */
-  ...(styleProps.color !== 'standard' && {
-    [`&.${toggleButtonClasses.selected}`]: {
-      color: theme.palette[styleProps.color].main,
-      backgroundColor: alpha(
-        theme.palette[styleProps.color].main,
-        theme.palette.action.selectedOpacity,
-      ),
-      '&:hover': {
-        backgroundColor: alpha(
-          theme.palette[styleProps.color].main,
-          theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
-        ),
-        // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
-          backgroundColor: alpha(
-            theme.palette[styleProps.color].main,
-            theme.palette.action.selectedOpacity,
-          ),
-        },
-      },
-    },
-  }),
-  /* Styles applied to the root element if `size="small"`. */
-  ...(styleProps.size === 'small' && {
-    padding: 7,
-    fontSize: theme.typography.pxToRem(13),
-  }),
-  /* Styles applied to the root element if `size="large"`. */
-  ...(styleProps.size === 'large' && {
-    padding: 15,
-    fontSize: theme.typography.pxToRem(15),
-  }),
-}));
-
-const ToggleButtonLabel = styled('span', {
-  name: 'MuiToggleButton',
-  slot: 'Label',
-  overridesResolver: (props, styles) => styles.label,
-})({
-  /* Styles applied to the label wrapper element. */
-  width: '100%', // Ensure the correct width for iOS Safari
-  display: 'inherit',
-  alignItems: 'inherit',
-  justifyContent: 'inherit',
+    /* Styles applied to the root element if `size="small"`. */
+    ...(styleProps.size === 'small' && {
+      padding: 7,
+      fontSize: theme.typography.pxToRem(13),
+    }),
+    /* Styles applied to the root element if `size="large"`. */
+    ...(styleProps.size === 'large' && {
+      padding: 15,
+      fontSize: theme.typography.pxToRem(15),
+    }),
+  };
 });
 
 const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
@@ -178,9 +144,7 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
       aria-pressed={selected}
       {...other}
     >
-      <ToggleButtonLabel className={classes.label} styleProps={styleProps}>
-        {children}
-      </ToggleButtonLabel>
+      {children}
     </ToggleButtonRoot>
   );
 });
@@ -207,7 +171,7 @@ ToggleButton.propTypes /* remove-proptypes */ = {
    * @default 'standard'
    */
   color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['standard', 'primary', 'secondary']),
+    PropTypes.oneOf(['standard', 'primary', 'secondary', 'error', 'info', 'success', 'warning']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -171,7 +171,7 @@ ToggleButton.propTypes /* remove-proptypes */ = {
    * @default 'standard'
    */
   color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['standard', 'primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.oneOf(['standard', 'primary', 'secondary']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.test.js
@@ -14,7 +14,6 @@ describe('<ToggleButton />', () => {
     render,
     muiName: 'MuiToggleButton',
     testVariantProps: { variant: 'foo' },
-    testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
     testStateOverrides: { prop: 'size', value: 'large', styleKey: 'sizeLarge' },
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'div',

--- a/packages/material-ui/src/ToggleButton/toggleButtonClasses.ts
+++ b/packages/material-ui/src/ToggleButton/toggleButtonClasses.ts
@@ -13,8 +13,6 @@ export interface ToggleButtonClasses {
   primary: string;
   /** Pseudo-class applied to the root element if `color="secondary"`. */
   secondary: string;
-  /** Styles applied to the `label` wrapper element. */
-  label: string;
   /** Styles applied to the root element if `size="small"`. */
   sizeSmall: string;
   /** Styles applied to the root element if `size="medium"`. */
@@ -36,7 +34,6 @@ const toggleButtonClasses: ToggleButtonClasses = generateUtilityClasses('MuiTogg
   'standard',
   'primary',
   'secondary',
-  'label',
   'sizeSmall',
   'sizeMedium',
   'sizeLarge',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

---

### Breaking changes

- [ToggleButton] Remove no longer necessary span wrapper

  `button > span > children` exists as a workaround for flex container bug on button BUT not anymore, so this PR remove the span.

  - ✅ Chrome 83+ (latest 90)
  - ✅ Safari 11+ (latest 14)
  - ✅ Edge
  - ✅ Firefox 63 (latest 89)

 https://github.com/philipwalton/flexbugs#flexbug-9

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
