### PR TITLE
[Fab] Remove no longer necessary span wrapper

### DIFF
--- a/docs/pages/api-docs/fab.json
+++ b/docs/pages/api-docs/fab.json
@@ -34,7 +34,6 @@
   "styles": {
     "classes": [
       "root",
-      "label",
       "primary",
       "secondary",
       "extended",

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -905,6 +905,16 @@ You can use the [`collapse-rename-collapsedheight` codemod](https://github.com/m
   +<Fab variant="circular">
   ```
 
+- `span` element that wraps children has been removed. `label` classKey is also removed. More details about [this change](https://github.com/mui-org/material-ui/pull/27112).
+
+  ```diff
+  <button class="MuiFab-root">
+  - <span class="MuiFab-label">
+      {children}
+  - </span>
+  </button>
+  ```
+
 ### FormControl
 
 - Change the default variant from `standard` to `outlined`. Standard has been removed from the Material Design guidelines.

--- a/docs/translations/api-docs/fab/fab.json
+++ b/docs/translations/api-docs/fab/fab.json
@@ -15,10 +15,6 @@
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },
-    "label": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the span element that wraps the children"
-    },
     "primary": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -20,7 +20,6 @@ const useUtilityClasses = (styleProps) => {
       color === 'primary' && 'primary',
       color === 'secondary' && 'secondary',
     ],
-    label: ['label'],
   };
 
   return composeClasses(slots, getFabUtilityClass, classes);
@@ -144,18 +143,6 @@ const FabRoot = styled(ButtonBase, {
   }),
 );
 
-const FabLabel = styled('span', {
-  name: 'MuiFab',
-  slot: 'Label',
-  overridesResolver: (props, styles) => styles.label,
-})({
-  /* Styles applied to the span element that wraps the children. */
-  width: '100%', // assure the correct width for iOS Safari
-  display: 'inherit',
-  alignItems: 'inherit',
-  justifyContent: 'inherit',
-});
-
 const Fab = React.forwardRef(function Fab(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiFab' });
   const {
@@ -194,9 +181,7 @@ const Fab = React.forwardRef(function Fab(inProps, ref) {
       ref={ref}
       {...other}
     >
-      <FabLabel className={classes.label} styleProps={styleProps}>
-        {children}
-      </FabLabel>
+      {children}
     </FabRoot>
   );
 });

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -20,7 +20,6 @@ describe('<Fab />', () => {
     render,
     muiName: 'MuiFab',
     testVariantProps: { variant: 'extended' },
-    testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
     testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentsProp'],

--- a/packages/material-ui/src/Fab/fabClasses.ts
+++ b/packages/material-ui/src/Fab/fabClasses.ts
@@ -3,8 +3,6 @@ import { generateUtilityClass, generateUtilityClasses } from '@material-ui/unsty
 export interface FabClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the span element that wraps the children. */
-  label: string;
   /** Styles applied to the root element if `color="primary"`. */
   primary: string;
   /** Styles applied to the root element if `color="secondary"`. */
@@ -33,7 +31,6 @@ export function getFabUtilityClass(slot: string): string {
 
 const fabClasses: FabClasses = generateUtilityClasses('MuiFab', [
   'root',
-  'label',
   'primary',
   'secondary',
   'extended',


### PR DESCRIPTION
### Breaking changes

- [Fab] Remove no longer necessary span wrapper

  `button > span > children` exists as a workaround for flex container bug on button BUT not anymore, so this PR remove the span.

- ✅ Chrome 83+ (latest 90)
- ✅ Safari 11+ (latest 14)
- ✅ Edge
- ✅ Firefox 63 (latest 89)

  https://github.com/philipwalton/flexbugs#flexbug-9

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
