### PR TITLE
[core] Run yarn deduplicate on Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -79,6 +79,11 @@
       }
     }
   ],
+  "postUpgradeTasks": {
+    "commands": ["deduplicate"],
+    "fileFilters": ["yarn.lock"],
+    "executionMode": "branch"
+  },
   "prConcurrentLimit": 30,
   "prHourlyLimit": 0,
   "schedule": "on sunday before 6:00am",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -79,11 +79,7 @@
       }
     }
   ],
-  "postUpgradeTasks": {
-    "commands": ["deduplicate"],
-    "fileFilters": ["yarn.lock"],
-    "executionMode": "branch"
-  },
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 30,
   "prHourlyLimit": 0,
   "schedule": "on sunday before 6:00am",


### PR DESCRIPTION
It's a CI check anyway so we might as well run it ourselfs. Safes CI and human resources.

~@oliviertassinari You need to `deduplicate` to `allowedPostUpgradeCommands` which is an admin-only configuration of Renovate (https://docs.renovatebot.com/configuration-options/#postupgradetasks)~