### PR TITLE
[examples] Remove `StyledEngineProvider` as JSS is not used

### DIFF
--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -26,7 +26,6 @@ const {
   Box,
   SvgIcon,
   Link,
-  StyledEngineProvider,
 } = MaterialUI;
 
 // Create a theme instance.
@@ -93,14 +92,11 @@ function App() {
 }
 
 ReactDOM.render(
-  // TODO v5: remove once migration to emotion is completed
-  <StyledEngineProvider injectFirst>
     <ThemeProvider theme={theme}>
       {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
       <CssBaseline />
       <App />
-    </ThemeProvider>
-  </StyledEngineProvider>,
+    </ThemeProvider>,
   document.querySelector('#root'),
 );
     </script>

--- a/examples/create-react-app-with-styled-components-typescript/src/index.tsx
+++ b/examples/create-react-app-with-styled-components-typescript/src/index.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import App from './App';
 
 ReactDOM.render(
-  <>
+  <React.Fragment>
     {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
     <CssBaseline />
     <App />
-  </>,
+  </React.Fragment>,
   document.getElementById('root'),
 );

--- a/examples/create-react-app-with-styled-components-typescript/src/index.tsx
+++ b/examples/create-react-app-with-styled-components-typescript/src/index.tsx
@@ -5,11 +5,10 @@ import { StyledEngineProvider } from '@material-ui/core/styles';
 import App from './App';
 
 ReactDOM.render(
-  // TODO v5: remove once migration to emotion is completed
-  <StyledEngineProvider injectFirst>
+  <>
     {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
     <CssBaseline />
     <App />
-  </StyledEngineProvider>,
+  </>,
   document.getElementById('root'),
 );

--- a/examples/create-react-app-with-styled-components/src/index.js
+++ b/examples/create-react-app-with-styled-components/src/index.js
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
-  // TODO v5: remove once migration to emotion is completed
-  <StyledEngineProvider injectFirst>
+  <>
     {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
     <CssBaseline />
     <App />
-  </StyledEngineProvider>,
+  </>,
   document.getElementById('root'),
 );
 

--- a/examples/create-react-app-with-styled-components/src/index.js
+++ b/examples/create-react-app-with-styled-components/src/index.js
@@ -5,11 +5,11 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
-  <>
+  <React.Fragment>
     {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
     <CssBaseline />
     <App />
-  </>,
+  </React.Fragment>,
   document.getElementById('root'),
 );
 

--- a/examples/create-react-app-with-typescript/src/index.tsx
+++ b/examples/create-react-app-with-typescript/src/index.tsx
@@ -1,19 +1,15 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 
 ReactDOM.render(
-  // TODO v5: remove once migration to emotion is completed
-  <StyledEngineProvider injectFirst>
-    <ThemeProvider theme={theme}>
-      {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-      <CssBaseline />
-      <App />
-    </ThemeProvider>
-  </StyledEngineProvider>,
+  <ThemeProvider theme={theme}>
+    {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+    <CssBaseline />
+    <App />
+  </ThemeProvider>,
   document.querySelector('#root'),
 );

--- a/examples/create-react-app/src/index.js
+++ b/examples/create-react-app/src/index.js
@@ -1,18 +1,15 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider, StyledEngineProvider } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 
 ReactDOM.render(
-  // TODO v5: remove once migration to emotion is completed
-  <StyledEngineProvider injectFirst>
-    <ThemeProvider theme={theme}>
-      {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-      <CssBaseline />
-      <App />
-    </ThemeProvider>
-  </StyledEngineProvider>,
+  <ThemeProvider theme={theme}>
+    {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+    <CssBaseline />
+    <App />
+  </ThemeProvider>,
   document.querySelector('#root'),
 );

--- a/examples/gatsby-theme/src/pages/index.js
+++ b/examples/gatsby-theme/src/pages/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
@@ -9,20 +8,17 @@ import Copyright from '../components/Copyright';
 
 export default function Index() {
   return (
-    // TODO v5: remove once migration to emotion is completed
-    <StyledEngineProvider injectFirst>
-      <Container maxWidth="sm">
-        <Box sx={{ my: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Gatsby v5-beta example
-          </Typography>
-          <Link to="/about" color="secondary">
-            Go to the about page
-          </Link>
-          <ProTip />
-          <Copyright />
-        </Box>
-      </Container>
-    </StyledEngineProvider>
+    <Container maxWidth="sm">
+      <Box sx={{ my: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Gatsby v5-beta example
+        </Typography>
+        <Link to="/about" color="secondary">
+          Go to the about page
+        </Link>
+        <ProTip />
+        <Copyright />
+      </Box>
+    </Container>
   );
 }

--- a/examples/gatsby/src/pages/about.js
+++ b/examples/gatsby/src/pages/about.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
@@ -9,18 +8,15 @@ import Copyright from '../components/Copyright';
 
 export default function About() {
   return (
-    // TODO v5: remove once migration to emotion is completed
-    <StyledEngineProvider injectFirst>
-      <Container maxWidth="sm">
-        <Box sx={{ my: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Gatsby v5-beta example
-          </Typography>
-          <Link to="/">Go to the main page</Link>
-          <ProTip />
-          <Copyright />
-        </Box>
-      </Container>
-    </StyledEngineProvider>
+    <Container maxWidth="sm">
+      <Box sx={{ my: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Gatsby v5-beta example
+        </Typography>
+        <Link to="/">Go to the main page</Link>
+        <ProTip />
+        <Copyright />
+      </Box>
+    </Container>
   );
 }

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
@@ -9,20 +8,17 @@ import Copyright from '../components/Copyright';
 
 export default function Index() {
   return (
-    // TODO v5: remove once migration to emotion is completed
-    <StyledEngineProvider injectFirst>
-      <Container maxWidth="sm">
-        <Box sx={{ my: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Gatsby v5-beta example
-          </Typography>
-          <Link to="/about" color="secondary">
-            Go to the about page
-          </Link>
-          <ProTip />
-          <Copyright />
-        </Box>
-      </Container>
-    </StyledEngineProvider>
+    <Container maxWidth="sm">
+      <Box sx={{ my: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Gatsby v5-beta example
+        </Typography>
+        <Link to="/about" color="secondary">
+          Go to the about page
+        </Link>
+        <ProTip />
+        <Copyright />
+      </Box>
+    </Container>
   );
 }

--- a/examples/preact/src/App.js
+++ b/examples/preact/src/App.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
@@ -8,17 +7,14 @@ import Copyright from './Copyright';
 
 export default function App() {
   return (
-    // TODO v5: remove once migration to emotion is completed
-    <StyledEngineProvider injectFirst>
-      <Container maxWidth="sm">
-        <Box sx={{ my: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Preact v5-beta example
-          </Typography>
-          <ProTip />
-          <Copyright />
-        </Box>
-      </Container>
-    </StyledEngineProvider>
+    <Container maxWidth="sm">
+      <Box sx={{ my: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Preact v5-beta example
+        </Typography>
+        <ProTip />
+        <Copyright />
+      </Box>
+    </Container>
   );
 }


### PR DESCRIPTION
It is safe to remove the `<StyledEngineProvider injectFirst />` from the examples, as all components are migrated to emotion and there is no dependency on `@material-ui/styles`.