### PR TITLE
[docs] Remove usage of `url` package

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import url from 'url';
 import clsx from 'clsx';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -200,7 +199,8 @@ export default function AppSearch() {
         },
         handleSelected: (input, event, suggestion) => {
           event.button = 0;
-          const parseUrl = url.parse(suggestion.url);
+          const parseUrl = document.createElement('a');
+          parseUrl.href = suggestion.url;
           handleEvent(event, parseUrl.pathname + parseUrl.hash);
           input.close();
         },

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import url from 'url';
 import Box from '@material-ui/core/Box';
 import ExpandIcon from '@material-ui/icons/ExpandMore';
 import CollapseIcon from '@material-ui/icons/ChevronRight';
@@ -238,9 +237,18 @@ function DefaultTheme() {
   const [darkTheme, setDarkTheme] = React.useState(false);
 
   React.useEffect(() => {
-    const URL = url.parse(document.location.href, true);
-    // 'expend-path' is for backwards compatibility of any external links with a prior typo.
-    const expandPath = URL.query['expand-path'] || URL.query['expend-path'];
+    let expandPath;
+    decodeURI(document.location.search.slice(1))
+      .split('&')
+      .forEach((param) => {
+        const [name, value] = param.split('=');
+        if (name === 'expand-path') {
+          expandPath = value;
+        } else if (name === 'expend-path' && !expandPath) {
+          // 'expend-path' is for backwards compatibility of any external links with a prior typo.
+          expandPath = value;
+        }
+      });
 
     if (!expandPath) {
       return;


### PR DESCRIPTION
Noticed that we're using the `url` polyfill which isn't even a declared dependency. I suspect that the package is responsible for https://github.com/mui-org/material-ui/issues/26943.

Closes https://github.com/mui-org/material-ui/issues/26943

Preview: https://deploy-preview-27151--material-ui.netlify.app/