### PR TITLE
[core] Fix generation of package.json file on Windows

### DIFF
--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -31,7 +31,7 @@ async function createModulePackages({ from, to }) {
     directoryPackages.map(async (directoryPackage) => {
       const packageJson = {
         sideEffects: false,
-        module: path.join('../esm', directoryPackage, 'index.js'),
+        module: path.posix.join('../esm', directoryPackage, 'index.js'),
         typings: './index.d.ts',
       };
       const packageJsonPath = path.join(to, directoryPackage, 'package.json');


### PR DESCRIPTION
The path for the `module` in v4.12.0 version was broken, as it was released from Windows. For example - https://unpkg.com/browse/@material-ui/core@4.12.0/Accordion/package.json 

The correct one should look like - https://unpkg.com/browse/@material-ui/core@4.11.4/Accordion/package.json

Fixes https://github.com/mui-org/material-ui/issues/27147

We should do a new release once this is merged.