### PR TITLE
[docs] Replace createMuiTheme with createTheme

### DIFF
--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -218,7 +218,7 @@ Starting from v5, Material-UI no longer uses JSS as its default styling solution
 import { makeStyles } from '@material-ui/styles';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-const theme = createMuiTheme();
+const theme = createTheme();
 
 const useStyles = makeStyles((theme) => ({
   root: {


### PR DESCRIPTION
Replaces `createMuiTheme` with `createTheme`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
