### PR TITLE
[docs] Don't crash page if an Ad crashes

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -98,6 +98,40 @@ const inHouseAds = [
   },
 ];
 
+class AdErrorBoundary extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    eventLabel: PropTypes.string.isRequired,
+  };
+
+  state = { didError: false };
+
+  static getDerivedStateFromError() {
+    return { didError: true };
+  }
+
+  componentDidCatch() {
+    const { eventLabel } = this.props;
+    // TODO: Use proper error monitoring service (e.g. Sentry) instead
+    window.ga('send', {
+      hitType: 'event',
+      eventCategory: 'ad',
+      eventAction: 'crash',
+      eventLabel,
+    });
+  }
+
+  render() {
+    const { didError } = this.state;
+    const { children } = this.props;
+
+    if (didError) {
+      return null;
+    }
+    return children;
+  }
+}
+
 function Ad(props) {
   const { classes } = props;
 
@@ -209,7 +243,7 @@ function Ad(props) {
       data-ga-event-action="click"
       data-ga-event-label={eventLabel}
     >
-      {children}
+      <AdErrorBoundary eventLabel={eventLabel}>{children}</AdErrorBoundary>
     </Box>
   );
 }

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -101,7 +101,7 @@ const inHouseAds = [
 class AdErrorBoundary extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    eventLabel: PropTypes.string.isRequired,
+    eventLabel: PropTypes.string,
   };
 
   state = { didError: false };
@@ -111,7 +111,8 @@ class AdErrorBoundary extends React.Component {
   }
 
   componentDidCatch() {
-    const { eventLabel } = this.props;
+    // send explicit `'null'`
+    const eventLabel = String(this.props.eventLabel);
     // TODO: Use proper error monitoring service (e.g. Sentry) instead
     window.ga('send', {
       hitType: 'event',


### PR DESCRIPTION
Follow-up to https://github.com/mui-org/material-ui/pull/27173 and https://github.com/mui-org/material-ui/pull/27151#pullrequestreview-700403457.

The page shouldn't crash if an Ad crashes. We get no ad impressions either way and a bad user impression when it does crash. 

The only downside would be that we won't get any reports when it does crash. Therefore we send custom google-analytics events on crash. Ultimately a proper error monitoring service would do this (e.g. Sentry).

Preview: https://deploy-preview-27178--material-ui.netlify.app/components/alert/

Report (not sure if "custom reports" are user or org specific): https://analytics.google.com/analytics/web/#/my-reports/tV0Fi0LzQT6Pq3dtgC-dFQ/a106598593w159022482p160376982/
Report template: https://analytics.google.com/analytics/web/template?uid=iI67mnEsRg2zboHOKceoiw  