### PR TITLE
[test] Increase BS timeout to 6min

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,7 +18,7 @@ const browserStack = {
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 5.5 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 6 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();


### PR DESCRIPTION
It seems that we have added more tests, the run is now slower and more often hit the limit:

<img width="1080" alt="Capture d’écran 2021-07-08 à 11 42 45" src="https://user-images.githubusercontent.com/3165635/124901595-71378900-dfe2-11eb-8541-dd4010316dc9.png">

https://automate.browserstack.com/dashboard/v2/builds/950ced05fbc968c6ce8e068a01034283c3f98714