### PR TITLE
[docs] Migrate rest of the docs to emotion

### DIFF
--- a/docs/src/modules/components/ComponentLinkHeader.js
+++ b/docs/src/modules/components/ComponentLinkHeader.js
@@ -9,20 +9,18 @@ import BundleSizeIcon from 'docs/src/modules/components/BundleSizeIcon';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import W3CIcon from 'docs/src/modules/components/W3CIcon';
 import MaterialDesignIcon from 'docs/src/modules/components/MaterialDesignIcon';
-import { makeStyles } from '@material-ui/styles';
+import { styled } from '@material-ui/core/styles';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    margin: 0,
-    padding: 0,
-    listStyle: 'none',
-    display: 'flex',
-    flexWrap: 'wrap',
-    marginBottom: theme.spacing(2),
-    '& li': {
-      margin: theme.spacing(0.5),
-    },
+const Root = styled('ul')(({ theme }) => ({
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  display: 'flex',
+  flexWrap: 'wrap',
+  marginBottom: theme.spacing(2),
+  '& li': {
+    margin: theme.spacing(0.5),
   },
 }));
 
@@ -32,7 +30,6 @@ export default function ComponentLinkHeader(props) {
     headers: { packageName = '@material-ui/core' },
     options,
   } = props;
-  const classes = useStyles();
   const t = useTranslate();
 
   if (headers.materialDesign && options.design === false) {
@@ -40,7 +37,7 @@ export default function ComponentLinkHeader(props) {
   }
 
   return (
-    <ul className={classes.root}>
+    <Root>
       {headers.githubLabel ? (
         <li>
           <Chip
@@ -167,7 +164,7 @@ export default function ComponentLinkHeader(props) {
           </li>
         </React.Fragment>
       ) : null}
-    </ul>
+    </Root>
   );
 }
 

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { useSelector } from 'react-redux';
-import { makeStyles } from '@material-ui/styles';
-import { alpha } from '@material-ui/core/styles';
+import { alpha, styled } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import Collapse from '@material-ui/core/Collapse';
 import NoSsr from '@material-ui/core/NoSsr';
@@ -17,27 +15,19 @@ import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 const DemoToolbar = React.lazy(() => import('./DemoToolbar'));
 // Sync with styles from DemoToolbar
 // Importing the styles results in no bundle size reduction
-const useDemoToolbarFallbackStyles = makeStyles(
-  (theme) => {
-    return {
-      root: {
-        display: 'none',
-        [theme.breakpoints.up('sm')]: {
-          display: 'flex',
-          height: theme.spacing(6),
-        },
-      },
-    };
-  },
-  { name: 'DemoToolbar' },
-);
+const DemoToolbarFallbackRoot = styled('div')(({ theme }) => {
+  return {
+    display: 'none',
+    [theme.breakpoints.up('sm')]: {
+      display: 'flex',
+      height: theme.spacing(6),
+    },
+  };
+});
 export function DemoToolbarFallback() {
-  const classes = useDemoToolbarFallbackStyles();
   const t = useTranslate();
 
-  return (
-    <div aria-busy aria-label={t('demoToolbarLabel')} className={classes.root} role="toolbar" />
-  );
+  return <DemoToolbarFallbackRoot aria-busy aria-label={t('demoToolbarLabel')} role="toolbar" />;
 }
 
 function getDemoName(location) {
@@ -81,91 +71,86 @@ function useUniqueId(prefix) {
   return id ? `${prefix}${id}` : id;
 }
 
-const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      marginBottom: 40,
-      marginLeft: theme.spacing(-2),
-      marginRight: theme.spacing(-2),
-      [theme.breakpoints.up('sm')]: {
-        padding: theme.spacing(0, 1),
-        marginLeft: 0,
-        marginRight: 0,
-      },
-    },
-    demo: {
-      position: 'relative',
-      outline: 0,
-      margin: 'auto',
-      display: 'flex',
-      justifyContent: 'center',
-      [theme.breakpoints.up('sm')]: {
-        borderRadius: theme.shape.borderRadius,
-      },
-    },
-    /* Isolate the demo with an outline. */
-    demoBgOutlined: {
-      padding: theme.spacing(3),
-      backgroundColor: theme.palette.background.paper,
-      border: `1px solid ${alpha(theme.palette.action.active, 0.12)}`,
-      borderLeftWidth: 0,
-      borderRightWidth: 0,
-      [theme.breakpoints.up('sm')]: {
-        borderLeftWidth: 1,
-        borderRightWidth: 1,
-      },
-    },
-    /* Prepare the background to display an inner elevation. */
-    demoBgTrue: {
-      padding: theme.spacing(3),
-      backgroundColor: theme.palette.mode === 'dark' ? '#333' : theme.palette.grey[100],
-    },
-    /* Make no difference between the demo and the markdown. */
-    demoBgInline: {
-      // Maintain alignment with the markdown text
-      [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(3),
-      },
-    },
-    demoHiddenToolbar: {
-      paddingTop: theme.spacing(2),
-      [theme.breakpoints.up('sm')]: {
-        paddingTop: theme.spacing(3),
-      },
-    },
-    code: {
-      padding: 0,
-      marginBottom: theme.spacing(1),
-      marginTop: theme.spacing(2),
-      [theme.breakpoints.up('sm')]: {
-        marginTop: theme.spacing(0),
-      },
-      '& pre': {
-        overflow: 'auto',
-        lineHeight: 1.5,
-        margin: '0 auto',
-        maxHeight: 'min(68vh, 1000px)',
-      },
-    },
-    anchorLink: {
-      marginTop: -64, // height of toolbar
-      position: 'absolute',
-    },
-    initialFocus: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: theme.spacing(4),
-      height: theme.spacing(4),
-      pointerEvents: 'none',
+const Root = styled('div')(({ theme }) => ({
+  marginBottom: 40,
+  marginLeft: theme.spacing(-2),
+  marginRight: theme.spacing(-2),
+  [theme.breakpoints.up('sm')]: {
+    padding: theme.spacing(0, 1),
+    marginLeft: 0,
+    marginRight: 0,
+  },
+}));
+const DemoRoot = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'hiddenToolbar' && prop !== 'bg',
+})(({ theme, hiddenToolbar, bg }) => ({
+  position: 'relative',
+  outline: 0,
+  margin: 'auto',
+  display: 'flex',
+  justifyContent: 'center',
+  [theme.breakpoints.up('sm')]: {
+    borderRadius: theme.shape.borderRadius,
+  },
+  /* Isolate the demo with an outline. */
+  ...(bg === 'outlined' && {
+    padding: theme.spacing(3),
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${alpha(theme.palette.action.active, 0.12)}`,
+    borderLeftWidth: 0,
+    borderRightWidth: 0,
+    [theme.breakpoints.up('sm')]: {
+      borderLeftWidth: 1,
+      borderRightWidth: 1,
     },
   }),
-  { name: 'Demo' },
-);
-
+  /* Prepare the background to display an inner elevation. */
+  ...(bg === true && {
+    padding: theme.spacing(3),
+    backgroundColor: theme.palette.mode === 'dark' ? '#333' : theme.palette.grey[100],
+  }),
+  /* Make no difference between the demo and the markdown. */
+  ...(bg === 'inline' && {
+    // Maintain alignment with the markdown text
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(3),
+    },
+  }),
+  ...(hiddenToolbar && {
+    paddingTop: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      paddingTop: theme.spacing(3),
+    },
+  }),
+}));
+const Code = styled(HighlightedCode)(({ theme }) => ({
+  padding: 0,
+  marginBottom: theme.spacing(1),
+  marginTop: theme.spacing(2),
+  [theme.breakpoints.up('sm')]: {
+    marginTop: theme.spacing(0),
+  },
+  '& pre': {
+    overflow: 'auto',
+    lineHeight: 1.5,
+    margin: '0 auto',
+    maxHeight: 'min(68vh, 1000px)',
+  },
+}));
+const AnchorLink = styled('div')({
+  marginTop: -64, // height of toolbar
+  position: 'absolute',
+});
+const InitialFocus = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: theme.spacing(4),
+  height: theme.spacing(4),
+  pointerEvents: 'none',
+}));
 export default function Demo(props) {
   const { demo, demoOptions, disableAd, githubLocation } = props;
-  const classes = useStyles();
   const t = useTranslate();
   const codeVariant = useSelector((state) => state.options.codeVariant);
   const demoData = useDemoData(codeVariant, demo, githubLocation);
@@ -224,25 +209,16 @@ export default function Demo(props) {
   const [showAd, setShowAd] = React.useState(false);
 
   return (
-    <div className={classes.root}>
-      <div className={classes.anchorLink} id={`${demoName}`} />
-      <div
-        className={clsx(classes.demo, {
-          [classes.demoHiddenToolbar]: demoOptions.hideToolbar,
-          [classes.demoBgOutlined]: demoOptions.bg === 'outlined',
-          [classes.demoBgTrue]: demoOptions.bg === true,
-          [classes.demoBgInline]: demoOptions.bg === 'inline',
-        })}
+    <Root>
+      <AnchorLink id={`${demoName}`} />
+      <DemoRoot
+        hiddenToolbar={demoOptions.hideToolbar}
+        bg={demoOptions.bg}
         id={demoId}
         onMouseEnter={handleDemoHover}
         onMouseLeave={handleDemoHover}
       >
-        <IconButton
-          aria-label={t('initialFocusLabel')}
-          className={classes.initialFocus}
-          action={initialFocusRef}
-          tabIndex={-1}
-        />
+        <InitialFocus aria-label={t('initialFocusLabel')} action={initialFocusRef} tabIndex={-1} />
         <DemoSandboxed
           key={demoKey}
           style={demoSandboxedStyle}
@@ -251,9 +227,9 @@ export default function Demo(props) {
           name={demoName}
           onResetDemoClick={resetDemo}
         />
-      </div>
-      <div className={classes.anchorLink} id={`${demoName}.js`} />
-      <div className={classes.anchorLink} id={`${demoName}.tsx`} />
+      </DemoRoot>
+      <AnchorLink id={`${demoName}.js`} />
+      <AnchorLink id={`${demoName}.tsx`} />
       {demoOptions.hideToolbar ? null : (
         <NoSsr defer fallback={<DemoToolbarFallback />}>
           <React.Suspense fallback={<DemoToolbarFallback />}>
@@ -281,8 +257,7 @@ export default function Demo(props) {
       )}
       <Collapse in={openDemoSource} unmountOnExit>
         <div>
-          <HighlightedCode
-            className={classes.code}
+          <Code
             id={demoSourceId}
             code={showPreview && !codeOpen ? jsx : demoData.raw}
             language={demoData.sourceLanguage}
@@ -290,7 +265,7 @@ export default function Demo(props) {
         </div>
       </Collapse>
       {showAd && !disableAd && !demoOptions.disableAd ? <AdCarbonInline /> : null}
-    </div>
+    </Root>
   );
 }
 

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -7,8 +7,8 @@ import rtlPluginSc from 'stylis-plugin-rtl-sc';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { StyleSheetManager } from 'styled-components';
-import { jssPreset, StylesProvider, makeStyles } from '@material-ui/styles';
-import { useTheme } from '@material-ui/core/styles';
+import { jssPreset, StylesProvider } from '@material-ui/styles';
+import { useTheme, styled } from '@material-ui/core/styles';
 import rtl from 'jss-rtl';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
@@ -64,23 +64,17 @@ FramedDemo.propTypes = {
   document: PropTypes.object.isRequired,
 };
 
-const useStyles = makeStyles(
-  (theme) => ({
-    frame: {
-      backgroundColor: theme.palette.background.default,
-      flexGrow: 1,
-      height: 400,
-      border: 0,
-      boxShadow: theme.shadows[1],
-    },
-  }),
-  { name: 'DemoFrame' },
-);
+const Frame = styled('iframe')(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+  flexGrow: 1,
+  height: 400,
+  border: 0,
+  boxShadow: theme.shadows[1],
+}));
 
 function DemoFrame(props) {
   const { children, name, ...other } = props;
   const title = `${name} demo`;
-  const classes = useStyles();
   /**
    * @type {import('react').Ref<HTMLIFrameElement>}
    */
@@ -107,7 +101,7 @@ function DemoFrame(props) {
   const document = frameRef.current?.contentDocument;
   return (
     <React.Fragment>
-      <iframe className={classes.frame} onLoad={onLoad} ref={frameRef} title={title} {...other} />
+      <Frame onLoad={onLoad} ref={frameRef} title={title} {...other} />
       {iframeLoaded !== false
         ? ReactDOM.createPortal(
             <FramedDemo document={document}>{children}</FramedDemo>,

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import copy from 'clipboard-copy';
 import LZString from 'lz-string';
 import { useDispatch } from 'react-redux';
-import { makeStyles } from '@material-ui/styles';
-import { useTheme } from '@material-ui/core/styles';
+import { useTheme, styled } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Fade from '@material-ui/core/Fade';
@@ -42,43 +42,31 @@ function addHiddenInput(form, name, value) {
   form.appendChild(input);
 }
 
-const useDemoToolbarStyles = makeStyles(
-  (theme) => {
-    return {
-      // Sync with styles form DemoToolbarFallback.
-      root: {
-        display: 'none',
-        [theme.breakpoints.up('sm')]: {
-          display: 'flex',
-          flip: false,
-          top: 0,
-          right: theme.spacing(1),
-          height: theme.spacing(6),
-        },
-        justifyContent: 'space-between',
-        alignItems: 'center',
-      },
-      toggleButtonGroup: {
-        margin: '8px 0',
-      },
-      toggleButton: {
-        padding: '4px 9px',
-      },
-      tooltip: {
-        zIndex: theme.zIndex.appBar - 1,
-      },
-    };
+const Root = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('sm')]: {
+    display: 'flex',
+    flip: false,
+    top: 0,
+    right: theme.spacing(1),
+    height: theme.spacing(6),
   },
-  { name: 'DemoToolbar' },
-);
+  justifyContent: 'space-between',
+  alignItems: 'center',
+}));
+
+const DemoTooltip = styled((props) => {
+  const { className, classes = {}, ...other } = props;
+
+  return <Tooltip {...other} classes={{ ...classes, popper: clsx(className, classes.popper) }} />;
+})(({ theme }) => ({
+  zIndex: theme.zIndex.appBar - 1,
+}));
 
 export function DemoToolbarFallback() {
-  const classes = useDemoToolbarStyles();
   const t = useTranslate();
 
-  return (
-    <div aria-busy aria-label={t('demoToolbarLabel')} className={classes.root} role="toolbar" />
-  );
+  return <Root aria-busy aria-label={t('demoToolbarLabel')} role="toolbar" />;
 }
 
 const alwaysTrue = () => true;
@@ -225,8 +213,6 @@ export default function DemoToolbar(props) {
     openDemoSource,
     showPreview,
   } = props;
-
-  const classes = useDemoToolbarStyles();
 
   const dispatch = useDispatch();
   const t = useTranslate();
@@ -438,16 +424,16 @@ export default function DemoToolbar(props) {
 
   return (
     <React.Fragment>
-      <div aria-label={t('demoToolbarLabel')} className={classes.root} {...toolbarProps}>
+      <Root aria-label={t('demoToolbarLabel')} {...toolbarProps}>
         <Fade in={codeOpen}>
           <ToggleButtonGroup
-            className={classes.toggleButtonGroup}
+            sx={{ margin: '8px 0' }}
             exclusive
             value={renderedCodeVariant()}
             onChange={handleCodeLanguageClick}
           >
             <ToggleButton
-              className={classes.toggleButton}
+              sx={{ padding: '4px 9px' }}
               value={CODE_VARIANTS.JS}
               aria-label={t('showJSSource')}
               data-ga-event-category="demo"
@@ -458,7 +444,7 @@ export default function DemoToolbar(props) {
               <JavaScriptIcon />
             </ToggleButton>
             <ToggleButton
-              className={classes.toggleButton}
+              sx={{ padding: '4px 9px' }}
               value={CODE_VARIANTS.TS}
               disabled={!hasTSVariant}
               aria-label={t('showTSSource')}
@@ -472,8 +458,7 @@ export default function DemoToolbar(props) {
           </ToggleButtonGroup>
         </Fade>
         <div>
-          <Tooltip
-            classes={{ popper: classes.tooltip }}
+          <DemoTooltip
             key={showSourceHint}
             open={showSourceHint && atLeastSmallViewport ? true : undefined}
             PopperProps={{ disablePortal: true }}
@@ -492,13 +477,9 @@ export default function DemoToolbar(props) {
             >
               <CodeIcon fontSize="small" />
             </IconButton>
-          </Tooltip>
+          </DemoTooltip>
           {demoOptions.hideEditButton ? null : (
-            <Tooltip
-              classes={{ popper: classes.tooltip }}
-              title={t('codesandbox')}
-              placement="bottom"
-            >
+            <DemoTooltip title={t('codesandbox')} placement="bottom">
               <IconButton
                 size="large"
                 data-ga-event-category="demo"
@@ -509,9 +490,9 @@ export default function DemoToolbar(props) {
               >
                 <EditIcon fontSize="small" />
               </IconButton>
-            </Tooltip>
+            </DemoTooltip>
           )}
-          <Tooltip classes={{ popper: classes.tooltip }} title={t('copySource')} placement="bottom">
+          <DemoTooltip title={t('copySource')} placement="bottom">
             <IconButton
               size="large"
               data-ga-event-category="demo"
@@ -522,8 +503,8 @@ export default function DemoToolbar(props) {
             >
               <FileCopyIcon fontSize="small" />
             </IconButton>
-          </Tooltip>
-          <Tooltip classes={{ popper: classes.tooltip }} title={t('resetFocus')} placement="bottom">
+          </DemoTooltip>
+          <DemoTooltip title={t('resetFocus')} placement="bottom">
             <IconButton
               size="large"
               data-ga-event-category="demo"
@@ -534,8 +515,8 @@ export default function DemoToolbar(props) {
             >
               <ResetFocusIcon fontSize="small" />
             </IconButton>
-          </Tooltip>
-          <Tooltip classes={{ popper: classes.tooltip }} title={t('resetDemo')} placement="bottom">
+          </DemoTooltip>
+          <DemoTooltip title={t('resetDemo')} placement="bottom">
             <IconButton
               size="large"
               aria-controls={demoId}
@@ -547,7 +528,7 @@ export default function DemoToolbar(props) {
             >
               <RefreshIcon fontSize="small" />
             </IconButton>
-          </Tooltip>
+          </DemoTooltip>
           <IconButton
             size="large"
             onClick={handleMoreClick}
@@ -603,7 +584,7 @@ export default function DemoToolbar(props) {
             {devMenuItems}
           </Menu>
         </div>
-      </div>
+      </Root>
       <Snackbar
         open={snackbarOpen}
         autoHideDuration={3000}

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -1,48 +1,45 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/styles';
-import { useTheme } from '@material-ui/core/styles';
+import { useTheme, styled } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& a': {
-      display: 'block',
-      marginBottom: theme.spacing(1),
-    },
-    '& img': {
-      display: 'inline-block',
-    },
+const Root = styled('div')(({ theme }) => ({
+  '& a': {
+    display: 'block',
+    marginBottom: theme.spacing(1),
   },
-  placeholder: {
-    width: 125,
-    height: 35,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: theme.shape.borderRadius,
-    color: theme.palette.divider,
-    border: `1px dashed ${theme.palette.divider}`,
-    transition: theme.transitions.create(['color', 'border-color']),
-    '&&': {
-      display: 'flex',
-    },
-    '&:hover': {
-      borderColor: 'currentColor',
-      color: theme.palette.text.secondary,
-    },
+  '& img': {
+    display: 'inline-block',
+  },
+}));
+
+const Placeholder = styled('a')(({ theme }) => ({
+  width: 125,
+  height: 35,
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: theme.shape.borderRadius,
+  color: theme.palette.divider,
+  border: `1px dashed ${theme.palette.divider}`,
+  transition: theme.transitions.create(['color', 'border-color']),
+  '&&': {
+    display: 'flex',
+  },
+  '&:hover': {
+    borderColor: 'currentColor',
+    color: theme.palette.text.secondary,
   },
 }));
 
 export default function DiamondSponsors(props) {
-  const classes = useStyles();
   const { spot } = props;
   const theme = useTheme();
   const t = useTranslate();
 
   return (
-    <div className={classes.root}>
+    <Root>
       <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
         {t('diamondSponsors')}
       </Typography>
@@ -82,16 +79,15 @@ export default function DiamondSponsors(props) {
           loading="lazy"
         />
       </a>
-      <a
+      <Placeholder
         aria-label={t('diamondSponsors')}
-        className={classes.placeholder}
         rel="noopener noreferrer"
         target="_blank"
         href="/discover-more/backers/#diamond"
       >
         <AddIcon />
-      </a>
-    </div>
+      </Placeholder>
+    </Root>
   );
 }
 

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -1,230 +1,224 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
-import { createTheme, alpha, darken } from '@material-ui/core/styles';
+import { alpha, darken, styled } from '@material-ui/core/styles';
 
-const styles = (theme) => ({
-  root: {
-    ...theme.typography.body1,
-    color: theme.palette.text.primary,
-    wordBreak: 'break-word',
-    '& .anchor-link': {
-      marginTop: -96, // Offset for the anchor.
-      position: 'absolute',
-    },
-    '& pre': {
-      margin: theme.spacing(3, 'auto'),
-      padding: theme.spacing(2),
-      backgroundColor: '#272c34',
-      direction: 'ltr',
-      borderRadius: theme.shape.borderRadius,
-      overflow: 'auto',
-      WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.
-      maxWidth: 'calc(100vw - 32px)',
-      [theme.breakpoints.up('md')]: {
-        maxWidth: 'calc(100vw - 32px - 16px)',
-      },
-    },
-    // inline code
-    '& code': {
-      direction: 'ltr',
-      lineHeight: 1.4,
-      display: 'inline-block',
-      fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
-      WebkitFontSmoothing: 'subpixel-antialiased',
-      padding: '0 3px',
-      color: theme.palette.text.primary,
-      backgroundColor:
-        theme.palette.mode === 'light'
-          ? 'rgba(255, 229, 100, 0.2)'
-          : alpha(theme.palette.primary.main, 0.08),
-      fontSize: '.85em',
-      borderRadius: 2,
-    },
-    '& code[class*="language-"]': {
-      backgroundColor: '#272c34',
-      color: '#fff',
-      // Avoid layout jump after hydration (style injected by prism)
-      lineHeight: 1.5,
-    },
-    // code blocks
-    '& pre code': {
-      fontSize: '.9em',
-    },
-    '& .token.operator': {
-      background: 'transparent',
-    },
-    '& h1': {
-      ...theme.typography.h3,
-      fontSize: 40,
-      margin: '16px 0',
-    },
-    '& .description': {
-      ...theme.typography.h5,
-      margin: '0 0 40px',
-    },
-    '& h2': {
-      ...theme.typography.h4,
-      fontSize: 30,
-      margin: '40px 0 16px',
-    },
-    '& h3': {
-      ...theme.typography.h5,
-      margin: '40px 0 16px',
-    },
-    '& h4': {
-      ...theme.typography.h6,
-      margin: '32px 0 16px',
-    },
-    '& h5': {
-      ...theme.typography.subtitle2,
-      margin: '32px 0 16px',
-    },
-    '& p, & ul, & ol': {
-      marginTop: 0,
-      marginBottom: 16,
-    },
-    '& ul': {
-      paddingLeft: 30,
-    },
-    '& h1, & h2, & h3, & h4': {
-      '& code': {
-        fontSize: 'inherit',
-        lineHeight: 'inherit',
-        // Remove scroll on small screens.
-        wordBreak: 'break-all',
-      },
-      '& .anchor-link-style': {
-        // To prevent the link to get the focus.
-        display: 'none',
-      },
-      '& a:not(.anchor-link-style):hover': {
-        color: 'currentColor',
-        borderBottom: '1px solid currentColor',
-        textDecoration: 'none',
-      },
-      '&:hover .anchor-link-style': {
-        display: 'inline-block',
-        padding: '0 8px',
-        color: theme.palette.text.secondary,
-        '&:hover': {
-          color: theme.palette.text.primary,
-        },
-        '& svg': {
-          width: '0.7em',
-          height: '0.7em',
-          fill: 'currentColor',
-        },
-      },
-    },
-    '& table': {
-      // Trade display table for scroll overflow
-      display: 'block',
-      wordBreak: 'normal',
-      width: '100%',
-      overflowX: 'auto',
-      WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.
-      borderCollapse: 'collapse',
-      marginBottom: '16px',
-      borderSpacing: 0,
-      overflow: 'hidden',
-      '& .prop-name': {
-        fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
-      },
-      '& .required': {
-        color: theme.palette.mode === 'light' ? '#006500' : '#a5ffa5',
-      },
-      '& .optional': {
-        color: theme.palette.type === 'light' ? '#080065' : '#a5b3ff',
-      },
-      '& .prop-type': {
-        fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
-        color: theme.palette.mode === 'light' ? '#932981' : '#ffb6ec',
-      },
-      '& .prop-default': {
-        fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
-        borderBottom: `1px dotted ${theme.palette.divider}`,
-      },
-    },
-    '& td': {
-      ...theme.typography.body2,
-      borderBottom: `1px solid ${theme.palette.divider}`,
-      padding: 16,
-      color: theme.palette.text.primary,
-    },
-    '& td code': {
-      lineHeight: 1.6,
-    },
-    '& th': {
-      lineHeight: theme.typography.pxToRem(24),
-      fontWeight: theme.typography.fontWeightMedium,
-      color: theme.palette.text.primary,
-      whiteSpace: 'pre',
-      borderBottom: `1px solid ${theme.palette.divider}`,
-      padding: 16,
-    },
-    '& blockquote': {
-      borderLeft: '5px solid #ffe564',
-      backgroundColor: 'rgba(255,229,100,0.2)',
-      padding: '4px 24px',
-      margin: '24px 0',
-      '& p': {
-        marginTop: '16px',
-      },
-    },
-    '& a, & a code': {
-      // Style taken from the Link component
-      color: theme.palette.primary.main,
-      textDecoration: 'underline',
-      textDecorationColor: alpha(theme.palette.primary.main, 0.4),
-      '&:hover': {
-        textDecorationColor: 'inherit',
-      },
-    },
-    '& a code': {
-      color:
-        theme.palette.mode === 'dark'
-          ? theme.palette.primary.main
-          : darken(theme.palette.primary.main, 0.04),
-    },
-    '& img, video': {
-      maxWidth: '100%',
-    },
-    '& img': {
-      // Avoid layout jump
-      display: 'inline-block',
-    },
-    '& hr': {
-      height: 1,
-      margin: theme.spacing(6, 0),
-      border: 0,
-      flexShrink: 0,
-      backgroundColor: theme.palette.divider,
-    },
-    '& kbd.key': {
-      // Style taken from GitHub
-      padding: '4px 5px',
-      display: 'inline-block',
-      whiteSpace: 'nowrap',
-      margin: '0 1px',
-      font: '11px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace',
-      lineHeight: '10px',
-      color: theme.palette.text.primary,
-      verticalAlign: 'middle',
-      backgroundColor: theme.palette.mode === 'dark' ? 'transparent' : '#fafbfc',
-      border: `1px solid ${theme.palette.mode === 'dark' ? '#6e7681' : '#d1d5da'}`,
-      borderRadius: 6,
-      boxShadow: `inset 0 -1px 0 ${theme.palette.mode === 'dark' ? '#6e7681' : '#d1d5da'}`,
+const Root = styled('div')(({ theme }) => ({
+  ...theme.typography.body1,
+  color: theme.palette.text.primary,
+  wordBreak: 'break-word',
+  '& .anchor-link': {
+    marginTop: -96, // Offset for the anchor.
+    position: 'absolute',
+  },
+  '& pre': {
+    margin: theme.spacing(3, 'auto'),
+    padding: theme.spacing(2),
+    backgroundColor: '#272c34',
+    direction: 'ltr',
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'auto',
+    WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.
+    maxWidth: 'calc(100vw - 32px)',
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 'calc(100vw - 32px - 16px)',
     },
   },
-});
-const defaultTheme = createTheme();
-const useStyles = makeStyles(styles, { name: 'MarkdownElement', flip: false, defaultTheme });
+  // inline code
+  '& code': {
+    direction: 'ltr',
+    lineHeight: 1.4,
+    display: 'inline-block',
+    fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
+    WebkitFontSmoothing: 'subpixel-antialiased',
+    padding: '0 3px',
+    color: theme.palette.text.primary,
+    backgroundColor:
+      theme.palette.mode === 'light'
+        ? 'rgba(255, 229, 100, 0.2)'
+        : alpha(theme.palette.primary.main, 0.08),
+    fontSize: '.85em',
+    borderRadius: 2,
+  },
+  '& code[class*="language-"]': {
+    backgroundColor: '#272c34',
+    color: '#fff',
+    // Avoid layout jump after hydration (style injected by prism)
+    lineHeight: 1.5,
+  },
+  // code blocks
+  '& pre code': {
+    fontSize: '.9em',
+  },
+  '& .token.operator': {
+    background: 'transparent',
+  },
+  '& h1': {
+    ...theme.typography.h3,
+    fontSize: 40,
+    margin: '16px 0',
+  },
+  '& .description': {
+    ...theme.typography.h5,
+    margin: '0 0 40px',
+  },
+  '& h2': {
+    ...theme.typography.h4,
+    fontSize: 30,
+    margin: '40px 0 16px',
+  },
+  '& h3': {
+    ...theme.typography.h5,
+    margin: '40px 0 16px',
+  },
+  '& h4': {
+    ...theme.typography.h6,
+    margin: '32px 0 16px',
+  },
+  '& h5': {
+    ...theme.typography.subtitle2,
+    margin: '32px 0 16px',
+  },
+  '& p, & ul, & ol': {
+    marginTop: 0,
+    marginBottom: 16,
+  },
+  '& ul': {
+    paddingLeft: 30,
+  },
+  '& h1, & h2, & h3, & h4': {
+    '& code': {
+      fontSize: 'inherit',
+      lineHeight: 'inherit',
+      // Remove scroll on small screens.
+      wordBreak: 'break-all',
+    },
+    '& .anchor-link-style': {
+      // To prevent the link to get the focus.
+      display: 'none',
+    },
+    '& a:not(.anchor-link-style):hover': {
+      color: 'currentColor',
+      borderBottom: '1px solid currentColor',
+      textDecoration: 'none',
+    },
+    '&:hover .anchor-link-style': {
+      display: 'inline-block',
+      padding: '0 8px',
+      color: theme.palette.text.secondary,
+      '&:hover': {
+        color: theme.palette.text.primary,
+      },
+      '& svg': {
+        width: '0.7em',
+        height: '0.7em',
+        fill: 'currentColor',
+      },
+    },
+  },
+  '& table': {
+    // Trade display table for scroll overflow
+    display: 'block',
+    wordBreak: 'normal',
+    width: '100%',
+    overflowX: 'auto',
+    WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.
+    borderCollapse: 'collapse',
+    marginBottom: '16px',
+    borderSpacing: 0,
+    overflow: 'hidden',
+    '& .prop-name': {
+      fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
+    },
+    '& .required': {
+      color: theme.palette.mode === 'light' ? '#006500' : '#a5ffa5',
+    },
+    '& .optional': {
+      color: theme.palette.type === 'light' ? '#080065' : '#a5b3ff',
+    },
+    '& .prop-type': {
+      fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
+      color: theme.palette.mode === 'light' ? '#932981' : '#ffb6ec',
+    },
+    '& .prop-default': {
+      fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
+      borderBottom: `1px dotted ${theme.palette.divider}`,
+    },
+  },
+  '& td': {
+    ...theme.typography.body2,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    padding: 16,
+    color: theme.palette.text.primary,
+  },
+  '& td code': {
+    lineHeight: 1.6,
+  },
+  '& th': {
+    lineHeight: theme.typography.pxToRem(24),
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.palette.text.primary,
+    whiteSpace: 'pre',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    padding: 16,
+  },
+  '& blockquote': {
+    borderLeft: '5px solid #ffe564',
+    backgroundColor: 'rgba(255,229,100,0.2)',
+    padding: '4px 24px',
+    margin: '24px 0',
+    '& p': {
+      marginTop: '16px',
+    },
+  },
+  '& a, & a code': {
+    // Style taken from the Link component
+    color: theme.palette.primary.main,
+    textDecoration: 'underline',
+    textDecorationColor: alpha(theme.palette.primary.main, 0.4),
+    '&:hover': {
+      textDecorationColor: 'inherit',
+    },
+  },
+  '& a code': {
+    color:
+      theme.palette.mode === 'dark'
+        ? theme.palette.primary.main
+        : darken(theme.palette.primary.main, 0.04),
+  },
+  '& img, video': {
+    maxWidth: '100%',
+  },
+  '& img': {
+    // Avoid layout jump
+    display: 'inline-block',
+  },
+  '& hr': {
+    height: 1,
+    margin: theme.spacing(6, 0),
+    border: 0,
+    flexShrink: 0,
+    backgroundColor: theme.palette.divider,
+  },
+  '& kbd.key': {
+    // Style taken from GitHub
+    padding: '4px 5px',
+    display: 'inline-block',
+    whiteSpace: 'nowrap',
+    margin: '0 1px',
+    font: '11px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace',
+    lineHeight: '10px',
+    color: theme.palette.text.primary,
+    verticalAlign: 'middle',
+    backgroundColor: theme.palette.mode === 'dark' ? 'transparent' : '#fafbfc',
+    border: `1px solid ${theme.palette.mode === 'dark' ? '#6e7681' : '#d1d5da'}`,
+    borderRadius: 6,
+    boxShadow: `inset 0 -1px 0 ${theme.palette.mode === 'dark' ? '#6e7681' : '#d1d5da'}`,
+  },
+}));
 
 const MarkdownElement = React.forwardRef(function MarkdownElement(props, ref) {
   const { className, renderedMarkdown, ...other } = props;
-  const classes = useStyles();
   const more = {};
 
   if (typeof renderedMarkdown === 'string') {
@@ -233,14 +227,7 @@ const MarkdownElement = React.forwardRef(function MarkdownElement(props, ref) {
     more.dangerouslySetInnerHTML = { __html: renderedMarkdown };
   }
 
-  return (
-    <div
-      className={clsx(classes.root, 'markdown-body', className)}
-      {...more}
-      {...other}
-      ref={ref}
-    />
-  );
+  return <Root className={clsx('markdown-body', className)} {...more} {...other} ref={ref} />;
 });
 
 MarkdownElement.propTypes = {

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger, react-hooks/exhaustive-deps */
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { makeStyles } from '@material-ui/styles';
+import { styled } from '@material-ui/core/styles';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import Tooltip from '@material-ui/core/Tooltip';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -10,40 +10,37 @@ import Badge from '@material-ui/core/Badge';
 import Typography from '@material-ui/core/Typography';
 import Popper from '@material-ui/core/Popper';
 import Grow from '@material-ui/core/Grow';
-import Paper from '@material-ui/core/Paper';
+import MuiPaper from '@material-ui/core/Paper';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import Divider from '@material-ui/core/Divider';
+import MuiList from '@material-ui/core/List';
+import MuiListItem from '@material-ui/core/ListItem';
+import MuiDivider from '@material-ui/core/Divider';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import { ACTION_TYPES } from 'docs/src/modules/constants';
 import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 
-const useStyles = makeStyles((theme) => ({
-  paper: {
-    transformOrigin: 'top right',
-  },
-  list: {
-    width: theme.spacing(40),
-    maxHeight: theme.spacing(40),
-    overflow: 'auto',
-  },
-  listItem: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  loading: {
-    display: 'flex',
-    justifyContent: 'center',
-    margin: theme.spacing(1, 0),
-  },
-  divider: {
-    margin: theme.spacing(1, 0),
-  },
+const Paper = styled(MuiPaper)({
+  transformOrigin: 'top right',
+});
+const List = styled(MuiList)(({ theme }) => ({
+  width: theme.spacing(40),
+  maxHeight: theme.spacing(40),
+  overflow: 'auto',
+}));
+const ListItem = styled(MuiListItem)({
+  display: 'flex',
+  flexDirection: 'column',
+});
+const Loading = styled('div')(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  margin: theme.spacing(1, 0),
+}));
+const Divider = styled(MuiDivider)(({ theme }) => ({
+  margin: theme.spacing(1, 0),
 }));
 
 export default function Notifications() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
   const anchorRef = React.useRef(null);
@@ -176,12 +173,12 @@ export default function Notifications() {
             }}
           >
             <Grow in={open} {...TransitionProps}>
-              <Paper className={classes.paper}>
-                <List className={classes.list}>
+              <Paper>
+                <List>
                   {messageList ? (
                     messageList.map((message, index) => (
                       <React.Fragment key={message.id}>
-                        <ListItem alignItems="flex-start" className={classes.listItem}>
+                        <ListItem alignItems="flex-start">
                           <Typography gutterBottom>{message.title}</Typography>
                           <Typography gutterBottom variant="body2">
                             <span
@@ -199,15 +196,13 @@ export default function Notifications() {
                             </Typography>
                           )}
                         </ListItem>
-                        {index < messageList.length - 1 ? (
-                          <Divider className={classes.divider} />
-                        ) : null}
+                        {index < messageList.length - 1 ? <Divider /> : null}
                       </React.Fragment>
                     ))
                   ) : (
-                    <div className={classes.loading}>
+                    <Loading>
                       <CircularProgress size={32} />
-                    </div>
+                    </Loading>
                   )}
                 </List>
               </Paper>

--- a/docs/src/pages/components/date-picker/CustomDay.js
+++ b/docs/src/pages/components/date-picker/CustomDay.js
@@ -49,7 +49,6 @@ export default function CustomDay() {
 
     return (
       <React.Fragment>
-        {/* @ts-ignore TODO: fix type issue with generics */}
         <CustomPickersDay
           {...pickersDayProps}
           disableMargin

--- a/docs/src/pages/components/date-picker/CustomDay.js
+++ b/docs/src/pages/components/date-picker/CustomDay.js
@@ -1,43 +1,38 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/styles';
-import { createTheme } from '@material-ui/core/styles';
+import { styled } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import StaticDatePicker from '@material-ui/lab/StaticDatePicker';
 import PickersDay from '@material-ui/lab/PickersDay';
-import clsx from 'clsx';
 import endOfWeek from 'date-fns/endOfWeek';
 import isSameDay from 'date-fns/isSameDay';
 import isWithinInterval from 'date-fns/isWithinInterval';
 import startOfWeek from 'date-fns/startOfWeek';
 
-const defaultTheme = createTheme();
-
-const useStyles = makeStyles(
-  (theme) => ({
-    highlight: {
-      borderRadius: 0,
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.common.white,
-      '&:hover, &:focus': {
-        backgroundColor: theme.palette.primary.dark,
-      },
-    },
-    firstHighlight: {
-      borderTopLeftRadius: '50%',
-      borderBottomLeftRadius: '50%',
-    },
-    endHighlight: {
-      borderTopRightRadius: '50%',
-      borderBottomRightRadius: '50%',
+const CustomPickersDay = styled(PickersDay, {
+  shouldForwardProp: (prop) =>
+    prop !== 'dayIsBetween' && prop !== 'isFirstDay' && prop !== 'isLastDay',
+})(({ theme, dayIsBetween, isFirstDay, isLastDay }) => ({
+  ...(dayIsBetween && {
+    borderRadius: 0,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.common.white,
+    '&:hover, &:focus': {
+      backgroundColor: theme.palette.primary.dark,
     },
   }),
-  { defaultTheme },
-);
+  ...(isFirstDay && {
+    borderTopLeftRadius: '50%',
+    borderBottomLeftRadius: '50%',
+  }),
+  ...(isLastDay && {
+    borderTopRightRadius: '50%',
+    borderBottomRightRadius: '50%',
+  }),
+}));
 
 export default function CustomDay() {
-  const classes = useStyles();
   const [value, setValue] = React.useState(new Date());
 
   const renderWeekPickerDay = (date, selectedDates, pickersDayProps) => {
@@ -53,15 +48,16 @@ export default function CustomDay() {
     const isLastDay = isSameDay(date, end);
 
     return (
-      <PickersDay
-        {...pickersDayProps}
-        disableMargin
-        className={clsx({
-          [classes.highlight]: dayIsBetween,
-          [classes.firstHighlight]: isFirstDay,
-          [classes.endHighlight]: isLastDay,
-        })}
-      />
+      <React.Fragment>
+        {/* @ts-ignore TODO: fix type issue with generics */}
+        <CustomPickersDay
+          {...pickersDayProps}
+          disableMargin
+          dayIsBetween={dayIsBetween}
+          isFirstDay={isFirstDay}
+          isLastDay={isLastDay}
+        />
+      </React.Fragment>
     );
   };
 

--- a/docs/src/pages/components/date-picker/CustomDay.js
+++ b/docs/src/pages/components/date-picker/CustomDay.js
@@ -48,15 +48,13 @@ export default function CustomDay() {
     const isLastDay = isSameDay(date, end);
 
     return (
-      <React.Fragment>
-        <CustomPickersDay
-          {...pickersDayProps}
-          disableMargin
-          dayIsBetween={dayIsBetween}
-          isFirstDay={isFirstDay}
-          isLastDay={isLastDay}
-        />
-      </React.Fragment>
+      <CustomPickersDay
+        {...pickersDayProps}
+        disableMargin
+        dayIsBetween={dayIsBetween}
+        isFirstDay={isFirstDay}
+        isLastDay={isLastDay}
+      />
     );
   };
 

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -1,43 +1,44 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/styles';
-import { Theme, createTheme } from '@material-ui/core/styles';
+import { styled } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import StaticDatePicker from '@material-ui/lab/StaticDatePicker';
 import PickersDay, { PickersDayProps } from '@material-ui/lab/PickersDay';
-import clsx from 'clsx';
 import endOfWeek from 'date-fns/endOfWeek';
 import isSameDay from 'date-fns/isSameDay';
 import isWithinInterval from 'date-fns/isWithinInterval';
 import startOfWeek from 'date-fns/startOfWeek';
 
-const defaultTheme = createTheme();
-
-const useStyles = makeStyles(
-  (theme: Theme) => ({
-    highlight: {
-      borderRadius: 0,
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.common.white,
-      '&:hover, &:focus': {
-        backgroundColor: theme.palette.primary.dark,
-      },
-    },
-    firstHighlight: {
-      borderTopLeftRadius: '50%',
-      borderBottomLeftRadius: '50%',
-    },
-    endHighlight: {
-      borderTopRightRadius: '50%',
-      borderBottomRightRadius: '50%',
+const CustomPickersDay = styled(PickersDay, {
+  shouldForwardProp: (prop) =>
+    prop !== 'dayIsBetween' && prop !== 'isFirstDay' && prop !== 'isLastDay',
+})<
+  PickersDayProps<Date> & {
+    dayIsBetween: boolean;
+    isFirstDay: boolean;
+    isLastDay: boolean;
+  }
+>(({ theme, dayIsBetween, isFirstDay, isLastDay }) => ({
+  ...(dayIsBetween && {
+    borderRadius: 0,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.common.white,
+    '&:hover, &:focus': {
+      backgroundColor: theme.palette.primary.dark,
     },
   }),
-  { defaultTheme },
-);
+  ...(isFirstDay && {
+    borderTopLeftRadius: '50%',
+    borderBottomLeftRadius: '50%',
+  }),
+  ...(isLastDay && {
+    borderTopRightRadius: '50%',
+    borderBottomRightRadius: '50%',
+  }),
+}));
 
 export default function CustomDay() {
-  const classes = useStyles();
   const [value, setValue] = React.useState<Date | null>(new Date());
 
   const renderWeekPickerDay = (
@@ -57,15 +58,16 @@ export default function CustomDay() {
     const isLastDay = isSameDay(date, end);
 
     return (
-      <PickersDay
-        {...pickersDayProps}
-        disableMargin
-        className={clsx({
-          [classes.highlight]: dayIsBetween,
-          [classes.firstHighlight]: isFirstDay,
-          [classes.endHighlight]: isLastDay,
-        })}
-      />
+      <React.Fragment>
+        {/* @ts-ignore TODO: fix type issue with generics */}
+        <CustomPickersDay
+          {...pickersDayProps}
+          disableMargin
+          dayIsBetween={dayIsBetween}
+          isFirstDay={isFirstDay}
+          isLastDay={isLastDay}
+        />
+      </React.Fragment>
     );
   };
 

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -58,15 +58,13 @@ export default function CustomDay() {
     const isLastDay = isSameDay(date, end);
 
     return (
-      <React.Fragment>
-        <CustomPickersDay
-          {...pickersDayProps}
-          disableMargin
-          dayIsBetween={dayIsBetween}
-          isFirstDay={isFirstDay}
-          isLastDay={isLastDay}
-        />
-      </React.Fragment>
+      <CustomPickersDay
+        {...pickersDayProps}
+        disableMargin
+        dayIsBetween={dayIsBetween}
+        isFirstDay={isFirstDay}
+        isLastDay={isLastDay}
+      />
     );
   };
 

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -59,7 +59,6 @@ export default function CustomDay() {
 
     return (
       <React.Fragment>
-        {/* @ts-ignore TODO: fix type issue with generics */}
         <CustomPickersDay
           {...pickersDayProps}
           disableMargin

--- a/docs/src/pages/components/date-picker/CustomDay.tsx
+++ b/docs/src/pages/components/date-picker/CustomDay.tsx
@@ -10,16 +10,16 @@ import isSameDay from 'date-fns/isSameDay';
 import isWithinInterval from 'date-fns/isWithinInterval';
 import startOfWeek from 'date-fns/startOfWeek';
 
+type CustomPickerDayProps = PickersDayProps<Date> & {
+  dayIsBetween: boolean;
+  isFirstDay: boolean;
+  isLastDay: boolean;
+};
+
 const CustomPickersDay = styled(PickersDay, {
   shouldForwardProp: (prop) =>
     prop !== 'dayIsBetween' && prop !== 'isFirstDay' && prop !== 'isLastDay',
-})<
-  PickersDayProps<Date> & {
-    dayIsBetween: boolean;
-    isFirstDay: boolean;
-    isLastDay: boolean;
-  }
->(({ theme, dayIsBetween, isFirstDay, isLastDay }) => ({
+})<CustomPickerDayProps>(({ theme, dayIsBetween, isFirstDay, isLastDay }) => ({
   ...(dayIsBetween && {
     borderRadius: 0,
     backgroundColor: theme.palette.primary.main,
@@ -36,7 +36,7 @@ const CustomPickersDay = styled(PickersDay, {
     borderTopRightRadius: '50%',
     borderBottomRightRadius: '50%',
   }),
-}));
+})) as React.ComponentType<CustomPickerDayProps>;
 
 export default function CustomDay() {
   const [value, setValue] = React.useState<Date | null>(new Date());

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
@@ -33,11 +33,7 @@ export default function CustomDateRangePickerDay() {
   const [value, setValue] = React.useState([null, null]);
 
   const renderWeekPickerDay = (date, dateRangePickerDayProps) => {
-    return (
-      <React.Fragment>
-        <DateRangePickerDay {...dateRangePickerDayProps} />
-      </React.Fragment>
-    );
+    return <DateRangePickerDay {...dateRangePickerDayProps} />;
   };
 
   return (

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
@@ -1,53 +1,43 @@
 import * as React from 'react';
-import { createTheme } from '@material-ui/core/styles';
-import { makeStyles } from '@material-ui/styles';
+import { styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
 import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 
 import StaticDateRangePicker from '@material-ui/lab/StaticDateRangePicker';
-import DateRangePickerDay from '@material-ui/lab/DateRangePickerDay';
-import clsx from 'clsx';
+import MuiDateRangePickerDay from '@material-ui/lab/DateRangePickerDay';
 
-const defaultTheme = createTheme();
-
-const useStyles = makeStyles(
-  (theme) => ({
-    highlight: {
+const DateRangePickerDay = styled(MuiDateRangePickerDay)(
+  ({ theme, isHighlighting, isStartOfHighlighting, isEndOfHighlighting }) => ({
+    ...(isHighlighting && {
       borderRadius: 0,
       backgroundColor: theme.palette.primary.main,
       color: theme.palette.common.white,
       '&:hover, &:focus': {
         backgroundColor: theme.palette.primary.dark,
       },
-    },
-    firstHighlight: {
+    }),
+    ...(isStartOfHighlighting && {
       borderTopLeftRadius: '50%',
       borderBottomLeftRadius: '50%',
-    },
-    endHighlight: {
+    }),
+    ...(isEndOfHighlighting && {
       borderTopRightRadius: '50%',
       borderBottomRightRadius: '50%',
-    },
+    }),
   }),
-  { defaultTheme },
 );
 
 export default function CustomDateRangePickerDay() {
-  const classes = useStyles();
   const [value, setValue] = React.useState([null, null]);
 
   const renderWeekPickerDay = (date, dateRangePickerDayProps) => {
     return (
-      <DateRangePickerDay
-        {...dateRangePickerDayProps}
-        className={clsx(dateRangePickerDayProps.className, {
-          [classes.firstHighlight]: dateRangePickerDayProps.isStartOfHighlighting,
-          [classes.endHighlight]: dateRangePickerDayProps.isEndOfHighlighting,
-          [classes.highlight]: dateRangePickerDayProps.isHighlighting,
-        })}
-      />
+      <React.Fragment>
+        {/* @ts-ignore TODO: fix type issue with generics */}
+        <DateRangePickerDay {...dateRangePickerDayProps} />
+      </React.Fragment>
     );
   };
 

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.js
@@ -35,7 +35,6 @@ export default function CustomDateRangePickerDay() {
   const renderWeekPickerDay = (date, dateRangePickerDayProps) => {
     return (
       <React.Fragment>
-        {/* @ts-ignore TODO: fix type issue with generics */}
         <DateRangePickerDay {...dateRangePickerDayProps} />
       </React.Fragment>
     );

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
@@ -1,43 +1,37 @@
 import * as React from 'react';
-import { createTheme, Theme } from '@material-ui/core/styles';
-import { makeStyles } from '@material-ui/styles';
+import { styled } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
 import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
 import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import { DateRange } from '@material-ui/lab/DateRangePicker';
 import StaticDateRangePicker from '@material-ui/lab/StaticDateRangePicker';
-import DateRangePickerDay, {
+import MuiDateRangePickerDay, {
   DateRangePickerDayProps,
 } from '@material-ui/lab/DateRangePickerDay';
-import clsx from 'clsx';
 
-const defaultTheme = createTheme();
-
-const useStyles = makeStyles(
-  (theme: Theme) => ({
-    highlight: {
+const DateRangePickerDay = styled(MuiDateRangePickerDay)(
+  ({ theme, isHighlighting, isStartOfHighlighting, isEndOfHighlighting }) => ({
+    ...(isHighlighting && {
       borderRadius: 0,
       backgroundColor: theme.palette.primary.main,
       color: theme.palette.common.white,
       '&:hover, &:focus': {
         backgroundColor: theme.palette.primary.dark,
       },
-    },
-    firstHighlight: {
+    }),
+    ...(isStartOfHighlighting && {
       borderTopLeftRadius: '50%',
       borderBottomLeftRadius: '50%',
-    },
-    endHighlight: {
+    }),
+    ...(isEndOfHighlighting && {
       borderTopRightRadius: '50%',
       borderBottomRightRadius: '50%',
-    },
+    }),
   }),
-  { defaultTheme },
 );
 
 export default function CustomDateRangePickerDay() {
-  const classes = useStyles();
   const [value, setValue] = React.useState<DateRange<Date>>([null, null]);
 
   const renderWeekPickerDay = (
@@ -45,14 +39,10 @@ export default function CustomDateRangePickerDay() {
     dateRangePickerDayProps: DateRangePickerDayProps<Date>,
   ) => {
     return (
-      <DateRangePickerDay
-        {...dateRangePickerDayProps}
-        className={clsx(dateRangePickerDayProps.className, {
-          [classes.firstHighlight]: dateRangePickerDayProps.isStartOfHighlighting,
-          [classes.endHighlight]: dateRangePickerDayProps.isEndOfHighlighting,
-          [classes.highlight]: dateRangePickerDayProps.isHighlighting,
-        })}
-      />
+      <React.Fragment>
+        {/* @ts-ignore TODO: fix type issue with generics */}
+        <DateRangePickerDay {...dateRangePickerDayProps} />
+      </React.Fragment>
     );
   };
 

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
@@ -38,11 +38,7 @@ export default function CustomDateRangePickerDay() {
     date: Date,
     dateRangePickerDayProps: DateRangePickerDayProps<Date>,
   ) => {
-    return (
-      <React.Fragment>
-        <DateRangePickerDay {...dateRangePickerDayProps} />
-      </React.Fragment>
-    );
+    return <DateRangePickerDay {...dateRangePickerDayProps} />;
   };
 
   return (

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
@@ -40,7 +40,6 @@ export default function CustomDateRangePickerDay() {
   ) => {
     return (
       <React.Fragment>
-        {/* @ts-ignore TODO: fix type issue with generics */}
         <DateRangePickerDay {...dateRangePickerDayProps} />
       </React.Fragment>
     );

--- a/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
+++ b/docs/src/pages/components/date-range-picker/CustomDateRangePickerDay.tsx
@@ -29,7 +29,7 @@ const DateRangePickerDay = styled(MuiDateRangePickerDay)(
       borderBottomRightRadius: '50%',
     }),
   }),
-);
+) as React.ComponentType<DateRangePickerDayProps<Date>>;
 
 export default function CustomDateRangePickerDay() {
   const [value, setValue] = React.useState<DateRange<Date>>([null, null]);

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -226,7 +226,7 @@ const CanvasComponent = styled(Box)(({ theme }) => ({
       : 'linear-gradient(45deg, #595959 25%, transparent 25%), linear-gradient(-45deg, #595959 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #595959 75%), linear-gradient(-45deg, transparent 75%, #595959 75%)',
 }));
 
-const FontSizeComponent = styled(Box)(({ theme }) => ({
+const FontSizeComponent = styled('span')(({ theme }) => ({
   margin: theme.spacing(2),
 }));
 
@@ -321,20 +321,20 @@ const DialogDetails = React.memo(function DialogDetails(props) {
                   <Grid item>
                     <Tooltip title="fontSize small">
                       <FontSizeComponent
-                        component={selectedIcon.Component}
+                        as={selectedIcon.Component}
                         fontSize="small"
                       />
                     </Tooltip>
                   </Grid>
                   <Grid item>
                     <Tooltip title="fontSize medium">
-                      <FontSizeComponent component={selectedIcon.Component} />
+                      <FontSizeComponent as={selectedIcon.Component} />
                     </Tooltip>
                   </Grid>
                   <Grid item>
                     <Tooltip title="fontSize large">
                       <FontSizeComponent
-                        component={selectedIcon.Component}
+                        as={selectedIcon.Component}
                         fontSize="large"
                       />
                     </Tooltip>

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/styles';
-import { createTheme } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
+import { styled } from '@material-ui/core/styles';
+import MuiPaper from '@material-ui/core/Paper';
+import Box from '@material-ui/core/Box';
 import copy from 'clipboard-copy';
-import clsx from 'clsx';
 import InputBase from '@material-ui/core/InputBase';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
@@ -83,8 +82,6 @@ if (process.env.NODE_ENV !== 'production') {
 //   DeleteForeverSharp,
 // };
 
-const defaultTheme = createTheme();
-
 function selectNode(node) {
   // Clear any current selection
   const selection = window.getSelection();
@@ -96,8 +93,42 @@ function selectNode(node) {
   selection.addRange(range);
 }
 
+const StyledIcon = styled('span')(({ theme }) => ({
+  display: 'inline-block',
+  width: 86,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  margin: '0 4px',
+  fontSize: 12,
+  '& p': {
+    margin: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+}));
+
+const StyledSvgIcon = styled(Box)(({ theme }) => ({
+  boxSizing: 'content-box',
+  cursor: 'pointer',
+  color: theme.palette.text.primary,
+  borderRadius: theme.shape.borderRadius,
+  transition: theme.transitions.create(['background-color', 'box-shadow'], {
+    duration: theme.transitions.duration.shortest,
+  }),
+  fontSize: 40,
+  padding: theme.spacing(2),
+  margin: theme.spacing(0.5, 0),
+  '&:hover': {
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: theme.shadows[1],
+  },
+}));
+
 const Icons = React.memo(function Icons(props) {
-  const { icons, classes, handleOpenClick } = props;
+  const { icons, handleOpenClick } = props;
 
   const handleIconClick = (icon) => () => {
     if (Math.random() < 0.1) {
@@ -125,21 +156,20 @@ const Icons = React.memo(function Icons(props) {
       {icons.map((icon) => {
         /* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
         return (
-          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-          <span
+          <StyledIcon
             key={icon.importName}
             onClick={handleIconClick(icon)}
-            className={clsx('markdown-body', classes.icon)}
+            className="markdown-body"
           >
-            <icon.Component
+            <StyledSvgIcon
+              component={icon.Component}
               tabIndex={-1}
               onClick={handleOpenClick}
               title={icon.importName}
-              className={classes.iconSvg}
             />
             <p onClick={handleLabelClick}>{icon.importName}</p>
             {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
-          </span>
+          </StyledIcon>
         );
       })}
     </div>
@@ -147,90 +177,90 @@ const Icons = React.memo(function Icons(props) {
 });
 
 Icons.propTypes = {
-  classes: PropTypes.object.isRequired,
   handleOpenClick: PropTypes.func.isRequired,
   icons: PropTypes.array.isRequired,
 };
 
-const useDialogStyles = makeStyles(
-  (theme) => ({
-    title: {
-      display: 'inline-block',
-      cursor: 'pointer',
-      transition: theme.transitions.create('background-color', {
-        duration: theme.transitions.duration.shortest,
-      }),
-      '&:hover': {
-        backgroundColor: '#96c6fd80',
-      },
-    },
-    markdown: {
-      cursor: 'pointer',
-      transition: theme.transitions.create('background-color', {
-        duration: theme.transitions.duration.shortest,
-      }),
-      '&:hover': {
-        '& code': {
-          backgroundColor: '#96c6fd80',
-        },
-      },
-      '& pre': {
-        borderRadius: 0,
-        margin: 0,
-      },
-    },
-    import: {
-      textAlign: 'right',
-      padding: theme.spacing(0.5, 1),
-    },
-    canvas: {
-      fontSize: 210,
-      marginTop: theme.spacing(2),
-      color: theme.palette.text.primary,
-      backgroundSize: '30px 30px',
-      backgroundColor: 'transparent',
-      backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0',
-      backgroundImage:
-        theme.palette.mode === 'light'
-          ? 'linear-gradient(45deg, #e6e6e6 25%, transparent 25%), linear-gradient(-45deg, #e6e6e6 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e6e6e6 75%), linear-gradient(-45deg, transparent 75%, #e6e6e6 75%)'
-          : 'linear-gradient(45deg, #595959 25%, transparent 25%), linear-gradient(-45deg, #595959 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #595959 75%), linear-gradient(-45deg, transparent 75%, #595959 75%)',
-    },
-    fontSize: {
-      margin: theme.spacing(2),
-    },
-    context: {
-      margin: theme.spacing(0.5),
-      padding: theme.spacing(1, 2),
-      borderRadius: theme.shape.borderRadius,
-      boxSizing: 'content-box',
-    },
-    contextPrimary: {
-      color: theme.palette.primary.main,
-    },
-    contextPrimaryInverse: {
-      color: theme.palette.primary.contrastText,
-      backgroundColor: theme.palette.primary.main,
-    },
-    contextTextPrimary: {
-      color: theme.palette.text.primary,
-    },
-    contextTextPrimaryInverse: {
-      color: theme.palette.background.paper,
-      backgroundColor: theme.palette.text.primary,
-    },
-    contextTextSecondary: {
-      color: theme.palette.text.secondary,
-    },
-    contextTextSecondaryInverse: {
-      color: theme.palette.background.paper,
-      backgroundColor: theme.palette.text.secondary,
-    },
+const ImportLink = styled(Link)(({ theme }) => ({
+  textAlign: 'right',
+  padding: theme.spacing(0.5, 1),
+}));
+
+const Markdown = styled(HighlightedCode)(({ theme }) => ({
+  cursor: 'pointer',
+  transition: theme.transitions.create('background-color', {
+    duration: theme.transitions.duration.shortest,
   }),
-  { defaultTheme },
-);
+  '&:hover': {
+    '& code': {
+      backgroundColor: '#96c6fd80',
+    },
+  },
+  '& pre': {
+    borderRadius: 0,
+    margin: 0,
+  },
+}));
+
+const Title = styled(Typography)(({ theme }) => ({
+  display: 'inline-block',
+  cursor: 'pointer',
+  transition: theme.transitions.create('background-color', {
+    duration: theme.transitions.duration.shortest,
+  }),
+  '&:hover': {
+    backgroundColor: '#96c6fd80',
+  },
+}));
+
+const CanvasComponent = styled(Box)(({ theme }) => ({
+  fontSize: 210,
+  marginTop: theme.spacing(2),
+  color: theme.palette.text.primary,
+  backgroundSize: '30px 30px',
+  backgroundColor: 'transparent',
+  backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0',
+  backgroundImage:
+    theme.palette.mode === 'light'
+      ? 'linear-gradient(45deg, #e6e6e6 25%, transparent 25%), linear-gradient(-45deg, #e6e6e6 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e6e6e6 75%), linear-gradient(-45deg, transparent 75%, #e6e6e6 75%)'
+      : 'linear-gradient(45deg, #595959 25%, transparent 25%), linear-gradient(-45deg, #595959 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #595959 75%), linear-gradient(-45deg, transparent 75%, #595959 75%)',
+}));
+
+const FontSizeComponent = styled(Box)(({ theme }) => ({
+  margin: theme.spacing(2),
+}));
+
+const ContextComponent = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'contextColor',
+})(({ theme, contextColor }) => ({
+  margin: theme.spacing(0.5),
+  padding: theme.spacing(1, 2),
+  borderRadius: theme.shape.borderRadius,
+  boxSizing: 'content-box',
+  ...(contextColor === 'primary' && {
+    color: theme.palette.primary.main,
+  }),
+  ...(contextColor === 'primaryInverse' && {
+    color: theme.palette.primary.contrastText,
+    backgroundColor: theme.palette.primary.main,
+  }),
+  ...(contextColor === 'textPrimary' && {
+    color: theme.palette.text.primary,
+  }),
+  ...(contextColor === 'textPrimaryInverse' && {
+    color: theme.palette.background.paper,
+    backgroundColor: theme.palette.text.primary,
+  }),
+  ...(contextColor === 'textSecondary' && {
+    color: theme.palette.text.secondary,
+  }),
+  ...(contextColor === 'textSecondaryInverse' && {
+    color: theme.palette.background.paper,
+    backgroundColor: theme.palette.text.secondary,
+  }),
+}));
 
 const DialogDetails = React.memo(function DialogDetails(props) {
-  const classes = useDialogStyles();
   const { open, selectedIcon, handleClose } = props;
 
   const t = useTranslate();
@@ -256,14 +286,9 @@ const DialogDetails = React.memo(function DialogDetails(props) {
                 onExited: () => setCopied1(false),
               }}
             >
-              <Typography
-                component="h2"
-                variant="h6"
-                className={classes.title}
-                onClick={handleClick(1)}
-              >
+              <Title component="h2" variant="h6" onClick={handleClick(1)}>
                 {selectedIcon.importName}
-              </Typography>
+              </Title>
             </Tooltip>
           </DialogTitle>
           <Tooltip
@@ -271,80 +296,78 @@ const DialogDetails = React.memo(function DialogDetails(props) {
             title={copied2 ? t('copied') : t('clickToCopy')}
             TransitionProps={{ onExited: () => setCopied2(false) }}
           >
-            <HighlightedCode
-              className={classes.markdown}
+            <Markdown
               onClick={handleClick(2)}
               code={`import ${selectedIcon.importName}Icon from '@material-ui/icons/${selectedIcon.importName}';`}
               language="js"
             />
           </Tooltip>
-          <Link
-            className={classes.import}
+          <ImportLink
             color="text.secondary"
             href="/components/icons/"
             variant="caption"
           >
             {t('searchIcons.learnMore')}
-          </Link>
+          </ImportLink>
           <DialogContent>
             <Grid container>
               <Grid item xs>
                 <Grid container justifyContent="center">
-                  <selectedIcon.Component className={classes.canvas} />
+                  <CanvasComponent component={selectedIcon.Component} />
                 </Grid>
               </Grid>
               <Grid item xs>
                 <Grid container alignItems="flex-end" justifyContent="center">
                   <Grid item>
                     <Tooltip title="fontSize small">
-                      <selectedIcon.Component
-                        className={classes.fontSize}
+                      <FontSizeComponent
+                        component={selectedIcon.Component}
                         fontSize="small"
                       />
                     </Tooltip>
                   </Grid>
                   <Grid item>
                     <Tooltip title="fontSize medium">
-                      <selectedIcon.Component className={classes.fontSize} />
+                      <FontSizeComponent component={selectedIcon.Component} />
                     </Tooltip>
                   </Grid>
                   <Grid item>
                     <Tooltip title="fontSize large">
-                      <selectedIcon.Component
-                        className={classes.fontSize}
+                      <FontSizeComponent
+                        component={selectedIcon.Component}
                         fontSize="large"
                       />
                     </Tooltip>
                   </Grid>
                 </Grid>
                 <Grid container justifyContent="center">
-                  <selectedIcon.Component
-                    className={clsx(classes.context, classes.contextPrimary)}
+                  <ContextComponent
+                    component={selectedIcon.Component}
+                    contextColor="primary"
                   />
-                  <selectedIcon.Component
-                    className={clsx(classes.context, classes.contextPrimaryInverse)}
-                  />
-                </Grid>
-                <Grid container justifyContent="center">
-                  <selectedIcon.Component
-                    className={clsx(classes.context, classes.contextTextPrimary)}
-                  />
-                  <selectedIcon.Component
-                    className={clsx(
-                      classes.context,
-                      classes.contextTextPrimaryInverse,
-                    )}
+                  <ContextComponent
+                    component={selectedIcon.Component}
+                    contextColor="primaryInverse"
                   />
                 </Grid>
                 <Grid container justifyContent="center">
-                  <selectedIcon.Component
-                    className={clsx(classes.context, classes.contextTextSecondary)}
+                  <ContextComponent
+                    component={selectedIcon.Component}
+                    contextColor="textPrimary"
                   />
-                  <selectedIcon.Component
-                    className={clsx(
-                      classes.context,
-                      classes.contextTextSecondaryInverse,
-                    )}
+                  <ContextComponent
+                    component={selectedIcon.Component}
+                    contextColor="textPrimaryInverse"
+                  />
+                </Grid>
+                <Grid container justifyContent="center">
+                  <ContextComponent
+                    component={selectedIcon.Component}
+                    contextColor="textSecondary"
+                  />
+                  <ContextComponent
+                    component={selectedIcon.Component}
+                    contextColor="textSecondaryInverse"
                   />
                 </Grid>
               </Grid>
@@ -367,68 +390,24 @@ DialogDetails.propTypes = {
   selectedIcon: PropTypes.object,
 };
 
-const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      minHeight: 500,
-    },
-    form: {
-      margin: theme.spacing(2, 0),
-    },
-    paper: {
-      position: 'sticky',
-      top: 80,
-      padding: '2px 4px',
-      display: 'flex',
-      alignItems: 'center',
-      marginBottom: theme.spacing(2),
-      width: '100%',
-    },
-    input: {
-      marginLeft: 8,
-      flex: 1,
-    },
-    iconButton: {
-      padding: 10,
-    },
-    icon: {
-      display: 'inline-block',
-      width: 86,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      textAlign: 'center',
-      color: theme.palette.text.secondary,
-      margin: '0 4px',
-      fontSize: 12,
-      '& p': {
-        margin: 0,
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-      },
-    },
-    iconSvg: {
-      boxSizing: 'content-box',
-      cursor: 'pointer',
-      color: theme.palette.text.primary,
-      borderRadius: theme.shape.borderRadius,
-      transition: theme.transitions.create(['background-color', 'box-shadow'], {
-        duration: theme.transitions.duration.shortest,
-      }),
-      fontSize: 40,
-      padding: theme.spacing(2),
-      margin: theme.spacing(0.5, 0),
-      '&:hover': {
-        backgroundColor: theme.palette.background.paper,
-        boxShadow: theme.shadows[1],
-      },
-    },
-    results: {
-      marginBottom: theme.spacing(1),
-    },
-  }),
-  { defaultTheme },
-);
+const Form = styled('form')(({ theme }) => ({
+  margin: theme.spacing(2, 0),
+}));
+
+const Paper = styled(MuiPaper)(({ theme }) => ({
+  position: 'sticky',
+  top: 80,
+  padding: '2px 4px',
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: theme.spacing(2),
+  width: '100%',
+}));
+
+const Input = styled(InputBase)({
+  marginLeft: 8,
+  flex: 1,
+});
 
 const searchIndex = new FlexSearchIndex({
   tokenize: 'full',
@@ -469,7 +448,6 @@ const allIcons = Object.keys(mui)
   });
 
 export default function SearchIcons() {
-  const classes = useStyles();
   const [theme, setTheme] = React.useState('Filled');
   const [keys, setKeys] = React.useState(null);
   const [open, setOpen] = React.useState(false);
@@ -523,9 +501,9 @@ export default function SearchIcons() {
   );
 
   return (
-    <Grid container className={classes.root}>
+    <Grid container sx={{ minHeight: 500 }}>
       <Grid item xs={12} sm={3}>
-        <form className={classes.form}>
+        <Form>
           <RadioGroup>
             {['Filled', 'Outlined', 'Rounded', 'Two tone', 'Sharp'].map(
               (currentTheme) => {
@@ -545,27 +523,24 @@ export default function SearchIcons() {
               },
             )}
           </RadioGroup>
-        </form>
+        </Form>
       </Grid>
       <Grid item xs={12} sm={9}>
-        <Paper className={classes.paper}>
-          <IconButton className={classes.iconButton} aria-label="search">
+        <Paper>
+          <IconButton sx={{ padding: '10px' }} aria-label="search">
             <SearchIcon />
           </IconButton>
-          <InputBase
+          <Input
             autoFocus
             onChange={(event) => {
               handleChange(event.target.value);
             }}
-            className={classes.input}
             placeholder="Search icons…"
             inputProps={{ 'aria-label': 'search icons' }}
           />
         </Paper>
-        <Typography
-          className={classes.results}
-        >{`${icons.length} matching results`}</Typography>
-        <Icons icons={icons} classes={classes} handleOpenClick={handleOpenClick} />
+        <Typography sx={{ mb: 1 }}>{`${icons.length} matching results`}</Typography>
+        <Icons icons={icons} handleOpenClick={handleOpenClick} />
       </Grid>
       <DialogDetails
         open={open}

--- a/docs/src/pages/components/popper/ScrollPlayground.js
+++ b/docs/src/pages/components/popper/ScrollPlayground.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { createTheme } from '@material-ui/core/styles';
-import { makeStyles } from '@material-ui/styles';
+import { styled } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
-import Popper from '@material-ui/core/Popper';
+import MuiPopper from '@material-ui/core/Popper';
 import Paper from '@material-ui/core/Paper';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -16,97 +16,66 @@ import Switch from '@material-ui/core/Switch';
 import TextField from '@material-ui/core/TextField';
 import FormGroup from '@material-ui/core/FormGroup';
 
-const defaultTheme = createTheme();
+const Popper = styled(MuiPopper)(({ theme }) => ({
+  zIndex: 1,
+  '&[data-popper-placement*="bottom"] $arrow': {
+    top: 0,
+    left: 0,
+    marginTop: '-0.9em',
+    width: '3em',
+    height: '1em',
+    '&::before': {
+      borderWidth: '0 1em 1em 1em',
+      borderColor: `transparent transparent ${theme.palette.background.paper} transparent`,
+    },
+  },
+  '&[data-popper-placement*="top"] $arrow': {
+    bottom: 0,
+    left: 0,
+    marginBottom: '-0.9em',
+    width: '3em',
+    height: '1em',
+    '&::before': {
+      borderWidth: '1em 1em 0 1em',
+      borderColor: `${theme.palette.background.paper} transparent transparent transparent`,
+    },
+  },
+  '&[data-popper-placement*="right"] $arrow': {
+    left: 0,
+    marginLeft: '-0.9em',
+    height: '3em',
+    width: '1em',
+    '&::before': {
+      borderWidth: '1em 1em 1em 0',
+      borderColor: `transparent ${theme.palette.background.paper} transparent transparent`,
+    },
+  },
+  '&[data-popper-placement*="left"] $arrow': {
+    right: 0,
+    marginRight: '-0.9em',
+    height: '3em',
+    width: '1em',
+    '&::before': {
+      borderWidth: '1em 0 1em 1em',
+      borderColor: `transparent transparent transparent ${theme.palette.background.paper}`,
+    },
+  },
+}));
 
-const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      flexGrow: 1,
-    },
-    scrollContainer: {
-      height: 400,
-      overflow: 'auto',
-      marginBottom: theme.spacing(3),
-    },
-    scroll: {
-      position: 'relative',
-      width: '230%',
-      backgroundColor: theme.palette.background.paper,
-      height: '230%',
-    },
-    legend: {
-      marginTop: theme.spacing(2),
-      maxWidth: 300,
-    },
-    paper: {
-      maxWidth: 400,
-      overflow: 'auto',
-    },
-    select: {
-      width: 200,
-    },
-    popper: {
-      zIndex: 1,
-      '&[data-popper-placement*="bottom"] $arrow': {
-        top: 0,
-        left: 0,
-        marginTop: '-0.9em',
-        width: '3em',
-        height: '1em',
-        '&::before': {
-          borderWidth: '0 1em 1em 1em',
-          borderColor: `transparent transparent ${theme.palette.background.paper} transparent`,
-        },
-      },
-      '&[data-popper-placement*="top"] $arrow': {
-        bottom: 0,
-        left: 0,
-        marginBottom: '-0.9em',
-        width: '3em',
-        height: '1em',
-        '&::before': {
-          borderWidth: '1em 1em 0 1em',
-          borderColor: `${theme.palette.background.paper} transparent transparent transparent`,
-        },
-      },
-      '&[data-popper-placement*="right"] $arrow': {
-        left: 0,
-        marginLeft: '-0.9em',
-        height: '3em',
-        width: '1em',
-        '&::before': {
-          borderWidth: '1em 1em 1em 0',
-          borderColor: `transparent ${theme.palette.background.paper} transparent transparent`,
-        },
-      },
-      '&[data-popper-placement*="left"] $arrow': {
-        right: 0,
-        marginRight: '-0.9em',
-        height: '3em',
-        width: '1em',
-        '&::before': {
-          borderWidth: '1em 0 1em 1em',
-          borderColor: `transparent transparent transparent ${theme.palette.background.paper}`,
-        },
-      },
-    },
-    arrow: {
-      position: 'absolute',
-      fontSize: 7,
-      width: '3em',
-      height: '3em',
-      '&::before': {
-        content: '""',
-        margin: 'auto',
-        display: 'block',
-        width: 0,
-        height: 0,
-        borderStyle: 'solid',
-      },
-    },
-  }),
-  { defaultTheme },
-);
+const Arrow = styled('div')({
+  position: 'absolute',
+  fontSize: 7,
+  width: '3em',
+  height: '3em',
+  '&::before': {
+    content: '""',
+    margin: 'auto',
+    display: 'block',
+    width: 0,
+    height: 0,
+    borderStyle: 'solid',
+  },
+});
 
 export default function ScrollPlayground() {
   const anchorRef = React.useRef(null);
@@ -144,8 +113,6 @@ export default function ScrollPlayground() {
     container.scrollTop = element.clientHeight / 4;
     container.scrollLeft = element.clientWidth / 4;
   };
-
-  const classes = useStyles();
 
   const jsx = `
 <Popper
@@ -185,10 +152,15 @@ export default function ScrollPlayground() {
   const id = open ? 'scroll-playground' : null;
 
   return (
-    <div className={classes.root}>
-      <div className={classes.scrollContainer}>
+    <Box sx={{ flexGrow: 1 }}>
+      <Box sx={{ height: 400, overflow: 'auto', mb: 3 }}>
         <Grid
-          className={classes.scroll}
+          sx={{
+            position: 'relative',
+            width: '230%',
+            bgcolor: 'background.paper',
+            height: '230%',
+          }}
           container
           alignItems="center"
           justifyContent="center"
@@ -203,7 +175,7 @@ export default function ScrollPlayground() {
             >
               Toggle Popper
             </Button>
-            <Typography className={classes.legend}>
+            <Typography sx={{ mt: 2, maxWidth: 300 }}>
               Scroll around this container to experiment with flip and
               preventOverflow modifiers.
             </Typography>
@@ -213,7 +185,6 @@ export default function ScrollPlayground() {
               anchorEl={anchorRef.current}
               placement={placement}
               disablePortal={disablePortal}
-              className={classes.popper}
               modifiers={[
                 {
                   name: 'flip',
@@ -244,8 +215,8 @@ export default function ScrollPlayground() {
                 },
               ]}
             >
-              {arrow ? <div className={classes.arrow} ref={setArrowRef} /> : null}
-              <Paper className={classes.paper}>
+              {arrow ? <Arrow ref={setArrowRef} /> : null}
+              <Paper sx={{ maxWidth: 400, overflow: 'auto' }}>
                 <DialogTitle>{"Use Google's location service?"}</DialogTitle>
                 <DialogContent>
                   <DialogContentText>
@@ -260,7 +231,7 @@ export default function ScrollPlayground() {
             </Popper>
           </div>
         </Grid>
-      </div>
+      </Box>
       <Grid container spacing={2}>
         <Grid container item xs={12}>
           <Grid item xs={12}>
@@ -271,7 +242,7 @@ export default function ScrollPlayground() {
           <Grid item xs={6}>
             <TextField
               margin="dense"
-              className={classes.select}
+              sx={{ width: 200 }}
               label="Placement"
               select
               InputLabelProps={{
@@ -498,6 +469,6 @@ export default function ScrollPlayground() {
         </Grid>
       </Grid>
       <HighlightedCode code={jsx} language="jsx" />
-    </div>
+    </Box>
   );
 }

--- a/docs/src/pages/customization/palette/Intentions.js
+++ b/docs/src/pages/customization/palette/Intentions.js
@@ -1,40 +1,36 @@
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/styles';
 import {
   createTheme,
   ThemeProvider,
   useTheme,
   rgbToHex,
+  styled,
 } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
-  },
-  group: {
-    marginTop: theme.spacing(3),
-  },
-  color: {
-    display: 'flex',
-    alignItems: 'center',
-    '& div:first-of-type': {
-      width: theme.spacing(6),
-      height: theme.spacing(6),
-      marginRight: theme.spacing(1),
-      borderRadius: theme.shape.borderRadius,
-      boxShadow: 'inset 0 2px 4px 0 rgba(0, 0, 0, .06)',
-    },
+const Group = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(3),
+}));
+
+const Color = styled(Grid)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  '& div:first-of-type': {
+    width: theme.spacing(6),
+    height: theme.spacing(6),
+    marginRight: theme.spacing(1),
+    borderRadius: theme.shape.borderRadius,
+    boxShadow: 'inset 0 2px 4px 0 rgba(0, 0, 0, .06)',
   },
 }));
 
 function IntentionsInner() {
-  const classes = useStyles();
   const theme = useTheme();
 
   const item = (color, name) => (
-    <Grid item xs={12} sm={6} md={4} className={classes.color}>
+    <Color item xs={12} sm={6} md={4}>
       <div style={{ backgroundColor: color }} />
       <div>
         <Typography variant="body2">{name}</Typography>
@@ -42,60 +38,48 @@ function IntentionsInner() {
           {rgbToHex(color)}
         </Typography>
       </div>
-    </Grid>
+    </Color>
   );
 
   return (
-    <div className={classes.root}>
-      <Typography gutterBottom className={classes.group}>
-        Primary
-      </Typography>
+    <Box sx={{ width: '100%' }}>
+      <Group>Primary</Group>
       <Grid container spacing={2}>
         {item(theme.palette.primary.light, 'palette.primary.light')}
         {item(theme.palette.primary.main, 'palette.primary.main')}
         {item(theme.palette.primary.dark, 'palette.primary.dark')}
       </Grid>
-      <Typography gutterBottom className={classes.group}>
-        Secondary
-      </Typography>
+      <Group>Secondary</Group>
       <Grid container spacing={2}>
         {item(theme.palette.secondary.light, 'palette.secondary.light')}
         {item(theme.palette.secondary.main, 'palette.secondary.main')}
         {item(theme.palette.secondary.dark, 'palette.secondary.dark')}
       </Grid>
-      <Typography gutterBottom className={classes.group}>
-        Error
-      </Typography>
+      <Group>Error</Group>
       <Grid container spacing={2}>
         {item(theme.palette.error.light, 'palette.error.light')}
         {item(theme.palette.error.main, 'palette.error.main')}
         {item(theme.palette.error.dark, 'palette.error.dark')}
       </Grid>
-      <Typography gutterBottom className={classes.group}>
-        Warning
-      </Typography>
+      <Group>Warning</Group>
       <Grid container spacing={2}>
         {item(theme.palette.warning.light, 'palette.warning.light')}
         {item(theme.palette.warning.main, 'palette.warning.main')}
         {item(theme.palette.warning.dark, 'palette.warning.dark')}
       </Grid>
-      <Typography gutterBottom className={classes.group}>
-        Info
-      </Typography>
+      <Group>Info</Group>
       <Grid container spacing={2}>
         {item(theme.palette.info.light, 'palette.info.light')}
         {item(theme.palette.info.main, 'palette.info.main')}
         {item(theme.palette.info.dark, 'palette.info.dark')}
       </Grid>
-      <Typography gutterBottom className={classes.group}>
-        Success
-      </Typography>
+      <Group>Success</Group>
       <Grid container spacing={2}>
         {item(theme.palette.success.light, 'palette.success.light')}
         {item(theme.palette.success.main, 'palette.success.main')}
         {item(theme.palette.success.dark, 'palette.success.dark')}
       </Grid>
-    </div>
+    </Box>
   );
 }
 

--- a/docs/src/pages/customization/palette/Intentions.js
+++ b/docs/src/pages/customization/palette/Intentions.js
@@ -43,37 +43,37 @@ function IntentionsInner() {
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Group>Primary</Group>
+      <Group gutterBottom>Primary</Group>
       <Grid container spacing={2}>
         {item(theme.palette.primary.light, 'palette.primary.light')}
         {item(theme.palette.primary.main, 'palette.primary.main')}
         {item(theme.palette.primary.dark, 'palette.primary.dark')}
       </Grid>
-      <Group>Secondary</Group>
+      <Group gutterBottom>Secondary</Group>
       <Grid container spacing={2}>
         {item(theme.palette.secondary.light, 'palette.secondary.light')}
         {item(theme.palette.secondary.main, 'palette.secondary.main')}
         {item(theme.palette.secondary.dark, 'palette.secondary.dark')}
       </Grid>
-      <Group>Error</Group>
+      <Group gutterBottom>Error</Group>
       <Grid container spacing={2}>
         {item(theme.palette.error.light, 'palette.error.light')}
         {item(theme.palette.error.main, 'palette.error.main')}
         {item(theme.palette.error.dark, 'palette.error.dark')}
       </Grid>
-      <Group>Warning</Group>
+      <Group gutterBottom>Warning</Group>
       <Grid container spacing={2}>
         {item(theme.palette.warning.light, 'palette.warning.light')}
         {item(theme.palette.warning.main, 'palette.warning.main')}
         {item(theme.palette.warning.dark, 'palette.warning.dark')}
       </Grid>
-      <Group>Info</Group>
+      <Group gutterBottom>Info</Group>
       <Grid container spacing={2}>
         {item(theme.palette.info.light, 'palette.info.light')}
         {item(theme.palette.info.main, 'palette.info.main')}
         {item(theme.palette.info.dark, 'palette.info.dark')}
       </Grid>
-      <Group>Success</Group>
+      <Group gutterBottom>Success</Group>
       <Grid container spacing={2}>
         {item(theme.palette.success.light, 'palette.success.light')}
         {item(theme.palette.success.main, 'palette.success.main')}

--- a/docs/src/pages/production-error/ErrorDecoder.js
+++ b/docs/src/pages/production-error/ErrorDecoder.js
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
-import { styled, createTheme } from '@material-ui/core/styles';
-import { makeStyles } from '@material-ui/styles';
+import { styled } from '@material-ui/core/styles';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { renderInline as renderInlineMarkdown } from '@material-ui/markdown';
 
@@ -14,29 +11,11 @@ const ErrorMessageSection = styled('div')({
   display: 'block',
 });
 
-const defaultTheme = createTheme();
-
-const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      boxShadow: theme.shadows['2'],
-      color: theme.palette.error.main,
-      padding: theme.spacing(1, 2),
-    },
-  }),
-  { defaultTheme },
-);
-
-const ErrorMessageMarkdown = (props) => {
-  const { className, ...other } = props;
-  const classes = useStyles();
-
-  return <MarkdownElement className={clsx(classes.root, className)} {...other} />;
-};
-
-ErrorMessageMarkdown.propTypes = {
-  className: PropTypes.string,
-};
+const ErrorMessageMarkdown = styled(MarkdownElement)(({ theme }) => ({
+  boxShadow: theme.shadows['2'],
+  color: theme.palette.error.main,
+  padding: theme.spacing(1, 2),
+}));
 
 export default function ErrorDecoder() {
   const {


### PR DESCRIPTION
This PR migrates the rest of the documentation to emotion. The only code related to emotion left is the one on the landing page. It will anyway go away with the branding so I didn't want to spend time on it.

Preview: https://deploy-preview-27184--material-ui.netlify.app/

---

Looks like in the first iteration I left the most complicated/extensive components 😄 