### PR TITLE
[docs] Sort the size in a more logical order

### DIFF
--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -71,7 +71,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/button-group.json
+++ b/docs/pages/api-docs/button-group.json
@@ -22,7 +22,7 @@
     "size": {
       "type": {
         "name": "enum",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/fab.json
+++ b/docs/pages/api-docs/fab.json
@@ -17,7 +17,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'large'"
     },

--- a/docs/pages/api-docs/pagination-item.json
+++ b/docs/pages/api-docs/pagination-item.json
@@ -19,7 +19,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/pagination.json
+++ b/docs/pages/api-docs/pagination.json
@@ -31,7 +31,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/rating.json
+++ b/docs/pages/api-docs/rating.json
@@ -24,7 +24,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -46,7 +46,7 @@
     },
     "scale": { "type": { "name": "func" }, "default": "(x) => x" },
     "size": {
-      "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" },
+      "type": { "name": "enum", "description": "'small'<br>&#124;&nbsp;'medium'" },
       "default": "'medium'"
     },
     "step": { "type": { "name": "number" }, "default": "1" },

--- a/docs/pages/api-docs/table-cell.json
+++ b/docs/pages/api-docs/table-cell.json
@@ -17,7 +17,7 @@
       }
     },
     "scope": { "type": { "name": "string" } },
-    "size": { "type": { "name": "enum", "description": "'medium'<br>&#124;&nbsp;'small'" } },
+    "size": { "type": { "name": "enum", "description": "'small'<br>&#124;&nbsp;'medium'" } },
     "sortDirection": {
       "type": { "name": "enum", "description": "'asc'<br>&#124;&nbsp;'desc'<br>&#124;&nbsp;false" }
     },

--- a/docs/pages/api-docs/toggle-button-group.json
+++ b/docs/pages/api-docs/toggle-button-group.json
@@ -19,7 +19,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/docs/pages/api-docs/toggle-button.json
+++ b/docs/pages/api-docs/toggle-button.json
@@ -18,7 +18,7 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
     },

--- a/framer/Material-UI.framerfx/code/Slider.tsx
+++ b/framer/Material-UI.framerfx/code/Slider.tsx
@@ -8,7 +8,7 @@ interface Props {
   max?: number;
   min?: number;
   orientation?: 'horizontal' | 'vertical';
-  size: 'medium' | 'small';
+  size: 'small' | 'medium';
   step?: number;
   tabIndex?: number;
   track?: 'inverted' | 'normal' | false;
@@ -53,7 +53,7 @@ addPropertyControls(Slider, {
   size: {
     type: ControlType.Enum,
     title: 'Size',
-    options: ['medium', 'small'],
+    options: ['small', 'medium'],
   },
   step: {
     type: ControlType.Number,

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -1002,7 +1002,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.oneOf(['small', 'medium']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -305,7 +305,7 @@ ButtonGroup.propTypes /* remove-proptypes */ = {
    * `small` is equivalent to the dense button styling.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -245,7 +245,7 @@ Fab.propTypes /* remove-proptypes */ = {
    * @default 'large'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/Pagination/Pagination.js
+++ b/packages/material-ui/src/Pagination/Pagination.js
@@ -230,7 +230,7 @@ Pagination.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -379,7 +379,7 @@ PaginationItem.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -736,7 +736,7 @@ Rating.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -652,7 +652,7 @@ Slider.propTypes /* remove-proptypes */ = {
    * The size of the slider.
    * @default 'medium'
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes.oneOf(['small', 'medium']),
   /**
    * The granularity with which the slider can step through values. (A "discrete" slider.)
    * The `min` prop serves as the origin for the valid values.

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -230,7 +230,7 @@ TableCell.propTypes /* remove-proptypes */ = {
    * Specify the size of the cell.
    * The prop defaults to the value (`'medium'`) inherited from the parent Table component.
    */
-  size: PropTypes.oneOf(['medium', 'small']),
+  size: PropTypes.oneOf(['small', 'medium']),
   /**
    * Set aria-sort direction.
    */

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -215,7 +215,7 @@ ToggleButton.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -227,7 +227,7 @@ ToggleButtonGroup.propTypes /* remove-proptypes */ = {
    * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['large', 'medium', 'small']),
+    PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
   /**

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -144,6 +144,12 @@ function sortBreakpointsLiteralByViewportAscending(a: ttp.LiteralType, b: ttp.Li
 
   return breakpointOrder.indexOf(a.value) - breakpointOrder.indexOf(b.value);
 }
+
+function sortSizeByScaleAscending(a: ttp.LiteralType, b: ttp.LiteralType) {
+  const sizeOrder: readonly unknown[] = ['"small"', '"medium"', '"large"'];
+  return sizeOrder.indexOf(a.value) - sizeOrder.indexOf(b.value);
+}
+
 // Custom order of literal unions by component
 const getSortLiteralUnions: ttp.InjectOptions['getSortLiteralUnions'] = (component, propType) => {
   if (
@@ -151,6 +157,10 @@ const getSortLiteralUnions: ttp.InjectOptions['getSortLiteralUnions'] = (compone
     (propType.name === 'initialWidth' || propType.name === 'only')
   ) {
     return sortBreakpointsLiteralByViewportAscending;
+  }
+
+  if (propType.name === 'size') {
+    return sortSizeByScaleAscending;
   }
 
   return undefined;


### PR DESCRIPTION
A quick follow-up on https://github.com/mui-org/material-ui/pull/27164#discussion_r666061712. Not really important

https://deploy-preview-27186--material-ui.netlify.app/api/button/

<img width="850" alt="Capture d’écran 2021-07-08 à 19 28 23" src="https://user-images.githubusercontent.com/3165635/124965672-ac59ac80-e022-11eb-8e68-cae2ac6c1e76.png">
