### PR TITLE
Edit createTheme import path to fix error #18377

### DIFF
--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -1,4 +1,4 @@
-import { createTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/styles';
 import { red } from '@material-ui/core/colors';
 
 // Create a theme instance.


### PR DESCRIPTION
Original import path would raise error `Attempted import error: 'ThemeProvider' is not exported from '@material-ui/core/styles'`.
Removing to `/core` part fixes it as mentioned in https://github.com/mui-org/material-ui/issues/18377 !

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
