### PR TITLE
[transitions] Skip implementation if no `node`

### DIFF
--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -66,20 +66,22 @@ const Fade = React.forwardRef(function Fade(props, ref) {
   const handleEntering = normalizedTransitionCallback(onEntering);
 
   const handleEnter = normalizedTransitionCallback((node, isAppearing) => {
-    reflow(node); // So the animation always start from the start.
+    if (node) {
+      reflow(node); // So the animation always start from the start.
 
-    const transitionProps = getTransitionProps(
-      { style, timeout, easing },
-      {
-        mode: 'enter',
-      },
-    );
+      const transitionProps = getTransitionProps(
+        { style, timeout, easing },
+        {
+          mode: 'enter',
+        },
+      );
 
-    node.style.webkitTransition = theme.transitions.create('opacity', transitionProps);
-    node.style.transition = theme.transitions.create('opacity', transitionProps);
+      node.style.webkitTransition = theme.transitions.create('opacity', transitionProps);
+      node.style.transition = theme.transitions.create('opacity', transitionProps);
 
-    if (onEnter) {
-      onEnter(node, isAppearing);
+      if (onEnter) {
+        onEnter(node, isAppearing);
+      }
     }
   });
 
@@ -88,18 +90,20 @@ const Fade = React.forwardRef(function Fade(props, ref) {
   const handleExiting = normalizedTransitionCallback(onExiting);
 
   const handleExit = normalizedTransitionCallback((node) => {
-    const transitionProps = getTransitionProps(
-      { style, timeout, easing },
-      {
-        mode: 'exit',
-      },
-    );
+    if (node) {
+      const transitionProps = getTransitionProps(
+        { style, timeout, easing },
+        {
+          mode: 'exit',
+        },
+      );
 
-    node.style.webkitTransition = theme.transitions.create('opacity', transitionProps);
-    node.style.transition = theme.transitions.create('opacity', transitionProps);
+      node.style.webkitTransition = theme.transitions.create('opacity', transitionProps);
+      node.style.transition = theme.transitions.create('opacity', transitionProps);
 
-    if (onExit) {
-      onExit(node);
+      if (onExit) {
+        onExit(node);
+      }
     }
   });
 

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -68,41 +68,43 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   const handleEntering = normalizedTransitionCallback(onEntering);
 
   const handleEnter = normalizedTransitionCallback((node, isAppearing) => {
-    reflow(node); // So the animation always start from the start.
+    if (node) {
+      reflow(node); // So the animation always start from the start.
 
-    const {
-      duration: transitionDuration,
-      delay,
-      easing: transitionTimingFunction,
-    } = getTransitionProps(
-      { style, timeout, easing },
-      {
-        mode: 'enter',
-      },
-    );
-
-    let duration;
-    if (timeout === 'auto') {
-      duration = theme.transitions.getAutoHeightDuration(node.clientHeight);
-      autoTimeout.current = duration;
-    } else {
-      duration = transitionDuration;
-    }
-
-    node.style.transition = [
-      theme.transitions.create('opacity', {
-        duration,
-        delay,
-      }),
-      theme.transitions.create('transform', {
-        duration: duration * 0.666,
+      const {
+        duration: transitionDuration,
         delay,
         easing: transitionTimingFunction,
-      }),
-    ].join(',');
+      } = getTransitionProps(
+        { style, timeout, easing },
+        {
+          mode: 'enter',
+        },
+      );
 
-    if (onEnter) {
-      onEnter(node, isAppearing);
+      let duration;
+      if (timeout === 'auto') {
+        duration = theme.transitions.getAutoHeightDuration(node.clientHeight);
+        autoTimeout.current = duration;
+      } else {
+        duration = transitionDuration;
+      }
+
+      node.style.transition = [
+        theme.transitions.create('opacity', {
+          duration,
+          delay,
+        }),
+        theme.transitions.create('transform', {
+          duration: duration * 0.666,
+          delay,
+          easing: transitionTimingFunction,
+        }),
+      ].join(',');
+
+      if (onEnter) {
+        onEnter(node, isAppearing);
+      }
     }
   });
 
@@ -111,42 +113,44 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   const handleExiting = normalizedTransitionCallback(onExiting);
 
   const handleExit = normalizedTransitionCallback((node) => {
-    const {
-      duration: transitionDuration,
-      delay,
-      easing: transitionTimingFunction,
-    } = getTransitionProps(
-      { style, timeout, easing },
-      {
-        mode: 'exit',
-      },
-    );
-
-    let duration;
-    if (timeout === 'auto') {
-      duration = theme.transitions.getAutoHeightDuration(node.clientHeight);
-      autoTimeout.current = duration;
-    } else {
-      duration = transitionDuration;
-    }
-
-    node.style.transition = [
-      theme.transitions.create('opacity', {
-        duration,
+    if (node) {
+      const {
+        duration: transitionDuration,
         delay,
-      }),
-      theme.transitions.create('transform', {
-        duration: duration * 0.666,
-        delay: delay || duration * 0.333,
         easing: transitionTimingFunction,
-      }),
-    ].join(',');
+      } = getTransitionProps(
+        { style, timeout, easing },
+        {
+          mode: 'exit',
+        },
+      );
 
-    node.style.opacity = '0';
-    node.style.transform = getScale(0.75);
+      let duration;
+      if (timeout === 'auto') {
+        duration = theme.transitions.getAutoHeightDuration(node.clientHeight);
+        autoTimeout.current = duration;
+      } else {
+        duration = transitionDuration;
+      }
 
-    if (onExit) {
-      onExit(node);
+      node.style.transition = [
+        theme.transitions.create('opacity', {
+          duration,
+          delay,
+        }),
+        theme.transitions.create('transform', {
+          duration: duration * 0.666,
+          delay: delay || duration * 0.333,
+          easing: transitionTimingFunction,
+        }),
+      ].join(',');
+
+      node.style.opacity = '0';
+      node.style.transform = getScale(0.75);
+
+      if (onExit) {
+        onExit(node);
+      }
     }
   });
 

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -110,34 +110,38 @@ const Slide = React.forwardRef(function Slide(props, ref) {
   };
 
   const handleEnter = normalizedTransitionCallback((node, isAppearing) => {
-    setTranslateValue(direction, node);
-    reflow(node);
+    if (node) {
+      setTranslateValue(direction, node);
+      reflow(node);
 
-    if (onEnter) {
-      onEnter(node, isAppearing);
+      if (onEnter) {
+        onEnter(node, isAppearing);
+      }
     }
   });
 
   const handleEntering = normalizedTransitionCallback((node, isAppearing) => {
-    const transitionProps = getTransitionProps(
-      { timeout, style, easing: easingProp },
-      {
-        mode: 'enter',
-      },
-    );
+    if (node) {
+      const transitionProps = getTransitionProps(
+        { timeout, style, easing: easingProp },
+        {
+          mode: 'enter',
+        },
+      );
 
-    node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
-      ...transitionProps,
-    });
+      node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
+        ...transitionProps,
+      });
 
-    node.style.transition = theme.transitions.create('transform', {
-      ...transitionProps,
-    });
+      node.style.transition = theme.transitions.create('transform', {
+        ...transitionProps,
+      });
 
-    node.style.webkitTransform = 'none';
-    node.style.transform = 'none';
-    if (onEntering) {
-      onEntering(node, isAppearing);
+      node.style.webkitTransform = 'none';
+      node.style.transform = 'none';
+      if (onEntering) {
+        onEntering(node, isAppearing);
+      }
     }
   });
 
@@ -145,35 +149,39 @@ const Slide = React.forwardRef(function Slide(props, ref) {
   const handleExiting = normalizedTransitionCallback(onExiting);
 
   const handleExit = normalizedTransitionCallback((node) => {
-    const transitionProps = getTransitionProps(
-      { timeout, style, easing: easingProp },
-      {
-        mode: 'exit',
-      },
-    );
+    if (node) {
+      const transitionProps = getTransitionProps(
+        { timeout, style, easing: easingProp },
+        {
+          mode: 'exit',
+        },
+      );
 
-    node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
-      ...transitionProps,
-    });
+      node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
+        ...transitionProps,
+      });
 
-    node.style.transition = theme.transitions.create('transform', {
-      ...transitionProps,
-    });
+      node.style.transition = theme.transitions.create('transform', {
+        ...transitionProps,
+      });
 
-    setTranslateValue(direction, node);
+      setTranslateValue(direction, node);
 
-    if (onExit) {
-      onExit(node);
+      if (onExit) {
+        onExit(node);
+      }
     }
   });
 
   const handleExited = normalizedTransitionCallback((node) => {
-    // No need for transitions when the component is hidden
-    node.style.webkitTransition = '';
-    node.style.transition = '';
+    if (node) {
+      // No need for transitions when the component is hidden
+      node.style.webkitTransition = '';
+      node.style.transition = '';
 
-    if (onExited) {
-      onExited(node);
+      if (onExited) {
+        onExited(node);
+      }
     }
   });
 

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -67,20 +67,22 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
   const handleEntering = normalizedTransitionCallback(onEntering);
 
   const handleEnter = normalizedTransitionCallback((node, isAppearing) => {
-    reflow(node); // So the animation always start from the start.
+    if (node) {
+      reflow(node); // So the animation always start from the start.
 
-    const transitionProps = getTransitionProps(
-      { style, timeout, easing },
-      {
-        mode: 'enter',
-      },
-    );
+      const transitionProps = getTransitionProps(
+        { style, timeout, easing },
+        {
+          mode: 'enter',
+        },
+      );
 
-    node.style.webkitTransition = theme.transitions.create('transform', transitionProps);
-    node.style.transition = theme.transitions.create('transform', transitionProps);
+      node.style.webkitTransition = theme.transitions.create('transform', transitionProps);
+      node.style.transition = theme.transitions.create('transform', transitionProps);
 
-    if (onEnter) {
-      onEnter(node, isAppearing);
+      if (onEnter) {
+        onEnter(node, isAppearing);
+      }
     }
   });
 
@@ -89,18 +91,20 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
   const handleExiting = normalizedTransitionCallback(onExiting);
 
   const handleExit = normalizedTransitionCallback((node) => {
-    const transitionProps = getTransitionProps(
-      { style, timeout, easing },
-      {
-        mode: 'exit',
-      },
-    );
+    if (node) {
+      const transitionProps = getTransitionProps(
+        { style, timeout, easing },
+        {
+          mode: 'exit',
+        },
+      );
 
-    node.style.webkitTransition = theme.transitions.create('transform', transitionProps);
-    node.style.transition = theme.transitions.create('transform', transitionProps);
+      node.style.webkitTransition = theme.transitions.create('transform', transitionProps);
+      node.style.transition = theme.transitions.create('transform', transitionProps);
 
-    if (onExit) {
-      onExit(node);
+      if (onExit) {
+        onExit(node);
+      }
     }
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #27154 

From this [reproduction](https://codesandbox.io/s/transition-v5-error-dide8?file=/src/App.tsx), the warnings are displayed correctly in devtool.

<img width="829" alt="Screen Shot 2564-07-13 at 16 25 23" src="https://user-images.githubusercontent.com/18292247/125427629-e82d762e-a3c2-4d0d-b943-1f2398e83163.png">

This PR prevent throwing error on the screen by do nothing if no `node`. I just add 

```js
if (node) {
  ...
}
```

to all transition components, is there a better way or it can be improved later.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
