### PR TITLE
[test] Remove `StyledEngineProvider` usage from regressions and e2e tests

### DIFF
--- a/test/e2e/TestViewer.js
+++ b/test/e2e/TestViewer.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 
 function TestViewer(props) {
   const { children } = props;
@@ -14,12 +13,9 @@ function TestViewer(props) {
   }, []);
 
   return (
-    // TODO v5: remove once migration to emotion is completed
-    <StyledEngineProvider injectFirst>
-      <div aria-busy={!ready} data-testid="testcase">
-        {children}
-      </div>
-    </StyledEngineProvider>
+    <div aria-busy={!ready} data-testid="testcase">
+      {children}
+    </div>
   );
 }
 

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { useFakeTimers } from 'sinon';
 import Box from '@material-ui/core/Box';
 import GlobalStyles from '@material-ui/core/GlobalStyles';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 
 function TestViewer(props) {
   const { children } = props;
@@ -47,8 +46,7 @@ function TestViewer(props) {
   }, []);
 
   return (
-    // TODO v5: remove once migration to emotion is completed
-    <StyledEngineProvider injectFirst>
+    <React.Fragment>
       <GlobalStyles
         styles={{
           html: {
@@ -76,7 +74,7 @@ function TestViewer(props) {
       >
         {children}
       </Box>
-    </StyledEngineProvider>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
