### PR TITLE
[docs] Fix https protocol

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -219,7 +219,7 @@ function AppFrame(props) {
       <AppBar className={appBarClassName}>
         <Typography variant="body2" className={classes.banner} noWrap>
           {t('v5IsOut')}{' '}
-          <Link color="inherit" className={classes.bannerLink} href="http://next.material-ui.com">
+          <Link color="inherit" className={classes.bannerLink} href="https://next.material-ui.com">
             {t('v5docsLink')}
           </Link>{' '}
           {t('v5startAdoption')}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Noticed while reviewing https://github.com/mui-org/material-ui-x/pull/2108. In the Material-UI X docs this error is very annoying. 

![image](https://user-images.githubusercontent.com/42154031/125510426-5afd8f0a-07e0-40ef-b081-7ec928a36217.png)

It's caused because we only consider HTTPS links as external:

https://github.com/mui-org/material-ui/blob/dc5daa7464c5bb35fc879431afd4b9ddd785bbb9/docs/src/modules/components/Link.js#L55