### PR TITLE
[docs] Fix layout regression

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -14,6 +14,9 @@ import AdManager from 'docs/src/modules/components/AdManager';
 import AdGuest from 'docs/src/modules/components/AdGuest';
 import AppLayoutDocsFooter from 'docs/src/modules/components/AppLayoutDocsFooter';
 
+const TOC_WIDTH = 175;
+const NAV_WIDTH = 240;
+
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
@@ -39,7 +42,10 @@ const useStyles = makeStyles((theme) => ({
   },
   toc: {
     [theme.breakpoints.up('sm')]: {
-      width: 'calc(100% - 175px)',
+      width: `calc(100% - ${TOC_WIDTH}px)`,
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: `calc(100% - ${TOC_WIDTH}px - ${NAV_WIDTH}px)`,
     },
   },
   disableToc: {


### PR DESCRIPTION
Fix https://github.com/mui-org/material-ui/pull/27138#issuecomment-878951342

---

Next up, we might want to look into https://github.com/mui-org/material-ui/pull/27043#issuecomment-877776720 before the release of v5.0.0-beta.1, it's a regression, and seems to have a large impact (my assumption is that we would quickly get a bug report if we release it). The transition is now technically strict mode compatible 👌  but does no longer serves its original product purpose. I will see what I can do to improve it tomorrow. The simplest might be to remove the transition, it would already be better, but I hope that with more effort we can get the best of the two worlds, a simple, strict mode transition, with a great UX.