### PR TITLE
Revert "[docs] Fix layout regression"

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -14,9 +14,6 @@ import AdManager from 'docs/src/modules/components/AdManager';
 import AdGuest from 'docs/src/modules/components/AdGuest';
 import AppLayoutDocsFooter from 'docs/src/modules/components/AppLayoutDocsFooter';
 
-const TOC_WIDTH = 175;
-const NAV_WIDTH = 240;
-
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
@@ -42,10 +39,7 @@ const useStyles = makeStyles((theme) => ({
   },
   toc: {
     [theme.breakpoints.up('sm')]: {
-      width: `calc(100% - ${TOC_WIDTH}px)`,
-    },
-    [theme.breakpoints.up('lg')]: {
-      width: `calc(100% - ${TOC_WIDTH}px - ${NAV_WIDTH}px)`,
+      width: 'calc(100% - 175px)',
     },
   },
   disableToc: {


### PR DESCRIPTION
Reverts mui-org/material-ui#27266 which was accidentally merged. There was no reproduction provided and we don't merge "fixes" that are unconfirmed.

Broke layout on 
- Chrome Version 91.0.4472.114 (Official Build) (64-bit) Ubuntu 20.04
- Firefox Version 89.0.2 Ubuntu 20.04
- Chrome Version 91.0.4472.114 (Official Build) (64-bit) macOS Catalina
- Safari Version 14.1.1 (Official Build) (64-bit) macOS Catalina

![Screenshot from 2021-07-14 11-54-02](https://user-images.githubusercontent.com/12292047/125602739-5045bb38-98c4-40fb-a245-b8006a1756b6.png)

