### PR TITLE
migrate test_lint to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,20 +175,6 @@ jobs:
       - run:
           name: Coverage
           command: bash <(curl -s https://codecov.io/bash) -Z -F $REACT_DIST_TAG
-  test_lint:
-    <<: *defaults
-    steps:
-      - checkout
-      - install_js
-      - run:
-          name: Eslint
-          command: yarn lint:ci
-      - run:
-          name: Stylelint
-          command: yarn stylelint
-      - run:
-          name: Lint JSON
-          command: yarn jsonlint
   test_static:
     <<: *defaults
     steps:
@@ -616,9 +602,6 @@ workflows:
     jobs:
       - checkout
       - test_unit:
-          requires:
-            - checkout
-      - test_lint:
           requires:
             - checkout
       - test_static:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,24 @@ jobs:
         run: |
           git remote -v
           yarn release:tag --dryRun
+  test_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # fetch all tags which are required for `yarn release:changelog`
+          fetch-depth: 0
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: yarn install
+        env:
+          # Don't need playwright in this job
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Eslint
+        run: yarn lint:ci
+      - name: Stylelint
+        run: yarn stylelint
+      - name: Lint JSON
+        run: yarn jsonlint


### PR DESCRIPTION
I found that GH Actions is faster than Circle CI, and this PR will migrate test_lint job to GH Actions. test_lint runs on GH Actions equally if not fasters even without CI cache.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
