### PR TITLE
[docs] Fix layout regression

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -14,10 +14,16 @@ import AdManager from 'docs/src/modules/components/AdManager';
 import AdGuest from 'docs/src/modules/components/AdGuest';
 import AppLayoutDocsFooter from 'docs/src/modules/components/AppLayoutDocsFooter';
 
+const TOC_WIDTH = 175;
+const NAV_WIDTH = 240;
+
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
     width: '100%',
+    [theme.breakpoints.up('lg')]: {
+      width: `calc(100% - ${NAV_WIDTH}px)`,
+    },
   },
   container: {
     position: 'relative',
@@ -39,7 +45,7 @@ const useStyles = makeStyles((theme) => ({
   },
   toc: {
     [theme.breakpoints.up('sm')]: {
-      width: 'calc(100% - 175px)',
+      width: `calc(100% - ${TOC_WIDTH}px)`,
     },
   },
   disableToc: {
@@ -76,12 +82,12 @@ function AppLayoutDocs(props) {
         )}
         <main
           className={clsx(classes.root, {
-            [classes.toc]: !disableToc,
             [classes.disableToc]: disableToc,
           })}
         >
           <AppContainer
             className={clsx(classes.container, {
+              [classes.toc]: !disableToc,
               [classes.ad]: !disableAd,
             })}
           >


### PR DESCRIPTION
This is another attempt to fix this issue:

1. Open https://next--material-ui.netlify.app/guides/migration-v4/ in BrowserStack in Windows 10, Chrome 91
2. Make sure your browser width is around 1400px
3. See that there is a horizontal scrollbar

<img width="296" alt="Capture d’écran 2021-07-14 à 13 43 16" src="https://user-images.githubusercontent.com/3165635/125616497-30c771a9-8c80-435b-a485-b86d8484264d.png">

The issue seems to be coming from a CSS `pre > code` overflow width bug. I can't spot any regression with this solution. If we don't like this solution, for instance, because it relies on knowing the width of the side nav and the toc, we can explore alternatives, I would propose we revert #27138 in the meantime if we don't move forward with this one.

https://deploy-preview-27272--material-ui.netlify.app/guides/migration-v4/