### PR TITLE
[CalendarPicker] Fix slide transition regression

### DIFF
--- a/packages/material-ui-lab/src/CalendarPicker/PickersCalendar.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/PickersCalendar.tsx
@@ -135,7 +135,10 @@ function PickersCalendar<TDate>(props: PickersCalendarProps<TDate>) {
     .filter(Boolean)
     .map((selectedDateItem) => selectedDateItem && utils.startOfDay(selectedDateItem));
 
-  const slideNodeRef = React.useRef(null);
+  // need a new ref whenever the `key` of the transition changes: https://reactcommunity.org/react-transition-group/transition#Transition-prop-nodeRef.
+  const transitionKey = currentMonthNumber;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const slideNodeRef = React.useMemo(() => React.createRef<HTMLDivElement>(), [transitionKey]);
 
   return (
     <React.Fragment>
@@ -151,7 +154,7 @@ function PickersCalendar<TDate>(props: PickersCalendarProps<TDate>) {
         <PickersCalendarLoadingContainer>{renderLoading()}</PickersCalendarLoadingContainer>
       ) : (
         <PickersCalendarSlideTransition
-          transKey={currentMonthNumber}
+          transKey={transitionKey}
           onExited={onMonthSwitchingAnimationEnd}
           reduceAnimations={reduceAnimations}
           slideDirection={slideDirection}


### PR DESCRIPTION
Regressed in https://github.com/mui-org/material-ui/pull/27043

Preview: https://deploy-preview-27273--material-ui.netlify.app/components/date-picker/#landscape-orientation

Changelog entry can be ignored if we have no release between https://github.com/mui-org/material-ui/pull/27043 and now