### PR TITLE
[docs] Sets the instruction to extend the DefaultTheme interface in t…

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -509,7 +509,7 @@ The `@material-ui/styles` package is no longer part of `@material-ui/core/styles
 // in your theme file that you call `createTheme()`
 import { Theme } from '@material-ui/core/styles';
 
-declare module '@material-ui/styles' {
+declare module '@material-ui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 ```


### PR DESCRIPTION
Was following the v4 migration guide.
I noticed there was a problem on this line here:

```tsx
declare module '@material-ui/styles' {
  interface DefaultTheme extends Theme {}
}
```
The problem is that it overrides every styles module, but what I really wanted was to extend the defaultTheme interface. 
For this case it would be more recommendable to use this here:

```tsx
declare module '@material-ui/styles/defaultTheme' {
  interface DefaultTheme extends Theme {}
}
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related to #21551