### PR TITLE
[pickers] Fix Fade animation behavior change

### DIFF
--- a/packages/material-ui-lab/src/CalendarPicker/PickersFadeTransitionGroup.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/PickersFadeTransitionGroup.tsx
@@ -39,6 +39,7 @@ const PickersFadeTransitionGroup = ({
   return (
     <PickersFadeTransitionGroupRoot className={clsx(classes.root, className)}>
       <Fade
+        appear={false}
         mountOnEnter
         unmountOnExit
         key={transKey}


### PR DESCRIPTION
This is a follow-up on https://github.com/mui-org/material-ui/pull/27273#pullrequestreview-706260994. It fixes something that I have noticed during the review. See the behavior when JavaScript is disabled:

v5.0.0-beta.0: https://next.material-ui.com/components/date-picker/#static-mode

<img width="691" alt="Capture d’écran 2021-07-14 à 16 42 08" src="https://user-images.githubusercontent.com/3165635/125641745-268011dc-5d8c-4282-8d5d-740e518a66e3.png">

HEAD: https://next--material-ui.netlify.app/components/date-picker/#static-mode

<img width="696" alt="Capture d’écran 2021-07-14 à 16 41 38" src="https://user-images.githubusercontent.com/3165635/125641739-8bfc1e0e-0ef1-412b-a1d9-7bb319454808.png">

The fix is to set http://reactcommunity.org/react-transition-group/transition#Transition-prop-appear. It makes me think of https://github.com/mui-org/material-ui/issues/26108#issue-874822103. We might want to change the default value in v6.

Preview: https://deploy-preview-27283--material-ui.netlify.app/components/date-picker/#static-mode