### PR TITLE
[docs] Fix deprecated props in StickyHeadTable demo (v5 migration)

### DIFF
--- a/docs/src/pages/components/tables/StickyHeadTable.js
+++ b/docs/src/pages/components/tables/StickyHeadTable.js
@@ -122,7 +122,7 @@ export default function StickyHeadTable() {
         count={rows.length}
         rowsPerPage={rowsPerPage}
         page={page}
-        onPageChange={handleChangePage}
+        onChangePage={handleChangePage}
         onRowsPerPageChange={handleChangeRowsPerPage}
       />
     </Paper>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
