### PR TITLE
[TextField] Add support for `minRows`

### DIFF
--- a/docs/pages/api-docs/text-field.md
+++ b/docs/pages/api-docs/text-field.md
@@ -75,6 +75,7 @@ The `MuiTextField` name can be used for providing [default props](/customization
 | <span class="prop-name">label</span> | <span class="prop-type">node</span> |  | The label content. |
 | <span class="prop-name">margin</span> | <span class="prop-type">'dense'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'</span> |  | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | <span class="prop-name">maxRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Maximum number of rows to display when multiline option is set to true. |
+| <span class="prop-name">minRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Minimum number of rows to display. |
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, a textarea element will be rendered instead of an input. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). |

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -96,8 +96,13 @@ export interface BaseTextFieldProps
   required?: boolean;
   /**
    * Number of rows to display when multiline option is set to true.
+   * @deprecated Use `minRows` instead.
    */
   rows?: string | number;
+  /**
+   * Minimum number of rows to display.
+   */
+  minRows?: string | number;
   /**
    * Maximum number of rows to display.
    * @deprecated Use `maxRows` instead.

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -100,10 +100,6 @@ export interface BaseTextFieldProps
    */
   rows?: string | number;
   /**
-   * Minimum number of rows to display.
-   */
-  minRows?: string | number;
-  /**
    * Maximum number of rows to display.
    * @deprecated Use `maxRows` instead.
    */
@@ -112,6 +108,10 @@ export interface BaseTextFieldProps
    * Maximum number of rows to display when multiline option is set to true.
    */
   maxRows?: string | number;
+  /**
+   * Minimum number of rows to display.
+   */
+  minRows?: string | number;
   /**
    * Render a [`Select`](/api/select/) element while passing the Input element to `Select` as `input` parameter.
    * If this option is set you must pass the options of the select as children.

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -75,7 +75,6 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     InputProps,
     inputRef,
     label,
-    minRows,
     multiline = false,
     name,
     onBlur,
@@ -86,6 +85,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     rows,
     rowsMax,
     maxRows,
+    minRows,
     select = false,
     SelectProps,
     type,
@@ -139,9 +139,9 @@ const TextField = React.forwardRef(function TextField(props, ref) {
       multiline={multiline}
       name={name}
       rows={rows}
-      minRows={minRows}
       rowsMax={rowsMax}
       maxRows={maxRows}
+      minRows={minRows}
       type={type}
       value={value}
       id={id}

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -75,6 +75,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     InputProps,
     inputRef,
     label,
+    minRows,
     multiline = false,
     name,
     onBlur,
@@ -138,6 +139,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
       multiline={multiline}
       name={name}
       rows={rows}
+      minRows={minRows}
       rowsMax={rowsMax}
       maxRows={maxRows}
       type={type}
@@ -294,6 +296,10 @@ TextField.propTypes = {
    */
   maxRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
+   * Minimum number of rows to display.
+   */
+  minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
    * If `true`, a textarea element will be rendered instead of an input.
    */
   multiline: PropTypes.bool,
@@ -326,6 +332,7 @@ TextField.propTypes = {
   required: PropTypes.bool,
   /**
    * Number of rows to display when multiline option is set to true.
+   * @deprecated Use `minRows` instead.
    */
   rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/27291: https://codesandbox.io/s/create-react-app-forked-fcujs?file=/src/App.js

Forgot to backport https://github.com/mui-org/material-ui/pull/22831.