### PR TITLE
[pickers] Minify error when LocalizationProvider is missing

### DIFF
--- a/docs/public/static/error-codes.json
+++ b/docs/public/static/error-codes.json
@@ -10,5 +10,6 @@
   "9": "Material-UI: Unsupported `%s` color.\nThe following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().",
   "10": "Material-UI: unsupported `%s` color space.\nThe following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rgb, rec-2020.",
   "11": "Material-UI: The color%s provided to augmentColor(color) is invalid.\nThe color object needs to have a `main` property or a `%s` property.",
-  "12": "Material-UI: The color%s provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createTheme({ palette: {\n  primary: { main: green[500] },\n} });"
+  "12": "Material-UI: The color%s provided to augmentColor(color) is invalid.\n`color.main` should be a string, but `%s` was provided instead.\n\nDid you intend to use one of the following approaches?\n\nimport { green } from \"@material-ui/core/colors\";\n\nconst theme1 = createTheme({ palette: {\n  primary: green,\n} });\n\nconst theme2 = createTheme({ palette: {\n  primary: { main: green[500] },\n} });",
+  "13": "Can not find utils in context. It looks like you forgot to wrap your component in LocalizationProvider, or pass dateAdapter prop directly."
 }

--- a/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
+++ b/packages/material-ui-lab/src/internal/pickers/hooks/useUtils.ts
@@ -1,22 +1,18 @@
 import * as React from 'react';
+import MuiError from '@material-ui/utils/macros/MuiError.macro';
 import { MuiPickersAdapterContext } from '../../../LocalizationProvider';
 
 // Required for babel https://github.com/vercel/next.js/issues/7882. Replace with `export type` in future
 export type MuiPickersAdapter<TDate = unknown> =
   import('../../../LocalizationProvider/LocalizationProvider').MuiPickersAdapter<TDate>;
 
-// TODO uncomment when syntax will be allowed by next babel
-function checkUtils(utils: MuiPickersAdapter | null) /* :asserts utils is MuiPickersAdapter */ {
-  if (!utils) {
-    throw new Error(
+export function useUtils<T = unknown>() {
+  const utils = React.useContext(MuiPickersAdapterContext);
+  if (utils === null) {
+    throw new MuiError(
       'Can not find utils in context. It looks like you forgot to wrap your component in LocalizationProvider, or pass dateAdapter prop directly.',
     );
   }
-}
-
-export function useUtils<T = unknown>() {
-  const utils = React.useContext(MuiPickersAdapterContext);
-  checkUtils(utils);
 
   return utils as MuiPickersAdapter<T>;
 }


### PR DESCRIPTION
Also improves the stack trace. Using functions to throw error is generally problematic since the last frame will no longer point to the very lint that caused the error. It's still not ideal since it's nested inside `useUtils` but that's at least right where we try to access the utils.
