### PR TITLE
[core] Fix GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,5 @@ packages/**/*.d.ts -linguist-vendored
 # These icons are imported from Google.
 # Kept so that we can review the impact when changing the generation script.
 packages/material-ui-icons/lib/** linguist-generated
+packages/material-ui-icons/material-icons/** linguist-generated
 packages/material-ui-icons/legacy/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@ packages/**/*.d.ts -linguist-vendored
 packages/material-ui-icons/lib/** linguist-generated
 packages/material-ui-icons/material-icons/** linguist-generated
 packages/material-ui-icons/legacy/** linguist-vendored
+# bundling fixtures
+test/bundling/scripts/packages.js linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,9 +5,5 @@
 packages/**/*.d.ts -linguist-vendored
 # These icons are imported from Google.
 # Kept so that we can review the impact when changing the generation script.
-packages/material-ui-icons/lib linguist-generated
-packages/material-ui-icons/material-icons linguist-vendored
-# bundling fixtures
-test/fixtures/bundling/node-esm/index.js linguist-generated
-test/fixtures/bundling/next-webpack4/pages/index.js linguist-generated
-test/fixtures/bundling/packages.js linguist-generated
+packages/material-ui-icons/lib/** linguist-generated
+packages/material-ui-icons/legacy/** linguist-vendored


### PR DESCRIPTION
I was working on #15984 to monitor our progress on the issue:

<img width="876" alt="Capture d’écran 2021-07-15 à 15 56 29" src="https://user-images.githubusercontent.com/3165635/125800292-7ee3de65-3530-4323-88ff-9d42a96ad95d.png">

When I realize that we broke the language stats. Before

```
89.82%  JavaScript
10.17%  TypeScript
0.01%   HTML
```

After

```
64.52%  JavaScript
35.44%  TypeScript
0.04%   HTML
```

The change is based on https://github.com/github/linguist/issues/5439#issuecomment-873066279.