### PR TITLE
[Tabs] Use theme transition duration for the Tab animation

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -421,7 +421,9 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
 
   const scroll = (scrollValue, { animation = true } = {}) => {
     if (animation) {
-      animate(scrollStart, tabsRef.current, scrollValue);
+      animate(scrollStart, tabsRef.current, scrollValue, {
+        duration: theme.transitions.duration.standard,
+      });
     } else {
       tabsRef.current[scrollStart] = scrollValue;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Use `theme.transitions.duration.standard` for scrollable Tabs animation instead of a hardcoded duration. Improves experience for people with motion sickness (prefer-reduced motion) as well as visual regression tests where one usually disables animations.

Fix #27300 