### PR TITLE
[Grid] Remove width prop for rowSpacing

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -131,7 +131,6 @@ export function generateRowGap({ theme, styleProps }) {
 
       if (themeSpacing !== '0px') {
         return {
-          width: `calc(100% + ${getOffset(themeSpacing)})`,
           marginTop: `-${getOffset(themeSpacing)}`,
           [`& > .${gridClasses.item}`]: {
             paddingTop: getOffset(themeSpacing),

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -87,14 +87,12 @@ describe('<Grid />', () => {
           paddingTop: '8px',
         },
         marginTop: '-8px',
-        width: 'calc(100% + 8px)',
       },
       [`@media (min-width:${defaultTheme.breakpoints.values.sm}px)`]: {
         '& > .MuiGrid-item': {
           paddingTop: '16px',
         },
         marginTop: '-16px',
-        width: 'calc(100% + 16px)',
       },
     });
 


### PR DESCRIPTION
No need to set `width` for `rowSpacing` as it makes Grid container wider than its parent.
Example: https://codesandbox.io/s/blazing-night-49tx4

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-27326--material-ui.netlify.app/components/grid/