### PR TITLE
[slider]: only terminate sliding for actual user generated events

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -583,7 +583,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const handleTouchEnd = useEventCallback((event) => {
     const finger = trackFinger(event, touchId);
 
-    if (!finger) {
+    if (!finger || !event.isTrusted) {
       return;
     }
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted

This is to fix an issue I've been experiencing where the sliding would be stopped by some third party code dispatching the mouseup event, even though the user was still holding the mouse down and trying to slide the slider.