### PR TITLE
[docs] Recommend the `direct-import` babel plugin over `transform-import`

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -162,6 +162,23 @@ Pick one of the following plugins:
   module.exports = { plugins };
   ```
 
+- [babel-plugin-direct-import](https://github.com/umidbekk/babel-plugin-direct-import) with the following configuration:
+
+  `yarn add -D babel-plugin-direct-import`
+
+  Create a `.babelrc.js` file in the root directory of your project:
+
+  ```js
+  const plugins = [
+    [
+      'babel-plugin-direct-import',
+      { modules: ['@material-ui/core', '@material-ui/icons'] },
+    ],
+  ];
+
+  module.exports = { plugins };
+  ```
+
 If you are using Create React App, you will need to use a couple of projects that let you use `.babelrc` configuration, without ejecting.
 
 `yarn add -D react-app-rewired customize-cra`

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -1,4 +1,4 @@
-# Minimizing Bundle Size
+# Minimizing bundle size
 
 <p class="description">Learn more about the tools you can leverage to reduce the bundle size.</p>
 
@@ -24,8 +24,9 @@ that doesn't support tree-shaking.
 
 ## Development environment
 
-Development bundles can contain the full library which can lead to **slower startup times**. This is especially noticeable if you
-import from `@material-ui/icons`. Startup times can be approximately 6x slower than without named imports from the top-level API.
+Development bundles can contain the full library which can lead to **slower startup times**.
+This is especially noticeable if you import from `@material-ui/icons`.
+Startup times can be approximately 6x slower than without named imports from the top-level API.
 
 If this is an issue for you, you have various options:
 
@@ -40,19 +41,19 @@ import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 ```
 
-instead of top level imports (without a Babel plugin):
+instead of top-level imports (without a Babel plugin):
 
 ```js
 import { Button, TextField } from '@material-ui/core';
 ```
 
-This is the option we document in all the demos, since it requires no configuration.
-It is encouraged for library authors extending the components.
+This is the option we document in all the demos since it requires no configuration.
+It is encouraged for library authors that are extending the components.
 Head to [Option 2](#option-2) for the approach that yields the best DX and UX.
 
 While importing directly in this manner doesn't use the exports in [the main file of `@material-ui/core`](https://unpkg.com/@material-ui/core), this file can serve as a handy reference as to which modules are public.
 
-Be aware that we only support first and second level imports.
+Be aware that we only support first and second-level imports.
 Anything deeper is considered private and can cause issues, such as module duplication in your bundle.
 
 ```js
@@ -90,7 +91,7 @@ If you're using `eslint` you can catch problematic imports with the [`no-restric
 
 This option provides the best User Experience and Developer Experience:
 
-- UX: The Babel plugin enables top level tree-shaking even if your bundler doesn't support it.
+- UX: The Babel plugin enables top-level tree-shaking even if your bundler doesn't support it.
 - DX: The Babel plugin makes startup time in dev mode as fast as Option 1.
 - DX: This syntax reduces the duplication of code, requiring only a single import for multiple modules.
   Overall, the code is easier to read, and you are less likely to make a mistake when importing a new module.

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -137,32 +137,6 @@ Pick one of the following plugins:
   module.exports = { plugins };
   ```
 
-- [babel-plugin-transform-imports](https://www.npmjs.com/package/babel-plugin-transform-imports) with the following configuration:
-
-  `yarn add -D babel-plugin-transform-imports`
-
-  Create a `.babelrc.js` file in the root directory of your project:
-
-  ```js
-  const plugins = [
-    [
-      'babel-plugin-transform-imports',
-      {
-        '@material-ui/core': {
-          transform: '@material-ui/core/${member}',
-          preventFullImport: true,
-        },
-        '@material-ui/icons': {
-          transform: '@material-ui/icons/${member}',
-          preventFullImport: true,
-        },
-      },
-    ],
-  ];
-
-  module.exports = { plugins };
-  ```
-
 - [babel-plugin-direct-import](https://github.com/umidbekk/babel-plugin-direct-import) with the following configuration:
 
   `yarn add -D babel-plugin-direct-import`


### PR DESCRIPTION
Preview: https://deploy-preview-27335--material-ui.netlify.app/guides/minimizing-bundle-size/

Background:
- At first it was a `babel-plugin-material-ui`: #5625, #5754
- Then it was reimplemented as generic `babel-plugin-direct-import`: #7707
- It was deprecated after `webpack` start to support `sideEffects` flag: https://github.com/umidbekk/babel-plugin-direct-import/issues/13#issuecomment-419017347
- Then it was removed from this section of the docs (can't find the link to PR)

Why returning back?

- `webpack` applies optimizations for `sideEffects` flag only during production, so importing single icon from `@material-ui/icons` drastically slows initial start for CRA server, same goes for NextJS (hopefully wide adaptation of Vite and Snowpack will resolve it's issue in the future)
- At first it has a shallow scanner, that only checked first facade import and redirects to the required module, but now it performs full scan of the dependency tree: [test/@material-ui/core/exports.spec.js](https://github.com/umidbekk/babel-plugin-direct-import/blob/master/test/%40material-ui/core/exports.spec.js#L8-L887)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
