### PR TITLE
[Modal] Prevent default instead of stop propagation on Esc keydown

### DIFF
--- a/docs/pages/api-docs/dialog.json
+++ b/docs/pages/api-docs/dialog.json
@@ -9,7 +9,6 @@
     },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "disableEscapeKeyDown": { "type": { "name": "bool" } },
     "fullScreen": { "type": { "name": "bool" } },
     "fullWidth": { "type": { "name": "bool" } },
     "maxWidth": {

--- a/docs/pages/api-docs/modal-unstyled.json
+++ b/docs/pages/api-docs/modal-unstyled.json
@@ -15,7 +15,6 @@
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
     "disableAutoFocus": { "type": { "name": "bool" } },
     "disableEnforceFocus": { "type": { "name": "bool" } },
-    "disableEscapeKeyDown": { "type": { "name": "bool" } },
     "disablePortal": { "type": { "name": "bool" } },
     "disableRestoreFocus": { "type": { "name": "bool" } },
     "disableScrollLock": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/modal.json
+++ b/docs/pages/api-docs/modal.json
@@ -18,7 +18,6 @@
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
     "disableAutoFocus": { "type": { "name": "bool" } },
     "disableEnforceFocus": { "type": { "name": "bool" } },
-    "disableEscapeKeyDown": { "type": { "name": "bool" } },
     "disablePortal": { "type": { "name": "bool" } },
     "disableRestoreFocus": { "type": { "name": "bool" } },
     "disableScrollLock": { "type": { "name": "bool" } },

--- a/docs/translations/api-docs/dialog/dialog.json
+++ b/docs/translations/api-docs/dialog/dialog.json
@@ -6,7 +6,6 @@
     "BackdropComponent": "A backdrop component. This prop enables custom backdrop rendering.",
     "children": "Dialog children, usually the included sub-components.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
-    "disableEscapeKeyDown": "If <code>true</code>, hitting escape will not fire the <code>onClose</code> callback.",
     "fullScreen": "If <code>true</code>, the dialog is full-screen.",
     "fullWidth": "If <code>true</code>, the dialog stretches to <code>maxWidth</code>.<br>Notice that the dialog width grow is limited by the default margin.",
     "maxWidth": "Determine the max-width of the dialog. The dialog width grows with the size of the screen. Set to <code>false</code> to disable <code>maxWidth</code>.",

--- a/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
+++ b/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
@@ -12,7 +12,6 @@
     "container": "An HTML element or function that returns one. The <code>container</code> will have the portal children appended to it.<br>By default, it uses the body of the top-level document object, so it&#39;s simply <code>document.body</code> most of the time.",
     "disableAutoFocus": "If <code>true</code>, the modal will not automatically shift focus to itself when it opens, and replace it to the last focused element when it closes. This also works correctly with any modal children that have the <code>disableAutoFocus</code> prop.<br>Generally this should never be set to <code>true</code> as it makes the modal less accessible to assistive technologies, like screen readers.",
     "disableEnforceFocus": "If <code>true</code>, the modal will not prevent focus from leaving the modal while open.<br>Generally this should never be set to <code>true</code> as it makes the modal less accessible to assistive technologies, like screen readers.",
-    "disableEscapeKeyDown": "If <code>true</code>, hitting escape will not fire the <code>onClose</code> callback.",
     "disablePortal": "The <code>children</code> will be under the DOM hierarchy of the parent component.",
     "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden.",
     "disableScrollLock": "Disable the scroll lock behavior.",

--- a/docs/translations/api-docs/modal/modal.json
+++ b/docs/translations/api-docs/modal/modal.json
@@ -11,7 +11,6 @@
     "container": "An HTML element or function that returns one. The <code>container</code> will have the portal children appended to it.<br>By default, it uses the body of the top-level document object, so it&#39;s simply <code>document.body</code> most of the time.",
     "disableAutoFocus": "If <code>true</code>, the modal will not automatically shift focus to itself when it opens, and replace it to the last focused element when it closes. This also works correctly with any modal children that have the <code>disableAutoFocus</code> prop.<br>Generally this should never be set to <code>true</code> as it makes the modal less accessible to assistive technologies, like screen readers.",
     "disableEnforceFocus": "If <code>true</code>, the modal will not prevent focus from leaving the modal while open.<br>Generally this should never be set to <code>true</code> as it makes the modal less accessible to assistive technologies, like screen readers.",
-    "disableEscapeKeyDown": "If <code>true</code>, hitting escape will not fire the <code>onClose</code> callback.",
     "disablePortal": "The <code>children</code> will be under the DOM hierarchy of the parent component.",
     "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden.",
     "disableScrollLock": "Disable the scroll lock behavior.",

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.d.ts
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.d.ts
@@ -72,11 +72,6 @@ export interface ModalUnstyledTypeMap<P = {}, D extends React.ElementType = 'div
      */
     disableEnforceFocus?: boolean;
     /**
-     * If `true`, hitting escape will not fire the `onClose` callback.
-     * @default false
-     */
-    disableEscapeKeyDown?: boolean;
-    /**
      * The `children` will be under the DOM hierarchy of the parent component.
      * @default false
      */

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalUnstyled.js
@@ -65,7 +65,6 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
     container,
     disableAutoFocus = false,
     disableEnforceFocus = false,
-    disableEscapeKeyDown = false,
     disablePortal = false,
     disableRestoreFocus = false,
     disableScrollLock = false,
@@ -157,7 +156,6 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
     closeAfterTransition,
     disableAutoFocus,
     disableEnforceFocus,
-    disableEscapeKeyDown,
     disablePortal,
     disableRestoreFocus,
     disableScrollLock,
@@ -211,20 +209,12 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
       onKeyDown(event);
     }
 
-    // The handler doesn't take event.defaultPrevented into account:
-    //
-    // event.preventDefault() is meant to stop default behaviors like
-    // clicking a checkbox to check it, hitting a button to submit a form,
-    // and hitting left arrow to move the cursor in a text input etc.
-    // Only special HTML elements have these default behaviors.
     if (event.key !== 'Escape' || !isTopModal()) {
       return;
     }
 
-    if (!disableEscapeKeyDown) {
-      // Swallow the event, in case someone is listening for the escape key on the body.
-      event.stopPropagation();
-
+    if (!event.defaultPrevented) {
+      event.preventDefault();
       if (onClose) {
         onClose(event, 'escapeKeyDown');
       }
@@ -360,11 +350,6 @@ ModalUnstyled.propTypes /* remove-proptypes */ = {
    * @default false
    */
   disableEnforceFocus: PropTypes.bool,
-  /**
-   * If `true`, hitting escape will not fire the `onClose` callback.
-   * @default false
-   */
-  disableEscapeKeyDown: PropTypes.bool,
   /**
    * The `children` will be under the DOM hierarchy of the parent component.
    * @default false

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -24,11 +24,6 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
    */
   classes?: Partial<DialogClasses>;
   /**
-   * If `true`, hitting escape will not fire the `onClose` callback.
-   * @default false
-   */
-  disableEscapeKeyDown?: boolean;
-  /**
    * If `true`, the dialog is full-screen.
    * @default false
    */

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -174,7 +174,6 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
     BackdropProps,
     children,
     className,
-    disableEscapeKeyDown = false,
     fullScreen = false,
     fullWidth = false,
     maxWidth = 'sm',
@@ -192,7 +191,6 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
 
   const styleProps = {
     ...props,
-    disableEscapeKeyDown,
     fullScreen,
     fullWidth,
     maxWidth,
@@ -239,7 +237,6 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
       }}
       closeAfterTransition
       BackdropComponent={DialogBackdrop}
-      disableEscapeKeyDown={disableEscapeKeyDown}
       onClose={onClose}
       open={open}
       ref={ref}
@@ -321,11 +318,6 @@ Dialog.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   className: PropTypes.string,
-  /**
-   * If `true`, hitting escape will not fire the `onClose` callback.
-   * @default false
-   */
-  disableEscapeKeyDown: PropTypes.bool,
   /**
    * If `true`, the dialog is full-screen.
    * @default false

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -111,10 +111,10 @@ describe('<Dialog />', () => {
   });
 
   it('can ignore backdrop click and Esc keydown', () => {
-    function DialogWithBackdropClickDisabled(props) {
+    function DialogWithBackdropClickEscKeydownDisabled(props) {
       const { onClose, ...other } = props;
       function handleClose(event, reason) {
-        if (reason !== 'backdropClick') {
+        if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
           onClose(event, reason);
         }
       }
@@ -123,14 +123,9 @@ describe('<Dialog />', () => {
     }
     const onClose = spy();
     const { getByRole } = render(
-      <DialogWithBackdropClickDisabled
-        open
-        disableEscapeKeyDown
-        onClose={onClose}
-        transitionDuration={0}
-      >
+      <DialogWithBackdropClickEscKeydownDisabled open onClose={onClose} transitionDuration={0}>
         foo
-      </DialogWithBackdropClickDisabled>,
+      </DialogWithBackdropClickEscKeydownDisabled>,
     );
     const dialog = getByRole('dialog');
     expect(dialog).not.to.equal(null);

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -69,7 +69,6 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     componentsProps = {},
     disableAutoFocus = false,
     disableEnforceFocus = false,
-    disableEscapeKeyDown = false,
     disablePortal = false,
     disableRestoreFocus = false,
     disableScrollLock = false,
@@ -84,7 +83,6 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     closeAfterTransition,
     disableAutoFocus,
     disableEnforceFocus,
-    disableEscapeKeyDown,
     disablePortal,
     disableRestoreFocus,
     disableScrollLock,
@@ -204,11 +202,6 @@ Modal.propTypes /* remove-proptypes */ = {
    * @default false
    */
   disableEnforceFocus: PropTypes.bool,
-  /**
-   * If `true`, hitting escape will not fire the `onClose` callback.
-   * @default false
-   */
-  disableEscapeKeyDown: PropTypes.bool,
   /**
    * The `children` will be under the DOM hierarchy of the parent component.
    * @default false

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -273,7 +273,7 @@ describe('<Modal />', () => {
       expect(onCloseSpy).to.have.property('callCount', 0);
     });
 
-    it('should call onClose when Esc is pressed and stop event propagation', () => {
+    it('should call onClose when Esc is pressed and prevent default', () => {
       const handleKeyDown = spy();
       const onCloseSpy = spy();
       const { getByTestId } = render(
@@ -292,15 +292,23 @@ describe('<Modal />', () => {
       });
 
       expect(onCloseSpy).to.have.property('callCount', 1);
-      expect(handleKeyDown).to.have.property('callCount', 0);
+      expect(onCloseSpy.firstCall.args[1]).to.equal('escapeKeyDown');
+      expect(handleKeyDown).to.have.property('callCount', 1);
+      expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
     });
 
-    it('should not call onClose when `disableEscapeKeyDown={true}`', () => {
+    it('can skip closing if the Escape key is pressed', () => {
       const handleKeyDown = spy();
       const onCloseSpy = spy();
       const { getByTestId } = render(
         <div onKeyDown={handleKeyDown}>
-          <Modal open disableEscapeKeyDown onClose={onCloseSpy}>
+          <Modal
+            open
+            onClose={onCloseSpy}
+            onKeyDown={(event) => {
+              event.preventDefault();
+            }}
+          >
             <div data-testid="modal" tabIndex={-1} />
           </Modal>
         </div>,


### PR DESCRIPTION
### Breaking changes

- [Dialog] Remove the `disableEscapeKeyDown` prop. It's redundant with the `reason` argument.

  ```diff
  <Dialog
  - disableEscapeKeyDown
  + onKeyDown={event => {
  +   event.preventDefault();
  + }}
  />
  ```

- `keydown` events continue to bubble of they closed a `Dialog` but have their `defaultPrevented` set to `true`
   This is in line with how we handle other `keydown` events

- [Modal] Remove the `disableEscapeKeyDown` prop. It's redundant with the `reason` argument.

  ```diff
  <Modal
  - disableEscapeKeyDown
  + onKeyDown={event => {
  +   event.preventDefault();
  + }}
  />
  ```
- `keydown` events continue to bubble of they closed a `Modal` but have their `defaultPrevented` set to `true`
   This is in line with how we handle other `keydown` events

Closes https://github.com/mui-org/material-ui/issues/27306