### PR TITLE
[TextField] Fix name of componentsProps

### DIFF
--- a/docs/pages/api-docs/form-control-label.json
+++ b/docs/pages/api-docs/form-control-label.json
@@ -3,7 +3,7 @@
     "control": { "type": { "name": "element" }, "required": true },
     "checked": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
-    "componentProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
     "disabled": { "type": { "name": "bool" } },
     "disableTypography": { "type": { "name": "bool" } },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },

--- a/docs/translations/api-docs/form-control-label/form-control-label.json
+++ b/docs/translations/api-docs/form-control-label/form-control-label.json
@@ -3,7 +3,7 @@
   "propDescriptions": {
     "checked": "If <code>true</code>, the component appears selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
-    "componentProps": "The props used for each slot inside.",
+    "componentsProps": "The props used for each slot inside.",
     "control": "A control element. For instance, it can be a <code>Radio</code>, a <code>Switch</code> or a <code>Checkbox</code>.",
     "disabled": "If <code>true</code>, the control is disabled.",
     "disableTypography": "If <code>true</code>, the label is rendered as it is passed without an additional typography node.",

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -18,7 +18,7 @@ export interface FormControlLabelProps
    * The props used for each slot inside.
    * @default {}
    */
-  componentProps?: {
+   componentsProps?: {
     /**
      * Props applied to the Typography wrapper of the passed label.
      * This is unused if disableTpography is true.

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -18,7 +18,7 @@ export interface FormControlLabelProps
    * The props used for each slot inside.
    * @default {}
    */
-   componentsProps?: {
+  componentsProps?: {
     /**
      * Props applied to the Typography wrapper of the passed label.
      * This is unused if disableTpography is true.

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -75,7 +75,7 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
   const {
     checked,
     className,
-    componentProps = {},
+    componentsProps = {},
     control,
     disabled: disabledProp,
     disableTypography,
@@ -128,7 +128,7 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
       {label.type === Typography || disableTypography ? (
         label
       ) : (
-        <Typography component="span" className={classes.label} {...componentProps.typography}>
+        <Typography component="span" className={classes.label} {...componentsProps.typography}>
           {label}
         </Typography>
       )}
@@ -157,7 +157,7 @@ FormControlLabel.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentProps: PropTypes.object,
+  componentsProps: PropTypes.object,
   /**
    * A control element. For instance, it can be a `Radio`, a `Switch` or a `Checkbox`.
    */

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -116,12 +116,12 @@ describe('<FormControlLabel />', () => {
     });
   });
 
-  describe('componentProps: typography', () => {
+  describe('componentsProps: typography', () => {
     it('should spread its contents to the typography element', () => {
       const { getByTestId } = render(
         <FormControlLabel
           label="Pizza"
-          componentProps={{
+          componentsProps={{
             typography: {
               'data-testid': 'labelTypography',
               name: 'test',


### PR DESCRIPTION
### Breaking changes

- [TextField] Fix name of componentsProps (#27338) @oliviertassinari

  ```diff
   <FormControlLabel
     label="Pizza"
  -  componentProps={{
  +  componentsProps={{
       typography: {
  ```

---

Something I have noticed in #26810. Confusion between `componentsProps` and `componentProps` coming from #25883.