### PR TITLE
[docs] Transpile markdown files

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -95,7 +95,10 @@ module.exports = {
             oneOf: [
               {
                 resourceQuery: /@material-ui\/markdown/,
-                use: require.resolve('@material-ui/markdown/loader'),
+                use: [
+                  options.defaultLoaders.babel,
+                  require.resolve('@material-ui/markdown/loader'),
+                ],
               },
               {
                 // used in some /getting-started/templates


### PR DESCRIPTION
Docs currently crash in IE11 because the markdown loader creates arrow functions. The generated JS should be transpiled regardless.