### PR TITLE
[core] Remove obsolete styles documentation

### DIFF
--- a/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js
@@ -20,7 +20,6 @@ const TimelineConnectorRoot = styled('span', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => {
-  /* Styles applied to the root element. */
   return {
     width: 2,
     backgroundColor: theme.palette.grey[400],

--- a/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/material-ui-lab/src/TimelineContent/TimelineContent.js
@@ -26,11 +26,9 @@ const TimelineContentRoot = styled(Typography, {
     return [styles.root, styles[`position${capitalize(styleProps.position)}`]];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   flex: 1,
   padding: '6px 16px',
   textAlign: 'left',
-  /* Styles applied to the root element if `position="left"`. */
   ...(styleProps.position === 'left' && {
     textAlign: 'right',
   }),

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
@@ -31,7 +31,6 @@ const TimelineDotRoot = styled('span', {
     ];
   },
 })(({ styleProps, theme }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   alignSelf: 'baseline',
   borderStyle: 'solid',

--- a/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -26,12 +26,10 @@ const TimelineOppositeContentRoot = styled(Typography, {
     return [styles.root, styles[`position${capitalize(styleProps.position)}`]];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   padding: '6px 16px',
   marginRight: 'auto',
   textAlign: 'right',
   flex: 1,
-  /* Styles applied to the root element if `position="left"`. */
   ...(styleProps.position === 'left' && {
     textAlign: 'left',
   }),

--- a/packages/material-ui/src/Accordion/Accordion.js
+++ b/packages/material-ui/src/Accordion/Accordion.js
@@ -49,7 +49,6 @@ const AccordionRoot = styled(Paper, {
     };
 
     return {
-      /* Styles applied to the root element. */
       position: 'relative',
       transition: theme.transitions.create(['margin'], transition),
       overflowAnchor: 'none', // Keep the same scrolling position
@@ -69,7 +68,6 @@ const AccordionRoot = styled(Paper, {
           display: 'none',
         },
       },
-      /* Styles applied to the root element if `expanded={true}`. */
       [`&.${accordionClasses.expanded}`]: {
         '&:before': {
           opacity: 0,
@@ -86,14 +84,12 @@ const AccordionRoot = styled(Paper, {
           },
         },
       },
-      /* Styles applied to the root element if `disabled={true}`. */
       [`&.${accordionClasses.disabled}`]: {
         backgroundColor: theme.palette.action.disabledBackground,
       },
     };
   },
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element unless `square={true}`. */
     ...(!styleProps.square && {
       borderRadius: 0,
       '&:first-of-type': {
@@ -110,7 +106,6 @@ const AccordionRoot = styled(Paper, {
         },
       },
     }),
-    /* Styles applied to the root element unless `disableGutters={true}`. */
     ...(!styleProps.disableGutters && {
       [`&.${accordionClasses.expanded}`]: {
         margin: '16px 0',

--- a/packages/material-ui/src/AccordionActions/AccordionActions.js
+++ b/packages/material-ui/src/AccordionActions/AccordionActions.js
@@ -25,12 +25,10 @@ const AccordionActionsRoot = styled('div', {
     return [styles.root, !styleProps.disableSpacing && styles.spacing];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   alignItems: 'center',
   padding: 8,
   justifyContent: 'flex-end',
-  /* Styles applied to the root element unless `disableSpacing={true}`. */
   ...(!styleProps.disableSpacing && {
     '& > :not(:first-of-type)': {
       marginLeft: 8,

--- a/packages/material-ui/src/AccordionDetails/AccordionDetails.js
+++ b/packages/material-ui/src/AccordionDetails/AccordionDetails.js
@@ -21,7 +21,6 @@ const AccordionDetailsRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   padding: theme.spacing(1, 2, 2),
 }));
 

--- a/packages/material-ui/src/AccordionSummary/AccordionSummary.js
+++ b/packages/material-ui/src/AccordionSummary/AccordionSummary.js
@@ -33,23 +33,19 @@ const AccordionSummaryRoot = styled(ButtonBase, {
   };
 
   return {
-    /* Styles applied to the root element. */
     display: 'flex',
     minHeight: 48,
     padding: theme.spacing(0, 2),
     transition: theme.transitions.create(['min-height', 'background-color'], transition),
-    /* Styles applied to the ButtonBase root element if the button is keyboard focused. */
     [`&.${accordionSummaryClasses.focusVisible}`]: {
       backgroundColor: theme.palette.action.focus,
     },
-    /* Styles applied to the root element if `disabled={true}`. */
     [`&.${accordionSummaryClasses.disabled}`]: {
       opacity: theme.palette.action.disabledOpacity,
     },
     [`&:hover:not(.${accordionSummaryClasses.disabled})`]: {
       cursor: 'pointer',
     },
-    /* Styles applied to the root element unless `disableGutters={true}`. */
     ...(!styleProps.disableGutters && {
       [`&.${accordionSummaryClasses.expanded}`]: {
         minHeight: 64,
@@ -63,11 +59,9 @@ const AccordionSummaryContent = styled('div', {
   slot: 'Content',
   overridesResolver: (props, styles) => styles.content,
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the children wrapper element. */
   display: 'flex',
   flexGrow: 1,
   margin: '12px 0',
-  /* Styles applied to the children wrapper element unless `disableGutters={true}`. */
   ...(!styleProps.disableGutters && {
     transition: theme.transitions.create(['margin'], {
       duration: theme.transitions.duration.shortest,
@@ -83,14 +77,12 @@ const AccordionSummaryExpandIconWrapper = styled('div', {
   slot: 'ExpandIconWrapper',
   overridesResolver: (props, styles) => styles.expandIconWrapper,
 })(({ theme }) => ({
-  /* Styles applied to the `expandIcon`'s wrapper element. */
   display: 'flex',
   color: theme.palette.action.active,
   transform: 'rotate(0deg)',
   transition: theme.transitions.create('transform', {
     duration: theme.transitions.duration.shortest,
   }),
-  /* Styles applied to the `expandIcon`'s wrapper element if `expanded={true}`. */
   [`&.${accordionSummaryClasses.expanded}`]: {
     transform: 'rotate(180deg)',
   },

--- a/packages/material-ui/src/Alert/Alert.js
+++ b/packages/material-ui/src/Alert/Alert.js
@@ -46,13 +46,11 @@ const AlertRoot = styled(Paper, {
   const color = styleProps.color || styleProps.severity;
 
   return {
-    /* Styles applied to the root element. */
     ...theme.typography.body2,
     borderRadius: theme.shape.borderRadius,
     backgroundColor: 'transparent',
     display: 'flex',
     padding: '6px 16px',
-    /* Styles applied to the root element if variant="standard". */
     ...(color &&
       styleProps.variant === 'standard' && {
         color: getColor(theme.palette[color].light, 0.6),
@@ -62,7 +60,6 @@ const AlertRoot = styled(Paper, {
             theme.palette.mode === 'dark' ? theme.palette[color].main : theme.palette[color].light,
         },
       }),
-    /* Styles applied to the root element if variant="outlined". */
     ...(color &&
       styleProps.variant === 'outlined' && {
         color: getColor(theme.palette[color].light, 0.6),
@@ -72,7 +69,6 @@ const AlertRoot = styled(Paper, {
             theme.palette.mode === 'dark' ? theme.palette[color].main : theme.palette[color].light,
         },
       }),
-    /* Styles applied to the root element if variant="filled". */
     ...(color &&
       styleProps.variant === 'filled' && {
         color: '#fff',
@@ -83,7 +79,6 @@ const AlertRoot = styled(Paper, {
   };
 });
 
-/* Styles applied to the icon wrapper element. */
 const AlertIcon = styled('div', {
   name: 'MuiAlert',
   slot: 'Icon',
@@ -96,7 +91,6 @@ const AlertIcon = styled('div', {
   opacity: 0.9,
 });
 
-/* Styles applied to the message wrapper element. */
 const AlertMessage = styled('div', {
   name: 'MuiAlert',
   slot: 'Message',
@@ -105,7 +99,6 @@ const AlertMessage = styled('div', {
   padding: '8px 0',
 });
 
-/* Styles applied to the action wrapper element if `action` is provided. */
 const AlertAction = styled('div', {
   name: 'MuiAlert',
   slot: 'Action',

--- a/packages/material-ui/src/AlertTitle/AlertTitle.js
+++ b/packages/material-ui/src/AlertTitle/AlertTitle.js
@@ -22,7 +22,6 @@ const AlertTitleRoot = styled(Typography, {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => {
-  /* Styles applied to the root element. */
   return {
     fontWeight: theme.typography.fontWeightMedium,
     marginTop: -2,

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -35,13 +35,11 @@ const AppBarRoot = styled(Paper, {
     theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[900];
 
   return {
-    /* Styles applied to the root element. */
     display: 'flex',
     flexDirection: 'column',
     width: '100%',
     boxSizing: 'border-box', // Prevent padding issue with the Modal and fixed positioned AppBar.
     flexShrink: 0,
-    /* Styles applied to the root element if `position="fixed"`. */
     ...(styleProps.position === 'fixed' && {
       position: 'fixed',
       zIndex: theme.zIndex.appBar,
@@ -53,7 +51,6 @@ const AppBarRoot = styled(Paper, {
         position: 'absolute',
       },
     }),
-    /* Styles applied to the root element if `position="absolute"`. */
     ...(styleProps.position === 'absolute' && {
       position: 'absolute',
       zIndex: theme.zIndex.appBar,
@@ -61,7 +58,6 @@ const AppBarRoot = styled(Paper, {
       left: 'auto',
       right: 0,
     }),
-    /* Styles applied to the root element if `position="sticky"`. */
     ...(styleProps.position === 'sticky' && {
       // ⚠️ sticky is not supported by IE11.
       position: 'sticky',
@@ -70,20 +66,16 @@ const AppBarRoot = styled(Paper, {
       left: 'auto',
       right: 0,
     }),
-    /* Styles applied to the root element if `position="static"`. */
     ...(styleProps.position === 'static' && {
       position: 'static',
     }),
-    /* Styles applied to the root element if `position="relative"`. */
     ...(styleProps.position === 'relative' && {
       position: 'relative',
     }),
-    /* Styles applied to the root element if `color="default"`. */
     ...(styleProps.color === 'default' && {
       backgroundColor: backgroundColorDefault,
       color: theme.palette.getContrastText(backgroundColorDefault),
     }),
-    /* Styles applied to the root element if colors comes from palette. */
     ...(styleProps.color &&
       styleProps.color !== 'default' &&
       styleProps.color !== 'inherit' &&
@@ -91,11 +83,9 @@ const AppBarRoot = styled(Paper, {
         backgroundColor: theme.palette[styleProps.color].main,
         color: theme.palette[styleProps.color].contrastText,
       }),
-    /* Styles applied to the root element if `color="inherit"`. */
     ...(styleProps.color === 'inherit' && {
       color: 'inherit',
     }),
-    /* Styles applied to the root element if `color="transparent"`. */
     ...(styleProps.color === 'transparent' && {
       backgroundColor: 'transparent',
       color: 'inherit',

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -77,7 +77,6 @@ const AutocompleteRoot = styled('div', {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   [`&.${autocompleteClasses.focused} .${autocompleteClasses.clearIndicator}`]: {
     visibility: 'visible',
   },
@@ -87,21 +86,17 @@ const AutocompleteRoot = styled('div', {
       visibility: 'visible',
     },
   },
-  /* Styles applied to the root element if `fullWidth={true}`. */
   ...(styleProps.fullWidth && {
     width: '100%',
   }),
-  /* Styles applied to the tag elements, e.g. the chips. */
   [`& .${autocompleteClasses.tag}`]: {
     margin: 3,
     maxWidth: 'calc(100% - 6px)',
-    /* Styles applied to the tag elements, e.g. the chips if `size="small"`. */
     ...(styleProps.size === 'small' && {
       margin: 2,
       maxWidth: 'calc(100% - 4px)',
     }),
   },
-  /* Styles applied to the Input element. */
   [`& .${autocompleteClasses.inputRoot}`]: {
     flexWrap: 'wrap',
     [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
@@ -169,12 +164,10 @@ const AutocompleteRoot = styled('div', {
       padding: '2.5px 4px',
     },
   },
-  /* Styles applied to the input element. */
   [`& .${autocompleteClasses.input}`]: {
     flexGrow: 1,
     textOverflow: 'ellipsis',
     opacity: 0,
-    /* Styles applied to the input element if tag focused. */
     ...(styleProps.inputFocused && {
       opacity: 1,
     }),
@@ -186,7 +179,6 @@ const AutocompleteEndAdornment = styled('div', {
   slot: 'EndAdornment',
   overridesResolver: (props, styles) => styles.endAdornment,
 })({
-  /* Styles applied to the endAdornment element. */
   // We use a position absolute to support wrapping tags.
   position: 'absolute',
   right: 0,
@@ -198,7 +190,6 @@ const AutocompleteClearIndicator = styled(IconButton, {
   slot: 'ClearIndicator',
   overridesResolver: (props, styles) => styles.clearIndicator,
 })({
-  /* Styles applied to the clear indicator. */
   marginRight: -2,
   padding: 4,
   visibility: 'hidden',
@@ -212,10 +203,8 @@ const AutocompletePopupIndicator = styled(IconButton, {
     ...(styleProps.popupOpen && styles.popupIndicatorOpen),
   }),
 })(({ styleProps }) => ({
-  /* Styles applied to the popup indicator. */
   padding: 2,
   marginRight: -2,
-  /* Styles applied to the popup indicator if the popup is open. */
   ...(styleProps.popupOpen && {
     transform: 'rotate(180deg)',
   }),
@@ -234,9 +223,7 @@ const AutocompletePopper = styled(Popper, {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the popper element. */
   zIndex: theme.zIndex.modal,
-  /* Styles applied to the popper element if `disablePortal={true}`. */
   ...(styleProps.disablePortal && {
     position: 'absolute',
   }),
@@ -247,7 +234,6 @@ const AutocompletePaper = styled(Paper, {
   slot: 'Paper',
   overridesResolver: (props, styles) => styles.paper,
 })(({ theme }) => ({
-  /* Styles applied to the Paper component. */
   ...theme.typography.body1,
   overflow: 'auto',
 }));
@@ -257,7 +243,6 @@ const AutocompleteLoading = styled('div', {
   slot: 'Loading',
   overridesResolver: (props, styles) => styles.loading,
 })(({ theme }) => ({
-  /* Styles applied to the loading wrapper. */
   color: theme.palette.text.secondary,
   padding: '14px 16px',
 }));
@@ -267,7 +252,6 @@ const AutocompleteNoOptions = styled('div', {
   slot: 'NoOptions',
   overridesResolver: (props, styles) => styles.noOptions,
 })(({ theme }) => ({
-  /* Styles applied to the no option wrapper. */
   color: theme.palette.text.secondary,
   padding: '14px 16px',
 }));
@@ -277,13 +261,11 @@ const AutocompleteListbox = styled('div', {
   slot: 'Listbox',
   overridesResolver: (props, styles) => styles.listbox,
 })(({ theme }) => ({
-  /* Styles applied to the listbox component. */
   listStyle: 'none',
   margin: 0,
   padding: '8px 0',
   maxHeight: '40vh',
   overflow: 'auto',
-  /* Styles applied to the option elements. */
   [`& .${autocompleteClasses.option}`]: {
     minHeight: 48,
     display: 'flex',
@@ -342,7 +324,6 @@ const AutocompleteGroupLabel = styled(ListSubheader, {
   slot: 'GroupLabel',
   overridesResolver: (props, styles) => styles.groupLabel,
 })(({ theme }) => ({
-  /* Styles applied to the group's label elements. */
   backgroundColor: theme.palette.background.paper,
   top: -8,
 }));
@@ -352,7 +333,6 @@ const AutocompleteGroupUl = styled('ul', {
   slot: 'GroupUl',
   overridesResolver: (props, styles) => styles.groupUl,
 })({
-  /* Styles applied to the group's ul elements. */
   padding: 0,
   [`& .${autocompleteClasses.option}`]: {
     paddingLeft: 24,

--- a/packages/material-ui/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui/src/AvatarGroup/AvatarGroup.js
@@ -41,7 +41,6 @@ const AvatarGroupRoot = styled('div', {
       marginLeft: 0,
     },
   },
-  /* Styles applied to the root element. */
   display: 'flex',
   flexDirection: 'row-reverse',
 }));

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -32,7 +32,6 @@ const BackdropRoot = styled('div', {
   left: 0,
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
   WebkitTapHighlightColor: 'transparent',
-  /* Styles applied to the root element if `invisible={true}`. */
   ...(styleProps.invisible && {
     backgroundColor: 'transparent',
   }),

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -22,7 +22,6 @@ const BottomNavigationRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   justifyContent: 'center',
   height: 56,

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -30,7 +30,6 @@ const BottomNavigationActionRoot = styled(ButtonBase, {
     return [styles.root, !styleProps.showLabel && !styleProps.selected && styles.iconOnly];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   transition: theme.transitions.create(['color', 'padding-top'], {
     duration: theme.transitions.duration.short,
   }),
@@ -55,7 +54,6 @@ const BottomNavigationActionLabel = styled('span', {
   slot: 'Label',
   overridesResolver: (props, styles) => styles.label,
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the label's span element. */
   fontFamily: theme.typography.fontFamily,
   fontSize: theme.typography.pxToRem(12),
   opacity: 1,

--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -23,7 +23,6 @@ const CardRoot = styled(Paper, {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(() => {
-  /* Styles applied to the root element. */
   return {
     overflow: 'hidden',
   };

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -23,7 +23,6 @@ const CardActionAreaRoot = styled(ButtonBase, {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   display: 'block',
   textAlign: 'inherit',
   width: '100%',
@@ -43,7 +42,6 @@ const CardActionAreaFocusHighlight = styled('span', {
   slot: 'FocusHighlight',
   overridesResolver: (props, styles) => styles.focusHighlight,
 })(({ theme }) => ({
-  /* Styles applied to the overlay that covers the action area when it is keyboard focused. */
   overflow: 'hidden',
   pointerEvents: 'none',
   position: 'absolute',

--- a/packages/material-ui/src/CardActions/CardActions.js
+++ b/packages/material-ui/src/CardActions/CardActions.js
@@ -25,11 +25,9 @@ const CardActionsRoot = styled('div', {
     return [styles.root, !styleProps.disableSpacing && styles.spacing];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   alignItems: 'center',
   padding: 8,
-  /* Styles applied to the root element unless `disableSpacing={true}`. */
   ...(!styleProps.disableSpacing && {
     '& > :not(:first-of-type)': {
       marginLeft: 8,

--- a/packages/material-ui/src/CardContent/CardContent.js
+++ b/packages/material-ui/src/CardContent/CardContent.js
@@ -21,7 +21,6 @@ const CardContentRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(() => {
-  /* Styles applied to the root element. */
   return {
     padding: 16,
     '&:last-child': {

--- a/packages/material-ui/src/CardHeader/CardHeader.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.js
@@ -31,7 +31,6 @@ const CardHeaderRoot = styled('div', {
     ...styles.root,
   }),
 })({
-  /* Styles applied to the root element. */
   display: 'flex',
   alignItems: 'center',
   padding: 16,
@@ -42,7 +41,6 @@ const CardHeaderAvatar = styled('div', {
   slot: 'Avatar',
   overridesResolver: (props, styles) => styles.avatar,
 })({
-  /* Styles applied to the avatar element. */
   display: 'flex',
   flex: '0 0 auto',
   marginRight: 16,
@@ -53,7 +51,6 @@ const CardHeaderAction = styled('div', {
   slot: 'Action',
   overridesResolver: (props, styles) => styles.action,
 })({
-  /* Styles applied to the action element. */
   flex: '0 0 auto',
   alignSelf: 'flex-start',
   marginTop: -4,
@@ -66,7 +63,6 @@ const CardHeaderContent = styled('div', {
   slot: 'Content',
   overridesResolver: (props, styles) => styles.content,
 })({
-  /* Styles applied to the content wrapper element. */
   flex: '1 1 auto',
 });
 

--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -27,16 +27,13 @@ const CardMediaRoot = styled('div', {
     return [styles.root, isMediaComponent && styles.media, isImageComponent && styles.img];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'block',
   backgroundSize: 'cover',
   backgroundRepeat: 'no-repeat',
   backgroundPosition: 'center',
-  /* Styles applied to the root element if `component="video, audio, picture, iframe, or img"`. */
   ...(styleProps.isMediaComponent && {
     width: '100%',
   }),
-  /* Styles applied to the root element if `component="picture or img"`. */
   ...(styleProps.isImageComponent && {
     // ⚠️ object-fit is not supported by IE11.
     objectFit: 'cover',

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -41,7 +41,6 @@ const CheckboxRoot = styled(SwitchBase, {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   color: theme.palette.text.secondary,
   '&:hover': {
     backgroundColor: alpha(
@@ -55,7 +54,6 @@ const CheckboxRoot = styled(SwitchBase, {
       backgroundColor: 'transparent',
     },
   },
-  /* Styles applied to the root element unless `color="default"`. */
   ...(styleProps.color !== 'default' && {
     [`&.${checkboxClasses.checked}, &.${checkboxClasses.indeterminate}`]: {
       color: theme.palette[styleProps.color].main,

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -76,7 +76,6 @@ const ChipRoot = styled('div', {
     const deleteIconColor = alpha(theme.palette.text.primary, 0.26);
 
     return {
-      /* Styles applied to the root element. */
       fontFamily: theme.typography.fontFamily,
       fontSize: theme.typography.pxToRem(13),
       display: 'inline-flex',
@@ -124,23 +123,19 @@ const ChipRoot = styled('div', {
         height: 18,
         fontSize: theme.typography.pxToRem(10),
       },
-      /* Styles applied to the icon element. */
       [`& .${chipClasses.icon}`]: {
         color: theme.palette.mode === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
         marginLeft: 5,
         marginRight: -6,
-        /* Styles applied to the icon element if `size="small"`. */
         ...(styleProps.size === 'small' && {
           fontSize: 18,
           marginLeft: 4,
           marginRight: -4,
         }),
-        /* Styles applied to the icon element unless `color="default"`. */
         ...(styleProps.color !== 'default' && {
           color: 'inherit',
         }),
       },
-      /* Styles applied to the deleteIcon element. */
       [`& .${chipClasses.deleteIcon}`]: {
         WebkitTapHighlightColor: 'transparent',
         color: deleteIconColor,
@@ -150,13 +145,11 @@ const ChipRoot = styled('div', {
         '&:hover': {
           color: alpha(deleteIconColor, 0.4),
         },
-        /* Styles applied to the deleteIcon element if `size="small"`. */
         ...(styleProps.size === 'small' && {
           fontSize: 16,
           marginRight: 4,
           marginLeft: -4,
         }),
-        /* Styles applied to the deleteIcon element if not `color="default"` and `variant="filled"`. */
         ...(styleProps.color !== 'default' && {
           color: alpha(theme.palette[styleProps.color].contrastText, 0.7),
           '&:hover, &:active': {
@@ -164,16 +157,13 @@ const ChipRoot = styled('div', {
           },
         }),
       },
-      /* Styles applied to the root element if `size="small"`. */
       ...(styleProps.size === 'small' && {
         height: 24,
       }),
-      /* Styles applied to the root element unless `color="default"`. */
       ...(styleProps.color !== 'default' && {
         backgroundColor: theme.palette[styleProps.color].main,
         color: theme.palette[styleProps.color].contrastText,
       }),
-      /* Styles applied to the root element if `onDelete` is defined. */
       ...(styleProps.onDelete && {
         [`&.${chipClasses.focusVisible}`]: {
           backgroundColor: alpha(
@@ -182,7 +172,6 @@ const ChipRoot = styled('div', {
           ),
         },
       }),
-      /* Styles applied to the root element if `onDelete` and not `color="default"` is defined. */
       ...(styleProps.onDelete &&
         styleProps.color !== 'default' && {
           [`&.${chipClasses.focusVisible}`]: {
@@ -192,7 +181,6 @@ const ChipRoot = styled('div', {
     };
   },
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if `onClick` is defined or `clickable={true}`. */
     ...(styleProps.clickable && {
       userSelect: 'none',
       WebkitTapHighlightColor: 'transparent',
@@ -213,7 +201,6 @@ const ChipRoot = styled('div', {
         boxShadow: theme.shadows[1],
       },
     }),
-    /* Styles applied to the root element if `onClick` and not `color="default"` is defined or `clickable={true}`. */
     ...(styleProps.clickable &&
       styleProps.color !== 'default' && {
         [`&:hover, &.${chipClasses.focusVisible}`]: {
@@ -222,7 +209,6 @@ const ChipRoot = styled('div', {
       }),
   }),
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if `variant="outlined"`. */
     ...(styleProps.variant === 'outlined' && {
       backgroundColor: 'transparent',
       border: `1px solid ${
@@ -253,7 +239,6 @@ const ChipRoot = styled('div', {
         marginRight: 3,
       },
     }),
-    /* Styles applied to the root element if `variant="outlined"` and not `color="default"`. */
     ...(styleProps.variant === 'outlined' &&
       styleProps.color !== 'default' && {
         color: theme.palette[styleProps.color].main,
@@ -270,7 +255,6 @@ const ChipRoot = styled('div', {
             theme.palette.action.focusOpacity,
           ),
         },
-        /* Styles applied to the deleteIcon element if `color="primary"` and `variant="outlined"`. */
         [`& .${chipClasses.deleteIcon}`]: {
           color: alpha(theme.palette[styleProps.color].main, 0.7),
           '&:hover, &:active': {
@@ -291,13 +275,11 @@ const ChipLabel = styled('span', {
     return [styles.label, styles[`label${capitalize(size)}`]];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the label `span` element. */
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   paddingLeft: 12,
   paddingRight: 12,
   whiteSpace: 'nowrap',
-  /* Styles applied to the label `span` element if `size="small"`. */
   ...(styleProps.size === 'small' && {
     paddingLeft: 8,
     paddingRight: 8,

--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -64,18 +64,14 @@ const CircularProgressRoot = styled('span', {
   },
 })(
   ({ styleProps, theme }) => ({
-    /* Styles applied to the root element. */
     display: 'inline-block',
-    /* Styles applied to the root element if `variant="determinate"`. */
     ...(styleProps.variant === 'determinate' && {
       transition: theme.transitions.create('transform'),
     }),
-    /* Styles applied to the root element unless `color="inherit"`. */
     ...(styleProps.color !== 'inherit' && {
       color: theme.palette[styleProps.color].main,
     }),
   }),
-  /* Styles applied to the root element if `variant="indeterminate"`. */
   ({ styleProps }) =>
     styleProps.variant === 'indeterminate' &&
     css`
@@ -88,7 +84,6 @@ const CircularProgressSVG = styled('svg', {
   slot: 'Svg',
   overridesResolver: (props, styles) => styles.svg,
 })({
-  /* Styles applied to the svg element. */
   display: 'block', // Keeps the progress centered
 });
 
@@ -106,15 +101,12 @@ const CircularProgressCircle = styled('circle', {
   },
 })(
   ({ styleProps, theme }) => ({
-    /* Styles applied to the `circle` svg path. */
     stroke: 'currentColor',
     // Use butt to follow the specification, by chance, it's already the default CSS value.
     // strokeLinecap: 'butt',
-    /* Styles applied to the `circle` svg path if `variant="determinate"`. */
     ...(styleProps.variant === 'determinate' && {
       transition: theme.transitions.create('stroke-dashoffset'),
     }),
-    /* Styles applied to the `circle` svg path if `variant="indeterminate"`. */
     ...(styleProps.variant === 'indeterminate' && {
       // Some default value that looks fine waiting for the animation to kicks in.
       strokeDasharray: '80px, 200px',

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -43,7 +43,6 @@ const CollapseRoot = styled('div', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   height: 0,
   overflow: 'hidden',
   transition: theme.transitions.create('height'),
@@ -52,7 +51,6 @@ const CollapseRoot = styled('div', {
     width: 0,
     transition: theme.transitions.create('width'),
   }),
-  /* Styles applied to the root element when the transition has entered. */
   ...(styleProps.state === 'entered' && {
     height: 'auto',
     overflow: 'visible',
@@ -60,7 +58,6 @@ const CollapseRoot = styled('div', {
       width: 'auto',
     }),
   }),
-  /* Styles applied to the root element when the transition has exited and `collapsedSize` = 0px. */
   ...(styleProps.state === 'exited' &&
     !styleProps.in &&
     styleProps.collapsedSize === '0px' && {
@@ -68,7 +65,6 @@ const CollapseRoot = styled('div', {
     }),
 }));
 
-/* Styles applied to the outer wrapper element. */
 const CollapseWrapper = styled('div', {
   name: 'MuiCollapse',
   slot: 'Wrapper',
@@ -83,7 +79,6 @@ const CollapseWrapper = styled('div', {
   }),
 }));
 
-/* Styles applied to the inner wrapper element. */
 const CollapseWrapperInner = styled('div', {
   name: 'MuiCollapse',
   slot: 'WrapperInner',

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -46,7 +46,6 @@ const DialogRoot = styled(Modal, {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })({
-  /* Styles applied to the root element. */
   '@media print': {
     // Use !important to override the Modal inline-style.
     position: 'absolute !important',
@@ -62,20 +61,17 @@ const DialogContainer = styled('div', {
     return [styles.container, styles[`scroll${capitalize(styleProps.scroll)}`]];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the container element. */
   height: '100%',
   '@media print': {
     height: 'auto',
   },
   // We disable the focus ring for mouse, touch and keyboard users.
   outline: 0,
-  /* Styles applied to the container element if `scroll="paper"`. */
   ...(styleProps.scroll === 'paper' && {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
   }),
-  /* Styles applied to the container element if `scroll="body"`. */
   ...(styleProps.scroll === 'body' && {
     overflowY: 'auto',
     overflowX: 'hidden',

--- a/packages/material-ui/src/DialogActions/DialogActions.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.js
@@ -25,13 +25,11 @@ const DialogActionsRoot = styled('div', {
     return [styles.root, !styleProps.disableSpacing && styles.spacing];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   alignItems: 'center',
   padding: 8,
   justifyContent: 'flex-end',
   flex: '0 0 auto',
-  /* Styles applied to the root element unless `disableSpacing={true}`. */
   ...(!styleProps.disableSpacing && {
     '& > :not(:first-of-type)': {
       marginLeft: 8,

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -55,54 +55,45 @@ const DividerRoot = styled('div', {
   },
 })(
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element. */
     margin: 0, // Reset browser default style.
     flexShrink: 0,
     borderWidth: 0,
     borderStyle: 'solid',
     borderColor: theme.palette.divider,
     borderBottomWidth: 'thin',
-    /* Styles applied to the root element if `absolute={true}`. */
     ...(styleProps.absolute && {
       position: 'absolute',
       bottom: 0,
       left: 0,
       width: '100%',
     }),
-    /* Styles applied to the root element if `light={true}`. */
     ...(styleProps.light && {
       borderColor: alpha(theme.palette.divider, 0.08),
     }),
-    /* Styles applied to the root element if `variant="inset"`. */
     ...(styleProps.variant === 'inset' && {
       marginLeft: 72,
     }),
-    /* Styles applied to the root element if `variant="middle"` and `orientation="horizontal"`. */
     ...(styleProps.variant === 'middle' &&
       styleProps.orientation === 'horizontal' && {
         marginLeft: theme.spacing(2),
         marginRight: theme.spacing(2),
       }),
-    /* Styles applied to the root element if `variant="middle"` and `orientation="vertical"`. */
     ...(styleProps.variant === 'middle' &&
       styleProps.orientation === 'vertical' && {
         marginTop: theme.spacing(1),
         marginBottom: theme.spacing(1),
       }),
-    /* Styles applied to the root element if `orientation="vertical"`. */
     ...(styleProps.orientation === 'vertical' && {
       height: '100%',
       borderBottomWidth: 0,
       borderRightWidth: 'thin',
     }),
-    /* Styles applied to the root element if `flexItem={true}`. */
     ...(styleProps.flexItem && {
       alignSelf: 'stretch',
       height: 'auto',
     }),
   }),
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if divider have text. */
     ...(styleProps.children && {
       display: 'flex',
       whiteSpace: 'nowrap',
@@ -119,7 +110,6 @@ const DividerRoot = styled('div', {
     }),
   }),
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if divider have text and `orientation="vertical"`. */
     ...(styleProps.children &&
       styleProps.orientation === 'vertical' && {
         flexDirection: 'column',
@@ -134,7 +124,6 @@ const DividerRoot = styled('div', {
       }),
   }),
   ({ styleProps }) => ({
-    /* Styles applied to the root element if `textAlign="right" orientation="horizontal"`. */
     ...(styleProps.textAlign === 'right' &&
       styleProps.orientation !== 'vertical' && {
         '&::before': {
@@ -144,7 +133,6 @@ const DividerRoot = styled('div', {
           width: '10%',
         },
       }),
-    /* Styles applied to the root element if `textAlign="left" orientation="horizontal"`. */
     ...(styleProps.textAlign === 'left' &&
       styleProps.orientation !== 'vertical' && {
         '&::before': {

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -55,7 +55,6 @@ const DrawerDockedRoot = styled('div', {
   skipVariantsResolver: false,
   overridesResolver,
 })({
-  /* Styles applied to the root element if `variant="permanent or persistent"`. */
   flex: '0 0 auto',
 });
 
@@ -73,7 +72,6 @@ const DrawerPaper = styled(Paper, {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the Paper component. */
   overflowY: 'auto',
   display: 'flex',
   flexDirection: 'column',
@@ -90,11 +88,9 @@ const DrawerPaper = styled(Paper, {
   // :focus-ring CSS pseudo-class will help.
   outline: 0,
   ...(styleProps.anchor === 'left' && {
-    /* Styles applied to the Paper component if `anchor="left"`. */
     left: 0,
   }),
   ...(styleProps.anchor === 'top' && {
-    /* Styles applied to the Paper component if `anchor="top"`. */
     top: 0,
     left: 0,
     right: 0,
@@ -102,11 +98,9 @@ const DrawerPaper = styled(Paper, {
     maxHeight: '100%',
   }),
   ...(styleProps.anchor === 'right' && {
-    /* Styles applied to the Paper component if `anchor="right"`. */
     right: 0,
   }),
   ...(styleProps.anchor === 'bottom' && {
-    /* Styles applied to the Paper component if `anchor="bottom"`. */
     top: 'auto',
     left: 0,
     bottom: 0,
@@ -116,22 +110,18 @@ const DrawerPaper = styled(Paper, {
   }),
   ...(styleProps.anchor === 'left' &&
     styleProps.variant !== 'temporary' && {
-      /* Styles applied to the Paper component if `anchor="left"` and `variant` is not "temporary". */
       borderRight: `1px solid ${theme.palette.divider}`,
     }),
   ...(styleProps.anchor === 'top' &&
     styleProps.variant !== 'temporary' && {
-      /* Styles applied to the Paper component if `anchor="top"` and `variant` is not "temporary". */
       borderBottom: `1px solid ${theme.palette.divider}`,
     }),
   ...(styleProps.anchor === 'right' &&
     styleProps.variant !== 'temporary' && {
-      /* Styles applied to the Paper component if `anchor="right"` and `variant` is not "temporary". */
       borderLeft: `1px solid ${theme.palette.divider}`,
     }),
   ...(styleProps.anchor === 'bottom' &&
     styleProps.variant !== 'temporary' && {
-      /* Styles applied to the Paper component if `anchor="bottom"` and `variant` is not "temporary". */
       borderTop: `1px solid ${theme.palette.divider}`,
     }),
 }));

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -42,7 +42,6 @@ const FabRoot = styled(ButtonBase, {
   },
 })(
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element. */
     ...theme.typography.button,
     minHeight: 36,
     transition: theme.transitions.create(['background-color', 'box-shadow', 'border-color'], {
@@ -75,17 +74,14 @@ const FabRoot = styled(ButtonBase, {
       boxShadow: theme.shadows[0],
       backgroundColor: theme.palette.action.disabledBackground,
     },
-    /* Styles applied to the root element if `size="small"``. */
     ...(styleProps.size === 'small' && {
       width: 40,
       height: 40,
     }),
-    /* Styles applied to the root element if `size="medium"``. */
     ...(styleProps.size === 'medium' && {
       width: 48,
       height: 48,
     }),
-    /* Styles applied to the root element if `variant="extended"`. */
     ...(styleProps.variant === 'extended' && {
       borderRadius: 48 / 2,
       padding: '0 16px',
@@ -110,13 +106,11 @@ const FabRoot = styled(ButtonBase, {
         minWidth: 40,
         height: 40,
       }),
-    /* Styles applied to the root element if `color="inherit"`. */
     ...(styleProps.color === 'inherit' && {
       color: 'inherit',
     }),
   }),
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if `color="primary"`. */
     ...(styleProps.color === 'primary' && {
       color: theme.palette.primary.contrastText,
       backgroundColor: theme.palette.primary.main,
@@ -128,7 +122,6 @@ const FabRoot = styled(ButtonBase, {
         },
       },
     }),
-    /* Styles applied to the root element if `color="secondary"`. */
     ...(styleProps.color === 'secondary' && {
       color: theme.palette.secondary.contrastText,
       backgroundColor: theme.palette.secondary.main,

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -45,7 +45,6 @@ const FilledInputRoot = styled(InputBaseRoot, {
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
   const backgroundColor = light ? 'rgba(0, 0, 0, 0.06)' : 'rgba(255, 255, 255, 0.09)';
   return {
-    /* Styles applied to the root element. */
     position: 'relative',
     backgroundColor,
     borderTopLeftRadius: theme.shape.borderRadius,
@@ -154,18 +153,15 @@ const FilledInputInput = styled(InputBaseInput, {
     paddingTop: 16,
     paddingBottom: 17,
   }),
-  /* Styles applied to the input element if `multiline={true}`. */
   ...(styleProps.multiline && {
     paddingTop: 0,
     paddingBottom: 0,
     paddingLeft: 0,
     paddingRight: 0,
   }),
-  /* Styles applied to the input element if `startAdornment` is provided. */
   ...(styleProps.startAdornment && {
     paddingLeft: 0,
   }),
-  /* Styles applied to the input element if `endAdornment` is provided. */
   ...(styleProps.endAdornment && {
     paddingRight: 0,
   }),

--- a/packages/material-ui/src/FormGroup/FormGroup.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.js
@@ -25,11 +25,9 @@ const FormGroupRoot = styled('div', {
     return [styles.root, styleProps.row && styles.row];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   flexDirection: 'column',
   flexWrap: 'wrap',
-  /* Styles applied to the root element if `row={true}`. */
   ...(styleProps.row && {
     flexDirection: 'row',
   }),

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -34,7 +34,6 @@ const IconRoot = styled('span', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   userSelect: 'none',
   width: '1em',
   height: '1em',

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -41,7 +41,6 @@ const IconButtonRoot = styled(ButtonBase, {
   },
 })(
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element. */
     textAlign: 'center',
     flex: '0 0 auto',
     fontSize: theme.typography.pxToRem(24),
@@ -59,17 +58,14 @@ const IconButtonRoot = styled(ButtonBase, {
         backgroundColor: 'transparent',
       },
     },
-    /* Styles applied to the root element if `edge="start"`. */
     ...(styleProps.edge === 'start' && {
       marginLeft: styleProps.size === 'small' ? -3 : -12,
     }),
-    /* Styles applied to the root element if `edge="end"`. */
     ...(styleProps.edge === 'end' && {
       marginRight: styleProps.size === 'small' ? -3 : -12,
     }),
   }),
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if `color="inherit"`. */
     ...(styleProps.color === 'inherit' && {
       color: 'inherit',
     }),
@@ -87,7 +83,6 @@ const IconButtonRoot = styled(ButtonBase, {
           },
         },
       }),
-    /* Styles applied to the root element if `size="small"`. */
     ...(styleProps.size === 'small' && {
       padding: 5,
       fontSize: theme.typography.pxToRem(18),
@@ -96,7 +91,6 @@ const IconButtonRoot = styled(ButtonBase, {
       padding: 12,
       fontSize: theme.typography.pxToRem(28),
     }),
-    /* Styles applied to the root element if `disabled={true}`. */
     [`&.${iconButtonClasses.disabled}`]: {
       backgroundColor: 'transparent',
       color: theme.palette.action.disabled,

--- a/packages/material-ui/src/ImageList/ImageList.js
+++ b/packages/material-ui/src/ImageList/ImageList.js
@@ -27,7 +27,6 @@ const ImageListRoot = styled('ul', {
     return [styles.root, styles[styleProps.variant]];
   },
 })(({ styleProps }) => {
-  /* Styles applied to the root element. */
   return {
     display: 'grid',
     overflowY: 'auto',
@@ -35,7 +34,6 @@ const ImageListRoot = styled('ul', {
     padding: 0,
     // Add iOS momentum scrolling for iOS < 13.0
     WebkitOverflowScrolling: 'touch',
-    /* Styles applied to the root element if `variant="masonry"`. */
     ...(styleProps.variant === 'masonry' && {
       display: 'block',
     }),

--- a/packages/material-ui/src/ImageListItem/ImageListItem.js
+++ b/packages/material-ui/src/ImageListItem/ImageListItem.js
@@ -37,13 +37,11 @@ const ImageListItemRoot = styled('li', {
   display: 'inline-block',
   position: 'relative',
   lineHeight: 0, // 🤷🏻‍♂️Fixes masonry item gap
-  /* Styles applied to the root element if `variant="standard"`. */
   ...(styleProps.variant === 'standard' && {
     // For titlebar under list item
     display: 'flex',
     flexDirection: 'column',
   }),
-  /* Styles applied to the root element if `variant="woven"`. */
   ...(styleProps.variant === 'woven' && {
     height: '100%',
     alignSelf: 'center',

--- a/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js
@@ -35,7 +35,6 @@ const ImageListItemBarRoot = styled('div', {
   },
 })(({ theme, styleProps }) => {
   return {
-    /* Styles applied to the root element. */
     position: 'absolute',
     left: 0,
     right: 0,
@@ -43,15 +42,12 @@ const ImageListItemBarRoot = styled('div', {
     display: 'flex',
     alignItems: 'center',
     fontFamily: theme.typography.fontFamily,
-    /* Styles applied to the root element if `position="bottom"`. */
     ...(styleProps.position === 'bottom' && {
       bottom: 0,
     }),
-    /* Styles applied to the root element if `position="top"`. */
     ...(styleProps.position === 'top' && {
       top: 0,
     }),
-    /* Styles applied to the root element if `position="below"`. */
     ...(styleProps.position === 'below' && {
       position: 'relative',
       background: 'transparent',
@@ -74,22 +70,18 @@ const ImageListItemBarTitleWrap = styled('div', {
   },
 })(({ theme, styleProps }) => {
   return {
-    /* Styles applied to the title and subtitle container element. */
     flexGrow: 1,
     padding: '12px 16px',
     color: theme.palette.common.white,
     overflow: 'hidden',
-    /* Styles applied to the title and subtitle container element if `position="below"`. */
     ...(styleProps.position === 'below' && {
       padding: '6px 0 12px',
       color: 'inherit',
     }),
-    /* Styles applied to the container element if `actionPosition="left"`. */
     ...(styleProps.actionIcon &&
       styleProps.actionPosition === 'left' && {
         paddingLeft: 0,
       }),
-    /* Styles applied to the container element if `actionPosition="right"`. */
     ...(styleProps.actionIcon &&
       styleProps.actionPosition === 'right' && {
         paddingRight: 0,
@@ -103,7 +95,6 @@ const ImageListItemBarTitle = styled('div', {
   overridesResolver: (props, styles) => styles.title,
 })(({ theme }) => {
   return {
-    /* Styles applied to the title container element. */
     fontSize: theme.typography.pxToRem(16),
     lineHeight: '24px',
     textOverflow: 'ellipsis',
@@ -118,7 +109,6 @@ const ImageListItemBarSubtitle = styled('div', {
   overridesResolver: (props, styles) => styles.subtitle,
 })(({ theme }) => {
   return {
-    /* Styles applied to the subtitle container element. */
     fontSize: theme.typography.pxToRem(12),
     lineHeight: 1,
     textOverflow: 'ellipsis',
@@ -140,7 +130,6 @@ const ImageListItemBarActionIcon = styled('div', {
   },
 })(({ styleProps }) => {
   return {
-    /* Styles applied to the actionIcon if `actionPosition="left"`. */
     ...(styleProps.actionPosition === 'left' && {
       order: -1,
     }),

--- a/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.ts
+++ b/packages/material-ui/src/ImageListItemBar/imageListItemBarClasses.ts
@@ -54,4 +54,4 @@ const imageListItemBarClasses: ImageListItemBarClasses = generateUtilityClasses(
   ],
 );
 
-export default imageListItemBarClasses; /* Styles applied to the root element. */
+export default imageListItemBarClasses;

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -199,14 +199,12 @@ export const InputBaseComponent = styled('input', {
     ...(styleProps.size === 'small' && {
       paddingTop: 1,
     }),
-    /* Styles applied to the input element if `multiline={true}`. */
     ...(styleProps.multiline && {
       height: 'auto',
       resize: 'none',
       padding: 0,
       paddingTop: 0,
     }),
-    /* Styles applied to the input element if `type="search"`. */
     ...(styleProps.type === 'search' && {
       // Improve type search style.
       MozAppearance: 'textfield',

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -108,7 +108,6 @@ const LinearProgressRoot = styled('span', {
     ];
   },
 })(({ styleProps, theme }) => ({
-  /* Styles applied to the root element. */
   position: 'relative',
   overflow: 'hidden',
   display: 'block',
@@ -132,9 +131,7 @@ const LinearProgressRoot = styled('span', {
         opacity: 0.3,
       },
     }),
-  /* Styles applied to the root element if `variant="buffer"`. */
   ...(styleProps.variant === 'buffer' && { backgroundColor: 'transparent' }),
-  /* Styles applied to the root element if `variant="query"`. */
   ...(styleProps.variant === 'query' && { transform: 'rotate(180deg)' }),
 }));
 
@@ -151,7 +148,6 @@ const LinearProgressDashed = styled('span', {
     const backgroundColor = getColorShade(theme, styleProps.color);
 
     return {
-      /* Styles applied to the additional bar element if `variant="buffer"`. */
       position: 'absolute',
       marginTop: 0,
       height: '100%',
@@ -186,7 +182,6 @@ const LinearProgressBar1 = styled('span', {
   },
 })(
   ({ styleProps, theme }) => ({
-    /* Styles applied to the additional bar element if `variant="buffer"`. */
     width: '100%',
     position: 'absolute',
     left: 0,
@@ -196,17 +191,14 @@ const LinearProgressBar1 = styled('span', {
     transformOrigin: 'left',
     backgroundColor:
       styleProps.color === 'inherit' ? 'currentColor' : theme.palette[styleProps.color].main,
-    /* Styles applied to the bar1 element if `variant="determinate"`. */
     ...(styleProps.variant === 'determinate' && {
       transition: `transform .${TRANSITION_DURATION}s linear`,
     }),
-    /* Styles applied to the bar1 element if `variant="buffer"`. */
     ...(styleProps.variant === 'buffer' && {
       zIndex: 1,
       transition: `transform .${TRANSITION_DURATION}s linear`,
     }),
   }),
-  /* Styles applied to the bar1 element if `variant="indeterminate or query"`. */
   ({ styleProps }) =>
     (styleProps.variant === 'indeterminate' || styleProps.variant === 'query') &&
     css`
@@ -231,7 +223,6 @@ const LinearProgressBar2 = styled('span', {
   },
 })(
   ({ styleProps, theme }) => ({
-    /* Styles applied to the additional bar element if `variant="buffer"`. */
     width: '100%',
     position: 'absolute',
     left: 0,
@@ -246,13 +237,11 @@ const LinearProgressBar2 = styled('span', {
     ...(styleProps.color === 'inherit' && {
       opacity: 0.3,
     }),
-    /* Styles applied to the bar2 element if `variant="buffer"`. */
     ...(styleProps.variant === 'buffer' && {
       backgroundColor: getColorShade(theme, styleProps.color),
       transition: `transform .${TRANSITION_DURATION}s linear`,
     }),
   }),
-  /* Styles applied to the bar1 element if `variant="indeterminate or query"`. */
   ({ styleProps }) =>
     (styleProps.variant === 'indeterminate' || styleProps.variant === 'query') &&
     css`

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -55,18 +55,15 @@ const LinkRoot = styled(Typography, {
   const color =
     getPath(theme, `palette.${transformDeprecatedColors(styleProps.color)}`) || styleProps.color;
   return {
-    /* Styles applied to the root element if `underline="none"`. */
     ...(styleProps.underline === 'none' && {
       textDecoration: 'none',
     }),
-    /* Styles applied to the root element if `underline="hover"`. */
     ...(styleProps.underline === 'hover' && {
       textDecoration: 'none',
       '&:hover': {
         textDecoration: 'underline',
       },
     }),
-    /* Styles applied to the root element if `underline="always"`. */
     ...(styleProps.underline === 'always' && {
       textDecoration: 'underline',
       textDecorationColor: color !== 'inherit' ? alpha(color, 0.4) : undefined,
@@ -75,7 +72,6 @@ const LinkRoot = styled(Typography, {
       },
     }),
     // Same reset as ButtonBase.root
-    /* Styles applied to the root element if `component="button"`. */
     ...(styleProps.component === 'button' && {
       position: 'relative',
       WebkitTapHighlightColor: 'transparent',

--- a/packages/material-ui/src/List/List.js
+++ b/packages/material-ui/src/List/List.js
@@ -31,17 +31,14 @@ const ListRoot = styled('ul', {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   listStyle: 'none',
   margin: 0,
   padding: 0,
   position: 'relative',
-  /* Styles applied to the root element unless `disablePadding={true}`. */
   ...(!styleProps.disablePadding && {
     paddingTop: 8,
     paddingBottom: 8,
   }),
-  /* Styles applied to the root element if a `subheader` is provided. */
   ...(styleProps.subheader && {
     paddingTop: 0,
   }),

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -76,16 +76,13 @@ export const ListItemRoot = styled('div', {
   width: '100%',
   boxSizing: 'border-box',
   textAlign: 'left',
-  /* Styles applied to the component element if `disablePadding={false}`. */
   ...(!styleProps.disablePadding && {
     paddingTop: 8,
     paddingBottom: 8,
-    /* Styles applied to the component element if dense and `disablePadding={false}`. */
     ...(styleProps.dense && {
       paddingTop: 4,
       paddingBottom: 4,
     }),
-    /* Styles applied to the inner `component` element unless `disableGutters={true}` and `disablePadding={true}`. */
     ...(!styleProps.disableGutters && {
       paddingLeft: 16,
       paddingRight: 16,
@@ -116,16 +113,13 @@ export const ListItemRoot = styled('div', {
   [`&.${listItemClasses.disabled}`]: {
     opacity: theme.palette.action.disabledOpacity,
   },
-  /* Styles applied to the component element if `alignItems="flex-start"`. */
   ...(styleProps.alignItems === 'flex-start' && {
     alignItems: 'flex-start',
   }),
-  /* Styles applied to the inner `component` element if `divider={true}`. */
   ...(styleProps.divider && {
     borderBottom: `1px solid ${theme.palette.divider}`,
     backgroundClip: 'padding-box',
   }),
-  /* Styles applied to the inner `component` element if `button={true}`. */
   ...(styleProps.button && {
     transition: theme.transitions.create('background-color', {
       duration: theme.transitions.duration.shortest,
@@ -149,7 +143,6 @@ export const ListItemRoot = styled('div', {
       },
     },
   }),
-  /* Styles applied to the component element if `children` includes `ListItemSecondaryAction`. */
   ...(styleProps.hasSecondaryAction && {
     // Add some space to avoid collision as `ListItemSecondaryAction`
     // is absolutely positioned.

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
@@ -26,10 +26,8 @@ const ListItemAvatarRoot = styled('div', {
     return [styles.root, styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   minWidth: 56,
   flexShrink: 0,
-  /* Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`. */
   ...(styleProps.alignItems === 'flex-start' && {
     marginTop: 8,
   }),

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -26,12 +26,10 @@ const ListItemIconRoot = styled('div', {
     return [styles.root, styleProps.alignItems === 'flex-start' && styles.alignItemsFlexStart];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   minWidth: 56,
   color: theme.palette.action.active,
   flexShrink: 0,
   display: 'inline-flex',
-  /* Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`. */
   ...(styleProps.alignItems === 'flex-start' && {
     marginTop: 8,
   }),

--- a/packages/material-ui/src/ListItemText/ListItemText.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.js
@@ -36,18 +36,15 @@ const ListItemTextRoot = styled('div', {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   flex: '1 1 auto',
   minWidth: 0,
   marginTop: 4,
   marginBottom: 4,
-  /* Styles applied to the root if primary and secondary are set. */
   ...(styleProps.primary &&
     styleProps.secondary && {
       marginTop: 6,
       marginBottom: 6,
     }),
-  /* Styles applied to the root element if `inset={true}`. */
   ...(styleProps.inset && {
     paddingLeft: 56,
   }),

--- a/packages/material-ui/src/ListSubheader/ListSubheader.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.js
@@ -38,7 +38,6 @@ const ListSubheaderRoot = styled('li', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   boxSizing: 'border-box',
   lineHeight: '48px',
   listStyle: 'none',
@@ -46,24 +45,19 @@ const ListSubheaderRoot = styled('li', {
   fontFamily: theme.typography.fontFamily,
   fontWeight: theme.typography.fontWeightMedium,
   fontSize: theme.typography.pxToRem(14),
-  /* Styles applied to the root element if `color="primary"`. */
   ...(styleProps.color === 'primary' && {
     color: theme.palette.primary.main,
   }),
-  /* Styles applied to the root element if `color="inherit"`. */
   ...(styleProps.color === 'inherit' && {
     color: 'inherit',
   }),
-  /* Styles applied to the root element unless `disableGutters={true}`. */
   ...(!styleProps.disableGutters && {
     paddingLeft: 16,
     paddingRight: 16,
   }),
-  /* Styles applied to the root element if `inset={true}`. */
   ...(styleProps.inset && {
     paddingLeft: 72,
   }),
-  /* Styles applied to the root element unless `disableSticky={true}`. */
   ...(!styleProps.disableSticky && {
     position: 'sticky',
     top: 0,

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -33,14 +33,12 @@ const MobileStepperRoot = styled(Paper, {
     return [styles.root, styles[`position${capitalize(styleProps.position)}`]];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
   background: theme.palette.background.default,
   padding: 8,
-  /* Styles applied to the root element if `position="bottom"`. */
   ...(styleProps.position === 'bottom' && {
     position: 'fixed',
     bottom: 0,
@@ -48,7 +46,6 @@ const MobileStepperRoot = styled(Paper, {
     right: 0,
     zIndex: theme.zIndex.mobileStepper,
   }),
-  /* Styles applied to the root element if `position="top"`. */
   ...(styleProps.position === 'top' && {
     position: 'fixed',
     top: 0,
@@ -63,7 +60,6 @@ const MobileStepperDots = styled('div', {
   slot: 'Dots',
   overridesResolver: (props, styles) => styles.dots,
 })(({ styleProps }) => ({
-  /* Styles applied to the dots container if `variant="dots"`. */
   ...(styleProps.variant === 'dots' && {
     display: 'flex',
     flexDirection: 'row',
@@ -79,7 +75,6 @@ const MobileStepperDot = styled('div', {
     return [styles.dot, styleProps.dotActive && styles.dotActive];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to each dot if `variant="dots"`. */
   ...(styleProps.variant === 'dots' && {
     transition: theme.transitions.create('background-color', {
       duration: theme.transitions.duration.shortest,
@@ -89,7 +84,6 @@ const MobileStepperDot = styled('div', {
     width: 8,
     height: 8,
     margin: '0 2px',
-    /* Styles applied to a dot if `variant="dots"` and this is the active step. */
     ...(styleProps.dotActive && {
       backgroundColor: theme.palette.primary.main,
     }),
@@ -101,7 +95,6 @@ const MobileStepperProgress = styled(LinearProgress, {
   slot: 'Progress',
   overridesResolver: (props, styles) => styles.progress,
 })(({ styleProps }) => ({
-  /* Styles applied to the Linear Progress component if `variant="progress"`. */
   ...(styleProps.variant === 'progress' && {
     width: '50%',
   }),

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -22,14 +22,12 @@ const ModalRoot = styled('div', {
     return [styles.root, !styleProps.open && styleProps.exited && styles.hidden];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   position: 'fixed',
   zIndex: theme.zIndex.modal,
   right: 0,
   bottom: 0,
   top: 0,
   left: 0,
-  /* Styles applied to the root element if the `Modal` has exited. */
   ...(!styleProps.open &&
     styleProps.exited && {
       visibility: 'hidden',

--- a/packages/material-ui/src/PaginationItem/PaginationItem.js
+++ b/packages/material-ui/src/PaginationItem/PaginationItem.js
@@ -64,7 +64,6 @@ const PaginationItemEllipsis = styled('div', {
   slot: 'Root',
   overridesResolver,
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   ...theme.typography.body2,
   borderRadius: 32 / 2,
   textAlign: 'center',
@@ -74,18 +73,15 @@ const PaginationItemEllipsis = styled('div', {
   margin: '0 3px',
   color: theme.palette.text.primary,
   height: 'auto',
-  /* Styles applied to the root element if `disabled="true"`. */
   [`&.${paginationItemClasses.disabled}`]: {
     opacity: theme.palette.action.disabledOpacity,
   },
-  /* Styles applied to the root element if `size="small"`. */
   ...(styleProps.size === 'small' && {
     minWidth: 26,
     borderRadius: 26 / 2,
     margin: '0 1px',
     padding: '0 4px',
   }),
-  /* Styles applied to the root element if `size="large"`. */
   ...(styleProps.size === 'large' && {
     minWidth: 40,
     borderRadius: 40 / 2,
@@ -100,7 +96,6 @@ const PaginationItemPage = styled(ButtonBase, {
   overridesResolver,
 })(
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element. */
     ...theme.typography.body2,
     borderRadius: 32 / 2,
     textAlign: 'center',
@@ -113,7 +108,6 @@ const PaginationItemPage = styled(ButtonBase, {
     [`&.${paginationItemClasses.focusVisible}`]: {
       backgroundColor: theme.palette.action.focus,
     },
-    /* Styles applied to the root element if `disabled="true"`. */
     [`&.${paginationItemClasses.disabled}`]: {
       opacity: theme.palette.action.disabledOpacity,
     },
@@ -151,7 +145,6 @@ const PaginationItemPage = styled(ButtonBase, {
         backgroundColor: theme.palette.action.selected,
       },
     },
-    /* Styles applied to the root element if `size="small"`. */
     ...(styleProps.size === 'small' && {
       minWidth: 26,
       height: 26,
@@ -159,7 +152,6 @@ const PaginationItemPage = styled(ButtonBase, {
       margin: '0 1px',
       padding: '0 4px',
     }),
-    /* Styles applied to the root element if `size="large"`. */
     ...(styleProps.size === 'large' && {
       minWidth: 40,
       height: 40,
@@ -167,13 +159,11 @@ const PaginationItemPage = styled(ButtonBase, {
       padding: '0 10px',
       fontSize: theme.typography.pxToRem(15),
     }),
-    /* Styles applied to the root element if `shape="rounded"`. */
     ...(styleProps.shape === 'rounded' && {
       borderRadius: theme.shape.borderRadius,
     }),
   }),
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element if `variant="text"`. */
     ...(styleProps.variant === 'text' && {
       [`&.${paginationItemClasses.selected}`]: {
         ...(styleProps.color !== 'standard' && {
@@ -195,7 +185,6 @@ const PaginationItemPage = styled(ButtonBase, {
         },
       },
     }),
-    /* Styles applied to the root element if `variant="outlined"`. */
     ...(styleProps.variant === 'outlined' && {
       border: `1px solid ${
         theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -49,19 +49,15 @@ const PaperRoot = styled('div', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   backgroundColor: theme.palette.background.paper,
   color: theme.palette.text.primary,
   transition: theme.transitions.create('box-shadow'),
-  /* Styles applied to the root element unless `square={true}`. */
   ...(!styleProps.square && {
     borderRadius: theme.shape.borderRadius,
   }),
-  /* Styles applied to the root element if `variant="outlined"`. */
   ...(styleProps.variant === 'outlined' && {
     border: `1px solid ${theme.palette.divider}`,
   }),
-  /* Styles applied to the root element if `variant="elevation"`. */
   ...(styleProps.variant === 'elevation' && {
     boxShadow: theme.shadows[styleProps.elevation],
     ...(theme.palette.mode === 'dark' && {

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -35,7 +35,6 @@ const RadioRoot = styled(SwitchBase, {
     return [styles.root, styles[`color${capitalize(styleProps.color)}`]];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   color: theme.palette.text.secondary,
   '&:hover': {
     backgroundColor: alpha(
@@ -49,7 +48,6 @@ const RadioRoot = styled(SwitchBase, {
       backgroundColor: 'transparent',
     },
   },
-  /* Styles applied to the root element unless `color="default"`. */
   ...(styleProps.color !== 'default' && {
     [`&.${radioClasses.checked}`]: {
       color: theme.palette[styleProps.color].main,

--- a/packages/material-ui/src/Rating/Rating.js
+++ b/packages/material-ui/src/Rating/Rating.js
@@ -81,7 +81,6 @@ const RatingRoot = styled('span', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'inline-flex',
   // Required to position the pristine input absolutely
   position: 'relative',
@@ -98,15 +97,12 @@ const RatingRoot = styled('span', {
     outline: '1px solid #999',
   },
   [`& .${ratingClasses.visuallyHidden}`]: visuallyHidden,
-  /* Styles applied to the root element if `size="small"`. */
   ...(styleProps.size === 'small' && {
     fontSize: theme.typography.pxToRem(18),
   }),
-  /* Styles applied to the root element if `size="large"`. */
   ...(styleProps.size === 'large' && {
     fontSize: theme.typography.pxToRem(30),
   }),
-  /* Styles applied to the root element if `readOnly={true}`. */
   ...(styleProps.readOnly && {
     pointerEvents: 'none',
   }),
@@ -117,9 +113,7 @@ const RatingLabel = styled('label', {
   slot: 'Label',
   overridesResolver: (props, styles) => styles.label,
 })(({ styleProps }) => ({
-  /* Styles applied to the label elements. */
   cursor: 'inherit',
-  /* Styles applied to the label of the "no value" input when it is active. */
   ...(styleProps.emptyValueFocused && {
     top: 0,
     bottom: 0,
@@ -145,7 +139,6 @@ const RatingIcon = styled('span', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the icon wrapping elements. */
   // Fit wrapper to actual icon size.
   display: 'flex',
   transition: theme.transitions.create('transform', {
@@ -154,11 +147,9 @@ const RatingIcon = styled('span', {
   // Fix mouseLeave issue.
   // https://github.com/facebook/react/issues/4492
   pointerEvents: 'none',
-  /* Styles applied to the icon wrapping elements when active. */
   ...(styleProps.iconActive && {
     transform: 'scale(1.2)',
   }),
-  /* Styles applied to the icon wrapping elements when empty. */
   ...(styleProps.iconEmpty && {
     color: theme.palette.action.disabled,
   }),
@@ -173,9 +164,7 @@ const RatingDecimal = styled('span', {
     return [styles.decimal, styleProps.iconActive && styles.iconActive];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the icon wrapping elements when decimals are necessary. */
   position: 'relative',
-  /* Styles applied to the icon wrapping elements when active. */
   ...(styleProps.iconActive && {
     transform: 'scale(1.2)',
   }),

--- a/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -22,7 +22,6 @@ const ScopedCssBaselineRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   ...html,
   ...body(theme),
   '& *, & *::before, & *::after': {

--- a/packages/material-ui/src/Skeleton/Skeleton.js
+++ b/packages/material-ui/src/Skeleton/Skeleton.js
@@ -75,7 +75,6 @@ const SkeletonRoot = styled('span', {
     const radiusValue = toUnitless(theme.shape.borderRadius);
 
     return {
-      /* Styles applied to the root element. */
       display: 'block',
       // Create a "on paper" color with sufficient contrast retaining the color
       backgroundColor: alpha(
@@ -83,7 +82,6 @@ const SkeletonRoot = styled('span', {
         theme.palette.mode === 'light' ? 0.11 : 0.13,
       ),
       height: '1.2em',
-      /* Styles applied to the root element if `variant="text"`. */
       ...(styleProps.variant === 'text' && {
         marginTop: 0,
         marginBottom: 0,
@@ -97,35 +95,29 @@ const SkeletonRoot = styled('span', {
           content: '"\\00a0"',
         },
       }),
-      /* Styles applied to the root element if `variant="circular"`. */
       ...(styleProps.variant === 'circular' && {
         borderRadius: '50%',
       }),
-      /* Styles applied when the component is passed children. */
       ...(styleProps.hasChildren && {
         '& > *': {
           visibility: 'hidden',
         },
       }),
-      /* Styles applied when the component is passed children and no width. */
       ...(styleProps.hasChildren &&
         !styleProps.width && {
           maxWidth: 'fit-content',
         }),
-      /* Styles applied when the component is passed children and no height. */
       ...(styleProps.hasChildren &&
         !styleProps.height && {
           height: 'auto',
         }),
     };
   },
-  /* Styles applied to the root element if `animation="pulse"`. */
   ({ styleProps }) =>
     styleProps.animation === 'pulse' &&
     css`
       animation: ${pulseKeyframe} 1.5s ease-in-out 0.5s infinite;
     `,
-  /* Styles applied to the root element if `animation="wave"`. */
   ({ styleProps, theme }) =>
     styleProps.animation === 'wave' &&
     css`

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -33,12 +33,10 @@ const StepRoot = styled('div', {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element if `orientation="horizontal"`. */
   ...(styleProps.orientation === 'horizontal' && {
     paddingLeft: 8,
     paddingRight: 8,
   }),
-  /* Styles applied to the root element if `alternativeLabel={true}`. */
   ...(styleProps.alternativeLabel && {
     flex: 1,
     position: 'relative',

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -35,19 +35,16 @@ const StepButtonRoot = styled(ButtonBase, {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   width: '100%',
   padding: '24px 16px',
   margin: '-24px -16px',
   boxSizing: 'content-box',
-  /* Styles applied to the root element if `orientation="vertical"`. */
   ...(styleProps.orientation === 'vertical' && {
     justifyContent: 'flex-start',
     padding: '8px',
     margin: '-8px',
   }),
   [`& .${stepButtonClasses.touchRipple}`]: {
-    /* Styles applied to the `ButtonBase` touch-ripple. */
     color: 'rgba(0, 0, 0, 0.3)',
   },
 }));

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -41,13 +41,10 @@ const StepConnectorRoot = styled('div', {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   flex: '1 1 auto',
-  /* Styles applied to the root element if `orientation="vertical"`. */
   ...(styleProps.orientation === 'vertical' && {
     marginLeft: 12, // half icon
   }),
-  /* Styles applied to the root element if `alternativeLabel={true}`. */
   ...(styleProps.alternativeLabel && {
     position: 'absolute',
     top: 8 + 4,
@@ -65,15 +62,12 @@ const StepConnectorLine = styled('span', {
     return [styles.line, styles[`line${capitalize(styleProps.orientation)}`]];
   },
 })(({ styleProps, theme }) => ({
-  /* Styles applied to the line element. */
   display: 'block',
   borderColor: theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
-  /* Styles applied to the root element if `orientation="horizontal"`. */
   ...(styleProps.orientation === 'horizontal' && {
     borderTopStyle: 'solid',
     borderTopWidth: 1,
   }),
-  /* Styles applied to the root element if `orientation="vertical"`. */
   ...(styleProps.orientation === 'vertical' && {
     borderLeftStyle: 'solid',
     borderLeftWidth: 1,

--- a/packages/material-ui/src/StepContent/StepContent.js
+++ b/packages/material-ui/src/StepContent/StepContent.js
@@ -26,20 +26,17 @@ const StepContentRoot = styled('div', {
     return [styles.root, styleProps.last && styles.last];
   },
 })(({ styleProps, theme }) => ({
-  /* Styles applied to the root element. */
   marginLeft: 12, // half icon
   paddingLeft: 8 + 12, // margin + half icon
   paddingRight: 8,
   borderLeft: `1px solid ${
     theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600]
   }`,
-  /* Styles applied to the root element if `last={true}` (controlled by `Step`). */
   ...(styleProps.last && {
     borderLeft: 'none',
   }),
 }));
 
-/* Styles applied to the Transition component. */
 const StepContentTransition = styled(Collapse, {
   name: 'MuiStepContent',
   slot: 'Transition',

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -25,7 +25,6 @@ const StepIconRoot = styled(SvgIcon, {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   display: 'block',
   transition: theme.transitions.create('color', {
     duration: theme.transitions.duration.shortest,
@@ -47,7 +46,6 @@ const StepIconText = styled('text', {
   slot: 'Text',
   overridesResolver: (props, styles) => styles.text,
 })(({ theme }) => ({
-  /* Styles applied to the SVG text element. */
   fill: theme.palette.primary.contrastText,
   fontSize: theme.typography.caption.fontSize,
   fontFamily: theme.typography.fontFamily,

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -44,7 +44,6 @@ const StepLabelRoot = styled('span', {
     return [styles.root, styles[styleProps.orientation]];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'flex',
   alignItems: 'center',
   [`&.${stepLabelClasses.alternativeLabel}`]: {
@@ -53,7 +52,6 @@ const StepLabelRoot = styled('span', {
   [`&.${stepLabelClasses.disabled}`]: {
     cursor: 'default',
   },
-  /* Styles applied to the root element if `orientation="vertical"`. */
   ...(styleProps.orientation === 'vertical' && {
     textAlign: 'left',
     padding: '8px 0',
@@ -67,7 +65,6 @@ const StepLabelLabel = styled('span', {
 })(({ theme }) => ({
   ...theme.typography.body2,
   display: 'block',
-  /* Styles applied to the Typography component that wraps `children`. */
   transition: theme.transitions.create('color', {
     duration: theme.transitions.duration.shortest,
   }),
@@ -93,7 +90,6 @@ const StepLabelIconContainer = styled('span', {
   slot: 'IconContainer',
   overridesResolver: (props, styles) => styles.iconContainer,
 })(() => ({
-  /* Styles applied to the `icon` container element. */
   flexShrink: 0, // Fix IE11 issue
   display: 'flex',
   paddingRight: 8,
@@ -107,7 +103,6 @@ const StepLabelLabelContainer = styled('span', {
   slot: 'LabelContainer',
   overridesResolver: (props, styles) => styles.labelContainer,
 })(({ theme }) => ({
-  /* Styles applied to the container element which wraps `Typography` and `optional`. */
   width: '100%',
   color: theme.palette.text.secondary,
 }));

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -34,7 +34,6 @@ const SvgIconRoot = styled('svg', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   userSelect: 'none',
   width: '1em',
   height: '1em',

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -48,7 +48,6 @@ const SwitchRoot = styled('span', {
     ];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'inline-flex',
   width: 34 + 12 * 2,
   height: 14 + 12 * 2,
@@ -62,11 +61,9 @@ const SwitchRoot = styled('span', {
   '@media print': {
     colorAdjust: 'exact',
   },
-  /* Styles applied to the root element if `edge="start"`. */
   ...(styleProps.edge === 'start' && {
     marginLeft: -8,
   }),
-  /* Styles applied to the root element if `edge="end"`. */
   ...(styleProps.edge === 'end' && {
     marginRight: -8,
   }),
@@ -101,7 +98,6 @@ const SwitchSwitchBase = styled(SwitchBase, {
   },
 })(
   ({ theme }) => ({
-    /* Styles applied to the internal `SwitchBase` component's `root` class. */
     position: 'absolute',
     top: 0,
     left: 0,
@@ -123,7 +119,6 @@ const SwitchSwitchBase = styled(SwitchBase, {
       opacity: theme.palette.mode === 'light' ? 0.12 : 0.2,
     },
     [`& .${switchClasses.input}`]: {
-      /* Styles applied to the internal SwitchBase component's input element. */
       left: '-100%',
       width: '300%',
     },
@@ -136,7 +131,6 @@ const SwitchSwitchBase = styled(SwitchBase, {
         backgroundColor: 'transparent',
       },
     },
-    /* Styles applied to the internal SwitchBase component element unless `color="default"`. */
     ...(styleProps.color !== 'default' && {
       [`&.${switchClasses.checked}`]: {
         color: theme.palette[styleProps.color].main,
@@ -168,7 +162,6 @@ const SwitchTrack = styled('span', {
   slot: 'Track',
   overridesResolver: (props, styles) => styles.track,
 })(({ theme }) => ({
-  /* Styles applied to the track element. */
   height: '100%',
   width: '100%',
   borderRadius: 14 / 2,
@@ -186,7 +179,6 @@ const SwitchThumb = styled('span', {
   slot: 'Thumb',
   overridesResolver: (props, styles) => styles.thumb,
 })(({ theme }) => ({
-  /* Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop. */
   boxShadow: theme.shadows[1],
   backgroundColor: 'currentColor',
   width: 20,

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -42,7 +42,6 @@ const TabRoot = styled(ButtonBase, {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   ...theme.typography.button,
   maxWidth: 360,
   minWidth: 90,
@@ -55,7 +54,6 @@ const TabRoot = styled(ButtonBase, {
   textAlign: 'center',
   flexDirection: 'column',
   lineHeight: 1.25,
-  /* Styles applied to the root element if both `icon` and `label` are provided. */
   ...(styleProps.icon &&
     styleProps.label && {
       minHeight: 72,
@@ -65,7 +63,6 @@ const TabRoot = styled(ButtonBase, {
         marginBottom: 6,
       },
     }),
-  /* Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="inherit"`. */
   ...(styleProps.textColor === 'inherit' && {
     color: 'inherit',
     opacity: 0.6, // same opacity as theme.palette.text.secondary
@@ -76,7 +73,6 @@ const TabRoot = styled(ButtonBase, {
       opacity: theme.palette.action.disabledOpacity,
     },
   }),
-  /* Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="primary"`. */
   ...(styleProps.textColor === 'primary' && {
     color: theme.palette.text.secondary,
     [`&.${tabClasses.selected}`]: {
@@ -86,7 +82,6 @@ const TabRoot = styled(ButtonBase, {
       color: theme.palette.text.disabled,
     },
   }),
-  /* Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="secondary"`. */
   ...(styleProps.textColor === 'secondary' && {
     color: theme.palette.text.secondary,
     [`&.${tabClasses.selected}`]: {
@@ -96,14 +91,12 @@ const TabRoot = styled(ButtonBase, {
       color: theme.palette.text.disabled,
     },
   }),
-  /* Styles applied to the root element if `fullWidth={true}` */
   ...(styleProps.fullWidth && {
     flexShrink: 1,
     flexGrow: 1,
     flexBasis: 0,
     maxWidth: 'none',
   }),
-  /* Styles applied to the root element if `wrapped={true}`. */
   ...(styleProps.wrapped && {
     fontSize: theme.typography.pxToRem(12),
   }),

--- a/packages/material-ui/src/TabScrollButton/TabScrollButton.js
+++ b/packages/material-ui/src/TabScrollButton/TabScrollButton.js
@@ -30,14 +30,12 @@ const TabScrollButtonRoot = styled(ButtonBase, {
     return [styles.root, styleProps.orientation && styles[styleProps.orientation]];
   },
 })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   width: 40,
   flexShrink: 0,
   opacity: 0.8,
   [`&.${tabScrollButtonClasses.disabled}`]: {
     opacity: 0,
   },
-  /* Styles applied to the root element if `orientation="vertical"`. */
   ...(styleProps.orientation === 'vertical' && {
     width: '100%',
     height: 40,

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -26,7 +26,6 @@ const TableRoot = styled('table', {
     return [styles.root, styleProps.stickyHeader && styles.stickyHeader];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   display: 'table',
   width: '100%',
   borderCollapse: 'collapse',
@@ -38,7 +37,6 @@ const TableRoot = styled('table', {
     textAlign: 'left',
     captionSide: 'bottom',
   },
-  /* Styles applied to the root element if `stickyHeader={true}`. */
   ...(styleProps.stickyHeader && {
     borderCollapse: 'separate',
   }),

--- a/packages/material-ui/src/TableBody/TableBody.js
+++ b/packages/material-ui/src/TableBody/TableBody.js
@@ -22,7 +22,6 @@ const TableBodyRoot = styled('tbody', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })({
-  /* Styles applied to the root element. */
   display: 'table-row-group',
 });
 

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -43,7 +43,6 @@ const TableCellRoot = styled('td', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the root element. */
   ...theme.typography.body2,
   display: 'table-cell',
   verticalAlign: 'inherit',
@@ -57,23 +56,19 @@ const TableCellRoot = styled('td', {
     }`,
   textAlign: 'left',
   padding: 16,
-  /* Styles applied to the root element if `variant="head"` or `context.table.head`. */
   ...(styleProps.variant === 'head' && {
     color: theme.palette.text.primary,
     lineHeight: theme.typography.pxToRem(24),
     fontWeight: theme.typography.fontWeightMedium,
   }),
-  /* Styles applied to the root element if `variant="body"` or `context.table.body`. */
   ...(styleProps.variant === 'body' && {
     color: theme.palette.text.primary,
   }),
-  /* Styles applied to the root element if `variant="footer"` or `context.table.footer`. */
   ...(styleProps.variant === 'footer' && {
     color: theme.palette.text.secondary,
     lineHeight: theme.typography.pxToRem(21),
     fontSize: theme.typography.pxToRem(12),
   }),
-  /* Styles applied to the root element if `size="small"`. */
   ...(styleProps.size === 'small' && {
     padding: '6px 16px',
     [`&.${tableCellClasses.paddingCheckbox}`]: {
@@ -84,33 +79,26 @@ const TableCellRoot = styled('td', {
       },
     },
   }),
-  /* Styles applied to the root element if `padding="checkbox"`. */
   ...(styleProps.padding === 'checkbox' && {
     width: 48, // prevent the checkbox column from growing
     padding: '0 0 0 4px',
   }),
-  /* Styles applied to the root element if `padding="none"`. */
   ...(styleProps.padding === 'none' && {
     padding: 0,
   }),
-  /* Styles applied to the root element if `align="left"`. */
   ...(styleProps.align === 'left' && {
     textAlign: 'left',
   }),
-  /* Styles applied to the root element if `align="center"`. */
   ...(styleProps.align === 'center' && {
     textAlign: 'center',
   }),
-  /* Styles applied to the root element if `align="right"`. */
   ...(styleProps.align === 'right' && {
     textAlign: 'right',
     flexDirection: 'row-reverse',
   }),
-  /* Styles applied to the root element if `align="justify"`. */
   ...(styleProps.align === 'justify' && {
     textAlign: 'justify',
   }),
-  /* Styles applied to the root element if `context.table.stickyHeader={true}`. */
   ...(styleProps.stickyHeader && {
     position: 'sticky',
     top: 0,

--- a/packages/material-ui/src/TableContainer/TableContainer.js
+++ b/packages/material-ui/src/TableContainer/TableContainer.js
@@ -21,7 +21,6 @@ const TableContainerRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })({
-  /* Styles applied to the root element. */
   width: '100%',
   overflowX: 'auto',
 });

--- a/packages/material-ui/src/TableFooter/TableFooter.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.js
@@ -22,7 +22,6 @@ const TableFooterRoot = styled('tfoot', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })({
-  /* Styles applied to the root element. */
   display: 'table-footer-group',
 });
 

--- a/packages/material-ui/src/TableHead/TableHead.js
+++ b/packages/material-ui/src/TableHead/TableHead.js
@@ -22,7 +22,6 @@ const TableHeadRoot = styled('thead', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })({
-  /* Styles applied to the root element. */
   display: 'table-header-group',
 });
 

--- a/packages/material-ui/src/TableRow/TableRow.js
+++ b/packages/material-ui/src/TableRow/TableRow.js
@@ -27,7 +27,6 @@ const TableRowRoot = styled('tr', {
     return [styles.root, styleProps.head && styles.head, styleProps.footer && styles.footer];
   },
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   color: 'inherit',
   display: 'table-row',
   verticalAlign: 'middle',

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -29,7 +29,6 @@ const TableSortLabelRoot = styled(ButtonBase, {
     return [styles.root, styleProps.active && styles.active];
   },
 })(({ theme }) => ({
-  /* Styles applied to the root element. */
   cursor: 'pointer',
   display: 'inline-flex',
   justifyContent: 'flex-start',
@@ -62,7 +61,6 @@ const TableSortLabelIcon = styled('span', {
     return [styles.icon, styles[`iconDirection${capitalize(styleProps.direction)}`]];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the icon component. */
   fontSize: 18,
   marginRight: 4,
   marginLeft: 4,
@@ -71,11 +69,9 @@ const TableSortLabelIcon = styled('span', {
     duration: theme.transitions.duration.shorter,
   }),
   userSelect: 'none',
-  /* Styles applied to the icon component if `direction="desc"`. */
   ...(styleProps.direction === 'desc' && {
     transform: 'rotate(0deg)',
   }),
-  /* Styles applied to the icon component if `direction="asc"`. */
   ...(styleProps.direction === 'asc' && {
     transform: 'rotate(180deg)',
   }),

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -10,7 +10,6 @@ function getStyleValue(computedStyle, property) {
 }
 
 const styles = {
-  /* Styles applied to the shadow textarea element. */
   shadow: {
     // Visibility needed to hide the extra text area on iPads
     visibility: 'hidden',

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -46,7 +46,6 @@ const ToggleButtonRoot = styled(ButtonBase, {
     padding: 11,
     border: `1px solid ${theme.palette.divider}`,
     color: theme.palette.action.active,
-    /* Styles applied to the root element if `fullWidth={true}`. */
     ...(styleProps.fullWidth && {
       width: '100%',
     }),
@@ -76,12 +75,10 @@ const ToggleButtonRoot = styled(ButtonBase, {
         },
       },
     },
-    /* Styles applied to the root element if `size="small"`. */
     ...(styleProps.size === 'small' && {
       padding: 7,
       fontSize: theme.typography.pxToRem(13),
     }),
-    /* Styles applied to the root element if `size="large"`. */
     ...(styleProps.size === 'large' && {
       padding: 15,
       fontSize: theme.typography.pxToRem(15),

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -40,20 +40,15 @@ const ToggleButtonGroupRoot = styled('div', {
     ];
   },
 })(({ styleProps, theme }) => ({
-  /* Styles applied to the root element. */
   display: 'inline-flex',
   borderRadius: theme.shape.borderRadius,
-  /* Styles applied to the root element if `orientation="vertical"`. */
   ...(styleProps.orientation === 'vertical' && {
     flexDirection: 'column',
   }),
-  /* Styles applied to the root element if `fullWidth={true}`. */
   ...(styleProps.fullWidth && {
     width: '100%',
   }),
-  /* Styles applied to the children. */
   [`& .${toggleButtonGroupClasses.grouped}`]: {
-    /* Styles applied to the children if `orientation="horizontal"`. */
     ...(styleProps.orientation === 'horizontal'
       ? {
           '&:not(:first-of-type)': {
@@ -73,7 +68,6 @@ const ToggleButtonGroupRoot = styled('div', {
             },
         }
       : {
-          /* Styles applied to the children if `orientation="vertical"`. */
           '&:not(:first-of-type)': {
             marginTop: -1,
             borderTop: '1px solid transparent',

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -26,11 +26,9 @@ const ToolbarRoot = styled('div', {
   },
 })(
   ({ theme, styleProps }) => ({
-    /* Styles applied to the root element. */
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
-    /* Styles applied to the root element unless `disableGutters={true}`. */
     ...(!styleProps.disableGutters && {
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
@@ -39,12 +37,10 @@ const ToolbarRoot = styled('div', {
         paddingRight: theme.spacing(3),
       },
     }),
-    /* Styles applied to the root element if `variant="dense"`. */
     ...(styleProps.variant === 'dense' && {
       minHeight: 48,
     }),
   }),
-  /* Styles applied to the root element if `variant="regular"`. */
   ({ theme, styleProps }) => styleProps.variant === 'regular' && theme.mixins.toolbar,
 );
 

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -52,17 +52,14 @@ const TooltipPopper = styled(Popper, {
     ];
   },
 })(({ theme, styleProps, open }) => ({
-  /* Styles applied to the Popper element. */
   zIndex: theme.zIndex.tooltip,
   pointerEvents: 'none', // disable jss-rtl plugin
-  /* Styles applied to the Popper component unless `disableInteractive={true}`. */
   ...(!styleProps.disableInteractive && {
     pointerEvents: 'auto',
   }),
   ...(!open && {
     pointerEvents: 'none',
   }),
-  /* Styles applied to the Popper element if `arrow={true}`. */
   ...(styleProps.arrow && {
     [`&[data-popper-placement*="bottom"] .${tooltipClasses.arrow}`]: {
       top: 0,
@@ -115,7 +112,6 @@ const TooltipTooltip = styled('div', {
     ];
   },
 })(({ theme, styleProps }) => ({
-  /* Styles applied to the tooltip (label wrapper) element. */
   backgroundColor: alpha(theme.palette.grey[700], 0.92),
   borderRadius: theme.shape.borderRadius,
   color: theme.palette.common.white,
@@ -126,19 +122,16 @@ const TooltipTooltip = styled('div', {
   margin: 2,
   wordWrap: 'break-word',
   fontWeight: theme.typography.fontWeightMedium,
-  /* Styles applied to the tooltip (label wrapper) element if `arrow={true}`. */
   ...(styleProps.arrow && {
     position: 'relative',
     margin: 0,
   }),
-  /* Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch. */
   ...(styleProps.touch && {
     padding: '8px 16px',
     fontSize: theme.typography.pxToRem(14),
     lineHeight: `${round(16 / 14)}em`,
     fontWeight: theme.typography.fontWeightRegular,
   }),
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
   [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
     marginRight: '14px',
@@ -146,7 +139,6 @@ const TooltipTooltip = styled('div', {
       marginRight: '24px',
     }),
   },
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "right". */
   [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
     marginLeft: '14px',
@@ -154,7 +146,6 @@ const TooltipTooltip = styled('div', {
       marginLeft: '24px',
     }),
   },
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "top". */
   [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',
     marginBottom: '14px',
@@ -162,7 +153,6 @@ const TooltipTooltip = styled('div', {
       marginBottom: '24px',
     }),
   },
-  /* Styles applied to the tooltip (label wrapper) element if `placement` contains "bottom". */
   [`.${tooltipClasses.popper}[data-popper-placement*="bottom"] &`]: {
     transformOrigin: 'center top',
     marginTop: '14px',
@@ -177,7 +167,6 @@ const TooltipArrow = styled('span', {
   slot: 'Arrow',
   overridesResolver: (props, styles) => styles.arrow,
 })(({ theme }) => ({
-  /* Styles applied to the arrow element. */
   overflow: 'hidden',
   position: 'absolute',
   width: '1em',

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -22,21 +22,17 @@ const useUtilityClasses = (styleProps) => {
 };
 
 const SwitchBaseRoot = styled(ButtonBase, { skipSx: true })(({ styleProps }) => ({
-  /* Styles applied to the root element. */
   padding: 9,
   borderRadius: '50%',
-  /* Styles applied to the root element if `edge="start"`. */
   ...(styleProps.edge === 'start' && {
     marginLeft: styleProps.size === 'small' ? -3 : -12,
   }),
-  /* Styles applied to the root element if `edge="end"`. */
   ...(styleProps.edge === 'end' && {
     marginRight: styleProps.size === 'small' ? -3 : -12,
   }),
 }));
 
 const SwitchBaseInput = styled('input', { skipSx: true })({
-  /* Styles applied to the internal input element. */
   cursor: 'inherit',
   position: 'absolute',
   opacity: 0,


### PR DESCRIPTION
These comments were previously used for the documentation which is now handled by TypeScript (https://github.com/mui-org/material-ui/pull/25933). They're prone to become outdated at this point so let's just remove them.