### PR TITLE
[docs] Remove use of `StyledEngineProvider` at the top of the App 

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -330,11 +330,11 @@ function AppWrapper(props) {
       </NextHead>
       <ReduxProvider store={redux}>
         <PageContext.Provider value={{ activePage, pages }}>
-            <StylesProvider jss={jss}>
-              <ThemeProvider>
-                <DocsStyledEngineProvider>{children}</DocsStyledEngineProvider>
-              </ThemeProvider>
-            </StylesProvider>
+          <StylesProvider jss={jss}>
+            <ThemeProvider>
+              <DocsStyledEngineProvider>{children}</DocsStyledEngineProvider>
+            </ThemeProvider>
+          </StylesProvider>
         </PageContext.Provider>
         <LanguageNegotiation />
         <Analytics />

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -11,7 +11,6 @@ import { create } from 'jss';
 import jssRtl from 'jss-rtl';
 import { useRouter } from 'next/router';
 import { StylesProvider, jssPreset } from '@material-ui/styles';
-import { StyledEngineProvider } from '@material-ui/core/styles';
 import pages from 'docs/src/pages';
 import initRedux from 'docs/src/modules/redux/initRedux';
 import PageContext from 'docs/src/modules/components/PageContext';

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -330,14 +330,11 @@ function AppWrapper(props) {
       </NextHead>
       <ReduxProvider store={redux}>
         <PageContext.Provider value={{ activePage, pages }}>
-          {/* TODO v5: remove once migration to emotion is completed */}
-          <StyledEngineProvider injectFirst>
             <StylesProvider jss={jss}>
               <ThemeProvider>
                 <DocsStyledEngineProvider>{children}</DocsStyledEngineProvider>
               </ThemeProvider>
             </StylesProvider>
-          </StyledEngineProvider>
         </PageContext.Provider>
         <LanguageNegotiation />
         <Analytics />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -136,9 +136,13 @@ MyDocument.getInitialProps = async (ctx) => {
     ctx.renderPage = () =>
       originalRenderPage({
         enhanceApp: (App) => (props) =>
-          styledComponentsSheet.collectStyles(materialSheets.collect(
-            <CacheProvider value={cache}><App {...props} /></CacheProvider>
-            )),
+          styledComponentsSheet.collectStyles(
+            materialSheets.collect(
+              <CacheProvider value={cache}>
+                <App {...props} />
+              </CacheProvider>,
+            ),
+          ),
       });
 
     const initialProps = await Document.getInitialProps(ctx);

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -136,14 +136,9 @@ MyDocument.getInitialProps = async (ctx) => {
     ctx.renderPage = () =>
       originalRenderPage({
         enhanceApp: (App) => (props) =>
-          styledComponentsSheet.collectStyles(materialSheets.collect(<App {...props} />)),
-        // Take precedence over the CacheProvider in our custom _app.js
-        enhanceComponent: (Component) => (props) =>
-          (
-            <CacheProvider value={cache}>
-              <Component {...props} />
-            </CacheProvider>
-          ),
+          styledComponentsSheet.collectStyles(materialSheets.collect(
+            <CacheProvider value={cache}><App {...props} /></CacheProvider>
+            )),
       });
 
     const initialProps = await Document.getInitialProps(ctx);

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -7,26 +7,23 @@ import rtlPlugin from 'stylis-plugin-rtl';
 import rtlPluginSc from 'stylis-plugin-rtl-sc';
 import { useTheme } from '@material-ui/core/styles';
 
-// Cache for the ltr version of the styles
-export const cacheLtr = createCache({ key: 'css', prepend: true });
-cacheLtr.compat = true;
-
 // Cache for the rtl version of the styles
 const cacheRtl = createCache({
   key: 'rtl',
   prepend: true,
   stylisPlugins: [rtlPlugin],
 });
-cacheRtl.compat = true;
 
 export default function StyledEngineProvider(props) {
   const theme = useTheme();
 
   const rtl = theme.direction === 'rtl';
+  const Wrapper = rtl ? CacheProvider : React.Fragment;
+  const wrapperProps = rtl ? { value: cacheRtl } : {};
 
   return (
     <StyleSheetManager stylisPlugins={rtl ? [rtlPluginSc] : []}>
-      <CacheProvider value={rtl ? cacheRtl : cacheLtr}>{props.children}</CacheProvider>
+      <Wrapper {...wrapperProps}>{props.children}</Wrapper>
     </StyleSheetManager>
   );
 }


### PR DESCRIPTION
Updates done in the PR:
- removes the use of `<StyledEngineProvider injectFirst>` at the top of the app
- uses custom cache provider only if `rtl` is on
- uses `enhanceApp` in favor of `enhanceComponent`

Tested:
- rtl is working
- dark mode is working
- global styles are not leaking

Preview: https://deploy-preview-27358--material-ui.netlify.app/