### PR TITLE
[docs] Improve unstyled docs

### DIFF
--- a/docs/src/pages/customization/unstyled-components/StylingCustomCss.js
+++ b/docs/src/pages/customization/unstyled-components/StylingCustomCss.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { SwitchUnstyled, switchUnstyledClasses } from '@material-ui/unstyled';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+} from '@material-ui/unstyled/SwitchUnstyled';
 
 const css = `
   .my-switch {

--- a/docs/src/pages/customization/unstyled-components/StylingCustomCss.tsx
+++ b/docs/src/pages/customization/unstyled-components/StylingCustomCss.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { SwitchUnstyled, switchUnstyledClasses } from '@material-ui/unstyled';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+} from '@material-ui/unstyled/SwitchUnstyled';
 
 const css = `
   .my-switch {

--- a/docs/src/pages/customization/unstyled-components/StylingHooks.js
+++ b/docs/src/pages/customization/unstyled-components/StylingHooks.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { useSwitch } from '@material-ui/unstyled';
+import { useSwitch } from '@material-ui/unstyled/SwitchUnstyled';
 import { styled } from '@material-ui/system';
 
 const BasicSwitchRoot = styled('span')(`

--- a/docs/src/pages/customization/unstyled-components/StylingHooks.tsx
+++ b/docs/src/pages/customization/unstyled-components/StylingHooks.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { useSwitch, UseSwitchProps } from '@material-ui/unstyled';
+import { useSwitch, UseSwitchProps } from '@material-ui/unstyled/SwitchUnstyled';
 import { styled } from '@material-ui/system';
 
 const BasicSwitchRoot = styled('span')(`

--- a/docs/src/pages/customization/unstyled-components/StylingSlots.js
+++ b/docs/src/pages/customization/unstyled-components/StylingSlots.js
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { styled } from '@material-ui/system';
-import { SwitchUnstyled, switchUnstyledClasses } from '@material-ui/unstyled';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+} from '@material-ui/unstyled/SwitchUnstyled';
 
 const Root = styled('span')(`
   font-size: 0;

--- a/docs/src/pages/customization/unstyled-components/StylingSlots.tsx
+++ b/docs/src/pages/customization/unstyled-components/StylingSlots.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { styled } from '@material-ui/system';
-import { SwitchUnstyled, switchUnstyledClasses } from '@material-ui/unstyled';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+} from '@material-ui/unstyled/SwitchUnstyled';
 
 const Root = styled('span')(`
   font-size: 0;

--- a/docs/src/pages/customization/unstyled-components/unstyled-components.md
+++ b/docs/src/pages/customization/unstyled-components/unstyled-components.md
@@ -1,10 +1,11 @@
 # Unstyled components
 
-<p class="description">Implementing a custom design system using Material-UI</p>
+<p class="description">Implementing a custom design system using Material-UI.</p>
 
-Material-UI unstyled provides a set of components without any styles. These can be used to implement a custom design system that is not based on Material Design.
+Material-UI unstyled provides a set of components without any styles.
+These can be used to implement a custom design system that is not based on Material Design.
 
-So far just a few components have been created,
+So far, just a few components have been created,
 but we intend to focus on the unstyled package extensively in the upcoming months.
 
 ## Use cases
@@ -39,7 +40,8 @@ Most of the unstyled components are implemented with the help of a hook (where i
 When creating custom components based on the unstyled ones, you can use either unstyled components or hooks.
 
 With components, you will usually be able write less code, but with hooks you have the ultimate control over the structure of the rendered HTML.
-However, in order to make the resulting component accessible, you need to create the components the hook expects and apply props returned by the hook. Concrete examples are provided in each hook's documentation.
+However, to make the resulting component accessible, you need to create the components the hook expects and apply props returned by the hook.
+Concrete examples are provided in each hook's documentation.
 
 ## Anatomy of an unstyled component
 
@@ -63,7 +65,8 @@ While each component has its own API, there are a few props common to all of the
   <BadgeUnstyled componentsProps={{ input: { className: 'my-badge' } }} />
   ```
 
-Additionally, all the extra props placed on the host component are propagated into the root component (just as if they were placed in `componentsProps.root`). These two examples are equivalent:
+Additionally, all the extra props placed on the host component are propagated into the root component (just as if they were placed in `componentsProps.root`).
+These two examples are equivalent:
 
 ```jsx
 <BadgeUnstyled id="badge1">
@@ -79,19 +82,26 @@ There are several levels of customization available:
 
 ### Applying custom CSS rules to unstyled components
 
-If you're happy with the structure of the HTML rendered by the unstyled component by default, you can just apply custom styles to the classes used by the component. Each component has its own set of classes. Some are static - present on different parts of the component all the time, and some are applied conditionally (like `Mui-disabled`, applied when a component is disabled).
+If you're happy with the structure of the HTML rendered by the unstyled component by default, you can apply custom styles to the classes used by the component.
+Each component has its own set of classes.
+Some are static - present on different parts of the component all the time, and some are applied conditionally (like `Mui-disabled`, applied when a component is disabled).
 
-Each component's API documentation lists all classes that the component uses. Additionally, you can import a `[componentName]Classes` object that describes all the classes a given component uses (see the demo below for an example).
+Each component's API documentation lists all classes that the component uses.
+Additionally, you can import a `[componentName]Classes` object that describes all the classes a given component uses (see the demo below for an example).
 
-{{"demo": "pages/customization/unstyled-components/stylingCustomCss.js"}}
+{{"demo": "pages/customization/unstyled-components/StylingCustomCss.js"}}
 
 ### Overriding the unstyled components' slots
 
-If you don't want to rely on default components, you can override them with your own. This makes it possible to provide a styled component. Each unstyled component has a specific set of "slots" - that is subcomponents that you can override.
+If you don't want to rely on default components, you can override them with your own.
+This makes it possible to provide a styled component.
+Each unstyled component has a specific set of "slots" - that is subcomponents that you can override.
 
-Let's take a [SwitchUnstyled](../api/switchUnstyled) as an example. It has three slots: `Root`, `Thumb` and `Input`. The demo below shows how to create a styled component (using [System](system/styled/) in this case, but it could well be any other solution)
+Let's take a [SwitchUnstyled](../api/switchUnstyled) as an example.
+It has three slots: `Root`, `Thumb` and `Input`.
+The demo below shows how to create a styled component (using [System](system/styled/) in this case, but it could well be any other solution)
 
-{{"demo": "pages/customization/unstyled-components/stylingSlots.js"}}
+{{"demo": "pages/customization/unstyled-components/StylingSlots.js"}}
 
 The components you pass in the `components` prop receive the `styleProps` prop from the top-level component (host).
 By convention, it contains all props passed to the host, merged with its rendering "state".
@@ -118,11 +128,13 @@ You can use this object to style your component.
 
 ### Creating custom components using hooks
 
-If you need to create your own component structure, you can use the provided hooks. They encapsulate the logic of the components while not enforcing structure.
+If you need to create your own component structure, you can use the provided hooks.
+They encapsulate the logic of the components while not enforcing structure.
 
 Hooks return the current state of the component (`checked`, `disabled`, `open`, etc., depending on the component) and provide functions that return props you can apply to your components.
 
-Again, let's take a Switch as an example. The corresponding hook is called `useSwitch`. It returns the following object:
+Again, let's take a Switch as an example. The corresponding hook is called `useSwitch`.
+It returns the following object:
 
 ```ts
 {
@@ -135,6 +147,7 @@ Again, let's take a Switch as an example. The corresponding hook is called `useS
 
 ```
 
-The `checked`, `disabled`, `readOnly` and `focusVisible` fields represent the state of the switch. Use them to apply styling to your HTML elements. The `getInputProps` function can be used to get the props to place on an HTML `input` to make the switch accessible.
+The `checked`, `disabled`, `readOnly`, and `focusVisible` fields represent the state of the switch. Use them to apply styling to your HTML elements.
+The `getInputProps` function can be used to get the props to place on an HTML `input` to make the switch accessible.
 
-{{"demo": "pages/customization/unstyled-components/stylingHooks.js"}}
+{{"demo": "pages/customization/unstyled-components/StylingHooks.js"}}

--- a/docs/src/pages/customization/unstyled-components/unstyled-components.md
+++ b/docs/src/pages/customization/unstyled-components/unstyled-components.md
@@ -39,7 +39,7 @@ Most of the unstyled components are implemented with the help of a hook (where i
 
 When creating custom components based on the unstyled ones, you can use either unstyled components or hooks.
 
-With components, you will usually be able write less code, but with hooks you have the ultimate control over the structure of the rendered HTML.
+With components, you will usually be able to write less code, but with hooks you have the ultimate control over the structure of the rendered HTML.
 However, to make the resulting component accessible, you need to create the components the hook expects and apply props returned by the hook.
 Concrete examples are provided in each hook's documentation.
 
@@ -98,7 +98,7 @@ This makes it possible to provide a styled component.
 Each unstyled component has a specific set of "slots" - that is subcomponents that you can override.
 
 Let's take a [SwitchUnstyled](../api/switchUnstyled) as an example.
-It has three slots: `Root`, `Thumb` and `Input`.
+It has three slots: `Root`, `Thumb`, and `Input`.
 The demo below shows how to create a styled component (using [System](system/styled/) in this case, but it could well be any other solution)
 
 {{"demo": "pages/customization/unstyled-components/StylingSlots.js"}}


### PR DESCRIPTION
A quick follow-up on #27158. The high-level changes, only details:

- Component name convention -> PascalCase.tsx
- Import convention: one level deep to get tree-shaking in dev mode. Also, mitigate that we don't have one package per component
- One sentence per markdown helps in the review and future updates.
- Remove "just" (I personally don't like this word, to put it nicely), but it was pinned by Grammarly too.