### PR TITLE
[codemod] Fix published version

### DIFF
--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material-ui/codemod",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "bin": "./codemod.js",
   "private": false,
   "author": "Material-UI Team",


### PR DESCRIPTION
Manually released that version from https://github.com/mui-org/material-ui/tree/v5.0.0-beta.1. Version bump was forgotten due to manual edits in https://github.com/mui-org/material-ui/pull/27230.
