### PR TITLE
[utils] Convert createChainedFunction to TypeScript

### DIFF
--- a/packages/material-ui-utils/src/createChainedFunction.d.ts
+++ b/packages/material-ui-utils/src/createChainedFunction.d.ts
@@ -1,5 +1,0 @@
-export type ChainedFunction = ((...args: any[]) => void) | undefined | null;
-
-export default function createChainedFunction(
-  ...funcs: ChainedFunction[]
-): (...args: any[]) => never;

--- a/packages/material-ui-utils/src/createChainedFunction.ts
+++ b/packages/material-ui-utils/src/createChainedFunction.ts
@@ -3,22 +3,14 @@
  *
  * Will only create a new function if needed,
  * otherwise will pass back existing functions or null.
- * @param {function} functions to chain
- * @returns {function|null}
  */
-export default function createChainedFunction(...funcs) {
+export default function createChainedFunction<Args extends any[], This>(
+  ...funcs: Array<(this: This, ...args: Args) => any>
+): (this: This, ...args: Args) => void {
   return funcs.reduce(
     (acc, func) => {
       if (func == null) {
         return acc;
-      }
-
-      if (process.env.NODE_ENV !== 'production') {
-        if (typeof func !== 'function') {
-          console.error(
-            'Material-UI: Invalid argument type - must only provide functions, undefined, or null.',
-          );
-        }
       }
 
       return function chainedFunction(...args) {


### PR DESCRIPTION
JSDoc types were inaccurate, TypeScript types not accurate enough.

Removed the console error message in the process. It's unhelpful the way we use `createChainedFunction` and for direct consumers we encourage proper type-checking.
