### PR TITLE
[docs] Add StackBlitz edit demo integration

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -11,8 +11,8 @@ import Fade from '@material-ui/core/Fade';
 import ToggleButton from '@material-ui/core/ToggleButton';
 import ToggleButtonGroup from '@material-ui/core/ToggleButtonGroup';
 import { JavaScript as JavaScriptIcon, TypeScript as TypeScriptIcon } from '@material-ui/docs';
-import EditIcon from '@material-ui/icons/Edit';
 import CodeIcon from '@material-ui/icons/Code';
+import SvgIcon from '@material-ui/core/SvgIcon';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import Snackbar from '@material-ui/core/Snackbar';
 import Menu from '@material-ui/core/Menu';
@@ -278,6 +278,30 @@ export default function DemoToolbar(props) {
     document.body.removeChild(form);
   };
 
+  const handleStackBlitzClick = () => {
+    const demoConfig = getDemoConfig(demoData, 'index.html');
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.target = '_blank';
+    form.action = 'https://stackblitz.com/run';
+    addHiddenInput(form, 'project[template]', 'create-react-app');
+    addHiddenInput(form, 'project[title]', demoConfig.title);
+    addHiddenInput(
+      form,
+      'project[description]',
+      `# ${demoConfig.title}\n${demoConfig.description}`,
+    );
+    addHiddenInput(form, 'project[dependencies]', JSON.stringify(demoConfig.dependencies));
+    addHiddenInput(form, 'project[devDependencies]', JSON.stringify(demoConfig.devDependencies));
+    Object.keys(demoConfig.files).forEach((key) => {
+      const value = demoConfig.files[key];
+      addHiddenInput(form, `project[files][${key}]`, value);
+    });
+    document.body.appendChild(form);
+    form.submit();
+    document.body.removeChild(form);
+  };
+
   const [anchorEl, setAnchorEl] = React.useState(null);
   const handleMoreClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -479,18 +503,36 @@ export default function DemoToolbar(props) {
             </IconButton>
           </DemoTooltip>
           {demoOptions.hideEditButton ? null : (
-            <DemoTooltip title={t('codesandbox')} placement="bottom">
-              <IconButton
-                size="large"
-                data-ga-event-category="demo"
-                data-ga-event-label={demoOptions.demo}
-                data-ga-event-action="codesandbox"
-                onClick={handleCodeSandboxClick}
-                {...getControlProps(3)}
-              >
-                <EditIcon fontSize="small" />
-              </IconButton>
-            </DemoTooltip>
+            <React.Fragment>
+              <DemoTooltip title={t('codesandbox')} placement="bottom">
+                <IconButton
+                  size="large"
+                  data-ga-event-category="demo"
+                  data-ga-event-label={demoOptions.demo}
+                  data-ga-event-action="codesandbox"
+                  onClick={handleCodeSandboxClick}
+                  {...getControlProps(3)}
+                >
+                  <SvgIcon fontSize="small" viewBox="0 0 1024 1024">
+                    <path d="M755 140.3l0.5-0.3h0.3L512 0 268.3 140h-0.3l0.8 0.4L68.6 256v512L512 1024l443.4-256V256L755 140.3z m-30 506.4v171.2L548 920.1V534.7L883.4 341v215.7l-158.4 90z m-584.4-90.6V340.8L476 534.4v385.7L300 818.5V646.7l-159.4-90.6zM511.7 280l171.1-98.3 166.3 96-336.9 194.5-337-194.6 165.7-95.7L511.7 280z" />
+                  </SvgIcon>
+                </IconButton>
+              </DemoTooltip>
+              <DemoTooltip title={t('stackblitz')} placement="bottom">
+                <IconButton
+                  size="large"
+                  data-ga-event-category="demo"
+                  data-ga-event-label={demoOptions.demo}
+                  data-ga-event-action="stackblitz"
+                  onClick={handleStackBlitzClick}
+                  {...getControlProps(3)}
+                >
+                  <SvgIcon fontSize="small" viewBox="0 0 19 28">
+                    <path d="M8.13378 16.1087H0L14.8696 0L10.8662 11.1522L19 11.1522L4.13043 27.2609L8.13378 16.1087Z" />
+                  </SvgIcon>
+                </IconButton>
+              </DemoTooltip>
+            </React.Fragment>
           )}
           <DemoTooltip title={t('copySource')} placement="bottom">
             <IconButton

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -279,7 +279,10 @@ export default function DemoToolbar(props) {
   };
 
   const handleStackBlitzClick = () => {
-    const demoConfig = getDemoConfig(demoData, 'index.html');
+    const demoConfig = getDemoConfig(demoData, {
+      indexPath: 'index.html',
+      previewPackage: false,
+    });
     const form = document.createElement('form');
     form.method = 'POST';
     form.target = '_blank';

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -373,6 +373,7 @@ export default function DemoToolbar(props) {
     React.useRef(null),
     React.useRef(null),
     React.useRef(null),
+    React.useRef(null),
   ];
   // if the code is not open we hide the first two language controls
   const isFocusableControl = React.useCallback(
@@ -528,7 +529,7 @@ export default function DemoToolbar(props) {
                   data-ga-event-label={demoOptions.demo}
                   data-ga-event-action="stackblitz"
                   onClick={handleStackBlitzClick}
-                  {...getControlProps(3)}
+                  {...getControlProps(4)}
                 >
                   <SvgIcon fontSize="small" viewBox="0 0 19 28">
                     <path d="M8.13378 16.1087H0L14.8696 0L10.8662 11.1522L19 11.1522L4.13043 27.2609L8.13378 16.1087Z" />
@@ -544,7 +545,7 @@ export default function DemoToolbar(props) {
               data-ga-event-label={demoOptions.demo}
               data-ga-event-action="copy"
               onClick={handleCopyClick}
-              {...getControlProps(4)}
+              {...getControlProps(5)}
             >
               <FileCopyIcon fontSize="small" />
             </IconButton>
@@ -556,7 +557,7 @@ export default function DemoToolbar(props) {
               data-ga-event-label={demoOptions.demo}
               data-ga-event-action="reset-focus"
               onClick={handleResetFocusClick}
-              {...getControlProps(5)}
+              {...getControlProps(6)}
             >
               <ResetFocusIcon fontSize="small" />
             </IconButton>
@@ -569,7 +570,7 @@ export default function DemoToolbar(props) {
               data-ga-event-label={demoOptions.demo}
               data-ga-event-action="reset"
               onClick={onResetDemoClick}
-              {...getControlProps(6)}
+              {...getControlProps(7)}
             >
               <RefreshIcon fontSize="small" />
             </IconButton>
@@ -580,7 +581,7 @@ export default function DemoToolbar(props) {
             aria-label={t('seeMore')}
             aria-owns={anchorEl ? 'demo-menu-more' : undefined}
             aria-haspopup="true"
-            {...getControlProps(7)}
+            {...getControlProps(8)}
           >
             <MoreVertIcon fontSize="small" />
           </IconButton>

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -93,7 +93,7 @@ function getLanguageConfig(demoData, options) {
   }
 }
 
-export default function getDemoConfig(demoData, options) {
+export default function getDemoConfig(demoData, options = {}) {
   const { indexPath = 'public/index.html', previewPackage = true } = options;
   const baseConfig = {
     title: demoData.title,

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -1,10 +1,11 @@
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
-import { getDependencies } from './helpers';
+import { getDependencies } from 'docs/src/modules/utils/helpers';
 
-function jsDemo(demoData) {
+function jsDemo(demoData, options) {
   return {
     dependencies: getDependencies(demoData.raw, {
-      muiCommitRef: process.env.PULL_REQUEST ? process.env.COMMIT_REF : undefined,
+      muiCommitRef:
+        process.env.PULL_REQUEST && options.previewPackage ? process.env.COMMIT_REF : undefined,
     }),
     files: {
       'demo.js': demoData.raw,
@@ -25,11 +26,12 @@ ReactDOM.render(
   };
 }
 
-function tsDemo(demoData) {
+function tsDemo(demoData, options) {
   return {
     dependencies: getDependencies(demoData.raw, {
       codeLanguage: CODE_VARIANTS.TS,
-      muiCommitRef: process.env.PULL_REQUEST ? process.env.COMMIT_REF : undefined,
+      muiCommitRef:
+        process.env.PULL_REQUEST && options.previewPackage ? process.env.COMMIT_REF : undefined,
     }),
     files: {
       'demo.tsx': demoData.raw,
@@ -80,18 +82,19 @@ ReactDOM.render(
   };
 }
 
-function getLanguageConfig(demoData) {
+function getLanguageConfig(demoData, options) {
   switch (demoData.codeVariant) {
     case CODE_VARIANTS.TS:
-      return tsDemo(demoData);
+      return tsDemo(demoData, options);
     case CODE_VARIANTS.JS:
-      return jsDemo(demoData);
+      return jsDemo(demoData, options);
     default:
       throw new Error(`Unsupported codeVariant: ${demoData.codeVariant}`);
   }
 }
 
-export default function getDemoConfig(demoData, indexPath = 'public/index.html') {
+export default function getDemoConfig(demoData, options) {
+  const { indexPath = 'public/index.html', previewPackage = true } = options;
   const baseConfig = {
     title: demoData.title,
     description: demoData.githubLocation,
@@ -119,7 +122,9 @@ export default function getDemoConfig(demoData, indexPath = 'public/index.html')
 `.trim(),
     },
   };
-  const languageConfig = getLanguageConfig(demoData);
+  const languageConfig = getLanguageConfig(demoData, {
+    previewPackage,
+  });
 
   return {
     ...baseConfig,

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -65,7 +65,7 @@ ReactDOM.render(
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve"
+    "jsx": "react"
   },
   "include": [
     "src"
@@ -91,12 +91,12 @@ function getLanguageConfig(demoData) {
   }
 }
 
-export default function getDemoConfig(demoData) {
+export default function getDemoConfig(demoData, indexPath = 'public/index.html') {
   const baseConfig = {
     title: demoData.title,
     description: demoData.githubLocation,
     files: {
-      'public/index.html': `
+      [indexPath]: `
 <!DOCTYPE html>
 <html lang="${demoData.language}">
   <head>

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -133,6 +133,7 @@
   "signUpTitle": "Sign Up",
   "sourceCode": "Source code",
   "spacingUnit": "Spacing unit",
+  "stackblitz": "Edit in StackBlitz",
   "stars": "GitHub stars",
   "stickyFooterDescr": "Attach a footer to the bottom of the viewport when page content is short.",
   "stickyFooterTitle": "Sticky footer",


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/27255 as per discussion with @oliviertassinari.

Additional notes:
- React+TypeScript support that's mentioned in the original issue has been fixed on the StackBlitz side
- the `"jsx": "preserve"` in the generated `tsconfig.json` for the demos is handled by CodeSandbox but not by StackBlitz, while `"jsx": "react"` is handled by both hence the updated value

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Preview: https://deploy-preview-27391--material-ui.netlify.app/components/alert/#basic-alerts

<img width="842" alt="Capture d’écran 2021-07-21 à 18 20 13" src="https://user-images.githubusercontent.com/3165635/126523858-048d6d2b-4629-4eaf-bb45-2e8120d0278a.png">
