### PR TITLE
[docs] Link to API page of components from highlighted code

### DIFF
--- a/docs/packages/markdown/prism.js
+++ b/docs/packages/markdown/prism.js
@@ -1,4 +1,5 @@
 const prism = require('prismjs');
+const camelCase = require('lodash/camelCase');
 require('prismjs/components/prism-css');
 require('prismjs/components/prism-diff');
 require('prismjs/components/prism-javascript');
@@ -7,7 +8,218 @@ require('prismjs/components/prism-jsx');
 require('prismjs/components/prism-markup');
 require('prismjs/components/prism-tsx');
 
+function createPrismComponentLinkerHook(getComponentApiPageLink) {
+  return prism.hooks.add('wrap', (env) => {
+    if (env.type === 'class-name') {
+      const possiblyComponentIdentifier = env.content;
+      const componentApiPage = getComponentApiPageLink(possiblyComponentIdentifier);
+      if (componentApiPage) {
+        env.content = `<a href="/api/${componentApiPage}">${env.content}</a>`;
+      }
+    }
+  });
+}
+
+let componentLinkerHook = null;
+
+const apiPages = [
+  { pathname: '/api-docs/accordion' },
+  { pathname: '/api-docs/accordion-actions' },
+  { pathname: '/api-docs/accordion-details' },
+  { pathname: '/api-docs/accordion-summary' },
+  { pathname: '/api-docs/alert' },
+  { pathname: '/api-docs/alert-title' },
+  { pathname: '/api-docs/app-bar' },
+  { pathname: '/api-docs/autocomplete' },
+  { pathname: '/api-docs/avatar' },
+  { pathname: '/api-docs/avatar-group' },
+  { pathname: '/api-docs/backdrop' },
+  { pathname: '/api-docs/backdrop-unstyled' },
+  { pathname: '/api-docs/badge' },
+  { pathname: '/api-docs/badge-unstyled' },
+  { pathname: '/api-docs/bottom-navigation' },
+  { pathname: '/api-docs/bottom-navigation-action' },
+  { pathname: '/api-docs/breadcrumbs' },
+  { pathname: '/api-docs/button' },
+  { pathname: '/api-docs/button-base' },
+  { pathname: '/api-docs/button-group' },
+  { pathname: '/api-docs/calendar-picker' },
+  { pathname: '/api-docs/calendar-picker-skeleton' },
+  { pathname: '/api-docs/card' },
+  { pathname: '/api-docs/card-action-area' },
+  { pathname: '/api-docs/card-actions' },
+  { pathname: '/api-docs/card-content' },
+  { pathname: '/api-docs/card-header' },
+  { pathname: '/api-docs/card-media' },
+  { pathname: '/api-docs/checkbox' },
+  { pathname: '/api-docs/chip' },
+  { pathname: '/api-docs/circular-progress' },
+  { pathname: '/api-docs/click-away-listener' },
+  { pathname: '/api-docs/clock-picker' },
+  { pathname: '/api-docs/collapse' },
+  { pathname: '/api-docs/container' },
+  { pathname: '/api-docs/css-baseline' },
+  { pathname: '/api-docs/date-picker' },
+  { pathname: '/api-docs/date-range-picker' },
+  { pathname: '/api-docs/date-range-picker-day' },
+  { pathname: '/api-docs/date-time-picker' },
+  { pathname: '/api-docs/desktop-date-picker' },
+  { pathname: '/api-docs/desktop-date-range-picker' },
+  { pathname: '/api-docs/desktop-date-time-picker' },
+  { pathname: '/api-docs/desktop-time-picker' },
+  { pathname: '/api-docs/dialog' },
+  { pathname: '/api-docs/dialog-actions' },
+  { pathname: '/api-docs/dialog-content' },
+  { pathname: '/api-docs/dialog-content-text' },
+  { pathname: '/api-docs/dialog-title' },
+  { pathname: '/api-docs/divider' },
+  { pathname: '/api-docs/drawer' },
+  { pathname: '/api-docs/fab' },
+  { pathname: '/api-docs/fade' },
+  { pathname: '/api-docs/filled-input' },
+  { pathname: '/api-docs/form-control' },
+  { pathname: '/api-docs/form-control-label' },
+  { pathname: '/api-docs/form-group' },
+  { pathname: '/api-docs/form-helper-text' },
+  { pathname: '/api-docs/form-label' },
+  { pathname: '/api-docs/global-styles' },
+  { pathname: '/api-docs/grid' },
+  { pathname: '/api-docs/grow' },
+  { pathname: '/api-docs/hidden' },
+  { pathname: '/api-docs/icon' },
+  { pathname: '/api-docs/icon-button' },
+  { pathname: '/api-docs/image-list' },
+  { pathname: '/api-docs/image-list-item' },
+  { pathname: '/api-docs/image-list-item-bar' },
+  { pathname: '/api-docs/input' },
+  { pathname: '/api-docs/input-adornment' },
+  { pathname: '/api-docs/input-base' },
+  { pathname: '/api-docs/input-label' },
+  { pathname: '/api-docs/linear-progress' },
+  { pathname: '/api-docs/link' },
+  { pathname: '/api-docs/list' },
+  { pathname: '/api-docs/list-item' },
+  { pathname: '/api-docs/list-item-avatar' },
+  { pathname: '/api-docs/list-item-button' },
+  { pathname: '/api-docs/list-item-icon' },
+  { pathname: '/api-docs/list-item-secondary-action' },
+  { pathname: '/api-docs/list-item-text' },
+  { pathname: '/api-docs/list-subheader' },
+  { pathname: '/api-docs/loading-button' },
+  { pathname: '/api-docs/menu' },
+  { pathname: '/api-docs/menu-item' },
+  { pathname: '/api-docs/menu-list' },
+  { pathname: '/api-docs/mobile-date-picker' },
+  { pathname: '/api-docs/mobile-date-range-picker' },
+  { pathname: '/api-docs/mobile-date-time-picker' },
+  { pathname: '/api-docs/mobile-stepper' },
+  { pathname: '/api-docs/mobile-time-picker' },
+  { pathname: '/api-docs/modal' },
+  { pathname: '/api-docs/modal-unstyled' },
+  { pathname: '/api-docs/month-picker' },
+  { pathname: '/api-docs/native-select' },
+  { pathname: '/api-docs/no-ssr' },
+  { pathname: '/api-docs/outlined-input' },
+  { pathname: '/api-docs/pagination' },
+  { pathname: '/api-docs/pagination-item' },
+  { pathname: '/api-docs/paper' },
+  { pathname: '/api-docs/pickers-day' },
+  { pathname: '/api-docs/popover' },
+  { pathname: '/api-docs/popper' },
+  { pathname: '/api-docs/portal' },
+  { pathname: '/api-docs/radio' },
+  { pathname: '/api-docs/radio-group' },
+  { pathname: '/api-docs/rating' },
+  { pathname: '/api-docs/scoped-css-baseline' },
+  { pathname: '/api-docs/select' },
+  { pathname: '/api-docs/skeleton' },
+  { pathname: '/api-docs/slide' },
+  { pathname: '/api-docs/slider' },
+  { pathname: '/api-docs/slider-unstyled' },
+  { pathname: '/api-docs/snackbar' },
+  { pathname: '/api-docs/snackbar-content' },
+  { pathname: '/api-docs/speed-dial' },
+  { pathname: '/api-docs/speed-dial-action' },
+  { pathname: '/api-docs/speed-dial-icon' },
+  { pathname: '/api-docs/stack' },
+  { pathname: '/api-docs/static-date-picker' },
+  { pathname: '/api-docs/static-date-range-picker' },
+  { pathname: '/api-docs/static-date-time-picker' },
+  { pathname: '/api-docs/static-time-picker' },
+  { pathname: '/api-docs/step' },
+  { pathname: '/api-docs/step-button' },
+  { pathname: '/api-docs/step-connector' },
+  { pathname: '/api-docs/step-content' },
+  { pathname: '/api-docs/step-icon' },
+  { pathname: '/api-docs/step-label' },
+  { pathname: '/api-docs/stepper' },
+  { pathname: '/api-docs/svg-icon' },
+  { pathname: '/api-docs/swipeable-drawer' },
+  { pathname: '/api-docs/switch' },
+  { pathname: '/api-docs/switch-unstyled' },
+  { pathname: '/api-docs/tab' },
+  { pathname: '/api-docs/tab-context' },
+  { pathname: '/api-docs/table' },
+  { pathname: '/api-docs/table-body' },
+  { pathname: '/api-docs/table-cell' },
+  { pathname: '/api-docs/table-container' },
+  { pathname: '/api-docs/table-footer' },
+  { pathname: '/api-docs/table-head' },
+  { pathname: '/api-docs/table-pagination' },
+  { pathname: '/api-docs/table-row' },
+  { pathname: '/api-docs/table-sort-label' },
+  { pathname: '/api-docs/tab-list' },
+  { pathname: '/api-docs/tab-panel' },
+  { pathname: '/api-docs/tabs' },
+  { pathname: '/api-docs/tab-scroll-button' },
+  { pathname: '/api-docs/textarea-autosize' },
+  { pathname: '/api-docs/text-field' },
+  { pathname: '/api-docs/timeline' },
+  { pathname: '/api-docs/timeline-connector' },
+  { pathname: '/api-docs/timeline-content' },
+  { pathname: '/api-docs/timeline-dot' },
+  { pathname: '/api-docs/timeline-item' },
+  { pathname: '/api-docs/timeline-opposite-content' },
+  { pathname: '/api-docs/timeline-separator' },
+  { pathname: '/api-docs/time-picker' },
+  { pathname: '/api-docs/toggle-button' },
+  { pathname: '/api-docs/toggle-button-group' },
+  { pathname: '/api-docs/toolbar' },
+  { pathname: '/api-docs/tooltip' },
+  { pathname: '/api-docs/tree-item' },
+  { pathname: '/api-docs/tree-view' },
+  { pathname: '/api-docs/typography' },
+  { pathname: '/api-docs/unstable-trap-focus' },
+  { pathname: '/api-docs/year-picker' },
+  { pathname: '/api-docs/zoom' },
+];
+
+function upperCaseFirst(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * @param {string} code
+ * @param {string} language
+ */
 function highlight(code, language) {
+  if (componentLinkerHook === null) {
+    const componentNameToPageName = {};
+    apiPages.forEach((apiPage) => {
+      const componentNameMatch = apiPage.pathname.match(/^\/api-docs\/([^/]+)/);
+      if (componentNameMatch == null) {
+        throw new TypeError(`Unable to parse pathname '${apiPage.pathname}'`);
+      }
+      const [, componentPageName] = componentNameMatch;
+      const componentName = upperCaseFirst(camelCase(componentPageName));
+      componentNameToPageName[componentName] = componentPageName;
+    });
+
+    componentLinkerHook = createPrismComponentLinkerHook((componentName) => {
+      return componentNameToPageName[componentName];
+    });
+  }
+
   let prismLanguage;
   switch (language) {
     case 'ts':


### PR DESCRIPTION
This is just a proof-of-concept.

Links to the API page of a component directly from the highlighted code.
Preview: https://deploy-preview-27393--material-ui.netlify.app/components/pickers/#MaterialUIPickers.tsx

I have some ideas for a way richer syntax highlighting that provides additional information (like an IDE would). Just want to test the waters how the team feels about these type of enhancements.

Though we probably can't go all in right now because it might be too expensive without React 18.

/cc @mui-org/maintainers 