### PR TITLE
[codemod] Fix running codemod CLI on Windows

### DIFF
--- a/packages/material-ui-codemod/codemod.js
+++ b/packages/material-ui-codemod/codemod.js
@@ -4,9 +4,10 @@ const childProcess = require('child_process');
 const { promises: fs } = require('fs');
 const path = require('path');
 const yargs = require('yargs');
+const jscodeshiftPackage = require('jscodeshift/package.json');
 
 const jscodeshiftDirectory = path.dirname(require.resolve('jscodeshift'));
-const jscodeshiftExecutable = path.join(jscodeshiftDirectory, 'bin/jscodeshift.js');
+const jscodeshiftExecutable = path.join(jscodeshiftDirectory, jscodeshiftPackage.bin.jscodeshift);
 
 async function runTransform(transform, files, flags, codemodFlags) {
   const transformerSrcPath = path.resolve(__dirname, './src', `${transform}.js`);

--- a/packages/material-ui-codemod/codemod.js
+++ b/packages/material-ui-codemod/codemod.js
@@ -5,7 +5,8 @@ const { promises: fs } = require('fs');
 const path = require('path');
 const yargs = require('yargs');
 
-const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
+const jscodeshiftDirectory = path.dirname(require.resolve('jscodeshift'));
+const jscodeshiftExecutable = path.join(jscodeshiftDirectory, 'bin/jscodeshift.js');
 
 async function runTransform(transform, files, flags, codemodFlags) {
   const transformerSrcPath = path.resolve(__dirname, './src', `${transform}.js`);


### PR DESCRIPTION
On Windows, Lerna does not create symlinks from `node_modules/.bin` but instead creates bash and cmd scripts that execute the target script. Thus `require.resolve('.bin/jscodeshift')` would point to the bash script that can't be executed by node. This PR changes the `jscodeshiftExecutable` finding logic to look in workspace root's node_modules.

Fixes #27320