### PR TITLE
[TextareaAutosize] Updated deprecation warning to suggest minRows instead of rowsMin

### DIFF
--- a/docs/pages/api-docs/textarea-autosize.md
+++ b/docs/pages/api-docs/textarea-autosize.md
@@ -28,7 +28,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">maxRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Maximum number of rows to display. |
 | <span class="prop-name">minRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">1</span> | Minimum number of rows to display. |
-| ~~<span class="prop-name">rows</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `rowsMin` instead.<br><br>Minimum number of rows to display. |
+| ~~<span class="prop-name">rows</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
 | ~~<span class="prop-name">rowsMax</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `maxRows` instead.<br><br>Maximum number of rows to display. |
 | ~~<span class="prop-name">rowsMin</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
 

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.d.ts
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.d.ts
@@ -6,7 +6,7 @@ export interface TextareaAutosizeProps
   ref?: React.Ref<HTMLTextAreaElement>;
   /**
    * Minimum number of rows to display.
-   * @deprecated Use `rowsMin` instead.
+   * @deprecated Use `minRows` instead.
    */
   rows?: string | number;
   /**

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -213,11 +213,11 @@ TextareaAutosize.propTypes = {
   placeholder: PropTypes.string,
   /**
    * Minimum number of rows to display.
-   * @deprecated Use `rowsMin` instead.
+   * @deprecated Use `minRows` instead.
    */
   rows: deprecatedPropType(
     PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    'Use `rowsMin` instead.',
+    'Use `minRows` instead.',
   ),
   /**
    * Maximum number of rows to display.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When using the `rows` prop on a `TextField`, you get a console error about `rows` being deprecated. It suggests using `rowsMin`, which is also deprecated. 

It should instead tell the developer to use `minRows`. 

![textAreaRows](https://user-images.githubusercontent.com/8048702/126551001-4d2ef001-44a8-4d00-96c3-e17e146700d0.png)

