### PR TITLE
[system] Compute display name of `styled` component if `name` isn't set

### DIFF
--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -1,4 +1,5 @@
 import styledEngineStyled from '@material-ui/styled-engine';
+import { getDisplayName } from '@material-ui/utils';
 import createTheme from './createTheme';
 import styleFunctionSx from './styleFunctionSx';
 import propsToClassKey from './propsToClassKey';
@@ -164,7 +165,10 @@ export default function createStyled(input = {}) {
 
       const Component = defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
 
-      if (displayName) {
+      if (process.env.NODE_ENV !== 'production') {
+        if (displayName === undefined) {
+          displayName = `Styled(${getDisplayName(tag)})`;
+        }
         Component.displayName = displayName;
       }
 

--- a/packages/material-ui-system/src/createStyled.test.js
+++ b/packages/material-ui-system/src/createStyled.test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import createStyled from './createStyled';
+
+describe('createStyled', () => {
+  describe('displayName', () => {
+    // These tests rely on implementation details (namely `displayName`)
+    // Ideally we'd just test if the proper name appears in a React warning.
+    // But React warnings are deduplicated during module lifetime.
+    // We would need to reset modules to make the tests work in watchmode.
+    before(function beforeHook() {
+      // display names are dev-only
+      if (process.env.NODE_ENV === 'production') {
+        this.skip();
+      }
+    });
+
+    it('uses the `componentName` if set', () => {
+      const styled = createStyled({});
+      const SomeMuiComponent = styled('div', { name: 'SomeMuiComponent' })({});
+
+      expect(SomeMuiComponent).to.have.property('displayName', 'SomeMuiComponent');
+    });
+
+    it('falls back to the decorated tag name', () => {
+      const styled = createStyled({});
+      const SomeMuiComponent = styled('div')({});
+
+      expect(SomeMuiComponent).to.have.property('displayName', 'Styled(div)');
+    });
+
+    it('falls back to the decorated computed displayName', () => {
+      const styled = createStyled({});
+      const SomeMuiComponent = styled(function SomeMuiComponent() {
+        return null;
+      })({});
+
+      expect(SomeMuiComponent).to.have.property('displayName', 'Styled(SomeMuiComponent)');
+    });
+
+    it('has a fallback name if the display name cannot be computed', () => {
+      const styled = createStyled({});
+      const SomeMuiComponent = styled(() => null)({});
+
+      expect(SomeMuiComponent).to.have.property('displayName', 'Styled(Component)');
+    });
+  });
+});


### PR DESCRIPTION
Otherwise the created components appear as anonymous in devtools. 

The `Styled` badge should ideally appear as well. Tracking in https://github.com/facebook/react/issues/21939

Before:
![Screenshot from 2021-07-22 11-36-23](https://user-images.githubusercontent.com/12292047/126622585-ad2263fb-89e7-4e4a-a451-fa25711e46f8.png)
After:
![Screenshot from 2021-07-22 11-35-43](https://user-images.githubusercontent.com/12292047/126622594-a47c4f7a-476a-4722-b088-f2b6c6d4fcfb.png)
