### PR TITLE
[Autocomplete] Explain how the loading prop works

### DIFF
--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -37,7 +37,7 @@
     "limitTags": "The maximum number of tags that will be visible when not focused. Set <code>-1</code> to disable the limit.",
     "ListboxComponent": "The component used to render the listbox.",
     "ListboxProps": "Props applied to the Listbox element.",
-    "loading": "If <code>true</code>, the component is in a loading state.",
+    "loading": "If <code>true</code>, the component is in a loading state. This shows the <code>loadingText</code> in place of suggestions (only if there are no suggestions to show, e.g. <code>options</code> are empty).",
     "loadingText": "Text to display when in a loading state.<br>For localization purposes, you can use the provided <a href=\"/guides/localization/\">translations</a>.",
     "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
     "noOptionsText": "Text to display when there are no options.<br>For localization purposes, you can use the provided <a href=\"/guides/localization/\">translations</a>.",

--- a/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.d.ts
@@ -140,6 +140,7 @@ export interface AutocompleteProps<
   ListboxProps?: ReturnType<ReturnType<typeof useAutocomplete>['getListboxProps']>;
   /**
    * If `true`, the component is in a loading state.
+   * This shows the `loadingText` in place of suggestions (only if there are no suggestions to show, e.g. `options` are empty).
    * @default false
    */
   loading?: boolean;

--- a/packages/material-ui/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.js
@@ -853,6 +853,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   ListboxProps: PropTypes.object,
   /**
    * If `true`, the component is in a loading state.
+   * This shows the `loadingText` in place of suggestions (only if there are no suggestions to show, e.g. `options` are empty).
    * @default false
    */
   loading: PropTypes.bool,


### PR DESCRIPTION
Made more clear how that the `loading` shows `loadingText` only when `options` are empty.

Fixes #27397