### PR TITLE
[core] Batch small changes

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -266,7 +266,7 @@ export default function DemoToolbar(props) {
     const form = document.createElement('form');
     form.method = 'POST';
     form.target = '_blank';
-    form.action = 'https://codeSandbox.io/api/v1/sandboxes/define';
+    form.action = 'https://codesandbox.io/api/v1/sandboxes/define';
     addHiddenInput(form, 'parameters', parameters);
     addHiddenInput(
       form,

--- a/docs/src/pages/components/transitions/transitions.md
+++ b/docs/src/pages/components/transitions/transitions.md
@@ -59,7 +59,7 @@ This example also demonstrates how to delay the enter transition.
 ## Child requirement
 
 - **Forward the style**: To better support server rendering, Material-UI provides a `style` prop to the children of some transition components (Fade, Grow, Zoom, Slide).
-The `style` prop must be applied to the DOM for the animation to work as expected.
+  The `style` prop must be applied to the DOM for the animation to work as expected.
 - **Forward the ref**: The transition components require the first child element to forward its ref to the DOM node. For more details about ref, check out [Caveat with refs](/guides/composition/#caveat-with-refs)
 - **Single element**: The transition components require only one child element (`React.Fragment` is not allowed).
 

--- a/docs/src/pages/components/transitions/transitions.md
+++ b/docs/src/pages/components/transitions/transitions.md
@@ -28,7 +28,7 @@ Fade in from transparent to opaque.
 
 ## Grow
 
-Expand outwards from the center of the child element while also fading in from transparent to opaque.
+Expands outwards from the center of the child element, while also fading in from transparent to opaque.
 
 The second example demonstrates how to change the `transform-origin`, and conditionally applies
 the `timeout` prop to change the entry speed.

--- a/docs/src/pages/components/transitions/transitions.md
+++ b/docs/src/pages/components/transitions/transitions.md
@@ -8,9 +8,7 @@ githubLabel: 'component: Transition'
 
 <p class="description">Transitions help to make a UI expressive and easy to use.</p>
 
-Material-UI provides a number of transitions that can be used to introduce some basic
-[motion](https://material.io/design/motion/)
-to your applications components.
+Material-UI provides transitions that can be used to introduce some basic [motion](https://material.io/design/motion/) to your applications.
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
@@ -30,8 +28,7 @@ Fade in from transparent to opaque.
 
 ## Grow
 
-Expand outwards from the center of the child element, while also fading in
-from transparent to opaque.
+Expand outwards from the center of the child element while also fading in from transparent to opaque.
 
 The second example demonstrates how to change the `transform-origin`, and conditionally applies
 the `timeout` prop to change the entry speed.
@@ -44,9 +41,10 @@ Slide in from the edge of the screen.
 The `direction` prop controls which edge of the screen the transition starts from.
 
 The Transition component's `mountOnEnter` prop prevents the child component from being mounted
-until `in` is `true`. This prevents the relatively positioned component from scrolling into view
-from its off-screen position. Similarly the `unmountOnExit` prop removes the component
-from the DOM after it has been transition off screen.
+until `in` is `true`.
+This prevents the relatively positioned component from scrolling into view
+from its off-screen position.
+Similarly, the `unmountOnExit` prop removes the component from the DOM after it has been transition off-screen.
 
 {{"demo": "pages/components/transitions/SimpleSlide.js", "bg": true}}
 
@@ -60,9 +58,10 @@ This example also demonstrates how to delay the enter transition.
 
 ## Child requirement
 
-- **Forward the style** : To better support server rendering, Material-UI provides a `style` prop to the children of some transition components, (Fade, Grow, Zoom, Slide). The `style` prop must be applied to the DOM for the animation to work as expected.
-- **Forward the ref** : The transition components require the first child element to forward its ref to the DOM node. For more details about ref, check out [Caveat with refs](/guides/composition/#caveat-with-refs)
-- **Single element** : The transition components require only 1 child element (`React.Fragment` is not allowed).
+- **Forward the style**: To better support server rendering, Material-UI provides a `style` prop to the children of some transition components (Fade, Grow, Zoom, Slide).
+The `style` prop must be applied to the DOM for the animation to work as expected.
+- **Forward the ref**: The transition components require the first child element to forward its ref to the DOM node. For more details about ref, check out [Caveat with refs](/guides/composition/#caveat-with-refs)
+- **Single element**: The transition components require only one child element (`React.Fragment` is not allowed).
 
 ```jsx
 // The `props` object contains a `style` prop.

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -83,6 +83,10 @@ This is a collection of third-party projects that extend Material-UI.
 
 - [material-ui-color](https://github.com/mikbry/material-ui-color): Collections of color components for material-ui. No dependencies, small, highly customizable and theming support!
 
+### Sparkline
+
+- [mui-plus](https://mui-plus.vercel.app/components/Sparkline): A sparkline is a tiny chart that can be used to indicate a certain trend of a value.
+
 ## Blocks
 
 - [components-extra](https://github.com/alexandre-lelain/components-extra): Provides a set of "molecule" components built on top of Material-UI like a Footer, a CookiesBanner, a BackToTop button and other complex elements highly customizable to help devs build the macro parts of their UI very quickly. Those components are often duplicated across sites - this library solves this exact problem.

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -85,11 +85,11 @@ This is a collection of third-party projects that extend Material-UI.
 
 ### Sparkline
 
-- [mui-plus](https://mui-plus.vercel.app/components/Sparkline): A sparkline is a tiny chart that can be used to indicate a certain trend of a value.
+- [mui-plus](https://mui-plus.vercel.app/components/Sparkline): A sparkline is a tiny chart that can be used to indicate the trend of a value.
 
 ## Blocks
 
-- [components-extra](https://github.com/alexandre-lelain/components-extra): Provides a set of "molecule" components built on top of Material-UI like a Footer, a CookiesBanner, a BackToTop button and other complex elements highly customizable to help devs build the macro parts of their UI very quickly. Those components are often duplicated across sites - this library solves this exact problem.
+- [components-extra](https://github.com/alexandre-lelain/components-extra): Provides a set of "molecule" components built on top of Material-UI, such as a Footer, a CookiesBanner, a BackToTop button, and other highly customizable complex elements, to help devs build the macro parts of their UI very quickly. Those components are often duplicated across sites. This library solves this exact problem.
 
 ## Theming
 

--- a/docs/src/pages/guides/api/api.md
+++ b/docs/src/pages/guides/api/api.md
@@ -98,7 +98,7 @@ The name of a boolean prop should be chosen based on the **default value**. This
   <Input disabled /> ✅
   ```
 
-- developers knowing what's the default value only reading the name of the boolean prop. It's always `false`.
+- developers to know what the default value is from the name of the boolean prop. It's always the opposite.
 
 ### Controlled components
 

--- a/docs/src/pages/guides/api/api.md
+++ b/docs/src/pages/guides/api/api.md
@@ -89,14 +89,16 @@ Nested components inside a component have:
 
 ### Property naming
 
-The name of a boolean prop should be chosen based on the **default value**.
-For example, the `disabled` attribute on an input element, if supplied, defaults to `true`.
-This choice allows the shorthand notation:
+The name of a boolean prop should be chosen based on the **default value**. This choice allows:
 
-```diff
--<Input enabled={false} />
-+<Input disabled />
-```
+- the shorthand notation. For example, the `disabled` attribute on an input element, if supplied, defaults to `true`:
+
+  ```jsx
+  <Input enabled={false} /> ❌
+  <Input disabled /> ✅
+  ```
+
+- developers knowing what's the default value only reading the name of the boolean prop. It's always `false`.
 
 ### Controlled components
 

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -172,7 +172,7 @@ Only the two most common use cases are covered. For more information see [this s
 +const SomeContent = React.forwardRef((props, ref) =>
 +  <div {...props} ref={ref}>Hello, World!</div>);
 
- <Tooltip title="Hello, again."><SomeContent /></Tooltip>;
+ <Tooltip title="Hello again."><SomeContent /></Tooltip>;
 ```
 
 To find out if the Material-UI component you're using has this requirement, check

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -164,13 +164,15 @@ Only the two most common use cases are covered. For more information see [this s
 +const MyButton = React.forwardRef((props, ref) =>
 +  <div role="button" {...props} ref={ref} />);
 
-<Button component={MyButton} />;
+ <Button component={MyButton} />;
 ```
 
 ```diff
 -const SomeContent = props => <div {...props}>Hello, World!</div>;
-+const SomeContent = React.forwardRef((props, ref) => <div {...props} ref={ref}>Hello, World!</div>);
-<Tooltip title="Hello, again."><SomeContent /></Tooltip>;
++const SomeContent = React.forwardRef((props, ref) =>
++  <div {...props} ref={ref}>Hello, World!</div>);
+
+ <Tooltip title="Hello, again."><SomeContent /></Tooltip>;
 ```
 
 To find out if the Material-UI component you're using has this requirement, check
@@ -186,13 +188,13 @@ You can use `React.forwardRef` and a designated prop in your class component to 
 Doing so should not trigger any more warnings related to the deprecation of `ReactDOM.findDOMNode`.
 
 ```diff
-class Component extends React.Component {
-  render() {
--   const { props } = this;
-+   const { forwardedRef, ...props } = this.props;
-    return <div {...props} ref={forwardedRef} />;
-  }
-}
+ class Component extends React.Component {
+   render() {
+-    const { props } = this;
++    const { forwardedRef, ...props } = this.props;
+     return <div {...props} ref={forwardedRef} />;
+   }
+ }
 
 -export default Component;
 +export default React.forwardRef((props, ref) => <Component {...props} forwardedRef={ref} />);

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -15,7 +15,7 @@ We'll do our best to keep things easy to follow, and as sequential as possible, 
 This documentation page covers the _how_ of migrating from v4 to v5.
 The _why_ will be covered in an upcoming blog post on Medium.
 
-## Migration Steps
+## Migration steps
 
 - [Update React & TypeScript](#update-react-amp-typescript-version)
 - [ThemeProvider setup](#themeprovider-setup)

--- a/docs/src/pages/guides/pickers-migration/pickers-migration.md
+++ b/docs/src/pages/guides/pickers-migration/pickers-migration.md
@@ -79,11 +79,11 @@ We introduced a new **required** `renderInput` prop. This simplifies using non-M
 Previously, props were spread on the `<TextField />` component. From now on you will need to use the new `renderInput` prop to provide these:
 
 ```diff
-<DatePicker
-- label="Date"
-- helperText="Something"
-+ renderInput={props => <TextField label="Date" helperText="Something" /> }
-/>
+ <DatePicker
+-  label="Date"
+-  helperText="Something"
++  renderInput={props => <TextField label="Date" helperText="Something" /> }
+ />
 ```
 
 ## State management
@@ -116,9 +116,9 @@ Mask is no longer required. Also, if your provided mask is not valid, pickers wi
 ## And many more
 
 - ```diff
-  <DatePicker
-  - format="DD-MMM-YYYY"
-  + inputFormat="DD-MMM-YYYY"
+   <DatePicker
+  -  format="DD-MMM-YYYY"
+  +  inputFormat="DD-MMM-YYYY"
   ```
 
 There are many changes, be careful, make sure your tests, and build pass.

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -38,7 +38,7 @@ function Header(props) {
             <Grid item xs />
             <Grid item>
               <Link
-                href="https://docs.paperbase.app/"
+                href="/"
                 variant="body2"
                 sx={{
                   textDecoration: 'none',

--- a/docs/src/pages/premium-themes/paperbase/Header.tsx
+++ b/docs/src/pages/premium-themes/paperbase/Header.tsx
@@ -41,7 +41,7 @@ export default function Header(props: HeaderProps) {
             <Grid item xs />
             <Grid item>
               <Link
-                href="https://docs.paperbase.app/"
+                href="/"
                 variant="body2"
                 sx={{
                   textDecoration: 'none',

--- a/docs/src/pages/system/styled/styled.md
+++ b/docs/src/pages/system/styled/styled.md
@@ -67,13 +67,13 @@ If you inspect this element with the browser DevTools, you will notice that the 
 If you would like to remove some of the Material-UI specific features, you can do it like this:
 
 ```diff
-const StyledComponent = styled('div', {}, {
+ const StyledComponent = styled('div', {}, {
    name: 'MuiStyled',
    slot: 'Root',
 -  overridesResolver: (props, styles) => styles.root, // disables theme.components[name].styleOverrides
 +  skipVariantsResolver: true, // disables theme.components[name].variants
 +  skipSx: true, // disables the sx prop
-})
+ });
 ```
 
 ## Create custom `styled()` utility

--- a/examples/create-react-app-with-styled-components-typescript/README.md
+++ b/examples/create-react-app-with-styled-components-typescript/README.md
@@ -20,6 +20,8 @@ Alternatively, to skip this configuration, you can set `skipLibCheck: true` in y
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app-with-styled-components-typescript
 cd create-react-app-with-styled-components-typescript
@@ -34,7 +36,9 @@ npm start
 
 ## CodeSandbox
 
-Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-styled-components-typescript).
+<!-- #default-branch-switch -->
+
+Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components-typescript).
 
 The following link leverages this demo: https://next.material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
 

--- a/examples/create-react-app-with-styled-components/README.md
+++ b/examples/create-react-app-with-styled-components/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app-with-styled-components
 cd create-react-app-with-styled-components
@@ -18,7 +20,9 @@ npm start
 
 ## CodeSandbox
 
-Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-styled-components).
+<!-- #default-branch-switch -->
+
+Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components).
 
 The following link leverages this demo: https://next.material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
 

--- a/examples/create-react-app-with-typescript/README.md
+++ b/examples/create-react-app-with-typescript/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app-with-typescript
 cd create-react-app-with-typescript
@@ -18,8 +20,12 @@ npm start
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-typescript)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app-with-typescript)
 
 ## The idea behind the example
 
-This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with [TypeScript](https://github.com/Microsoft/TypeScript). It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with [TypeScript](https://github.com/Microsoft/TypeScript).
+It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
+If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app
 cd create-react-app
@@ -18,8 +20,12 @@ npm start
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/create-react-app)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app)
 
 ## The idea behind the example
 
-This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app). It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app).
+It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
+If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/gatsby
 cd gatsby
@@ -18,8 +20,12 @@ npm run develop
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/gatsby)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/gatsby)
 
 ## The idea behind the example
 
-The project uses [Gatsby](https://github.com/gatsbyjs/gatsby), which is a static site generator for React. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+The project uses [Gatsby](https://github.com/gatsbyjs/gatsby), which is a static site generator for React.
+It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
+If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).

--- a/examples/nextjs-with-styled-components-typescript/README.md
+++ b/examples/nextjs-with-styled-components-typescript/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/nextjs-with-styled-components-typescript
 cd nextjs-with-styled-components-typescript
@@ -18,11 +20,14 @@ npm run dev
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/nextjs-with-styled-components-typescript)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/nextjs-with-styled-components-typescript)
 
 ## The idea behind the example
 
-The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `styled-components`, which is used instead of the default style engine in Material-UI v5.
+The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps.
+It includes `@material-ui/core` and its peer dependencies, including `styled-components`, which is used instead of the default style engine in Material-UI v5.
 
 ## The link component
 

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/nextjs-with-typescript
 cd nextjs-with-typescript
@@ -18,11 +20,14 @@ npm run dev
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/nextjs-with-typescript)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/nextjs-with-typescript)
 
 ## The idea behind the example
 
-The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps.
+It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
 
 ## The link component
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/nextjs
 cd nextjs
@@ -18,11 +20,15 @@ npm run dev
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/nextjs)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/nextjs)
 
 ## The idea behind the example
 
-The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps. It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps.
+It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
+If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
 
 ## The link component
 

--- a/examples/preact/README.md
+++ b/examples/preact/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/preact
 cd preact
@@ -18,7 +20,9 @@ npm run start
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/preact)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/preact)
 
 ## The idea behind the example
 
@@ -26,4 +30,5 @@ The project uses [Preact](https://github.com/developit/preact), which is a fast 
 
 This example uses CRA with `react-app-rewired` for adding webpack aliases for preact.
 
-It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+It includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
+If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
+<!-- #default-branch-switch -->
+
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/ssr
 cd ssr
@@ -18,10 +20,13 @@ npm run start
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/HEAD/examples/ssr)
+<!-- #default-branch-switch -->
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/ssr)
 
 ## The idea behind the example
 
 This is the reference implementation of the [Server Rendering tutorial](https://next.material-ui.com/guides/server-rendering/).
 
-The example project includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+The example project includes `@material-ui/core` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
+If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).

--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -87,11 +87,9 @@ export default function createStyled(input = {}) {
 
     const skipSx = inputSkipSx || false;
 
-    let displayName;
     let className;
 
     if (componentName) {
-      displayName = `${componentName}${componentSlot || ''}`;
       className = `${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
     }
 
@@ -166,6 +164,10 @@ export default function createStyled(input = {}) {
       const Component = defaultStyledResolver(transformedStyleArg, ...expressionsWithDefaultTheme);
 
       if (process.env.NODE_ENV !== 'production') {
+        let displayName;
+        if (componentName) {
+          displayName = `${componentName}${componentSlot || ''}`;
+        }
         if (displayName === undefined) {
           displayName = `Styled(${getDisplayName(tag)})`;
         }


### PR DESCRIPTION
- [docs] Fix typo https://codeSandbox.io f61df45: the upper case in the URL doesn't make sense.
- [docs] Fix git diff format 0716179. Before:

<img width="868" alt="Capture d’écran 2021-07-25 à 11 03 56" src="https://user-images.githubusercontent.com/3165635/126895011-a96cf57f-6d9f-4c86-a17b-2dfa992319b2.png">

After:

<img width="882" alt="Capture d’écran 2021-07-25 à 11 03 46" src="https://user-images.githubusercontent.com/3165635/126895010-6134f5df-a5ff-47c6-8f19-0b689f9e9fe6.png">

- no need to compute displayName in production cf1698c: I have noticed the opportunity in #27401. I push it one step further.
- [examples] Fix codesandbox links to match the installation instructions cc30191: the installation instructions point to a specific branch so that we can work on two different versions. I have updated the codesandbox link to be consistent.
- [docs] Remove space before `:` b7c95a8. It was introduced in #27319. cc @siriwatknp
- [docs] Header convention 593889f: It was introduced in #26948.
- clarifies a bit more this rule 46e53f9. We had a chat in the X team about how we should name booleans. I have realized that this documentation didn't mention a second advantage of the rule.
- [docs] Link Sparkline from third-party 6b71e0e. By @Janpot
- [docs] Link our docs, not a third-party project 87b1cbb. This is a follow-up on #27063. We have no affiliations with https://docs.paperbase.app/. cc @eps1lon 