### PR TITLE
[docs] Non greedy description matchers

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -8,7 +8,7 @@ const LANGUAGES_IN_PROGRESS = ['en', 'zh', 'ru', 'pt', 'es', 'fr', 'de', 'ja'];
 
 const headerRegExp = /---[\r\n]([\s\S]*)[\r\n]---/;
 const titleRegExp = /# (.*)[\r\n]/;
-const descriptionRegExp = /<p class="description">(.*)<\/p>/s;
+const descriptionRegExp = /<p class="description">(.*?)<\/p>/s;
 const headerKeyValueRegExp = /(.*?): (.*)/g;
 const emptyRegExp = /^\s*$/;
 const notEnglishMarkdownRegExp = /-([a-z]{2})\.md$/;

--- a/docs/packages/markdown/parseMarkdown.test.js
+++ b/docs/packages/markdown/parseMarkdown.test.js
@@ -12,6 +12,18 @@ describe('parseMarkdown', () => {
       `),
       ).to.equal('Some description');
     });
+
+    it('should not be greedy', () => {
+      expect(
+        getDescription(`
+        <p class="description">
+          Some description
+        </p>
+        ## Foo
+        <p>bar</p>
+      `),
+      ).to.equal('Some description');
+    });
   });
 
   describe('getHeaders', () => {


### PR DESCRIPTION
#22836 introduced a regression on pages that have another `</p>` element in the page. For instance: 

https://github.com/mui-org/material-ui/blob/af26cc697e4342251499bb6fb243d9992789396b/docs/src/pages/components/modal/modal.md#L125

Turns into a very long description: https://next.material-ui.com/components/modal/

<img width="623" alt="Capture d’écran 2021-07-25 à 12 19 08" src="https://user-images.githubusercontent.com/3165635/126895762-9a58152e-a4b4-4546-8260-98154212031b.png">

Which is flagged as causing SEO issues by our crawlers.