### PR TITLE
onRowsPerPageChange interface incorrectly entered

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -83,7 +83,7 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
        *
        * @param {React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>} event The event source of the callback.
        */
-      onRowsPerPageChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+      onRowsPerPageChange?: (event: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement> | null) => void;
       /**
        * The zero-based index of the current page.
        */


### PR DESCRIPTION
onRowsPerPageChange interface incorrectly entered
[as-is]
onRowsPerPageChange?:  React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement> ;

[to-be]
onRowsPerPageChange?: (event: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement> | null) => void;
