### PR TITLE
[docs] Bring back Select#onChange signature API

### DIFF
--- a/docs/translations/api-docs/select/select.json
+++ b/docs/translations/api-docs/select/select.json
@@ -15,7 +15,7 @@
     "MenuProps": "Props applied to the <a href=\"/api/menu/\"><code>Menu</code></a> element.",
     "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
     "native": "If <code>true</code>, the component uses a native <code>select</code> element.",
-    "onChange": "Callback fired when a menu item is selected.",
+    "onChange": "Callback fired when a menu item is selected.<br><br><strong>Signature:</strong><br><code>function(event: SelectChangeEvent&lt;T&gt;, child?: object) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (any). <strong>Warning</strong>: This is a generic event not a change event unless the change event is caused by browser autofill.<br><em>child:</em> The react element that was selected when <code>native</code> is <code>false</code> (default).",
     "onClose": "Callback fired when the component requests to be closed. Use in controlled mode (see open).<br><br><strong>Signature:</strong><br><code>function(event: object) =&gt; void</code><br><em>event:</em> The event source of the callback.",
     "onOpen": "Callback fired when the component requests to be opened. Use in controlled mode (see open).<br><br><strong>Signature:</strong><br><code>function(event: object) =&gt; void</code><br><em>event:</em> The event source of the callback.",
     "open": "If <code>true</code>, the component is shown. You can only use it when the <code>native</code> prop is <code>false</code> (default).",

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -88,7 +88,7 @@ export interface SelectProps<T = unknown>
   /**
    * Callback fired when a menu item is selected.
    *
-   * @param {(Event & { target: { value: T; name: string } }) | React.ChangeEvent<HTMLInputElement>} event The event source of the callback.
+   * @param {SelectChangeEvent<T>} event The event source of the callback.
    * You can pull out the new value by accessing `event.target.value` (any).
    * **Warning**: This is a generic event not a change event unless the change event is caused by browser autofill.
    * @param {object} [child] The react element that was selected when `native` is `false` (default).

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -193,7 +193,7 @@ Select.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when a menu item is selected.
    *
-   * @param {(Event & { target: { value: T; name: string } }) | React.ChangeEvent<HTMLInputElement>} event The event source of the callback.
+   * @param {SelectChangeEvent<T>} event The event source of the callback.
    * You can pull out the new value by accessing `event.target.value` (any).
    * **Warning**: This is a generic event not a change event unless the change event is caused by browser autofill.
    * @param {object} [child] The react element that was selected when `native` is `false` (default).


### PR DESCRIPTION
Follow-up to https://github.com/mui-org/material-ui/pull/27370. The documented signature wasn't ideal anyway. `doctrine` can't parse more complex types as well. We may want to switch to TSDoc parsers to support more complex types. For example, here I would've wanted to type `event` as `import('@material-ui/core/Select').SelectChangeEvent` so that people know where the type comes from.

Noticed when reviewing snapshot changes: https://github.com/eps1lon/mui-scripts-incubator/pull/2795/files