### PR TITLE
[docs] Hardcode listed colors in /customization/color/#playground

### DIFF
--- a/docs/src/pages/customization/color/ColorTool.js
+++ b/docs/src/pages/customization/color/ColorTool.js
@@ -19,7 +19,25 @@ const defaults = {
   primary: '#2196f3',
   secondary: '#f50057',
 };
-const hues = Object.keys(colors).slice(1, 17);
+const hues = [
+  'red',
+  'pink',
+  'purple',
+  'deepPurple',
+  'indigo',
+  'blue',
+  'lightBlue',
+  'cyan',
+  'teal',
+  'green',
+  'lightGreen',
+  'lime',
+  'yellow',
+  'amber',
+  'orange',
+  'deepOrange',
+];
+
 const shades = [
   900,
   800,


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/27413
Preview: https://deploy-preview-27446--material-ui.netlify.app/customization/color/#playground

Seems like `import * as namespace` doesn't have a guaranteed order in production (webpack? spec?). See https://60ef10f597a6c60008ffde24--material-ui-docs.netlify.app/customization/color/#playground where the order is completely different (and `common` is included) than what you see locally (`common` is excluded).