### PR TITLE
fix removing the injected css in nextjs example after migrating to v11

### DIFF
--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -11,7 +11,7 @@ export default function MyApp(props) {
   React.useEffect(() => {
     // Remove the server-side injected CSS.
     const jssStyles = document.querySelector('#jss-server-side');
-    if (jssStyles) {
+    if (jssStyles && !process.browser) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
   }, []);


### PR DESCRIPTION
after migrating to nextjs v11 most of SSR components got broken

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
