### PR TITLE
[core] Receive patch and minor dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -82,6 +82,7 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 30,
   "prHourlyLimit": 0,
+  "rangeStrategy": "update-lockfile",
   "schedule": "on sunday before 6:00am",
   "timezone": "UTC"
 }


### PR DESCRIPTION
> Please check the docs for `rangeStrategy`. The default value is `replace` but it sounds like you're perhaps expecting `update-lockfile`.

-- https://github.com/renovatebot/renovate/discussions/10968#discussioncomment-1051343

Yes we do want `update-lockfile`:

> update-lockfile = Update the lock file when in-range updates are available, otherwise replace for updates out of range. Works for bundler, composer, npm, yarn and poetry so far

-- https://docs.renovatebot.com/configuration-options/#rangestrategy