### PR TITLE
[test] Allow tests to run for 6s before timeout

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = function setKarmaConfig(config) {
     client: {
       mocha: {
         // Some BrowserStack browsers can be slow.
-        timeout: (process.env.CIRCLECI === 'true' ? 5 : 2) * 1000,
+        timeout: (process.env.CIRCLECI === 'true' ? 6 : 2) * 1000,
       },
     },
     frameworks: ['mocha'],


### PR DESCRIPTION
I have seen this type of fail come up every now and then https://app.circleci.com/pipelines/github/mui-org/material-ui/49708/workflows/6199969c-e3c9-4825-88ca-7bd23dd719ad/jobs/277789

> Firefox 78.0 (Windows 10) <DesktopDateRangePicker /> scrolls current month to the active selection on focusing appropriate field FAILED
	Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

I didn't look into what's going wrong in Firefox, but the tests are x2 slower than in the other environments:

<img width="901" alt="Capture d’écran 2021-07-26 à 18 13 47" src="https://user-images.githubusercontent.com/3165635/127022857-b494ee31-0c01-4f2a-8c14-bde28b5774e9.png">

Maybe we should run with a more recent version of Firefox or find  the performance bottleneck 🤷‍♂️