### PR TITLE
[PickersDay] Allow custom children for component

### DIFF
--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -243,6 +243,7 @@ const PickersDay = React.forwardRef(function PickersDay<TDate>(
     outsideCurrentMonth,
     selected = false,
     showDaysOutsideCurrentMonth = false,
+    children,
     today: isToday = false,
     ...other
   } = props;
@@ -364,7 +365,7 @@ const PickersDay = React.forwardRef(function PickersDay<TDate>(
       onClick={handleClick}
       {...other}
     >
-      {utils.format(day, 'dayOfMonth')}
+      {!children ? utils.format(day, 'dayOfMonth') : children}
     </PickersDayRoot>
   );
 });


### PR DESCRIPTION
I mentioned that `PickersDay` component has `children` prop, but in code it's never used. This PR enables optional rendering for `children` prop so in case there is a children - it will be rendered. Otherwise component will proceed with the default behavior. This will allow for more customization one the component. Google Flights demonstrates pretty good usecase for this and this is actually why I need it 😄 

![image](https://user-images.githubusercontent.com/17240507/127068477-3702c046-07d1-4bad-94ca-35be4c8c59d7.png)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
