### PR TITLE
[pickers] Fix missing export of AdapterDateFns

### DIFF
--- a/packages/material-ui-lab/src/index.js
+++ b/packages/material-ui-lab/src/index.js
@@ -1,4 +1,16 @@
 /* eslint-disable import/export */
+export { default as AdapterDateFns } from './AdapterDateFns';
+export * from './AdapterDateFns';
+
+export { default as AdapterDayjs } from './AdapterDayjs';
+export * from './AdapterDayjs';
+
+export { default as AdapterLuxon } from './AdapterLuxon';
+export * from './AdapterLuxon';
+
+export { default as AdapterMoment } from './AdapterMoment';
+export * from './AdapterMoment';
+
 export { default as Alert } from './Alert';
 export * from './Alert';
 
@@ -13,6 +25,9 @@ export * from './AvatarGroup';
 
 export { default as CalendarPicker } from './CalendarPicker';
 export * from './CalendarPicker';
+
+export { default as CalendarPickerSkeleton } from './CalendarPickerSkeleton';
+export * from './CalendarPickerSkeleton';
 
 export { default as ClockPicker } from './ClockPicker';
 export * from './ClockPicker';
@@ -67,9 +82,6 @@ export * from './Pagination';
 
 export { default as PaginationItem } from './PaginationItem';
 export * from './PaginationItem';
-
-export { default as CalendarPickerSkeleton } from './CalendarPickerSkeleton';
-export * from './CalendarPickerSkeleton';
 
 export { default as PickersDay } from './PickersDay';
 export * from './PickersDay';


### PR DESCRIPTION
### Version: @material-ui/lab@latest (v5 using next branch)

### Expected Behavior:
I noticed `AdapterDateFns` was missing from `@material-ui/lab` so I figured others were missing.

### New Behavior:
I copied pasted the names of each file in `@material-ui/packages/material-ui-lab/src` into its `index.js` as named exports.

![image](https://user-images.githubusercontent.com/761231/127095284-0e92038b-8191-4977-9e92-fbd3419949db.png)

I used this find & replace in VS Code to do the chore:

Find:
```
.+
```

Replace:
```
export { default as $0 } from './$0';
export * from './$0';
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [✅] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
