### PR TITLE
[Modal] Restore `overflowX` and `overflowY` styles

### DIFF
--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
@@ -167,60 +167,68 @@ describe('ModalManager', () => {
       expect(fixedNode.style.paddingRight).to.equal('');
     });
 
-    it('should restore styles correctly if overflow existed before', () => {
-      const modal = {};
-      const container2 = document.createElement('div');
-      container2.style.overflow = 'overlay';
+    describe('restore styles', () => {
+      let container2;
 
-      Object.defineProperty(container2, 'scrollHeight', {
-        value: 100,
-        writable: false,
-      });
-      Object.defineProperty(container2, 'clientHeight', {
-        value: 100,
-        writable: false,
+      beforeEach(() => {
+        container2 = document.createElement('div');
       });
 
-      document.body.appendChild(container2);
-      modalManager.add(modal, container2);
-      modalManager.mount(modal, {});
-
-      expect(container2.style.overflow).to.equal('hidden');
-      modalManager.remove(modal);
-
-      expect(container2.style.overflow).to.equal('overlay');
-      expect(fixedNode.style.paddingRight).to.equal('');
-
-      document.body.removeChild(container2);
-    });
-
-    it('should restore styles correctly if overflow-x existed before', () => {
-      const modal = {};
-      const container2 = document.createElement('div');
-      container2.style.overflowX = 'hidden';
-
-      Object.defineProperty(container2, 'scrollHeight', {
-        value: 100,
-        writable: false,
-      });
-      Object.defineProperty(container2, 'clientHeight', {
-        value: 100,
-        writable: false,
+      afterEach(() => {
+        document.body.removeChild(container2);
       });
 
-      document.body.appendChild(container2);
+      it('should restore styles correctly if overflow existed before', () => {
+        const modal = {};
 
-      modalManager.add(modal, container2);
-      modalManager.mount(modal, {});
+        container2.style.overflow = 'scroll';
 
-      expect(container2.style.overflow).to.equal('hidden');
+        Object.defineProperty(container2, 'scrollHeight', {
+          value: 100,
+          writable: false,
+        });
+        Object.defineProperty(container2, 'clientHeight', {
+          value: 90,
+          writable: false,
+        });
 
-      modalManager.remove(modal);
+        document.body.appendChild(container2);
+        modalManager.add(modal, container2);
+        modalManager.mount(modal, {});
 
-      expect(container2.style.overflow).to.equal('');
-      expect(container2.style.overflowX).to.equal('hidden');
+        expect(container2.style.overflow).to.equal('hidden');
+        modalManager.remove(modal);
 
-      document.body.removeChild(container2);
+        expect(container2.style.overflow).to.equal('scroll');
+        expect(fixedNode.style.paddingRight).to.equal('');
+      });
+
+      it('should restore styles correctly if overflow-x existed before', () => {
+        const modal = {};
+
+        container2.style.overflowX = 'hidden';
+
+        Object.defineProperty(container2, 'scrollHeight', {
+          value: 100,
+          writable: false,
+        });
+        Object.defineProperty(container2, 'clientHeight', {
+          value: 90,
+          writable: false,
+        });
+
+        document.body.appendChild(container2);
+
+        modalManager.add(modal, container2);
+        modalManager.mount(modal, {});
+
+        expect(container2.style.overflow).to.equal('hidden');
+
+        modalManager.remove(modal);
+
+        expect(container2.style.overflow).to.equal('');
+        expect(container2.style.overflowX).to.equal('hidden');
+      });
     });
   });
 

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
@@ -139,7 +139,7 @@ describe('ModalManager', () => {
         writable: false,
       });
       Object.defineProperty(container2, 'clientHeight', {
-        value: 100,
+        value: 90,
         writable: false,
       });
       document.body.appendChild(container2);
@@ -167,10 +167,9 @@ describe('ModalManager', () => {
       expect(fixedNode.style.paddingRight).to.equal('');
     });
 
-    it('should restore styles correctly if overflow and padding existed before', () => {
+    it('should restore styles correctly if overflow existed before', () => {
       const modal = {};
       const container2 = document.createElement('div');
-      container2.style.paddingRight = '20px';
       container2.style.overflow = 'overlay';
 
       Object.defineProperty(container2, 'scrollHeight', {
@@ -182,24 +181,22 @@ describe('ModalManager', () => {
         writable: false,
       });
 
+      document.body.appendChild(container2);
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
 
       expect(container2.style.overflow).to.equal('hidden');
-      expect(container2.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
-      expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize(document)}px`);
-
       modalManager.remove(modal);
 
       expect(container2.style.overflow).to.equal('overlay');
-      expect(container2.style.paddingRight).to.equal('20px');
       expect(fixedNode.style.paddingRight).to.equal('');
+
+      document.body.removeChild(container2);
     });
 
     it('should restore styles correctly if overflow-x existed before', () => {
       const modal = {};
       const container2 = document.createElement('div');
-      container2.style.paddingRight = '20px';
       container2.style.overflowX = 'hidden';
 
       Object.defineProperty(container2, 'scrollHeight', {
@@ -211,20 +208,19 @@ describe('ModalManager', () => {
         writable: false,
       });
 
+      document.body.appendChild(container2);
+
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
 
       expect(container2.style.overflow).to.equal('hidden');
-      expect(container2.style.overflowX).to.equal('');
-      expect(container2.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
-      expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize(document)}px`);
 
       modalManager.remove(modal);
 
       expect(container2.style.overflow).to.equal('');
       expect(container2.style.overflowX).to.equal('hidden');
-      expect(container2.style.paddingRight).to.equal('20px');
-      expect(fixedNode.style.paddingRight).to.equal('');
+
+      document.body.removeChild(container2);
     });
   });
 

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
@@ -166,6 +166,66 @@ describe('ModalManager', () => {
       expect(container1.style.paddingRight).to.equal('20px');
       expect(fixedNode.style.paddingRight).to.equal('');
     });
+
+    it('should restore styles correctly if overflow and padding existed before', () => {
+      const modal = {};
+      const container2 = document.createElement('div');
+      container2.style.paddingRight = '20px';
+      container2.style.overflow = 'overlay';
+
+      Object.defineProperty(container2, 'scrollHeight', {
+        value: 100,
+        writable: false,
+      });
+      Object.defineProperty(container2, 'clientHeight', {
+        value: 100,
+        writable: false,
+      });
+
+      modalManager.add(modal, container2);
+      modalManager.mount(modal, {});
+
+      expect(container1.style.overflow).to.equal('hidden');
+      expect(container1.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
+      expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize(document)}px`);
+
+      modalManager.remove(modal);
+
+      expect(container1.style.overflow).to.equal('overlay');
+      expect(container1.style.paddingRight).to.equal('20px');
+      expect(fixedNode.style.paddingRight).to.equal('');
+    });
+
+    it('should restore styles correctly if overflow-x existed before', () => {
+      const modal = {};
+      const container2 = document.createElement('div');
+      container2.style.paddingRight = '20px';
+      container2.style.overflowX = 'hidden';
+
+      Object.defineProperty(container2, 'scrollHeight', {
+        value: 100,
+        writable: false,
+      });
+      Object.defineProperty(container2, 'clientHeight', {
+        value: 100,
+        writable: false,
+      });
+
+      modalManager.add(modal, container2);
+      modalManager.mount(modal, {});
+
+      expect(container1.style.overflow).to.equal('hidden');
+      expect(container1.style.overflowX).to.equal('');
+      expect(container1.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
+      expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize(document)}px`);
+
+      modalManager.remove(modal);
+
+      expect(container1.style.overflow).to.equal('');
+      expect(container1.style.overflowX).to.equal('hidden');
+      expect(container1.style.paddingRight).to.equal('20px');
+      expect(fixedNode.style.paddingRight).to.equal('');
+    });
   });
 
   describe('multi container', () => {

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
@@ -139,7 +139,7 @@ describe('ModalManager', () => {
         writable: false,
       });
       Object.defineProperty(container2, 'clientHeight', {
-        value: 90,
+        value: 100,
         writable: false,
       });
       document.body.appendChild(container2);

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.test.js
@@ -185,14 +185,14 @@ describe('ModalManager', () => {
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
 
-      expect(container1.style.overflow).to.equal('hidden');
-      expect(container1.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
+      expect(container2.style.overflow).to.equal('hidden');
+      expect(container2.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
       expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize(document)}px`);
 
       modalManager.remove(modal);
 
-      expect(container1.style.overflow).to.equal('overlay');
-      expect(container1.style.paddingRight).to.equal('20px');
+      expect(container2.style.overflow).to.equal('overlay');
+      expect(container2.style.paddingRight).to.equal('20px');
       expect(fixedNode.style.paddingRight).to.equal('');
     });
 
@@ -214,16 +214,16 @@ describe('ModalManager', () => {
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
 
-      expect(container1.style.overflow).to.equal('hidden');
-      expect(container1.style.overflowX).to.equal('');
-      expect(container1.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
+      expect(container2.style.overflow).to.equal('hidden');
+      expect(container2.style.overflowX).to.equal('');
+      expect(container2.style.paddingRight).to.equal(`${20 + getScrollbarSize(document)}px`);
       expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize(document)}px`);
 
       modalManager.remove(modal);
 
-      expect(container1.style.overflow).to.equal('');
-      expect(container1.style.overflowX).to.equal('hidden');
-      expect(container1.style.paddingRight).to.equal('20px');
+      expect(container2.style.overflow).to.equal('');
+      expect(container2.style.overflowX).to.equal('hidden');
+      expect(container2.style.paddingRight).to.equal('20px');
       expect(fixedNode.style.paddingRight).to.equal('');
     });
   });

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.ts
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.ts
@@ -111,9 +111,17 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
       value: scrollContainer.style.overflow,
       property: 'overflow',
       el: scrollContainer,
+    },
+    {
+      value: scrollContainer.style.overflowX,
+      property: 'overflow-x',
+      el: scrollContainer,
+    },
+    {
+      value: scrollContainer.style.overflowY,
+      property: 'overflow-y',
+      el: scrollContainer,
     });
-    scrollContainer.style.overflow = 'hidden';
-  }
 
   const restore = () => {
     restoreStyle.forEach(({ value, el, property }) => {

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.ts
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.ts
@@ -122,6 +122,9 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
       property: 'overflow-y',
       el: scrollContainer,
     });
+    
+    scrollContainer.style.overflow = 'hidden';
+  }
 
   const restore = () => {
     restoreStyle.forEach(({ value, el, property }) => {

--- a/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.ts
+++ b/packages/material-ui-unstyled/src/ModalUnstyled/ModalManager.ts
@@ -107,22 +107,24 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
 
     // Block the scroll even if no scrollbar is visible to account for mobile keyboard
     // screensize shrink.
-    restoreStyle.push({
-      value: scrollContainer.style.overflow,
-      property: 'overflow',
-      el: scrollContainer,
-    },
-    {
-      value: scrollContainer.style.overflowX,
-      property: 'overflow-x',
-      el: scrollContainer,
-    },
-    {
-      value: scrollContainer.style.overflowY,
-      property: 'overflow-y',
-      el: scrollContainer,
-    });
-    
+    restoreStyle.push(
+      {
+        value: scrollContainer.style.overflow,
+        property: 'overflow',
+        el: scrollContainer,
+      },
+      {
+        value: scrollContainer.style.overflowX,
+        property: 'overflow-x',
+        el: scrollContainer,
+      },
+      {
+        value: scrollContainer.style.overflowY,
+        property: 'overflow-y',
+        el: scrollContainer,
+      },
+    );
+
     scrollContainer.style.overflow = 'hidden';
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #27486 