### PR TITLE
[codemod] Fix `jss-to-styled` PREFIX generation on Windows

### DIFF
--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
@@ -7,7 +7,7 @@ export default function transformer(file, api, options) {
   const root = j(file.source);
 
   function getFileNameWithoutExt() {
-    return (file.path.split('/').slice(-1)[0] || '').replace(/^([^.]*)\.(.*)/, '$1');
+    return (file.path.split(/(\\|\/)/g).slice(-1)[0] || '').replace(/^([^.]*)\.(.*)/, '$1');
   }
 
   /**
@@ -16,6 +16,7 @@ export default function transformer(file, api, options) {
    */
   function getPrefix(withStylesCall) {
     let prefix;
+
     // 1. check from withStylesFn
     if (withStylesCall && withStylesCall.arguments[1] && withStylesCall.arguments[1].properties) {
       const name = withStylesCall.arguments[1].properties.find((prop) => prop.key.name === 'name');

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
@@ -7,7 +7,7 @@ export default function transformer(file, api, options) {
   const root = j(file.source);
 
   function getFileNameWithoutExt() {
-    return (file.path.split(/(\\|\/)/g).slice(-1)[0] || '').replace(/^([^.]*)\.(.*)/, '$1');
+    return path.basename(file.path).replace(/^([^.]*)\.(.*)/, '$1');
   }
 
   /**

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
@@ -1,3 +1,5 @@
+const nodePath = require('path');
+
 /**
  * @param {import('jscodeshift').FileInfo} file
  * @param {import('jscodeshift').API} api
@@ -7,7 +9,7 @@ export default function transformer(file, api, options) {
   const root = j(file.source);
 
   function getFileNameWithoutExt() {
-    return path.basename(file.path).replace(/^([^.]*)\.(.*)/, '$1');
+    return nodePath.basename(file.path).replace(/^([^.]*)\.(.*)/, '$1');
   }
 
   /**


### PR DESCRIPTION
When testing the codemod on the store (https://github.com/mui-org/material-ui-store/pull/55) the PREFIX was wrongly generated on Windows:

```js
const PREFIX = 'D:\\workspace\\material-ui-store\\web\\src\\modules\\components\\FormButton';
```
This PR fixes it to be:
```js
const PREFIX = 'FormButton'
```