### PR TITLE
[Select] Fix regression for icon not rotating

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -88,7 +88,7 @@ export const nativeSelectIconStyles = ({ styleProps, theme }) => ({
     color: theme.palette.action.disabled,
   },
   ...(styleProps.open && {
-    right: 7,
+    transform: 'rotate(180deg)',
   }),
   ...(styleProps.variant === 'filled' && {
     right: 7,


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/27449 

Preview: https://deploy-preview-27511--material-ui.netlify.app/components/selects/#basic-select

Accidentally the styles for the filled variant were copied when the select is opened.