### PR TITLE
[Grid] Fix "auto" behavior to match natural width of its content

### DIFF
--- a/docs/src/pages/components/grid/VariableWidthGrid.js
+++ b/docs/src/pages/components/grid/VariableWidthGrid.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function VariableWidthGrid() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Grid container spacing={3}>
+        <Grid item xs="auto">
+          <Item>variable width content</Item>
+        </Grid>
+        <Grid item xs={6}>
+          <Item>xs=6</Item>
+        </Grid>
+        <Grid item xs>
+          <Item>xs</Item>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/grid/VariableWidthGrid.tsx
+++ b/docs/src/pages/components/grid/VariableWidthGrid.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { styled } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function VariableWidthGrid() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Grid container spacing={3}>
+        <Grid item xs="auto">
+          <Item>variable width content</Item>
+        </Grid>
+        <Grid item xs={6}>
+          <Item>xs=6</Item>
+        </Grid>
+        <Grid item xs>
+          <Item>xs</Item>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -102,6 +102,13 @@ That also means you can set the width of one _item_ and the others will automati
 
 {{"demo": "pages/components/grid/AutoGrid.js", "bg": true}}
 
+### Variable width content
+
+Set one of the size breakpoint props to `"auto"` instead of `true` / a `number` to size
+a column based on the natural width of its content.
+
+{{"demo": "pages/components/grid/VariableWidthGrid.js", "bg": true}}
+
 ## Complex Grid
 
 The following demo doesn't follow the Material Design guidelines, but illustrates how the grid can be used to build complex layouts.

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -64,7 +64,9 @@ function generateGrid(globalStyles, theme, breakpoint, styleProps) {
     styles = {
       flexBasis: 'auto',
       flexGrow: 0,
+      flexShrink: 0,
       maxWidth: 'none',
+      width: 'auto',
     };
   } else {
     const columnsBreakpointValues = resolveBreakpointValues({

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -64,7 +64,7 @@ describe('<Grid />', () => {
         flexGrow: '0',
         flexShrink: '0',
         maxWidth: 'none',
-        width: Boolean(process.env.KARMA) ? '300px' : 'auto',
+        width: process.env.KARMA ? '300px' : 'auto',
       });
     });
   });

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -49,6 +49,17 @@ describe('<Grid />', () => {
       const { container } = render(<Grid item xs="auto" />);
       expect(container.firstChild).to.have.class(classes['grid-xs-auto']);
     });
+
+    it('should apply the styles necessary for variable width nested item when set to auto', () => {
+      const { container } = render(<Grid container item xs="auto" />);
+      expect(container.firstChild).toHaveComputedStyle({
+        flexBasis: 'auto',
+        flexGrow: '0',
+        flexShrink: '0',
+        maxWidth: 'none',
+        width: 'auto',
+      });
+    });
   });
 
   describe('prop: spacing', () => {

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -50,7 +50,12 @@ describe('<Grid />', () => {
       expect(container.firstChild).to.have.class(classes['grid-xs-auto']);
     });
 
-    it('should apply the styles necessary for variable width nested item when set to auto', () => {
+    it('should apply the styles necessary for variable width nested item when set to auto', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // Need full CSS resolution
+        this.skip();
+      }
+
       render(
         <Grid container>
           <Grid container item xs="auto" data-testid="auto">
@@ -64,7 +69,7 @@ describe('<Grid />', () => {
         flexGrow: '0',
         flexShrink: '0',
         maxWidth: 'none',
-        width: process.env.KARMA ? '300px' : 'auto',
+        width: '300px',
       });
     });
   });

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -51,13 +51,20 @@ describe('<Grid />', () => {
     });
 
     it('should apply the styles necessary for variable width nested item when set to auto', () => {
-      const { container } = render(<Grid container item xs="auto" />);
-      expect(container.firstChild).toHaveComputedStyle({
+      render(
+        <Grid container>
+          <Grid container item xs="auto" data-testid="auto">
+            <div style={{ width: '300px' }} />
+          </Grid>
+          <Grid item xs={11} />
+        </Grid>,
+      );
+      expect(screen.getByTestId('auto')).toHaveComputedStyle({
         flexBasis: 'auto',
         flexGrow: '0',
         flexShrink: '0',
         maxWidth: 'none',
-        width: 'auto',
+        width: Boolean(process.env.KARMA) ? '300px' : 'auto',
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Problem

In #11804, support for the `"auto"` value was added to props like `xs`, `sm` et. al.

This prop value causes the MUI grid to work just like [Bootstrap's grid "auto" setting](https://getbootstrap.com/docs/4.0/layout/grid/#variable-width-content) _most_ of the time, with a few exceptions:

1. `flex-shrink` remains set to `1`, which means the item will not always remain sized based on the "natural" width of its contents like users expect. 
    * [Reduced test case](https://codesandbox.io/s/variablewidthgrid-material-demo-forked-juoqo)
1. `width: 100%` is still applied when using the `"auto"` setting on a [nested `Grid` container items](https://next.material-ui.com/components/grid/#heading-nested-grid) (`<Grid container item xs="auto" />`), which causes the item to not be sized based on the "natural" width at all.
    * [Reduced test case](https://codesandbox.io/s/nestedgrid-material-demo-forked-57w5q)

### Proposed Solution

Add `flexShrink: 0` and `width: auto` when a breakpoint size is set to `"auto"` so that MUI's grid behaves in a way that is [truly "auto"](https://getbootstrap.com/docs/4.0/layout/grid/#variable-width-content) - in the sense that it scales to accommodate the natural width of its content.

I realize this constitutes a potentially breaking visual change for consumers, but 5.0 seems like a good time to include it!

Thank you for considering the change!

Preview: https://deploy-preview-27514--material-ui.netlify.app/components/grid/#variable-width-content