### PR TITLE
[docs] fix syntax error in v5 migration `styled` api example

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2415,7 +2415,7 @@ npx @material-ui/codemod@next v5.0.0/jss-to-styled <path>
 +  cta: `${PREFIX}-cta`,
 +  content: `${PREFIX}-content`,
 +}
-+const Root = styled('div')(({ theme }) => ({
++const Root = styled('div')(({theme}) => ({
 +  [`&.${classes.root}`]: {
 +    display: 'flex',
 +    alignItems: 'center',

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2415,7 +2415,7 @@ npx @material-ui/codemod@next v5.0.0/jss-to-styled <path>
 +  cta: `${PREFIX}-cta`,
 +  content: `${PREFIX}-content`,
 +}
-+const Root = styled('div')((theme) => ({
++const Root = styled('div')(({ theme }) => ({
 +  [`&.${classes.root}`]: {
 +    display: 'flex',
 +    alignItems: 'center',

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2415,7 +2415,7 @@ npx @material-ui/codemod@next v5.0.0/jss-to-styled <path>
 +  cta: `${PREFIX}-cta`,
 +  content: `${PREFIX}-content`,
 +}
-+const Root = styled('div')(({theme}) => ({
++const Root = styled('div')(({ theme }) => ({
 +  [`&.${classes.root}`]: {
 +    display: 'flex',
 +    alignItems: 'center',


### PR DESCRIPTION
* destructure `theme` in `styled` when migration `makeStyles`
  to emotion

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
