### PR TITLE
[test] Update coverage to include all @material-ui packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,13 +202,11 @@
   },
   "nyc": {
     "include": [
-      "packages/material-ui/src/**/*.js",
-      "packages/material-ui/lab/**/*.{ts,tsx}",
-      "packages/material-ui-utils/src/**/*.js",
-      "packages/material-ui-styles/src/**/*.js"
+      "packages/material-ui*/src/**/*.{js,ts,tsx}"
     ],
     "exclude": [
-      "**/*.test.{js,ts,tsx}"
+      "**/*.test.{js,ts,tsx}",
+      "**/*.test/*"
     ],
     "sourceMap": false,
     "instrument": false


### PR DESCRIPTION
The previous include pattern was inconsistent with file extensions. I would've expected e.g. `/unstyled`  to not be monitored (since it's not part of the include pattern) but it was already included in codecov though I don't understand why.

`/codemod` is now monitored. We leverage codemods more and more so we also need to be able to monitor test coverage.

coverage changes: https://codecov.io/gh/mui-org/material-ui/compare/b9a55392af4cd19086898dbfcd9d55a4c9396983...3b71b3045cc15c117f282ec839b4e8506349f26e