### PR TITLE
[core] rebaseWhen=auto does not seem to work

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "commitMessageExtra": "to {{newValue}}",
   "commitMessageTopic": "{{depName}}",
   "dependencyDashboard": true,
+  "rebaseWhen": "conflicted",
   "ignoreDeps": [],
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
As soon as one renovate PR is merged, all the other ones are rerun. It's not scaling with our CI. Try to force the value.

I'm testing the fix in https://github.com/mui-org/material-ui-x/pull/2271. No, it doesn't work.