### PR TITLE
[docs] Remove backticks in the title

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -80,7 +80,7 @@ function getTitle(markdown) {
     throw new Error('Missing title in the page');
   }
 
-  return matches[1];
+  return matches[1].replace(/`/g, '');
 }
 
 function getDescription(markdown) {

--- a/docs/packages/markdown/parseMarkdown.test.js
+++ b/docs/packages/markdown/parseMarkdown.test.js
@@ -1,14 +1,32 @@
 import { expect } from 'chai';
-import { getContents, getDescription, getHeaders, prepareMarkdown } from './parseMarkdown';
+import {
+  getContents,
+  getDescription,
+  getTitle,
+  getHeaders,
+  prepareMarkdown,
+} from './parseMarkdown';
 
 describe('parseMarkdown', () => {
+  describe('getTitle', () => {
+    it('remove backticks', () => {
+      expect(
+        getTitle(`
+# \`@material-ui/styled-engine\`
+
+<p class="description">Configuring your preferred styling library.</p>
+      `),
+      ).to.equal('@material-ui/styled-engine');
+    });
+  });
+
   describe('getDescription', () => {
     it('trims the description', () => {
       expect(
         getDescription(`
-        <p class="description">
-          Some description
-        </p>
+<p class="description">
+  Some description
+</p>
       `),
       ).to.equal('Some description');
     });
@@ -16,11 +34,11 @@ describe('parseMarkdown', () => {
     it('should not be greedy', () => {
       expect(
         getDescription(`
-        <p class="description">
-          Some description
-        </p>
-        ## Foo
-        <p>bar</p>
+<p class="description">
+  Some description
+</p>
+## Foo
+<p>bar</p>
       `),
       ).to.equal('Some description');
     });


### PR DESCRIPTION
We are using the backtick ` for stylistic purposes in the headers. However, this has other implications, for instance: https://next.material-ui.com/guides/styled-engine/

- Wasted space in the tab
<img width="188" alt="Capture d’écran 2021-08-02 à 00 01 35" src="https://user-images.githubusercontent.com/3165635/127786574-538aaca5-a8b9-46b6-ac00-a43072edcc91.png">

- Weird rendering in the social sharing
<img width="469" alt="Capture d’écran 2021-08-02 à 00 03 29" src="https://user-images.githubusercontent.com/3165635/127786587-19ae769e-555b-4d10-85a9-c127340ce6cb.png">
