### PR TITLE
[core] Reduce use CSS when Checkbox disableRipple is set

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -42,20 +42,20 @@ const CheckboxRoot = styled(SwitchBase, {
   },
 })(({ theme, styleProps }) => ({
   color: theme.palette.text.secondary,
-  '&:hover': {
-    ...(!styleProps.disableRipple && {
+  ...(!styleProps.disableRipple && {
+    '&:hover': {
       backgroundColor: alpha(
         styleProps.color === 'default'
           ? theme.palette.action.active
           : theme.palette[styleProps.color].main,
         theme.palette.action.hoverOpacity,
       ),
-    }),
-    // Reset on touch devices, it doesn't add specificity
-    '@media (hover: none)': {
-      backgroundColor: 'transparent',
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
     },
-  },
+  }),
   ...(styleProps.color !== 'default' && {
     [`&.${checkboxClasses.checked}, &.${checkboxClasses.indeterminate}`]: {
       color: theme.palette[styleProps.color].main,


### PR DESCRIPTION
It's a follow-up on #27314, we don't need any of the hover styles when disableRipple is true.