### PR TITLE
[docs] Fix api generation for `deprecatedPropType`

### DIFF
--- a/docs/pages/api-docs/collapse.md
+++ b/docs/pages/api-docs/collapse.md
@@ -32,7 +32,7 @@ The `MuiCollapse` name can be used for providing [default props](/customization/
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content node to be collapsed. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| ~~<span class="prop-name">collapsedHeight</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. The prop was renamed to support the vertical orientation, use `collapsedSize` instead<br><br>The height of the container when collapsed. |
+| ~~<span class="prop-name">collapsedHeight</span>~~ | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | *Deprecated*. The prop was renamed to support the vertical orientation, use `collapsedSize` instead<br><br>The height of the container when collapsed. |
 | <span class="prop-name">collapsedSize</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">'0px'</span> | The height of the container when collapsed. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">disableStrictModeCompat</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Enable this prop if you encounter 'Function components cannot be given refs', use `unstable_createStrictModeTheme`, and can't forward the ref in the passed `Component`. |

--- a/docs/pages/api-docs/collapse.md
+++ b/docs/pages/api-docs/collapse.md
@@ -32,7 +32,7 @@ The `MuiCollapse` name can be used for providing [default props](/customization/
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content node to be collapsed. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| ~~<span class="prop-name">collapsedHeight</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. The prop was renamed to support the vertical orientation, use `collapsedSize` instead<br><br>The height of the container when collapsed. |
+| ~~<span class="prop-name">collapsedHeight</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. The prop was renamed to support the vertical orientation, use `collapsedSize` instead<br><br>The height of the container when collapsed. |
 | <span class="prop-name">collapsedSize</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">'0px'</span> | The height of the container when collapsed. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a HTML element or a component. |
 | <span class="prop-name">disableStrictModeCompat</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Enable this prop if you encounter 'Function components cannot be given refs', use `unstable_createStrictModeTheme`, and can't forward the ref in the passed `Component`. |

--- a/docs/pages/api-docs/grid.md
+++ b/docs/pages/api-docs/grid.md
@@ -36,8 +36,14 @@ The `MuiGrid` name can be used for providing [default props](/customization/glob
 | <span class="prop-name">container</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
 | <span class="prop-name">direction</span> | <span class="prop-type">'row'<br>&#124;&nbsp;'row-reverse'<br>&#124;&nbsp;'column'<br>&#124;&nbsp;'column-reverse'</span> | <span class="prop-default">'row'</span> | Defines the `flex-direction` style property. It is applied for all screen sizes. |
 | <span class="prop-name">item</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will have the flex *item* behavior. You should be wrapping *items* with a *container*. |
-| ~~<span class="prop-name">justify</span>~~ | <span class="prop-type">oneOf([
-    'flex-start'</span> |  | *Deprecated*. Use `justifyContent` instead, the prop was renamed.<br><br>Defines the `justify-content` style property. It is applied for all screen sizes. |
+| ~~<span class="prop-name">justify</span>~~ | <span class="prop-type">PropTypes.oneOf([
+    'flex-start',
+    'center',
+    'flex-end',
+    'space-between',
+    'space-around',
+    'space-evenly',
+  ])</span> |  | *Deprecated*. Use `justifyContent` instead, the prop was renamed.<br><br>Defines the `justify-content` style property. It is applied for all screen sizes. |
 | <span class="prop-name">justifyContent</span> | <span class="prop-type">'flex-start'<br>&#124;&nbsp;'center'<br>&#124;&nbsp;'flex-end'<br>&#124;&nbsp;'space-between'<br>&#124;&nbsp;'space-around'<br>&#124;&nbsp;'space-evenly'</span> | <span class="prop-default">'flex-start'</span> | Defines the `justify-content` style property. It is applied for all screen sizes. |
 | <span class="prop-name">lg</span> | <span class="prop-type">false<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;true<br>&#124;&nbsp;1<br>&#124;&nbsp;2<br>&#124;&nbsp;3<br>&#124;&nbsp;4<br>&#124;&nbsp;5<br>&#124;&nbsp;6<br>&#124;&nbsp;7<br>&#124;&nbsp;8<br>&#124;&nbsp;9<br>&#124;&nbsp;10<br>&#124;&nbsp;11<br>&#124;&nbsp;12</span> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for the `lg` breakpoint and wider screens if not overridden. |
 | <span class="prop-name">md</span> | <span class="prop-type">false<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;true<br>&#124;&nbsp;1<br>&#124;&nbsp;2<br>&#124;&nbsp;3<br>&#124;&nbsp;4<br>&#124;&nbsp;5<br>&#124;&nbsp;6<br>&#124;&nbsp;7<br>&#124;&nbsp;8<br>&#124;&nbsp;9<br>&#124;&nbsp;10<br>&#124;&nbsp;11<br>&#124;&nbsp;12</span> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for the `md` breakpoint and wider screens if not overridden. |

--- a/docs/pages/api-docs/grid.md
+++ b/docs/pages/api-docs/grid.md
@@ -36,14 +36,7 @@ The `MuiGrid` name can be used for providing [default props](/customization/glob
 | <span class="prop-name">container</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
 | <span class="prop-name">direction</span> | <span class="prop-type">'row'<br>&#124;&nbsp;'row-reverse'<br>&#124;&nbsp;'column'<br>&#124;&nbsp;'column-reverse'</span> | <span class="prop-default">'row'</span> | Defines the `flex-direction` style property. It is applied for all screen sizes. |
 | <span class="prop-name">item</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will have the flex *item* behavior. You should be wrapping *items* with a *container*. |
-| ~~<span class="prop-name">justify</span>~~ | <span class="prop-type">PropTypes.oneOf([
-    'flex-start',
-    'center',
-    'flex-end',
-    'space-between',
-    'space-around',
-    'space-evenly',
-  ])</span> |  | *Deprecated*. Use `justifyContent` instead, the prop was renamed.<br><br>Defines the `justify-content` style property. It is applied for all screen sizes. |
+| ~~<span class="prop-name">justify</span>~~ | <span class="prop-type">'flex-start'<br>&#124;&nbsp;'center'<br>&#124;&nbsp;'flex-end'<br>&#124;&nbsp;'space-between'<br>&#124;&nbsp;'space-around'<br>&#124;&nbsp;'space-evenly'<br>&#124;&nbsp;</span> |  | *Deprecated*. Use `justifyContent` instead, the prop was renamed.<br><br>Defines the `justify-content` style property. It is applied for all screen sizes. |
 | <span class="prop-name">justifyContent</span> | <span class="prop-type">'flex-start'<br>&#124;&nbsp;'center'<br>&#124;&nbsp;'flex-end'<br>&#124;&nbsp;'space-between'<br>&#124;&nbsp;'space-around'<br>&#124;&nbsp;'space-evenly'</span> | <span class="prop-default">'flex-start'</span> | Defines the `justify-content` style property. It is applied for all screen sizes. |
 | <span class="prop-name">lg</span> | <span class="prop-type">false<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;true<br>&#124;&nbsp;1<br>&#124;&nbsp;2<br>&#124;&nbsp;3<br>&#124;&nbsp;4<br>&#124;&nbsp;5<br>&#124;&nbsp;6<br>&#124;&nbsp;7<br>&#124;&nbsp;8<br>&#124;&nbsp;9<br>&#124;&nbsp;10<br>&#124;&nbsp;11<br>&#124;&nbsp;12</span> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for the `lg` breakpoint and wider screens if not overridden. |
 | <span class="prop-name">md</span> | <span class="prop-type">false<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;true<br>&#124;&nbsp;1<br>&#124;&nbsp;2<br>&#124;&nbsp;3<br>&#124;&nbsp;4<br>&#124;&nbsp;5<br>&#124;&nbsp;6<br>&#124;&nbsp;7<br>&#124;&nbsp;8<br>&#124;&nbsp;9<br>&#124;&nbsp;10<br>&#124;&nbsp;11<br>&#124;&nbsp;12</span> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for the `md` breakpoint and wider screens if not overridden. |

--- a/docs/pages/api-docs/image-list-item-bar.md
+++ b/docs/pages/api-docs/image-list-item-bar.md
@@ -34,7 +34,7 @@ The `MuiImageListItemBar` name can be used for providing [default props](/custom
 | <span class="prop-name">position</span> | <span class="prop-type">'bottom'<br>&#124;&nbsp;'top'</span> | <span class="prop-default">'bottom'</span> | Position of the title bar. |
 | <span class="prop-name">subtitle</span> | <span class="prop-type">node</span> |  | String or element serving as subtitle (support text). |
 | <span class="prop-name">title</span> | <span class="prop-type">node</span> |  | Title to be displayed on item. |
-| ~~<span class="prop-name">titlePosition</span>~~ | <span class="prop-type">PropTypes.oneOf(['bottom', 'top'])</span> |  | *Deprecated*. Use the `position` prop instead.<br><br>Position of the title bar. |
+| ~~<span class="prop-name">titlePosition</span>~~ | <span class="prop-type">'bottom'<br>&#124;&nbsp;'top'</span> |  | *Deprecated*. Use the `position` prop instead.<br><br>Position of the title bar. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/image-list-item-bar.md
+++ b/docs/pages/api-docs/image-list-item-bar.md
@@ -34,7 +34,7 @@ The `MuiImageListItemBar` name can be used for providing [default props](/custom
 | <span class="prop-name">position</span> | <span class="prop-type">'bottom'<br>&#124;&nbsp;'top'</span> | <span class="prop-default">'bottom'</span> | Position of the title bar. |
 | <span class="prop-name">subtitle</span> | <span class="prop-type">node</span> |  | String or element serving as subtitle (support text). |
 | <span class="prop-name">title</span> | <span class="prop-type">node</span> |  | Title to be displayed on item. |
-| ~~<span class="prop-name">titlePosition</span>~~ | <span class="prop-type">oneOf(['bottom'</span> |  | *Deprecated*. Use the `position` prop instead.<br><br>Position of the title bar. |
+| ~~<span class="prop-name">titlePosition</span>~~ | <span class="prop-type">PropTypes.oneOf(['bottom', 'top'])</span> |  | *Deprecated*. Use the `position` prop instead.<br><br>Position of the title bar. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/image-list.md
+++ b/docs/pages/api-docs/image-list.md
@@ -28,7 +28,7 @@ The `MuiImageList` name can be used for providing [default props](/customization
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| ~~<span class="prop-name">cellHeight</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])</span> |  | *Deprecated*. Use the `rowHeight` prop instead.<br><br>Cell height in `px`. Set to `'auto'` to let the children determine the height. |
+| ~~<span class="prop-name">cellHeight</span>~~ | <span class="prop-type">number<br>&#124;&nbsp;oneOf(['auto'</span> |  | *Deprecated*. Use the `rowHeight` prop instead.<br><br>Cell height in `px`. Set to `'auto'` to let the children determine the height. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Items that will be in the image list. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">cols</span> | <span class="prop-type">number</span> | <span class="prop-default">2</span> | Number of columns. |

--- a/docs/pages/api-docs/image-list.md
+++ b/docs/pages/api-docs/image-list.md
@@ -28,7 +28,7 @@ The `MuiImageList` name can be used for providing [default props](/customization
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| ~~<span class="prop-name">cellHeight</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use the `rowHeight` prop instead.<br><br>Cell height in `px`. Set to `'auto'` to let the children determine the height. |
+| ~~<span class="prop-name">cellHeight</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])</span> |  | *Deprecated*. Use the `rowHeight` prop instead.<br><br>Cell height in `px`. Set to `'auto'` to let the children determine the height. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Items that will be in the image list. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">cols</span> | <span class="prop-type">number</span> | <span class="prop-default">2</span> | Number of columns. |

--- a/docs/pages/api-docs/textarea-autosize.md
+++ b/docs/pages/api-docs/textarea-autosize.md
@@ -28,9 +28,9 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">maxRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Maximum number of rows to display. |
 | <span class="prop-name">minRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">1</span> | Minimum number of rows to display. |
-| ~~<span class="prop-name">rows</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
-| ~~<span class="prop-name">rowsMax</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. Use `maxRows` instead.<br><br>Maximum number of rows to display. |
-| ~~<span class="prop-name">rowsMin</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
+| ~~<span class="prop-name">rows</span>~~ | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
+| ~~<span class="prop-name">rowsMax</span>~~ | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | *Deprecated*. Use `maxRows` instead.<br><br>Maximum number of rows to display. |
+| ~~<span class="prop-name">rowsMin</span>~~ | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/textarea-autosize.md
+++ b/docs/pages/api-docs/textarea-autosize.md
@@ -28,9 +28,9 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">maxRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Maximum number of rows to display. |
 | <span class="prop-name">minRows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">1</span> | Minimum number of rows to display. |
-| ~~<span class="prop-name">rows</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
-| ~~<span class="prop-name">rowsMax</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `maxRows` instead.<br><br>Maximum number of rows to display. |
-| ~~<span class="prop-name">rowsMin</span>~~ | <span class="prop-type">oneOfType([PropTypes.number</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
+| ~~<span class="prop-name">rows</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
+| ~~<span class="prop-name">rowsMax</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. Use `maxRows` instead.<br><br>Maximum number of rows to display. |
+| ~~<span class="prop-name">rowsMin</span>~~ | <span class="prop-type">PropTypes.oneOfType([PropTypes.number, PropTypes.string])</span> |  | *Deprecated*. Use `minRows` instead.<br><br>Minimum number of rows to display. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -17,6 +17,13 @@ function generateHeader(reactAPI) {
   return ['---', `filename: ${normalizePath(reactAPI.filename)}`, '---'].join('\n');
 }
 
+function getPropTypeString(str) {
+  if (str.indexOf('oneOfType') >= 0 || str.indexOf('oneOf') >= 0) {
+    return 'PropTypes.' + str.substring(0, str.indexOf(')') + 1);
+  }
+  return str.substring(0, str.indexOf(','));
+}
+
 function getDeprecatedInfo(type) {
   const marker = /deprecatedPropType\((\r*\n)*\s*PropTypes\./g;
   const match = type.raw.match(marker);
@@ -25,7 +32,7 @@ function getDeprecatedInfo(type) {
     const offset = match[0].length;
 
     return {
-      propTypes: type.raw.substring(startIndex + offset, type.raw.indexOf(',')),
+      propTypes: getPropTypeString(type.raw.substring(startIndex + offset, type.raw.length)),
       explanation: recast.parse(type.raw).program.body[0].expression.arguments[1].value,
     };
   }

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -19,7 +19,23 @@ function generateHeader(reactAPI) {
 
 function getPropTypeString(str) {
   if (str.indexOf('oneOfType') >= 0 || str.indexOf('oneOf') >= 0) {
-    return `PropTypes.${str.substring(0, str.indexOf(')') + 1)}`;
+    let propTypes = str.substring(0, str.indexOf(')') + 1);
+
+    if (propTypes.indexOf('oneOfType') === 0) {
+      propTypes = propTypes.substring(11, propTypes.length - 2);
+    } else {
+      propTypes = propTypes.substring(7, propTypes.length - 2);
+    }
+
+    // Remove commas, 'PropTypes.' prefix, and replace invalid spacings
+    propTypes = propTypes
+      .replace(/,/g, '<br>&#124;&nbsp;')
+      .replace(/PropTypes\./g, '')
+      .replace(/\r?\n/g, '')
+      .replace(/ +/g, '');
+    propTypes = propTypes.trim();
+
+    return propTypes;
   }
   return str.substring(0, str.indexOf(','));
 }

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -19,7 +19,7 @@ function generateHeader(reactAPI) {
 
 function getPropTypeString(str) {
   if (str.indexOf('oneOfType') >= 0 || str.indexOf('oneOf') >= 0) {
-    return 'PropTypes.' + str.substring(0, str.indexOf(')') + 1);
+    return `PropTypes.${str.substring(0, str.indexOf(')') + 1)}`;
   }
   return str.substring(0, str.indexOf(','));
 }


### PR DESCRIPTION
This PR fixes the generation for the deprecated prop types using `deprecatedPropType`. Previosly the generation handled only the primitive proptypes, like PropTypes.number, PropTypes.string etc. When there was `oneOfType`, or `oneOf` usages it broke. 

## Previously
**Collapse**
https://material-ui.com/api/collapse/#collapse-api
![image](https://user-images.githubusercontent.com/4512430/127871570-111c9cc8-cf64-4fa8-954d-1afe915d065e.png)

**Grid**
https://material-ui.com/api/grid/
![image](https://user-images.githubusercontent.com/4512430/127871698-b6d46497-17ba-450e-9e30-a75c25c5cd12.png)

-----

## Now:
**Collapse**
https://deploy-preview-27576--material-ui.netlify.app/api/collapse/#collapse-api
![image](https://user-images.githubusercontent.com/4512430/127875569-9b35fa1d-f832-4cd4-b7a4-34dacfa3e0a5.png)

**Grid**
https://deploy-preview-27576--material-ui.netlify.app/api/grid/
![image](https://user-images.githubusercontent.com/4512430/127875525-de1b0190-f89d-48bd-a2f5-300cb3deaab8.png)
