### PR TITLE
[codemod] Add support for `createStyles` usage in `jss-to-styled`

### DIFF
--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
@@ -169,12 +169,22 @@ export default function transformer(file, api, options) {
       if (functionExpression.body.type === 'ObjectExpression') {
         return functionExpression.body;
       }
+      if (functionExpression.body.type === 'CallExpression') {
+        if (functionExpression.body.callee.name === 'createStyles') {
+          return functionExpression.body.arguments[0];
+        }
+      }
     }
     if (functionExpression.type === 'FunctionDeclaration') {
       const returnStatement = functionExpression.body.body.find(
         (b) => b.type === 'ReturnStatement',
       );
       return returnStatement.argument;
+    }
+    if (functionExpression.type === 'CallExpression') {
+      if (functionExpression.callee.name === 'createStyles') {
+        return functionExpression.arguments[0];
+      }
     }
     return null;
   }
@@ -272,7 +282,7 @@ export default function transformer(file, api, options) {
       .find(j.CallExpression, { callee: { name: 'withStyles' } })
       .at(0)
       .forEach((path) => {
-        const arg = path.node.arguments[0];
+        let arg = path.node.arguments[0];
         if (arg.type === 'Identifier') {
           stylesFnName = arg.name;
         }
@@ -287,10 +297,24 @@ export default function transformer(file, api, options) {
       .find(j.VariableDeclarator, { id: { name: stylesFnName } })
       .at(0)
       .forEach((path) => {
-        const objectExpression = getReturnStatement(path.node.init);
+        let fnArg = path.node.init;
+
+        const objectExpression = getReturnStatement(fnArg);
+        if (fnArg.type === 'ArrowFunctionExpression') {
+          if (fnArg.body.type === 'CallExpression') {
+            if (fnArg.body.callee.name === 'createStyles') {
+              fnArg.body = fnArg.body.arguments[0];
+            }
+          }
+        }
+        if (fnArg.type === 'CallExpression') {
+          if (fnArg.callee.name === 'createStyles') {
+            fnArg = fnArg.arguments[0];
+          }
+        }
         if (objectExpression) {
           result.classes = createClasses(objectExpression, prefix);
-          result.styledArg = convertToStyledArg(path.node.init, rootClassKeys);
+          result.styledArg = convertToStyledArg(fnArg, rootClassKeys);
         }
       })
       .remove();
@@ -312,11 +336,18 @@ export default function transformer(file, api, options) {
       .find(j.CallExpression, { callee: { name: 'makeStyles' } })
       .at(0)
       .forEach((path) => {
-        const arg = path.node.arguments[0];
+        let arg = path.node.arguments[0];
         if (arg.type === 'Identifier') {
           stylesFnName = arg.name;
         }
         const objectExpression = getReturnStatement(arg);
+        if (arg.type === 'ArrowFunctionExpression') {
+          if (arg.body.type === 'CallExpression') {
+            if (arg.body.callee.name === 'createStyles') {
+              arg.body = arg.body.arguments[0];
+            }
+          }
+        }
         if (objectExpression) {
           result.classes = createClasses(objectExpression, prefix);
           result.styledArg = convertToStyledArg(arg, rootClassKeys);
@@ -415,11 +446,16 @@ export default function transformer(file, api, options) {
   root
     .find(j.ImportDeclaration)
     .filter((path) =>
-      path.node.source.value.match(/^@material-ui\/styles\/?(withStyles|makeStyles)?$/),
+      path.node.source.value.match(
+        /^@material-ui\/styles\/?(withStyles|makeStyles|createStyles)?$/,
+      ),
     )
     .forEach((path) => {
       path.node.specifiers = path.node.specifiers.filter(
-        (s) => s.local.name !== 'withStyles' && s.local.name !== 'makeStyles',
+        (s) =>
+          s.local.name !== 'withStyles' &&
+          s.local.name !== 'makeStyles' &&
+          s.local.name !== 'createStyles',
       );
     })
     .filter((path) => !path.node.specifiers.length)

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.js
@@ -282,7 +282,7 @@ export default function transformer(file, api, options) {
       .find(j.CallExpression, { callee: { name: 'withStyles' } })
       .at(0)
       .forEach((path) => {
-        let arg = path.node.arguments[0];
+        const arg = path.node.arguments[0];
         if (arg.type === 'Identifier') {
           stylesFnName = arg.name;
         }
@@ -346,6 +346,11 @@ export default function transformer(file, api, options) {
             if (arg.body.callee.name === 'createStyles') {
               arg.body = arg.body.arguments[0];
             }
+          }
+        }
+        if (arg.type === 'CallExpression') {
+          if (arg.callee.name === 'createStyles') {
+            arg = arg.arguments[0];
           }
         }
         if (objectExpression) {

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test.js
@@ -311,5 +311,35 @@ describe('@material-ui/codemod', () => {
         expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
+
+    describe('with createStyles directly', () => {
+      it.only('transforms as needed', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-styled.test/withCreateStyles3.actual.tsx'),
+            path: require.resolve('./jss-to-styled.test/withCreateStyles3.actual.tsx'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-styled.test/withCreateStyles3.expected.tsx');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+
+      it('should be idempotent', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-styled.test/withCreateStyles3.expected.tsx'),
+            path: require.resolve('./jss-to-styled.test/withCreateStyles3.expected.tsx'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-styled.test/withCreateStyles3.expected.tsx');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
   });
 });

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test.js
@@ -313,7 +313,7 @@ describe('@material-ui/codemod', () => {
     });
 
     describe('with createStyles directly', () => {
-      it.only('transforms as needed', () => {
+      it('transforms as needed', () => {
         const actual = transform(
           {
             source: read('./jss-to-styled.test/withCreateStyles3.actual.tsx'),

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test.js
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test.js
@@ -220,6 +220,96 @@ describe('@material-ui/codemod', () => {
           expect(actual).to.equal(expected, 'The transformed version should be correct');
         });
       });
+
+      describe('with createStyles', () => {
+        it('transforms as needed', () => {
+          const actual = transform(
+            {
+              source: read('./jss-to-styled.test/withCreateStyles.actual.tsx'),
+              path: require.resolve('./jss-to-styled.test/withCreateStyles.actual.tsx'),
+            },
+            { jscodeshift },
+            {},
+          );
+
+          const expected = read('./jss-to-styled.test/withCreateStyles.expected.tsx');
+          expect(actual).to.equal(expected, 'The transformed version should be correct');
+        });
+
+        it('should be idempotent', () => {
+          const actual = transform(
+            {
+              source: read('./jss-to-styled.test/withCreateStyles.expected.tsx'),
+              path: require.resolve('./jss-to-styled.test/withCreateStyles.expected.tsx'),
+            },
+            { jscodeshift },
+            {},
+          );
+
+          const expected = read('./jss-to-styled.test/withCreateStyles.expected.tsx');
+          expect(actual).to.equal(expected, 'The transformed version should be correct');
+        });
+      });
+    });
+
+    describe('with createStyles on withStyles', () => {
+      it('transforms as needed', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-styled.test/withCreateStyles1.actual.tsx'),
+            path: require.resolve('./jss-to-styled.test/withCreateStyles1.actual.tsx'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-styled.test/withCreateStyles1.expected.tsx');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+
+      it('should be idempotent', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-styled.test/withCreateStyles1.expected.tsx'),
+            path: require.resolve('./jss-to-styled.test/withCreateStyles1.expected.tsx'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-styled.test/withCreateStyles1.expected.tsx');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
+
+    describe('with createStyles on withStyles directly', () => {
+      it('transforms as needed', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-styled.test/withCreateStyles2.actual.tsx'),
+            path: require.resolve('./jss-to-styled.test/withCreateStyles2.actual.tsx'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-styled.test/withCreateStyles2.expected.tsx');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+
+      it('should be idempotent', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-styled.test/withCreateStyles2.expected.tsx'),
+            path: require.resolve('./jss-to-styled.test/withCreateStyles2.expected.tsx'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-styled.test/withCreateStyles2.expected.tsx');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
     });
   });
 });

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles.actual.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles.actual.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import createStyles from '@material-ui/styles/createStyles';
+import makeStyles from '@material-ui/styles/makeStyles';
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    root: {
+      background: theme.background,
+    },
+  }),
+);
+
+const MyComponent = (props) => {
+  const classes = useStyles();
+
+  return (
+    <div {...props} className={classes.root} />
+  );
+};
+
+export default MyComponent;

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles.expected.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles.expected.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { styled } from '@material-ui/core/styles';
+const PREFIX = 'MyComponent';
+
+const classes = {
+  root: `${PREFIX}-root`
+};
+
+const Root = styled('div')((
+  {
+    theme
+  }
+) => ({
+  [`&.${classes.root}`]: {
+    background: theme.background,
+  }
+}));
+
+const MyComponent = (props) => {
+
+  return <Root {...props} className={classes.root} />;
+};
+
+export default MyComponent;

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles1.actual.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles1.actual.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import createStyles from '@material-ui/styles/createStyles';
+import withStyles from '@material-ui/styles/withStyles';
+
+const styles = (theme) =>
+  createStyles({
+    root: {
+      background: theme.background,
+    },
+  });
+
+const MyComponent = (props) => {
+  const { classes } = props;
+
+  return (
+    <div {...props} className={classes.root} />
+  );
+};
+
+export default withStyles(styles)(MyComponent);

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles1.expected.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles1.expected.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { styled } from '@material-ui/core/styles';
+const PREFIX = 'withCreateStyles1';
+
+const classes = {
+  root: `${PREFIX}-root`
+};
+
+const Root = styled('div')((
+  {
+    theme
+  }
+) => ({
+  [`&.${classes.root}`]: {
+    background: theme.background,
+  }
+}));
+
+const MyComponent = (props) => {
+  const { } = props;
+
+  return <Root {...props} className={classes.root} />;
+};
+
+export default (MyComponent);

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles2.actual.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles2.actual.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import createStyles from '@material-ui/styles/createStyles';
+import withStyles from '@material-ui/styles/withStyles';
+
+const styles = createStyles({
+    root: {
+      background: 'red',
+    },
+  });
+
+const MyComponent = (props) => {
+  const { classes } = props;
+
+  return (
+    <div {...props} className={classes.root} />
+  );
+};
+
+export default withStyles(styles)(MyComponent);

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles2.expected.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles2.expected.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { styled } from '@material-ui/core/styles';
+const PREFIX = 'withCreateStyles2';
+
+const classes = {
+  root: `${PREFIX}-root`
+};
+
+const Root = styled('div')({
+    [`&.${classes.root}`]: {
+      background: 'red',
+    },
+  });
+
+const MyComponent = (props) => {
+  const { } = props;
+
+  return <Root {...props} className={classes.root} />;
+};
+
+export default (MyComponent);

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles3.actual.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles3.actual.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import createStyles from '@material-ui/styles/createStyles';
+import makeStyles from '@material-ui/styles/makeStyles';
+
+const useStyles = makeStyles(createStyles({
+    root: {
+      background: 'red',
+    },
+  })
+);
+
+const MyComponent = (props) => {
+  const classes = useStyles();
+
+  return (
+    <div {...props} className={classes.root} />
+  );
+};
+
+export default MyComponent;

--- a/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles3.expected.tsx
+++ b/packages/material-ui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles3.expected.tsx
@@ -6,15 +6,11 @@ const classes = {
   root: `${PREFIX}-root`
 };
 
-const Root = styled('div')((
-  {
-    theme
-  }
-) => ({
-  [`&.${classes.root}`]: {
-    background: theme.background,
-  }
-}));
+const Root = styled('div')({
+    [`&.${classes.root}`]: {
+      background: 'red',
+    },
+  });
 
 const MyComponent = (props) => {
 


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/27490

Adds support for converting `makeStyles` and `withStyles` usages when `createStyles` is used.
