### PR TITLE
[TreeView] Fix TreeItem label overflow

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -106,6 +106,8 @@ const StyledTreeItemContent = styled(TreeItemContent, {
   },
   [`& .${treeItemClasses.label}`]: {
     width: '100%',
+    // fixes overflow - see https://github.com/mui-org/material-ui/issues/27372
+    minWidth: 0,
     paddingLeft: 4,
     position: 'relative',
     ...theme.typography.body1,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Applied the suggested changes by @eps1lon 

Closes #27372 