### PR TITLE
[docs] Update guides for @material-ui/styled-engine-sc installation

### DIFF
--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -291,7 +291,7 @@ By default, Material-UI components come with emotion as their style engine. If,
 however, you would like to use `styled-components`, you can configure your app by following the [styled engine guide](/guides/styled-engine/#how-to-switch-to-styled-components) or starting with one of the example projects:
 
 - [Create React App with styled-components](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components)
-- [create react app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components-typescript)
+- [Create React App with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components-typescript)
 - [Next.js app with styled-components and TypeScript](https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-styled-components-typescript)
 
 Following this approach reduces the bundle size, and removes the need to configure the CSS injection order.

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -292,7 +292,7 @@ however, you would like to use `styled-components`, you can configure your app b
 
 - [Create React App with styled-components](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components)
 - [create react app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components-typescript)
-- [nextjs app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-styled-components-typescript)
+- [Next.js app with styled-components and TypeScript](https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-styled-components-typescript)
 
 Following this approach reduces the bundle size, and removes the need to configure the CSS injection order.
 

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -290,7 +290,7 @@ export default function GlobalCssSliderDeep() {
 By default, Material-UI components come with emotion as their style engine. If,
 however, you would like to use `styled-components`, you can configure your app by following the [styled engine guide](/guides/styled-engine/#how-to-switch-to-styled-components) or starting with one of the example projects:
 
-- [create react app with styled-components](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components)
+- [Create React App with styled-components](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components)
 - [create react app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components-typescript)
 - [nextjs app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-styled-components-typescript)
 

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -288,7 +288,12 @@ export default function GlobalCssSliderDeep() {
 ### Change the default styled engine
 
 By default, Material-UI components come with emotion as their style engine. If,
-however, you would like to use `styled-components`, you can configure your app by following this [example project](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components).
+however, you would like to use `styled-components`, you can configure your app by following the [styled engine guide](/guides/styled-engine/#how-to-switch-to-styled-components) or starting with one of the example projects:
+
+- [create react app with styled-components](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components)
+- [create react app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components-typescript)
+- [nextjs app with styled-components and typescript](https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-styled-components-typescript)
+
 Following this approach reduces the bundle size, and removes the need to configure the CSS injection order.
 
 After the style engine is configured properly, you can use the [`styled()`](/system/styled/) utility

--- a/docs/src/pages/guides/styled-engine/styled-engine.md
+++ b/docs/src/pages/guides/styled-engine/styled-engine.md
@@ -15,7 +15,7 @@ There are currently two packages available to choose from:
 - `@material-ui/styled-engine-sc` - a similar wrapper around `styled-components`.
 
 These two packages implement the same interface, which makes it makes possible to replace one with the other.
-By default, `@material-ui/core` has `@material-ui/styled-engine` as a dependency, but you can configure your bundler to replace it with `@material-ui/styled-engine-sc` using package alias:
+By default, `@material-ui/core` has `@material-ui/styled-engine` as a dependency, but you can configure your bundler to replace it with `@material-ui/styled-engine-sc` using a package alias:
 
 **package.json**
 

--- a/docs/src/pages/guides/styled-engine/styled-engine.md
+++ b/docs/src/pages/guides/styled-engine/styled-engine.md
@@ -15,20 +15,22 @@ There are currently two packages available to choose from:
 - `@material-ui/styled-engine-sc` - a similar wrapper around `styled-components`.
 
 These two packages implement the same interface, which makes it makes possible to replace one with the other.
-By default, `@material-ui/core` has `@material-ui/styled-engine` as a dependency, but you can configure your bundler to replace it with `@material-ui/styled-engine-sc`.
-For example, if you are using webpack you can configure this by adding a resolver:
+By default, `@material-ui/core` has `@material-ui/styled-engine` as a dependency, but you can configure your bundler to replace it with `@material-ui/styled-engine-sc` using package alias:
 
-**webpack.config.js**
+**package.json**
 
-```js
-module.exports = {
-  //...
-  resolve: {
-    alias: {
-      '@material-ui/styled-engine': '@material-ui/styled-engine-sc',
-    },
-  },
-};
+<!-- #default-branch-switch -->
+
+```diff
+ {
+   "dependencies": {
+-    "@material-ui/styled-engine": "next",
++    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next",
+   },
++  "resolutions": {
++    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next"
++  },
+ }
 ```
 
 If you are using create-react-app, there is a ready-to-use template in the example projects.

--- a/docs/src/pages/guides/styled-engine/styled-engine.md
+++ b/docs/src/pages/guides/styled-engine/styled-engine.md
@@ -24,7 +24,7 @@ By default, `@material-ui/core` has `@material-ui/styled-engine` as a dependency
 ```diff
  {
    "dependencies": {
--    "@material-ui/styled-engine": "next",
+-    "@material-ui/styled-engine": "next"
 +    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next"
    },
 +  "resolutions": {

--- a/docs/src/pages/guides/styled-engine/styled-engine.md
+++ b/docs/src/pages/guides/styled-engine/styled-engine.md
@@ -25,7 +25,7 @@ By default, `@material-ui/core` has `@material-ui/styled-engine` as a dependency
  {
    "dependencies": {
 -    "@material-ui/styled-engine": "next",
-+    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next",
++    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next"
    },
 +  "resolutions": {
 +    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next"


### PR DESCRIPTION
Updates the guides for how to configure styled-components as a styled engine.