### PR TITLE
[Calendarpicker] Improve contrast between enabled and disabled days

### DIFF
--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -164,7 +164,7 @@ const styleArg = ({ theme, styleProps }: { theme: Theme; styleProps: StyleProps 
     },
   },
   [`&.${pickersDayClasses.disabled}`]: {
-    color: theme.palette.text.secondary,
+    color: theme.palette.text.disabled,
   },
   ...(!styleProps.disableMargin && {
     margin: `0 ${DAY_MARGIN}px`,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes [#27506](https://github.com/mui-org/material-ui/issues/27506)

Improve contrast color of disabled days in calendar