### PR TITLE
[system] Fix missing filterProps in compose type

### DIFF
--- a/packages/material-ui-system/src/Box/Box.d.ts
+++ b/packages/material-ui-system/src/Box/Box.d.ts
@@ -138,7 +138,7 @@ type ComposedStyleProps<T> = ComposedArg<T>;
 
 export type ComposedStyleFunction<T extends Array<StyleFunction<any>>> = StyleFunction<
   ComposedStyleProps<T>
->;
+> & { filterProps: string[] };
 
 export interface CustomSystemProps extends AliasesCSSProperties, OverwriteCSSProperties {}
 

--- a/packages/material-ui-system/src/index.spec.tsx
+++ b/packages/material-ui-system/src/index.spec.tsx
@@ -17,6 +17,9 @@ function composeTest() {
   // @ts-expect-error missing `color`
   styler({ spacing: 1 });
   styler({ color: 'test', spacing: 1 });
+
+  // filterProps should exist
+  styler.filterProps;
 }
 
 /**


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #27605

This is a simple PR that exposes the `filterProps` string array on the `compose` function from the `@material-ui/system` package.  The changes apply to the TypeScript types for the aforementioned function.    
