### PR TITLE
[docs] Fix layout shift when opening hash anchor

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -39,10 +39,10 @@ const StyledAppContainer = styled(AppContainer, {
   return {
     position: 'relative',
     ...(!disableAd && {
-      '& .description': {
+      '&& .description': {
         marginBottom: 198,
       },
-      '& .description.ad': {
+      '&& .description.ad': {
         marginBottom: 40,
       },
       ...(!disableToc && {


### PR DESCRIPTION
Open https://next.material-ui.com/components/alert/ with SSR disabled

**Actual**

<img width="691" alt="Capture d’écran 2021-08-05 à 20 30 26" src="https://user-images.githubusercontent.com/3165635/128402560-79cc9e12-255d-43af-814f-bf5c627dbde0.png">

**Expected**

<img width="622" alt="Capture d’écran 2021-08-05 à 20 31 28" src="https://user-images.githubusercontent.com/3165635/128402664-185ce8f2-3620-4940-8434-024f971e435f.png">

This regression happened because JSS was determining the resolution based on the import order, emotion, on the other hand, provides no guarantees. See actual:

<img width="353" alt="Capture d’écran 2021-08-05 à 20 32 12" src="https://user-images.githubusercontent.com/3165635/128402751-93631eaa-24b8-4817-9b7a-02c0b1e39a08.png">

I was annoyed by the layout shift, hates them.

Preview: https://deploy-preview-27619--material-ui.netlify.app/components/alert/