### PR TITLE
[docs] img should have a src attribute

### DIFF
--- a/docs/src/pages/components/image-list/CustomImageList.js
+++ b/docs/src/pages/components/image-list/CustomImageList.js
@@ -7,8 +7,12 @@ import IconButton from '@material-ui/core/IconButton';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
 
 function srcset(image, width, height, rows = 1, cols = 1) {
-  return `${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format 1x,
-  ${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format&dpr=2 2x`;
+  return {
+    src: `${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format`,
+    srcSet: `${image}?w=${width * cols}&h=${
+      height * rows
+    }&fit=crop&auto=format&dpr=2 2x`,
+  };
 }
 
 export default function CustomImageList() {
@@ -30,7 +34,7 @@ export default function CustomImageList() {
         return (
           <ImageListItem key={item.img} cols={cols} rows={rows}>
             <img
-              srcSet={srcset(item.img, 250, 200, rows, cols)}
+              {...srcset(item.img, 250, 200, rows, cols)}
               alt={item.title}
               loading="lazy"
             />

--- a/docs/src/pages/components/image-list/CustomImageList.tsx
+++ b/docs/src/pages/components/image-list/CustomImageList.tsx
@@ -7,8 +7,12 @@ import IconButton from '@material-ui/core/IconButton';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
 
 function srcset(image: string, width: number, height: number, rows = 1, cols = 1) {
-  return `${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format 1x,
-  ${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format&dpr=2 2x`;
+  return {
+    src: `${image}?w=${width * cols}&h=${height * rows}&fit=crop&auto=format`,
+    srcSet: `${image}?w=${width * cols}&h=${
+      height * rows
+    }&fit=crop&auto=format&dpr=2 2x`,
+  };
 }
 
 export default function CustomImageList() {
@@ -30,7 +34,7 @@ export default function CustomImageList() {
         return (
           <ImageListItem key={item.img} cols={cols} rows={rows}>
             <img
-              srcSet={srcset(item.img, 250, 200, rows, cols)}
+              {...srcset(item.img, 250, 200, rows, cols)}
               alt={item.title}
               loading="lazy"
             />

--- a/docs/src/pages/components/image-list/MasonryImageList.js
+++ b/docs/src/pages/components/image-list/MasonryImageList.js
@@ -11,8 +11,8 @@ export default function MasonryImageList() {
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
             <img
-              srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
-                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+              src={`${item.img}?w=248&fit=crop&auto=format`}
+              srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
               alt={item.title}
               loading="lazy"
             />

--- a/docs/src/pages/components/image-list/MasonryImageList.tsx
+++ b/docs/src/pages/components/image-list/MasonryImageList.tsx
@@ -11,8 +11,8 @@ export default function MasonryImageList() {
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
             <img
-              srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
-                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+              src={`${item.img}?w=248&fit=crop&auto=format`}
+              srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
               alt={item.title}
               loading="lazy"
             />

--- a/docs/src/pages/components/image-list/QuiltedImageList.js
+++ b/docs/src/pages/components/image-list/QuiltedImageList.js
@@ -4,8 +4,12 @@ import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
 function srcset(image, size, rows = 1, cols = 1) {
-  return `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format 1x,
-  ${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format&dpr=2 2x`;
+  return {
+    src: `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format`,
+    srcSet: `${image}?w=${size * cols}&h=${
+      size * rows
+    }&fit=crop&auto=format&dpr=2 2x`,
+  };
 }
 
 export default function QuiltedImageList() {
@@ -19,7 +23,7 @@ export default function QuiltedImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img} cols={item.cols || 1} rows={item.rows || 1}>
           <img
-            srcSet={srcset(item.img, 121, item.rows, item.cols)}
+            {...srcset(item.img, 121, item.rows, item.cols)}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/QuiltedImageList.tsx
+++ b/docs/src/pages/components/image-list/QuiltedImageList.tsx
@@ -4,8 +4,12 @@ import ImageList from '@material-ui/core/ImageList';
 import ImageListItem from '@material-ui/core/ImageListItem';
 
 function srcset(image: string, size: number, rows = 1, cols = 1) {
-  return `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format 1x,
-  ${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format&dpr=2 2x`;
+  return {
+    src: `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format`,
+    srcSet: `${image}?w=${size * cols}&h=${
+      size * rows
+    }&fit=crop&auto=format&dpr=2 2x`,
+  };
 }
 
 export default function QuiltedImageList() {
@@ -19,7 +23,7 @@ export default function QuiltedImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img} cols={item.cols || 1} rows={item.rows || 1}>
           <img
-            srcSet={srcset(item.img, 121, item.rows, item.cols)}
+            {...srcset(item.img, 121, item.rows, item.cols)}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/StandardImageList.js
+++ b/docs/src/pages/components/image-list/StandardImageList.js
@@ -9,8 +9,8 @@ export default function StandardImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=164&h=164&fit=crop&auto=format 1x,
-                ${item.img}?w=164&h=164&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=164&h=164&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=164&h=164&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/StandardImageList.tsx
+++ b/docs/src/pages/components/image-list/StandardImageList.tsx
@@ -9,8 +9,8 @@ export default function StandardImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=164&h=164&fit=crop&auto=format 1x,
-                ${item.img}?w=164&h=164&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=164&h=164&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=164&h=164&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/TitlebarBelowImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarBelowImageList.js
@@ -10,8 +10,8 @@ export default function TitlebarBelowImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
-                ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=248&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/TitlebarBelowImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarBelowImageList.tsx
@@ -10,8 +10,8 @@ export default function TitlebarBelowImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
-                ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=248&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.js
@@ -12,8 +12,8 @@ export default function TitlebarBelowMasonryImageList() {
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
             <img
-              srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
-                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+              src={`${item.img}?w=248&fit=crop&auto=format`}
+              srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
               alt={item.title}
               loading="lazy"
             />

--- a/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarBelowMasonryImageList.tsx
@@ -12,8 +12,8 @@ export default function TitlebarBelowMasonryImageList() {
         {itemData.map((item) => (
           <ImageListItem key={item.img}>
             <img
-              srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
-                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+              src={`${item.img}?w=248&fit=crop&auto=format`}
+              srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
               alt={item.title}
               loading="lazy"
             />

--- a/docs/src/pages/components/image-list/TitlebarImageList.js
+++ b/docs/src/pages/components/image-list/TitlebarImageList.js
@@ -16,8 +16,8 @@ export default function TitlebarImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
-                ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=248&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/TitlebarImageList.tsx
+++ b/docs/src/pages/components/image-list/TitlebarImageList.tsx
@@ -16,8 +16,8 @@ export default function TitlebarImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=248&fit=crop&auto=format 1x,
-                ${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=248&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=248&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/WovenImageList.js
+++ b/docs/src/pages/components/image-list/WovenImageList.js
@@ -9,8 +9,8 @@ export default function WovenImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
-                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=161&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />

--- a/docs/src/pages/components/image-list/WovenImageList.tsx
+++ b/docs/src/pages/components/image-list/WovenImageList.tsx
@@ -9,8 +9,8 @@ export default function WovenImageList() {
       {itemData.map((item) => (
         <ImageListItem key={item.img}>
           <img
-            srcSet={`${item.img}?w=161&fit=crop&auto=format 1x,
-                ${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+            src={`${item.img}?w=161&fit=crop&auto=format`}
+            srcSet={`${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
             alt={item.title}
             loading="lazy"
           />


### PR DESCRIPTION
I have found this by chance on https://github.com/mui-org/material-ui/pull/27439/commits/a25140632299fc917992801d1990dc1a0bf43dd8. See the issue with the page https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext.material-ui.com%2Fcomponents%2Fimage-list%2F

<img width="548" alt="Capture d’écran 2021-08-07 à 21 39 14" src="https://user-images.githubusercontent.com/3165635/128612074-c42a1cfe-5ce0-4896-bc40-ca04f4c28f7e.png">

Preview https://deploy-preview-27632--material-ui.netlify.app/components/image-list/ 