### PR TITLE
[ToggleButton] Fix handling of color prop

### DIFF
--- a/docs/pages/api-docs/toggle-button-group.json
+++ b/docs/pages/api-docs/toggle-button-group.json
@@ -4,8 +4,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'standard'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'"
+        "name": "union",
+        "description": "'standard'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
       },
       "default": "'standard'"
     },

--- a/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.d.ts
@@ -7,6 +7,8 @@ import { ToggleButtonClasses } from './toggleButtonClasses';
 
 export interface ToggleButtonPropsSizeOverrides {}
 
+export interface ToggleButtonPropsColorOverrides {}
+
 export type ToggleButtonTypeMap<
   P = {},
   D extends React.ElementType = 'button',
@@ -24,7 +26,10 @@ export type ToggleButtonTypeMap<
      * The color of the button when it is in an active state.
      * @default 'standard'
      */
-    color?: 'standard' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+    color?: OverridableStringUnion<
+      'standard' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+      ToggleButtonPropsColorOverrides
+    >;
     /**
      * If `true`, the component is disabled.
      * @default false

--- a/packages/material-ui/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui/src/ToggleButton/ToggleButton.js
@@ -130,7 +130,6 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
   return (
     <ToggleButtonRoot
       className={clsx(classes.root, className)}
-      color={color}
       disabled={disabled}
       focusRipple={!disableFocusRipple}
       ref={ref}

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -7,6 +7,8 @@ import { ToggleButtonGroupClasses } from './toggleButtonGroupClasses';
 
 export interface ToggleButtonGroupPropsSizeOverrides {}
 
+export interface ToggleButtonGroupPropsColorOverrides {}
+
 export interface ToggleButtonGroupProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {
   /**
@@ -21,7 +23,10 @@ export interface ToggleButtonGroupProps
    * The color of a button when it is selected.
    * @default 'standard'
    */
-  color?: 'standard' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+  color?: OverridableStringUnion<
+    'standard' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+    ToggleButtonGroupPropsColorOverrides
+  >;
   /**
    * If `true`, only allow one of the child ToggleButton values to be selected.
    * @default false

--- a/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -191,14 +191,9 @@ ToggleButtonGroup.propTypes /* remove-proptypes */ = {
    * The color of a button when it is selected.
    * @default 'standard'
    */
-  color: PropTypes.oneOf([
-    'error',
-    'info',
-    'primary',
-    'secondary',
-    'standard',
-    'success',
-    'warning',
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['standard', 'primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.string,
   ]),
   /**
    * If `true`, only allow one of the child ToggleButton values to be selected.


### PR DESCRIPTION
This PR fixes two independent bugs related to the toggle button.

1. The `color` prop is applied for nothing, leading to https://validator.w3.org/nu/?doc=https%3A%2F%2Fnext.material-ui.com%2Fcomponents%2Ftoggle-button%2F

<img width="768" alt="Capture d’écran 2021-08-07 à 22 18 55" src="https://user-images.githubusercontent.com/3165635/128612919-787772b1-be3d-4f6d-8dce-dd1593d07c5a.png">

I have noticed it on https://next--material-ui.netlify.app/branding/home/

2. The `color` migration to custom values with the theme and module augmentation was missed. I'm doing a follow-up on https://github.com/mui-org/material-ui/pull/27337#issuecomment-884365468.