### PR TITLE
[core] Batch small changes

### DIFF
--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -401,14 +401,6 @@ const company = [
     github: 'eps1lon',
   },
   {
-    name: 'Damien Tassone',
-    src: '/static/branding/about/damien.jpg',
-    title: 'Advanced components team',
-    location: 'Barcelona, Spain',
-    twitter: 'madKakoO',
-    github: 'dtassone',
-  },
-  {
     name: 'Marija Najdova',
     src: '/static/branding/about/marija.jpg',
     title: 'Core components team',

--- a/docs/src/pages/discover-more/team/Team.js
+++ b/docs/src/pages/discover-more/team/Team.js
@@ -33,13 +33,6 @@ const activeCore = [
     location: 'Dresden, Germany',
   },
   {
-    name: 'Damien Tassone',
-    github: 'dtassone',
-    twitter: 'madKakoO',
-    flag: 'Advanced components team',
-    location: 'Barcelona, Spain',
-  },
-  {
     name: 'Marija Najdova',
     github: 'mnajdova',
     twitter: 'marijanajdova',

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2656,7 +2656,8 @@ declare module "@material-ui/private-theming" {
 
 ### [Jest] SyntaxError: Unexpected token 'export'
 
-In v5, `@material-ui/core/colors/red` is considered private and should not be used in your project. [More details about this error](https://github.com/mui-org/material-ui/issues/27296).
+`@material-ui/core/colors/red` is considered private since v1.0.0.
+You should replace the import, [more details about this error](https://github.com/mui-org/material-ui/issues/27296).
 
 You can use this codemod (**recommended**) to fix all the import in your project:
 

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -22,7 +22,8 @@ export type StandardProps<
   };
 
 /**
- * @private ONLY USE FROM WITHIN mui-org/material-ui
+ * @internal
+ * ONLY USE FROM WITHIN mui-org/material-ui
  *
  * Internal helper type for conform (describeConformance) components
  * However, we don't declare classes on this type.

--- a/packages/material-ui/src/styles/createTransitions.d.ts
+++ b/packages/material-ui/src/styles/createTransitions.d.ts
@@ -28,7 +28,7 @@ export interface TransitionsOptions {
 }
 
 /**
- * @private
+ * @internal
  * @param props
  * @param options
  */
@@ -38,7 +38,7 @@ export function create(
 ): string;
 
 /**
- * @private
+ * @internal
  * @param height
  */
 export function getAutoHeightDuration(height: number): number;


### PR DESCRIPTION
- [docs] It has been private for longer than v5 7058704: We made it private in v1: https://v1.material-ui.com/guides/minimizing-bundle-size/#option-1

> Anything not listed there should be considered private, and subject to change without notice

- [core] TSDoc encourage @internal over alternatives 6e31dee: It was raised in https://github.com/mui-org/material-ui-x/pull/2249#discussion_r681273260. See https://typedoc.org/guides/doccomments/#%40public%2C-%40protected%2C-and-%40private

> These modifier tags are supported for overriding the visibility of documented items. Their use is discouraged as they do not conform to the TSDoc standard and they may be removed in a future release.

- [docs] Keep the team in sync fc83598: Damien wasn't coming from the community, so I think that the git history is enough to recognize his work. A follow-up on https://github.com/mui-org/material-ui/pull/27575#issuecomment-892501529.