### PR TITLE
[core] Automatically close issues that are incomplete and inactive

### DIFF
--- a/.github/workflows/close-incomplete-inactive.yml
+++ b/.github/workflows/close-incomplete-inactive.yml
@@ -15,6 +15,6 @@ jobs:
           labels: 'status: incomplete'
           inactive-day: 7
           body: |
-            The issue misses key information to move its resolution forward.
-            Because the issue has been inactive for 7 days, we are automatically closing it.
-            If you wish to see the issue reopen, please provide more information.
+            Since the issue is missing key information,
+            and has been inactive for seven days, it has been automatically closed.
+            If you wish to see the issue reopened, please provide more information.

--- a/.github/workflows/close-incomplete-inactive.yml
+++ b/.github/workflows/close-incomplete-inactive.yml
@@ -1,0 +1,20 @@
+name: Close incomplete inactive
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Need more information
+        uses: actions-cool/issues-helper@v2
+        with:
+          actions: 'close-issues'
+          labels: 'status: incomplete'
+          inactive-day: 7
+          body: |
+            The issue misses key information to move its resolution forward.
+            Because the issue has been inactive for 7 days, we are automatically closing it.
+            If you wish to see the issue reopen, please provide more information.

--- a/.github/workflows/contributor-twitter.yml
+++ b/.github/workflows/contributor-twitter.yml
@@ -1,7 +1,9 @@
-name: contributor-twitter
+name: Contributor twitter
+
 on:
   issues:
     types: [labeled]
+
 jobs:
   tweet:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -1,4 +1,4 @@
-name: Issue Mark Duplicate
+name: Issue mark duplicate
 
 on:
   issue_comment:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,4 +1,5 @@
-name: 'Maintenance'
+name: Maintenance
+
 on:
   # So that PRs touching the same files as the push are updated
   push:


### PR DESCRIPTION
We started a thread about this problem on Slack a while ago. I'm moving it to GitHub. The action is [taken from](https://github.com/ant-design/ant-design/blob/bf54f363eee10a55198b3f538ca84744a0d0a9a5/.github/workflows/issue-close-require.yml) Ant Design with two modifications:

1. It uses one label instead of two
2. It closes after 7 days of inactivity instead of 3 days. I personally feel that 3 hits a better balance between creating urgency and keeping the context fresh in mind for the author. But they were internal push back, so move it to a higher value. Note that it also means that if a user answers to provide the missing information and we take more than 7 days to review, we close the issue. If we can't process the notification in 7 days, it's probably that we have more important to do.

To apply on https://github.com/mui-org/material-ui-x too afterward.