### PR TITLE
[docs] Document that @material-ui/styles is not strict mode compatible

### DIFF
--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -292,6 +292,7 @@ const pages: readonly MuiPage[] = [
   },
   {
     pathname: '/styles',
+    title: 'Styles (legacy)',
     children: [
       { pathname: '/styles/basics' },
       { pathname: '/styles/advanced' },

--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -7,7 +7,7 @@
 > It depends on [JSS](https://cssinjs.org/).
 > If you don't want to have both emotion & JSS in your bundle, please refer to the [`@material-ui/system`](/system/basics/) documentation which is the recommended alternative.
 
-> ⚠️ `@material-ui/styles` is not compatible with [React.StrictMode](https://reactjs.org/docs/strict-mode.html).
+> ⚠️ `@material-ui/styles` is not compatible with [React.StrictMode](https://reactjs.org/docs/strict-mode.html) or React 18.
 
 Material-UI aims to provide a strong foundation for building dynamic UIs.
 For the sake of simplicity, **we expose the styling solution used in Material-UI components** as the `@material-ui/styles` package.

--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -1,8 +1,13 @@
 # @material-ui/styles
 
-<p class="description">You can use Material-UI's styling solution in your app, whether or not you are using Material-UI components.</p>
+<p class="description">The legacy styling solution of Material-UI.</p>
 
-> **Note**: `@material-ui/styles` is the _**legacy**_ styling solution for Material-UI. It is deprecated in v5. It depends on [JSS](https://cssinjs.org/) as a styling solution, which is not used in the `@material-ui/core` anymore. If you don't want to have both emotion & JSS in your bundle, please refer to the [`@material-ui/system`](/system/basics/) documentation which is the recommended alternative.
+> ⚠️ `@material-ui/styles` is the legacy styling solution for Material-UI.
+> It's **deprecated** in v5, which is not used by the other packages anymore.
+> It depends on [JSS](https://cssinjs.org/).
+> If you don't want to have both emotion & JSS in your bundle, please refer to the [`@material-ui/system`](/system/basics/) documentation which is the recommended alternative.
+
+> ⚠️ `@material-ui/styles` is not compatible with [React.StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 Material-UI aims to provide a strong foundation for building dynamic UIs.
 For the sake of simplicity, **we expose the styling solution used in Material-UI components** as the `@material-ui/styles` package.

--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -2,9 +2,9 @@
 
 <p class="description">The legacy styling solution of Material-UI.</p>
 
-> ⚠️ `@material-ui/styles` is the legacy styling solution for Material-UI.
-> It's **deprecated** in v5, which is not used by the other packages anymore.
-> It depends on [JSS](https://cssinjs.org/).
+> ⚠️ `@material-ui/styles` is the _**legacy**_ styling solution for Material-UI.
+> It is deprecated in v5.
+> It depends on [JSS](https://cssinjs.org/) as a styling solution, which is not used in the `@material-ui/core` anymore.
 > If you don't want to have both emotion & JSS in your bundle, please refer to the [`@material-ui/system`](/system/basics/) documentation which is the recommended alternative.
 
 > ⚠️ `@material-ui/styles` is not compatible with [React.StrictMode](https://reactjs.org/docs/strict-mode.html) or React 18.

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -315,7 +315,7 @@
     "/guides/content-security-policy": "Content Security Policy",
     "/guides/right-to-left": "Right-to-left",
     "/guides/flow": "Flow",
-    "/styles": "Styles",
+    "/styles": "Styles (legacy)",
     "/styles/basics": "Basics",
     "/styles/advanced": "Advanced",
     "https://material-ui.com/store/": "Premium themes",


### PR DESCRIPTION
Act on https://github.com/mui-org/material-ui/issues/13394#issuecomment-885455260. I have also used the opportunity to push the legacy notice further than what we did so far for `@material-ui/styles`.

Preview: https://deploy-preview-27639--material-ui.netlify.app/styles/basics/