### PR TITLE
[core] Change range strategy to bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,7 +83,7 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 30,
   "prHourlyLimit": 0,
-  "rangeStrategy": "update-lockfile",
+  "rangeStrategy": "bump",
   "schedule": "on sunday before 6:00am",
   "timezone": "UTC"
 }


### PR DESCRIPTION
We were initially using the default value: "replace". It wasn't updating for in-range updates, we weren't not updating enough. So we changed it to "update-lockfile" #27455. This is not working either, per https://github.com/renovatebot/renovate/discussions/11083, it reruns all the PRs's CI each time one of them is merged. I'm trying a new one.

I have merged this change in x, it seems to work https://github.com/mui-org/material-ui-x/pull/2304