### PR TITLE
[test] Dodge double logging in dev mode

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -95,7 +95,9 @@ module.exports = function setKarmaConfig(config) {
       '/fake.png': '/base/test/assets/fake.png',
       '/fake2.png': '/base/test/assets/fake2.png',
     },
-    reporters: ['dots', 'coverage-istanbul'],
+    // The CI branch fixes double log issue
+    // https://github.com/karma-runner/karma/issues/2342
+    reporters: ['dots', ...(CI ? ['coverage-istanbul'] : [])],
     webpack: {
       mode: 'development',
       devtool: CI ? 'inline-source-map' : 'eval-source-map',


### PR DESCRIPTION
See https://github.com/mui-org/material-ui/pull/27389#issuecomment-894820124 for the issue. Judging from https://github.com/karma-runner/karma/issues/2342, there is no real workaround for the logs in th CI.