### PR TITLE
[Radio] Fix size prop forwarding with custom icons

### DIFF
--- a/docs/pages/api-docs/radio.json
+++ b/docs/pages/api-docs/radio.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "checked": { "type": { "name": "bool" } },
-    "checkedIcon": { "type": { "name": "node" } },
+    "checkedIcon": { "type": { "name": "node" }, "default": "<RadioButtonIcon checked />" },
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
@@ -12,7 +12,7 @@
     },
     "disabled": { "type": { "name": "bool" } },
     "disableRipple": { "type": { "name": "bool" } },
-    "icon": { "type": { "name": "node" } },
+    "icon": { "type": { "name": "node" }, "default": "<RadioButtonIcon />" },
     "id": { "type": { "name": "string" } },
     "inputProps": { "type": { "name": "object" } },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -103,14 +103,10 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
         ...inputProps,
       }}
       icon={React.cloneElement(icon, {
-        fontSize:
-          icon.props.fontSize === undefined && size !== 'medium' ? size : icon.props.fontSize,
+        fontSize: icon.props.fontSize ?? size,
       })}
       checkedIcon={React.cloneElement(indeterminateIcon, {
-        fontSize:
-          indeterminateIcon.props.fontSize === undefined && size !== 'medium'
-            ? size
-            : indeterminateIcon.props.fontSize,
+        fontSize: indeterminateIcon.props.fontSize ?? size,
       })}
       styleProps={styleProps}
       ref={ref}

--- a/packages/material-ui/src/Radio/Radio.d.ts
+++ b/packages/material-ui/src/Radio/Radio.d.ts
@@ -13,6 +13,7 @@ export interface RadioProps
   extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon' | 'type'> {
   /**
    * The icon to display when the component is checked.
+   * @default <RadioButtonIcon checked />
    */
   checkedIcon?: React.ReactNode;
   /**
@@ -33,6 +34,7 @@ export interface RadioProps
   disabled?: boolean;
   /**
    * The icon to display when the component is unchecked.
+   * @default <RadioButtonIcon />
    */
   icon?: React.ReactNode;
   /**

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -98,7 +98,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   return (
     <RadioRoot
       type="radio"
-      icon={React.cloneElement(icon, { fontSize: defaultIcon.props.fontSize ?? size, })}
+      icon={React.cloneElement(icon, { fontSize: defaultIcon.props.fontSize ?? size })}
       checkedIcon={React.cloneElement(checkedIcon, {
         fontSize: defaultCheckedIcon.props.fontSize ?? size,
       })}

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -124,6 +124,7 @@ Radio.propTypes /* remove-proptypes */ = {
   checked: PropTypes.bool,
   /**
    * The icon to display when the component is checked.
+   * @default <RadioButtonIcon checked />
    */
   checkedIcon: PropTypes.node,
   /**
@@ -148,6 +149,7 @@ Radio.propTypes /* remove-proptypes */ = {
   disableRipple: PropTypes.bool,
   /**
    * The icon to display when the component is unchecked.
+   * @default <RadioButtonIcon />
    */
   icon: PropTypes.node,
   /**

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -65,7 +65,9 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiRadio' });
   const {
     checked: checkedProp,
+    checkedIcon = defaultCheckedIcon,
     color = 'primary',
+    icon = defaultIcon,
     name: nameProp,
     onChange: onChangeProp,
     size = 'medium',
@@ -96,9 +98,9 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   return (
     <RadioRoot
       type="radio"
-      icon={React.cloneElement(defaultIcon, { fontSize: size === 'small' ? 'small' : 'medium' })}
-      checkedIcon={React.cloneElement(defaultCheckedIcon, {
-        fontSize: size === 'small' ? 'small' : 'medium',
+      icon={React.cloneElement(icon, { fontSize: defaultIcon.props.fontSize ?? size, })}
+      checkedIcon={React.cloneElement(checkedIcon, {
+        fontSize: defaultCheckedIcon.props.fontSize ?? size,
       })}
       styleProps={styleProps}
       classes={classes}

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -4,6 +4,7 @@ import { describeConformanceV5, createClientRender } from 'test/utils';
 import Radio, { radioClasses as classes } from '@material-ui/core/Radio';
 import FormControl from '@material-ui/core/FormControl';
 import ButtonBase from '@material-ui/core/ButtonBase';
+import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
 
 describe('<Radio />', () => {
   const render = createClientRender();
@@ -37,6 +38,19 @@ describe('<Radio />', () => {
     it('should render a checked icon', () => {
       const { getAllByTestId } = render(<Radio checked />);
       expect(getAllByTestId('RadioButtonCheckedIcon').length).to.equal(1);
+    });
+  });
+
+  describe('with icon', () => {
+    describe('with size small', () => {
+      it('should have the same fontSize with and without icon', () => {
+        const { getAllByTestId } = render(<React.Fragment>
+          <Radio size="small" /> 
+          <Radio size="small" icon={<RadioButtonUncheckedIcon />} />
+        </React.Fragment>);
+        expect(getAllByTestId('RadioButtonUncheckedIcon')[0]).to.have.style('fontSize', '1.25rem');
+        expect(getAllByTestId('RadioButtonUncheckedIcon')[1]).to.have.style('fontSize', '1.25rem');
+      });
     });
   });
 

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -4,7 +4,6 @@ import { describeConformanceV5, createClientRender } from 'test/utils';
 import Radio, { radioClasses as classes } from '@material-ui/core/Radio';
 import FormControl from '@material-ui/core/FormControl';
 import ButtonBase from '@material-ui/core/ButtonBase';
-import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 
 describe('<Radio />', () => {
   const render = createClientRender();
@@ -38,21 +37,6 @@ describe('<Radio />', () => {
     it('should render a checked icon', () => {
       const { getAllByTestId } = render(<Radio checked />);
       expect(getAllByTestId('RadioButtonCheckedIcon').length).to.equal(1);
-    });
-  });
-
-  describe('with icon', () => {
-    describe('with size small', () => {
-      it('should have the same fontSize with and without icon', () => {
-        const { getAllByTestId } = render(
-          <React.Fragment>
-            <Radio size="small" />
-            <Radio size="small" icon={<RadioButtonUncheckedIcon />} />
-          </React.Fragment>,
-        );
-        expect(getAllByTestId('RadioButtonUncheckedIcon')[0]).to.have.style('fontSize', '1.25rem');
-        expect(getAllByTestId('RadioButtonUncheckedIcon')[1]).to.have.style('fontSize', '1.25rem');
-      });
     });
   });
 

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -4,7 +4,7 @@ import { describeConformanceV5, createClientRender } from 'test/utils';
 import Radio, { radioClasses as classes } from '@material-ui/core/Radio';
 import FormControl from '@material-ui/core/FormControl';
 import ButtonBase from '@material-ui/core/ButtonBase';
-import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 
 describe('<Radio />', () => {
   const render = createClientRender();
@@ -44,10 +44,12 @@ describe('<Radio />', () => {
   describe('with icon', () => {
     describe('with size small', () => {
       it('should have the same fontSize with and without icon', () => {
-        const { getAllByTestId } = render(<React.Fragment>
-          <Radio size="small" /> 
-          <Radio size="small" icon={<RadioButtonUncheckedIcon />} />
-        </React.Fragment>);
+        const { getAllByTestId } = render(
+          <React.Fragment>
+            <Radio size="small" />
+            <Radio size="small" icon={<RadioButtonUncheckedIcon />} />
+          </React.Fragment>,
+        );
         expect(getAllByTestId('RadioButtonUncheckedIcon')[0]).to.have.style('fontSize', '1.25rem');
         expect(getAllByTestId('RadioButtonUncheckedIcon')[1]).to.have.style('fontSize', '1.25rem');
       });

--- a/test/regressions/fixtures/Radio/RadioIconSizeSmall.js
+++ b/test/regressions/fixtures/Radio/RadioIconSizeSmall.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Radio from '@material-ui/core/Radio';
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
+
+export default function RadioIconSizeSmall() {
+  return (
+    <div>
+      <Radio size="small" />
+      <Radio size="small" icon={<RadioButtonUncheckedIcon />} />
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Changed the way to set the fontSize for Radio and Checkbox components. And added a test case to match the fontSize in the Radio button standard and icon.
With the bug, the Radio was rendered with fontSize of 1.50rem 24x24 and now is render as expected with 1.25rem 20x20.

Closes #27510 
