### PR TITLE
[test] Add current behavior for a11y name vs visible name for PickersDay

### DIFF
--- a/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.test.tsx
@@ -48,4 +48,20 @@ describe('<PickersDay />', () => {
     expect(handleDaySelect.callCount).to.equal(1);
     expect(handleDaySelect.args[0][0]).toEqualDateTime(day);
   });
+
+  it('renders the day of the month by default', () => {
+    render(
+      <PickersDay
+        day={adapterToUse.date('2020-02-02T02:02:02.000')}
+        onDaySelect={() => {}}
+        outsideCurrentMonth={false}
+      />,
+    );
+
+    const day = screen.getByRole('button');
+    // TODO: This can be disorienting if the accessible name is not the same as the visible label
+    // Investigate if we can drop `aria-label` and let screenreaders announce the full date in a calendar picker.
+    expect(day).to.have.text('2');
+    expect(day).toHaveAccessibleName('Feb 2, 2020');
+  });
 });


### PR DESCRIPTION
I wasn't really aware of the difference between a11y name and visible label in `PickersDay` so let's encode it in tests.

Sparked by https://github.com/mui-org/material-ui/pull/27462