### PR TITLE
(typescript) ClickAwayListener - Remove typescipt children mission error

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.tsx
@@ -26,7 +26,7 @@ export interface ClickAwayListenerProps {
   /**
    * The wrapped element.
    */
-  children: React.ReactElement;
+  children?: React.ReactElement;
   /**
    * If `true`, the React tree is ignored and only the DOM tree is considered.
    * This prop changes how portaled elements are handled.


### PR DESCRIPTION
![Screen Shot 2021-08-09 at 10 42 22](https://user-images.githubusercontent.com/17257576/128680386-34471c37-9e9b-4ef0-ae34-7b27002c88ae.png)


When setting the children like this:
```
<ClickAwayListener>
    <Typography>Children component</Typography>
</ClickAwayListener> 
```