### PR TITLE
styled-engine: Expose cache

### DIFF
--- a/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.d.ts
+++ b/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.d.ts
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import type { EmotionCache } from '@emotion/cache';
 
 export interface StyledEngineProviderProps {
   children?: React.ReactNode;
   injectFirst?: boolean;
 }
+
+export const cache: EmotionCache;
 
 export default function StyledEngineProvider(props: StyledEngineProviderProps): JSX.Element;

--- a/packages/material-ui-styled-engine/src/StyledEngineProvider/index.js
+++ b/packages/material-ui-styled-engine/src/StyledEngineProvider/index.js
@@ -1,1 +1,1 @@
-export { default } from './StyledEngineProvider';
+export { default, cache } from './StyledEngineProvider';

--- a/packages/material-ui-styled-engine/src/index.d.ts
+++ b/packages/material-ui-styled-engine/src/index.d.ts
@@ -2,7 +2,7 @@ export * from '@emotion/styled';
 export { default } from '@emotion/styled';
 export { ThemeContext, keyframes, css } from '@emotion/react';
 
-export { default as StyledEngineProvider } from './StyledEngineProvider';
+export { default as StyledEngineProvider, cache } from './StyledEngineProvider';
 
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';

--- a/packages/material-ui-styled-engine/src/index.js
+++ b/packages/material-ui-styled-engine/src/index.js
@@ -26,5 +26,5 @@ export default function styled(tag, options) {
 }
 
 export { ThemeContext, keyframes, css } from '@emotion/react';
-export { default as StyledEngineProvider } from './StyledEngineProvider';
+export { default as StyledEngineProvider, cache } from './StyledEngineProvider';
 export { default as GlobalStyles } from './GlobalStyles';


### PR DESCRIPTION
Hi @oliviertassinari, @mnajdova  👋🏻 ,

It would be nice if I could access the emotion cache used internally by mui.  
It would be for a tighter integration with [tss-react](https://github.com/garronej/tss-react) when SSR is involved.  
The goal would be to enable users to write [something like this](https://github.com/garronej/tss-react/blob/e9245c804f4d0a79e10afbbb7089646316a91325/src/test/ssr/pages/_document.tsx#L3-L7) to enable SSR in next.js projects. 
The mui cache would be provided as usual by users using the [`<StyledEngineProvider />`](https://github.com/garronej/tss-react/blob/adf6e35689d29e7d9e75841eab0830b2b15e2e41/src/test/ssr/pages/index.tsx#L15-L17).  

Now that said I would understand if you prefer to keep it internal. 
In this case there is an easy workaround. The user would write [this](https://github.com/garronej/tss-react/blob/c15efff74660367dc30a7d1f5c210004c59976e5/src/test/ssr/pages/_document.tsx#L2-L6) and [this](https://github.com/garronej/tss-react/blob/c15efff74660367dc30a7d1f5c210004c59976e5/src/test/ssr/pages/index.tsx#L16-L18) instead.

I though you might be encline to expose it as [it is already exported](https://github.com/mui-org/material-ui/blob/49d4ac1db3c086bbc8a92a66a294d5e15ecb106f/packages/material-ui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js#L7) from `StyledEngineProvider.js` but never used elsewhere.  

Best,
