### PR TITLE
[docs] Improve accessible labels for Card demos

### DIFF
--- a/docs/src/pages/components/cards/ActionAreaCard.js
+++ b/docs/src/pages/components/cards/ActionAreaCard.js
@@ -10,9 +10,10 @@ export default function ActionAreaCard() {
     <Card sx={{ maxWidth: 345 }}>
       <CardActionArea>
         <CardMedia
-          sx={{ height: 140 }}
+          component="img"
+          height="140"
           image="/static/images/cards/contemplative-reptile.jpg"
-          title="Contemplative Reptile"
+          alt="green iguana"
         />
         <CardContent>
           <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/ActionAreaCard.tsx
+++ b/docs/src/pages/components/cards/ActionAreaCard.tsx
@@ -10,9 +10,10 @@ export default function ActionAreaCard() {
     <Card sx={{ maxWidth: 345 }}>
       <CardActionArea>
         <CardMedia
-          sx={{ height: 140 }}
+          component="img"
+          height="140"
           image="/static/images/cards/contemplative-reptile.jpg"
-          title="Contemplative Reptile"
+          alt="green iguana"
         />
         <CardContent>
           <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/ImgMediaCard.js
+++ b/docs/src/pages/components/cards/ImgMediaCard.js
@@ -11,10 +11,9 @@ export default function ImgMediaCard() {
     <Card sx={{ maxWidth: 345 }}>
       <CardMedia
         component="img"
-        alt="Contemplative Reptile"
+        alt="green iguana"
         height="140"
         image="/static/images/cards/contemplative-reptile.jpg"
-        title="Contemplative Reptile"
       />
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/ImgMediaCard.tsx
+++ b/docs/src/pages/components/cards/ImgMediaCard.tsx
@@ -11,10 +11,9 @@ export default function ImgMediaCard() {
     <Card sx={{ maxWidth: 345 }}>
       <CardMedia
         component="img"
-        alt="Contemplative Reptile"
+        alt="green iguana"
         height="140"
         image="/static/images/cards/contemplative-reptile.jpg"
-        title="Contemplative Reptile"
       />
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/MediaCard.js
+++ b/docs/src/pages/components/cards/MediaCard.js
@@ -10,9 +10,10 @@ export default function MediaCard() {
   return (
     <Card sx={{ maxWidth: 345 }}>
       <CardMedia
-        sx={{ height: 140 }}
+        component="img"
+        height="140"
         image="/static/images/cards/contemplative-reptile.jpg"
-        title="Contemplative Reptile"
+        alt="green iguana"
       />
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/MediaCard.tsx
+++ b/docs/src/pages/components/cards/MediaCard.tsx
@@ -10,9 +10,10 @@ export default function MediaCard() {
   return (
     <Card sx={{ maxWidth: 345 }}>
       <CardMedia
-        sx={{ height: 140 }}
+        component="img"
+        height="140"
         image="/static/images/cards/contemplative-reptile.jpg"
-        title="Contemplative Reptile"
+        alt="green iguana"
       />
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/MediaControlCard.js
+++ b/docs/src/pages/components/cards/MediaControlCard.js
@@ -37,9 +37,10 @@ export default function MediaControlCard() {
         </Box>
       </Box>
       <CardMedia
+        component="img"
         sx={{ width: 151 }}
         image="/static/images/cards/live-from-space.jpg"
-        title="Live from space album cover"
+        alt="Live from space album cover"
       />
     </Card>
   );

--- a/docs/src/pages/components/cards/MediaControlCard.tsx
+++ b/docs/src/pages/components/cards/MediaControlCard.tsx
@@ -37,9 +37,10 @@ export default function MediaControlCard() {
         </Box>
       </Box>
       <CardMedia
+        component="img"
         sx={{ width: 151 }}
         image="/static/images/cards/live-from-space.jpg"
-        title="Live from space album cover"
+        alt="Live from space album cover"
       />
     </Card>
   );

--- a/docs/src/pages/components/cards/MultiActionAreaCard.js
+++ b/docs/src/pages/components/cards/MultiActionAreaCard.js
@@ -10,9 +10,10 @@ export default function MultiActionAreaCard() {
     <Card sx={{ maxWidth: 345 }}>
       <CardActionArea>
         <CardMedia
-          sx={{ height: 140 }}
+          component="img"
+          height="140"
           image="/static/images/cards/contemplative-reptile.jpg"
-          title="Contemplative Reptile"
+          alt="green iguana"
         />
         <CardContent>
           <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/MultiActionAreaCard.tsx
+++ b/docs/src/pages/components/cards/MultiActionAreaCard.tsx
@@ -10,9 +10,10 @@ export default function MultiActionAreaCard() {
     <Card sx={{ maxWidth: 345 }}>
       <CardActionArea>
         <CardMedia
-          sx={{ height: 140 }}
+          component="img"
+          height="140"
           image="/static/images/cards/contemplative-reptile.jpg"
-          title="Contemplative Reptile"
+          alt="green iguana"
         />
         <CardContent>
           <Typography gutterBottom variant="h5" component="div">

--- a/docs/src/pages/components/cards/NotificationCard.js
+++ b/docs/src/pages/components/cards/NotificationCard.js
@@ -145,10 +145,18 @@ export default function NotificationCard() {
   return (
     <ThemeProvider theme={theme}>
       <Card variant="outlined" sx={{ display: 'flex', p: 1.5, maxWidth: 283 }}>
-        <Avatar src="/static/images/avatar/3.jpg" variant="rounded" />
+        <Avatar
+          imgProps={{ 'aria-labelledby': 'demo-notification-card-messenger-name' }}
+          src="/static/images/avatar/3.jpg"
+          variant="rounded"
+        />
         <Box sx={{ ml: 1, flexBasis: 180, flexGrow: 1, minWidth: '0px' }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-            <Typography color="text.secondary" variant="caption">
+            <Typography
+              id="demo-notification-card-messenger-name"
+              color="text.secondary"
+              variant="caption"
+            >
               Angela Erickson
             </Typography>
             <Typography color="text.secondary" variant="caption">

--- a/docs/src/pages/components/cards/NotificationCard.tsx
+++ b/docs/src/pages/components/cards/NotificationCard.tsx
@@ -148,10 +148,18 @@ export default function NotificationCard() {
   return (
     <ThemeProvider theme={theme}>
       <Card variant="outlined" sx={{ display: 'flex', p: 1.5, maxWidth: 283 }}>
-        <Avatar src="/static/images/avatar/3.jpg" variant="rounded" />
+        <Avatar
+          imgProps={{ 'aria-labelledby': 'demo-notification-card-messenger-name' }}
+          src="/static/images/avatar/3.jpg"
+          variant="rounded"
+        />
         <Box sx={{ ml: 1, flexBasis: 180, flexGrow: 1, minWidth: '0px' }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-            <Typography color="text.secondary" variant="caption">
+            <Typography
+              id="demo-notification-card-messenger-name"
+              color="text.secondary"
+              variant="caption"
+            >
               Angela Erickson
             </Typography>
             <Typography color="text.secondary" variant="caption">

--- a/docs/src/pages/components/cards/PlayerCard.js
+++ b/docs/src/pages/components/cards/PlayerCard.js
@@ -37,7 +37,7 @@ const grey = {
 };
 
 export default function PlayerCard() {
-  const [paused, setPaused] = React.useState(false);
+  const [paused, setPaused] = React.useState(true);
   /*
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
@@ -111,6 +111,7 @@ export default function PlayerCard() {
     <ThemeProvider theme={theme}>
       <Card variant="outlined" sx={{ display: 'flex', p: 1 }}>
         <Avatar
+          alt="Beside Myself album cover"
           sx={{ width: 100, height: 100 }}
           src="/static/images/cards/basement-beside-myself.jpg"
           variant="rounded"
@@ -123,13 +124,17 @@ export default function PlayerCard() {
             Basement • Beside Myself
           </Typography>
           <Box sx={{ mt: 2 }}>
-            <IconButton disabled>
+            <IconButton aria-label="fast rewind" disabled>
               <FastRewindRounded />
             </IconButton>
-            <IconButton sx={{ mx: 2 }} onClick={() => setPaused((val) => !val)}>
-              {paused ? <PauseRounded /> : <PlayArrowRounded />}
+            <IconButton
+              aria-label={paused ? 'play' : 'pause'}
+              sx={{ mx: 2 }}
+              onClick={() => setPaused((val) => !val)}
+            >
+              {paused ? <PlayArrowRounded /> : <PauseRounded />}
             </IconButton>
-            <IconButton disabled>
+            <IconButton aria-label="fast forward" disabled>
               <FastForwardRounded />
             </IconButton>
           </Box>

--- a/docs/src/pages/components/cards/PlayerCard.js
+++ b/docs/src/pages/components/cards/PlayerCard.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ThemeProvider, createTheme, useTheme } from '@material-ui/core/styles';
-import Avatar from '@material-ui/core/Avatar';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import IconButton from '@material-ui/core/IconButton';
@@ -110,11 +109,12 @@ export default function PlayerCard() {
   return (
     <ThemeProvider theme={theme}>
       <Card variant="outlined" sx={{ display: 'flex', p: 1 }}>
-        <Avatar
+        <img
           alt="Beside Myself album cover"
-          sx={{ width: 100, height: 100 }}
+          style={{ borderRadius: 8 }}
           src="/static/images/cards/basement-beside-myself.jpg"
-          variant="rounded"
+          width="100"
+          height="100"
         />
         <Box sx={{ alignSelf: 'center', mx: 2 }}>
           <Typography variant="body2" fontWeight={500}>

--- a/docs/src/pages/components/cards/PlayerCard.tsx
+++ b/docs/src/pages/components/cards/PlayerCard.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ThemeProvider, createTheme, useTheme } from '@material-ui/core/styles';
-import Avatar from '@material-ui/core/Avatar';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import IconButton from '@material-ui/core/IconButton';
@@ -108,11 +107,12 @@ export default function PlayerCard() {
   return (
     <ThemeProvider theme={theme}>
       <Card variant="outlined" sx={{ display: 'flex', p: 1 }}>
-        <Avatar
+        <img
           alt="Beside Myself album cover"
-          sx={{ width: 100, height: 100 }}
+          style={{ borderRadius: 8 }}
           src="/static/images/cards/basement-beside-myself.jpg"
-          variant="rounded"
+          width="100"
+          height="100"
         />
         <Box sx={{ alignSelf: 'center', mx: 2 }}>
           <Typography variant="body2" fontWeight={500}>

--- a/docs/src/pages/components/cards/PlayerCard.tsx
+++ b/docs/src/pages/components/cards/PlayerCard.tsx
@@ -36,7 +36,7 @@ const grey = {
 };
 
 export default function PlayerCard() {
-  const [paused, setPaused] = React.useState(false);
+  const [paused, setPaused] = React.useState(true);
   /*
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
@@ -109,6 +109,7 @@ export default function PlayerCard() {
     <ThemeProvider theme={theme}>
       <Card variant="outlined" sx={{ display: 'flex', p: 1 }}>
         <Avatar
+          alt="Beside Myself album cover"
           sx={{ width: 100, height: 100 }}
           src="/static/images/cards/basement-beside-myself.jpg"
           variant="rounded"
@@ -121,13 +122,17 @@ export default function PlayerCard() {
             Basement • Beside Myself
           </Typography>
           <Box sx={{ mt: 2 }}>
-            <IconButton disabled>
+            <IconButton aria-label="fast rewind" disabled>
               <FastRewindRounded />
             </IconButton>
-            <IconButton sx={{ mx: 2 }} onClick={() => setPaused((val) => !val)}>
-              {paused ? <PauseRounded /> : <PlayArrowRounded />}
+            <IconButton
+              aria-label={paused ? 'play' : 'pause'}
+              sx={{ mx: 2 }}
+              onClick={() => setPaused((val) => !val)}
+            >
+              {paused ? <PlayArrowRounded /> : <PauseRounded />}
             </IconButton>
-            <IconButton disabled>
+            <IconButton aria-label="fast forward" disabled>
               <FastForwardRounded />
             </IconButton>
           </Box>

--- a/docs/src/pages/components/cards/RecipeReviewCard.js
+++ b/docs/src/pages/components/cards/RecipeReviewCard.js
@@ -50,12 +50,10 @@ export default function RecipeReviewCard() {
         subheader="September 14, 2016"
       />
       <CardMedia
-        sx={{
-          height: 0,
-          paddingTop: '56.25%', // 16:9
-        }}
+        component="img"
+        height="194"
         image="/static/images/cards/paella.jpg"
-        title="Paella dish"
+        alt="Paella dish"
       />
       <CardContent>
         <Typography variant="body2" color="text.secondary">

--- a/docs/src/pages/components/cards/RecipeReviewCard.tsx
+++ b/docs/src/pages/components/cards/RecipeReviewCard.tsx
@@ -54,12 +54,10 @@ export default function RecipeReviewCard() {
         subheader="September 14, 2016"
       />
       <CardMedia
-        sx={{
-          height: 0,
-          paddingTop: '56.25%', // 16:9
-        }}
+        component="img"
+        height="194"
         image="/static/images/cards/paella.jpg"
-        title="Paella dish"
+        alt="Paella dish"
       />
       <CardContent>
         <Typography variant="body2" color="text.secondary">

--- a/docs/src/pages/components/cards/TaskCard.js
+++ b/docs/src/pages/components/cards/TaskCard.js
@@ -111,12 +111,16 @@ export default function TaskCard() {
           </Typography>
         </Box>
         <Box sx={{ display: 'flex' }}>
-          <Avatar src="/static/images/avatar/1.jpg" variant="rounded" />
+          <Avatar
+            imgProps={{ 'aria-labelledby': 'demo-task-card-assigne-name' }}
+            src="/static/images/avatar/1.jpg"
+            variant="rounded"
+          />
           <Box sx={{ ml: 1 }}>
             <Typography variant="body2" color="text.secondary">
               Assigned to
             </Typography>
-            <Typography>Michael Scott</Typography>
+            <Typography id="demo-task-card-assigne-name">Michael Scott</Typography>
           </Box>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: -0.5, mt: 0.5 }}>

--- a/docs/src/pages/components/cards/TaskCard.tsx
+++ b/docs/src/pages/components/cards/TaskCard.tsx
@@ -117,12 +117,16 @@ export default function TaskCard() {
           </Typography>
         </Box>
         <Box sx={{ display: 'flex' }}>
-          <Avatar src="/static/images/avatar/1.jpg" variant="rounded" />
+          <Avatar
+            imgProps={{ 'aria-labelledby': 'demo-task-card-assigne-name' }}
+            src="/static/images/avatar/1.jpg"
+            variant="rounded"
+          />
           <Box sx={{ ml: 1 }}>
             <Typography variant="body2" color="text.secondary">
               Assigned to
             </Typography>
-            <Typography>Michael Scott</Typography>
+            <Typography id="demo-task-card-assigne-name">Michael Scott</Typography>
           </Box>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: -0.5, mt: 0.5 }}>

--- a/docs/src/pages/components/skeleton/Facebook.js
+++ b/docs/src/pages/components/skeleton/Facebook.js
@@ -57,9 +57,10 @@ function Media(props) {
         <Skeleton sx={{ height: 190 }} animation="wave" variant="rectangular" />
       ) : (
         <CardMedia
-          sx={{ height: 190 }}
+          component="img"
+          height="140"
           image="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
-          title="Ted talk"
+          alt="Nicola Sturgeon on a TED talk stage"
         />
       )}
 

--- a/docs/src/pages/components/skeleton/Facebook.tsx
+++ b/docs/src/pages/components/skeleton/Facebook.tsx
@@ -60,9 +60,10 @@ function Media(props: MediaProps) {
         <Skeleton sx={{ height: 190 }} animation="wave" variant="rectangular" />
       ) : (
         <CardMedia
-          sx={{ height: 190 }}
+          component="img"
+          height="140"
           image="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
-          title="Ted talk"
+          alt="Nicola Sturgeon on a TED talk stage"
         />
       )}
       <CardContent>

--- a/docs/src/pages/getting-started/templates/album/Album.js
+++ b/docs/src/pages/getting-started/templates/album/Album.js
@@ -86,12 +86,13 @@ export default function Album() {
                   sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
                 >
                   <CardMedia
+                    component="img"
                     sx={{
                       // 16:9
                       pt: '56.25%',
                     }}
                     image="https://source.unsplash.com/random"
-                    title="Image title"
+                    alt="random"
                   />
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Typography gutterBottom variant="h5" component="h2">

--- a/docs/src/pages/getting-started/templates/album/Album.tsx
+++ b/docs/src/pages/getting-started/templates/album/Album.tsx
@@ -86,12 +86,13 @@ export default function Album() {
                   sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
                 >
                   <CardMedia
+                    component="img"
                     sx={{
                       // 16:9
                       pt: '56.25%',
                     }}
                     image="https://source.unsplash.com/random"
-                    title="Image title"
+                    alt="random"
                   />
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Typography gutterBottom variant="h5" component="h2">

--- a/docs/src/pages/getting-started/templates/blog/Blog.js
+++ b/docs/src/pages/getting-started/templates/blog/Blog.js
@@ -44,7 +44,7 @@ const featuredPosts = [
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
     image: 'https://source.unsplash.com/random',
-    imageText: 'Image Text',
+    imageLabel: 'Image Text',
   },
   {
     title: 'Post title',
@@ -52,7 +52,7 @@ const featuredPosts = [
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
     image: 'https://source.unsplash.com/random',
-    imageText: 'Image Text',
+    imageLabel: 'Image Text',
   },
 ];
 

--- a/docs/src/pages/getting-started/templates/blog/Blog.tsx
+++ b/docs/src/pages/getting-started/templates/blog/Blog.tsx
@@ -44,7 +44,7 @@ const featuredPosts = [
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
     image: 'https://source.unsplash.com/random',
-    imageText: 'Image Text',
+    imageLabel: 'Image Text',
   },
   {
     title: 'Post title',
@@ -52,7 +52,7 @@ const featuredPosts = [
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
     image: 'https://source.unsplash.com/random',
-    imageText: 'Image Text',
+    imageLabel: 'Image Text',
   },
 ];
 

--- a/docs/src/pages/getting-started/templates/blog/FeaturedPost.js
+++ b/docs/src/pages/getting-started/templates/blog/FeaturedPost.js
@@ -29,9 +29,10 @@ function FeaturedPost(props) {
             </Typography>
           </CardContent>
           <CardMedia
+            component="img"
             sx={{ width: 160, display: { xs: 'none', sm: 'block' } }}
             image={post.image}
-            title={post.imageText}
+            alt={post.imageLabel}
           />
         </Card>
       </CardActionArea>
@@ -44,7 +45,7 @@ FeaturedPost.propTypes = {
     date: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     image: PropTypes.string.isRequired,
-    imageText: PropTypes.string.isRequired,
+    imageLabel: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/docs/src/pages/getting-started/templates/blog/FeaturedPost.tsx
+++ b/docs/src/pages/getting-started/templates/blog/FeaturedPost.tsx
@@ -11,7 +11,7 @@ interface FeaturedPostProps {
     date: string;
     description: string;
     image: string;
-    imageText: string;
+    imageLabel: string;
     title: string;
   };
 }
@@ -38,9 +38,10 @@ export default function FeaturedPost(props: FeaturedPostProps) {
             </Typography>
           </CardContent>
           <CardMedia
+            component="img"
             sx={{ width: 160, display: { xs: 'none', sm: 'block' } }}
             image={post.image}
-            title={post.imageText}
+            alt={post.imageLabel}
           />
         </Card>
       </CardActionArea>


### PR DESCRIPTION
- Add `alt` to existing images
- Remove `title` in favor of `alt`
- Name `button`
- Expose image semantics of `<CardMedia image />`
- https://www.argos-ci.com/mui-org/material-ui/builds/676 revealed that the PlayerCard album cover shouldn't use an avatar 

Increases a11y lighthouse score from 85 (https://61119ce4bacc510008cb3ee1--material-ui.netlify.app/components/cards/) to 96 (https://deploy-preview-27675--material-ui.netlify.app/components/cards).

 The improvement is actually higher since some elements that were clearly images (`<CardMedia image />`) were not exposed as images at all. I'll follow-up with a patch to `CardMedia` that patches this up for older demos.

Visual changes are expected: https://www.argos-ci.com/mui-org/material-ui/builds/681