### PR TITLE
[docs] Reorder and rename "enforce value" ToggleButton demo

### DIFF
--- a/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.js
+++ b/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
 import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
 import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
@@ -7,19 +6,14 @@ import FormatAlignJustifyIcon from '@material-ui/icons/FormatAlignJustify';
 import LaptopIcon from '@material-ui/icons/Laptop';
 import TvIcon from '@material-ui/icons/Tv';
 import PhoneAndroidIcon from '@material-ui/icons/PhoneAndroid';
-import Grid from '@material-ui/core/Grid';
+import Stack from '@material-ui/core/Stack';
+
 import ToggleButton from '@material-ui/core/ToggleButton';
 import ToggleButtonGroup from '@material-ui/core/ToggleButtonGroup';
 
 export default function ToggleButtonNotEmpty() {
   const [alignment, setAlignment] = React.useState('left');
-  const [formats, setFormats] = React.useState(() => ['phone']);
-
-  const handleFormat = (event, newFormats) => {
-    if (newFormats.length) {
-      setFormats(newFormats);
-    }
-  };
+  const [devices, setDevices] = React.useState(() => ['phone']);
 
   const handleAlignment = (event, newAlignment) => {
     if (newAlignment !== null) {
@@ -27,50 +21,46 @@ export default function ToggleButtonNotEmpty() {
     }
   };
 
+  const handleDevices = (event, newDevices) => {
+    if (newDevices.length) {
+      setDevices(newDevices);
+    }
+  };
+
   return (
-    <Grid container spacing={2}>
-      <Grid item sm={12} md={6}>
-        <Box sx={{ my: 2 }}>
-          <ToggleButtonGroup
-            value={alignment}
-            exclusive
-            onChange={handleAlignment}
-            aria-label="text alignment"
-          >
-            <ToggleButton value="left" aria-label="left aligned">
-              <FormatAlignLeftIcon />
-            </ToggleButton>
-            <ToggleButton value="center" aria-label="centered">
-              <FormatAlignCenterIcon />
-            </ToggleButton>
-            <ToggleButton value="right" aria-label="right aligned">
-              <FormatAlignRightIcon />
-            </ToggleButton>
-            <ToggleButton value="justify" aria-label="justified" disabled>
-              <FormatAlignJustifyIcon />
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
-      </Grid>
-      <Grid item sm={12} md={6}>
-        <Box sx={{ my: 2 }}>
-          <ToggleButtonGroup
-            value={formats}
-            onChange={handleFormat}
-            aria-label="device"
-          >
-            <ToggleButton value="laptop" aria-label="laptop">
-              <LaptopIcon />
-            </ToggleButton>
-            <ToggleButton value="tv" aria-label="tv">
-              <TvIcon />
-            </ToggleButton>
-            <ToggleButton value="phone" aria-label="phone">
-              <PhoneAndroidIcon />
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
-      </Grid>
-    </Grid>
+    <Stack direction="row" spacing={4}>
+      <ToggleButtonGroup
+        value={alignment}
+        exclusive
+        onChange={handleAlignment}
+        aria-label="text alignment"
+      >
+        <ToggleButton value="left" aria-label="left aligned">
+          <FormatAlignLeftIcon />
+        </ToggleButton>
+        <ToggleButton value="center" aria-label="centered">
+          <FormatAlignCenterIcon />
+        </ToggleButton>
+        <ToggleButton value="right" aria-label="right aligned">
+          <FormatAlignRightIcon />
+        </ToggleButton>
+      </ToggleButtonGroup>
+
+      <ToggleButtonGroup
+        value={devices}
+        onChange={handleDevices}
+        aria-label="device"
+      >
+        <ToggleButton value="laptop" aria-label="laptop">
+          <LaptopIcon />
+        </ToggleButton>
+        <ToggleButton value="tv" aria-label="tv">
+          <TvIcon />
+        </ToggleButton>
+        <ToggleButton value="phone" aria-label="phone">
+          <PhoneAndroidIcon />
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.js
+++ b/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.js
@@ -2,12 +2,10 @@ import * as React from 'react';
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
 import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
 import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
-import FormatAlignJustifyIcon from '@material-ui/icons/FormatAlignJustify';
 import LaptopIcon from '@material-ui/icons/Laptop';
 import TvIcon from '@material-ui/icons/Tv';
 import PhoneAndroidIcon from '@material-ui/icons/PhoneAndroid';
 import Stack from '@material-ui/core/Stack';
-
 import ToggleButton from '@material-ui/core/ToggleButton';
 import ToggleButtonGroup from '@material-ui/core/ToggleButtonGroup';
 

--- a/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.tsx
+++ b/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
 import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
 import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
-import FormatAlignJustifyIcon from '@material-ui/icons/FormatAlignJustify';
 import LaptopIcon from '@material-ui/icons/Laptop';
 import TvIcon from '@material-ui/icons/Tv';
 import PhoneAndroidIcon from '@material-ui/icons/PhoneAndroid';

--- a/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.tsx
+++ b/docs/src/pages/components/toggle-button/ToggleButtonNotEmpty.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Box from '@material-ui/core/Box';
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
 import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
 import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
@@ -7,22 +6,13 @@ import FormatAlignJustifyIcon from '@material-ui/icons/FormatAlignJustify';
 import LaptopIcon from '@material-ui/icons/Laptop';
 import TvIcon from '@material-ui/icons/Tv';
 import PhoneAndroidIcon from '@material-ui/icons/PhoneAndroid';
-import Grid from '@material-ui/core/Grid';
+import Stack from '@material-ui/core/Stack';
 import ToggleButton from '@material-ui/core/ToggleButton';
 import ToggleButtonGroup from '@material-ui/core/ToggleButtonGroup';
 
 export default function ToggleButtonNotEmpty() {
   const [alignment, setAlignment] = React.useState('left');
-  const [formats, setFormats] = React.useState(() => ['phone']);
-
-  const handleFormat = (
-    event: React.MouseEvent<HTMLElement>,
-    newFormats: string[],
-  ) => {
-    if (newFormats.length) {
-      setFormats(newFormats);
-    }
-  };
+  const [devices, setDevices] = React.useState(() => ['phone']);
 
   const handleAlignment = (
     event: React.MouseEvent<HTMLElement>,
@@ -33,50 +23,49 @@ export default function ToggleButtonNotEmpty() {
     }
   };
 
+  const handleDevices = (
+    event: React.MouseEvent<HTMLElement>,
+    newDevices: string[],
+  ) => {
+    if (newDevices.length) {
+      setDevices(newDevices);
+    }
+  };
+
   return (
-    <Grid container spacing={2}>
-      <Grid item sm={12} md={6}>
-        <Box sx={{ my: 2 }}>
-          <ToggleButtonGroup
-            value={alignment}
-            exclusive
-            onChange={handleAlignment}
-            aria-label="text alignment"
-          >
-            <ToggleButton value="left" aria-label="left aligned">
-              <FormatAlignLeftIcon />
-            </ToggleButton>
-            <ToggleButton value="center" aria-label="centered">
-              <FormatAlignCenterIcon />
-            </ToggleButton>
-            <ToggleButton value="right" aria-label="right aligned">
-              <FormatAlignRightIcon />
-            </ToggleButton>
-            <ToggleButton value="justify" aria-label="justified" disabled>
-              <FormatAlignJustifyIcon />
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
-      </Grid>
-      <Grid item sm={12} md={6}>
-        <Box sx={{ my: 2 }}>
-          <ToggleButtonGroup
-            value={formats}
-            onChange={handleFormat}
-            aria-label="device"
-          >
-            <ToggleButton value="laptop" aria-label="laptop">
-              <LaptopIcon />
-            </ToggleButton>
-            <ToggleButton value="tv" aria-label="tv">
-              <TvIcon />
-            </ToggleButton>
-            <ToggleButton value="phone" aria-label="phone">
-              <PhoneAndroidIcon />
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
-      </Grid>
-    </Grid>
+    <Stack direction="row" spacing={4}>
+      <ToggleButtonGroup
+        value={alignment}
+        exclusive
+        onChange={handleAlignment}
+        aria-label="text alignment"
+      >
+        <ToggleButton value="left" aria-label="left aligned">
+          <FormatAlignLeftIcon />
+        </ToggleButton>
+        <ToggleButton value="center" aria-label="centered">
+          <FormatAlignCenterIcon />
+        </ToggleButton>
+        <ToggleButton value="right" aria-label="right aligned">
+          <FormatAlignRightIcon />
+        </ToggleButton>
+      </ToggleButtonGroup>
+
+      <ToggleButtonGroup
+        value={devices}
+        onChange={handleDevices}
+        aria-label="device"
+      >
+        <ToggleButton value="laptop" aria-label="laptop">
+          <LaptopIcon />
+        </ToggleButton>
+        <ToggleButton value="tv" aria-label="tv">
+          <TvIcon />
+        </ToggleButton>
+        <ToggleButton value="phone" aria-label="phone">
+          <PhoneAndroidIcon />
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Stack>
   );
 }

--- a/docs/src/pages/components/toggle-button/toggle-button.md
+++ b/docs/src/pages/components/toggle-button/toggle-button.md
@@ -50,15 +50,15 @@ The buttons can be stacked vertically with the `orientation` prop set to "vertic
 If you want to enforce that at least one button must be active, you can adapt your handleChange function.
 
 ```jsx
-const handleFormat = (event, newFormats) => {
-  if (newFormats.length) {
-    setFormats(newFormats);
-  }
-};
-
 const handleAlignment = (event, newAlignment) => {
   if (newAlignment !== null) {
     setAlignment(newAlignment);
+  }
+};
+
+const handleDevices = (event, newDevices) => {
+  if (newDevices.length) {
+    setDevices(newDevices);
   }
 };
 ```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In [this example](https://next.material-ui.com/components/toggle-button/#enforce-value-set) the order of the handle functions is not the same as the order of the rendered components.

Some of my colleagues (myself included) trip over this every now and then, so I decided to change it :smile:

(I've added this example in the first place, so it's my fault it's out of order anyway :grin:)

I've also used the chance to do a bit of cleanup:
- replace the `Grid` wrapper with a `Stack`
- rename "format" to "device", so the demo is simpler to understand

## Before:
![image](https://user-images.githubusercontent.com/10603631/128860201-10f451f7-58f4-4c2c-b708-c797cd0e36ef.png)


## After:
![image](https://user-images.githubusercontent.com/10603631/128860242-789e28df-754d-4eec-9a8b-7ce1fe90622b.png)
