### PR TITLE
[docs] Fix MobileTextStepper example to match description

### DIFF
--- a/docs/src/pages/components/steppers/TextMobileStepper.js
+++ b/docs/src/pages/components/steppers/TextMobileStepper.js
@@ -61,6 +61,7 @@ export default function TextMobileStepper() {
         {steps[activeStep].description}
       </Box>
       <MobileStepper
+        variant="text"
         steps={maxSteps}
         position="static"
         activeStep={activeStep}

--- a/docs/src/pages/components/steppers/TextMobileStepper.tsx
+++ b/docs/src/pages/components/steppers/TextMobileStepper.tsx
@@ -61,6 +61,7 @@ export default function TextMobileStepper() {
         {steps[activeStep].description}
       </Box>
       <MobileStepper
+        variant="text"
         steps={maxSteps}
         position="static"
         activeStep={activeStep}


### PR DESCRIPTION
I updated the demo of the Mobile Text Stepper, adding variant="text".  The description said that it would show the current step number in text form but it actually showed the current step number with the default dots. 
@siriwatknp also recommended this change
--- a/docs/src/pages/components/steppers/TextMobileStepper.tsx
+++ b/docs/src/pages/components/steppers/TextMobileStepper.tsx
But I couldn't find the place in the file tree where the "a" and "b" versions of the docs are.

Closes https://github.com/mui-org/material-ui/issues/27608