### PR TITLE
[ButtonBase]: Fix tabIndex type

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -75,7 +75,7 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
     /**
      * @default 0
      */
-    tabIndex?: number;
+    tabIndex?: NonNullable<React.HTMLAttributes<any>['tabIndex']>;
     /**
      * Props applied to the `TouchRipple` element.
      */

--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -72,11 +72,10 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */
     sx?: SxProps<Theme>;
-    // @types/react is stricter
     /**
      * @default 0
      */
-    tabIndex?: string | number;
+    tabIndex?: number;
     /**
      * Props applied to the `TouchRipple` element.
      */

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -510,7 +510,7 @@ ButtonBase.propTypes /* remove-proptypes */ = {
   /**
    * @default 0
    */
-  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  tabIndex: PropTypes.number,
   /**
    * Props applied to the `TouchRipple` element.
    */

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -268,7 +268,7 @@ MenuItem.propTypes /* remove-proptypes */ = {
   /**
    * @default 0
    */
-  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  tabIndex: PropTypes.number,
 };
 
 export default MenuItem;


### PR DESCRIPTION
Closes #27669

Type now matches that of @types/react.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
