### PR TITLE
[docs] Link to "Customization of Theme" from relevant theme interfaces

### DIFF
--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -24,6 +24,58 @@ The strict mode options are the same that are required for every types package
 published in the `@types/` namespace. Using a less strict `tsconfig.json` or omitting some of the libraries might cause errors. To get the best type experience with the types we recommend
 setting `"strict": true`.
 
+## Customization of `Theme`
+
+When adding custom properties to the `Theme`, you may continue to use it in a strongly typed way by exploiting
+[TypeScript's module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
+
+The following example adds an `appDrawer` prop that is merged into the one exported by `material-ui`:
+
+```ts
+import { Breakpoint, Theme } from '@material-ui/core/styles';
+declare module '@material-ui/core/styles' {
+  interface Theme {
+    appDrawer: {
+      width: React.CSSProperties['width'];
+      breakpoint: Breakpoint;
+    };
+  }
+  // allow configuration using `createTheme`
+  interface ThemeOptions {
+    appDrawer?: {
+      width?: React.CSSProperties['width'];
+      breakpoint?: Breakpoint;
+    };
+  }
+}
+```
+
+And a custom theme factory with additional defaulted options:
+
+**./styles/createMyTheme**:
+
+```ts
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
+export default function createMyTheme(options: ThemeOptions) {
+  return createTheme({
+    appDrawer: {
+      width: 225,
+      breakpoint: 'lg',
+    },
+    ...options,
+  });
+}
+```
+
+This could be used like:
+
+```ts
+import createMyTheme from './styles/createMyTheme';
+const theme = createMyTheme({
+  appDrawer: { breakpoint: 'md' },
+});
+```
+
 ## Usage of `component` prop
 
 Many Material-UI components allow you to replace their root node via a `component`

--- a/packages/material-ui-private-theming/src/defaultTheme/index.d.ts
+++ b/packages/material-ui-private-theming/src/defaultTheme/index.d.ts
@@ -1,4 +1,5 @@
 /**
- * The default theme interface, augment this to avoid having to set the theme type everywhere
+ * The default theme interface, augment this to avoid having to set the theme type everywhere.
+ * Our [TypeScript guide on theme customization](https://material-ui.com/guides/typescript/#customization-of-theme) explains in detail how you would add custom properties.
  */
 export interface DefaultTheme {}

--- a/packages/material-ui/src/styles/createTheme.d.ts
+++ b/packages/material-ui/src/styles/createTheme.d.ts
@@ -18,6 +18,9 @@ export interface ThemeOptions extends SystemThemeOptions {
   unstable_strictMode?: boolean;
 }
 
+/**
+ * Our [TypeScript guide on theme customization](https://material-ui.com/guides/typescript/#customization-of-theme) explains in detail how you would add custom properties.
+ */
 export interface Theme extends SystemTheme {
   mixins: Mixins;
   components?: Components;


### PR DESCRIPTION
Restores "Customization of `Theme`" removed in https://github.com/mui-org/material-ui/pull/27417 (resolves https://github.com/mui-org/material-ui/pull/27417#discussion_r686585397)

Closes https://github.com/mui-org/material-ui/issues/21551