### PR TITLE
[docs] Display TypeScript code of demo if requested

### DIFF
--- a/docs/packages/markdown/loader.js
+++ b/docs/packages/markdown/loader.js
@@ -109,7 +109,7 @@ module.exports = async function demoLoader() {
         const moduleTS = moduleID.replace(/\.js$/, '.tsx');
         const moduleTSFilepath = path.join(
           path.dirname(this.resourcePath),
-          moduleID.replace(/\//g, path.sep),
+          moduleTS.replace(/\//g, path.sep),
         );
         this.addDependency(moduleTSFilepath);
         const rawTS = await fs.readFile(moduleTSFilepath, { encoding: 'utf-8' });


### PR DESCRIPTION
Broke in https://github.com/mui-org/material-ui/pull/27406 and was not caught in review.

Preview: https://deploy-preview-27691--material-ui.netlify.app/components/date-picker/#main-content

Also fixes a crash in development when the TypeScript version of a demo doesn't exist (e.g. `/getting-started/usage/`)