### PR TITLE
[docs] Fix duplicate headers in List

### DIFF
--- a/docs/src/pages/components/lists/lists.md
+++ b/docs/src/pages/components/lists/lists.md
@@ -104,11 +104,10 @@ If this library doesn't cover your use case, you should consider using [react-vi
 
 ## Customization
 
-Here are some examples of customizing the component. You can learn more about this in the
+Here are some examples of customizing the component.
+You can learn more about this in the
 [overrides documentation page](/customization/how-to-customize/).
 
-{{"demo": "pages/components/lists/CustomizedList.js"}}
-
-## Customization
-
 🎨 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/styles/list-item).
+
+{{"demo": "pages/components/lists/CustomizedList.js"}}

--- a/docs/src/pages/components/lists/lists.md
+++ b/docs/src/pages/components/lists/lists.md
@@ -108,6 +108,6 @@ Here are some examples of customizing the component.
 You can learn more about this in the
 [overrides documentation page](/customization/how-to-customize/).
 
-🎨 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/styles/list-item).
-
 {{"demo": "pages/components/lists/CustomizedList.js"}}
+
+🎨 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/styles/list-item).


### PR DESCRIPTION
It's confusing to use the same name for different section. Our implementation for page table of contents also doesn't support it (see duplicate key warnings on affected pages). 

https://deploy-preview-27694--material-ui.netlify.app/components/lists/#customization