### PR TITLE
[docs] Zero runtime themeAugmentation documentation

### DIFF
--- a/docs/src/pages/components/about-the-lab/about-the-lab.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab.md
@@ -43,7 +43,10 @@ yarn add @material-ui/core@next
 In order to benefit from the [CSS overrides](/customization/theme-components/#global-style-overrides) and [default prop customization](/customization/theme-components/#default-props) with the theme, TypeScript users need to import the following types. Internally, it uses [module augmentation](/guides/typescript/#customization-of-theme) to extend the default theme structure with the extension components available in the lab.
 
 ```tsx
-import '@material-ui/lab/themeAugmentation';
+// When using TypeScript 4.x and above
+import type {} from '@material-ui/lab/themeAugmentation';
+// When using TypeScript 3.x and below
+import from '@material-ui/lab/themeAugmentation';
 
 const theme = createTheme({
   components: {

--- a/docs/src/pages/components/about-the-lab/about-the-lab.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab.md
@@ -46,7 +46,7 @@ In order to benefit from the [CSS overrides](/customization/theme-components/#gl
 // When using TypeScript 4.x and above
 import type {} from '@material-ui/lab/themeAugmentation';
 // When using TypeScript 3.x and below
-import from '@material-ui/lab/themeAugmentation';
+import '@material-ui/lab/themeAugmentation';
 
 const theme = createTheme({
   components: {

--- a/packages/material-ui-lab/src/themeAugmentation/index.js
+++ b/packages/material-ui-lab/src/themeAugmentation/index.js
@@ -1,1 +1,1 @@
-export default {};
+// Prefer to use `import type {} from '@material-ui/lab/themeAugmentation';` instead to avoid importing an empty file.


### PR DESCRIPTION
Runtime and types should have the same shape. The types don't export any runtime so neither should the actual runtime. 

Closes https://github.com/mui-org/material-ui/issues/27704