### PR TITLE
[docs] Don't dispatch ignored "reset code variant" actions

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -226,7 +226,7 @@ export default function DemoToolbar(props) {
   };
 
   const handleCodeLanguageClick = (event, clickedCodeVariant) => {
-    if (codeVariant !== clickedCodeVariant) {
+    if (clickedCodeVariant !== null && codeVariant !== clickedCodeVariant) {
       dispatch({
         type: ACTION_TYPES.OPTIONS_CHANGE,
         payload: {


### PR DESCRIPTION
We default to the previous `codeVariant` anyway if we receive a falsy `codeVariant`. Might as well not dispatch it at all.