### PR TITLE
[docs] Use country image instead of emoji

### DIFF
--- a/docs/pages/branding/about.tsx
+++ b/docs/pages/branding/about.tsx
@@ -114,7 +114,10 @@ const Person = (props: Profile & { sx?: PaperProps['sx'] }) => {
             >
               <img
                 loading="lazy"
-                src={`https://www.countryflags.io/${props.country}/flat/64.png`}
+                width="32"
+                height="32"
+                src={`https://www.countryflags.io/${props.country}/flat/32.png`}
+                srcSet={`https://www.countryflags.io/${props.country}/flat/64.png 2x`}
                 alt=""
               />
             </Box>

--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -13,15 +13,13 @@ export default function CountrySelect() {
       autoHighlight
       getOptionLabel={(option) => option.label}
       renderOption={(props, option) => (
-        <Box
-          component="li"
-          sx={{ fontSize: 15, '& > img': { mr: '10px' } }}
-          {...props}
-        >
+        <Box component="li" sx={{ '& > img': { mr: 2 } }} {...props}>
           <img
             loading="lazy"
-            src={`https://www.countryflags.io/${option.code}/shiny/16.png`}
-            alt={option.label}
+            width="20"
+            src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
+            srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
+            alt=""
           />
           {option.label} ({option.code}) +{option.phone}
         </Box>

--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -4,16 +4,6 @@ import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/core/Autocomplete';
 
-// ISO 3166-1 alpha-2
-// ⚠️ No support for IE11
-function countryToFlag(isoCode) {
-  return typeof String.fromCodePoint !== 'undefined'
-    ? isoCode
-        .toUpperCase()
-        .replace(/./g, (char) => String.fromCodePoint(char.charCodeAt(0) + 127397))
-    : isoCode;
-}
-
 export default function CountrySelect() {
   return (
     <Autocomplete
@@ -25,10 +15,14 @@ export default function CountrySelect() {
       renderOption={(props, option) => (
         <Box
           component="li"
-          sx={{ fontSize: 15, '& > span': { mr: '10px', fontSize: 18 } }}
+          sx={{ fontSize: 15, '& > img': { mr: '10px' } }}
           {...props}
         >
-          <span>{countryToFlag(option.code)}</span>
+          <img
+            loading="lazy"
+            src={`https://www.countryflags.io/${option.code}/shiny/16.png`}
+            alt={option.label}
+          />
           {option.label} ({option.code}) +{option.phone}
         </Box>
       )}

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -13,15 +13,13 @@ export default function CountrySelect() {
       autoHighlight
       getOptionLabel={(option) => option.label}
       renderOption={(props, option) => (
-        <Box
-          component="li"
-          sx={{ fontSize: 15, '& > img': { mr: '10px' } }}
-          {...props}
-        >
+        <Box component="li" sx={{ '& > img': { mr: 2 } }} {...props}>
           <img
             loading="lazy"
-            src={`https://www.countryflags.io/${option.code}/shiny/16.png`}
-            alt={option.label}
+            width="20"
+            src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
+            srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
+            alt=""
           />
           {option.label} ({option.code}) +{option.phone}
         </Box>

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -4,16 +4,6 @@ import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/core/Autocomplete';
 
-// ISO 3166-1 alpha-2
-// ⚠️ No support for IE11
-function countryToFlag(isoCode: string) {
-  return typeof String.fromCodePoint !== 'undefined'
-    ? isoCode
-        .toUpperCase()
-        .replace(/./g, (char) => String.fromCodePoint(char.charCodeAt(0) + 127397))
-    : isoCode;
-}
-
 export default function CountrySelect() {
   return (
     <Autocomplete
@@ -25,10 +15,14 @@ export default function CountrySelect() {
       renderOption={(props, option) => (
         <Box
           component="li"
-          sx={{ fontSize: 15, '& > span': { mr: '10px', fontSize: 18 } }}
+          sx={{ fontSize: 15, '& > img': { mr: '10px' } }}
           {...props}
         >
-          <span>{countryToFlag(option.code)}</span>
+          <img
+            loading="lazy"
+            src={`https://www.countryflags.io/${option.code}/shiny/16.png`}
+            alt={option.label}
+          />
           {option.label} ({option.code}) +{option.phone}
         </Box>
       )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #27525

Preview: https://deploy-preview-27723--material-ui.netlify.app/components/autocomplete/#country-select