### PR TITLE
[lab] Use the public API for module augmentation

### DIFF
--- a/packages/material-ui-lab/src/themeAugmentation/components.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/components.d.ts
@@ -1,4 +1,4 @@
-import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@material-ui/core';
+import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@material-ui/core/styles';
 
 export interface LabComponents {
   MuiCalendarPicker?: {
@@ -98,6 +98,6 @@ export interface LabComponents {
   };
 }
 
-declare module '@material-ui/core/styles/components' {
+declare module '@material-ui/core/styles' {
   interface Components extends LabComponents {}
 }

--- a/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
@@ -41,7 +41,7 @@ export interface LabComponentNameToClassKey {
   MuiYearPicker: YearPickerClassKey;
 }
 
-declare module '@material-ui/core/styles/overrides' {
+declare module '@material-ui/core/styles' {
   interface ComponentNameToClassKey extends LabComponentNameToClassKey {}
 }
 

--- a/packages/material-ui-lab/src/themeAugmentation/props.d.ts
+++ b/packages/material-ui-lab/src/themeAugmentation/props.d.ts
@@ -64,7 +64,7 @@ export interface LabComponentsPropsList {
   MuiYearPicker: YearPickerProps<unknown>;
 }
 
-declare module '@material-ui/core/styles/props' {
+declare module '@material-ui/core/styles' {
   interface ComponentsPropsList extends LabComponentsPropsList {}
 }
 


### PR DESCRIPTION
A follow-up on https://github.com/mui-org/material-ui-x/pull/2307#discussion_r684743848. I assume that the author of this PR has copyed our source. 