### PR TITLE
[InputLabel] Apply `asterisk` class when `required`

### DIFF
--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -19,9 +19,7 @@ const useUtilityClasses = (styleProps) => {
       size === 'small' && 'sizeSmall',
       variant,
     ],
-    asterisk: [
-      required && 'asterisk',
-    ]
+    asterisk: [required && 'asterisk'],
   };
 
   const composedClasses = composeClasses(slots, getInputLabelUtilityClasses, classes);

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -9,7 +9,7 @@ import styled, { rootShouldForwardProp } from '../styles/styled';
 import { getInputLabelUtilityClasses } from './inputLabelClasses';
 
 const useUtilityClasses = (styleProps) => {
-  const { classes, formControl, size, shrink, disableAnimation, variant } = styleProps;
+  const { classes, formControl, size, shrink, disableAnimation, variant, required } = styleProps;
   const slots = {
     root: [
       'root',
@@ -19,6 +19,9 @@ const useUtilityClasses = (styleProps) => {
       size === 'small' && 'sizeSmall',
       variant,
     ],
+    asterisk: [
+      required && 'asterisk',
+    ]
   };
 
   const composedClasses = composeClasses(slots, getInputLabelUtilityClasses, classes);
@@ -124,7 +127,7 @@ const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
   const fcs = formControlState({
     props,
     muiFormControl,
-    states: ['size', 'variant'],
+    states: ['size', 'variant', 'required'],
   });
 
   const styleProps = {
@@ -134,6 +137,7 @@ const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
     shrink,
     size: fcs.size,
     variant: fcs.variant,
+    required: fcs.required,
   };
 
   const classes = useUtilityClasses(styleProps);

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -36,13 +36,13 @@ describe('<InputLabel />', () => {
   });
 
   it('should forward the asterisk class to AsteriskComponent when required', () => {
-    const { container } = render(<InputLabel required>Foo</InputLabel>);
-    expect(container.querySelector('.MuiInputLabel-root > :last-child')).to.have.class(
-      'MuiFormLabel-asterisk',
+    const { container } = render(
+      <InputLabel classes={{ asterisk: 'my-asterisk' }} required>
+        Foo
+      </InputLabel>,
     );
-    expect(container.querySelector('.MuiInputLabel-root > :last-child')).to.have.class(
-      'MuiInputLabel-asterisk',
-    );
+    expect(container.querySelector('.my-asterisk')).to.have.class('MuiFormLabel-asterisk');
+    expect(container.querySelector('.my-asterisk')).to.have.class('MuiInputLabel-asterisk');
   });
 
   describe('with FormControl', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -37,8 +37,12 @@ describe('<InputLabel />', () => {
 
   it('should forward the asterisk class to AsteriskComponent when required', () => {
     const { container } = render(<InputLabel required>Foo</InputLabel>);
-    expect(container.firstChild.childNodes[1]).to.have.class('MuiFormLabel-asterisk');
-    expect(container.firstChild.childNodes[1]).to.have.class('MuiInputLabel-asterisk');
+    expect(container.querySelector('.MuiInputLabel-root > :last-child')).to.have.class(
+      'MuiFormLabel-asterisk',
+    );
+    expect(container.querySelector('.MuiInputLabel-root > :last-child')).to.have.class(
+      'MuiInputLabel-asterisk',
+    );
   });
 
   describe('with FormControl', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -37,7 +37,9 @@ describe('<InputLabel />', () => {
 
   it('should forward the asterisk class to AsteriskComponent when required', () => {
     const { container } = render(<InputLabel required>Foo</InputLabel>);
-    expect(container.querySelector('.MuiFormLabel-asterisk.MuiInputLabel-asterisk')).not.to.equal(null);
+    expect(container.querySelector('.MuiFormLabel-asterisk.MuiInputLabel-asterisk')).not.to.equal(
+      null,
+    );
   });
 
   describe('with FormControl', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -37,9 +37,8 @@ describe('<InputLabel />', () => {
 
   it('should forward the asterisk class to AsteriskComponent when required', () => {
     const { container } = render(<InputLabel required>Foo</InputLabel>);
-    expect(container.querySelector('.MuiFormLabel-asterisk.MuiInputLabel-asterisk')).not.to.equal(
-      null,
-    );
+    expect(container.firstChild.childNodes[1]).to.have.class('MuiFormLabel-asterisk');
+    expect(container.firstChild.childNodes[1]).to.have.class('MuiInputLabel-asterisk');
   });
 
   describe('with FormControl', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -35,6 +35,11 @@ describe('<InputLabel />', () => {
     expect(container.firstChild).not.to.have.class(classes.animated);
   });
 
+  it('should forward the asterisk class to AsteriskComponent when required', () => {
+    const { container } = render(<InputLabel required>Foo</InputLabel>);
+    expect(container.querySelector('.MuiFormLabel-asterisk.MuiInputLabel-asterisk')).not.to.equal(null);
+  });
+
   describe('with FormControl', () => {
     it('should have the formControl class', () => {
       const { getByTestId } = render(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #27707

Problem

As it's pointed out in the #27707 , `InputLabel` doesn't forward the `asterisk` class to `FormLabel`'s `AsteriskComponent` despite it's specifically mentioned in the documentation. It causes problems with both tests and styling.

Changes

- Forward the `asterisk` class to `FormLabel`'s `AsteriskComponent` if `InputLabel` has the `required` property
- Add a test to ensure that `AsteriskComponent` receives both (`.MuiFormLabel-asterisk.MuiInputLabel-asterisk`) classes
