### PR TITLE
[Stack] Match the customization standard

### DIFF
--- a/packages/material-ui/src/Stack/Stack.js
+++ b/packages/material-ui/src/Stack/Stack.js
@@ -98,7 +98,13 @@ export const style = ({ styleProps, theme }) => {
   return styles;
 };
 
-const StackRoot = styled('div', { name: 'Stack' })(style);
+const StackRoot = styled('div', {
+  name: 'MuiStack',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    return [styles.root];
+  },
+})(style);
 
 const Stack = React.forwardRef(function Stack(inProps, ref) {
   const themeProps = useThemeProps({ props: inProps, name: 'MuiStack' });


### PR DESCRIPTION
I have first noticed how we were using `Stack` instead of `MuiStack` for the name by chance. Then, I realized we could close #27498 at the same time.