### PR TITLE
[docs] Fix outdated styled-engine docs

### DIFF
--- a/packages/material-ui-icons/README.md
+++ b/packages/material-ui-icons/README.md
@@ -29,5 +29,7 @@ yarn add @material-ui/core@next
 
 ## Documentation
 
-- [The documentation](https://material-ui.com/components/icons/#svg-material-icons)
-- [The icons search](https://material-ui.com/components/material-icons/)
+<!-- #default-branch-switch -->
+
+- [The documentation](https://next.material-ui.com/components/icons/#svg-material-icons)
+- [The icons search](https://next.material-ui.com/components/material-icons/)

--- a/packages/material-ui-lab/README.md
+++ b/packages/material-ui-lab/README.md
@@ -27,4 +27,6 @@ yarn add @material-ui/core@next
 
 ## Documentation
 
-[The documentation](https://material-ui.com/components/about-the-lab/)
+<!-- #default-branch-switch -->
+
+[The documentation](https://next.material-ui.com/components/about-the-lab/)

--- a/packages/material-ui-styled-engine-sc/README.md
+++ b/packages/material-ui-styled-engine-sc/README.md
@@ -1,23 +1,10 @@
 # @material-ui/styled-engine-sc
 
-This package is a wrapper around the `styled-components` package.
-It is created to be used as alias for the `@material-ui/styled-engine` package, for the developers who would like to use `styled-components` as a styled engine instead of `@emotion/styled`.
+This package is a wrapper around the `styled-components` package implementing the interface of `@material-ui/styled-engine`.
+It's designed for developers who would like to use `styled-components` as the main styled engine instead of `@emotion/styled`.
 
-## Installation
+## Documentation
 
-The installation of the dependency in your package is slightly different from the usual.
-You need to alias the default `emotion` implementation to the `styled-components` one.
-Depending on the bundler you are using, you made add it like this:
+<!-- #default-branch-switch -->
 
-### webpack
-
-```js
-module.exports = {
-  //...
-  resolve: {
-    alias: {
-      '@material-ui/styled-engine': '@material-ui/styled-engine-sc',
-    },
-  },
-};
-```
+[The documentation](https://next.material-ui.com/guides/styled-engine/)

--- a/packages/material-ui-styled-engine-sc/package.json
+++ b/packages/material-ui-styled-engine-sc/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mui-org/material-ui.git",
-    "directory": "packages/material-ui-styled"
+    "directory": "packages/material-ui-styled-engine-sc"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-styled-engine/README.md
+++ b/packages/material-ui-styled-engine/README.md
@@ -1,5 +1,11 @@
 # @material-ui/styled-engine
 
 This package is a wrapper around the `@emotion/react` package.
-It is used internally in the `@material-ui/core` package.
-If you wish to use `styled-components` instead please use an alias to replace this package with `@material-ui/styled-engine-sc`.
+It also provides a shared interface that can be used with other styled engines, like styled-components.
+It is used internally in the `@material-ui/system` package.
+
+## Documentation
+
+<!-- #default-branch-switch -->
+
+[The documentation](https://next.material-ui.com/guides/styled-engine/)

--- a/packages/material-ui-styled-engine/package.json
+++ b/packages/material-ui-styled-engine/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mui-org/material-ui.git",
-    "directory": "packages/material-ui-styled"
+    "directory": "packages/material-ui-styled-engine"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-system/README.md
+++ b/packages/material-ui-system/README.md
@@ -18,4 +18,6 @@ yarn add @material-ui/system@next @emotion/react @emotion/styled
 
 ## Documentation
 
-[The documentation](https://material-ui.com/system/basics/)
+<!-- #default-branch-switch -->
+
+[The documentation](https://next.material-ui.com/system/basics/)

--- a/packages/material-ui-unstyled/README.md
+++ b/packages/material-ui-unstyled/README.md
@@ -16,4 +16,6 @@ yarn add @material-ui/unstyled@next
 
 ## Documentation
 
-[The documentation](https://material-ui.com/)
+<!-- #default-branch-switch -->
+
+[The documentation](https://next.material-ui.com/customization/unstyled-components/)


### PR DESCRIPTION
The mention of webpack in the package README is no longer relevant. I noticed this in #27776