### PR TITLE
[styled-engine] Remove unecessary aliases

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -124,8 +124,6 @@ module.exports = {
                         '@material-ui/icons': '../packages/material-ui-icons/lib',
                         '@material-ui/lab': '../packages/material-ui-lab/src',
                         '@material-ui/styled-engine': '../packages/material-ui-styled-engine/src',
-                        '@material-ui/styled-engine-sc':
-                          '../packages/material-ui-styled-engine-sc/src',
                         '@material-ui/styles': '../packages/material-ui-styles/src',
                         '@material-ui/system': '../packages/material-ui-system/src',
                         '@material-ui/private-theming':

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -165,7 +165,6 @@ export function getDependencies(
     '@material-ui/icons': getMuiPackageVersion('icons', muiCommitRef),
     '@material-ui/lab': getMuiPackageVersion('lab', muiCommitRef),
     '@material-ui/styled-engine': getMuiPackageVersion('styled-engine', muiCommitRef),
-    '@material-ui/styled-engine-sc': getMuiPackageVersion('styled-engine-sc', muiCommitRef),
     '@material-ui/styles': getMuiPackageVersion('styles', muiCommitRef),
     '@material-ui/system': getMuiPackageVersion('system', muiCommitRef),
     '@material-ui/private-theming': getMuiPackageVersion('theming', muiCommitRef),

--- a/packages/material-ui/scripts/rollup.config.js
+++ b/packages/material-ui/scripts/rollup.config.js
@@ -105,15 +105,6 @@ const nestedFolder = {
       return resolved;
     }
 
-    if (importee.indexOf('@material-ui/styled-engine-sc/') === 0) {
-      const folder = importee.split('/')[2];
-      const resolved = path.resolve(
-        __dirname,
-        `../../../packages/material-ui-styled-engine-sc/src/${folder}/index.js`,
-      );
-      return resolved;
-    }
-
     if (importee.indexOf('@material-ui/system/') === 0) {
       const folder = importee.split('/')[2];
       const resolved = path.resolve(


### PR DESCRIPTION
I have noticed this in #27776. The value of removing the alias is to fail sooner. I have made one commit for each removal to explain why.