### PR TITLE
[styled-engine] Drop withComponent support

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -6,39 +6,36 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import Link from 'docs/src/modules/components/Link';
 
-const Item = styled('div', {
-  shouldForwardProp:
-    // disable `as` prop
-    () => true,
-})(({ theme }) => {
-  return {
-    ...theme.typography.body2,
-    display: 'flex',
-    borderRadius: theme.shape.borderRadius,
-    outline: 0,
-    width: '100%',
-    paddingTop: 8,
-    paddingBottom: 8,
-    justifyContent: 'flex-start',
-    fontWeight: theme.typography.fontWeightMedium,
-    transition: theme.transitions.create(['color', 'background-color'], {
-      duration: theme.transitions.duration.shortest,
-    }),
-    '&:hover': {
-      color: theme.palette.text.primary,
-      backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.hoverOpacity),
-    },
-    '&.Mui-focusVisible': {
-      backgroundColor: theme.palette.action.focus,
-    },
-    [theme.breakpoints.up('md')]: {
-      paddingTop: 6,
-      paddingBottom: 6,
-    },
-  };
-});
+const Item = styled(({ component: Component = 'div', ...props }) => <Component {...props} />, {
+  // disable `as` prop
+  shouldForwardProp: () => true,
+})(({ theme }) => ({
+  ...theme.typography.body2,
+  display: 'flex',
+  borderRadius: theme.shape.borderRadius,
+  outline: 0,
+  width: '100%',
+  paddingTop: 8,
+  paddingBottom: 8,
+  justifyContent: 'flex-start',
+  fontWeight: theme.typography.fontWeightMedium,
+  transition: theme.transitions.create(['color', 'background-color'], {
+    duration: theme.transitions.duration.shortest,
+  }),
+  '&:hover': {
+    color: theme.palette.text.primary,
+    backgroundColor: alpha(theme.palette.text.primary, theme.palette.action.hoverOpacity),
+  },
+  '&.Mui-focusVisible': {
+    backgroundColor: theme.palette.action.focus,
+  },
+  [theme.breakpoints.up('md')]: {
+    paddingTop: 6,
+    paddingBottom: 6,
+  },
+}));
 
-const ItemLink = styled(Item.withComponent(Link), {
+const ItemLink = styled(Item, {
   shouldForwardProp: (prop) => prop !== 'depth',
 })(({ depth, theme }) => {
   return {
@@ -78,7 +75,7 @@ const ItemButtonIcon = styled(ArrowRightIcon, {
   };
 });
 
-const ItemButton = styled(Item.withComponent(ButtonBase), {
+const ItemButton = styled(Item, {
   shouldForwardProp: (prop) => prop !== 'depth',
 })(({ depth, theme }) => {
   return {
@@ -120,6 +117,7 @@ export default function AppNavDrawerItem(props) {
     return (
       <StyledLi {...other} depth={depth}>
         <ItemLink
+          component={Link}
           activeClassName="app-drawer-active"
           href={href}
           underline="none"
@@ -136,6 +134,7 @@ export default function AppNavDrawerItem(props) {
   return (
     <StyledLi {...other} depth={depth}>
       <ItemButton
+        component={ButtonBase}
         depth={depth}
         disableRipple
         className={topLevel && 'algolia-lvl0'}

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -77,17 +77,7 @@ export type Overwrapped<T, U> = Pick<T, Extract<keyof T, keyof U>>;
 
 export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
   extends React.FunctionComponent<InnerProps & StyleProps & { theme?: Theme }>,
-    ComponentSelector {
-  /**
-   * @desc this method is type-unsafe
-   */
-  withComponent<NewTag extends keyof JSX.IntrinsicElements>(
-    tag: NewTag,
-  ): StyledComponent<JSX.IntrinsicElements[NewTag], StyleProps, Theme>;
-  withComponent<Tag extends React.JSXElementConstructor<any>>(
-    tag: Tag,
-  ): StyledComponent<PropsOf<Tag>, StyleProps, Theme>;
-}
+    ComponentSelector {}
 
 export interface StyledOptions {
   label?: string;


### PR DESCRIPTION
### Breaking changes

- [styled-engine] Drop withComponent support (`#27780`) @oliviertassinari
  Use the `as` prop instead. It's not style destructive when using multiple layers of styled() calls.

---

Why?

1. styled-components talks about removing it

<img width="969" alt="Capture d’écran 2021-08-15 à 19 11 05" src="https://user-images.githubusercontent.com/3165635/129486609-d73d6420-6fd5-4581-95bf-74196272fdc5.png">

https://styled-components.com/docs/api#withcomponent

2. goober doesn't support it

<img width="556" alt="Capture d’écran 2021-08-15 à 19 11 40" src="https://user-images.githubusercontent.com/3165635/129486623-4fd7e884-e500-486f-b673-e8cb4950b809.png">

https://goober.js.org/

3. We almost never use it in the codebase, the smaller the API surface, the easier we can make changes.

I have noticed this in #27776.