### PR TITLE
[docs] Prefer linking API source TypeScript

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -214,6 +214,9 @@ function ApiDocs(props) {
     // convert things like `/Table/Table.js` to ``
     .replace(/\/([^/]+)\/\1\.(js|tsx)$/, '');
 
+  // Prefer linking the .tsx or .d.ts for the "Edit this page" link.
+  const apiSourceLocation = filename.replace('.js', '.d.ts');
+
   function createTocEntry(sectionName) {
     return {
       text: getTranslatedHeader(t, sectionName),
@@ -263,7 +266,7 @@ function ApiDocs(props) {
       description={description}
       disableAd={false}
       disableToc={false}
-      location={filename}
+      location={apiSourceLocation}
       title={`${componentName} API – Material-UI`}
       toc={toc}
     >


### PR DESCRIPTION
This is based on feedback that @mbrookes left on the new docs UI in the Figma file where he was concerned about the usefulness of the button. When clicking on the "Edit this page" link in https://next.material-ui.com/api/alert/.

It seems more relevant to link the TypeScript definitions than the JavaScript file. I'm not 100% sure it's better, but it seems to be a change worth considering.