### PR TITLE
[docs] Move TypeScript docs in context

### DIFF
--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -158,12 +158,12 @@ function GenericCustomComponent<C extends React.ElementType>(
 If the `GenericCustomComponent` will be used with a `component` prop provided, it should also have all props required by the provided component.
 
 ```ts
-function ThirdPartyComponent({ prop1 } : { prop1: string }) {
-  return <div />
+function ThirdPartyComponent({ prop1 }: { prop1: string }) {
+  return <div />;
 }
 // ...
-function ThirdPartyComponent({ prop1 } : { prop1: string }) {
-  return <div />
+function ThirdPartyComponent({ prop1 }: { prop1: string }) {
+  return <div />;
 }
 // ...
 ```

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -4,18 +4,14 @@
 
 ## Wrapping components
 
-In order to provide the maximum flexibility and performance,
-we need a way to know the nature of the child elements a component receives.
-To solve this problem, we tag some of the components
-with a `muiName` static property when needed.
+To provide maximum flexibility and performance, Material-UI needs a way to know the nature of the child elements a component receives.
+To solve this problem, we tag some of the components with a `muiName` static property when needed.
 
-You may, however, need to wrap a component in order to enhance it,
-which can conflict with the `muiName` solution. If you wrap a component, verify if
-that component has this static property set.
+You may, however, need to wrap a component in order to enhance it, which can conflict with the `muiName` solution.
+If you wrap a component, verify if that component has this static property set.
 
-If you encounter this issue, you need to use the same tag for your wrapping component
-that is used with the wrapped component. In addition, you should forward the props,
-as the parent component may need to control the wrapped components props.
+If you encounter this issue, you need to use the same tag for your wrapping component that is used with the wrapped component.
+In addition, you should forward the props, as the parent component may need to control the wrapped components props.
 
 Let's see an example:
 
@@ -129,7 +125,54 @@ The component providing the `component` prop (e.g. ListItem) might not forward a
 
 ### With TypeScript
 
-You can find the details in the [TypeScript guide](/guides/typescript/#usage-of-component-prop).
+Many Material-UI components allow you to replace their root node via a `component` prop, this is detailed in the component's API documentation.
+For example, a Button's root node can be replaced with a React Router's Link, and any additional props that are passed to Button, such as `to`, will be spread to the Link component.
+For a code example concerning Button and react-router-dom checkout [these demos](/guides/routing/#component-prop).
+
+To be able to use props of such a Material-UI component on their own, props should be used with type arguments. Otherwise, the `component` prop will not be present in the props of the Material-UI component.
+
+The examples below use `TypographyProps` but the same will work for any component which has props defined with `OverrideProps`.
+
+The following `CustomComponent` component has the same props as the `Typography` component.
+
+```ts
+function CustomComponent(props: TypographyProps<'a', { component: 'a' }>) {
+  /* ... */
+}
+```
+
+Now the `CustomComponent` can be used with a `component` prop which should be set to `'a'`.
+In addition, the `CustomComponent` will have all props of a `<a>` HTML element.
+The other props of the `Typography` component will also be present in props of the `CustomComponent`.
+
+It is possible to have generic `CustomComponent` which will accept any React component, custom, and HTML elements.
+
+```ts
+function GenericCustomComponent<C extends React.ElementType>(
+  props: TypographyProps<C, { component?: C }>,
+) {
+  /* ... */
+}
+```
+
+If the `GenericCustomComponent` will be used with a `component` prop provided, it should also have all props required by the provided component.
+
+```ts
+function ThirdPartyComponent({ prop1 } : { prop1: string }) {
+  return <div />
+}
+// ...
+function ThirdPartyComponent({ prop1 } : { prop1: string }) {
+  return <div />
+}
+// ...
+```
+
+The `prop1` became required for the `GenericCustomComponent` as the `ThirdPartyComponent` has it as a requirement.
+
+Not every component fully supports any component type you pass in.
+If you encounter a component that rejects its `component` props in TypeScript, please open an issue.
+There is an ongoing effort to fix this by making component props generic.
 
 ## Caveat with refs
 
@@ -153,7 +196,7 @@ React in your console similar to:
 > Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
 
 Note that you will still get this warning for `lazy` and `memo` components if their wrapped component can't hold a ref.
-In some instances an additional warning is issued to help with debugging, similar to:
+In some instances, an additional warning is issued to help with debugging, similar to:
 
 > Invalid prop `component` supplied to `ComponentName`. Expected an element type that can hold a ref.
 

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -2,11 +2,11 @@
 
 <p class="description">You can add static typing to JavaScript to improve developer productivity and code quality thanks to TypeScript.</p>
 
-Material-UI requires a minimum version of TypeScript 3.5.
+## Minimum configuration
 
-Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app-with-typescript) example.
+Material-UI requires a minimum version of TypeScript 3.5. Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app-with-typescript) example.
 
-In order for types to work, you have to at least have the following options enabled
+For types to work, you should have at the minimum the following options enabled
 in your `tsconfig.json`:
 
 ```json
@@ -21,58 +21,9 @@ in your `tsconfig.json`:
 ```
 
 The strict mode options are the same that are required for every types package
-published in the `@types/` namespace. Using a less strict `tsconfig.json` or omitting some of the libraries might cause errors. To get the best type experience with the types we recommend
-setting `"strict": true`.
-
-## Customization of `Theme`
-
-Moved to [/customization/theming/#custom-variables](/customization/theming/#custom-variables).
-
-## Usage of `component` prop
-
-Many Material-UI components allow you to replace their root node via a `component`
-prop, this will be detailed in the component's API documentation.
-For example, a Button's root node can be replaced with a React Router's Link, and any additional props that are passed to Button, such as `to`, will be spread to the Link component.
-For a code example concerning Button and react-router-dom checkout [these demos](/guides/routing/#component-prop).
-
-To be able to use props of such a Material-UI component on their own, props should be used with type arguments. Otherwise, the `component` prop will not be present in the props of the Material-UI component.
-
-The examples below use `TypographyProps` but the same will work for any component which has props defined with `OverrideProps`.
-
-The following `CustomComponent` component has the same props as the `Typography` component.
-
-```ts
-function CustomComponent(props: TypographyProps<'a', { component: 'a' }>) {
-  /* ... */
-}
-```
-
-Now the `CustomComponent` can be used with a `component` prop which should be set to `'a'`. In addition, the `CustomComponent` will have all props of a `<a>` HTML element. The other props of the `Typography` component will also be present in props of the `CustomComponent`.
-
-It is possible to have generic `CustomComponent` which will accept any React component, custom and HTML elements.
-
-```ts
-function GenericCustomComponent<C extends React.ElementType>(
-  props: TypographyProps<C, { component?: C }>,
-) {
-  /* ... */
-}
-```
-
-Now if the `GenericCustomComponent` will be used with a `component` prop provided, it should also have all props required by the provided component.
-
-```ts
-function ThirdPartyComponent({ prop1 }: { prop1: string }) {
-  return <div />;
-}
-// ...
-<GenericCustomComponent component={ThirdPartyComponent} prop1="some value" />;
-```
-
-The `prop1` became required for the `GenericCustomComponent` as the `ThirdPartyComponent` has it as a requirement.
-
-Not every component fully supports any component type you pass in. If you encounter a component that rejects its `component` props in TypeScript please open an issue.
-There is an ongoing effort to fix this by making component props generic.
+published in the `@types/` namespace.
+Using a less strict `tsconfig.json` or omitting some of the libraries might cause errors.
+To get the best type experience with the types we recommend setting `"strict": true`.
 
 ## Handling `value` and event handlers
 
@@ -90,3 +41,11 @@ The demos include typed variants that use type casting. It is an acceptable trad
 because the types are all located in a single file and are very basic. You have to decide for yourself
 if the same tradeoff is acceptable for you. The library types are be strict
 by default and loose via opt-in.
+
+## Customization of `Theme`
+
+Moved to [/customization/theming/#custom-variables](/customization/theming/#custom-variables).
+
+## Usage of `component` prop
+
+Moved to [/guides/composition/#with-typescript](/guides/composition/#with-typescript).


### PR DESCRIPTION
The high-level change of this PR is about hosting the content here https://next.material-ui.com/guides/composition/#with-typescript instead of linking it.

It's a continuation of https://github.com/mui-org/material-ui/pull/27417#discussion_r686585397. We can keep the TypeScript page for things that have no better places, and keep the TypeScript coverage of specific features at the same place where we talk about the JavaScript behavior. I think that it could help make the docs clearer by providing more context to the developers, and to make the content easier to discover.

Preview https://deploy-preview-27782--material-ui.netlify.app/guides/typescript/#usage-of-component-prop 