### PR TITLE
[docs] Make API documentation tables horizontally scrollable

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -126,7 +126,6 @@ const Root = styled('div')(({ theme }) => ({
     borderCollapse: 'collapse',
     marginBottom: '16px',
     borderSpacing: 0,
-    overflow: 'hidden',
     '& .prop-name': {
       fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
     },


### PR DESCRIPTION
Removed the CSS property that was hiding overflow.

Fixes #27612 

I have visually confirmed that this fixes the bug in Chrome and Firefox and that other components do not seem to be affected.

Preview: https://deploy-preview-27787--material-ui.netlify.app/api/swipeable-drawer/

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
