### PR TITLE
[docs] Apply the new branding theme and do the AppBar redesign

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -29,6 +29,7 @@ import { LANGUAGES_LABEL } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import PageContext from 'docs/src/modules/components/PageContext';
 import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
+import LanguageIcon from '@material-ui/icons/Translate';
 
 const LOCALES = { zh: 'zh-CN', pt: 'pt-BR', es: 'es-ES' };
 const CROWDIN_ROOT_URL = 'https://translate.material-ui.com/project/material-ui-docs/';
@@ -251,7 +252,16 @@ function AppFrame(props) {
                 data-ga-event-category="header"
                 data-ga-event-action="language"
               >
-                <LanguageSpan>
+                <Box
+                  component={LanguageIcon}
+                  fontSize="medium"
+                  sx={{
+                    display: { xs: 'block', md: 'none' },
+                    color: (theme) =>
+                      theme.palette.mode === 'dark' ? '#FFF' : theme.palette.primary[500],
+                  }}
+                />
+                <LanguageSpan sx={{ display: { xs: 'none', md: 'block' } }}>
                   {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
                 </LanguageSpan>
                 <ArrowDropDownRoundedIcon fontSize="small" color="primary" />

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -79,7 +79,7 @@ function DeferredAppSearch() {
 const RootDiv = styled('div')(({ theme }) => {
   return {
     display: 'flex',
-    backgroundColor: theme.palette.mode === 'dark' && theme.palette.grey[900],
+    background: theme.palette.mode === 'dark' && theme.palette.primaryDark[900],
     // TODO: Should be handled by the main component
     '& #main-content': {
       outline: 0,
@@ -91,7 +91,7 @@ const SkipLink = styled(MuiLink)(({ theme }) => {
   return {
     position: 'fixed',
     padding: theme.spacing(1),
-    backgroundColor: theme.palette.background.paper,
+    background: theme.palette.background.paper,
     transition: theme.transitions.create('top', {
       easing: theme.transitions.easing.easeIn,
       duration: theme.transitions.duration.leavingScreen,
@@ -128,7 +128,7 @@ const StyledAppBar = styled(AppBar, {
     boxShadow: `inset 0px -1px 1px ${
       theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[100]
     }`,
-    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : 'white',
+    background: theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : '#FFF',
     color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
     '& .MuiIconButton-root': {
       border: `1px solid ${
@@ -136,7 +136,7 @@ const StyledAppBar = styled(AppBar, {
       }`,
       borderRadius: theme.shape.borderRadius,
       color: theme.palette.mode === 'dark' ? '#FFF' : theme.palette.primary[500],
-      backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
+      background: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
     },
   };
 });

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -221,6 +221,15 @@ function AppFrame(props) {
 
   const disablePermanent = activePage?.disableDrawer === true || disableDrawer === true;
 
+  const languageButtonProps = {
+    color: 'inherit',
+    onClick: handleLanguageIconClick,
+    'aria-owns': languageMenu ? 'language-menu' : undefined,
+    'aria-haspopup': 'true',
+    'data-ga-event-category': 'header',
+    'data-ga-event-action': 'language',
+  };
+
   return (
     <RootDiv>
       <NextNProgressBar />
@@ -244,28 +253,23 @@ function AppFrame(props) {
           <GrowingDiv />
           <Stack direction="row" gap={2.5}>
             <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
-              <Button
-                color="inherit"
-                aria-owns={languageMenu ? 'language-menu' : undefined}
-                aria-haspopup="true"
-                onClick={handleLanguageIconClick}
-                data-ga-event-category="header"
-                data-ga-event-action="language"
-              >
-                <Box
-                  component={LanguageIcon}
-                  fontSize="medium"
-                  sx={{
-                    display: { xs: 'block', md: 'none' },
-                    color: (theme) =>
-                      theme.palette.mode === 'dark' ? '#FFF' : theme.palette.primary[500],
-                  }}
-                />
+              <Button {...languageButtonProps} sx={{ display: { xs: 'none', md: 'flex' } }}>
                 <LanguageSpan sx={{ display: { xs: 'none', md: 'block' } }}>
                   {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
                 </LanguageSpan>
                 <ArrowDropDownRoundedIcon fontSize="small" color="primary" />
               </Button>
+            </Tooltip>
+            <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
+              <IconButton
+                {...languageButtonProps}
+                sx={{
+                  display: { xs: 'flex', md: 'none' },
+                  px: '10px',
+                }}
+              >
+                <LanguageIcon fontSize="small" />
+              </IconButton>
             </Tooltip>
             <NoSsr defer>
               <Menu

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
-import { styled } from '@material-ui/core/styles';
+import { styled, alpha } from '@material-ui/core/styles';
 import NProgress from 'nprogress';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import MuiLink from '@material-ui/core/Link';
 import AppBar from '@material-ui/core/AppBar';
+import Stack from '@material-ui/core/Stack';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
@@ -13,12 +14,11 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 import NoSsr from '@material-ui/core/NoSsr';
-import LanguageIcon from '@material-ui/icons/Translate';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
-import SettingsIcon from '@material-ui/icons/Settings';
+import SettingsIcon from '@material-ui/icons/SettingsOutlined';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import NProgressBar from '@material-ui/docs/NProgressBar';
 import AppNavDrawer from 'docs/src/modules/components/AppNavDrawer';
@@ -125,6 +125,20 @@ const StyledAppBar = styled(AppBar, {
         width: 'calc(100% - 240px)',
       },
     }),
+    boxShadow: `inset 0px -1px 1px ${
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[100]
+    }`,
+    backgroundColor:
+      theme.palette.mode === 'dark'
+        ? theme.palette.primaryDark[900]
+        : 'white',
+    color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
+    '& .MuiIconButton-root': {
+      border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'}`,
+      borderRadius: theme.shape.borderRadius,
+      color: theme.palette.mode === 'dark' ? '#FFF' : theme.palette.primary[500],
+      backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
+    }
   };
 });
 
@@ -134,7 +148,6 @@ const GrowingDiv = styled('div')({
 
 const LanguageSpan = styled('span')(({ theme }) => {
   return {
-    margin: theme.spacing(0, 0.5, 0, 1),
     display: 'none',
     [theme.breakpoints.up('md')]: {
       display: 'block',
@@ -228,7 +241,7 @@ function AppFrame(props) {
             <MenuIcon />
           </NavIconButton>
           <GrowingDiv />
-          <DeferredAppSearch />
+          <Stack direction="rot" gap={2}>
           <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
             <Button
               color="inherit"
@@ -238,7 +251,6 @@ function AppFrame(props) {
               data-ga-event-category="header"
               data-ga-event-action="language"
             >
-              <LanguageIcon />
               <LanguageSpan>
                 {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
               </LanguageSpan>
@@ -288,12 +300,7 @@ function AppFrame(props) {
               </MenuItem>
             </Menu>
           </NoSsr>
-          <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-            <IconButton color="inherit" size="large" onClick={handleSettingsDrawerOpen}>
-              <SettingsIcon />
-            </IconButton>
-          </Tooltip>
-          <Notifications />
+          <DeferredAppSearch />
           <Tooltip title={t('appFrame.github')} enterDelay={300}>
             <IconButton
               component="a"
@@ -301,11 +308,17 @@ function AppFrame(props) {
               href={process.env.SOURCE_CODE_REPO}
               data-ga-event-category="header"
               data-ga-event-action="github"
-              size="large"
             >
               <GitHubIcon />
             </IconButton>
           </Tooltip>
+          <Notifications />
+          <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
+            <IconButton color="inherit" onClick={handleSettingsDrawerOpen}>
+              <SettingsIcon />
+            </IconButton>
+          </Tooltip>
+          </Stack>
         </Toolbar>
       </StyledAppBar>
       <StyledAppNavDrawer

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -14,7 +14,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 import NoSsr from '@material-ui/core/NoSsr';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ArrowDropDownRoundedIcon from '@material-ui/icons/ArrowDropDownRounded';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
@@ -116,6 +116,7 @@ const StyledAppBar = styled(AppBar, {
   shouldForwardProp: (prop) => prop !== 'disablePermanent',
 })(({ disablePermanent, theme }) => {
   return {
+    padding: 2,
     transition: theme.transitions.create('width'),
     ...(disablePermanent && {
       boxShadow: 'none',
@@ -132,11 +133,11 @@ const StyledAppBar = styled(AppBar, {
     color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
     '& .MuiIconButton-root': {
       border: `1px solid ${
-        theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'
+        theme.palette.mode === 'dark' ? theme.palette.primaryDark[600] : theme.palette.grey[200]
       }`,
       borderRadius: theme.shape.borderRadius,
       color: theme.palette.mode === 'dark' ? '#FFF' : theme.palette.primary[500],
-      background: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
+      background: theme.palette.mode === 'dark' ? theme.palette.primaryDark[800] : '#FFF',
     },
   };
 });
@@ -230,7 +231,7 @@ function AppFrame(props) {
       <StyledAppBar disablePermanent={disablePermanent}>
         <Toolbar>
           <NavIconButton
-            size="large"
+            fontSize="small"
             edge="start"
             color="inherit"
             aria-label={t('appFrame.openDrawer')}
@@ -240,7 +241,7 @@ function AppFrame(props) {
             <MenuIcon />
           </NavIconButton>
           <GrowingDiv />
-          <Stack direction="row" gap={2}>
+          <Stack direction="row" gap={2.5}>
             <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
               <Button
                 color="inherit"
@@ -253,7 +254,7 @@ function AppFrame(props) {
                 <LanguageSpan>
                   {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
                 </LanguageSpan>
-                <ExpandMoreIcon fontSize="small" />
+                <ArrowDropDownRoundedIcon fontSize="small" color="primary"/>
               </Button>
             </Tooltip>
             <NoSsr defer>
@@ -308,13 +309,13 @@ function AppFrame(props) {
                 data-ga-event-category="header"
                 data-ga-event-action="github"
               >
-                <GitHubIcon />
+                <GitHubIcon fontSize="small" />
               </IconButton>
             </Tooltip>
             <Notifications />
             <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
               <IconButton color="inherit" onClick={handleSettingsDrawerOpen}>
-                <SettingsIcon />
+                <SettingsIcon fontSize="small" />
               </IconButton>
             </Tooltip>
           </Stack>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -241,7 +241,7 @@ function AppFrame(props) {
             <MenuIcon />
           </NavIconButton>
           <GrowingDiv />
-          <Stack direction="rot" gap={2}>
+          <Stack direction="row" gap={2}>
           <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
             <Button
               color="inherit"

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
-import { styled, alpha } from '@material-ui/core/styles';
+import { styled } from '@material-ui/core/styles';
 import NProgress from 'nprogress';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import MuiLink from '@material-ui/core/Link';
@@ -128,17 +128,16 @@ const StyledAppBar = styled(AppBar, {
     boxShadow: `inset 0px -1px 1px ${
       theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[100]
     }`,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? theme.palette.primaryDark[900]
-        : 'white',
+    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : 'white',
     color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
     '& .MuiIconButton-root': {
-      border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'}`,
+      border: `1px solid ${
+        theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'
+      }`,
       borderRadius: theme.shape.borderRadius,
       color: theme.palette.mode === 'dark' ? '#FFF' : theme.palette.primary[500],
       backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
-    }
+    },
   };
 });
 
@@ -242,82 +241,82 @@ function AppFrame(props) {
           </NavIconButton>
           <GrowingDiv />
           <Stack direction="row" gap={2}>
-          <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
-            <Button
-              color="inherit"
-              aria-owns={languageMenu ? 'language-menu' : undefined}
-              aria-haspopup="true"
-              onClick={handleLanguageIconClick}
-              data-ga-event-category="header"
-              data-ga-event-action="language"
-            >
-              <LanguageSpan>
-                {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
-              </LanguageSpan>
-              <ExpandMoreIcon fontSize="small" />
-            </Button>
-          </Tooltip>
-          <NoSsr defer>
-            <Menu
-              id="language-menu"
-              anchorEl={languageMenu}
-              open={Boolean(languageMenu)}
-              onClose={handleLanguageMenuClose}
-            >
-              {LANGUAGES_LABEL.map((language) => (
+            <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
+              <Button
+                color="inherit"
+                aria-owns={languageMenu ? 'language-menu' : undefined}
+                aria-haspopup="true"
+                onClick={handleLanguageIconClick}
+                data-ga-event-category="header"
+                data-ga-event-action="language"
+              >
+                <LanguageSpan>
+                  {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
+                </LanguageSpan>
+                <ExpandMoreIcon fontSize="small" />
+              </Button>
+            </Tooltip>
+            <NoSsr defer>
+              <Menu
+                id="language-menu"
+                anchorEl={languageMenu}
+                open={Boolean(languageMenu)}
+                onClose={handleLanguageMenuClose}
+              >
+                {LANGUAGES_LABEL.map((language) => (
+                  <MenuItem
+                    component="a"
+                    data-no-link="true"
+                    href={language.code === 'en' ? canonical : `/${language.code}${canonical}`}
+                    key={language.code}
+                    selected={userLanguage === language.code}
+                    onClick={handleLanguageMenuClose}
+                    lang={language.code}
+                    hrefLang={language.code}
+                  >
+                    {language.text}
+                  </MenuItem>
+                ))}
+                <Box sx={{ my: 1 }}>
+                  <Divider />
+                </Box>
                 <MenuItem
                   component="a"
                   data-no-link="true"
-                  href={language.code === 'en' ? canonical : `/${language.code}${canonical}`}
-                  key={language.code}
-                  selected={userLanguage === language.code}
+                  href={
+                    userLanguage === 'en'
+                      ? `${CROWDIN_ROOT_URL}`
+                      : `${CROWDIN_ROOT_URL}${crowdInLocale}#/staging`
+                  }
+                  rel="noopener nofollow"
+                  target="_blank"
+                  key={userLanguage}
+                  lang={userLanguage}
+                  hrefLang="en"
                   onClick={handleLanguageMenuClose}
-                  lang={language.code}
-                  hrefLang={language.code}
                 >
-                  {language.text}
+                  {t('appFrame.helpToTranslate')}
                 </MenuItem>
-              ))}
-              <Box sx={{ my: 1 }}>
-                <Divider />
-              </Box>
-              <MenuItem
+              </Menu>
+            </NoSsr>
+            <DeferredAppSearch />
+            <Tooltip title={t('appFrame.github')} enterDelay={300}>
+              <IconButton
                 component="a"
-                data-no-link="true"
-                href={
-                  userLanguage === 'en'
-                    ? `${CROWDIN_ROOT_URL}`
-                    : `${CROWDIN_ROOT_URL}${crowdInLocale}#/staging`
-                }
-                rel="noopener nofollow"
-                target="_blank"
-                key={userLanguage}
-                lang={userLanguage}
-                hrefLang="en"
-                onClick={handleLanguageMenuClose}
+                color="inherit"
+                href={process.env.SOURCE_CODE_REPO}
+                data-ga-event-category="header"
+                data-ga-event-action="github"
               >
-                {t('appFrame.helpToTranslate')}
-              </MenuItem>
-            </Menu>
-          </NoSsr>
-          <DeferredAppSearch />
-          <Tooltip title={t('appFrame.github')} enterDelay={300}>
-            <IconButton
-              component="a"
-              color="inherit"
-              href={process.env.SOURCE_CODE_REPO}
-              data-ga-event-category="header"
-              data-ga-event-action="github"
-            >
-              <GitHubIcon />
-            </IconButton>
-          </Tooltip>
-          <Notifications />
-          <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-            <IconButton color="inherit" onClick={handleSettingsDrawerOpen}>
-              <SettingsIcon />
-            </IconButton>
-          </Tooltip>
+                <GitHubIcon />
+              </IconButton>
+            </Tooltip>
+            <Notifications />
+            <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
+              <IconButton color="inherit" onClick={handleSettingsDrawerOpen}>
+                <SettingsIcon />
+              </IconButton>
+            </Tooltip>
           </Stack>
         </Toolbar>
       </StyledAppBar>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -254,7 +254,7 @@ function AppFrame(props) {
                 <LanguageSpan>
                   {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
                 </LanguageSpan>
-                <ArrowDropDownRoundedIcon fontSize="small" color="primary"/>
+                <ArrowDropDownRoundedIcon fontSize="small" color="primary" />
               </Button>
             </Tooltip>
             <NoSsr defer>
@@ -308,13 +308,14 @@ function AppFrame(props) {
                 href={process.env.SOURCE_CODE_REPO}
                 data-ga-event-category="header"
                 data-ga-event-action="github"
+                sx={{ px: '10px' }}
               >
                 <GitHubIcon fontSize="small" />
               </IconButton>
             </Tooltip>
             <Notifications />
             <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-              <IconButton color="inherit" onClick={handleSettingsDrawerOpen}>
+              <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
                 <SettingsIcon fontSize="small" />
               </IconButton>
             </Tooltip>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -213,6 +213,10 @@ function AppNavDrawer(props) {
           PaperProps={{
             className: 'algolia-drawer',
             component: SwipeableDrawerPaperComponent,
+            sx: {
+              background: (theme) =>
+                theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : '#FFF',
+            },
           }}
         >
           <PersistScroll slot="swipeable" enabled={mobileOpen}>
@@ -226,6 +230,10 @@ function AppNavDrawer(props) {
           PaperProps={{
             component: SwipeableDrawerPaperComponent,
             elevation: 2,
+            sx: {
+              background: (theme) =>
+                theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : '#FFF',
+            },
           }}
           open
         >

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -99,12 +99,18 @@ const RootDiv = styled('div')(({ theme }) => {
     },
     fontFamily: theme.typography.fontFamily,
     position: 'relative',
-    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[50],
+    backgroundColor:
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[50],
     '&:hover': {
-      backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : alpha(theme.palette.common.white, 0.25),
+      backgroundColor:
+        theme.palette.mode === 'dark'
+          ? theme.palette.primaryDark[700]
+          : alpha(theme.palette.common.white, 0.25),
     },
     color: theme.palette.mode === 'dark' ? 'white' : theme.palette.grey[800],
-    border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'}`,
+    border: `1px solid ${
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'
+    }`,
     borderRadius: 10,
   };
 });
@@ -126,7 +132,7 @@ const Shortcut = styled('div')(({ theme }) => {
     fontSize: theme.typography.pxToRem(13),
     lineHeight: '21px',
     border: `1px solid #D7DCE1`,
-    backgroundColor:  theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
+    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
     padding: theme.spacing(0, 0.5),
     position: 'absolute',
     right: theme.spacing(1),

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -103,9 +103,7 @@ const RootDiv = styled('div')(({ theme }) => {
       theme.palette.mode === 'dark' ? theme.palette.primaryDark[800] : theme.palette.grey[50],
     '&:hover': {
       backgroundColor:
-        theme.palette.mode === 'dark'
-          ? theme.palette.primaryDark[700]
-          : theme.palette.grey[100],
+        theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[100],
     },
     color: theme.palette.mode === 'dark' ? 'white' : theme.palette.grey[900],
     border: `1px solid ${
@@ -124,14 +122,14 @@ const SearchDiv = styled('div')(({ theme }) => {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    color: theme.palette.grey[700]
+    color: theme.palette.grey[700],
   };
 });
 
 const Shortcut = styled('div')(({ theme }) => {
   return {
     fontSize: theme.typography.pxToRem(13),
-    fontWeight: 600, 
+    fontWeight: 600,
     color: theme.palette.mode === 'dark' ? theme.palette.grey[200] : theme.palette.grey[700],
     lineHeight: '21px',
     border: `1px solid ${
@@ -270,7 +268,13 @@ export default function AppSearch() {
   return (
     <RootDiv>
       <SearchDiv>
-        <SearchIcon fontSize="small" sx={{color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.primary[500],}}/>
+        <SearchIcon
+          fontSize="small"
+          sx={{
+            color:
+              theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.primary[500],
+          }}
+        />
       </SearchDiv>
       <AlgoliaStyles />
       <StyledInput

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -13,7 +13,7 @@ import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 const StyledInput = styled(Input)(({ theme }) => {
   const placeholder = {
     color: theme.palette.mode === 'dark' ? 'white' : 'black',
-  }
+  };
   return {
     color: 'inherit',
     '& input': {
@@ -29,7 +29,8 @@ const StyledInput = styled(Input)(({ theme }) => {
       '&:-ms-input-placeholder': placeholder, // IE11
       '&::-ms-input-placeholder': placeholder, // Edge
     },
-}});
+  };
+});
 
 function AlgoliaStyles() {
   return (

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -14,9 +14,9 @@ const StyledInput = styled(Input)(({ theme }) => ({
   color: 'inherit',
   '& input': {
     padding: theme.spacing(1),
-    paddingLeft: theme.spacing(9),
+    paddingLeft: theme.spacing(6),
     transition: theme.transitions.create('width'),
-    width: 140,
+    width: 150,
     '&:focus': {
       width: 170,
     },
@@ -100,16 +100,16 @@ const RootDiv = styled('div')(({ theme }) => {
     fontFamily: theme.typography.fontFamily,
     position: 'relative',
     backgroundColor:
-      theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[50],
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[800] : theme.palette.grey[50],
     '&:hover': {
       backgroundColor:
         theme.palette.mode === 'dark'
           ? theme.palette.primaryDark[700]
-          : alpha(theme.palette.common.white, 0.25),
+          : theme.palette.grey[100],
     },
-    color: theme.palette.mode === 'dark' ? 'white' : theme.palette.grey[800],
+    color: theme.palette.mode === 'dark' ? 'white' : theme.palette.grey[900],
     border: `1px solid ${
-      theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[600] : theme.palette.grey[200]
     }`,
     borderRadius: 10,
   };
@@ -117,28 +117,33 @@ const RootDiv = styled('div')(({ theme }) => {
 
 const SearchDiv = styled('div')(({ theme }) => {
   return {
-    width: theme.spacing(9),
+    width: theme.spacing(6),
     height: '100%',
     position: 'absolute',
     pointerEvents: 'none',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+    color: theme.palette.grey[700]
   };
 });
 
 const Shortcut = styled('div')(({ theme }) => {
   return {
     fontSize: theme.typography.pxToRem(13),
+    fontWeight: 600, 
+    color: theme.palette.mode === 'dark' ? theme.palette.grey[200] : theme.palette.grey[700],
     lineHeight: '21px',
-    border: `1px solid #D7DCE1`,
+    border: `1px solid ${
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[400] : theme.palette.grey[200]
+    }`,
     backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
-    padding: theme.spacing(0, 0.5),
+    padding: theme.spacing(0, 1),
     position: 'absolute',
     right: theme.spacing(1),
     height: 23,
     top: 'calc(50% - 11px)',
-    borderRadius: 4,
+    borderRadius: 5,
     transition: theme.transitions.create('opacity', {
       duration: theme.transitions.duration.shortest,
     }),
@@ -265,7 +270,7 @@ export default function AppSearch() {
   return (
     <RootDiv>
       <SearchDiv>
-        <SearchIcon />
+        <SearchIcon fontSize="small" sx={{color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.primary[500],}}/>
       </SearchDiv>
       <AlgoliaStyles />
       <StyledInput

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -99,13 +99,13 @@ const RootDiv = styled('div')(({ theme }) => {
     },
     fontFamily: theme.typography.fontFamily,
     position: 'relative',
-    marginRight: theme.spacing(2),
-    marginLeft: theme.spacing(1),
-    borderRadius: theme.shape.borderRadius,
-    backgroundColor: alpha(theme.palette.common.white, 0.15),
+    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[50],
     '&:hover': {
-      backgroundColor: alpha(theme.palette.common.white, 0.25),
+      backgroundColor: theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : alpha(theme.palette.common.white, 0.25),
     },
+    color: theme.palette.mode === 'dark' ? 'white' : theme.palette.grey[800],
+    border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : '#E5E8EC'}`,
+    borderRadius: 10,
   };
 });
 
@@ -125,15 +125,14 @@ const Shortcut = styled('div')(({ theme }) => {
   return {
     fontSize: theme.typography.pxToRem(13),
     lineHeight: '21px',
-    color: alpha(theme.palette.common.white, 0.8),
-    border: `1px solid ${alpha(theme.palette.common.white, 0.4)}`,
-    backgroundColor: alpha(theme.palette.common.white, 0.1),
+    border: `1px solid #D7DCE1`,
+    backgroundColor:  theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : '#FFF',
     padding: theme.spacing(0, 0.5),
     position: 'absolute',
     right: theme.spacing(1),
     height: 23,
     top: 'calc(50% - 11px)',
-    borderRadius: theme.shape.borderRadius,
+    borderRadius: 4,
     transition: theme.transitions.create('opacity', {
       duration: theme.transitions.duration.shortest,
     }),

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { alpha, styled, useTheme } from '@material-ui/core/styles';
+import { styled, useTheme } from '@material-ui/core/styles';
 import GlobalStyles from '@material-ui/core/GlobalStyles';
 import Input from '@material-ui/core/Input';
 import SearchIcon from '@material-ui/icons/Search';
@@ -10,18 +10,26 @@ import docsearch from 'docsearch.js';
 import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 
-const StyledInput = styled(Input)(({ theme }) => ({
-  color: 'inherit',
-  '& input': {
-    padding: theme.spacing(1),
-    paddingLeft: theme.spacing(6),
-    transition: theme.transitions.create('width'),
-    width: 150,
-    '&:focus': {
-      width: 170,
+const StyledInput = styled(Input)(({ theme }) => {
+  const placeholder = {
+    color: theme.palette.mode === 'dark' ? 'white' : 'black',
+  }
+  return {
+    color: 'inherit',
+    '& input': {
+      padding: theme.spacing(1),
+      paddingLeft: theme.spacing(6),
+      transition: theme.transitions.create('width'),
+      width: 150,
+      '&:focus': {
+        width: 170,
+      },
+      '&::-webkit-input-placeholder': placeholder,
+      '&::-moz-placeholder': placeholder, // Firefox 19+
+      '&:-ms-input-placeholder': placeholder, // IE11
+      '&::-ms-input-placeholder': placeholder, // Edge
     },
-  },
-}));
+}});
 
 function AlgoliaStyles() {
   return (

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -11,7 +11,7 @@ import ToggleButtonGroup from '@material-ui/core/ToggleButtonGroup';
 import ToggleButton from '@material-ui/core/ToggleButton';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
-import Brightness4Icon from '@material-ui/icons/Brightness4';
+import Brightness2RoundedIcon from '@material-ui/icons/Brightness2Rounded';
 import Brightness7Icon from '@material-ui/icons/Brightness7';
 import SettingsBrightnessIcon from '@material-ui/icons/SettingsBrightness';
 import FormatTextdirectionLToRIcon from '@material-ui/icons/FormatTextdirectionLToR';
@@ -22,11 +22,11 @@ import { useChangeTheme } from 'docs/src/modules/components/ThemeContext';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 
 const DrawerPaper = styled(Paper)({
-  width: 352,
+  width: 360,
 });
 
 const Heading = styled(Typography)({
-  margin: '16px 0 8px',
+  margin: '20px 0 10px',
 });
 
 const IconToggleButton = styled(ToggleButton)({
@@ -80,9 +80,9 @@ function AppSettingsDrawer(props) {
       {...other}
     >
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 2 }}>
-        <Typography variant="h5">{t('settings.settings')}</Typography>
+        <Typography variant="h6">{t('settings.settings')}</Typography>
         <IconButton color="inherit" onClick={onClose} edge="end">
-          <CloseIcon />
+          <CloseIcon color="primary" fontSize="small" />
         </IconButton>
       </Box>
       <Divider />
@@ -104,7 +104,7 @@ function AppSettingsDrawer(props) {
             data-ga-event-category="settings"
             data-ga-event-action="light"
           >
-            <Brightness7Icon />
+            <Brightness7Icon fontSize="small" />
             {t('settings.light')}
           </IconToggleButton>
           <IconToggleButton
@@ -113,7 +113,7 @@ function AppSettingsDrawer(props) {
             data-ga-event-category="settings"
             data-ga-event-action="system"
           >
-            <SettingsBrightnessIcon />
+            <SettingsBrightnessIcon fontSize="small" />
             {t('settings.system')}
           </IconToggleButton>
           <IconToggleButton
@@ -122,7 +122,7 @@ function AppSettingsDrawer(props) {
             data-ga-event-category="settings"
             data-ga-event-action="dark"
           >
-            <Brightness4Icon />
+            <Brightness2RoundedIcon fontSize="small" />
             {t('settings.dark')}
           </IconToggleButton>
         </ToggleButtonGroup>

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -119,6 +119,7 @@ DemoFrame.propTypes = {
 
 // Use the default MUI theme for the demos
 const theme = createTheme();
+const darkModeTheme = createTheme({ palette: { mode: 'dark' } });
 
 /**
  * Isolates the demo component as best as possible. Additional props are spread
@@ -134,7 +135,7 @@ function DemoSandboxed(props) {
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
       <Sandbox {...sandboxProps}>
-        <ThemeProvider theme={theme}>
+        <ThemeProvider theme={outerTheme => outerTheme?.palette?.mode === 'dark' ? darkModeTheme : theme}>
           <Component />
         </ThemeProvider>
       </Sandbox>

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -135,7 +135,9 @@ function DemoSandboxed(props) {
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
       <Sandbox {...sandboxProps}>
-        <ThemeProvider theme={outerTheme => outerTheme?.palette?.mode === 'dark' ? darkModeTheme : theme}>
+        <ThemeProvider
+          theme={(outerTheme) => (outerTheme?.palette?.mode === 'dark' ? darkModeTheme : theme)}
+        >
           <Component />
         </ThemeProvider>
       </Sandbox>

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -8,11 +8,10 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { StyleSheetManager } from 'styled-components';
 import { jssPreset, StylesProvider } from '@material-ui/styles';
-import { useTheme, styled } from '@material-ui/core/styles';
+import { useTheme, styled, createTheme, ThemeProvider } from '@material-ui/core/styles';
 import rtl from 'jss-rtl';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
-import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
 function FramedDemo(props) {
   const { children, document } = props;

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -12,6 +12,7 @@ import { useTheme, styled } from '@material-ui/core/styles';
 import rtl from 'jss-rtl';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
 function FramedDemo(props) {
   const { children, document } = props;
@@ -117,6 +118,9 @@ DemoFrame.propTypes = {
   name: PropTypes.string.isRequired,
 };
 
+// Use the default MUI theme for the demos
+const theme = createTheme();
+
 /**
  * Isolates the demo component as best as possible. Additional props are spread
  * to an `iframe` if `iframe={true}`.
@@ -131,7 +135,9 @@ function DemoSandboxed(props) {
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
       <Sandbox {...sandboxProps}>
-        <Component />
+        <ThemeProvider theme={theme}>
+          <Component />
+        </ThemeProvider>
       </Sandbox>
     </DemoErrorBoundary>
   );

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { styled } from '@material-ui/core/styles';
-import NotificationsIcon from '@material-ui/icons/Notifications';
+import NotificationsIcon from '@material-ui/icons/NotificationsNoneOutlined';
 import Tooltip from '@material-ui/core/Tooltip';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import IconButton from '@material-ui/core/IconButton';
@@ -134,7 +134,6 @@ export default function Notifications() {
       >
         <IconButton
           color="inherit"
-          size="large"
           ref={anchorRef}
           aria-controls={open ? 'notifications-popup' : undefined}
           aria-haspopup="true"

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -140,6 +140,7 @@ export default function Notifications() {
           onClick={handleToggle}
           data-ga-event-category="AppBar"
           data-ga-event-action="toggleNotifications"
+          sx={{ px: '10px' }}
         >
           <Badge
             color="error"

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { styled } from '@material-ui/core/styles';
-import NotificationsIcon from '@material-ui/icons/NotificationsNoneOutlined';
+import NotificationsNoneRoundedIcon from '@material-ui/icons/NotificationsNoneRounded';
 import Tooltip from '@material-ui/core/Tooltip';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import IconButton from '@material-ui/core/IconButton';
@@ -152,7 +152,7 @@ export default function Notifications() {
                 : 0
             }
           >
-            <NotificationsIcon />
+            <NotificationsNoneRoundedIcon fontSize="small" />
           </Badge>
         </IconButton>
       </Tooltip>

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -12,6 +12,7 @@ import { unstable_useEnhancedEffect as useEnhancedEffect } from '@material-ui/co
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
+import { getDesignTokens, getThemedComponents } from 'docs/src/modules/brandingTheme';
 
 const languageMap = {
   en: enUS,
@@ -199,15 +200,18 @@ export function ThemeProvider(props) {
   }, [direction]);
 
   const theme = React.useMemo(() => {
-    const nextTheme = createTheme(
+    const brandingDesignTokens = getDesignTokens(paletteMode);
+    let nextTheme = createTheme(
       {
         direction,
+        ...brandingDesignTokens,
         nprogress: {
           color: paletteMode === 'light' ? '#000' : '#fff',
         },
         palette: {
-          mode: paletteMode,
+          ...brandingDesignTokens.palette,
           ...paletteColors,
+          mode: paletteMode,
         },
         spacing,
       },
@@ -223,6 +227,10 @@ export function ThemeProvider(props) {
       },
       languageMap[userLanguage],
     );
+
+    nextTheme = createTheme(nextTheme, {
+      ...getThemedComponents(nextTheme),
+    });
 
     return nextTheme;
   }, [dense, direction, paletteColors, paletteMode, spacing, userLanguage]);


### PR DESCRIPTION
Preview - https://deploy-preview-27789--material-ui.netlify.app/

Changes done in the PR:
- Use the branding theme on all website
- Wrap each demo with `ThemeProvider` with the default theme
- Updated AppBar and SideBar 
- Updated the container background colors to match the new branding colors

Should we fragment the changes and do them step by step? I think these changes are an important foundation to do all other changes. It is important to have the branding theme out here on the docs so that the other changes can use it as well.

----

In a follow up PRs we can do the changes on the:
- Sidebar
- The page legend
- The demos icons
- ....