### PR TITLE
[Tabs] Update indicator position when tab size changes (ResizeObserver)

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "react-router-dom": "^5.2.0",
     "react-test-renderer": "^17.0.1",
     "remark": "^13.0.0",
+    "resize-observer": "^1.0.2",
     "rimraf": "^3.0.0",
     "rollup": "^2.56.2",
     "rollup-plugin-babel": "^4.3.3",

--- a/packages/material-ui-unstyled/src/utils/index.ts
+++ b/packages/material-ui-unstyled/src/utils/index.ts
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 
 export { default as isHostComponent } from './isHostComponent';
+export { default as unstable_useResizeObserver } from './useResizeObserver';

--- a/packages/material-ui-unstyled/src/utils/useResizeObserver.ts
+++ b/packages/material-ui-unstyled/src/utils/useResizeObserver.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+interface Rect {
+  width: number;
+  height: number;
+}
+
+export default function useResizeObserver(
+  resizeItemRef: React.RefObject<Element | null>,
+  resizeHandler?: () => void,
+  observeChildren?: boolean,
+): Rect[] | null {
+  const [items, setItems] = React.useState<Rect[] | null>(null);
+  const resizeObserverRef = React.useRef<ResizeObserver | null>(null);
+  const resizeHandlerRef = React.useRef<() => void>();
+  resizeHandlerRef.current = resizeHandler;
+
+  React.useEffect(() => {
+    resizeObserverRef.current = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+      setItems(entries.map((entry) => entry.contentRect));
+      if (resizeHandlerRef.current) {
+        resizeHandlerRef.current();
+      }
+    });
+    if (resizeItemRef.current) {
+      if (observeChildren) {
+        Array.from(resizeItemRef.current.children).forEach((child) => {
+          resizeObserverRef.current?.observe(child);
+        });
+      } else {
+        resizeObserverRef.current?.observe(resizeItemRef.current);
+      }
+    }
+
+    return () => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+      }
+    };
+  }, [resizeItemRef, observeChildren]);
+  return items;
+}

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -3,12 +3,14 @@ import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { refType } from '@material-ui/utils';
-import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
+import {
+  unstable_composeClasses as composeClasses,
+  unstable_useResizeObserver as useResizeObserver,
+} from '@material-ui/unstyled';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import useTheme from '../styles/useTheme';
 import debounce from '../utils/debounce';
-import ownerWindow from '../utils/ownerWindow';
 import { getNormalizedScrollLeft, detectScrollType } from '../utils/scrollLeft';
 import animate from '../internal/animate';
 import ScrollbarSize from './ScrollbarSize';
@@ -554,19 +556,11 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
     }
   });
 
-  React.useEffect(() => {
-    const handleResize = debounce(() => {
-      updateIndicatorState();
-      updateScrollButtonState();
-    });
-
-    const win = ownerWindow(tabsRef.current);
-    win.addEventListener('resize', handleResize);
-    return () => {
-      handleResize.clear();
-      win.removeEventListener('resize', handleResize);
-    };
-  }, [updateIndicatorState, updateScrollButtonState]);
+  const handleResize = debounce(() => {
+    updateIndicatorState();
+    updateScrollButtonState();
+  });
+  useResizeObserver(tabListRef, handleResize, true);
 
   const handleTabsScroll = React.useMemo(
     () =>

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -11,6 +11,7 @@ import {
 } from 'test/utils';
 import Tab from '@material-ui/core/Tab';
 import Tabs, { tabsClasses as classes } from '@material-ui/core/Tabs';
+import { ResizeObserver } from 'resize-observer';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import capitalize from '../utils/capitalize';
 
@@ -53,7 +54,12 @@ describe('<Tabs />', () => {
     // expect(container.scrollLeft).to.equal(200); 💥
     if (isSafari) {
       this.skip();
+      global.ResizeObserver = ResizeObserver;
     }
+  });
+
+  after(() => {
+    delete global.ResizeObserver;
   });
 
   describeConformanceV5(<Tabs value={0} />, () => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -14353,6 +14353,11 @@ resize-observer-polyfill@^1.5.1:
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
+resize-observer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/resize-observer/-/resize-observer-1.0.2.tgz#9a87697b275343d12d8b371940e02e9a93e1f452"
+  integrity sha512-X0lHFNsxItpBRIRsdwOTkl/VguTaLGx7Gz9xoTGix9ObBN3jRYq9J/rSIuYDrey8AdU3IkfgIMpCeVSEW1QS0Q==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is a continuation of this issue: https://github.com/mui-org/material-ui/issues/9337

Problem: as mentioned in the issue, changing the width of a tab container currently does not update indicator's width. Rather, indicator's width updates only in response to the viewport's resizing. 

Solution: apply ResizeObserver API to the tab containers so that indicator's width updates in response to their resizing.