### PR TITLE
[Timeline] Fix color="inherit" on TimelineDot

### DIFF
--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.js
@@ -41,26 +41,30 @@ const TimelineDotRoot = styled('span', {
   margin: '11.5px 0',
   ...(styleProps.variant === 'filled' && {
     borderColor: 'transparent',
-    ...(styleProps.color === 'grey'
-      ? {
-          color: theme.palette.grey[50],
-          backgroundColor: theme.palette.grey[400],
-        }
-      : {
-          color: theme.palette[styleProps.color].contrastText,
-          backgroundColor: theme.palette[styleProps.color].main,
-        }),
+    ...(styleProps.color !== 'inherit' && {
+      ...(styleProps.color === 'grey'
+        ? {
+            color: theme.palette.grey[50],
+            backgroundColor: theme.palette.grey[400],
+          }
+        : {
+            color: theme.palette[styleProps.color].contrastText,
+            backgroundColor: theme.palette[styleProps.color].main,
+          }),
+    }),
   }),
   ...(styleProps.variant === 'outlined' && {
     boxShadow: 'none',
     backgroundColor: 'transparent',
-    ...(styleProps.color === 'grey'
-      ? {
-          borderColor: theme.palette.grey[400],
-        }
-      : {
-          borderColor: theme.palette[styleProps.color].main,
-        }),
+    ...(styleProps.color !== 'inherit' && {
+      ...(styleProps.color === 'grey'
+        ? {
+            borderColor: theme.palette.grey[400],
+          }
+        : {
+            borderColor: theme.palette[styleProps.color].main,
+          }),
+    }),
   }),
 }));
 

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { createClientRender, describeConformanceV5 } from 'test/utils';
 import TimelineDot, { timelineDotClasses as classes } from '@material-ui/lab/TimelineDot';
 
@@ -14,4 +15,15 @@ describe('<TimelineDot />', () => {
     testVariantProps: { color: 'secondary', variant: 'outlined' },
     skip: ['componentProp', 'componentsProp'],
   }));
+
+  it('should render with color inherit', () => {
+    expect(() =>
+      render(
+        <>
+          <TimelineDot color="inherit" />
+          <TimelineDot variant="outlined" color="inherit" />
+        </>,
+      ),
+    ).not.to.throw();
+  });
 });

--- a/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/material-ui-lab/src/TimelineDot/TimelineDot.test.js
@@ -19,10 +19,10 @@ describe('<TimelineDot />', () => {
   it('should render with color inherit', () => {
     expect(() =>
       render(
-        <>
+        <React.Fragment>
           <TimelineDot color="inherit" />
           <TimelineDot variant="outlined" color="inherit" />
-        </>,
+        </React.Fragment>,
       ),
     ).not.to.throw();
   });


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/27688

Currently when using `color="inherit"` on the `TimelineDot` it crashes. We need to apply the styles for the background/border color on the TimelineDot only if the color is not `inherited`