### PR TITLE
[system] Forward `classes` prop if no slot specified in the options

### DIFF
--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -93,10 +93,17 @@ export default function createStyled(input = {}) {
       className = `${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
     }
 
+    let shouldForwardPropOption = shouldForwardProp;
+
+    if (componentSlot === 'Root') {
+      shouldForwardPropOption = rootShouldForwardProp;
+    } else if (componentSlot) {
+      // any other slot specified
+      shouldForwardPropOption = slotShouldForwardProp;
+    }
+
     const defaultStyledResolver = styledEngineStyled(tag, {
-      ...(!componentSlot || componentSlot === 'Root'
-        ? { shouldForwardProp: rootShouldForwardProp }
-        : { shouldForwardProp: slotShouldForwardProp }),
+      shouldForwardProp: shouldForwardPropOption,
       label: className || componentName || '',
       ...options,
     });

--- a/packages/material-ui/src/styles/styled.test.js
+++ b/packages/material-ui/src/styles/styled.test.js
@@ -595,6 +595,28 @@ describe('styled', () => {
       expect(getByTestId('without-classes').getAttribute('data-with-classes')).to.equal('false');
     });
 
+    it('should propagate classes props to component if no slot is specified', () => {
+      const Component = styled((props) => {
+        const { classes, ...other } = props;
+        return <div data-with-classes={classes !== undefined} {...other} />;
+      })`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { getByTestId } = render(
+        <React.Fragment>
+          <Component data-testid="with-classes" classes={{ root: 'foo' }}>
+            Test
+          </Component>
+          <Component data-testid="without-classes">Test</Component>
+        </React.Fragment>,
+      );
+
+      expect(getByTestId('with-classes').getAttribute('data-with-classes')).to.equal('true');
+      expect(getByTestId('without-classes').getAttribute('data-with-classes')).to.equal('false');
+    });
+
     it('classes props should be correctly applied to root and slot elements', () => {
       const Child = (props) => {
         const { classes = {}, className, ...other } = props;


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/27697

The `rootShouldForwardProps` option is added only if the `slot` option is specified explicitly as `Root`. Otherwise the default shouldForwardProps are being propagated.
