### PR TITLE
[Autocomplete] Rename Value type to AutocompleteValue

### DIFF
--- a/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui/src/useAutocomplete/useAutocomplete.d.ts
@@ -1,16 +1,2 @@
-export {
-  useAutocomplete as default,
-  AutocompleteChangeDetails,
-  AutocompleteChangeReason,
-  AutocompleteCloseReason,
-  AutocompleteFreeSoloValueMapping,
-  AutocompleteGetTagProps,
-  AutocompleteGroupedOption,
-  AutocompleteHighlightChangeReason,
-  AutocompleteInputChangeReason,
-  AutocompleteValue as Value,
-  createFilterOptions,
-  CreateFilterOptionsConfig,
-  FilterOptionsState,
-  UseAutocompleteProps,
-} from '@material-ui/unstyled/AutocompleteUnstyled';
+export { useAutocomplete as default } from '@material-ui/unstyled/AutocompleteUnstyled';
+export * from '@material-ui/unstyled/AutocompleteUnstyled';


### PR DESCRIPTION
The useAutocomplete hook uses a type called `Value`. It's a very generic name for a type specific to the Autocomplete control. This PR renames it to AutocompleteValue.

### Breaking changes

* The type 'Value' exported from @material-ui/core is now named 'AutocompleteValue'