### PR TITLE
[docs] Correct the useAutocomplete import path

### DIFF
--- a/docs/src/pages/components/autocomplete/CustomizedHook.js
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import useAutocomplete from '@material-ui/core/useAutocomplete';
+import { useAutocomplete } from '@material-ui/unstyled/AutocompleteUnstyled';
 import CheckIcon from '@material-ui/icons/Check';
 import CloseIcon from '@material-ui/icons/Close';
 import { styled } from '@material-ui/core/styles';

--- a/docs/src/pages/components/autocomplete/CustomizedHook.tsx
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import useAutocomplete, {
+import {
+  useAutocomplete,
   AutocompleteGetTagProps,
-} from '@material-ui/core/useAutocomplete';
+} from '@material-ui/unstyled/AutocompleteUnstyled';
 import CheckIcon from '@material-ui/icons/Check';
 import CloseIcon from '@material-ui/icons/Close';
 import { styled } from '@material-ui/core/styles';

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -116,8 +116,14 @@ It accepts almost the same options as the Autocomplete component minus all the p
 related to the rendering of JSX.
 The Autocomplete component is built on this hook.
 
-```jsx
+```js
 import { useAutocomplete } from '@material-ui/unstyled/AutocompleteUnstyled';
+```
+
+The `useAutocomplete` hook is also reexported from @material-ui/core for convenience and backwards compatibility.
+
+```js
+import useAutocomplete from '@material-ui/core/useAutocomplete';
 ```
 
 - 📦 [4.5 kB gzipped](/size-snapshot).

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -116,13 +116,13 @@ It accepts almost the same options as the Autocomplete component minus all the p
 related to the rendering of JSX.
 The Autocomplete component is built on this hook.
 
-```js
+```tsx
 import { useAutocomplete } from '@material-ui/unstyled/AutocompleteUnstyled';
 ```
 
 The `useAutocomplete` hook is also reexported from @material-ui/core for convenience and backward compatibility.
 
-```js
+```tsx
 import useAutocomplete from '@material-ui/core/useAutocomplete';
 ```
 

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -120,7 +120,7 @@ The Autocomplete component is built on this hook.
 import { useAutocomplete } from '@material-ui/unstyled/AutocompleteUnstyled';
 ```
 
-The `useAutocomplete` hook is also reexported from @material-ui/core for convenience and backwards compatibility.
+The `useAutocomplete` hook is also reexported from @material-ui/core for convenience and backward compatibility.
 
 ```js
 import useAutocomplete from '@material-ui/core/useAutocomplete';


### PR DESCRIPTION
As discussed in https://github.com/mui-org/material-ui/pull/27524/files/d927b0af38eae07b78c1e5ed4899dedd246a2382#r683710492, this PR changes the useAutocomplete import path in one demo, making it consistent with other demos showcasing the unstyled building blocks.