### PR TITLE
[Autocomplete] clearOnBlur is ignored

### DIFF
--- a/packages/material-ui-unstyled/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/material-ui-unstyled/src/AutocompleteUnstyled/useAutocomplete.js
@@ -185,6 +185,10 @@ export default function useAutocomplete(props) {
       return;
     }
 
+    if (!focused && !clearOnBlur) {
+      return;
+    }
+
     resetInputValue(null, value);
   }, [value, resetInputValue, focused, prevValue]);
 


### PR DESCRIPTION
Currently  input value is always cleared whenever `focused` is changed.
I thought `clearOnBlur` option works for this, but it doesn't. 
https://github.com/mui-org/material-ui/blob/next/packages/material-ui-unstyled/src/AutocompleteUnstyled/useAutocomplete.d.ts#L73-L80
```
  /**
   * If `true`, the input's text is cleared on blur if no value is selected.
   *
   * Set to `true` if you want to help the user enter a new value.
   * Set to `false` if you want to help the user resume his search.
   * @default !props.freeSolo
   */
  clearOnBlur?: boolean;
```
The useAutocomplete should check the value of `clearOnBlur` option.