### PR TITLE
[docs] Fix Autocomplete country layout shift

### DIFF
--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -13,7 +13,7 @@ export default function CountrySelect() {
       autoHighlight
       getOptionLabel={(option) => option.label}
       renderOption={(props, option) => (
-        <Box component="li" sx={{ '& > img': { mr: 2 } }} {...props}>
+        <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
           <img
             loading="lazy"
             width="20"

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -13,7 +13,7 @@ export default function CountrySelect() {
       autoHighlight
       getOptionLabel={(option) => option.label}
       renderOption={(props, option) => (
-        <Box component="li" sx={{ '& > img': { mr: 2 } }} {...props}>
+        <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
           <img
             loading="lazy"
             width="20"


### PR DESCRIPTION
A follow-up on https://github.com/mui-org/material-ui/pull/27723, it fixes the layout shift when the image is loading. Before:

https://user-images.githubusercontent.com/3165635/129696620-87a30c9a-a3e3-4f8b-b9c8-c84d1ad55181.mp4

