### PR TITLE
[test] Improve test for checking if classes is forwarded to any DOM element

### DIFF
--- a/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/material-ui-lab/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -31,6 +31,7 @@ describe('<DateRangePickerDay />', () => {
       // cannot test reactTestRenderer because of required context
       skip: [
         'componentProp',
+        'rootClass', // forwards classes to DateRangePickerDayDay, but applies root class on DateRangePickerDayRoot
         'componentsProp',
         'reactTestRenderer',
         'propsSpread',

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -103,22 +103,4 @@ describe('<NativeSelect />', () => {
     expect(getByTestId('root')).to.have.class('foo');
     expect(getByTestId('root')).to.have.class('bar');
   });
-
-  it('should not add classes on the DOM element', () => {
-    const { getByTestId } = render(
-      <NativeSelect
-        defaultValue={30}
-        inputProps={{
-          'data-testid': 'select',
-          name: 'age',
-          id: 'uncontrolled-native',
-        }}
-      >
-        <option value={10}>Ten</option>
-        <option value={20}>Twenty</option>
-        <option value={30}>Thirty</option>
-      </NativeSelect>,
-    );
-    expect(getByTestId('select')).not.to.have.attribute('classes');
-  });
 });

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -154,8 +154,13 @@ export function testRootClass(element, getOptions) {
     }
 
     const className = randomStringValue();
-    const { container, setProps } = render(React.cloneElement(element, { className }));
-
+    const classesRootClassname = randomStringValue();
+    const { container } = render(
+      React.cloneElement(element, {
+        className,
+        classes: { ...classes, root: `${classes.root} ${classesRootClassname}` },
+      }),
+    );
     // we established that the root component renders the outermost host previously. We immediately
     // jump to the host component because some components pass the `root` class
     // to the `classes` prop of the root component.
@@ -165,8 +170,7 @@ export function testRootClass(element, getOptions) {
     expect(document.querySelectorAll(`.${classes.root}`).length).to.equal(1);
 
     // Test that classes prop works
-    setProps({ classes: { ...classes, root: `${classes.root} ${className}` } });
-    expect(container.firstChild).to.have.class(className);
+    expect(container.firstChild).to.have.class(classesRootClassname);
     expect(document.querySelectorAll('[classes]').length).to.equal(0);
   });
 }

--- a/test/utils/describeConformance.js
+++ b/test/utils/describeConformance.js
@@ -167,7 +167,7 @@ export function testRootClass(element, getOptions) {
     // Test that classes prop works
     setProps({ classes: { ...classes, root: `${classes.root} ${className}` } });
     expect(container.firstChild).to.have.class(className);
-    expect(container.firstChild).not.to.have.attribute('classes');
+    expect(document.querySelectorAll('[classes]').length).to.equal(0);
   });
 }
 


### PR DESCRIPTION
The PR updates the way of how we test if the `classes` prop is forwarded to some DOM element. Previously, it was checking for only the first child, but that was not enough, for example for ensuring it works in the `NativeSelect` where the prop was spread to the `select` element. Now we test that there isn't any DOM element with a `classes` attribute. 

~There wasn't any new failing test.~ Not true, here are the logs from the unit tests - https://app.circleci.com/pipelines/github/mui-org/material-ui/50805/workflows/4d4535b3-89fd-4404-989e-8b0cb1197d17/jobs/285659 Going to fix them now

----

Edit: Turns out there was a problem with how the `classes` prop was tested, especially if `wrapMount` was used, that is why the tests were failing. All fixed with https://github.com/mui-org/material-ui/pull/27815/commits/07c6bcdfd751f54055484594b5edd5f81d5e76d6

Resolves https://github.com/mui-org/material-ui/pull/27797#discussion_r690118491