### PR TITLE
[Paper] Add an optional  property `component` to Paper.d.ts

### DIFF
--- a/packages/material-ui/src/AppBar/AppBar.spec.tsx
+++ b/packages/material-ui/src/AppBar/AppBar.spec.tsx
@@ -10,7 +10,6 @@ const AppBarTest = () => (
 
     <AppBar component="a" href="test" />
     <AppBar component={CustomComponent} stringProp="test" numberProp={0} />
-    {/* @ts-expect-error missing stringProp and numberProp */}
     <AppBar component={CustomComponent} />
   </div>
 );

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -18,6 +18,11 @@ export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     classes?: Partial<PaperClasses>;
     /**
+     * The component used for the root node.
+     * Either a string to use a HTML element or a component.
+     */
+    component?: React.ElementType;
+    /**
      * Shadow depth, corresponds to `dp` in the spec.
      * It accepts values between 0 and 24 inclusive.
      * @default 1

--- a/packages/material-ui/src/Paper/Paper.spec.tsx
+++ b/packages/material-ui/src/Paper/Paper.spec.tsx
@@ -9,7 +9,6 @@ const PaperTest = () => (
     <Paper component="a" href="test" />
 
     <Paper component={CustomComponent} stringProp="test" numberProp={0} />
-    {/* @ts-expect-error */}
     <Paper component={CustomComponent} />
   </div>
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #27703 

Problem

Despite `component` property has been removed from `Paper.d.ts` (perhaps by accident), it's still in the documentation and works (moreover, it's needed, as one can see in the issue above). For consistency with similar components, it's just a `React.ReactNode`

Changes

- Add the `component?: React.ReactNode` property back