### PR TITLE
[ButtonGroup] Allow `size` customization via module augmentation

### DIFF
--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
@@ -7,6 +7,7 @@ import { ButtonGroupClasses } from './buttonGroupClasses';
 
 export interface ButtonGroupPropsColorOverrides {}
 export interface ButtonGroupPropsVariantOverrides {}
+export interface ButtonGroupPropsSizeOverrides {}
 
 export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -61,7 +62,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
      * `small` is equivalent to the dense button styling.
      * @default 'medium'
      */
-    size?: 'small' | 'medium' | 'large';
+    size?: OverridableStringUnion<'small' | 'medium' | 'large', ButtonGroupPropsSizeOverrides>;
     /**
      * The variant to use.
      * @default 'outlined'


### PR DESCRIPTION
### Problem

Currently, typescript consumers can augment the available values for `ButtonProps.size`. However, they cannot do the same for `ButtonGroupProps.size`.

This can cause consumers to have inconsistent prop API options for button sizes when set on the group versus the individual buttons.

### Proposed Solution

1. Add/export the `ButtonGroupPropsSizeOverrides` interface
1. Use `OverridableStringUnion` to allow the MUI size values, or any values specified by the consumer in the aforementioned interface.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
