### PR TITLE
[TextareaAutosize] Sync height when the width of the textarea changes

### DIFF
--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import sinon, { spy, stub, useFakeTimers } from 'sinon';
+import sinon, { spy, stub } from 'sinon';
 import { describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import TextareaAutosize from '@material-ui/core/TextareaAutosize';
 
@@ -49,42 +49,6 @@ describe('<TextareaAutosize />', () => {
 
     after(() => {
       sinon.restore();
-    });
-
-    describe('resize', () => {
-      let clock;
-
-      beforeEach(() => {
-        clock = useFakeTimers();
-      });
-
-      afterEach(() => {
-        clock.restore();
-      });
-
-      it('should handle the resize event', () => {
-        const { container } = render(<TextareaAutosize />);
-        const input = container.querySelector('textarea[aria-hidden=null]');
-        const shadow = container.querySelector('textarea[aria-hidden=true]');
-        expect(input.style).to.have.property('height', '');
-        expect(input.style).to.have.property('overflow', '');
-
-        setLayout(input, shadow, {
-          getComputedStyle: {
-            'box-sizing': 'content-box',
-          },
-          scrollHeight: 30,
-          lineHeight: 15,
-        });
-        window.dispatchEvent(new window.Event('resize', {}));
-
-        act(() => {
-          clock.tick(166);
-        });
-
-        expect(input.style).to.have.property('height', '30px');
-        expect(input.style).to.have.property('overflow', 'hidden');
-      });
     });
 
     it('should update when uncontrolled', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is a continuation of this issue: https://github.com/mui-org/material-ui/issues/23641

**Problem**: as mentioned in the issue, change in the width of a textarea currently does not update the height. Hence, unwanted whitespace ends up existing in multi-line textarea.

**Solution**: use ResizeObserver API to observe the textarea and update the height in response to the textarea's resizing.

Consider the following textarea:
![Screenshot 2021-08-19 at 08 45 54](https://user-images.githubusercontent.com/32841130/130030570-3c4e9caf-282f-43f6-80d8-ff16f8d86313.png)

**Without** the implementation of this pull request (when there is change in the width of the textarea):
![Screenshot 2021-08-19 at 08 46 01](https://user-images.githubusercontent.com/32841130/130030595-51131022-5411-4564-a92c-7d27e1e19863.png)

**With** the implementation of this pull request (when there is change in the width of the textarea):
![Screenshot 2021-08-19 at 08 51 06](https://user-images.githubusercontent.com/32841130/130030613-44e3407b-809d-41c9-8471-c1cd8698d185.png)