### PR TITLE
[docs] Fix Tooltip flicker when hovering between code icon and demo

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -63,6 +63,25 @@ const DemoTooltip = styled((props) => {
   zIndex: theme.zIndex.appBar - 1,
 }));
 
+function ToggleCodeTooltip(props) {
+  const { showSourceHint, ...other } = props;
+  const atLeastSmallViewport = useMediaQuery((theme) => theme.breakpoints.up('sm'));
+
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <DemoTooltip
+      {...other}
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={showSourceHint && atLeastSmallViewport ? true : open}
+    />
+  );
+}
+ToggleCodeTooltip.propTypes = {
+  showSourceHint: PropTypes.bool,
+};
+
 export function DemoToolbarFallback() {
   const t = useTranslate();
 
@@ -362,8 +381,6 @@ export default function DemoToolbar(props) {
     showCodeLabel = showPreview ? t('showFullSource') : t('showSource');
   }
 
-  const atLeastSmallViewport = useMediaQuery((theme) => theme.breakpoints.up('sm'));
-
   const controlRefs = [
     React.useRef(null),
     React.useRef(null),
@@ -486,9 +503,8 @@ export default function DemoToolbar(props) {
           </ToggleButtonGroup>
         </Fade>
         <div>
-          <DemoTooltip
-            key={showSourceHint}
-            open={showSourceHint && atLeastSmallViewport ? true : undefined}
+          <ToggleCodeTooltip
+            showSourceHint={showSourceHint}
             PopperProps={{ disablePortal: true }}
             title={showCodeLabel}
             placement="bottom"
@@ -505,7 +521,7 @@ export default function DemoToolbar(props) {
             >
               <CodeIcon fontSize="small" />
             </IconButton>
-          </DemoTooltip>
+          </ToggleCodeTooltip>
           {demoOptions.hideEditButton ? null : (
             <React.Fragment>
               <DemoTooltip title={t('codesandbox')} placement="bottom">


### PR DESCRIPTION
When landing on page while hovering over a demo you previously got a "switching from controlled to uncontrolled mode" because we didn't actually update the `key` when the mode changed.


https://user-images.githubusercontent.com/12292047/130036835-73ba1286-4c49-4346-8e36-fdacc4cd143d.mp4


We don't need to remount the Tooltip to begin with and can just use a fully controlled Tooltip.

Also fixes flickering of the tooltip when we move the cursor from icon to demo:

Before:

https://user-images.githubusercontent.com/12292047/130039772-246bd0d4-a983-4ea1-b67c-36121d361802.mp4


After:


https://user-images.githubusercontent.com/12292047/130039785-9e78c5dd-1a78-4603-aba2-c70beb15b3af.mp4



This also allows pushing usage of `useMediaQuery` further down avoiding unnecessary work when the value changes. 