### PR TITLE
[docs] Fix false-positive useToolbar warning when using the demo toolbar menu

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -585,52 +585,52 @@ export default function DemoToolbar(props) {
           >
             <MoreVertIcon fontSize="small" />
           </IconButton>
-          <Menu
-            id="demo-menu-more"
-            anchorEl={anchorEl}
-            open={Boolean(anchorEl)}
-            onClose={handleMoreClose}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-          >
-            <MenuItem
-              data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
-              data-ga-event-action="github"
-              component="a"
-              href={demoData.githubLocation}
-              target="_blank"
-              rel="noopener nofollow"
-              onClick={handleMoreClose}
-            >
-              {t('viewGitHub')}
-            </MenuItem>
-            <MenuItem
-              data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
-              data-ga-event-action="copy-js-source-link"
-              onClick={createHandleCodeSourceLink(`${demoName}.js`)}
-            >
-              {t('copySourceLinkJS')}
-            </MenuItem>
-            <MenuItem
-              data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
-              data-ga-event-action="copy-ts-source-link"
-              onClick={createHandleCodeSourceLink(`${demoName}.tsx`)}
-            >
-              {t('copySourceLinkTS')}
-            </MenuItem>
-            {devMenuItems}
-          </Menu>
         </div>
       </Root>
+      <Menu
+        id="demo-menu-more"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMoreClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        <MenuItem
+          data-ga-event-category="demo"
+          data-ga-event-label={demoOptions.demo}
+          data-ga-event-action="github"
+          component="a"
+          href={demoData.githubLocation}
+          target="_blank"
+          rel="noopener nofollow"
+          onClick={handleMoreClose}
+        >
+          {t('viewGitHub')}
+        </MenuItem>
+        <MenuItem
+          data-ga-event-category="demo"
+          data-ga-event-label={demoOptions.demo}
+          data-ga-event-action="copy-js-source-link"
+          onClick={createHandleCodeSourceLink(`${demoName}.js`)}
+        >
+          {t('copySourceLinkJS')}
+        </MenuItem>
+        <MenuItem
+          data-ga-event-category="demo"
+          data-ga-event-label={demoOptions.demo}
+          data-ga-event-action="copy-ts-source-link"
+          onClick={createHandleCodeSourceLink(`${demoName}.tsx`)}
+        >
+          {t('copySourceLinkTS')}
+        </MenuItem>
+        {devMenuItems}
+      </Menu>
       <Snackbar
         open={snackbarOpen}
         autoHideDuration={3000}


### PR DESCRIPTION
We previously nested the `Menu` inside the `Toolbar`:

```jsx
<Toolbar>
  {...controls}
  <Menu />
</Toolbar>
```

Now `Toolbar` and `Menu` are siblings

The issue was that we warn on any focus event from inside `Toolbar` since only the `Toolbar` should control focus. 

There's an argument to be made that it shouldn't do that to begin with or at least check if focused element is part of the toolbar (since the Toolbar becomes inaccessible when the Menu is open there's no reason to warn).

However, this is a bit more complicated and the warning is valueable since we need to manually wire up each toolbar control to the toolbar. 

Though definitely something to consider when we want to work on a Toolbar. Ideally it would "just" know what the controls are. 