### PR TITLE
[docs] Don't log if a request was aborted in ServerRequestDatePicker demo

### DIFF
--- a/docs/src/pages/components/date-picker/ServerRequestDatePicker.js
+++ b/docs/src/pages/components/date-picker/ServerRequestDatePicker.js
@@ -27,7 +27,7 @@ function fakeFetch(date, { signal }) {
 
     signal.onabort = () => {
       clearTimeout(timeout);
-      reject(new Error('aborted'));
+      reject(new DOMException('aborted', 'AbortError'));
     };
   });
 }
@@ -49,7 +49,12 @@ export default function ServerRequestDatePicker() {
         setHighlightedDays(daysToHighlight);
         setIsLoading(false);
       })
-      .catch(() => console.log('Wow, you are switching months too quickly 🐕'));
+      .catch((error) => {
+        // ignore the error if it's caused by `controller.abort`
+        if (error.name !== 'AbortError') {
+          throw error;
+        }
+      });
 
     requestAbortController.current = controller;
   };

--- a/docs/src/pages/components/date-picker/ServerRequestDatePicker.tsx
+++ b/docs/src/pages/components/date-picker/ServerRequestDatePicker.tsx
@@ -27,7 +27,7 @@ function fakeFetch(date: Date, { signal }: { signal: AbortSignal }) {
 
     signal.onabort = () => {
       clearTimeout(timeout);
-      reject(new Error('aborted'));
+      reject(new DOMException('aborted', 'AbortError'));
     };
   });
 }
@@ -49,7 +49,12 @@ export default function ServerRequestDatePicker() {
         setHighlightedDays(daysToHighlight);
         setIsLoading(false);
       })
-      .catch(() => console.log('Wow, you are switching months too quickly 🐕'));
+      .catch((error) => {
+        // ignore the error if it's caused by `controller.abort`
+        if (error.name !== 'AbortError') {
+          throw error;
+        }
+      });
 
     requestAbortController.current = controller;
   };


### PR DESCRIPTION
Previously we logged "Wow, you are switching months too quickly 🐕" which is not useful. The whole point was to abort gracefully, not log that this abortion is excessive (which it isn't).

It also hid actual fetch errors.

Now we just ignore the abort errors and let the actual fetch error surface.
