### PR TITLE
[theme] Fix pseudo class overridden in variants

### DIFF
--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -34,7 +34,7 @@ const getVariantStyles = (name, theme) => {
 
 const variantsResolver = (props, styles, theme, name) => {
   const { ownerState = {} } = props;
-  let variantsStyles = {};
+  const variantsStyles = [];
   const themeVariants = theme?.components?.[name]?.variants;
   if (themeVariants) {
     themeVariants.forEach((themeVariant) => {
@@ -45,7 +45,7 @@ const variantsResolver = (props, styles, theme, name) => {
         }
       });
       if (isMatch) {
-        variantsStyles = { ...variantsStyles, ...styles[propsToClassKey(themeVariant.props)] };
+        variantsStyles.push(styles[propsToClassKey(themeVariant.props)]);
       }
     });
   }

--- a/packages/material-ui-system/src/createStyled.test.js
+++ b/packages/material-ui-system/src/createStyled.test.js
@@ -60,7 +60,7 @@ describe('createStyled', () => {
                 props: { variant: 'contained' },
                 style: {
                   '&.Mui-disabled': {
-                    opacity: 0.65,
+                    width: '300px',
                   },
                 },
               },
@@ -68,8 +68,7 @@ describe('createStyled', () => {
                 props: { variant: 'contained', color: 'primary' },
                 style: {
                   '&.Mui-disabled': {
-                    color: '#fff',
-                    backgroundColor: '#f00',
+                    height: '200px',
                   },
                 },
               },
@@ -96,9 +95,8 @@ describe('createStyled', () => {
       );
 
       expect(container.getElementsByTagName('button')[0]).toHaveComputedStyle({
-        color: 'rgb(255, 255, 255)',
-        backgroundColor: 'rgb(255, 0, 0)',
-        opacity: '0.65',
+        width: '300px',
+        height: '200px',
       });
     });
   });

--- a/packages/material-ui-system/src/createStyled.test.js
+++ b/packages/material-ui-system/src/createStyled.test.js
@@ -1,7 +1,12 @@
+import * as React from 'react';
 import { expect } from 'chai';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { createClientRender } from 'test/utils';
 import createStyled from './createStyled';
 
 describe('createStyled', () => {
+  const render = createClientRender();
+
   describe('displayName', () => {
     // These tests rely on implementation details (namely `displayName`)
     // Ideally we'd just test if the proper name appears in a React warning.
@@ -42,6 +47,59 @@ describe('createStyled', () => {
       const SomeMuiComponent = styled(() => null)({});
 
       expect(SomeMuiComponent).to.have.property('displayName', 'Styled(Component)');
+    });
+  });
+
+  describe('styles', () => {
+    it('styles of pseudo classes of variants are merged', () => {
+      const theme = createTheme({
+        components: {
+          MuiButton: {
+            variants: [
+              {
+                props: { variant: 'contained' },
+                style: {
+                  '&.Mui-disabled': {
+                    opacity: 0.65,
+                  },
+                },
+              },
+              {
+                props: { variant: 'contained', color: 'primary' },
+                style: {
+                  '&.Mui-disabled': {
+                    color: '#fff',
+                    backgroundColor: '#f00',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+      const styled = createStyled({});
+      const Button = styled('button', {
+        shouldForwardProp: (prop) => prop !== 'color' && prop !== 'contained',
+        name: 'MuiButton',
+        slot: 'Root',
+        overridesResolver: (props, styles) => styles.root,
+      })({
+        display: 'flex',
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Button color="primary" variant="contained" className="Mui-disabled">
+            Hello
+          </Button>
+        </ThemeProvider>,
+      );
+
+      expect(container.getElementsByTagName('button')[0]).toHaveComputedStyle({
+        color: 'rgb(255, 255, 255)',
+        backgroundColor: 'rgb(255, 0, 0)',
+        opacity: '0.65',
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is a continuation of this issue: https://github.com/mui-org/material-ui/issues/26944

Problem:
You can see that the styles of pseudo classes of variants are not merged correctly here: https://codesandbox.io/s/musing-darkness-2cd8d?file=/src/App.js:119-613

Solution: Following @oliviertassinari 's suggestion (https://github.com/mui-org/material-ui/issues/26944#issuecomment-869223488), using an array to store variant styles rather than an object does the fix.
```diff
@@ -33,7 +33,7 @@ const getVariantStyles = (name, theme) => {

 const variantsResolver = (props, styles, theme, name) => {
   const { styleProps = {} } = props;
-  let variantsStyles = {};
+  const variantsStyles = [];
   const themeVariants = theme?.components?.[name]?.variants;
   if (themeVariants) {
     themeVariants.forEach((themeVariant) => {
@@ -44,7 +44,7 @@ const variantsResolver = (props, styles, theme, name) => {
         }
       });
       if (isMatch) {
-        variantsStyles = { ...variantsStyles, ...styles[propsToClassKey(themeVariant.props)] };
+        variantsStyles.push(styles[propsToClassKey(themeVariant.props)]);
       }
     });
   }
```