### PR TITLE
[docs] Fix circular integration demo

### DIFF
--- a/docs/src/pages/components/progress/CircularIntegration.js
+++ b/docs/src/pages/components/progress/CircularIntegration.js
@@ -79,8 +79,8 @@ export default function CircularIntegration() {
               position: 'absolute',
               top: '50%',
               left: '50%',
-              marginTop: -12,
-              marginLeft: -12,
+              marginTop: '-12px',
+              marginLeft: '-12px',
             }}
           />
         )}

--- a/docs/src/pages/components/progress/CircularIntegration.tsx
+++ b/docs/src/pages/components/progress/CircularIntegration.tsx
@@ -79,8 +79,8 @@ export default function CircularIntegration() {
               position: 'absolute',
               top: '50%',
               left: '50%',
-              marginTop: -12,
-              marginLeft: -12,
+              marginTop: '-12px',
+              marginLeft: '-12px',
             }}
           />
         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Since `sx` `marginTop` and `marginLeft` are coefficients now, the demo is broken:

![image](https://user-images.githubusercontent.com/10603631/130149006-539e2631-1841-42ec-8351-b9727c0e9827.png)

Note that the right button progress is outside of the demo box.