### PR TITLE
[system] Remove dependency on `overridesResolver` for the `variants`

### DIFF
--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -136,7 +136,7 @@ export default function createStyled(input = {}) {
         });
       }
 
-      if (componentName && overridesResolver && !skipVariantsResolver) {
+      if (componentName && !skipVariantsResolver) {
         expressionsWithDefaultTheme.push((props) => {
           const theme = isEmpty(props.theme) ? defaultTheme : props.theme;
           return variantsResolver(

--- a/packages/material-ui-system/src/styled.test.js
+++ b/packages/material-ui-system/src/styled.test.js
@@ -288,6 +288,7 @@ describe('styled', () => {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
         name: 'MuiTest',
         slot: 'Slot',
+        overridesResolver: (props, styles) => styles.slot,
       })`
         width: 200px;
         height: 300px;

--- a/packages/material-ui-system/src/styled.test.js
+++ b/packages/material-ui-system/src/styled.test.js
@@ -283,12 +283,11 @@ describe('styled', () => {
       });
     });
 
-    it('variants should not be skipped for non root slots', () => {
+    it('variants should be skipped for non root slots', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
         name: 'MuiTest',
         slot: 'Slot',
-        overridesResolver: (props, styles) => styles.slot,
       })`
         width: 200px;
         height: 300px;
@@ -312,7 +311,7 @@ describe('styled', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
         name: 'MuiTest',
-        slot: 'Slot',
+        slot: 'Root',
       })`
         width: 800px;
         height: 300px;
@@ -327,8 +326,8 @@ describe('styled', () => {
       );
 
       expect(container.firstChild).toHaveComputedStyle({
-        width: '800px',
-        height: '300px',
+        width: '400px',
+        height: '400px',
       });
     });
 

--- a/packages/material-ui-system/src/styled.test.js
+++ b/packages/material-ui-system/src/styled.test.js
@@ -283,14 +283,14 @@ describe('styled', () => {
       });
     });
 
-    it('variants should be skipped for non root slots', () => {
+    it('variants should not be skipped for non root slots', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
         name: 'MuiTest',
         slot: 'Slot',
         overridesResolver: (props, styles) => styles.slot,
       })`
-        width: 200px;
+        width: 800px;
         height: 300px;
       `;
 
@@ -303,7 +303,31 @@ describe('styled', () => {
       );
 
       expect(container.firstChild).toHaveComputedStyle({
-        width: '200px',
+        width: '800px',
+        height: '300px',
+      });
+    });
+
+    it('variants should not be skipped if overridesResolver is not defined', () => {
+      const TestSlot = styled('div', {
+        shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
+        name: 'MuiTest',
+        slot: 'Slot',
+      })`
+        width: 800px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestSlot variant="rect" size="large">
+            Test
+          </TestSlot>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '800px',
         height: '300px',
       });
     });

--- a/packages/material-ui-system/src/styled.test.js
+++ b/packages/material-ui-system/src/styled.test.js
@@ -290,7 +290,7 @@ describe('styled', () => {
         slot: 'Slot',
         overridesResolver: (props, styles) => styles.slot,
       })`
-        width: 800px;
+        width: 200px;
         height: 300px;
       `;
 
@@ -303,7 +303,7 @@ describe('styled', () => {
       );
 
       expect(container.firstChild).toHaveComputedStyle({
-        width: '800px',
+        width: '200px',
         height: '300px',
       });
     });

--- a/packages/material-ui-system/src/styled.test.js
+++ b/packages/material-ui-system/src/styled.test.js
@@ -308,6 +308,30 @@ describe('styled', () => {
       });
     });
 
+    it('variants should not be skipped if overridesResolver is not defined', () => {
+      const TestSlot = styled('div', {
+        shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
+        name: 'MuiTest',
+        slot: 'Root',
+      })`
+        width: 800px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestSlot variant="rect" size="large">
+            Test
+          </TestSlot>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '400px',
+        height: '400px',
+      });
+    });
+
     it('variants should respect skipVariantsResolver if defined', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',

--- a/packages/material-ui-system/src/styled.test.js
+++ b/packages/material-ui-system/src/styled.test.js
@@ -308,30 +308,6 @@ describe('styled', () => {
       });
     });
 
-    it('variants should not be skipped if overridesResolver is not defined', () => {
-      const TestSlot = styled('div', {
-        shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
-        name: 'MuiTest',
-        slot: 'Root',
-      })`
-        width: 800px;
-        height: 300px;
-      `;
-
-      const { container } = render(
-        <ThemeProvider theme={theme}>
-          <TestSlot variant="rect" size="large">
-            Test
-          </TestSlot>
-        </ThemeProvider>,
-      );
-
-      expect(container.firstChild).toHaveComputedStyle({
-        width: '400px',
-        height: '400px',
-      });
-    });
-
     it('variants should respect skipVariantsResolver if defined', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',


### PR DESCRIPTION
I noticed this issue when working on a test case for https://github.com/mui-org/material-ui/pull/27847

Here is a codesandbox that illustrates the issue - https://codesandbox.io/s/ancient-snow-45mhz?file=/src/App.js Note that the styles from the variants are being applied only if the `overridesResolver` is defined. These are not related and this dependency is not expected. 