### PR TITLE
[Tooltip] Fix broken arrow position in rtl

### DIFF
--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -121,6 +121,12 @@ DemoFrame.propTypes = {
 const theme = createTheme();
 const darkModeTheme = createTheme({ palette: { mode: 'dark' } });
 
+const getTheme = (outerTheme) => {
+  const resultTheme = outerTheme?.palette?.mode === 'dark' ? darkModeTheme : theme;
+  resultTheme.direction = outerTheme?.direction;
+  return resultTheme;
+};
+
 /**
  * Isolates the demo component as best as possible. Additional props are spread
  * to an `iframe` if `iframe={true}`.
@@ -135,9 +141,7 @@ function DemoSandboxed(props) {
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
       <Sandbox {...sandboxProps}>
-        <ThemeProvider
-          theme={(outerTheme) => (outerTheme?.palette?.mode === 'dark' ? darkModeTheme : theme)}
-        >
+        <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
           <Component />
         </ThemeProvider>
       </Sandbox>

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -76,13 +76,15 @@ const TooltipPopper = styled(Popper, {
       },
     },
     [`&[data-popper-placement*="right"] .${tooltipClasses.arrow}`]: {
-      ...(!ownerState.isRtl ? {
-        left: 0,
-        marginLeft: '-0.71em',
-      } : {
-        right: 0,
-        marginRight: '-0.71em',
-      }),
+      ...(!ownerState.isRtl
+        ? {
+            left: 0,
+            marginLeft: '-0.71em',
+          }
+        : {
+            right: 0,
+            marginRight: '-0.71em',
+          }),
       height: '1em',
       width: '0.71em',
       '&::before': {
@@ -90,7 +92,9 @@ const TooltipPopper = styled(Popper, {
       },
     },
     [`&[data-popper-placement*="left"] .${tooltipClasses.arrow}`]: {
-      ...(!ownerState.isRtl ? { right: 0, marginRight: '-0.71em' } : { left: 0, marginLeft: '-0.71em' }),
+      ...(!ownerState.isRtl
+        ? { right: 0, marginRight: '-0.71em' }
+        : { left: 0, marginLeft: '-0.71em' }),
       height: '1em',
       width: '0.71em',
       '&::before': {
@@ -136,31 +140,35 @@ const TooltipTooltip = styled('div', {
   }),
   [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
-    ...(!ownerState.isRtl ? {
-      marginRight: '14px',
-      ...(ownerState.touch && {
-        marginRight: '24px',
-      }),
-    }: {
-      marginLeft: '14px',
-      ...(ownerState.touch && {
-        marginLeft: '24px',
-      }),
-    })
+    ...(!ownerState.isRtl
+      ? {
+          marginRight: '14px',
+          ...(ownerState.touch && {
+            marginRight: '24px',
+          }),
+        }
+      : {
+          marginLeft: '14px',
+          ...(ownerState.touch && {
+            marginLeft: '24px',
+          }),
+        }),
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
-    ...(!ownerState.isRtl ? {
-      marginLeft: '14px',
-      ...(ownerState.touch && {
-        marginLeft: '24px',
-      }),
-    } : {
-      marginRight: '14px',
-      ...(ownerState.touch && {
-        marginRight: '24px',
-      }),
-    })
+    ...(!ownerState.isRtl
+      ? {
+          marginLeft: '14px',
+          ...(ownerState.touch && {
+            marginLeft: '24px',
+          }),
+        }
+      : {
+          marginRight: '14px',
+          ...(ownerState.touch && {
+            marginRight: '24px',
+          }),
+        }),
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -63,7 +63,6 @@ const TooltipPopper = styled(Popper, {
   ...(ownerState.arrow && {
     [`&[data-popper-placement*="bottom"] .${tooltipClasses.arrow}`]: {
       top: 0,
-      left: 0,
       marginTop: '-0.71em',
       '&::before': {
         transformOrigin: '0 100%',
@@ -71,15 +70,19 @@ const TooltipPopper = styled(Popper, {
     },
     [`&[data-popper-placement*="top"] .${tooltipClasses.arrow}`]: {
       bottom: 0,
-      left: 0,
       marginBottom: '-0.71em',
       '&::before': {
         transformOrigin: '100% 0',
       },
     },
     [`&[data-popper-placement*="right"] .${tooltipClasses.arrow}`]: {
-      left: 0,
-      marginLeft: '-0.71em',
+      ...(!ownerState.isRtl ? {
+        left: 0,
+        marginLeft: '-0.71em',
+      } : {
+        right: 0,
+        marginRight: '-0.71em',
+      }),
       height: '1em',
       width: '0.71em',
       '&::before': {
@@ -87,8 +90,7 @@ const TooltipPopper = styled(Popper, {
       },
     },
     [`&[data-popper-placement*="left"] .${tooltipClasses.arrow}`]: {
-      right: 0,
-      marginRight: '-0.71em',
+      ...(!ownerState.isRtl ? { right: 0, marginRight: '-0.71em' } : { left: 0, marginLeft: '-0.71em' }),
       height: '1em',
       width: '0.71em',
       '&::before': {
@@ -134,17 +136,31 @@ const TooltipTooltip = styled('div', {
   }),
   [`.${tooltipClasses.popper}[data-popper-placement*="left"] &`]: {
     transformOrigin: 'right center',
-    marginRight: '14px',
-    ...(ownerState.touch && {
-      marginRight: '24px',
-    }),
+    ...(!ownerState.isRtl ? {
+      marginRight: '14px',
+      ...(ownerState.touch && {
+        marginRight: '24px',
+      }),
+    }: {
+      marginLeft: '14px',
+      ...(ownerState.touch && {
+        marginLeft: '24px',
+      }),
+    })
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="right"] &`]: {
     transformOrigin: 'left center',
-    marginLeft: '14px',
-    ...(ownerState.touch && {
-      marginLeft: '24px',
-    }),
+    ...(!ownerState.isRtl ? {
+      marginLeft: '14px',
+      ...(ownerState.touch && {
+        marginLeft: '24px',
+      }),
+    } : {
+      marginRight: '14px',
+      ...(ownerState.touch && {
+        marginRight: '24px',
+      }),
+    })
   },
   [`.${tooltipClasses.popper}[data-popper-placement*="top"] &`]: {
     transformOrigin: 'center bottom',
@@ -232,6 +248,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   } = props;
 
   const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
 
   const [childNode, setChildNode] = React.useState();
   const [arrowRef, setArrowRef] = React.useState(null);
@@ -586,6 +603,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
 
   const ownerState = {
     ...props,
+    isRtl,
     arrow,
     disableInteractive,
     placement,

--- a/test/regressions/fixtures/Tooltip/PositionedTooltipsRtl.js
+++ b/test/regressions/fixtures/Tooltip/PositionedTooltipsRtl.js
@@ -1,20 +1,20 @@
-import * as React from "react";
-import Box from "@material-ui/core/Box";
-import Grid from "@material-ui/core/Grid";
-import Button from "@material-ui/core/Button";
-import Tooltip from "@material-ui/core/Tooltip";
-import rtlPlugin from "stylis-plugin-rtl";
-import { CacheProvider } from "@emotion/react";
-import { createTheme, ThemeProvider } from "@material-ui/core/styles";
-import createCache from "@emotion/cache";
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import rtlPlugin from 'stylis-plugin-rtl';
+import { CacheProvider } from '@emotion/react';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
+import createCache from '@emotion/cache';
 
 // Create rtl cache
 const cacheRtl = createCache({
-  key: "muirtl",
-  stylisPlugins: [rtlPlugin]
+  key: 'muirtl',
+  stylisPlugins: [rtlPlugin],
 });
 
-const theme = createTheme({ direction: "rtl" });
+const theme = createTheme({ direction: 'rtl' });
 
 export default function PositionedTooltips() {
   return (
@@ -48,13 +48,7 @@ export default function PositionedTooltips() {
                 <Button>left-end</Button>
               </Tooltip>
             </Grid>
-            <Grid
-              item
-              container
-              xs={6}
-              alignItems="flex-end"
-              direction="column"
-            >
+            <Grid item container xs={6} alignItems="flex-end" direction="column">
               <Grid item>
                 <Tooltip title="Add" arrow open placement="right-start">
                   <Button>right-start</Button>

--- a/test/regressions/fixtures/Tooltip/PositionedTooltipsRtl.js
+++ b/test/regressions/fixtures/Tooltip/PositionedTooltipsRtl.js
@@ -1,0 +1,92 @@
+import * as React from "react";
+import Box from "@material-ui/core/Box";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
+import rtlPlugin from "stylis-plugin-rtl";
+import { CacheProvider } from "@emotion/react";
+import { createTheme, ThemeProvider } from "@material-ui/core/styles";
+import createCache from "@emotion/cache";
+
+// Create rtl cache
+const cacheRtl = createCache({
+  key: "muirtl",
+  stylisPlugins: [rtlPlugin]
+});
+
+const theme = createTheme({ direction: "rtl" });
+
+export default function PositionedTooltips() {
+  return (
+    <CacheProvider value={cacheRtl}>
+      <ThemeProvider theme={theme}>
+        <Box sx={{ width: 500, margin: 10 }} dir="rtl">
+          <Grid container justifyContent="center">
+            <Grid item>
+              <Tooltip title="Add" arrow open placement="top-start">
+                <Button>top-start</Button>
+              </Tooltip>
+              <Tooltip title="Add" arrow open placement="top">
+                <Button>top</Button>
+              </Tooltip>
+              <Tooltip title="Add" arrow open placement="top-end">
+                <Button>top-end</Button>
+              </Tooltip>
+            </Grid>
+          </Grid>
+          <Grid container justifyContent="center">
+            <Grid item xs={6}>
+              <Tooltip title="Add" arrow open placement="left-start">
+                <Button>left-start</Button>
+              </Tooltip>
+              <br />
+              <Tooltip title="Add" arrow open placement="left">
+                <Button>left</Button>
+              </Tooltip>
+              <br />
+              <Tooltip title="Add" arrow open placement="left-end">
+                <Button>left-end</Button>
+              </Tooltip>
+            </Grid>
+            <Grid
+              item
+              container
+              xs={6}
+              alignItems="flex-end"
+              direction="column"
+            >
+              <Grid item>
+                <Tooltip title="Add" arrow open placement="right-start">
+                  <Button>right-start</Button>
+                </Tooltip>
+              </Grid>
+              <Grid item>
+                <Tooltip title="Add" arrow open placement="right">
+                  <Button>right</Button>
+                </Tooltip>
+              </Grid>
+              <Grid item>
+                <Tooltip title="Add" arrow open placement="right-end">
+                  <Button>right-end</Button>
+                </Tooltip>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid container justifyContent="center">
+            <Grid item>
+              <Tooltip title="Add" arrow open placement="bottom-start">
+                <Button>bottom-start</Button>
+              </Tooltip>
+              <Tooltip title="Add" arrow open placement="bottom">
+                <Button>bottom</Button>
+              </Tooltip>
+              <Tooltip title="Add" arrow open placement="bottom-end">
+                <Button>bottom-end</Button>
+              </Tooltip>
+            </Grid>
+          </Grid>
+        </Box>
+      </ThemeProvider>
+    </CacheProvider>
+  );
+}


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/27858 The fix was to prevent some styles from flipping in rtl. As `/* @noflip */` is working only with string templates, I've added the `isRtl` prop and added the appropriate styles based on it.

# Isolated codesandbox examples

Codesandbox in RTL on master: 

https://codesandbox.io/s/material-demo-forked-qh2ds?file=/demo.js

<img src="https://user-images.githubusercontent.com/4512430/130256245-80333a64-ef54-4071-93a4-097f2c9f1bdc.png" width="600px" />

Codesandbox in RTL on next:

https://codesandbox.io/s/basictooltip-material-demo-forked-5gc67?file=/demo.js

<img src="https://user-images.githubusercontent.com/4512430/130256532-8e6c5fdc-9182-4bcf-88d1-71e59b97e7b1.png" width="600px" />

Codesandbox using the packages in the PR:

https://codesandbox.io/s/basictooltip-material-demo-forked-44bhg?file=/demo.js

<img src="https://user-images.githubusercontent.com/4512430/130259204-2f45cd27-a722-4b2c-8cb3-e1f68bfa93e6.png" width="600px" />
-----

# Docs demos:

Next docs 😢 :

<img src="https://user-images.githubusercontent.com/4512430/130257224-1ba5bbc1-b7f4-48ca-9b6b-dbacc3e341d9.png" width="600px" />

Current PR docs:

<img src="https://user-images.githubusercontent.com/4512430/130256913-ce180918-1900-4713-8e9f-3a2636024948.png" width="600px" />
