### PR TITLE
[docs] Add notistack example compatible with v5.x.x

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -86,7 +86,7 @@
     "markdown-to-jsx": "^7.0.0",
     "material-ui-popup-state": "^1.9.2",
     "next": "^11.0.1",
-    "notistack": "^1.0.0",
+    "notistack": "1.0.6-next.2",
     "nprogress": "^0.2.0",
     "postcss": "^8.0.6",
     "prop-types": "^15.7.2",

--- a/docs/src/pages/components/snackbars/IntegrationNotistack.js
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import { SnackbarProvider, useSnackbar } from 'notistack';
+
+function MyApp() {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleClick = () => {
+    enqueueSnackbar('I love snacks.');
+  };
+
+  const handleClickVariant = (variant) => () => {
+    // variant could be success, error, warning, info, or default
+    enqueueSnackbar('This is a success message!', { variant });
+  };
+
+  return (
+    <React.Fragment>
+      <Button onClick={handleClick}>Show snackbar</Button>
+      <Button onClick={handleClickVariant('success')}>Show success snackbar</Button>
+    </React.Fragment>
+  );
+}
+
+export default function IntegrationNotistack() {
+  return (
+    <SnackbarProvider maxSnack={3}>
+      <MyApp />
+    </SnackbarProvider>
+  );
+}

--- a/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import { SnackbarProvider, VariantType, useSnackbar } from 'notistack';
+
+function MyApp() {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleClick = () => {
+    enqueueSnackbar('I love snacks.');
+  };
+
+  const handleClickVariant = (variant: VariantType) => () => {
+    // variant could be success, error, warning, info, or default
+    enqueueSnackbar('This is a success message!', { variant });
+  };
+
+  return (
+    <React.Fragment>
+      <Button onClick={handleClick}>Show snackbar</Button>
+      <Button onClick={handleClickVariant('success')}>Show success snackbar</Button>
+    </React.Fragment>
+  );
+}
+
+export default function IntegrationNotistack() {
+  return (
+    <SnackbarProvider maxSnack={3}>
+      <MyApp />
+    </SnackbarProvider>
+  );
+}

--- a/docs/src/pages/components/snackbars/snackbars.md
+++ b/docs/src/pages/components/snackbars/snackbars.md
@@ -86,7 +86,7 @@ This example demonstrates how to use [notistack](https://github.com/iamhosseindh
 notistack has an **imperative API** that makes it easy to display snackbars, without having to handle their open/close state.
 It also enables you to **stack** them on top of one another (although this is discouraged by the Material Design guidelines).
 
-TODO: Add example once notistack is compatible with v5 or replace with [#1824](https://github.com/mui-org/material-ui/issues/1824).
+{{"demo": "pages/components/snackbars/IntegrationNotistack.js", "defaultCodeOpen": false}}
 
 ## Accessibility
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11945,10 +11945,10 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.4.1.tgz#81e9c153b0ad5743755696f2aa20488d48e962b6"
   integrity sha512-rjH3yRt0Ssx19mUwS0hrDUOdG9VI+oRLpLHJ7tXRdjcuQ7v7wo6qPvOZppHRrqfslTKr0L2yBhjj4UXd7c3cQg==
 
-notistack@^1.0.0:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-1.0.9.tgz#8b3d692bb0c70413efd7424d85d563d667206542"
-  integrity sha512-Dal2HtTpWrdYCZ3t0HhJt47NJZwVSPee36WzORRbqUkFR0k9pxFszxBuPSWshBLwF6Av8s86XPP+ED5zRz0CGw==
+notistack@1.0.6-next.2:
+  version "1.0.6-next.2"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-1.0.6-next.2.tgz#025e98cd077919c5380f0cd5b30b67e3df48678e"
+  integrity sha512-ilyy7W2R7NZQG3xVe2fFkF39JtrnwkGS6CR+VekDI5aYLf+umvDrmImqs+R0WZc498C3HERFXxPOVNooPBKm0g==
   dependencies:
     clsx "^1.1.0"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

It took a while for notistack to be compatible with v5, but I'm glad that it is compatible now.
