### PR TITLE
[core] Fix various flip: false regressions

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -46,9 +46,13 @@ const Root = styled('div')(({ theme }) => ({
   display: 'none',
   [theme.breakpoints.up('sm')]: {
     display: 'flex',
-    flip: false,
     top: 0,
-    right: theme.spacing(1),
+    ...(theme.direction === 'rtl' && {
+      left: theme.spacing(1),
+    }),
+    ...(theme.direction !== 'rtl' && {
+      right: theme.spacing(1),
+    }),
     height: theme.spacing(6),
   },
   justifyContent: 'space-between',

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -84,7 +84,12 @@ const Root = styled('div')(({ theme }) => ({
     marginBottom: 16,
   },
   '& ul': {
-    paddingLeft: 30,
+    ...(theme.direction === 'rtl' && {
+      paddingRight: 30,
+    }),
+    ...(theme.direction !== 'rtl' && {
+      paddingLeft: 30,
+    }),
   },
   '& h1, & h2, & h3, & h4': {
     '& code': {

--- a/docs/src/pages/components/tables/ReactVirtualizedTable.js
+++ b/docs/src/pages/components/tables/ReactVirtualizedTable.js
@@ -17,8 +17,12 @@ const styles = (theme) => ({
     // temporary right-to-left patch, waiting for
     // https://github.com/bvaughn/react-virtualized/issues/454
     '& .ReactVirtualized__Table__headerRow': {
-      flip: false,
-      paddingRight: theme.direction === 'rtl' ? '0 !important' : undefined,
+      ...(theme.direction === 'rtl' && {
+        paddingLeft: '0 !important',
+      }),
+      ...(theme.direction !== 'rtl' && {
+        paddingRight: undefined,
+      }),
     },
   },
   tableRow: {

--- a/docs/src/pages/components/tables/ReactVirtualizedTable.tsx
+++ b/docs/src/pages/components/tables/ReactVirtualizedTable.tsx
@@ -12,16 +12,6 @@ import {
   TableHeaderProps,
 } from 'react-virtualized';
 
-declare module '@material-ui/core/styles' {
-  // Augment the BaseCSSProperties so that we can control jss-rtl
-  interface BaseCSSProperties {
-    /*
-     * Used to control if the rule-set should be affected by rtl transformation
-     */
-    flip?: boolean;
-  }
-}
-
 const styles = (theme: Theme) =>
   ({
     flexContainer: {
@@ -33,8 +23,12 @@ const styles = (theme: Theme) =>
       // temporary right-to-left patch, waiting for
       // https://github.com/bvaughn/react-virtualized/issues/454
       '& .ReactVirtualized__Table__headerRow': {
-        flip: false,
-        paddingRight: theme.direction === 'rtl' ? '0 !important' : undefined,
+        ...(theme.direction === 'rtl' && {
+          paddingLeft: '0 !important',
+        }),
+        ...(theme.direction !== 'rtl' && {
+          paddingRight: undefined,
+        }),
       },
     },
     tableRow: {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -102,7 +102,8 @@ export const TouchRippleRipple = styled(Ripple, {
 
   & .${touchRippleClasses.childPulsate} {
     position: absolute;
-    left: 0;
+    /* @noflip */
+    left: 0px;
     top: 0;
     animation-name: ${pulsateKeyframe};
     animation-duration: 2500ms;

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@material-ui/unstyled';
 import styled from '../styles/styled';
+import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import { duration } from '../styles/createTransitions';
 import ClickAwayListener from '../ClickAwayListener';
@@ -42,9 +43,16 @@ const SnackbarRoot = styled('div', {
   },
 })(({ theme, ownerState }) => {
   const center = {
-    left: '50%',
-    right: 'auto',
-    transform: 'translateX(-50%)',
+    ...(!ownerState.isRtl && {
+      left: '50%',
+      right: 'auto',
+      transform: 'translateX(-50%)',
+    }),
+    ...(ownerState.isRtl && {
+      right: '50%',
+      left: 'auto',
+      transform: 'translateX(50%)',
+    }),
   };
 
   return {
@@ -61,8 +69,26 @@ const SnackbarRoot = styled('div', {
     [theme.breakpoints.up('sm')]: {
       ...(ownerState.anchorOrigin.vertical === 'top' ? { top: 24 } : { bottom: 24 }),
       ...(ownerState.anchorOrigin.horizontal === 'center' && center),
-      ...(ownerState.anchorOrigin.horizontal === 'left' && { left: 24, right: 'auto' }),
-      ...(ownerState.anchorOrigin.horizontal === 'right' && { right: 24, left: 'auto' }),
+      ...(ownerState.anchorOrigin.horizontal === 'left' && {
+        ...(!ownerState.isRtl && {
+          left: 24,
+          right: 'auto',
+        }),
+        ...(ownerState.isRtl && {
+          right: 24,
+          left: 'auto',
+        }),
+      }),
+      ...(ownerState.anchorOrigin.horizontal === 'right' && {
+        ...(!ownerState.isRtl && {
+          right: 24,
+          left: 'auto',
+        }),
+        ...(ownerState.isRtl && {
+          left: 24,
+          right: 'auto',
+        }),
+      }),
     },
   };
 });
@@ -93,7 +119,10 @@ const Snackbar = React.forwardRef(function Snackbar(inProps, ref) {
     ...other
   } = props;
 
-  const ownerState = { ...props, anchorOrigin: { vertical, horizontal } };
+  const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
+
+  const ownerState = { ...props, anchorOrigin: { vertical, horizontal }, isRtl };
   const classes = useUtilityClasses(ownerState);
 
   const timerAutoHide = React.useRef();


### PR DESCRIPTION
I've searched on master and found the following occurrences of `flip: false` (I've ignored the docs documenting this feature):

```
// Fixed with the changes in DemoToolbar.js
docs\src\modules\components\Demo.js:
  90            display: 'flex',
  91:           flip: false,
  92            top: 0,

// Fixed with the changes in MarkdownElement.js
docs\src\modules\components\MarkdownElement.js:
  203  });
  204: const useStyles = makeStyles(styles, { name: 'MarkdownElement', flip: false });
  205  

// Fixed with the changes in ReactVirtualizedTable.js
docs\src\pages\components\tables\ReactVirtualizedTable.js:
  18      '& .ReactVirtualized__Table__headerRow': {
  19:       flip: false,
  20        paddingRight: theme.direction === 'rtl' ? '0 !important' : undefined,

// Fixed with the changes in ReactVirtualizedTable.tsx
docs\src\pages\components\tables\ReactVirtualizedTable.tsx:
  28        '& .ReactVirtualized__Table__headerRow': {
  29:         flip: false,
  30          paddingRight: theme.direction === 'rtl' ? '0 !important' : undefined,

// Fixed by using /* @noflip */ as the styles are defined with string template (I've verified that it works)
packages\material-ui\src\ButtonBase\TouchRipple.js:
  297  
  298: export default withStyles(styles, { flip: false, name: 'MuiTouchRipple' })(React.memo(TouchRipple));

// Coudn't find any styles that needs transforming
packages\material-ui\src\CircularProgress\CircularProgress.js:
  227  
  228: export default withStyles(styles, { name: 'MuiCircularProgress', flip: false })(CircularProgress);

// No need for transforming as the check for rtl is done in https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/Drawer/Drawer.js#L141
packages\material-ui\src\Drawer\Drawer.js:
  271  
  272: export default withStyles(styles, { name: 'MuiDrawer', flip: false })(Drawer);

// Fixed with the changes in Snackbar.js
packages\material-ui\src\Snackbar\Snackbar.js:
  396  
  397: export default withStyles(styles, { flip: false, name: 'MuiSnackbar' })(Snackbar);

// Fixed in https://github.com/mui-org/material-ui/pull/27868
packages\material-ui\src\Tooltip\Tooltip.js:
  651  
  652: export default withStyles(styles, { name: 'MuiTooltip', flip: false })(Tooltip);

// Couldn't find any styles that needs transforming
packages\material-ui-docs\src\NProgressBar\NProgressBar.js:
  80  
  81: const GlobalStyles = withStyles(styles, { flip: false, name: 'MuiNProgressBar' })(() => null);
  82  
```