### PR TITLE
Revert "[examples] Fix nextjs with styled-components example"

### DIFF
--- a/examples/nextjs-with-styled-components-typescript/next.config.js
+++ b/examples/nextjs-with-styled-components-typescript/next.config.js
@@ -1,0 +1,12 @@
+const withTM = require('next-transpile-modules')(['@material-ui/core', '@material-ui/system']); // pass the modules you would like to see transpiled
+
+module.exports = withTM({
+  reactStrictMode: true,
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@material-ui/styled-engine': '@material-ui/styled-engine-sc',
+    };
+    return config;
+  },
+});

--- a/examples/nextjs-with-styled-components-typescript/package.json
+++ b/examples/nextjs-with-styled-components-typescript/package.json
@@ -10,15 +10,13 @@
   },
   "dependencies": {
     "@material-ui/core": "next",
-    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next",
+    "@material-ui/styled-engine-sc": "next",
     "next": "latest",
+    "next-transpile-modules": "latest",
     "react": "latest",
     "react-dom": "latest",
     "react-is": "latest",
     "styled-components": "latest"
-  },
-  "resolutions": {
-    "@material-ui/styled-engine": "npm:@material-ui/styled-engine-sc@next"
   },
   "devDependencies": {
     "@types/react": "latest",

--- a/examples/nextjs-with-styled-components-typescript/tsconfig.json
+++ b/examples/nextjs-with-styled-components-typescript/tsconfig.json
@@ -12,7 +12,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "paths": {
+      "@material-ui/styled-engine": ["./node_modules/@material-ui/styled-engine-sc"] // this mapping is relative to "baseUrl"
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Reverts mui-org/material-ui#27583

Follow up on https://github.com/mui-org/material-ui/pull/27917 I've tested installing and starting with `npm` it doesn't work - it requires emotion.

Reopens https://github.com/mui-org/material-ui/issues/27512