### PR TITLE
[SvgIcon] Apply custom color if defined in the theme

### DIFF
--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -50,17 +50,13 @@ const SvgIconRoot = styled('svg', {
     large: theme.typography.pxToRem(35),
   }[ownerState.fontSize],
   // TODO v5 deprecate, v6 remove for sx
-  color: {
-    primary: theme.palette.primary.main,
-    secondary: theme.palette.secondary.main,
-    info: theme.palette.info.main,
-    success: theme.palette.success.main,
-    warning: theme.palette.warning.main,
-    action: theme.palette.action.active,
-    error: theme.palette.error.main,
-    disabled: theme.palette.action.disabled,
-    inherit: undefined,
-  }[ownerState.color],
+  color:
+    theme.palette[ownerState.color]?.main ??
+    {
+      action: theme.palette.action.active,
+      disabled: theme.palette.action.disabled,
+      inherit: undefined,
+    }[ownerState.color],
 }));
 
 const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {

--- a/test/regressions/fixtures/SvgIcon/CustomColorSvgIcon.js
+++ b/test/regressions/fixtures/SvgIcon/CustomColorSvgIcon.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+function FavoriteRounded(props) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M13.35 20.13c-.76.69-1.93.69-2.69-.01l-.11-.1C5.3 15.27 1.87 12.16 2 8.28c.06-1.7.93-3.33 2.34-4.29 2.64-1.8 5.9-.96 7.66 1.1 1.76-2.06 5.02-2.91 7.66-1.1 1.41.96 2.28 2.59 2.34 4.29.14 3.88-3.3 6.99-8.55 11.76l-.1.09z" />
+    </SvgIcon>
+  );
+}
+
+export default function SvgIconsColor() {
+  const theme = createTheme({
+    palette: {
+      custom: { main: '#ec407a' },
+    },
+  });
+
+  return (
+    <ThemeProvider theme={theme}>
+      <FavoriteRounded fontSize="large" />
+      <FavoriteRounded fontSize="large" color="secondary" />
+      <FavoriteRounded fontSize="large" color="custom" />
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
Given
```jsx
export default function SvgIconsColor() {
  const theme = createTheme({
    palette: {
      custom: { main: '#ec407a' },
    },
  });

  return (
    <ThemeProvider theme={theme}>
      <FavoriteRounded fontSize="large" />
      <FavoriteRounded fontSize="large" color="secondary" />
      <FavoriteRounded fontSize="large" color="custom" />
    </ThemeProvider>
  );
}
```

Before:
![localhost_5000_regression-SvgIcon_CustomColorSvgIcon_before](https://user-images.githubusercontent.com/12292047/130455240-5b7f404e-a34a-416f-9d98-33e4392d1c0e.png)


After:
![localhost_5000_regression-SvgIcon_CustomColorSvgIcon_after](https://user-images.githubusercontent.com/12292047/130455252-2b73a6af-47eb-4877-95f8-ad54316f2b79.png)


Closes https://github.com/mui-org/material-ui/issues/27831 see https://codesandbox.io/s/material-ui-v5-icons-custom-color-bug-forked-mzyxm