### PR TITLE
[docs] Pass window of iframe to framed demos

### DIFF
--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -140,11 +140,12 @@ function DemoSandboxed(props) {
 
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
-      <Sandbox {...sandboxProps}>
-        <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
+      <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
+        <Sandbox {...sandboxProps}>
+          {/* WARNING: `<Component />` needs to be a child of `Sandbox` since certain implementations rely on `cloneElement` */}
           <Component />
-        </ThemeProvider>
-      </Sandbox>
+        </Sandbox>
+      </ThemeProvider>
     </DemoErrorBoundary>
   );
 }


### PR DESCRIPTION
Just flipped the composition order of `Sandbox -> ThemeProvider` to `ThemeProvider -> Sandbox`.

The demo component needs to be a child of `Sandbox` since some implementations rely on `cloneElement` (this is why `cloneElement` is bad). Otherwise the `window` of the current frame would be incorrect (due to lexical scope).

Notice how the "scroll to top" button is always visible regardless of the scrollbar position of the demo. Or simpler: See the prop-types warning in the `BackToTop` demo on 0ab84c3b0246ef123c9abad3d1aee34c823fc159.
Before:
https://6123aa67c1b1b700071a0df2--material-ui.netlify.app/components/app-bar/#BackToTop
After:
https://deploy-preview-27924--material-ui.netlify.app/components/app-bar/#BackToTop

It's the simplest solution I can come up with since we have to consider that the demo code should be easily copyable. So context doesn't really work (especially due to its boilerplate). We could come up with some transpiling shenanigans but these might not be trivial (to guard against regressions).

So I just added a warning if the composition is changed in the future.

Broke in https://github.com/mui-org/material-ui/pull/27865