### PR TITLE
Add getValue method for getting value when we need inside an event

### DIFF
--- a/packages/material-ui-utils/src/useControlled.js
+++ b/packages/material-ui-utils/src/useControlled.js
@@ -1,10 +1,11 @@
 /* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import * as React from 'react';
+import useStateRef from './useStateRef';
 
 export default function useControlled({ controlled, default: defaultProp, name, state = 'value' }) {
   // isControlled is ignored in the hook dependency lists as it should never change.
   const { current: isControlled } = React.useRef(controlled !== undefined);
-  const [valueState, setValue] = React.useState(defaultProp);
+  const [valueState, setValue, getValue] = useStateRef(defaultProp);
   const value = isControlled ? controlled : valueState;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -45,5 +46,5 @@ export default function useControlled({ controlled, default: defaultProp, name, 
     }
   }, []);
 
-  return [value, setValueIfUncontrolled];
+  return [value, setValueIfUncontrolled, getValue];
 }

--- a/packages/material-ui-utils/src/useStateRef.ts
+++ b/packages/material-ui-utils/src/useStateRef.ts
@@ -1,0 +1,11 @@
+import { useCallback, useRef, useState } from 'react';
+
+function useStateRef<T>(initialValue: T): [T, (nextState: T) => void, () => T] {
+  const [state, setState] = useState(initialValue);
+  const stateRef = useRef(initialValue);
+  stateRef.current = state;
+  const getState = useCallback(() => stateRef.current, []);
+  return [state, setState, getState];
+}
+
+export default useStateRef;

--- a/packages/material-ui/src/Accordion/Accordion.js
+++ b/packages/material-ui/src/Accordion/Accordion.js
@@ -130,7 +130,7 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
     ...other
   } = props;
 
-  const [expanded, setExpandedState] = useControlled({
+  const [expanded, setExpandedState, getExpandedState] = useControlled({
     controlled: expandedProp,
     default: defaultExpanded,
     name: 'Accordion',
@@ -139,13 +139,14 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
 
   const handleChange = React.useCallback(
     (event) => {
-      setExpandedState(!expanded);
+      const nextExpandedState = !getExpandedState();
+      setExpandedState(nextExpandedState);
 
       if (onChange) {
-        onChange(event, !expanded);
+        onChange(event, nextExpandedState);
       }
     },
-    [expanded, onChange, setExpandedState],
+    [getExpandedState, onChange, setExpandedState],
   );
 
   const [summary, ...children] = React.Children.toArray(childrenProp);


### PR DESCRIPTION
`handleChange` just redefines when `onChange` change

Also, we can use `useStateRef` where we need state's value inside an event that we won't redefines by `useCallback`