### PR TITLE
[system] Shorten class names in production

### DIFF
--- a/packages/material-ui-system/src/createStyled.js
+++ b/packages/material-ui-system/src/createStyled.js
@@ -87,10 +87,12 @@ export default function createStyled(input = {}) {
 
     const skipSx = inputSkipSx || false;
 
-    let className;
+    let label;
 
-    if (componentName) {
-      className = `${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
+    if (process.env.NODE_ENV !== 'production') {
+      if (componentName) {
+        label = `${componentName}-${lowercaseFirstLetter(componentSlot || 'Root')}`;
+      }
     }
 
     let shouldForwardPropOption = shouldForwardProp;
@@ -104,7 +106,7 @@ export default function createStyled(input = {}) {
 
     const defaultStyledResolver = styledEngineStyled(tag, {
       shouldForwardProp: shouldForwardPropOption,
-      label: className || componentName || '',
+      label,
       ...options,
     });
     const muiStyledResolver = (styleArg, ...expressions) => {


### PR DESCRIPTION
Testing this idea https://github.com/mui-org/material-ui/pull/27838#issuecomment-902731446 out.

- Before: https://next--material-ui.netlify.app/branding/home/: 15.5 kB - 136 kB
- After: https://deploy-preview-27932--material-ui.netlify.app/branding/home/ 15.2 kB - 125 kB

It doesn't make a major difference but it seems harmless and consistent with how emotion & styled-components handles debuggable class names.

I have tried https://www.webpagetest.org/ but the variance was too high to see a real difference. So I guess, it's more around, do we want the long class names in production at the expense of an inlined CSS a bit larger?