### PR TITLE
[docs] Fix missing `href` for AppDrawerNavItems

### DIFF
--- a/docs/src/components/productDesignKit/DesignKitDemo.tsx
+++ b/docs/src/components/productDesignKit/DesignKitDemo.tsx
@@ -65,7 +65,7 @@ export default function TemplateDemo() {
                 />
               </Highlighter>
             ))}
-            <More component={Link} href={ROUTES.storeDesign} passHref noLinkStyle />
+            <More component={Link} href={ROUTES.storeDesign} noLinkStyle />
           </Group>
         </Grid>
         <Grid item xs={12} md={6}>
@@ -177,7 +177,6 @@ export default function TemplateDemo() {
               </Box>
               <Button
                 component={Link}
-                passHref
                 noLinkStyle
                 href={ROUTES.storeDesign}
                 endIcon={<LaunchRounded sx={{ '&&': { fontSize: 16 } }} />}

--- a/docs/src/components/productDesignKit/DesignKitFAQ.tsx
+++ b/docs/src/components/productDesignKit/DesignKitFAQ.tsx
@@ -29,11 +29,9 @@ const faqData = [
     detail: (
       <React.Fragment>
         We&apos;ll send you an email when a new release is available. You can access the item on the{' '}
-        <InternalLink href="/store/account/download" passHref>
-          download
-        </InternalLink>{' '}
-        page of your store account. You can find a detailed description of the changes under the
-        &quot;Changelog&quot; tab on this page.
+        <InternalLink href="/store/account/download">download</InternalLink> page of your store
+        account. You can find a detailed description of the changes under the &quot;Changelog&quot;
+        tab on this page.
       </React.Fragment>
     ),
   },

--- a/docs/src/components/productDesignKit/DesignKitHero.tsx
+++ b/docs/src/components/productDesignKit/DesignKitHero.tsx
@@ -43,7 +43,6 @@ export default function TemplateHero() {
           </Typography>
           <Button
             component={Link}
-            passHref
             noLinkStyle
             href={ROUTES.storeDesign}
             size="large"

--- a/docs/src/components/productTemplate/TemplateHero.tsx
+++ b/docs/src/components/productTemplate/TemplateHero.tsx
@@ -42,7 +42,6 @@ export default function TemplateHero() {
           </Typography>
           <Button
             component={Link}
-            passHref
             noLinkStyle
             href={ROUTES.storePopular}
             size="large"

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -8,7 +8,7 @@ import { useUserLanguage } from 'docs/src/modules/utils/i18n';
 
 interface NextLinkComposedProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
-    Omit<NextLinkProps, 'href' | 'as'> {
+    Omit<NextLinkProps, 'href' | 'as' | 'passHref'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];
   href?: NextLinkProps['href'];
@@ -16,10 +16,9 @@ interface NextLinkComposedProps
 
 const Anchor = styled('a')({ cursor: 'pointer' });
 
-export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
+const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, locale, ...other } =
-      props;
+    const { to, linkAs, href, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
     return (
       <NextLink
@@ -29,7 +28,7 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         replace={replace}
         scroll={scroll}
         shallow={shallow}
-        passHref={passHref}
+        passHref
         locale={locale}
       >
         <Anchor ref={ref} {...other} />


### PR DESCRIPTION
The nav items didn't include the common affordances for links (e.g. open new tab, copy link adress etc).

Before: https://6124b8cbdf676e0008cc3e43--material-ui.netlify.app/components/box/
After: https://deploy-preview-27936--material-ui.netlify.app/components/box/

Bisecting lead to 49f21f82bec4a6bb5bec8248c044374bc58f3d5a which makes sense since the child element of `next/link` no longer had the `a` type and therefore needed an explicit `passHref`. 

It's unclear why `passHref` was a supported prop. It wouldn't be useful since the child type is controlled by the implementation not its usage. But we may have destructured it in `NextLinkComposed` because its callsites didn't properly filter `passHref`. This is a responsibility of the callsite of `NextLinkComposed`. Good think is that `passHref` leaking to an `a` would trigger React warnings so we'll see if this is/was ever an issue.