### PR TITLE
[docs] Fix href propagation to anchor

### DIFF
--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -18,8 +18,18 @@ const Anchor = styled('a')({ cursor: 'pointer' });
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, passHref, shallow, prefetch, locale, ...other } =
-      props;
+    const {
+      to,
+      linkAs,
+      href,
+      replace,
+      scroll,
+      passHref = true,
+      shallow,
+      prefetch,
+      locale,
+      ...other
+    } = props;
 
     return (
       <NextLink


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Before

Due to a change in rebranding
```diff
// docs/src/mobules/components/Link.tsx
-<a>...</a>

+const Anchor = styled('a')({}) // to enable `sx` from outside
+<Anchor>...</Anchor>
```

This change cause Nextjs Link to not propagate `href` since `<Anchor>` is a react component. When clicking on the links in docs, will get this error.

<img width="795" alt="Screen Shot 2564-08-24 at 16 55 53" src="https://user-images.githubusercontent.com/18292247/130597577-d7a7937a-384d-4bfa-b925-2709e55e1b37.png">

<img width="911" alt="Screen Shot 2564-08-24 at 17 00 34" src="https://user-images.githubusercontent.com/18292247/130597699-d21692b3-e69e-4349-b155-ca68fda3aaf9.png">

### After

<img width="921" alt="Screen Shot 2564-08-24 at 17 02 14" src="https://user-images.githubusercontent.com/18292247/130597952-4eb6c5d8-d550-47f2-a7ce-09fe29354826.png">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
