### PR TITLE
[Badge] Add missing classes to exported class object

### DIFF
--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -13,7 +13,7 @@ import capitalize from '../utils/capitalize';
 
 export const badgeClasses = {
   ...badgeUnstyledClasses,
-  ...generateUtilityClasses('MuiBadge', ['colorError', 'colorPrimary', 'colorSecondary']),
+  ...generateUtilityClasses('MuiBadge', ['colorError', 'colorInfo', 'colorPrimary', 'colorSecondary', 'colorSuccess', 'colorWarning']),
 };
 
 const RADIUS_STANDARD = 10;

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -13,7 +13,14 @@ import capitalize from '../utils/capitalize';
 
 export const badgeClasses = {
   ...badgeUnstyledClasses,
-  ...generateUtilityClasses('MuiBadge', ['colorError', 'colorInfo', 'colorPrimary', 'colorSecondary', 'colorSuccess', 'colorWarning']),
+  ...generateUtilityClasses('MuiBadge', [
+    'colorError',
+    'colorInfo',
+    'colorPrimary',
+    'colorSecondary',
+    'colorSuccess',
+    'colorWarning',
+  ]),
 };
 
 const RADIUS_STANDARD = 10;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Noticed they were missing. TypeScript told me I could use them, the browser got angry with me for trying to use `undefined` 😄