### PR TITLE
Fix composeClasses order

### DIFF
--- a/packages/material-ui-unstyled/src/composeClasses/composeClasses.test.ts
+++ b/packages/material-ui-unstyled/src/composeClasses/composeClasses.test.ts
@@ -32,8 +32,8 @@ describe('composeClasses', () => {
         },
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root standardOverride MuiTest-standard',
-      slot: 'slotOverride MuiTest-slot',
+      root: 'MuiTest-root MuiTest-standard standardOverride',
+      slot: 'MuiTest-slot slotOverride',
     });
   });
 
@@ -51,8 +51,8 @@ describe('composeClasses', () => {
         },
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root standardOverride MuiTest-standard',
-      slot: 'slotOverride MuiTest-slot',
+      root: 'MuiTest-root MuiTest-standard standardOverride',
+      slot: 'MuiTest-slot slotOverride',
     });
   });
 });

--- a/packages/material-ui-unstyled/src/composeClasses/composeClasses.ts
+++ b/packages/material-ui-unstyled/src/composeClasses/composeClasses.ts
@@ -12,10 +12,10 @@ export default function composeClasses<ClassKey extends string>(
       output[slot] = slots[slot]
         .reduce((acc, key) => {
           if (key) {
+            acc.push(getUtilityClass(key));
             if (classes && classes[key]) {
               acc.push(classes[key]);
             }
-            acc.push(getUtilityClass(key));
           }
           return acc;
         }, [] as string[])


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Resolves #27945

For each `slot`, `composeClasses` appends the custom class in `classes` after the default value instead of prepending it.
This should match how `withStyles` used to work with v4, where you would pass external `classes` which would have higher specificity than the default ones.
