### PR TITLE
[ClockPicker] Fix hours distance

### DIFF
--- a/packages/material-ui-lab/src/ClockPicker/shared.ts
+++ b/packages/material-ui-lab/src/ClockPicker/shared.ts
@@ -48,7 +48,7 @@ export const getHours = (offsetX: number, offsetY: number, ampm: boolean) => {
   let hour = value || 12;
 
   if (!ampm) {
-    if (distance < 90) {
+    if (distance < 76) {
       hour += 12;
       hour %= 24;
     }


### PR DESCRIPTION
Distance of `90` was correct for a clock width of `260` as found in previous versions (https://github.com/mui-org/material-ui-pickers/blob/v3-x/lib/src/_helpers/time-utils.ts#L5). Now that `CLOCK_WIDTH = 220`, the distance needs to be reduced by the same ratio to ~76.15 or `76` in order to get the correct time value.