### PR TITLE
[Masonry] Improve the styling on the demos

### DIFF
--- a/docs/src/pages/components/masonry/BasicMasonry.js
+++ b/docs/src/pages/components/masonry/BasicMasonry.js
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function BasicMasonry() {

--- a/docs/src/pages/components/masonry/BasicMasonry.js
+++ b/docs/src/pages/components/masonry/BasicMasonry.js
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function BasicMasonry() {
   return (
@@ -11,16 +21,7 @@ export default function BasicMasonry() {
       <Masonry columns={4} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/BasicMasonry.tsx
+++ b/docs/src/pages/components/masonry/BasicMasonry.tsx
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function BasicMasonry() {

--- a/docs/src/pages/components/masonry/BasicMasonry.tsx
+++ b/docs/src/pages/components/masonry/BasicMasonry.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function BasicMasonry() {
   return (
@@ -11,16 +21,7 @@ export default function BasicMasonry() {
       <Masonry columns={4} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/DiffColSizeMasonry.js
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonry.js
@@ -1,7 +1,17 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function DiffColSizeMasonry() {
   return (
@@ -9,16 +19,7 @@ export default function DiffColSizeMasonry() {
       <Masonry columns={4} spacing={1}>
         {itemData.map((item, index) => (
           <MasonryItem key={index} columnSpan={item.span}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height: item.height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height: item.height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/DiffColSizeMasonry.js
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonry.js
@@ -9,8 +9,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function DiffColSizeMasonry() {

--- a/docs/src/pages/components/masonry/DiffColSizeMasonry.tsx
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonry.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function DiffColSizeMasonry() {
   return (
@@ -9,16 +19,7 @@ export default function DiffColSizeMasonry() {
       <Masonry columns={4} spacing={1}>
         {itemData.map((item, index) => (
           <MasonryItem key={index} columnSpan={item.span}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height: item.height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height: item.height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/DiffColSizeMasonry.tsx
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonry.tsx
@@ -9,8 +9,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function DiffColSizeMasonry() {

--- a/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.js
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.js
@@ -1,7 +1,17 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function DiffColSizeMasonryBroken() {
   return (
@@ -9,16 +19,7 @@ export default function DiffColSizeMasonryBroken() {
       <Masonry columns={4} spacing={1}>
         {itemData.map((item, index) => (
           <MasonryItem key={index} columnSpan={item.span}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height: item.height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height: item.height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.js
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.js
@@ -9,8 +9,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function DiffColSizeMasonryBroken() {

--- a/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.tsx
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function DiffColSizeMasonryBroken() {
   return (
@@ -9,16 +19,7 @@ export default function DiffColSizeMasonryBroken() {
       <Masonry columns={4} spacing={1}>
         {itemData.map((item, index) => (
           <MasonryItem key={index} columnSpan={item.span}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height: item.height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height: item.height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.tsx
+++ b/docs/src/pages/components/masonry/DiffColSizeMasonryBroken.tsx
@@ -9,8 +9,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function DiffColSizeMasonryBroken() {

--- a/docs/src/pages/components/masonry/FixedColumns.js
+++ b/docs/src/pages/components/masonry/FixedColumns.js
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function FixedColumns() {
   return (
@@ -11,16 +21,7 @@ export default function FixedColumns() {
       <Masonry columns={4} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/FixedColumns.js
+++ b/docs/src/pages/components/masonry/FixedColumns.js
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function FixedColumns() {

--- a/docs/src/pages/components/masonry/FixedColumns.tsx
+++ b/docs/src/pages/components/masonry/FixedColumns.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function FixedColumns() {
   return (
@@ -11,16 +21,7 @@ export default function FixedColumns() {
       <Masonry columns={4} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/FixedColumns.tsx
+++ b/docs/src/pages/components/masonry/FixedColumns.tsx
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function FixedColumns() {

--- a/docs/src/pages/components/masonry/FixedSpacing.js
+++ b/docs/src/pages/components/masonry/FixedSpacing.js
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function FixedSpacing() {

--- a/docs/src/pages/components/masonry/FixedSpacing.js
+++ b/docs/src/pages/components/masonry/FixedSpacing.js
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function FixedSpacing() {
   return (
@@ -11,16 +21,7 @@ export default function FixedSpacing() {
       <Masonry columns={3} spacing={3}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/FixedSpacing.tsx
+++ b/docs/src/pages/components/masonry/FixedSpacing.tsx
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function FixedSpacing() {

--- a/docs/src/pages/components/masonry/FixedSpacing.tsx
+++ b/docs/src/pages/components/masonry/FixedSpacing.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function FixedSpacing() {
   return (
@@ -11,16 +21,7 @@ export default function FixedSpacing() {
       <Masonry columns={3} spacing={3}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/ResponsiveColumns.js
+++ b/docs/src/pages/components/masonry/ResponsiveColumns.js
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function ResponsiveColumns() {

--- a/docs/src/pages/components/masonry/ResponsiveColumns.js
+++ b/docs/src/pages/components/masonry/ResponsiveColumns.js
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function ResponsiveColumns() {
   return (
@@ -11,16 +21,7 @@ export default function ResponsiveColumns() {
       <Masonry columns={{ xs: 3, sm: 4 }} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/ResponsiveColumns.tsx
+++ b/docs/src/pages/components/masonry/ResponsiveColumns.tsx
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function ResponsiveColumns() {

--- a/docs/src/pages/components/masonry/ResponsiveColumns.tsx
+++ b/docs/src/pages/components/masonry/ResponsiveColumns.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function ResponsiveColumns() {
   return (
@@ -11,16 +21,7 @@ export default function ResponsiveColumns() {
       <Masonry columns={{ xs: 3, sm: 4 }} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/ResponsiveSpacing.js
+++ b/docs/src/pages/components/masonry/ResponsiveSpacing.js
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function ResponsiveSpacing() {
   return (
@@ -11,16 +21,7 @@ export default function ResponsiveSpacing() {
       <Masonry columns={3} spacing={{ xs: 1, sm: 2, md: 3 }}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/ResponsiveSpacing.js
+++ b/docs/src/pages/components/masonry/ResponsiveSpacing.js
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function ResponsiveSpacing() {

--- a/docs/src/pages/components/masonry/ResponsiveSpacing.tsx
+++ b/docs/src/pages/components/masonry/ResponsiveSpacing.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function ResponsiveSpacing() {
   return (
@@ -11,16 +21,7 @@ export default function ResponsiveSpacing() {
       <Masonry columns={3} spacing={{ xs: 1, sm: 2, md: 3 }}>
         {heights.map((height, index) => (
           <MasonryItem key={index}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                height,
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item sx={{ height }}>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/ResponsiveSpacing.tsx
+++ b/docs/src/pages/components/masonry/ResponsiveSpacing.tsx
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function ResponsiveSpacing() {

--- a/docs/src/pages/components/masonry/SSRMasonry.js
+++ b/docs/src/pages/components/masonry/SSRMasonry.js
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function SSRMasonry() {

--- a/docs/src/pages/components/masonry/SSRMasonry.js
+++ b/docs/src/pages/components/masonry/SSRMasonry.js
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function SSRMasonry() {
   return (
@@ -11,15 +21,7 @@ export default function SSRMasonry() {
       <Masonry columns={4} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index} defaultHeight={height}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>

--- a/docs/src/pages/components/masonry/SSRMasonry.tsx
+++ b/docs/src/pages/components/masonry/SSRMasonry.tsx
@@ -11,8 +11,8 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.palette.text.secondary,
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 }));
 
 export default function SSRMasonry() {

--- a/docs/src/pages/components/masonry/SSRMasonry.tsx
+++ b/docs/src/pages/components/masonry/SSRMasonry.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import Masonry from '@mui/lab/Masonry';
 import MasonryItem from '@mui/lab/MasonryItem';
 
 const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
 
 export default function SSRMasonry() {
   return (
@@ -11,15 +21,7 @@ export default function SSRMasonry() {
       <Masonry columns={4} spacing={1}>
         {heights.map((height, index) => (
           <MasonryItem key={index} defaultHeight={height}>
-            <Box
-              sx={{
-                textAlign: 'center',
-                border: 1,
-                bgcolor: 'background.paper',
-              }}
-            >
-              {index + 1}
-            </Box>
+            <Item>{index + 1}</Item>
           </MasonryItem>
         ))}
       </Masonry>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The style of the div items used for demo of `Masonry` can be improved to be consistent with those used for demo of `Grid`, which can be found here: https://next.material-ui.com/components/grid/#main-content

**Before**:
https://deploy-preview-27439--material-ui.netlify.app/components/masonry/
![Screenshot 2021-08-25 at 13 55 43](https://user-images.githubusercontent.com/32841130/130797306-73f997a1-5c7d-402b-b633-11c20cf4f9e3.png)


**After**:
https://deploy-preview-27957--material-ui.netlify.app/components/masonry/
![Screenshot 2021-08-25 at 14 15 24](https://user-images.githubusercontent.com/32841130/130797292-374f6356-f448-4324-ae48-ca9286e675e1.png)
