### PR TITLE
[docs] Update correct variable name

### DIFF
--- a/docs/src/pages/system/the-sx-prop/the-sx-prop.md
+++ b/docs/src/pages/system/the-sx-prop/the-sx-prop.md
@@ -198,7 +198,7 @@ const styles = {
 };
 
 export default function App() {
-  return <Button sx={sx}>Example</Button>;
+  return <Button sx={styles}>Example</Button>;
 }
 //    Type '{ flexDirection: string; }' is not assignable to type 'SxProps<Theme> | undefined'.
 //    Type '{ flexDirection: string; }' is not assignable to type 'CSSSelectorObject<Theme>'.


### PR DESCRIPTION
I suppose the `sx` prop should take the `styles` constant there (even if it throws an error anyways)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
