### PR TITLE
[docs] Fix Performance typo

### DIFF
--- a/docs/src/pages/components/steppers/steppers.md
+++ b/docs/src/pages/components/steppers/steppers.md
@@ -70,7 +70,7 @@ Vertical steppers are designed for narrow screen sizes. They are ideal for mobil
 
 {{"demo": "pages/components/steppers/VerticalLinearStepper.js"}}
 
-### Perfomance
+### Performance
 
 The content of a step is unmounted when closed.
 If you need to make the content available to search engines or render expensive component trees inside your modal while optimizing for interaction responsiveness it might be a good idea to keep the step mounted with:


### PR DESCRIPTION
Hello, I am not 100% sure if this was intentional but when going through the docs for Stepper. I noticed what I presume to be a misspelling of the word "Performance". I think this is the only place where it needs changed and the [translation bot](https://github.com/l10nbot) can do a cleanup job changing it elsewhere, not sure how that works.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
