### PR TITLE
[system] Add type safety to styled `overridesResolver`

### DIFF
--- a/docs/src/pages/system/styled/UsingOptions.js
+++ b/docs/src/pages/system/styled/UsingOptions.js
@@ -40,11 +40,11 @@ const MyThemeComponent = styled('div', {
   name: 'MyThemeComponent',
   slot: 'Root',
   // We are specifying here how the styleOverrides are being applied based on props
-  overridesResolver: (props, styles) => ({
-    ...styles.root,
-    ...(props.color === 'primary' && styles.primary),
-    ...(props.color === 'secondary' && styles.secondary),
-  }),
+  overridesResolver: (props, styles) => [
+    styles.root,
+    props.color === 'primary' && styles.primary,
+    props.color === 'secondary' && styles.secondary,
+  ],
 })(({ theme }) => ({
   backgroundColor: 'aliceblue',
   padding: theme.spacing(1),

--- a/docs/src/pages/system/styled/UsingOptions.tsx
+++ b/docs/src/pages/system/styled/UsingOptions.tsx
@@ -45,11 +45,11 @@ const MyThemeComponent = styled('div', {
   name: 'MyThemeComponent',
   slot: 'Root',
   // We are specifying here how the styleOverrides are being applied based on props
-  overridesResolver: (props, styles) => ({
-    ...styles.root,
-    ...(props.color === 'primary' && styles.primary),
-    ...(props.color === 'secondary' && styles.secondary),
-  }),
+  overridesResolver: (props, styles) => [
+    styles.root,
+    props.color === 'primary' && styles.primary,
+    props.color === 'secondary' && styles.secondary,
+  ],
 })<MyThemeComponentProps>(({ theme }) => ({
   backgroundColor: 'aliceblue',
   padding: theme.spacing(1),

--- a/packages/material-ui-lab/src/CalendarPicker/PickersSlideTransition.tsx
+++ b/packages/material-ui-lab/src/CalendarPicker/PickersSlideTransition.tsx
@@ -107,7 +107,7 @@ const PickersSlideTransition = ({
   return (
     <PickersSlideTransitionRoot
       className={clsx(classes.root, className)}
-      childFactory={(element) =>
+      childFactory={(element: React.ReactElement) =>
         React.cloneElement(element, {
           classNames: transitionClasses,
         })

--- a/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/material-ui-lab/src/PickersDay/PickersDay.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { SxProps } from '@mui/system';
+import { CSSInterpolation, SxProps } from '@mui/system';
 import ButtonBase, { ButtonBaseProps } from '@mui/material/ButtonBase';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 import {
@@ -183,7 +183,7 @@ const styleArg = ({ theme, ownerState }: { theme: Theme; ownerState: OwnerState 
 
 const overridesResolver = (
   props: { ownerState: OwnerState },
-  styles: Record<PickersDayClassKey, object>,
+  styles: Record<PickersDayClassKey, CSSInterpolation>,
 ) => {
   const { ownerState } = props;
   return [

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -85,7 +85,7 @@ export interface StyledOptions {
   target?: string;
 }
 
-export interface MuiStyledOptions<Props extends {}, ClassKey extends string | number | symbol> {
+export interface MuiStyledOptions<Props extends {}, ClassKey extends string> {
   name?: string;
   slot?: string;
   overridesResolver?: (
@@ -148,7 +148,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
     ComponentProps extends {} = any,
-    ClassKey extends string | number | symbol = any,
+    ClassKey extends string = any,
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
@@ -168,7 +168,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ComponentProps extends {} = any,
-    ClassKey extends string | number | symbol = any,
+    ClassKey extends string = any,
   >(
     component: C,
     options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
@@ -188,7 +188,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
     ComponentProps extends {} = any,
-    ClassKey extends string | number | symbol = any,
+    ClassKey extends string = any,
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
@@ -204,7 +204,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ComponentProps extends {} = any,
-    ClassKey extends string | number | symbol = any,
+    ClassKey extends string = any,
   >(
     component: C,
     options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
@@ -220,7 +220,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     Tag extends keyof JSX.IntrinsicElements,
     ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
     ComponentProps extends {} = any,
-    ClassKey extends string | number | symbol = any,
+    ClassKey extends string = any,
   >(
     tag: Tag,
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> &
@@ -237,7 +237,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     Tag extends keyof JSX.IntrinsicElements,
     ComponentProps extends {} = any,
-    ClassKey extends string | number | symbol = any,
+    ClassKey extends string = any,
   >(
     tag: Tag,
     options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -90,8 +90,8 @@ export interface MuiStyledOptions<Props extends {}, ClassKey extends string | nu
   slot?: string;
   overridesResolver?: (
     props: Props,
-    styles: Record<ClassKey, Record<string, any>>,
-  ) => Record<string, any>;
+    styles: Record<ClassKey, CSSInterpolation>,
+  ) => CSSInterpolation;
   skipVariantsResolver?: boolean;
   skipSx?: boolean;
 }

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -85,13 +85,13 @@ export interface StyledOptions {
   target?: string;
 }
 
-export interface MuiStyledOptions<Props, ClassKey extends string | number | symbol = ''> {
+export interface MuiStyledOptions<Props extends {}, ClassKey extends string | number | symbol> {
   name?: string;
   slot?: string;
   overridesResolver?: (
     props: Props,
     styles: Record<ClassKey, Record<string, any>>,
-  ) => CSSInterpolation;
+  ) => Record<string, any>;
   skipVariantsResolver?: boolean;
   skipSx?: boolean;
 }
@@ -147,8 +147,8 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
-    ComponentProps = {},
-    ClassKey extends string | number | symbol = '',
+    ComponentProps extends {} = any,
+    ClassKey extends string | number | symbol = any,
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
@@ -167,8 +167,8 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
 
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
-    ComponentProps = {},
-    ClassKey extends string | number | symbol = '',
+    ComponentProps extends {} = any,
+    ClassKey extends string | number | symbol = any,
   >(
     component: C,
     options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
@@ -187,8 +187,8 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
-    ComponentProps = {},
-    ClassKey extends string | number | symbol = '',
+    ComponentProps extends {} = any,
+    ClassKey extends string | number | symbol = any,
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
@@ -203,8 +203,8 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
 
   <
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
-    ComponentProps = {},
-    ClassKey extends string | number | symbol = '',
+    ComponentProps extends {} = any,
+    ClassKey extends string | number | symbol = any,
   >(
     component: C,
     options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
@@ -219,8 +219,8 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     Tag extends keyof JSX.IntrinsicElements,
     ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
-    ComponentProps = {},
-    ClassKey extends string | number | symbol = '',
+    ComponentProps extends {} = any,
+    ClassKey extends string | number | symbol = any,
   >(
     tag: Tag,
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> &
@@ -236,8 +236,8 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
 
   <
     Tag extends keyof JSX.IntrinsicElements,
-    ComponentProps = {},
-    ClassKey extends string | number | symbol = '',
+    ComponentProps extends {} = any,
+    ClassKey extends string | number | symbol = any,
   >(
     tag: Tag,
     options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -85,10 +85,13 @@ export interface StyledOptions {
   target?: string;
 }
 
-export interface MuiStyledOptions {
+export interface MuiStyledOptions<Props, ClassKey extends string | number | symbol = ''> {
   name?: string;
   slot?: string;
-  overridesResolver?: (props: any, styles: Record<string, any>) => Record<string, any>;
+  overridesResolver?: (
+    props: Props,
+    styles: Record<ClassKey, Record<string, any>>,
+  ) => CSSInterpolation;
   skipVariantsResolver?: boolean;
   skipSx?: boolean;
 }
@@ -144,31 +147,38 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
+    ComponentProps = {},
+    ClassKey extends string | number | symbol = '',
   >(
     component: C,
-    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
+      MuiStyledOptions<ComponentProps, ClassKey>,
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
     },
-    {},
+    ComponentProps,
     {
       ref?: React.Ref<InstanceType<C>>;
     }
   >;
 
-  <C extends React.ComponentClass<React.ComponentProps<C>>>(
+  <
+    C extends React.ComponentClass<React.ComponentProps<C>>,
+    ComponentProps = {},
+    ClassKey extends string | number | symbol = '',
+  >(
     component: C,
-    options?: StyledOptions & MuiStyledOptions,
+    options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme;
       as?: React.ElementType;
       sx?: SxProps<Theme>;
     },
-    {},
+    ComponentProps,
     {
       ref?: React.Ref<InstanceType<C>>;
     }
@@ -177,9 +187,12 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
+    ComponentProps = {},
+    ClassKey extends string | number | symbol = '',
   >(
     component: C,
-    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
+      MuiStyledOptions<ComponentProps, ClassKey>,
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme;
@@ -188,9 +201,13 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     }
   >;
 
-  <C extends React.JSXElementConstructor<React.ComponentProps<C>>>(
+  <
+    C extends React.JSXElementConstructor<React.ComponentProps<C>>,
+    ComponentProps = {},
+    ClassKey extends string | number | symbol = '',
+  >(
     component: C,
-    options?: StyledOptions & MuiStyledOptions,
+    options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme;
@@ -202,9 +219,12 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     Tag extends keyof JSX.IntrinsicElements,
     ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
+    ComponentProps = {},
+    ClassKey extends string | number | symbol = '',
   >(
     tag: Tag,
-    options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> &
+      MuiStyledOptions<ComponentProps, ClassKey>,
   ): CreateStyledComponent<
     {
       theme?: Theme;
@@ -214,9 +234,13 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     Pick<JSX.IntrinsicElements[Tag], ForwardedProps>
   >;
 
-  <Tag extends keyof JSX.IntrinsicElements>(
+  <
+    Tag extends keyof JSX.IntrinsicElements,
+    ComponentProps = {},
+    ClassKey extends string | number | symbol = '',
+  >(
     tag: Tag,
-    options?: StyledOptions & MuiStyledOptions,
+    options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
   ): CreateStyledComponent<
     {
       theme?: Theme;

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -85,12 +85,12 @@ export interface StyledOptions {
   target?: string;
 }
 
-export interface MuiStyledOptions<Props extends {}, ClassKey extends string> {
+export interface MuiStyledOptions<Props extends {}, Classes extends {}> {
   name?: string;
   slot?: string;
   overridesResolver?: (
     props: Props,
-    styles: Record<ClassKey, CSSInterpolation>,
+    styles: Record<keyof Classes, CSSInterpolation>,
   ) => CSSInterpolation;
   skipVariantsResolver?: boolean;
   skipSx?: boolean;
@@ -148,11 +148,11 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
     ComponentProps extends {} = any,
-    ClassKey extends string = any,
+    Classes extends {} = any,
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
-      MuiStyledOptions<ComponentProps, ClassKey>,
+      MuiStyledOptions<ComponentProps, Classes>,
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme;
@@ -168,10 +168,10 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ComponentProps extends {} = any,
-    ClassKey extends string = any,
+    Classes extends {} = any,
   >(
     component: C,
-    options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
+    options?: StyledOptions & MuiStyledOptions<ComponentProps, Classes>,
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme;
@@ -188,11 +188,11 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
     ComponentProps extends {} = any,
-    ClassKey extends string = any,
+    Classes extends {} = any,
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> &
-      MuiStyledOptions<ComponentProps, ClassKey>,
+      MuiStyledOptions<ComponentProps, Classes>,
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme;
@@ -204,10 +204,10 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
     ComponentProps extends {} = any,
-    ClassKey extends string = any,
+    Classes extends {} = any,
   >(
     component: C,
-    options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
+    options?: StyledOptions & MuiStyledOptions<ComponentProps, Classes>,
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme;
@@ -220,11 +220,11 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     Tag extends keyof JSX.IntrinsicElements,
     ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
     ComponentProps extends {} = any,
-    ClassKey extends string = any,
+    Classes extends {} = any,
   >(
     tag: Tag,
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> &
-      MuiStyledOptions<ComponentProps, ClassKey>,
+      MuiStyledOptions<ComponentProps, Classes>,
   ): CreateStyledComponent<
     {
       theme?: Theme;
@@ -237,10 +237,10 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     Tag extends keyof JSX.IntrinsicElements,
     ComponentProps extends {} = any,
-    ClassKey extends string = any,
+    Classes extends {} = any,
   >(
     tag: Tag,
-    options?: StyledOptions & MuiStyledOptions<ComponentProps, ClassKey>,
+    options?: StyledOptions & MuiStyledOptions<ComponentProps, Classes>,
   ): CreateStyledComponent<
     {
       theme?: Theme;

--- a/packages/material-ui-system/test/system.spec.tsx
+++ b/packages/material-ui-system/test/system.spec.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { createStyled } from '@mui/system';
+
+const styled = createStyled({});
+type TestProps = {
+  ownerState: {
+    fullWidth: boolean;
+  };
+};
+type TestClasses = {
+  root: string;
+  fullWidth: string;
+};
+
+// Example 1
+const Button1 = styled<any, any, TestProps, TestClasses>('button', {
+  name: 'MuiButton',
+  slot: 'Root',
+  overridesResolver: ({ ownerState }, styles) => [
+    styles.root,
+    ownerState.fullWidth && styles.fullWidth,
+  ],
+})({
+  display: 'flex',
+});
+
+// Example 2
+const Button2 = styled<any, any, TestProps, TestClasses>('button', {
+  name: 'MuiButton',
+  slot: 'Root',
+  overridesResolver: ({ ownerState }, styles) => [
+    // root1 does not exist in `TestClasses`
+    // @ts-expect-error
+    styles.root1,
+    ownerState.fullWidth && styles.fullWidth,
+  ],
+})({
+  display: 'flex',
+});
+
+// Example 3
+const Button3 = styled<any, any, TestProps, TestClasses>('button', {
+  name: 'MuiButton',
+  slot: 'Root',
+  overridesResolver: ({ ownerState }, styles) => [
+    styles.root,
+    // fullWidth1 does not exist in `TestProps`
+    // @ts-expect-error
+    ownerState.fullWidth1 && styles.fullWidth,
+  ],
+})({
+  display: 'flex',
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/27234

> `overridesResolver` current type is `overridesResolver?: (props: any, styles: Record<string, any>) => Record<string, any>;` This isn't particularly useful and type safe.

Solution:
1. Accept two generic types, one for props and the other for classes. 
2. Apply the (received) type for props to `props` of `overridesResolver`. 
3. Apply the (received) type for classes to `styles` of `overridesResolver`. More specifically, we can do this by applying this type: `Record<keys of Classes, CSSInterpolation>`.
4. Change the type of the return value of `overridesResolver` to `CSSInterpolation` from `Record<string, any>`.