### PR TITLE
[core] Use lintable pattern for debounced callbacks

### DIFF
--- a/docs/src/components/home/ElementPointer.tsx
+++ b/docs/src/components/home/ElementPointer.tsx
@@ -48,11 +48,11 @@ export default function PointerContainer({
     name: null,
     target: null,
   });
-  /* eslint-disable react-hooks/exhaustive-deps */
-  const handleMouseOver = React.useCallback(
-    debounce((elementData: Data) => {
-      setData(elementData);
-    }, 200),
+  const handleMouseOver = React.useMemo(
+    () =>
+      debounce((elementData: Data) => {
+        setData(elementData);
+      }, 200),
     [],
   );
   React.useEffect(() => {


### PR DESCRIPTION
`useCallback(debounce(fn))` is not lintable by `exhaustive-deps` (see https://github.com/facebook/react/issues/20904).

However, we can make it lintable by just using `useMemo`:
```diff
-const handleSomething = useCallback(debounce(() => doSomething(someVariable)), [someVariable])
+const handleSomething = useMemo(() => debounce(() => doSomething(someVariable)), [someVariable])
```

Also: Please use global eslint-disable sparringly. There's rarely ever a reson to. Use `eslint-disable-next-line` instead. And if you do disable a rule, please add a rationale.