### PR TITLE
[docs] Don't use nested ternary

### DIFF
--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
@@ -26,11 +25,16 @@ function ListItemLink(props) {
   const { to, open, ...other } = props;
   const primary = breadcrumbNameMap[to];
 
+  let icon = null;
+  if (open != null) {
+    icon = open ? <ExpandLess /> : <ExpandMore />;
+  }
+
   return (
     <li>
       <ListItem button component={RouterLink} to={to} {...other}>
         <ListItemText primary={primary} />
-        {open != null ? open ? <ExpandLess /> : <ExpandMore /> : null}
+        {icon}
       </ListItem>
     </li>
   );

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
 import List from '@material-ui/core/List';
@@ -30,11 +29,16 @@ function ListItemLink(props: ListItemLinkProps) {
   const { to, open, ...other } = props;
   const primary = breadcrumbNameMap[to];
 
+  let icon = null;
+  if (open != null) {
+    icon = open ? <ExpandLess /> : <ExpandMore />;
+  }
+
   return (
     <li>
       <ListItem button component={RouterLink as any} to={to} {...other}>
         <ListItemText primary={primary} />
-        {open != null ? open ? <ExpandLess /> : <ExpandMore /> : null}
+        {icon}
       </ListItem>
     </li>
   );


### PR DESCRIPTION
Either we disable the rule or not. But I feel like every nested ternary can be written more readable without a nested ternary. And especially for demos we want to prioritize readability.

And it makes it more obvious that there might be a better composition possible in the feature `ListItemLink` that is "expandable" and one that isn't.