### PR TITLE
[docs] Change sign-up template autocomplete to use "new-password"

### DIFF
--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.js
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.js
@@ -94,7 +94,7 @@ export default function SignUp() {
                 label="Password"
                 type="password"
                 id="password"
-                autoComplete="current-password"
+                autoComplete="new-password"
               />
             </Grid>
             <Grid item xs={12}>

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
@@ -94,7 +94,7 @@ export default function SignUp() {
                 label="Password"
                 type="password"
                 id="password"
-                autoComplete="current-password"
+                autoComplete="new-password"
               />
             </Grid>
             <Grid item xs={12}>

--- a/docs/src/pages/premium-themes/onepirate/SignUp.js
+++ b/docs/src/pages/premium-themes/onepirate/SignUp.js
@@ -95,7 +95,7 @@ function SignUp() {
                 disabled={submitting || sent}
                 required
                 name="password"
-                autoComplete="current-password"
+                autoComplete="new-password"
                 label="Password"
                 type="password"
                 margin="normal"

--- a/docs/src/pages/premium-themes/onepirate/SignUp.tsx
+++ b/docs/src/pages/premium-themes/onepirate/SignUp.tsx
@@ -95,7 +95,7 @@ function SignUp() {
                 disabled={submitting || sent}
                 required
                 name="password"
-                autoComplete="current-password"
+                autoComplete="new-password"
                 label="Password"
                 type="password"
                 margin="normal"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Just updating the sign-up template to comply with the HTML form control infrastructure standards. 

You can find [here](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password), that `new-password` is preferred in the `autocomplete` field over `current-password` when creating a new account.

Thank you for this awesome package, keep up the good work :)

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
