### PR TITLE
[core] Simplify ResizeObserver logic

### DIFF
--- a/packages/material-ui-lab/src/MasonryItem/MasonryItem.js
+++ b/packages/material-ui-lab/src/MasonryItem/MasonryItem.js
@@ -30,7 +30,9 @@ export const style = ({ ownerState, theme }) => {
       // all contents should have a width of 100%
       width: '100%',
       boxSizing: 'inherit',
-      ...(ownerState.isSSR && { height: '100%' }),
+      ...(ownerState.hasDefaultHeight && {
+        height: '100%',
+      }),
     },
     visibility: ownerState.height ? 'visible' : 'hidden',
     gridColumnEnd: `span ${ownerState.columnSpan}`,
@@ -81,12 +83,14 @@ const MasonryItem = React.forwardRef(function MasonryItem(inProps, ref) {
 
   const { spacing = 1 } = React.useContext(MasonryContext);
   const { children, className, component = 'div', columnSpan = 1, defaultHeight, ...other } = props;
+  const hasDefaultHeight = defaultHeight !== undefined;
 
   const [height, setHeight] = React.useState(defaultHeight);
 
   const ownerState = {
     ...props,
     spacing,
+    hasDefaultHeight,
     columnSpan,
     height: height < 0 ? 0 : height, // MasonryItems to which negative or zero height is passed will be hidden
   };
@@ -94,6 +98,11 @@ const MasonryItem = React.forwardRef(function MasonryItem(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   React.useEffect(() => {
+    // Do not create a resize observer in case of provided height masonry
+    if (hasDefaultHeight) {
+      return null;
+    }
+
     if (typeof ResizeObserver === 'undefined') {
       return null;
     }
@@ -106,7 +115,7 @@ const MasonryItem = React.forwardRef(function MasonryItem(inProps, ref) {
     return () => {
       resizeObserver.disconnect();
     };
-  }, []);
+  }, [hasDefaultHeight]);
 
   const handleRef = useForkRef(ref, masonryItemRef);
 

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -17,14 +17,6 @@ import tabsClasses, { getTabsUtilityClass } from './tabsClasses';
 import ownerDocument from '../utils/ownerDocument';
 import ownerWindow from '../utils/ownerWindow';
 
-const MockResizeObserver = () => {
-  return {
-    observe: () => {},
-    unobserve: () => {},
-    disconnect: () => {},
-  };
-};
-
 const nextItem = (list, item) => {
   if (list === item) {
     return list.firstChild;
@@ -569,21 +561,22 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
     });
     const win = ownerWindow(tabsRef.current);
     win.addEventListener('resize', handleResize);
-    let resizeObserver;
-    try {
-      resizeObserver = new ResizeObserver(handleResize);
-    } catch (err) {
-      resizeObserver = MockResizeObserver(); // Prevent crash for old browsers
-    }
 
-    Array.from(tabListRef.current.children).forEach((child) => {
-      resizeObserver.observe(child);
-    });
+    let resizeObserver;
+
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(handleResize);
+      Array.from(tabListRef.current.children).forEach((child) => {
+        resizeObserver.observe(child);
+      });
+    }
 
     return () => {
       handleResize.clear();
       win.removeEventListener('resize', handleResize);
-      resizeObserver.disconnect();
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
     };
   }, [updateIndicatorState, updateScrollButtonState]);
 

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -5,14 +5,6 @@ import useForkRef from '../utils/useForkRef';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 import ownerWindow from '../utils/ownerWindow';
 
-const MockResizeObserver = () => {
-  return {
-    observe: () => {},
-    unobserve: () => {},
-    disconnect: () => {},
-  };
-};
-
 function getStyleValue(computedStyle, property) {
   return parseInt(computedStyle[property], 10) || 0;
 }
@@ -131,18 +123,18 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
     const containerWindow = ownerWindow(inputRef.current);
     containerWindow.addEventListener('resize', handleResize);
     let resizeObserver;
-    try {
+
+    if (typeof ResizeObserver !== 'undefined') {
       resizeObserver = new ResizeObserver(handleResize);
-    } catch (err) {
-      resizeObserver = MockResizeObserver(); // Prevent crash for old browsers and test failure
+      resizeObserver.observe(inputRef.current);
     }
-    const item = inputRef.current;
-    resizeObserver.observe(item);
 
     return () => {
       handleResize.clear();
       containerWindow.removeEventListener('resize', handleResize);
-      resizeObserver.unobserve(item);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
     };
   }, [syncHeight]);
 


### PR DESCRIPTION
A follow-up on #27791 and #27840, it seems that we could simplify the logic, without having to mock.

<img width="944" alt="Screenshot 2021-08-30 at 00 30 21" src="https://user-images.githubusercontent.com/3165635/131267370-3d37b46f-3fde-4639-ad15-d49cc2aaa20e.png">

Preview: https://deploy-preview-28037--material-ui.netlify.app/components/masonry/#server-side-rendering