### PR TITLE
[eslint-plugin-material-ui] Only require translation of word characters and not API

### DIFF
--- a/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.js
+++ b/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.js
@@ -6,7 +6,7 @@ module.exports = {
   meta: {
     messages: {
       'literal-label':
-        "Don't use hardcoded labels. Prefer translated values by using `t` from the redux store.",
+        "Don't use hardcoded labels. Prefer translated values by using `useTranslates`. New translations should be added to `docs/translations/translations.json`.",
     },
   },
   create(context) {

--- a/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.js
+++ b/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.js
@@ -6,7 +6,7 @@ module.exports = {
   meta: {
     messages: {
       'literal-label':
-        "Don't use hardcoded labels. Prefer translated values by using `useTranslates`. New translations should be added to `docs/translations/translations.json`.",
+        "Don't use hardcoded labels. Prefer translated values by using `useTranslate`. New translations should be added to `docs/translations/translations.json`.",
     },
   },
   create(context) {

--- a/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.js
+++ b/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.js
@@ -1,5 +1,7 @@
 const createEmojiRegex = require('emoji-regex');
 
+const defaultAllow = ['API'];
+
 module.exports = {
   meta: {
     messages: {
@@ -8,12 +10,15 @@ module.exports = {
     },
   },
   create(context) {
-    const { allow = [] } = context.options[0] || {};
+    const { allow: allowOption = [] } = context.options[0] || {};
     const emojiRegex = createEmojiRegex();
+
+    const allow = defaultAllow.concat(allowOption);
 
     function valueViolatesRule(value) {
       const sanitizedValue = typeof value === 'string' ? value.trim() : value;
-      const hasTranslateableContent = sanitizedValue !== '' && !emojiRegex.test(sanitizedValue);
+      const hasTranslateableContent =
+        sanitizedValue !== '' && !emojiRegex.test(sanitizedValue) && /\w+/.test(sanitizedValue);
 
       return hasTranslateableContent && !allow.includes(sanitizedValue);
     }

--- a/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/no-hardcoded-labels.test.js
@@ -18,6 +18,9 @@ ruleTester.run('no-hardcoded-labels', rule, {
     { code: '<a>Material-UI</a>', options: [{ allow: 'Material-UI' }] },
     '<span> ❤️</span>',
     `<button>{t("a")}{' '}</button>`,
+    '<h2>{componentName} API</h2>',
+    '<span>*</span>',
+    '<span>.{className}</span>',
   ],
   invalid: [
     { code: '<button aria-label="a" />', errors: [{ messageId: 'literal-label' }] },


### PR DESCRIPTION
The following patterns are now considered valid:

```jsx
<h2>{componentName} API</h2>
// ignore literals that only consist of non-word characters
<span>*</span>
<span>.{className}</span>
```

`API` is tech jargon. I'm not aware of translations of the abbreviation that are used in other languages.

All of these patterns were reported in `docs/src/modules/components/ApiPage.js`

Also updated the error message now that `t` has its own hook and is no longer tied to redux.