### PR TITLE
[core] Use shallow clone in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,9 @@ jobs:
     displayName: 'Bundle size monitoring'
     condition: eq(variables['command'], 'sizeSnapshot')
     steps:
+      - checkout: self
+        fetchDepth: 1
+
       - task: NodeTool@0
         inputs:
           versionSpec: '12.x'
@@ -151,6 +154,9 @@ jobs:
     displayName: 'Performance monitoring'
     condition: eq(variables['command'], 'benchmark')
     steps:
+      - checkout: self
+        fetchDepth: 1
+
       - task: NodeTool@0
         inputs:
           versionSpec: '12.x'


### PR DESCRIPTION
All Azure Pipelines only need the current source and no older version history. We can just use a shallow clone to safe 30-60s.

Generally, [treeless or blobless clones](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/) should be sufficient for all things we need in CI. But there's no 1st class API for that yet so I'd rather not inline their full git checkout script.