### PR TITLE
[docs] Update toolbar menu to behave closer to default

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -678,7 +678,7 @@ export default function DemoToolbar(props) {
         open={Boolean(anchorEl)}
         onClose={handleMoreClose}
         anchorOrigin={{
-          vertical: 'top',
+          vertical: 'bottom',
           horizontal: 'right',
         }}
         transformOrigin={{


### PR DESCRIPTION
To behave more closely to https://next.material-ui.com/components/menus/#basic-menu

Before 

<img width="334" alt="Screenshot 2021-09-01 at 11 04 15" src="https://user-images.githubusercontent.com/3165635/131643929-4006d7e6-4345-404c-b635-3c329127dfc2.png">

After

<img width="302" alt="Screenshot 2021-09-01 at 11 04 06" src="https://user-images.githubusercontent.com/3165635/131643925-4040e87d-4bb4-42eb-babc-1c8ed2939bf9.png">
