### PR TITLE
[docs] Remove style duplication

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -57,6 +57,10 @@ const Root = styled('div')(({ theme }) => ({
   },
   justifyContent: 'space-between',
   alignItems: 'center',
+  '& .MuiSvgIcon-root': {
+    fontSize: 17,
+    color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
+  },
 }));
 
 const DemoTooltip = styled((props) => {
@@ -532,15 +536,7 @@ export default function DemoToolbar(props) {
               color={demoHovered ? 'primary' : 'default'}
               {...getControlProps(2)}
             >
-              <CodeRoundedIcon
-                sx={{
-                  fontSize: 17,
-                  color: (theme) =>
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.grey[500]
-                      : theme.palette.grey[800],
-                }}
-              />
+              <CodeRoundedIcon />
             </IconButton>
           </ToggleCodeTooltip>
           {demoOptions.hideEditButton ? null : (
@@ -554,16 +550,7 @@ export default function DemoToolbar(props) {
                   onClick={handleCodeSandboxClick}
                   {...getControlProps(3)}
                 >
-                  <SvgIcon
-                    sx={{
-                      fontSize: 17,
-                      color: (theme) =>
-                        theme.palette.mode === 'dark'
-                          ? theme.palette.grey[500]
-                          : theme.palette.grey[800],
-                    }}
-                    viewBox="0 0 1024 1024"
-                  >
+                  <SvgIcon viewBox="0 0 1024 1024">
                     <path d="M755 140.3l0.5-0.3h0.3L512 0 268.3 140h-0.3l0.8 0.4L68.6 256v512L512 1024l443.4-256V256L755 140.3z m-30 506.4v171.2L548 920.1V534.7L883.4 341v215.7l-158.4 90z m-584.4-90.6V340.8L476 534.4v385.7L300 818.5V646.7l-159.4-90.6zM511.7 280l171.1-98.3 166.3 96-336.9 194.5-337-194.6 165.7-95.7L511.7 280z" />
                   </SvgIcon>
                 </IconButton>
@@ -577,16 +564,7 @@ export default function DemoToolbar(props) {
                   onClick={handleStackBlitzClick}
                   {...getControlProps(4)}
                 >
-                  <SvgIcon
-                    sx={{
-                      fontSize: 17,
-                      color: (theme) =>
-                        theme.palette.mode === 'dark'
-                          ? theme.palette.grey[500]
-                          : theme.palette.grey[800],
-                    }}
-                    viewBox="0 0 19 28"
-                  >
+                  <SvgIcon viewBox="0 0 19 28">
                     <path d="M8.13378 16.1087H0L14.8696 0L10.8662 11.1522L19 11.1522L4.13043 27.2609L8.13378 16.1087Z" />
                   </SvgIcon>
                 </IconButton>
@@ -602,15 +580,7 @@ export default function DemoToolbar(props) {
               onClick={handleCopyClick}
               {...getControlProps(5)}
             >
-              <ContentCopyRoundedIcon
-                sx={{
-                  fontSize: 17,
-                  color: (theme) =>
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.grey[500]
-                      : theme.palette.grey[800],
-                }}
-              />
+              <ContentCopyRoundedIcon />
             </IconButton>
           </DemoTooltip>
           <DemoTooltip title={t('resetFocus')} placement="bottom">
@@ -622,15 +592,7 @@ export default function DemoToolbar(props) {
               onClick={handleResetFocusClick}
               {...getControlProps(6)}
             >
-              <ResetFocusIcon
-                sx={{
-                  fontSize: 17,
-                  color: (theme) =>
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.grey[500]
-                      : theme.palette.grey[800],
-                }}
-              />
+              <ResetFocusIcon />
             </IconButton>
           </DemoTooltip>
           <DemoTooltip title={t('resetDemo')} placement="bottom">
@@ -643,15 +605,7 @@ export default function DemoToolbar(props) {
               onClick={onResetDemoClick}
               {...getControlProps(7)}
             >
-              <RefreshRoundedIcon
-                sx={{
-                  fontSize: 17,
-                  color: (theme) =>
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.grey[500]
-                      : theme.palette.grey[800],
-                }}
-              />
+              <RefreshRoundedIcon />
             </IconButton>
           </DemoTooltip>
           <IconButton
@@ -662,13 +616,7 @@ export default function DemoToolbar(props) {
             aria-haspopup="true"
             {...getControlProps(8)}
           >
-            <MoreVertIcon
-              sx={{
-                fontSize: 17,
-                color: (theme) =>
-                  theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
-              }}
-            />
+            <MoreVertIcon />
           </IconButton>
         </div>
       </Root>


### PR DESCRIPTION
I think that we should be careful with the `sx` prop. It seems that we can easily overuse it. In #27956 I saw similar patterns where we were using styled(), then overriding the same property in sx.