### PR TITLE
[docs] Add a recommendation for hoisting GlobalStyles to static constant

### DIFF
--- a/docs/src/pages/customization/how-to-customize/how-to-customize.md
+++ b/docs/src/pages/customization/how-to-customize/how-to-customize.md
@@ -207,7 +207,7 @@ If you are already using the [CssBaseline](/components/css-baseline/) component 
 
 {{"demo": "pages/customization/how-to-customize/OverrideCssBaseline.js", "iframe": true, "height": 100}}
 
-> Note: It is a good practice to hoist the `<GlobalStyles />` to a static constant, to avoid rerendering. This will ensure that the `<style>` tag generated would not change on each render.
+> Note: It is a good practice to hoist the `<GlobalStyles />` to a static constant, to avoid rerendering. This will ensure that the `<style>` tag generated would not recalculate on each render.
 
 ```diff
  import * as React from 'react';

--- a/docs/src/pages/customization/how-to-customize/how-to-customize.md
+++ b/docs/src/pages/customization/how-to-customize/how-to-customize.md
@@ -206,3 +206,22 @@ If you just want to add some global baseline styles for some of the HTML element
 If you are already using the [CssBaseline](/components/css-baseline/) component for setting baseline styles, you can also add these global styles as overrides for this component. Here is how you can achieve the same by using this approach.
 
 {{"demo": "pages/customization/how-to-customize/OverrideCssBaseline.js", "iframe": true, "height": 100}}
+
+> Note: It is a good practice to hoist the `<GlobalStyles />` to a static constant, to avoid rerendering. This will ensure that the `<style>` tag generated would not change on each render.
+
+```diff
+ import * as React from 'react';
+ import GlobalStyles from '@mui/material/GlobalStyles';
+
++const inputGlobalStyles = <GlobalStyles styles={...} />;
+
+ const Input = (props) => {
+   return (
+     <React.Fragment>
+-      <GlobalStyles styles={...} />
++      {inputGlobalStyles}
+       <input {...props} />
+     </React.Fragment>
+   )
+ }
+```


### PR DESCRIPTION
`GlobalStyles` when rendered with `styled-components` update the `<style>` tag on each render (see https://github.com/mui-org/material-ui/pull/28070 for example). Adding a note on the documentation that will suggest to hoist the `GlobalStyles` to static const whenever possible.