### PR TITLE
[docs] Reorder app bar actions

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -257,6 +257,24 @@ function AppFrame(props) {
           <GrowingDiv />
           <Stack direction="row" gap={2.5}>
             <DeferredAppSearch />
+            <Tooltip title={t('appFrame.github')} enterDelay={300}>
+              <IconButton
+                component="a"
+                color="inherit"
+                href={process.env.SOURCE_CODE_REPO}
+                data-ga-event-category="header"
+                data-ga-event-action="github"
+                sx={{ px: '10px' }}
+              >
+                <GitHubIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Notifications />
+            <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
+              <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
+                <SettingsIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
             <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
               <Button {...languageButtonProps} sx={{ display: { xs: 'none', md: 'flex' } }}>
                 <LanguageSpan sx={{ display: { xs: 'none', md: 'block' } }}>
@@ -319,24 +337,6 @@ function AppFrame(props) {
                 </MenuItem>
               </Menu>
             </NoSsr>
-            <Tooltip title={t('appFrame.github')} enterDelay={300}>
-              <IconButton
-                component="a"
-                color="inherit"
-                href={process.env.SOURCE_CODE_REPO}
-                data-ga-event-category="header"
-                data-ga-event-action="github"
-                sx={{ px: '10px' }}
-              >
-                <GitHubIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Notifications />
-            <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-              <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
-                <SettingsIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
           </Stack>
         </Toolbar>
       </StyledAppBar>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -270,28 +270,19 @@ function AppFrame(props) {
               </IconButton>
             </Tooltip>
             <Notifications />
-            <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-              <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
-                <SettingsIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
-              <Button {...languageButtonProps} sx={{ display: { xs: 'none', md: 'flex' } }}>
-                <LanguageSpan sx={{ display: { xs: 'none', md: 'block' } }}>
-                  {LANGUAGES_LABEL.filter((language) => language.code === userLanguage)[0].text}
-                </LanguageSpan>
-                <ArrowDropDownRoundedIcon fontSize="small" color="primary" />
-              </Button>
-            </Tooltip>
             <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
               <IconButton
                 {...languageButtonProps}
                 sx={{
-                  display: { xs: 'flex', md: 'none' },
                   px: '10px',
                 }}
               >
                 <LanguageIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
+              <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
+                <SettingsIcon fontSize="small" />
               </IconButton>
             </Tooltip>
             <NoSsr defer>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -11,10 +11,8 @@ import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import Tooltip from '@mui/material/Tooltip';
-import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import NoSsr from '@mui/material/NoSsr';
-import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Divider from '@mui/material/Divider';
@@ -148,16 +146,6 @@ const StyledAppBar = styled(AppBar, {
 
 const GrowingDiv = styled('div')({
   flex: '1 1 auto',
-});
-
-const LanguageSpan = styled('span')(({ theme }) => {
-  return {
-    display: 'none',
-    fontWeight: theme.typography.fontWeightMedium,
-    [theme.breakpoints.up('md')]: {
-      display: 'block',
-    },
-  };
 });
 
 const NavIconButton = styled(IconButton, {

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -60,7 +60,6 @@ const ToolbarDiv = styled('div')(({ theme }) => {
   return {
     ...theme.mixins.toolbar,
     paddingLeft: theme.spacing(3),
-    marginBottom: '3px',
     display: 'flex',
     flexGrow: 1,
     flexDirection: 'row',


### PR DESCRIPTION
I am proposing we push the Language last, it looked a bit strange to be between the icon buttons and the input, as it doesn't have any borders around.

Previously:

<img src="https://user-images.githubusercontent.com/4512430/131655905-afe21384-4051-47cb-b37c-2a3f936bd616.png" width="400px" />

Now:

<img width="400" alt="Screen Shot 2021-09-01 at 12 22 59" src="https://user-images.githubusercontent.com/67129314/131698753-2e657378-59da-41d7-82aa-40e0c7f71d8d.png">
