### PR TITLE
[docs] Fix preview for multiline JSX attributes

### DIFF
--- a/docs/src/modules/utils/getJsxPreview.js
+++ b/docs/src/modules/utils/getJsxPreview.js
@@ -10,7 +10,7 @@ export default function getJsxPreview(code) {
    * `  );\n}` or `;\n}`
    */
   let jsx = code.match(
-    /export default .*(?:\n {2}return \(\n|\n {2}return )(?: {4}<(?:div|Stack|Box).*?>\n)?(.*?)(\n {4}<\/(?:div|Stack|Box)>)?(\n {2}\);\n}|;\n})/s,
+    /export default .*(?:\n {2}return \(\n|\n {2}return )(?: {4}<(?:div|Stack|Box)(?:[^\n]*>|.*\n\s+>)?\n)?(.*?)(\n {4}<\/(?:div|Stack|Box)>)?(\n {2}\);\n}|;\n})/s,
   );
   // Just the match, otherwise the full source if either no match or preview disabled,
   // so as not to break the Collapse transition.

--- a/docs/src/modules/utils/getJsxPreview.js
+++ b/docs/src/modules/utils/getJsxPreview.js
@@ -10,7 +10,7 @@ export default function getJsxPreview(code) {
    * `  );\n}` or `;\n}`
    */
   let jsx = code.match(
-    /export default .*(?:\n {2}return \(\n|\n {2}return )(?: {4}<div.*?>\n)?(?: {4}<Stack.*?>\n)?(?: {4}<Box.*?>\n)?(.*?)(\n {4}<\/Box>)?(\n {4}<\/Stack>)?(\n {4}<\/div>)?(\n {2}\);\n}|;\n})/s,
+    /export default .*(?:\n {2}return \(\n|\n {2}return )(?: {4}<(?:div|Stack|Box).*?>\n)?(.*?)(\n {4}<\/(?:div|Stack|Box)>)?(\n {2}\);\n}|;\n})/s,
   );
   // Just the match, otherwise the full source if either no match or preview disabled,
   // so as not to break the Collapse transition.

--- a/docs/src/modules/utils/getJsxPreview.test.js
+++ b/docs/src/modules/utils/getJsxPreview.test.js
@@ -87,4 +87,47 @@ export default function HalfRating() {
     ).to.equal(`<Rating />
 `);
   });
+
+  it('should ignore sx prop', () => {
+    expect(
+      getJsxPreview(`
+export default function SlideFromContainer() {
+  const [checked, setChecked] = React.useState(false);
+  const containerRef = React.useRef(null);
+
+  const handleChange = () => {
+    setChecked((prev) => !prev);
+  };
+
+  return (
+    <Box
+      sx={{
+        height: 180,
+        width: 240,
+        display: 'flex',
+        padding: 2,
+        borderRadius: 1,
+        bgcolor: (theme) =>
+          theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
+        overflow: 'hidden',
+      }}
+      ref={containerRef}
+    >
+      <Box sx={{ width: 200 }}>
+        <Slide />
+      </Box>
+    </Box>
+  );
+}
+    `),
+    ).to.equal(`theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
+erflow: 'hidden',
+
+{containerRef}
+
+ sx={{ width: 200 }}>
+lide />
+x>
+`);
+  });
 });

--- a/docs/src/modules/utils/getJsxPreview.test.js
+++ b/docs/src/modules/utils/getJsxPreview.test.js
@@ -120,14 +120,9 @@ export default function SlideFromContainer() {
   );
 }
     `),
-    ).to.equal(`theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
-erflow: 'hidden',
-
-{containerRef}
-
- sx={{ width: 200 }}>
-lide />
-x>
+    ).to.equal(`<Box sx={{ width: 200 }}>
+  <Slide />
+</Box>
 `);
   });
 });


### PR DESCRIPTION
Per-commit review advised.

1. Group detection of wrapper elements
   Hopefully it's clearer now that `div`, `Box` and `Stack` are all considered the same.
2. Showcase current behavior causing 
3. Fix current behavior

Closes https://github.com/mui-org/material-ui/issues/27958
Closes https://github.com/mui-org/material-ui/pull/27994

Before: https://612f5f75432821000775a0be--material-ui.netlify.app/components/transitions#SlideFromContainer
After: https://deploy-preview-28092--material-ui.netlify.app/components/transitions/#SlideFromContainer

Note that a regular expression will never be 100% accurate. JavaScript uses a context-sensitive grammar and regular expressions are not powerful enough to parse this type of grammar.

If we hit another edge case, we should move this work into a babel plugin that extracts the preview by parsing the AST (e.g. piggy-back on `yarn docs:typescript:formatted` and create `ExampleComponent.js.preview` files).