### PR TITLE
[Link] Infer `ref` type from `component`

### DIFF
--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -59,7 +59,7 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
 declare const Link: OverridableComponent<LinkTypeMap>;
 
 export type LinkBaseProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> &
-  DistributiveOmit<TypographyProps, 'children' | 'component' | 'color' | 'variant'>;
+  DistributiveOmit<TypographyProps, 'children' | 'component' | 'color' | 'ref' | 'variant'>;
 
 export type LinkProps<
   D extends React.ElementType = LinkTypeMap['defaultComponent'],

--- a/packages/material-ui/src/Link/Link.spec.tsx
+++ b/packages/material-ui/src/Link/Link.spec.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import Link from '@mui/material/Link';
+import { expectType } from '@mui/types';
+
+<Link
+  ref={(elem) => {
+    expectType<HTMLAnchorElement | null, typeof elem>(elem);
+  }}
+>
+  Home
+</Link>;
+
+<Link
+  component="button"
+  // @ts-expect-error Implicit any
+  ref={(elem) => {
+    expectType<any, typeof elem>(elem);
+  }}
+>
+  Home
+</Link>;
+
+<Link
+  component="button"
+  ref={(elem: HTMLButtonElement | null) => {
+    expectType<HTMLButtonElement | null, typeof elem>(elem);
+  }}
+>
+  Home
+</Link>;


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/pull/28046
Closes https://github.com/mui-org/material-ui/issues/24901