### PR TITLE
[website] Fix uneven heights of nav and main headers

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -60,7 +60,6 @@ const ToolbarDiv = styled('div')(({ theme }) => {
   return {
     ...theme.mixins.toolbar,
     paddingLeft: theme.spacing(3),
-    marginBottom: '3px',
     display: 'flex',
     flexGrow: 1,
     flexDirection: 'row',


### PR DESCRIPTION
Feels like a déjà vu after #28085 ;)

Previously:
<img width="244" alt="prev" src="https://user-images.githubusercontent.com/4696105/131850657-b6575961-bdd0-4a8c-b16a-b8105bcc9d46.PNG">

Now:
<img width="237" alt="curr" src="https://user-images.githubusercontent.com/4696105/131850677-fee7ea17-24f6-46e6-a5cb-5bd2baee24d1.PNG">
