### PR TITLE
[docs] Fix Link outdated default `underline` prop

### DIFF
--- a/docs/src/pages/components/links/links.md
+++ b/docs/src/pages/components/links/links.md
@@ -23,7 +23,7 @@ However, the Link component has some different default props than the Typography
 
 ## Underline
 
-The `underline` prop can be used to set the underline behavior. The default is `hover`.
+The `underline` prop can be used to set the underline behavior. The default is `always`.
 
 {{"demo": "pages/components/links/UnderlineLink.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #28133 