### PR TITLE
[docs] Spelling Error: ComposedTextField.js/tsx

### DIFF
--- a/docs/src/pages/components/text-fields/ComposedTextField.js
+++ b/docs/src/pages/components/text-fields/ComposedTextField.js
@@ -8,7 +8,7 @@ import InputLabel from '@mui/material/InputLabel';
 import OutlinedInput from '@mui/material/OutlinedInput';
 
 export default function ComposedTextField() {
-  const [name, setName] = React.useState('Composed TextField');
+  const [name, setName] = React.useState('Composed Text Field');
 
   const handleChange = (event) => {
     setName(event.target.value);

--- a/docs/src/pages/components/text-fields/ComposedTextField.tsx
+++ b/docs/src/pages/components/text-fields/ComposedTextField.tsx
@@ -8,7 +8,7 @@ import InputLabel from '@mui/material/InputLabel';
 import OutlinedInput from '@mui/material/OutlinedInput';
 
 export default function ComposedTextField() {
-  const [name, setName] = React.useState('Composed TextField');
+  const [name, setName] = React.useState('Composed Text Field');
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setName(event.target.value);


### PR DESCRIPTION
Suggest the initial state 'Composed TextField' be changed to 'Composed Text Field' to remove browser rendered spelling error.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
