### PR TITLE
classes property optional and classes object partial

### DIFF
--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -107,7 +107,7 @@ export type WithStyles<
   StylesType extends ClassKeyInferable<any, any>,
   IncludeTheme extends boolean | undefined = false,
 > = (IncludeTheme extends true ? { theme: ThemeOfStyles<StylesType> } : {}) & {
-  classes: ClassNameMap<ClassKeyOfStyles<StylesType>>;
+  classes?: Partial<ClassNameMap<ClassKeyOfStyles<StylesType>>>;
 } & PropsOfStyles<StylesType>;
 
 export interface StyledComponentProps<ClassKey extends string = string> {


### PR DESCRIPTION
in this way the example in https://material-ui.com/guides/typescript/#usage-of-withstyles does not create a component that requires a mandatory 'classes' property and, moreover, this property must contain all the classnames

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
