### PR TITLE
[MasonryItem] Fix crash on unmount when using React 18

### DIFF
--- a/packages/mui-lab/src/MasonryItem/MasonryItem.js
+++ b/packages/mui-lab/src/MasonryItem/MasonryItem.js
@@ -100,11 +100,11 @@ const MasonryItem = React.forwardRef(function MasonryItem(inProps, ref) {
   React.useEffect(() => {
     // Do not create a resize observer in case of provided height masonry
     if (hasDefaultHeight) {
-      return null;
+      return undefined;
     }
 
     if (typeof ResizeObserver === 'undefined') {
-      return null;
+      return undefined;
     }
 
     const resizeObserver = new ResizeObserver(([item]) => {


### PR DESCRIPTION
Bad return values for effects will crash React 18.

I think the constraint was always in place but not actively used. See https://github.com/reactwg/react-18/discussions/95