### PR TITLE
[docs] Demo how to use a specific slide direction for Snackbar

### DIFF
--- a/docs/src/pages/components/snackbars/snackbars.md
+++ b/docs/src/pages/components/snackbars/snackbars.md
@@ -61,7 +61,7 @@ Snackbars should appear above FABs (on mobile).
 
 {{"demo": "pages/components/snackbars/FabIntegrationSnackbar.js", "iframe": true, "maxWidth": 400}}
 
-### Change Transition
+### Change transition
 
 [Grow](/components/transitions/#grow) is the default transition but you can use a different one.
 
@@ -70,6 +70,22 @@ Snackbars should appear above FABs (on mobile).
 ### Control Slide direction
 
 You can change the direction of the [Slide](/components/transitions/#slide) transition.
+
+Example of making the slide transition to the left:
+
+```jsx
+import Slide from '@material-ui/core/Slide';
+
+function TransitionLeft(props) {
+  return <Slide {...props} direction="left" />;
+}
+
+export default function MyComponent() {
+  return <Snackbar TransitionComponent={TransitionLeft} />;
+}
+```
+
+Other examples:
 
 {{"demo": "pages/components/snackbars/DirectionSnackbar.js"}}
 


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #21053

In [this comment](https://github.com/mui-org/material-ui/issues/21053#issuecomment-861394577), Olivier suggested putting the plain example under the ["Change Transition"](https://next.material-ui.com/components/snackbars/#change-transition) heading. However, I placed it under the ["Control Slide direction"](https://next.material-ui.com/components/snackbars/#control-slide-direction) heading because I thought it suited better here. Please confirm.