### PR TITLE
[system] Change type of `styles` arg and return value of `overridesResolver`

### DIFF
--- a/docs/src/pages/system/styled/UsingOptions.js
+++ b/docs/src/pages/system/styled/UsingOptions.js
@@ -40,11 +40,11 @@ const MyThemeComponent = styled('div', {
   name: 'MyThemeComponent',
   slot: 'Root',
   // We are specifying here how the styleOverrides are being applied based on props
-  overridesResolver: (props, styles) => ({
-    ...styles.root,
-    ...(props.color === 'primary' && styles.primary),
-    ...(props.color === 'secondary' && styles.secondary),
-  }),
+  overridesResolver: (props, styles) => [
+    styles.root,
+    props.color === 'primary' && styles.primary,
+    props.color === 'secondary' && styles.secondary,
+  ],
 })(({ theme }) => ({
   backgroundColor: 'aliceblue',
   padding: theme.spacing(1),

--- a/docs/src/pages/system/styled/UsingOptions.tsx
+++ b/docs/src/pages/system/styled/UsingOptions.tsx
@@ -45,11 +45,11 @@ const MyThemeComponent = styled('div', {
   name: 'MyThemeComponent',
   slot: 'Root',
   // We are specifying here how the styleOverrides are being applied based on props
-  overridesResolver: (props, styles) => ({
-    ...styles.root,
-    ...(props.color === 'primary' && styles.primary),
-    ...(props.color === 'secondary' && styles.secondary),
-  }),
+  overridesResolver: (props, styles) => [
+    styles.root,
+    props.color === 'primary' && styles.primary,
+    props.color === 'secondary' && styles.secondary,
+  ],
 })<MyThemeComponentProps>(({ theme }) => ({
   backgroundColor: 'aliceblue',
   padding: theme.spacing(1),

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { SxProps } from '@mui/system';
+import { CSSInterpolation, SxProps } from '@mui/system';
 import ButtonBase, { ButtonBaseProps } from '@mui/material/ButtonBase';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 import {
@@ -183,7 +183,7 @@ const styleArg = ({ theme, ownerState }: { theme: Theme; ownerState: OwnerState 
 
 const overridesResolver = (
   props: { ownerState: OwnerState },
-  styles: Record<PickersDayClassKey, object>,
+  styles: Record<PickersDayClassKey, CSSInterpolation>,
 ) => {
   const { ownerState } = props;
   return [

--- a/packages/mui-system/src/createStyled.d.ts
+++ b/packages/mui-system/src/createStyled.d.ts
@@ -88,7 +88,7 @@ export interface StyledOptions {
 export interface MuiStyledOptions {
   name?: string;
   slot?: string;
-  overridesResolver?: (props: any, styles: Record<string, any>) => Record<string, any>;
+  overridesResolver?: (props: any, styles: Record<string, CSSInterpolation>) => CSSInterpolation;
   skipVariantsResolver?: boolean;
   skipSx?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Continuation of https://github.com/mui-org/material-ui/pull/27983

It was suggested in this issue (https://github.com/mui-org/material-ui/issues/27234) to add generics to `overridesResolver` for type safety. However, it was decided to not implement this for the reasons mentioned here (https://github.com/mui-org/material-ui/pull/27983#pullrequestreview-746952414).

This simply changes the types of `styles` arg and the return value of `overridesResolver`: from `Record<string, any>` to `Record<string, CSSInterpolation>` and from `Record<string, any>` to `CSSInterpolation` respectively.