### PR TITLE
[pickers] Add visual regression tests for open views

### DIFF
--- a/test/regressions/fixtures/pickers/OpenDatePicker.tsx
+++ b/test/regressions/fixtures/pickers/OpenDatePicker.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import TextField from '@mui/material/TextField';
+import { TransitionProps } from '@mui/material/transitions';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import DatePicker from '@mui/lab/DatePicker';
+
+const adapterToUse = new AdapterDateFns();
+
+const NoTransition = React.forwardRef(function NoTransition(
+  props: TransitionProps & { children?: React.ReactNode },
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const { children, in: inProp } = props;
+
+  if (!inProp) {
+    return null;
+  }
+  return (
+    <div ref={ref} tabIndex={-1}>
+      {children}
+    </div>
+  );
+});
+
+export default function OpenDatePicker() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DatePicker
+        onChange={() => {}}
+        open
+        renderInput={(params) => <TextField {...params} />}
+        TransitionComponent={NoTransition}
+        value={adapterToUse.date('2019-01-01T00:00:00.000')}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/fixtures/pickers/OpenDatePicker.tsx
+++ b/test/regressions/fixtures/pickers/OpenDatePicker.tsx
@@ -29,6 +29,10 @@ export default function OpenDatePicker() {
       <DatePicker
         onChange={() => {}}
         open
+        PopperProps={{
+          // @ts-expect-error
+          'data-testid': 'screenshot-target',
+        }}
         renderInput={(params) => <TextField {...params} />}
         TransitionComponent={NoTransition}
         value={adapterToUse.date('2019-01-01T00:00:00.000')}

--- a/test/regressions/fixtures/pickers/OpenDateTimePicker.tsx
+++ b/test/regressions/fixtures/pickers/OpenDateTimePicker.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import TextField from '@mui/material/TextField';
+import { TransitionProps } from '@mui/material/transitions';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import DateTimePicker from '@mui/lab/DateTimePicker';
+
+const adapterToUse = new AdapterDateFns();
+
+const NoTransition = React.forwardRef(function NoTransition(
+  props: TransitionProps & { children?: React.ReactNode },
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const { children, in: inProp } = props;
+
+  if (!inProp) {
+    return null;
+  }
+  return (
+    <div ref={ref} tabIndex={-1}>
+      {children}
+    </div>
+  );
+});
+
+export default function OpenDateTimePicker() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DateTimePicker
+        onChange={() => {}}
+        open
+        renderInput={(params) => <TextField {...params} />}
+        TransitionComponent={NoTransition}
+        value={adapterToUse.date('2019-01-01T00:00:00.000')}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/fixtures/pickers/OpenDateTimePicker.tsx
+++ b/test/regressions/fixtures/pickers/OpenDateTimePicker.tsx
@@ -29,6 +29,10 @@ export default function OpenDateTimePicker() {
       <DateTimePicker
         onChange={() => {}}
         open
+        PopperProps={{
+          // @ts-expect-error
+          'data-testid': 'screenshot-target',
+        }}
         renderInput={(params) => <TextField {...params} />}
         TransitionComponent={NoTransition}
         value={adapterToUse.date('2019-01-01T00:00:00.000')}

--- a/test/regressions/fixtures/pickers/OpenDateTimePickerClock.tsx
+++ b/test/regressions/fixtures/pickers/OpenDateTimePickerClock.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import TextField from '@mui/material/TextField';
+import { TransitionProps } from '@mui/material/transitions';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import DateTimePicker from '@mui/lab/DateTimePicker';
+
+const adapterToUse = new AdapterDateFns();
+
+const NoTransition = React.forwardRef(function NoTransition(
+  props: TransitionProps & { children?: React.ReactNode },
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const { children, in: inProp } = props;
+
+  if (!inProp) {
+    return null;
+  }
+  return (
+    <div ref={ref} tabIndex={-1}>
+      {children}
+    </div>
+  );
+});
+
+export default function OpenDateTimePicker() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DateTimePicker
+        onChange={() => {}}
+        open
+        openTo="hours"
+        renderInput={(params) => <TextField {...params} />}
+        TransitionComponent={NoTransition}
+        value={adapterToUse.date('2019-01-01T00:00:00.000')}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/fixtures/pickers/OpenDateTimePickerClock.tsx
+++ b/test/regressions/fixtures/pickers/OpenDateTimePickerClock.tsx
@@ -30,6 +30,10 @@ export default function OpenDateTimePicker() {
         onChange={() => {}}
         open
         openTo="hours"
+        PopperProps={{
+          // @ts-expect-error
+          'data-testid': 'screenshot-target',
+        }}
         renderInput={(params) => <TextField {...params} />}
         TransitionComponent={NoTransition}
         value={adapterToUse.date('2019-01-01T00:00:00.000')}

--- a/test/regressions/fixtures/pickers/OpenTimePicker.tsx
+++ b/test/regressions/fixtures/pickers/OpenTimePicker.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import TextField from '@mui/material/TextField';
+import { TransitionProps } from '@mui/material/transitions';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import TimePicker from '@mui/lab/TimePicker';
+
+const adapterToUse = new AdapterDateFns();
+
+const NoTransition = React.forwardRef(function NoTransition(
+  props: TransitionProps & { children?: React.ReactNode },
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const { children, in: inProp } = props;
+
+  if (!inProp) {
+    return null;
+  }
+  return (
+    <div ref={ref} tabIndex={-1}>
+      {children}
+    </div>
+  );
+});
+
+export default function OpenTimePicker() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <TimePicker
+        onChange={() => {}}
+        open
+        renderInput={(params) => <TextField {...params} />}
+        TransitionComponent={NoTransition}
+        value={adapterToUse.date('2019-01-01T00:00:00.000')}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/fixtures/pickers/OpenTimePicker.tsx
+++ b/test/regressions/fixtures/pickers/OpenTimePicker.tsx
@@ -29,6 +29,10 @@ export default function OpenTimePicker() {
       <TimePicker
         onChange={() => {}}
         open
+        PopperProps={{
+          // @ts-expect-error
+          'data-testid': 'screenshot-target',
+        }}
         renderInput={(params) => <TextField {...params} />}
         TransitionComponent={NoTransition}
         value={adapterToUse.date('2019-01-01T00:00:00.000')}

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -66,7 +66,11 @@ async function main() {
   async function takeScreenshot({ testcase, route }) {
     const screenshotPath = path.resolve(screenshotDir, `.${route}.png`);
     await fse.ensureDir(path.dirname(screenshotPath));
-    await testcase.screenshot({ path: screenshotPath, type: 'png' });
+
+    const explicitScreenshotTarget = await page.$('[data-testid="screenshot-target"]');
+    const screenshotTarget = explicitScreenshotTarget || testcase;
+
+    await screenshotTarget.screenshot({ path: screenshotPath, type: 'png' });
   }
 
   // prepare screenshots


### PR DESCRIPTION
These are required to catch https://github.com/mui-org/material-ui/issues/25422

Including separately as opposed to inside https://github.com/mui-org/material-ui/pull/27534 so that we see the fix better and keep the tests even if we have to revert https://github.com/mui-org/material-ui/pull/27534