### PR TITLE
[docs] Prepare for v4.material-ui.com deploy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "rimraf ./node_modules/.cache/babel-loader && next dev",
-    "deploy": "git push material-ui-docs master:latest",
+    "deploy": "git push material-ui-docs v4.x:v4",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",

--- a/docs/pages/blog/2019.md
+++ b/docs/pages/blog/2019.md
@@ -16,7 +16,7 @@ It puts us on an exciting path to solve even greater challenges in the coming ye
 - ⭐️ From 43.1k to 53.3k stars, leave us [yours 🌟](https://github.com/mui-org/material-ui).
 - 👨‍👩‍👧‍👦 From 1,064 to [1,581](https://github.com/mui-org/material-ui/graphs/contributors) contributors.
 - 💰 Grew financial support by 76% in 2019, compared to 2018.
-- 🏢 From 1.5 to 3 full-time equivalent developers, spread among multiple financially supported [core team members](https://material-ui.com/discover-more/team/).
+- 🏢 From 1.5 to 3 full-time equivalent developers, spread among multiple financially supported [core team members](https://v4.material-ui.com/discover-more/team/).
 
 The numbers speak for themselves. 2019 was super exciting and made Material-UI one of the most advanced open-source, React-based, UI component libraries!
 

--- a/docs/pages/blog/2019.md
+++ b/docs/pages/blog/2019.md
@@ -16,7 +16,7 @@ It puts us on an exciting path to solve even greater challenges in the coming ye
 - ⭐️ From 43.1k to 53.3k stars, leave us [yours 🌟](https://github.com/mui-org/material-ui).
 - 👨‍👩‍👧‍👦 From 1,064 to [1,581](https://github.com/mui-org/material-ui/graphs/contributors) contributors.
 - 💰 Grew financial support by 76% in 2019, compared to 2018.
-- 🏢 From 1.5 to 3 full-time equivalent developers, spread among multiple financially supported [core team members](https://v4.material-ui.com/discover-more/team/).
+- 🏢 From 1.5 to 3 full-time equivalent developers, spread among multiple financially supported [core team members](/discover-more/team/).
 
 The numbers speak for themselves. 2019 was super exciting and made Material-UI one of the most advanced open-source, React-based, UI component libraries!
 

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -195,8 +195,8 @@ export default function LandingPage(props) {
   "@context": "https://schema.org",
   "@type": "Organization",
   "name": "Material-UI",
-  "url": "https://material-ui.com/",
-  "logo": "https://material-ui.com/static/logo.png",
+  "url": "https://v4.material-ui.com/",
+  "logo": "https://v4.material-ui.com/static/logo.png",
   "sameAs": [
     "https://twitter.com/materialUI",
     "https://github.com/mui-org/material-ui",

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -156,7 +156,7 @@ export default function AppSearch() {
         indexName: 'material-ui',
         inputSelector: '#docsearch-input',
         algoliaOptions: {
-          facetFilters: ['version:master', `language:${userLanguage}`],
+          facetFilters: ['version:v4', `language:${userLanguage}`],
         },
         autocompleteOptions: {
           openOnFocus: true,

--- a/docs/src/modules/components/Head.js
+++ b/docs/src/modules/components/Head.js
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux';
 export default function Head(props) {
   const t = useSelector((state) => state.options.t);
   const {
-    card = 'https://material-ui.com/static/logo.png',
+    card = 'https://v4.material-ui.com/static/logo.png',
     children,
     description = t('strapline'),
     largeCard = false,
@@ -26,7 +26,7 @@ export default function Head(props) {
       {/* Twitter */}
       <meta name="twitter:card" content={largeCard ? 'summary_large_image' : 'summary'} />
       <meta name="twitter:site" content="@MaterialUI" />
-      <meta name="twitter:title" content={title} />
+      <meta name="twitter:title" content={`${title} [v4]`} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={card} />
       {/* Facebook */}
@@ -34,14 +34,14 @@ export default function Head(props) {
       <meta property="og:title" content={title} />
       <meta
         property="og:url"
-        content={`https://material-ui.com${rewriteUrlForNextExport(router.asPath)}`}
+        content={`https://v4.material-ui.com${rewriteUrlForNextExport(router.asPath)}`}
       />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={card} />
       <meta property="og:ttl" content="604800" />
       {/* Algolia */}
       <meta name="docsearch:language" content={userLanguage} />
-      <meta name="docsearch:version" content="master" />
+      <meta name="docsearch:version" content="v4" />
       {children}
     </NextHead>
   );


### PR DESCRIPTION
The PR prepares the deploy for https://v4.material-ui.com

I followed the last three commits from https://github.com/mui-org/material-ui-docs/commits/v3 

I hope I haven't missed something important.