### PR TITLE
[SvgIcon] Allow viewBox to inherit from Component through inheritViewBox prop

### DIFF
--- a/docs/pages/api-docs/svg-icon.json
+++ b/docs/pages/api-docs/svg-icon.json
@@ -18,6 +18,7 @@
       "default": "'medium'"
     },
     "htmlColor": { "type": { "name": "string" } },
+    "inheritViewBox": { "type": { "name": "bool" } },
     "shapeRendering": { "type": { "name": "string" } },
     "sx": { "type": { "name": "object" } },
     "titleAccess": { "type": { "name": "string" } },

--- a/docs/translations/api-docs/svg-icon/svg-icon.json
+++ b/docs/translations/api-docs/svg-icon/svg-icon.json
@@ -7,6 +7,7 @@
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "fontSize": "The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.",
     "htmlColor": "Applies a color attribute to the SVG element.",
+    "inheritViewBox": "Useful when you want to reference a custom <code>component</code> and have <code>SvgIcon</code> pass that <code>component</code>&#39;s viewBox to the root node. If <code>true</code>, the root node will inherit the custom <code>component</code>&#39;s viewBox and the <code>viewBox</code> prop below is ignored.",
     "shapeRendering": "The shape-rendering attribute. The behavior of the different options is described on the <a href=\"https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering\">MDN Web Docs</a>. If you are having issues with blurry icons you should investigate this prop.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "titleAccess": "Provides a human-readable title for the element that contains it. <a href=\"https://www.w3.org/TR/SVG-access/#Equivalent\">https://www.w3.org/TR/SVG-access/#Equivalent</a>",

--- a/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
@@ -49,6 +49,14 @@ export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
      */
     htmlColor?: string;
     /**
+     * Useful when you want to reference a custom `component` and have `SvgIcon` pass that 
+     * `component`'s viewBox to the root node.
+     * If `true`, the root node will inherit the custom `component`'s viewBox and the `viewBox` 
+     * prop below is ignored.
+     * @default false
+     */
+    inheritViewBox?: boolean;
+    /**
      * The shape-rendering attribute. The behavior of the different options is described on the
      * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering).
      * If you are having issues with blurry icons you should investigate this prop.
@@ -91,6 +99,6 @@ declare const SvgIcon: OverridableComponent<SvgIconTypeMap> & { muiName: string 
 export type SvgIconProps<
   D extends React.ElementType = SvgIconTypeMap['defaultComponent'],
   P = {},
-> = OverrideProps<SvgIconTypeMap<P, D>, D>;
+  > = OverrideProps<SvgIconTypeMap<P, D>, D>;
 
 export default SvgIcon;

--- a/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
@@ -49,9 +49,9 @@ export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
      */
     htmlColor?: string;
     /**
-     * Useful when you want to reference a custom `component` and have `SvgIcon` pass that 
+     * Useful when you want to reference a custom `component` and have `SvgIcon` pass that
      * `component`'s viewBox to the root node.
-     * If `true`, the root node will inherit the custom `component`'s viewBox and the `viewBox` 
+     * If `true`, the root node will inherit the custom `component`'s viewBox and the `viewBox`
      * prop below is ignored.
      * @default false
      */

--- a/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
@@ -99,6 +99,6 @@ declare const SvgIcon: OverridableComponent<SvgIconTypeMap> & { muiName: string 
 export type SvgIconProps<
   D extends React.ElementType = SvgIconTypeMap['defaultComponent'],
   P = {},
-  > = OverrideProps<SvgIconTypeMap<P, D>, D>;
+> = OverrideProps<SvgIconTypeMap<P, D>, D>;
 
 export default SvgIcon;

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -69,6 +69,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
     fontSize = 'medium',
     htmlColor,
     titleAccess,
+    inheritViewBox = false,
     viewBox = '0 0 24 24',
     ...other
   } = props;
@@ -81,6 +82,12 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
     viewBox,
   };
 
+  const more = {};
+
+  if (!inheritViewBox) {
+    more.viewBox = viewBox;
+  }
+
   const classes = useUtilityClasses(ownerState);
 
   return (
@@ -89,11 +96,11 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
       className={clsx(classes.root, className)}
       ownerState={ownerState}
       focusable="false"
-      viewBox={viewBox}
       color={htmlColor}
       aria-hidden={titleAccess ? undefined : true}
       role={titleAccess ? 'img' : undefined}
       ref={ref}
+      {...more}
       {...other}
     >
       {children}
@@ -155,6 +162,14 @@ SvgIcon.propTypes /* remove-proptypes */ = {
    * Applies a color attribute to the SVG element.
    */
   htmlColor: PropTypes.string,
+  /**
+   * Useful when you want to reference a custom `component` and have `SvgIcon` pass that
+   * `component`'s viewBox to the root node.
+   * If `true`, the root node will inherit the custom `component`'s viewBox and the `viewBox`
+   * prop below is ignored.
+   * @default false
+   */
+  inheritViewBox: PropTypes.bool,
   /**
    * The shape-rendering attribute. The behavior of the different options is described on the
    * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering).

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -99,13 +99,19 @@ describe('<SvgIcon />', () => {
 
   describe('prop: inheritViewBox', () => {
     it('should render with given viewBox if false', () => {
-      const { container } = render(<SvgIcon inheritViewBox={false} viewBox='0 0 24 24'>{path}</SvgIcon>);
+      const { container } = render(
+        <SvgIcon inheritViewBox={false} viewBox="0 0 24 24">
+          {path}
+        </SvgIcon>,
+      );
 
       expect(container.firstChild).to.have.attribute('viewBox', '0 0 24 24');
     });
 
-    it('should pass custom component\'s viewBox if true', () => {
-      const { container } = render(<SvgIcon component={() => <svg viewBox='-4 -4 24 24'>{path}</svg>} inheritViewBox={true} />);
+    it("should pass custom component's viewBox if true", () => {
+      const { container } = render(
+        <SvgIcon component={() => <svg viewBox="-4 -4 24 24">{path}</svg>} inheritViewBox />,
+      );
 
       expect(container.firstChild).to.have.attribute('viewBox', '-4 -4 24 24');
     });

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -96,4 +96,18 @@ describe('<SvgIcon />', () => {
       expect(container.firstChild).to.have.class(classes.fontSizeInherit);
     });
   });
+
+  describe('prop: inheritViewBox', () => {
+    it('should render with given viewBox if false', () => {
+      const { container } = render(<SvgIcon inheritViewBox={false} viewBox='0 0 24 24'>{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.attribute('viewBox', '0 0 24 24');
+    });
+
+    it('should pass custom component\'s viewBox if true', () => {
+      const { container } = render(<SvgIcon component={() => <svg viewBox='-4 -4 24 24'>{path}</svg>} inheritViewBox={true} />);
+
+      expect(container.firstChild).to.have.attribute('viewBox', '-4 -4 24 24');
+    });
+  });
 });


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #18782

- Implemented the solution suggested in [Olivier's comment](https://github.com/mui-org/material-ui/issues/18782#issuecomment-875720110).
- Based on suggested implementation in #27110

I only updated the [SvgIcon API docs](https://next.material-ui.com/api/svg-icon/) with the new logic implemented here. Do you think that this deserves to be mentioned in the [SvgIcon docs](https://next.material-ui.com/components/icons/#svgicon)?