### PR TITLE
[core] Prepare for v5 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,8 @@ _Sep 1, 2021_
 A big thanks to the 18 contributors who made this release possible. Here are some highlights ✨:
 
 - 🎉 Renamed packages to `@mui/*` as part of rebranding the company, following the strategy of expanding the library scope beyond Material Design. For more details about it, check the [GitHub discussion](https://github.com/mui-org/material-ui/discussions/27803).
-- 🛠 Added `mui-replace` codemod for migrating `@material-ui/*` to new packages `@mui/*`. Check out this [codemod detail](https://github.com/mui-org/material-ui/blob/next/packages/mui-codemod/README.md#mui-replace) or head to [migration guide](https://next.material-ui.com/guides/migration-v4/#preset-safe)
-- 🧪 Added new `<Mansory>` component to the lab, [check it out](https://next.material-ui.com/components/masonry/). It has been crafted by our first intern, @hbjORbj 👏!
+- 🛠 Added `mui-replace` codemod for migrating `@material-ui/*` to new packages `@mui/*`. Check out this [codemod detail](https://github.com/mui-org/material-ui/blob/next/packages/mui-codemod/README.md#mui-replace) or head to [migration guide](https://material-ui.com/guides/migration-v4/#preset-safe)
+- 🧪 Added new `<Mansory>` component to the lab, [check it out](https://material-ui.com/components/masonry/). It has been crafted by our first intern, @hbjORbj 👏!
 
 ### `@mui/material@5.0.0-rc.0`
 
@@ -579,16 +579,16 @@ _Jul 14, 2021_
 A big thanks to the 17 contributors who made this release possible. Here are some highlights ✨:
 
 - ✨ We have introduced a new unstyled component: the Switch (#26688) @michaldudak
-  You can find two new versions of the Switch. A component without any styles: [`SwitchUnstyled`](https://next.material-ui.com/components/switches/#unstyled-switches), and a hook: [`useSwitch`](https://next.material-ui.com/components/switches/#useswitch-hook).
+  You can find two new versions of the Switch. A component without any styles: [`SwitchUnstyled`](https://material-ui.com/components/switches/#unstyled-switches), and a hook: [`useSwitch`](https://material-ui.com/components/switches/#useswitch-hook).
 
-  <a href="https://next.material-ui.com/components/switches/#unstyled-switches"><img width="832" alt="switch" src="https://user-images.githubusercontent.com/3165635/125192249-236f8a80-e247-11eb-9df9-17d476379a32.png"></a>
+  <a href="https://material-ui.com/components/switches/#unstyled-switches"><img width="832" alt="switch" src="https://user-images.githubusercontent.com/3165635/125192249-236f8a80-e247-11eb-9df9-17d476379a32.png"></a>
 
   You can follow our progress at https://github.com/mui-org/material-ui/issues/27170.
 
 - 💄 We have updated the default `info` `success` `warning` color to be more accessible (#26817) @siriwatknp.
-  You can find the new [default values](https://next.material-ui.com/customization/palette/#default-values) in the documentation.
+  You can find the new [default values](https://material-ui.com/customization/palette/#default-values) in the documentation.
 
-  <a href="https://next.material-ui.com/customization/palette/#default-values"><img width="780" alt="colors" src="https://user-images.githubusercontent.com/3165635/125192657-4864fd00-e249-11eb-9dc1-44857b25b3b8.png"></a>
+  <a href="https://material-ui.com/customization/palette/#default-values"><img width="780" alt="colors" src="https://user-images.githubusercontent.com/3165635/125192657-4864fd00-e249-11eb-9dc1-44857b25b3b8.png"></a>
 
 ### `@material-ui/core@5.0.0-beta.1`
 
@@ -828,12 +828,12 @@ A big thanks to the 18 contributors who made this release possible. Here are som
 - 🚀 We have only 2 left in the [breaking changes](https://github.com/mui-org/material-ui/issues/20012). The plan to release 5.0.0-beta.0 is on July 1st and will start to promote its usage over v4.
 - 🎨 We have updated `Slider` to match current [Material Design guidelines](https://material.io/components/sliders).
 
-  <a href="https://next.material-ui.com/components/slider/#continuous-sliders"><img width="247" alt="" src="https://user-images.githubusercontent.com/3165635/121884800-a8808600-cd13-11eb-8cdf-e25de8f1ba73.png" style="margin: auto"></a>
+  <a href="https://material-ui.com/components/slider/#continuous-sliders"><img width="247" alt="" src="https://user-images.githubusercontent.com/3165635/121884800-a8808600-cd13-11eb-8cdf-e25de8f1ba73.png" style="margin: auto"></a>
 
-- 💡 `IconButton` now supports 3 sizes (`small, medium, large`). [See demo](https://next.material-ui.com/components/buttons/#sizes-2).
+- 💡 `IconButton` now supports 3 sizes (`small, medium, large`). [See demo](https://material-ui.com/components/buttons/#sizes-2).
 - ♿️ We have improved the default style of the `Link` to be more accessible (#26145) @ahmed-28
 
-  <a href="https://next.material-ui.com/components/links/"><img width="543" alt="" src="https://user-images.githubusercontent.com/3165635/123097983-ef1b6200-d430-11eb-97da-b491fba5df49.png"></a>
+  <a href="https://material-ui.com/components/links/"><img width="543" alt="" src="https://user-images.githubusercontent.com/3165635/123097983-ef1b6200-d430-11eb-97da-b491fba5df49.png"></a>
 
 ### `@material-ui/core@5.0.0-alpha.38`
 
@@ -911,13 +911,13 @@ A big thanks to the 18 contributors who made this release possible. Here are som
 
 - &#8203;<!-- 08 -->[Slider] Adjust css to match the specification (#26632) @siriwatknp
 
-  Rework the CSS to match the latest [Material Design guidelines](https://material.io/components/sliders) and make custom styles more intuitive. [See documentation](https://next.material-ui.com/components/slider/).
+  Rework the CSS to match the latest [Material Design guidelines](https://material.io/components/sliders) and make custom styles more intuitive. [See documentation](https://material-ui.com/components/slider/).
 
-  <a href="https://next.material-ui.com/components/slider/#continuous-sliders"><img width="247" alt="" src="https://user-images.githubusercontent.com/3165635/121884800-a8808600-cd13-11eb-8cdf-e25de8f1ba73.png" style="margin: auto"></a>
+  <a href="https://material-ui.com/components/slider/#continuous-sliders"><img width="247" alt="" src="https://user-images.githubusercontent.com/3165635/121884800-a8808600-cd13-11eb-8cdf-e25de8f1ba73.png" style="margin: auto"></a>
 
-  You can reduce the density of the slider, closer to v4 with the [`size="small"` prop](https://next.material-ui.com/components/slider/#sizes).
+  You can reduce the density of the slider, closer to v4 with the [`size="small"` prop](https://material-ui.com/components/slider/#sizes).
 
-  <a href="https://next.material-ui.com/components/slider/#sizes"><img width="330" alt="" src="https://user-images.githubusercontent.com/3165635/123076549-8aa0d880-d419-11eb-8835-06cd2b21b2d3.png" style="margin: auto"></a>
+  <a href="https://material-ui.com/components/slider/#sizes"><img width="330" alt="" src="https://user-images.githubusercontent.com/3165635/123076549-8aa0d880-d419-11eb-8835-06cd2b21b2d3.png" style="margin: auto"></a>
 
 - &#8203;<!-- 14 -->[IconButton] Remove label span (#26801) @siriwatknp
 
@@ -1038,7 +1038,7 @@ A big thanks to the 11 contributors who made this release possible. Here are som
   </Grid>
   ```
 
-  Head to the [documentation](https://next.material-ui.com/components/grid/#responsive-values) for more details.
+  Head to the [documentation](https://material-ui.com/components/grid/#responsive-values) for more details.
 
 - ⚒️ We've introduced a new `useTheme` and `useThemeProps` hooks in the `@material-ui/system` package.
   We believe that this package can be used as a standalone styling solution for building custom design systems (#26649) @mnajdova.
@@ -1148,10 +1148,10 @@ A big thanks to the 14 contributors who made this release possible. Here are som
   We're confident that its API shouldn't receive any major changes until the stable release of v5 (#26558) @mnajdova.
 - 📦 `@material-ui/icons` only ships ES modules and no longer CommonJS modules.
   This reduces the download size of the package from 1.7 MB to 1.2 MB and install size from 15.6 MB to 6.7 MB (#26310) @eps1lon.
-- 💄 Add support for [row and column spacing](https://next.material-ui.com/components/grid/#row-amp-column-spacing) in the Grid component (#26559) @likitarai1.
+- 💄 Add support for [row and column spacing](https://material-ui.com/components/grid/#row-amp-column-spacing) in the Grid component (#26559) @likitarai1.
   <img width="549" alt="grid spacing demo" src="https://user-images.githubusercontent.com/3165635/121089288-383fa500-c7e7-11eb-8c43-53457b7430f1.png">
 
-  Note that this feature was already available for [CSS grid users](https://next.material-ui.com/components/grid/#css-grid-layout) with the `rowGap` and `columnGap` props.
+  Note that this feature was already available for [CSS grid users](https://material-ui.com/components/grid/#css-grid-layout) with the `rowGap` and `columnGap` props.
 
 ### `@material-ui/core@5.0.0-alpha.36`
 
@@ -1492,7 +1492,7 @@ A big thanks to the 16 contributors who made this release possible. Here are som
   />
   ```
 
-> Follow [this link](https://next.material-ui.com/guides/migration-v4/#main-content) for full migration from v4 => v5
+> Follow [this link](https://material-ui.com/guides/migration-v4/#main-content) for full migration from v4 => v5
 
 #### Changes
 
@@ -1743,7 +1743,7 @@ A big thanks to the 17 contributors who made this release possible. Here are som
 
 - &#8203;<!-- 64 -->[withWidth] Remove API (#26136) @m4theushw
 
-  Removed in favor of the `useMediaQuery` hook. You can reproduce the same functionality creating a custom hook as described [here](https://next.material-ui.com/components/use-media-query/#migrating-from-withwidth).
+  Removed in favor of the `useMediaQuery` hook. You can reproduce the same functionality creating a custom hook as described [here](https://material-ui.com/components/use-media-query/#migrating-from-withwidth).
 
 - &#8203;<!-- 75 -->[Autocomplete] Rename values of the reason argument (#26172) @m4theushw
 
@@ -2382,7 +2382,7 @@ A big thanks to the 34 contributors who made this release possible. Here are som
 
   <img width="830" alt="stack" src="https://user-images.githubusercontent.com/3165635/112068427-29434200-8b6a-11eb-94e8-057535423b0f.png">
 
-  See the documentation for [more details](https://next.material-ui.com/components/stack/).
+  See the documentation for [more details](https://material-ui.com/components/stack/).
 
 - And many more 🐛 bug fixes and 📚 improvements.
 
@@ -2783,7 +2783,7 @@ A big thanks to the 30 contributors who made this release possible. Here are som
   ```
 
 - 📅 Focus on the date pickers, 5 fixes and 3 docs improvements.
-- 💅 Provide a new [`darkScrollbar()`](https://next.material-ui.com/components/css-baseline/#scrollbars) CSS utility to improve the native scrollbar in dark mode. The documentation uses it.
+- 💅 Provide a new [`darkScrollbar()`](https://material-ui.com/components/css-baseline/#scrollbars) CSS utility to improve the native scrollbar in dark mode. The documentation uses it.
 
 ### `@material-ui/core@5.0.0-alpha.25`
 
@@ -3632,7 +3632,7 @@ A big thanks to the 18 contributors who made this release possible. Here are som
   );
   ```
 
-  This enforces emotion being injected first. [More details](https://next.material-ui.com/guides/interoperability/#css-injection-order) in the documentation.
+  This enforces emotion being injected first. [More details](https://material-ui.com/guides/interoperability/#css-injection-order) in the documentation.
 
 - [Autocomplete] Rename `closeIcon` prop with `clearIcon` to avoid confusion (#23617) @akhilmhdh.
 
@@ -3768,11 +3768,11 @@ A big thanks to the 18 contributors who made this release possible. Here are som
 A big thanks to the 34 contributors who made this release possible. Here are some highlights ✨:
 
 - 📅 Migrate the date picker to the lab (#22692) @dmtrKovalenko.
-  We have integrated the components with the code infrastructure. Next we will migrate all the GitHub issues from [material-ui-pickers](https://github.com/mui-org/material-ui-pickers) and archive the repository. This migration will help provide first-class support for the date picker components. The component will stay in the lab as long as necessary to reach the high quality bar we have for core components. You can find the [new documentation here](https://next.material-ui.com/components/pickers/).
+  We have integrated the components with the code infrastructure. Next we will migrate all the GitHub issues from [material-ui-pickers](https://github.com/mui-org/material-ui-pickers) and archive the repository. This migration will help provide first-class support for the date picker components. The component will stay in the lab as long as necessary to reach the high quality bar we have for core components. You can find the [new documentation here](https://material-ui.com/components/pickers/).
 
   While the source code is currently hosted in the [main repository](https://github.com/mui-org/material-ui), we might move it to the [x repository](https://github.com/mui-org/material-ui-x) in the future, depending on what is easier for the commercial date range picker. The date picker will stay open source no matter what.
 
-- 📚 Revamp the documentation for [the system](https://next.material-ui.com/system/basics/). The System contains CSS utilities. The documentation now promotes the use of the `sx` prop. It's ideal for adding one-off styles, e.g. padding, but when pushed to its limits, it can be used to implement quickly a complete page.
+- 📚 Revamp the documentation for [the system](https://material-ui.com/system/basics/). The System contains CSS utilities. The documentation now promotes the use of the `sx` prop. It's ideal for adding one-off styles, e.g. padding, but when pushed to its limits, it can be used to implement quickly a complete page.
 - 👩‍🎨 Upgrade emotion to v11 (#23007) @mnajdova.
 - And many more 🐛 bug fixes and 📚 improvements.
 
@@ -3874,7 +3874,7 @@ A big thanks to the 20 contributors who made this release possible. Here are som
 - ⚛️ Add support for React 17 (#23311) @eps1lon.
   React 17 release is unusual because it doesn't add any new developer-facing features. It was released a couple of days ago. You can learn more about it in the [introduction post](https://reactjs.org/blog/2020/10/20/react-v17.html). Material-UI now supports `^16.8.0 || ^17.0.0`.
 - 🛠 Introduce a new `@material-ui/unstyled` package (#23270) @mnajdova.
-  This package will host the unstyled version of the components. In this first iteration, only the Slider is available. You can find it documented under the [same page](https://next.material-ui.com/components/slider-styled/#unstyled-slider) as the styled version.
+  This package will host the unstyled version of the components. In this first iteration, only the Slider is available. You can find it documented under the [same page](https://material-ui.com/components/slider-styled/#unstyled-slider) as the styled version.
 
   **Why an unstyled package?**
 
@@ -3884,7 +3884,7 @@ A big thanks to the 20 contributors who made this release possible. Here are som
 
   Another reason for introducing this package is to prepare the groundwork for a [second theme](https://github.com/mui-org/material-ui/issues/22485) (not Material Design based).
 
-  A note on the terminology: "unstyled" means that the components have the same API as the "styled" components but come without CSS. Material-UI also contains "headless" components that exposes a hook API, e.g. [useAutocomplete](https://next.material-ui.com/components/autocomplete/#useautocomplete) or [usePagination](https://next.material-ui.com/components/pagination/#usepagination).
+  A note on the terminology: "unstyled" means that the components have the same API as the "styled" components but come without CSS. Material-UI also contains "headless" components that exposes a hook API, e.g. [useAutocomplete](https://material-ui.com/components/autocomplete/#useautocomplete) or [usePagination](https://material-ui.com/components/pagination/#usepagination).
 
   This change is part of our strategy to iterate on the v5 architecture with the `Slider` first. In the next alpha release, we plan to replace the v4 slider with the v5 slider. Once the new approach is stress-tested and validated, we will roll it out to all the components.
 
@@ -4156,7 +4156,7 @@ A big thanks to the 25 contributors who made this release possible.
 Here are some highlights ✨:
 
 - 📦 Ship modern bundle (#22814) @eps1lon.
-  This is a significant update to the [browsers supported](https://next.material-ui.com/getting-started/supported-platforms/) by Material-UI.
+  This is a significant update to the [browsers supported](https://material-ui.com/getting-started/supported-platforms/) by Material-UI.
   The previous policy was defined 2 years ago, and the landscape has evolved since then. The package now includes 4 bundles:
 
   1. `stable` (default, formerly `esm`) which targets a snapshot (on release) of `> 0.5%, last 2 versions, Firefox ESR, not dead, not IE 11"`
@@ -4167,12 +4167,12 @@ Here are some highlights ✨:
   The change yields a 6% reduction in bundle size 📦 (Babel only).
   In the coming weeks, we will refactor the internals to take advantage of the new browser capabilities that dropping these older platforms allows. For instance, we might be able to remove the span we render inside the `<Button>` to work around [Flexbug #9](https://github.com/philipwalton/flexbugs/blob/master/README.md#flexbug-9).
 
-  Check the updated [Supported platforms documentation](https://next.material-ui.com/getting-started/supported-platforms/) and [new "minimizing bundle size" guide](https://next.material-ui.com/guides/minimizing-bundle-size/).
+  Check the updated [Supported platforms documentation](https://material-ui.com/getting-started/supported-platforms/) and [new "minimizing bundle size" guide](https://material-ui.com/guides/minimizing-bundle-size/).
 
   If you target IE11, you need to use the new bundle (`legacy`). We are treating IE11 as a second class-citizen, which is a continuation of the direction taken in #22873.
 
 - 🚀 Improve the internal benchmark suite (#22923, #23058) @mnajdova.
-  This was a prerequisite step to improve the [system](https://next.material-ui.com/system/basics/). We needed to be able to measure performance. After #22945, we have measured that the `Box` component is x3 faster in v5-alpha compared to v4.
+  This was a prerequisite step to improve the [system](https://material-ui.com/system/basics/). We needed to be able to measure performance. After #22945, we have measured that the `Box` component is x3 faster in v5-alpha compared to v4.
 - ✏️ A new blog post: [Q3 2020 Update](https://material-ui.com/blog/2020-q3-update/) (#23055) @oliviertassinari.
 - 🐙 Migrate more tests to react-testing-library @deiga, @Morteza-Jenabzadeh, @nicholas-l.
 - And many more 🐛 bug fixes and 📚 improvements.
@@ -4286,7 +4286,7 @@ Here are some highlights ✨:
   The early benchmark we have run shows that performance has improved. We will share more detailed results in #21657.
 - 🐙 Migrate a large portion of the tests from enzyme to react-testing-library @eladmotola, @baterson, @bewong89, @devrasec, @guillermaster, @itamar244, @jeferson-sb, @The24thDS.
   Last month, react-testing-library had [more downloads](https://npm-stat.com/charts.html?package=enzyme&package=%40testing-library%2Freact&from=2019-10-10&to=2020-10-10) than enzyme in the ecosystem!
-- 🏷 Add support for tooltips [following the cursor](https://next.material-ui.com/components/tooltips/#follow-cursor) (#22876) @xtrixia.
+- 🏷 Add support for tooltips [following the cursor](https://material-ui.com/components/tooltips/#follow-cursor) (#22876) @xtrixia.
 - And many more 🐛 bug fixes and 📚 improvements.
 
 ### `@material-ui/core@v5.0.0-alpha.12`
@@ -4507,7 +4507,7 @@ Here are some highlights ✨:
 
 - 👩‍🎨 A first iteration on the new styling solution.
 
-  You can find a [new version](https://next.material-ui.com/components/slider-styled/) of the slider in the lab powered by [emotion](https://emotion.sh/).
+  You can find a [new version](https://material-ui.com/components/slider-styled/) of the slider in the lab powered by [emotion](https://emotion.sh/).
 
   In the event that you are already using styled-components in your application, you can swap emotion for styled-components 💅. Check [this CodeSandbox](https://codesandbox.io/s/sliderstyled-with-styled-components-forked-olc27?file=/package.json) for a demo. It relies on aliases to prevent any bundle size overhead.
 
@@ -4520,7 +4520,7 @@ Here are some highlights ✨:
 
 - 🛠 A first iteration on the unstyled components.
 
-  You can find a [new version](https://next.material-ui.com/components/slider-styled/#UnstyledSlider.tsx) of the slider in the lab without any styles.
+  You can find a [new version](https://material-ui.com/components/slider-styled/#UnstyledSlider.tsx) of the slider in the lab without any styles.
   The unstyled component weighs 6.5 kB gzipped, compared with 26 kB for the styled version when used standalone. The component is best suited for use when you want to fully customize the look of the component without reimplementing the JavaScript and accessibility logic.
 
 - ⚡️ A first alpha of the [DataGrid](https://material-ui.com/components/data-grid/) component.
@@ -4943,7 +4943,7 @@ const theme = createMuiTheme({
 });
 ```
 
-- ✨ Add [text in divider](https://next.material-ui.com/components/dividers/#dividers-with-text) support (#22285) @ShehryarShoukat96
+- ✨ Add [text in divider](https://material-ui.com/components/dividers/#dividers-with-text) support (#22285) @ShehryarShoukat96
 
   ```jsx
   <Divider>{'CENTER'}</Divider>
@@ -5260,7 +5260,7 @@ Here are some highlights ✨:
 
   More details in [the documentation](https://material-ui.com/customization/components/#adding-new-component-variants) and [RFC](#21749).
 
-- 👮 Add documentation for the [TrapFocus](https://next.material-ui.com/components/trap-focus/) component (#22062) @oliviertassinari.
+- 👮 Add documentation for the [TrapFocus](https://material-ui.com/components/trap-focus/) component (#22062) @oliviertassinari.
 - ⚛️ Prepare support for React v17 (#22093, #22105, #22143, #22111) @eps1lon.
 - 🚧 We have undertaken breaking changes.
 

--- a/README.md
+++ b/README.md
@@ -26,37 +26,24 @@ Quickly build beautiful [React](https://reactjs.org/) apps. Material-UI is a sim
 
 Material-UI is available as an [npm package](https://www.npmjs.com/package/@mui/material).
 
-**[Stable channel v4](https://material-ui.com/)**
+**[Stable channel v5](https://material-ui.com/)**
 
 ```sh
 // with npm
-npm install @mui/material
+npm install @mui/material @emotion/react @emotion/styled
 
 // with yarn
-yarn add @mui/material
-```
-
-⚠️ All ongoing work has moved to v5. The development of v4 is limited to important bug fixes, security patches and easing the upgrade path to v5.
-
-**[Alpha channel v5](https://next.material-ui.com/)**
-
-```sh
-// with npm
-npm install @mui/material@next @emotion/react @emotion/styled
-
-// with yarn
-yarn add @mui/material@next @emotion/react @emotion/styled
+yarn add @mui/material @emotion/react @emotion/styled
 ```
 
 <details>
   <summary>Older versions</summary>
 
+- **[v4.x](https://v4.material-ui.com/)** ([Migration from v4 to v5](https://material-ui.com/guides/migration-v4/))
 - **[v3.x](https://v3.material-ui.com/)** ([Migration from v3 to v4](https://material-ui.com/guides/migration-v3/))
 - **[v0.x](https://v0.material-ui.com/)** ([Migration to v1](https://material-ui.com/guides/migration-v0x/))
 
 </details>
-
-Please note that `@next` will only point to pre-releases; to get the latest stable release use `@latest` instead.
 
 ## Who sponsors Material-UI?
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ yarn add @mui/material @emotion/react @emotion/styled
 
 </details>
 
+Please note that `@next` will only point to pre-releases; to get the latest stable release use `@latest` instead.
+
 ## Who sponsors Material-UI?
 
 ### Diamond 💎

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -174,7 +174,7 @@ module.exports = {
     REACT_STRICT_MODE: reactStrictMode,
     FEEDBACK_URL: process.env.FEEDBACK_URL,
     // #default-branch-switch
-    SOURCE_CODE_ROOT_URL: 'https://github.com/mui-org/material-ui/blob/next',
+    SOURCE_CODE_ROOT_URL: 'https://github.com/mui-org/material-ui/blob/master',
     SOURCE_CODE_REPO: 'https://github.com/mui-org/material-ui',
     STAGING: staging,
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev",
-    "deploy": "git push material-ui-docs next:next",
+    "deploy": "git push material-ui-docs master:latest",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",

--- a/docs/pages/blog/2020-q2-update.md
+++ b/docs/pages/blog/2020-q2-update.md
@@ -14,9 +14,9 @@ Here are the most significant improvements since March 2020:
 
 - 🚧 Work has started on [the next major version: v5](https://github.com/mui-org/material-ui/issues/20012).<br />
   The last 14 months have been spent focusing on improving the library under the v4.x development branch, while not introducing any breaking changes. During this period we have identified several important areas for improvement. While the absence of breaking changes is a significant time-saver for developers, it also limits the scope of the problems that can be solved and the quality of the solutions. We're excited about what comes next!<br /><br />
-  You can find the documentation for the next version at http://next.material-ui.com/. The next 6-8 months will see weekly releases as always, following [the roadmap](https://github.com/mui-org/material-ui/issues/20012) and [milestone](https://github.com/mui-org/material-ui/milestone/35).
+  You can find the documentation for the next version at http://material-ui.com/. The next 6-8 months will see weekly releases as always, following [the roadmap](https://github.com/mui-org/material-ui/issues/20012) and [milestone](https://github.com/mui-org/material-ui/milestone/35).
 
-- 📍 The icons package has been updated with changes made by Google, leading to [200+ new icons](https://next.material-ui.com/components/material-icons/).
+- 📍 The icons package has been updated with changes made by Google, leading to [200+ new icons](https://material-ui.com/components/material-icons/).
 
   <img src="/static/blog/2020-q2-update/icons.png" alt="icons" style="width: 615px; margin-bottom: 24px;" />
 
@@ -26,7 +26,7 @@ Here are the most significant improvements since March 2020:
 
   Adobe XD and Framer support are also up for consideration if they attract a significant audience, but not until we've polished the Sketch and Figma assets.
 
-- 🔄 `LoadingButton` – [a new component in the lab](https://next.material-ui.com/components/buttons/#loading-buttons). This work is influenced by the [concurrent UI patterns](https://reactjs.org/docs/concurrent-mode-patterns.html) presented by the React team.
+- 🔄 `LoadingButton` – [a new component in the lab](https://material-ui.com/components/buttons/#loading-buttons). This work is influenced by the [concurrent UI patterns](https://reactjs.org/docs/concurrent-mode-patterns.html) presented by the React team.
 
   <img src="/static/blog/2020-q2-update/loading.gif" alt="loading" style="margin-bottom: 24px;" />
 

--- a/docs/pages/blog/2020-q3-update.md
+++ b/docs/pages/blog/2020-q3-update.md
@@ -18,7 +18,7 @@ Here are the most significant improvements since June 2020. This was a dense qua
 - 🧪 We have promoted 7 components from the lab to the core: Alert, Autocomplete, Pagination, Rating, Skeleton, SpeedDial, and ToggleButton.
   Thank you for all your feedback on these components.
   While we still plan a couple of breaking changes on them, we are confident that they have reached the same level of quality as the other core components.
-- 👮 We have introduced a new component in the lab, the [TrapFocus](https://next.material-ui.com/components/trap-focus/). It manages focus for its descendants. This is useful when implementing overlays such as modal dialogs, which should not allow the focus to escape while open:
+- 👮 We have introduced a new component in the lab, the [TrapFocus](https://material-ui.com/components/trap-focus/). It manages focus for its descendants. This is useful when implementing overlays such as modal dialogs, which should not allow the focus to escape while open:
 
   <video autoplay muted loop style="max-height: 416px; margin-bottom: 24px;">
     <source src="/static/blog/2020-q3-update/trap-focus.mp4" type="video/mp4" />
@@ -91,7 +91,7 @@ Here are the most significant improvements since June 2020. This was a dense qua
 
   <img src="/static/blog/2020-q3-update/react-testing-library.png" alt="" style="width: 640px; margin-bottom: 40px; margin-top: 24px;" />
 
-- 💅 We have completed the first iteration of the unstyled components for v5.<br />You can find a [new version](https://next.material-ui.com/components/slider-styled/#UnstyledSlider.tsx) of the slider in the lab without any styles.
+- 💅 We have completed the first iteration of the unstyled components for v5.<br />You can find a [new version](https://material-ui.com/components/slider-styled/#UnstyledSlider.tsx) of the slider in the lab without any styles.
   The unstyled component weighs in at [5.2 kB gzipped](https://bundlephobia.com/result?p=@mui/lab@5.0.0-alpha.12), compared with 26 kB for the styled version (when used standalone). The component is best suited for use when you want to fully customize the look, without reimplementing the JavaScript and accessibility logic.<br />
   We're also pushing in this direction to address a concern we hear from large enterprises
   that want to be able to go one layer down in the abstraction, in order to gain more control.
@@ -103,7 +103,7 @@ Here are the most significant improvements since June 2020. This was a dense qua
   Note that we have experimented with headless components (hooks only) in the past. For instance, you can leverage the [useAutocomplete](/components/autocomplete/#useautocomplete), and [usePagination](/components/pagination/#usepagination) hooks. However, we are pushing with unstyled first as a required step for the next item: ⬇️.
 
 - 👩‍🎨 We have completed the first iteration of the new styling solution of v5.<br />
-  You can find a [new version](https://next.material-ui.com/components/slider-styled/) of the slider in the lab powered by [emotion](https://emotion.sh/docs/introduction).<br />
+  You can find a [new version](https://material-ui.com/components/slider-styled/) of the slider in the lab powered by [emotion](https://emotion.sh/docs/introduction).<br />
   If you are already using styled-components in your application, you can swap emotion for styled-components 💅. Check this [CodeSandbox](https://codesandbox.io/s/sliderstyled-with-styled-components-forked-olc27?file=/package.json) or [CRA](https://github.com/mui-org/material-ui/blob/next/examples/create-react-app-with-styled-components/) for a demo. It relies on aliases to prevent any bundle size overhead.<br />
   The new styling solution saves 2kB+ gzipped in the bundle compared to JSS, and about 14 kB gzipped if you were already using styled-components or emotion.<br />
   Last but not least, this change allows us to take advantage of dynamic style props. We will use them for dynamic color props, variant props, and new style props available in the core components.

--- a/docs/pages/blog/2020.md
+++ b/docs/pages/blog/2020.md
@@ -38,19 +38,19 @@ We have started to leverage these trends as opportunities in the next version of
 We have achieved most of what we could have hoped for.
 
 - The most important, we have welcome 3 new members in the company: [Damien](/blog/spotlight-damien-tassone/), [Marija](/blog/marija-najdova-joining/), and [Danail](/blog/danail-hadjiatanasov-joining/).
-- We have made significant progress with [v5](https://next.material-ui.com/). We have made half the breaking changes planned. We have migrated our [first component](https://next.material-ui.com/components/slider/) to the new style architecture (emotion by default, adapter for styled-components, and unstyled).
+- We have made significant progress with [v5](https://material-ui.com/). We have made half the breaking changes planned. We have migrated our [first component](https://material-ui.com/components/slider/) to the new style architecture (emotion by default, adapter for styled-components, and unstyled).
 - We have introduced new components (some in the core, some in the lab):
   - [Alert](/components/alert/)
   - [DataGrid](/components/data-grid/)
-  - [DatePicker](https://next.material-ui.com/components/date-picker/)
-  - [LoadingButton](https://next.material-ui.com/components/buttons/#loading-buttons)
+  - [DatePicker](https://material-ui.com/components/date-picker/)
+  - [LoadingButton](https://material-ui.com/components/buttons/#loading-buttons)
   - [Timeline](/components/timeline/)
-  - [TrapFocus](https://next.material-ui.com/components/trap-focus/)
+  - [TrapFocus](https://material-ui.com/components/trap-focus/)
 - We have fixed most of the issues with the [Autocomplete](/components/autocomplete/). We have received an overwhelming interest in the component. It was impressive to see.
 - We have completed the work for [strict mode](https://reactjs.org/docs/strict-mode.html) support.
 - We have increased the adoption of TypeScript in the codebase. We don't plan a dedicated migration but to write new code in TypeScript, as we go.
 - We have migrated most of the tests from Enzyme to [Testing Library](https://testing-library.com/).
-- We have modernized the system, introducing an [`sx` prop](https://next.material-ui.com/system/basics/) to be used in all the core components.
+- We have modernized the system, introducing an [`sx` prop](https://material-ui.com/system/basics/) to be used in all the core components.
 - We have added support for [Figma](/store/items/figma-react/) and [Adobe XD](/store/items/adobe-xd-react/).
 - We have released the first Enterprise component in an alpha version: [XGrid](/components/data-grid/#commercial-version).
 
@@ -66,7 +66,7 @@ The [material-ui.com](https://material-ui.com/) marketing website will soon wear
 
 ### Material-UI X
 
-We started to deliver advanced React components in 2020 with the data grid, including a [commercial version](/components/data-grid/#commercial-version) and the beginning of a [date range picker](https://next.material-ui.com/components/date-range-picker/).
+We started to deliver advanced React components in 2020 with the data grid, including a [commercial version](/components/data-grid/#commercial-version) and the beginning of a [date range picker](https://material-ui.com/components/date-range-picker/).
 We will double down on these existing components as long as necessary to have them find the market.
 
 By the end of 2021, we aim to have released these components as stable, implement all the [features planned](/components/data-grid/getting-started/#feature-comparison), and at least double the size of the team.
@@ -77,7 +77,7 @@ We will release the next major iteration of the library. A highlight of the key 
 
 - Polish and promote most of the components that were in the lab in v4 to the core.
 - A new style engine. Migrate from JSS to emotion (default) and styled-components's `styled` API.
-- Improve customizability. Add new powers to the theme with dynamic color & [variant](https://next.material-ui.com/customization/typography/#adding-amp-disabling-variants) support. Add a new [`sx` prop](https://next.material-ui.com/system/basics/) for quick customizations to all the components. Expose global class names. Deprecate the `makeStyles` and `withStyles` API.
+- Improve customizability. Add new powers to the theme with dynamic color & [variant](https://material-ui.com/customization/typography/#adding-amp-disabling-variants) support. Add a new [`sx` prop](https://material-ui.com/system/basics/) for quick customizations to all the components. Expose global class names. Deprecate the `makeStyles` and `withStyles` API.
 - Breaking changes on the API to make it more intuitive.
 - Add full support for React strict mode. We recommend to enable it.
 - Improve the performance of the system by a x3-x5 [factor](https://github.com/mui-org/material-ui/issues/21657#issuecomment-707140999).

--- a/docs/pages/blog/2021-q1-update.md
+++ b/docs/pages/blog/2021-q1-update.md
@@ -43,7 +43,7 @@ Here are the most significant improvements since December 2020.
 
   <img src="/static/blog/2021-q1-update/stack.png" alt="" style="width: 502px; margin-bottom: 16px;" />
 
-  You can find [more details](https://next.material-ui.com/components/stack/) in the documentation.
+  You can find [more details](https://material-ui.com/components/stack/) in the documentation.
 
 - 🎨 We have improved the support for custom colors and variants.
   This is [one](https://github.com/mui-org/material-ui/issues/13875) of the most upvoted issues in the GitHub issue tracker.
@@ -120,7 +120,7 @@ We have primarily focused on the data grid components, fixing a lot of bugs, but
 The date picker is at the border between the advanced components and the design system realms.
 
 - 📚 We have fixed the generation of the API pages.
-  We now document all the props supported by the public pickers components, e.g. [DatePicker](https://next.material-ui.com/api/date-picker/).
+  We now document all the props supported by the public pickers components, e.g. [DatePicker](https://material-ui.com/api/date-picker/).
 - ⚙️ We have mostly focused on addressing the technical debt present in the picker components (ported from `@materal-ui/pickers`).
 
 #### Data Grid
@@ -197,7 +197,7 @@ We will cross the ten-person milestone in the coming weeks (11).
 
 We have the following objectives:
 
-- Finish the implementation of the rebranding. A preview, the [about](https://next.material-ui.com/branding/about/) and [pricing](https://next.material-ui.com/branding/pricing/) pages.
+- Finish the implementation of the rebranding. A preview, the [about](https://material-ui.com/branding/about/) and [pricing](https://material-ui.com/branding/pricing/) pages.
 - Onboard the new members and scale our processes as we double the size of the organization this quarter.
 
 ### Core components

--- a/docs/pages/blog/2021-q2-update.md
+++ b/docs/pages/blog/2021-q2-update.md
@@ -36,37 +36,37 @@ Here are the most significant improvements since March 2021.
 
 - 👩‍🎤 We have rolled out the new **style engine** to all the components.
   The community provided invaluable assistance in completing this effort.
-  In v5, we have standardized on the `styled()` API as the styling foundation we build on top of, and introduced the [the `sx` prop](https://next.material-ui.com/system/the-sx-prop/) for one-off customizations.
-  The `styled()` API is loved by the community, and implemented by a number of styling libraries: styled-components, emotion, stitches, goober, etc. It allows us to support them all with [adapters](https://next.material-ui.com/guides/styled-engine/#how-to-switch-to-styled-components).
+  In v5, we have standardized on the `styled()` API as the styling foundation we build on top of, and introduced the [the `sx` prop](https://material-ui.com/system/the-sx-prop/) for one-off customizations.
+  The `styled()` API is loved by the community, and implemented by a number of styling libraries: styled-components, emotion, stitches, goober, etc. It allows us to support them all with [adapters](https://material-ui.com/guides/styled-engine/#how-to-switch-to-styled-components).
 
 - ⚒️ We added a [codemod CLI](https://github.com/mui-org/material-ui/tree/HEAD/packages/mui-codemod) and 17 transformations (so far) to automatically migrate codebases from v4 to v5.
   If you're not familiar with what a codemod is, check out [Effective Refactoring with Codemods by Edd Yerburgh](https://www.youtube.com/watch?v=H9qtLutnT_g).
 
-- 💄 We have [updated the style of the Slider](https://next.material-ui.com/components/slider/#sizes) to better match the Material Design guidelines, and kept a similar style as before under `size="small"`:
+- 💄 We have [updated the style of the Slider](https://material-ui.com/components/slider/#sizes) to better match the Material Design guidelines, and kept a similar style as before under `size="small"`:
 
-  <a href="https://next.material-ui.com/components/slider/#sizes"><img loading="lazy" src="/static/blog/2021-q2-update/slider.png" alt="" style="width: 838px; margin-bottom: 16px;" /></a>
+  <a href="https://material-ui.com/components/slider/#sizes"><img loading="lazy" src="/static/blog/2021-q2-update/slider.png" alt="" style="width: 838px; margin-bottom: 16px;" /></a>
 
 - ✨ The new style engine has unlocked problems on the `Grid` component that we couldn't solve before with JSS:
 
-  We have added support for [row & column](https://next.material-ui.com/components/grid/#row-amp-column-spacing) spacing:
+  We have added support for [row & column](https://material-ui.com/components/grid/#row-amp-column-spacing) spacing:
 
 ```jsx
 <Grid container rowSpacing={1} columnSpacing={2} />
 ```
 
-We have added support for [responsive values](https://next.material-ui.com/components/grid/#responsive-values) on all the props:
+We have added support for [responsive values](https://material-ui.com/components/grid/#responsive-values) on all the props:
 
 ```jsx
 <Grid container spacing={{ xs: 2, md: 3 }} />
 ```
 
-We have added support for a different [number of columns](https://next.material-ui.com/components/grid/#columns) than 12:
+We have added support for a different [number of columns](https://material-ui.com/components/grid/#columns) than 12:
 
 ```jsx
 <Grid container columns={16}>
 ```
 
-We have added an alternative implementation that uses [CSS grid](https://next.material-ui.com/components/grid/#css-grid-layout):
+We have added an alternative implementation that uses [CSS grid](https://material-ui.com/components/grid/#css-grid-layout):
 
 ```jsx
 <Box display="grid" gridTemplateColumns="repeat(12, 1fr)" gap={2}>
@@ -87,7 +87,7 @@ We have added an alternative implementation that uses [CSS grid](https://next.ma
 
 - 💄 We have improved the accessibility of the Link component:
 
-  <a href="https://next.material-ui.com/components/links/">
+  <a href="https://material-ui.com/components/links/">
     <img loading="lazy" src="/static/blog/2021-q2-update/link.png" alt="" style="width: 129px; margin-bottom: 16px;" />
   </a>
 
@@ -215,7 +215,7 @@ We have the following objectives:
   We want to make the upgrade feel painless.
 - ⚛️ Support [React 18](https://reactjs.org/blog/2021/06/08/the-plan-for-react-18.html). [Sebastian](https://github.com/eps1lon) is part of the React [Working Group](https://github.com/reactwg/react-18/discussions), focusing on making us ready ahead of time.
   We want our most demanding users to feel empowered by Material-UI, not slowed down by a third-party.
-- 🦴 Migrate more components to `@mui/core`. [Michał](https://github.com/michaldudak) has recently added support for the [Switch](https://next.material-ui.com/components/switches/#unstyled-switches).
+- 🦴 Migrate more components to `@mui/core`. [Michał](https://github.com/michaldudak) has recently added support for the [Switch](https://material-ui.com/components/switches/#unstyled-switches).
   You can follow our progress in the [umbrella issue](https://github.com/mui-org/material-ui/issues/27170).
 - 🌈 Do a proof of concept on supporting a second design system.
   Some of our users (and potential users) dislike Material Design. We will try to make the second design system one that they love!

--- a/docs/pages/blog/marija-najdova-joining.md
+++ b/docs/pages/blog/marija-najdova-joining.md
@@ -10,7 +10,7 @@ We are excited to share that [Marija Najdova](https://twitter.com/marijanajdova)
 
 Before joining Material-UI, Marija worked on the React implementation of [Fluent UI](https://www.microsoft.com/design/fluent/) at Microsoft. She's passionate about React, design systems, and component driven development. At Microsoft, as part of the Fluent UI core team since 2018, she was responsible for the icons, animations and various theme related features.
 
-Marija is off to a running start, having made important changes happen during her free time, even before starting! These include a new structure for the theme object, as well as the ability to [add custom variants](https://next.material-ui.com/customization/theme-components/#adding-new-component-variants) in v5:
+Marija is off to a running start, having made important changes happen during her free time, even before starting! These include a new structure for the theme object, as well as the ability to [add custom variants](https://material-ui.com/customization/theme-components/#adding-new-component-variants) in v5:
 
 She is now actively working on the unstyled components and [the update of the style engine](https://github.com/mui-org/material-ui/issues/22342). These are two items we've been eager to push forward since the release of v1 but that required someone to be dedicated to tackling them.
 

--- a/docs/pages/blog/michal-dudak-joining.md
+++ b/docs/pages/blog/michal-dudak-joining.md
@@ -18,7 +18,7 @@ We were impressed by his technical challenge.
 He leveraged most of the best practices we enforce when writing components, without prior experience contributing to our codebase.
 
 While we can't predict the future, Michał is currently responsible for the development of a new vertical for Material-UI: the unstyled & headless React components.
-Marija initiated this effort with a couple of new modules under the [@mui/core](https://unpkg.com/browse/@mui/core@next/) package.
+Marija initiated this effort with a couple of new modules under the [@mui/core](https://unpkg.com/browse/@mui/core@latest/) package.
 This is a strategic effort for us, with the intent to solve two problems:
 
 1. Share logic between Material Design and the second design specification that [Jun will work on](/blog/siriwat-kunaporn-joining/). This is important to stay efficient.

--- a/docs/pages/branding/mui-x.tsx
+++ b/docs/pages/branding/mui-x.tsx
@@ -860,7 +860,7 @@ export default function Page() {
         description="Material-UI X is the last React UI library you'll ever need.
 It contains the best React Data Grid on the market and a
 growing list of advanced components."
-        card="https://next.material-ui.com/static/branding/mui-x/card.png"
+        card="https://material-ui.com/static/branding/mui-x/card.png"
       />
       <BrandingHeader mode="dark" />
       <AdvancedReactComponent />

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -7,7 +7,7 @@
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/master/latest/size-snapshot.json 200
 
 # To add when we finish work on v5
-# https://next.material-ui.com/* https://material-ui.com/:splat 301!
+https://next.material-ui.com/* https://material-ui.com/:splat 301!
 
 # Support multiple domains
 https://material-ui.dev/* https://material-ui.com/:splat 301!

--- a/docs/src/components/showcase/FolderTable.tsx
+++ b/docs/src/components/showcase/FolderTable.tsx
@@ -107,7 +107,7 @@ export default function BasicTable() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/NotificationCard.tsx
+++ b/docs/src/components/showcase/NotificationCard.tsx
@@ -57,7 +57,7 @@ export default function NotificationCard() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/PlayerCard.tsx
+++ b/docs/src/components/showcase/PlayerCard.tsx
@@ -41,7 +41,7 @@ export default function PlayerCard({ theme: externalTheme }: { theme?: Theme }) 
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeAccordion.tsx
+++ b/docs/src/components/showcase/ThemeAccordion.tsx
@@ -51,7 +51,7 @@ export default function ThemeAccordion() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeChip.tsx
+++ b/docs/src/components/showcase/ThemeChip.tsx
@@ -33,7 +33,7 @@ export default function ThemeChip() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeDatePicker.tsx
+++ b/docs/src/components/showcase/ThemeDatePicker.tsx
@@ -50,7 +50,7 @@ export default function ThemeDatePicker() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeSlider.tsx
+++ b/docs/src/components/showcase/ThemeSlider.tsx
@@ -50,7 +50,7 @@ export default function ThemeSlider() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeSwitch.tsx
+++ b/docs/src/components/showcase/ThemeSwitch.tsx
@@ -33,7 +33,7 @@ export default function ThemeSwitch() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeTabs.tsx
+++ b/docs/src/components/showcase/ThemeTabs.tsx
@@ -23,7 +23,7 @@ export default function ThemeTabs() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeTimeline.tsx
+++ b/docs/src/components/showcase/ThemeTimeline.tsx
@@ -55,7 +55,7 @@ export default function BasicTimeline() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ThemeToggleButton.tsx
+++ b/docs/src/components/showcase/ThemeToggleButton.tsx
@@ -47,7 +47,7 @@ export default function ThemeToggleButton() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/components/showcase/ViewToggleButton.tsx
+++ b/docs/src/components/showcase/ViewToggleButton.tsx
@@ -64,7 +64,7 @@ export default function ViewToggleButton() {
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
    * Normally, you would implement dark mode via internal state and/or system preference at the root of the application.
-   * For more detail about toggling dark mode: https://next.material-ui.com/customization/palette/#toggling-color-mode
+   * For more detail about toggling dark mode: https://material-ui.com/customization/palette/#toggling-color-mode
    */
   const globalTheme = useTheme();
   const mode = globalTheme.palette.mode;

--- a/docs/src/modules/components/ComponentLinkHeader.js
+++ b/docs/src/modules/components/ComponentLinkHeader.js
@@ -86,7 +86,7 @@ export default function ComponentLinkHeader(props) {
             size="small"
             variant="outlined"
             rel="nofollow"
-            href={`https://bundlephobia.com/result?p=${packageName}@next`}
+            href={`https://bundlephobia.com/result?p=${packageName}@latest`}
             icon={<BundleSizeIcon />}
             data-ga-event-category="ComponentLinkHeader"
             data-ga-event-action="click"

--- a/docs/src/modules/components/Head.js
+++ b/docs/src/modules/components/Head.js
@@ -7,7 +7,7 @@ import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 export default function Head(props) {
   const t = useTranslate();
   const {
-    card = 'https://next.material-ui.com/static/branding/card.jpeg',
+    card = 'https://material-ui.com/static/branding/card.jpeg',
     children,
     description = t('strapline'),
     largeCard = true,
@@ -36,7 +36,7 @@ export default function Head(props) {
       <meta property="og:ttl" content="604800" />
       {/* Algolia */}
       <meta name="docsearch:language" content={userLanguage} />
-      <meta name="docsearch:version" content="next" />
+      <meta name="docsearch:version" content="master" />
       {children}
     </NextHead>
   );

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -36,8 +36,8 @@ const styles = theme => ({
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       '@foo-bar/bip': 'latest',
-      '@mui/material': 'next',
-      '@mui/core': 'next',
+      '@mui/material': 'latest',
+      '@mui/core': 'latest',
       'prop-types': 'latest',
     });
   });
@@ -62,7 +62,7 @@ const suggestions = [
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'next',
+      '@mui/material': 'latest',
       '@unexisting/thing': 'latest',
       'autosuggest-highlight': 'latest',
       'prop-types': 'latest',
@@ -86,8 +86,8 @@ import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePic
       'prop-types': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'next',
-      '@mui/lab': 'next',
+      '@mui/material': 'latest',
+      '@mui/lab': 'latest',
       'date-fns': 'latest',
     });
   });
@@ -100,8 +100,8 @@ import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePic
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       '@foo-bar/bip': 'latest',
-      '@mui/material': 'next',
-      '@mui/core': 'next',
+      '@mui/material': 'latest',
+      '@mui/core': 'latest',
       '@types/foo-bar__bip': 'latest',
       '@types/prop-types': 'latest',
       '@types/react-dom': 'latest',
@@ -126,8 +126,8 @@ import {
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'next',
-      '@mui/lab': 'next',
+      '@mui/material': 'latest',
+      '@mui/lab': 'latest',
       'date-fns': 'latest',
     });
   });
@@ -142,8 +142,8 @@ import lab from '@mui/lab';
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'next',
-      '@mui/lab': 'next',
+      '@mui/material': 'latest',
+      '@mui/lab': 'latest',
     });
   });
 
@@ -190,8 +190,8 @@ import AdapterMoment from '@mui/lab/AdapterMoment';
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'next',
-      '@mui/lab': 'next',
+      '@mui/material': 'latest',
+      '@mui/lab': 'latest',
       'date-fns': 'latest',
       dayjs: 'latest',
       luxon: 'latest',

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -132,7 +132,7 @@ function getMuiPackageVersion(packageName: string, commitRef?: string): string {
     process.env.SOURCE_CODE_REPO !== 'https://github.com/mui-org/material-ui'
   ) {
     // #default-branch-switch
-    return 'next';
+    return 'master';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui-org/material-ui/commit/${shortSha}/@mui/${packageName}`;

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -132,7 +132,7 @@ function getMuiPackageVersion(packageName: string, commitRef?: string): string {
     process.env.SOURCE_CODE_REPO !== 'https://github.com/mui-org/material-ui'
   ) {
     // #default-branch-switch
-    return 'master';
+    return 'latest';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui-org/material-ui/commit/${shortSha}/@mui/${packageName}`;

--- a/docs/src/pages/company/careers/developer-advocate.md
+++ b/docs/src/pages/company/careers/developer-advocate.md
@@ -12,7 +12,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://next.material-ui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](https://material-ui.com/branding/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/company/careers/full-stack-engineer.md
+++ b/docs/src/pages/company/careers/full-stack-engineer.md
@@ -13,7 +13,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://next.material-ui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](https://material-ui.com/branding/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/company/careers/product-manager.md
+++ b/docs/src/pages/company/careers/product-manager.md
@@ -12,7 +12,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://next.material-ui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](https://material-ui.com/branding/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/company/careers/react-engineer.md
+++ b/docs/src/pages/company/careers/react-engineer.md
@@ -13,7 +13,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://next.material-ui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](https://material-ui.com/branding/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/components/about-the-lab/about-the-lab.md
+++ b/docs/src/pages/components/about-the-lab/about-the-lab.md
@@ -21,10 +21,10 @@ Install the package in your project directory with:
 
 ```sh
 // with npm
-npm install @mui/lab@next
+npm install @mui/lab
 
 // with yarn
-yarn add @mui/lab@next
+yarn add @mui/lab
 ```
 
 The lab has a peer dependency on the core components.
@@ -32,10 +32,10 @@ If you are not already using Material-UI in your project, you can install it wit
 
 ```sh
 // with npm
-npm install @mui/material@next
+npm install @mui/material
 
 // with yarn
-yarn add @mui/material@next
+yarn add @mui/material
 ```
 
 ## TypeScript

--- a/docs/src/pages/components/icons/icons.md
+++ b/docs/src/pages/components/icons/icons.md
@@ -27,10 +27,10 @@ Install the package in your project directory with:
 
 ```sh
 // with npm
-npm install @mui/icons-material@next
+npm install @mui/icons-material
 
 // with yarn
-yarn add @mui/icons-material@next
+yarn add @mui/icons-material
 ```
 
 These components use the Material-UI `SvgIcon` component to render the SVG path for each icon, and so have a peer-dependency on `@materialui/core`.
@@ -39,10 +39,10 @@ If you aren't already using Material-UI in your project, you can add it with:
 
 ```sh
 // with npm
-npm install @mui/material@next
+npm install @mui/material
 
 // with yarn
-yarn add @mui/material@next
+yarn add @mui/material
 ```
 
 ### Usage

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -41,7 +41,7 @@ Notice that you can disable the outline (often blue or gold) with the `outline: 
 
 ## Unstyled
 
-- 📦 [4.7 kB gzipped](https://bundlephobia.com/result?p=@mui/core@next)
+- 📦 [4.7 kB gzipped](https://bundlephobia.com/result?p=@mui/core@latest)
 
 The modal also comes with an unstyled version.
 It's ideal for doing heavy customizations and minimizing bundle size.

--- a/docs/src/pages/components/no-ssr/no-ssr.md
+++ b/docs/src/pages/components/no-ssr/no-ssr.md
@@ -34,7 +34,7 @@ React does [2 commits](https://reactjs.org/docs/strict-mode.html#detecting-unexp
 
 ## Unstyled
 
-- 📦 [784 B gzipped](https://bundlephobia.com/result?p=@mui/core@next)
+- 📦 [784 B gzipped](https://bundlephobia.com/result?p=@mui/core@latest)
 
 As the component does not have any styles, it also comes with the unstyled package.
 

--- a/docs/src/pages/components/portal/portal.md
+++ b/docs/src/pages/components/portal/portal.md
@@ -24,7 +24,7 @@ You have to wait for the client-side hydration to see the children.
 
 ## Unstyled
 
-- 📦 [970 B gzipped](https://bundlephobia.com/result?p=@mui/core@next)
+- 📦 [970 B gzipped](https://bundlephobia.com/result?p=@mui/core@latest)
 
 As the component does not have any styles, it also comes with the unstyled package.
 

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -135,7 +135,7 @@ Increasing _x_ by one increases the represented value by factor _2_.
 
 <!-- #default-branch-switch -->
 
-- 📦 [5.6 kB gzipped](https://bundlephobia.com/result?p=@mui/core@next)
+- 📦 [5.6 kB gzipped](https://bundlephobia.com/result?p=@mui/core@latest)
 
 The slider also comes with an unstyled version.
 It's ideal for doing heavy customizations and minimizing bundle size.

--- a/docs/src/pages/components/trap-focus/trap-focus.md
+++ b/docs/src/pages/components/trap-focus/trap-focus.md
@@ -23,7 +23,7 @@ When `open={true}` the trap is enabled, and pressing <kbd class="key">Tab</kbd> 
 
 ## Unstyled
 
-- 📦 [2.0 kB gzipped](https://bundlephobia.com/result?p=@mui/core@next)
+- 📦 [2.0 kB gzipped](https://bundlephobia.com/result?p=@mui/core@latest)
 
 As the component does not have any styles, it also comes with the unstyled package.
 

--- a/docs/src/pages/customization/default-theme/default-theme.md
+++ b/docs/src/pages/customization/default-theme/default-theme.md
@@ -14,5 +14,5 @@ Explore the default theme object:
 
 <!-- #default-branch-switch -->
 
-If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/next/packages/mui-material/src/styles/createTheme.js),
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/master/packages/mui-material/src/styles/createTheme.js),
 and the related imports which `createTheme` uses.

--- a/docs/src/pages/getting-started/example-projects/example-projects.md
+++ b/docs/src/pages/getting-started/example-projects/example-projects.md
@@ -4,24 +4,24 @@
 
 ## Official examples
 
-You can find some example projects in the [GitHub repository](https://github.com/mui-org/material-ui) under the [`/examples`](https://github.com/mui-org/material-ui/tree/next/examples) folder:
+You can find some example projects in the [GitHub repository](https://github.com/mui-org/material-ui) under the [`/examples`](https://github.com/mui-org/material-ui/tree/master/examples) folder:
 
 <!-- #default-branch-switch -->
 
-- [Next.js](https://github.com/mui-org/material-ui/tree/next/examples/nextjs) ([TypeScript version](https://github.com/mui-org/material-ui/tree/next/examples/nextjs-with-typescript))
-- [Create React App](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app) ([TypeScript version](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app-with-typescript))
-- [Gatsby](https://github.com/mui-org/material-ui/tree/next/examples/gatsby)
-- [Preact](https://github.com/mui-org/material-ui/tree/next/examples/preact)
-- [CDN](https://github.com/mui-org/material-ui/tree/next/examples/cdn)
-- [Plain server-side](https://github.com/mui-org/material-ui/tree/next/examples/ssr)
-- [Use styled-components as style engine](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components) ([TypeScript version](https://github.com/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components-typescript))
+- [Next.js](https://github.com/mui-org/material-ui/tree/master/examples/nextjs) ([TypeScript version](https://github.com/mui-org/material-ui/tree/master/examples/nextjs-with-typescript))
+- [Create React App](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app) ([TypeScript version](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript))
+- [Gatsby](https://github.com/mui-org/material-ui/tree/master/examples/gatsby)
+- [Preact](https://github.com/mui-org/material-ui/tree/master/examples/preact)
+- [CDN](https://github.com/mui-org/material-ui/tree/master/examples/cdn)
+- [Plain server-side](https://github.com/mui-org/material-ui/tree/master/examples/ssr)
+- [Use styled-components as style engine](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-styled-components) ([TypeScript version](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript))
 
 Create React App is an awesome project for learning React.
 Have a look at [the alternatives available](https://github.com/facebook/create-react-app/blob/master/README.md#popular-alternatives) to see which project best fits your needs.
 
 The source code for this documentation site is also included in the repository.
 This is a slightly more complex project.
-Check out the [`/docs`](https://github.com/mui-org/material-ui/tree/next/docs) folder for
+Check out the [`/docs`](https://github.com/mui-org/material-ui/tree/master/docs) folder for
 build instructions.
 
 ## More advanced example projects

--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -10,10 +10,10 @@ To install and save in your `package.json` dependencies, run:
 
 ```sh
 // with npm
-npm install @mui/material@next @emotion/react @emotion/styled
+npm install @mui/material @emotion/react @emotion/styled
 
 // with yarn
-yarn add @mui/material@next @emotion/react @emotion/styled
+yarn add @mui/material @emotion/react @emotion/styled
 ```
 
 <!-- #react-peer-version -->
@@ -24,10 +24,10 @@ Or if you want to use `styled-components` as a styling engine:
 
 ```sh
 // with npm
-npm install @mui/material@next @mui/styled-engine-sc@next styled-components
+npm install @mui/material @mui/styled-engine-sc styled-components
 
 // with yarn
-yarn add @mui/material@next @mui/styled-engine-sc@next styled-components
+yarn add @mui/material @mui/styled-engine-sc styled-components
 ```
 
 Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
@@ -68,10 +68,10 @@ you must first install the [@mui/icons-material](https://www.npmjs.com/package/@
 
 ```sh
 // with npm
-npm install @mui/icons-material@next
+npm install @mui/icons-material
 
 // with yarn
-yarn add @mui/icons-material@next
+yarn add @mui/icons-material
 ```
 
 ## CDN

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -15,7 +15,7 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 
 <!-- #default-branch-switch -->
 
-An extensive list can be found in our [.browserlistrc](https://github.com/mui-org/material-ui/blob/next/.browserslistrc#L12-L27) (check the `stable` entry).
+An extensive list can be found in our [.browserlistrc](https://github.com/mui-org/material-ui/blob/master/.browserslistrc#L12-L27) (check the `stable` entry).
 
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that Material-UI supports it.
 [WRS regularly updates the rendering engine it uses](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).

--- a/docs/src/pages/getting-started/templates/album/README.md
+++ b/docs/src/pages/getting-started/templates/album/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `Album` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `Album` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/album/.
+View the demo at https://material-ui.com/getting-started/templates/album/.

--- a/docs/src/pages/getting-started/templates/blog/README.md
+++ b/docs/src/pages/getting-started/templates/blog/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `Blog` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `Blog` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/blog/.
+View the demo at https://material-ui.com/getting-started/templates/blog/.

--- a/docs/src/pages/getting-started/templates/checkout/README.md
+++ b/docs/src/pages/getting-started/templates/checkout/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `Checkout` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `Checkout` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/checkout/.
+View the demo at https://material-ui.com/getting-started/templates/checkout/.

--- a/docs/src/pages/getting-started/templates/dashboard/README.md
+++ b/docs/src/pages/getting-started/templates/dashboard/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `Dashboard` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `Dashboard` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/dashboard/.
+View the demo at https://material-ui.com/getting-started/templates/dashboard/.

--- a/docs/src/pages/getting-started/templates/pricing/README.md
+++ b/docs/src/pages/getting-started/templates/pricing/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `Pricing` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `Pricing` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/pricing/.
+View the demo at https://material-ui.com/getting-started/templates/pricing/.

--- a/docs/src/pages/getting-started/templates/sign-in-side/README.md
+++ b/docs/src/pages/getting-started/templates/sign-in-side/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `SignInSide` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `SignInSide` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/sign-in-side/.
+View the demo at https://material-ui.com/getting-started/templates/sign-in-side/.

--- a/docs/src/pages/getting-started/templates/sign-in/README.md
+++ b/docs/src/pages/getting-started/templates/sign-in/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `SignIn` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `SignIn` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/sign-in/.
+View the demo at https://material-ui.com/getting-started/templates/sign-in/.

--- a/docs/src/pages/getting-started/templates/sign-up/README.md
+++ b/docs/src/pages/getting-started/templates/sign-up/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `SignUp` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `SignUp` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/sign-up/.
+View the demo at https://material-ui.com/getting-started/templates/sign-up/.

--- a/docs/src/pages/getting-started/templates/sticky-footer/README.md
+++ b/docs/src/pages/getting-started/templates/sticky-footer/README.md
@@ -2,10 +2,12 @@
 
 ## Usage
 
-Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples), and import and use the `StickyFooter` component.
+<!-- #default-branch-switch -->
+
+Copy the files into your project, or one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `StickyFooter` component.
 
 ## Demo
 
 <!-- #default-branch-switch -->
 
-View the demo at https://next.material-ui.com/getting-started/templates/sticky-footer/.
+View the demo at https://material-ui.com/getting-started/templates/sticky-footer/.

--- a/docs/src/pages/getting-started/templates/templates.md
+++ b/docs/src/pages/getting-started/templates/templates.md
@@ -8,7 +8,7 @@ title: 9+ Free React Templates
 
 <!-- #default-branch-switch -->
 
-The templates can be combined with one of the [example projects](https://github.com/mui-org/material-ui/tree/next/examples) to form a complete starter.
+The templates can be combined with one of the [example projects](https://github.com/mui-org/material-ui/tree/master/examples) to form a complete starter.
 
 Sections of each layout are clearly defined either by comments or use of separate files,
 making it simple to extract parts of a page (such as a "hero unit", or footer, for example)

--- a/docs/src/pages/guides/localization/localization.md
+++ b/docs/src/pages/guides/localization/localization.md
@@ -79,7 +79,7 @@ const theme = createTheme(
 
 <!-- #default-branch-switch -->
 
-You can [find the source](https://github.com/mui-org/material-ui/blob/next/packages/mui-material/src/locale/index.ts) in the GitHub repository.
+You can [find the source](https://github.com/mui-org/material-ui/blob/master/packages/mui-material/src/locale/index.ts) in the GitHub repository.
 
 To create your own translation, or to customize the English text, copy this file to your project, make any changes needed and import the locale from there.
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -76,24 +76,24 @@ function App() {
 
 ## Update Material-UI version
 
-To use the `next` version of Material-UI.
+To use the `v5` version of Material-UI.
 
 > 💡 If you want to use Material-UI v5 with **styled-components** instead of emotion, check out [the installation guide](/getting-started/installation/#npm)
 
 ```sh
-npm install @mui/material@next @emotion/react @emotion/styled
+npm install @mui/material @emotion/react @emotion/styled
 
 // or with `yarn`
-yarn add @mui/material@next @emotion/react @emotion/styled
+yarn add @mui/material @emotion/react @emotion/styled
 ```
 
-**Optional** if your project includes `@mui/icons-material` and/or `@mui/lab`, use the `next` version of them.
+**Optional** if your project includes `@mui/icons-material` and/or `@mui/lab`, use the `v5` version of them.
 
 ```sh
-npm install @mui/icons-material@next @mui/lab@next
+npm install @mui/icons-material @mui/lab
 
 // or with `yarn`
-yarn add @mui/icons-material@next @mui/lab@next
+yarn add @mui/icons-material @mui/lab
 ```
 
 > **Note:** if you are using `@material-ui/pickers`, it has moved to `@mui/lab`. The details is in "Handling breaking changes" section.
@@ -101,10 +101,10 @@ yarn add @mui/icons-material@next @mui/lab@next
 In this migration process, you will need to install/update `@mui/styles` (JSS) for temporary transition to v5.
 
 ```sh
-npm install @mui/styles@next
+npm install @mui/styles
 
 // or with `yarn`
-yarn add @mui/styles@next
+yarn add @mui/styles
 ```
 
 > After the migration, you should remove all `@material-ui/*` packages by running `yarn remove` or `npm uninstall`.
@@ -118,10 +118,10 @@ We have prepared these codemods to ease your migration experience.
 This codemod contains most of the transformers that are useful for migration. (**This codemod should be applied only once per folder**)
 
 ```sh
-npx @mui/codemod@next v5.0.0/preset-safe <path>
+npx @mui/codemod v5.0.0/preset-safe <path>
 ```
 
-> If you want to run the transformers one by one, check out [preset-safe codemod](https://github.com/mui-org/material-ui/blob/next/packages/mui-codemod/README.md#-preset-safe) for more details.
+> If you want to run the transformers one by one, check out [preset-safe codemod](https://github.com/mui-org/material-ui/blob/master/packages/mui-codemod/README.md#-preset-safe) for more details.
 
 ### variant-prop
 
@@ -144,10 +144,10 @@ createMuiTheme({
 However, if you want to keep `variant="standard"` to you components, run this codemod or configure theme default props.
 
 ```sh
-npx @mui/codemod@next v5.0.0/variant-prop <path>
+npx @mui/codemod v5.0.0/variant-prop <path>
 ```
 
-For more details, checkout [variant-prop codemod](https://github.com/mui-org/material-ui/blob/next/packages/mui-codemod/README.md#variant-prop).
+For more details, checkout [variant-prop codemod](https://github.com/mui-org/material-ui/blob/master/packages/mui-codemod/README.md#variant-prop).
 
 ### link-underline-hover
 
@@ -170,10 +170,10 @@ createMuiTheme({
 However, if you want to keep `variant="hover"` to you components, run this codemod or configure theme default props.
 
 ```sh
-npx @mui/codemod@next v5.0.0/link-underline-hover <path>
+npx @mui/codemod v5.0.0/link-underline-hover <path>
 ```
 
-For more details, checkout [link-underline-hover codemod](https://github.com/mui-org/material-ui/blob/next/packages/mui-codemod/README.md#link-underline-hover).
+For more details, checkout [link-underline-hover codemod](https://github.com/mui-org/material-ui/blob/master/packages/mui-codemod/README.md#link-underline-hover).
 
 Once you have completed the codemod step, try running your application again. At this point, it should be running without error. Otherwise check out the [Troubleshooting](#troubleshooting) section. Next step, handling breaking changes in each component.
 
@@ -251,7 +251,7 @@ Here is an example:
  }
 ```
 
-> **Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. To see how it can be done, take a look at the [`StyledEngineProvider` implementation](https://github.com/mui-org/material-ui/blob/next/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) in the `@mui/styled-engine-sc` package.
+> **Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. To see how it can be done, take a look at the [`StyledEngineProvider` implementation](https://github.com/mui-org/material-ui/blob/master/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) in the `@mui/styled-engine-sc` package.
 
 ### Theme structure
 
@@ -2384,10 +2384,10 @@ We recommend two options.
 
 #### Codemod
 
-We provide [a codemod](https://github.com/mui-org/material-ui/blob/next/packages/mui-codemod/README.md#jss-to-styled) to help migrate JSS styles to `styled` API, but this approach **increases the CSS specificity**.
+We provide [a codemod](https://github.com/mui-org/material-ui/blob/master/packages/mui-codemod/README.md#jss-to-styled) to help migrate JSS styles to `styled` API, but this approach **increases the CSS specificity**.
 
 ```sh
-npx @mui/codemod@next v5.0.0/jss-to-styled <path>
+npx @mui/codemod v5.0.0/jss-to-styled <path>
 ```
 
 **Example transformation**:
@@ -2665,7 +2665,7 @@ You should replace the import, [more details about this error](https://github.co
 You can use this codemod (**recommended**) to fix all the import in your project:
 
 ```sh
-npx @mui/codemod@next v5.0.0/optimal-imports <path>
+npx @mui/codemod v5.0.0/optimal-imports <path>
 ```
 
 or fix it manually like this:

--- a/docs/src/pages/guides/styled-engine/styled-engine.md
+++ b/docs/src/pages/guides/styled-engine/styled-engine.md
@@ -24,11 +24,11 @@ By default, `@mui/material` has `@mui/styled-engine` as a dependency, but you ca
 ```diff
  {
    "dependencies": {
--    "@mui/styled-engine": "next"
-+    "@mui/styled-engine": "npm:@mui/styled-engine-sc@next"
+-    "@mui/styled-engine": "latest"
++    "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest"
    },
 +  "resolutions": {
-+    "@mui/styled-engine": "npm:@mui/styled-engine-sc@next"
++    "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest"
 +  },
  }
 ```

--- a/docs/src/pages/landing/Steps.js
+++ b/docs/src/pages/landing/Steps.js
@@ -87,13 +87,13 @@ function HomeSteps() {
                 {t('installDescr')}
               </Typography>
               <HighlightedCode
-                code="$ npm install @mui/material@next @emotion/react @emotion/styled"
+                code="$ npm install @mui/material @emotion/react @emotion/styled"
                 language="sh"
               />
               <Link
                 variant="subtitle1"
                 color="inherit"
-                href="https://github.com/mui-org/material-ui/tree/next/examples/cdn"
+                href="https://github.com/mui-org/material-ui/tree/master/examples/cdn"
                 gutterBottom
               >
                 {t('cdn')}

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Button.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Button.js
@@ -22,7 +22,7 @@ const ButtonRoot = styled(MuiButton)(({ theme, size }) => ({
   }),
 }));
 
-// See https://next.material-ui.com/guides/typescript/#usage-of-component-prop for why the types uses `C`.
+// See https://material-ui.com/guides/typescript/#usage-of-component-prop for why the types uses `C`.
 function Button(props) {
   return <ButtonRoot {...props} />;
 }

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Button.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Button.tsx
@@ -22,7 +22,7 @@ const ButtonRoot = styled(MuiButton)(({ theme, size }) => ({
   }),
 }));
 
-// See https://next.material-ui.com/guides/typescript/#usage-of-component-prop for why the types uses `C`.
+// See https://material-ui.com/guides/typescript/#usage-of-component-prop for why the types uses `C`.
 function Button<C extends React.ElementType>(
   props: ButtonProps<C, { component?: C }>,
 ) {

--- a/docs/src/pages/styles/advanced/advanced.md
+++ b/docs/src/pages/styles/advanced/advanced.md
@@ -396,13 +396,15 @@ Refer to the plugin's page for setup and usage instructions.
 
 <!-- #default-branch-switch -->
 
-Refer to [this example Gatsby project](https://github.com/mui-org/material-ui/blob/next/examples/gatsby) for an up-to-date usage example.
+Refer to [this example Gatsby project](https://github.com/mui-org/material-ui/blob/master/examples/gatsby) for an up-to-date usage example.
 
 ### Next.js
 
 You need to have a custom `pages/_document.js`, then copy [this logic](https://github.com/mui-org/material-ui/blob/814fb60bbd8e500517b2307b6a297a638838ca89/examples/nextjs/pages/_document.js#L52-L59) to inject the server-side rendered styles into the `<head>` element.
 
-Refer to [this example project](https://github.com/mui-org/material-ui/blob/next/examples/nextjs) for an up-to-date usage example.
+<!-- #default-branch-switch -->
+
+Refer to [this example project](https://github.com/mui-org/material-ui/blob/master/examples/nextjs) for an up-to-date usage example.
 
 ## Class names
 

--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -38,10 +38,10 @@ To install and save in your `package.json` dependencies, run:
 
 ```sh
 // with npm
-npm install @mui/styles@next
+npm install @mui/styles
 
 // with yarn
-yarn add @mui/styles@next
+yarn add @mui/styles
 ```
 
 ## Getting started

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -19,20 +19,22 @@ _(Resize the window to see the responsive breakpoints)_
 
 ```jsx
 // with npm
-npm install @mui/system@next @emotion/react @emotion/styled
+npm install @mui/system @emotion/react @emotion/styled
 
 // with yarn
-yarn add @mui/system@next @emotion/react @emotion/styled
+yarn add @mui/system @emotion/react @emotion/styled
 ```
 
 Or if you want to use `styled-components` as a styling engine:
 
+<!-- #default-branch-switch -->
+
 ```sh
 // with npm
-npm install @mui/system@next @mui/styled-engine-sc@next styled-components
+npm install @mui/system @mui/styled-engine-sc styled-components
 
 // with yarn
-yarn add @mui/system@next @mui/styled-engine-sc@next styled-components
+yarn add @mui/system @mui/styled-engine-sc styled-components
 ```
 
 Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.

--- a/examples/cdn/README.md
+++ b/examples/cdn/README.md
@@ -23,20 +23,20 @@ The client has to download the entire library, regardless of which components ar
 
 <!-- #default-branch-switch -->
 
-[The live preview.](https://combinatronics.com/mui-org/material-ui/next/examples/cdn/index.html)
+[The live preview.](https://combinatronics.com/mui-org/material-ui/master/examples/cdn/index.html)
 
 ## UMD releases
 
 We are providing two Universal Module Definition (UMD) files:
 
-- one for development: https://unpkg.com/@mui/material@next/umd/material-ui.development.js
-- one for production: https://unpkg.com/@mui/material@next/umd/material-ui.production.min.js
+- one for development: https://unpkg.com/@mui/material@latest/umd/material-ui.development.js
+- one for production: https://unpkg.com/@mui/material@latest/umd/material-ui.production.min.js
 
 <!-- #default-branch-switch -->
 
 ## What's next?
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.
 
 <!-- #default-branch-switch -->

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <script src="https://unpkg.com/react@latest/umd/react.development.js" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/react-dom@latest/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@mui/material@next/umd/material-ui.development.js" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@mui/material@latest/umd/material-ui.development.js" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/babel-standalone@latest/babel.min.js" crossorigin="anonymous"></script>
     <!-- Fonts to support Material Design -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />

--- a/examples/create-react-app-with-styled-components-typescript/README.md
+++ b/examples/create-react-app-with-styled-components-typescript/README.md
@@ -23,7 +23,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app-with-styled-components-typescript
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/create-react-app-with-styled-components-typescript
 cd create-react-app-with-styled-components-typescript
 ```
 
@@ -38,9 +38,9 @@ npm start
 
 <!-- #default-branch-switch -->
 
-Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components-typescript).
+Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript).
 
-The following link leverages this demo: https://next.material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
+The following link leverages this demo: https://material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-interoperability-w9z9d)
 
@@ -53,4 +53,4 @@ This example demonstrates how you can setup [Create React App](https://github.co
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/create-react-app-with-styled-components/README.md
+++ b/examples/create-react-app-with-styled-components/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app-with-styled-components
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/create-react-app-with-styled-components
 cd create-react-app-with-styled-components
 ```
 
@@ -22,9 +22,9 @@ npm start
 
 <!-- #default-branch-switch -->
 
-Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app-with-styled-components).
+Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-styled-components).
 
-The following link leverages this demo: https://next.material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
+The following link leverages this demo: https://material-ui.com/guides/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-interoperability-w9z9d)
 
@@ -37,4 +37,4 @@ This example demonstrates how you can setup [Create React App](https://github.co
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/create-react-app-with-typescript/README.md
+++ b/examples/create-react-app-with-typescript/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app-with-typescript
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/create-react-app-with-typescript
 cd create-react-app-with-typescript
 ```
 
@@ -22,17 +22,17 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app-with-typescript)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript)
 
 ## The idea behind the example
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with [TypeScript](https://github.com/Microsoft/TypeScript).
 It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
-If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/create-react-app
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/create-react-app
 cd create-react-app
 ```
 
@@ -22,17 +22,19 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/create-react-app)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app)
 
 ## The idea behind the example
 
+<!-- #default-branch-switch -->
+
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app).
 It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
-If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/gatsby
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/gatsby
 cd gatsby
 ```
 
@@ -22,17 +22,17 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/gatsby)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/gatsby)
 
 ## The idea behind the example
 
 The project uses [Gatsby](https://github.com/gatsbyjs/gatsby), which is a static site generator for React.
 It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
-If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/nextjs-with-styled-components-typescript/README.md
+++ b/examples/nextjs-with-styled-components-typescript/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/nextjs-with-styled-components-typescript
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs-with-styled-components-typescript
 cd nextjs-with-styled-components-typescript
 ```
 
@@ -22,7 +22,7 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/nextjs-with-styled-components-typescript)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs-with-styled-components-typescript)
 
 ## The idea behind the example
 
@@ -33,11 +33,11 @@ It includes `@mui/material` and its peer dependencies, including `styled-compone
 
 Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
 The example folder provides adapters for usage with Material-UI.
-More information [in the documentation](https://next.material-ui.com/guides/routing/#next-js).
+More information [in the documentation](https://material-ui.com/guides/routing/#next-js).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/nextjs-with-styled-components-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-styled-components-typescript/pages/_document.tsx
@@ -3,7 +3,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 import theme from '../src/theme';
 
-// https://next.material-ui.com/styles/advanced/#next-js
+// https://material-ui.com/styles/advanced/#next-js
 export default class MyDocument extends Document {
   render() {
     return (

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/nextjs-with-typescript
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs-with-typescript
 cd nextjs-with-typescript
 ```
 
@@ -22,22 +22,22 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/nextjs-with-typescript)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs-with-typescript)
 
 ## The idea behind the example
 
 The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5. If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## The link component
 
 Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
 The example folder provides adapters for usage with Material-UI.
-More information [in the documentation](https://next.material-ui.com/guides/routing/#next-js).
+More information [in the documentation](https://material-ui.com/guides/routing/#next-js).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/nextjs
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs
 cd nextjs
 ```
 
@@ -22,23 +22,23 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/nextjs)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs)
 
 ## The idea behind the example
 
 The project uses [Next.js](https://github.com/zeit/next.js), which is a framework for server-rendered React apps.
 It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
-If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## The link component
 
 Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
 The example folder provides adapters for usage with Material-UI.
-More information [in the documentation](https://next.material-ui.com/guides/routing/#next-js).
+More information [in the documentation](https://material-ui.com/guides/routing/#next-js).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/preact/README.md
+++ b/examples/preact/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/preact
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/preact
 cd preact
 ```
 
@@ -22,7 +22,7 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/preact)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/preact)
 
 ## The idea behind the example
 
@@ -31,11 +31,14 @@ The project uses [Preact](https://github.com/developit/preact), which is a fast 
 This example uses CRA with `react-app-rewired` for adding webpack aliases for preact.
 
 It includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
-If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+
+<!-- #default-branch-switch -->
+
+If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/ssr
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/ssr
 cd ssr
 ```
 
@@ -22,18 +22,18 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/next/examples/ssr)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/ssr)
 
 ## The idea behind the example
 
-This is the reference implementation of the [Server Rendering tutorial](https://next.material-ui.com/guides/server-rendering/).
+This is the reference implementation of the [Server Rendering tutorial](https://material-ui.com/guides/server-rendering/).
 
 The example project includes `@mui/material` and its peer dependencies, including `emotion`, the default style engine in Material-UI v5.
-If you prefer, you can [use styled-components instead](https://next.material-ui.com/guides/interoperability/#styled-components).
+If you prefer, you can [use styled-components instead](https://material-ui.com/guides/interoperability/#styled-components).
 
 ## What's next?
 
 <!-- #default-branch-switch -->
 
 You now have a working example project.
-You can head back to the documentation, continuing browsing it from the [templates](https://next.material-ui.com/getting-started/templates/) section.
+You can head back to the documentation, continuing browsing it from the [templates](https://material-ui.com/getting-started/templates/) section.

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -13,7 +13,7 @@ This repository contains a collection of codemod scripts based for use with
 <!-- #default-branch-switch -->
 
 ```bash
-npx @mui/codemod@next <codemod> <paths...>
+npx @mui/codemod <codemod> <paths...>
 
 Applies a `@mui/codemod` to the specified paths
 
@@ -31,8 +31,8 @@ Options:
   --jscodeshift                                  [string] [default: false]
 
 Examples:
-  npx @mui/codemod@next v4.0.0/theme-spacing-api src
-  npx @mui/codemod@next v5.0.0/component-rename-prop src --
+  npx @mui/codemod v4.0.0/theme-spacing-api src
+  npx @mui/codemod v5.0.0/component-rename-prop src --
   --component=Grid --from=prop --to=newProp
 ```
 
@@ -41,7 +41,7 @@ Examples:
 To pass more options directly to jscodeshift, use `--jscodeshift="..."`. For example:
 
 ```sh
-npx @mui/codemod@next --jscodeshift="--run-in-band --verbose=2"
+npx @mui/codemod --jscodeshift="--run-in-band --verbose=2"
 ```
 
 See all available options [here](https://github.com/facebook/jscodeshift#usage-cli).
@@ -52,7 +52,7 @@ Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through jscodeshift's `printOptions` command line argument
 
 ```sh
-npx @mui/codemod@next <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
+npx @mui/codemod <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
 ```
 
 ## Included scripts
@@ -64,7 +64,7 @@ npx @mui/codemod@next <transform> <path> --jscodeshift="--printOptions='{\"quote
 A combination of all important transformers for migrating v4 to v5. ⚠️ This codemod should be run only once.
 
 ```sh
-npx @mui/codemod@next v5.0.0/preset-safe <path|folder>
+npx @mui/codemod v5.0.0/preset-safe <path|folder>
 ```
 
 The list includes these transformers
@@ -131,10 +131,10 @@ Imports and inserts `adaptV4Theme` into `createTheme` (or `createMuiTheme`)
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/adapter-v4 <path>
+npx @mui/codemod v5.0.0/adapter-v4 <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#theme).
 
 #### `autocomplete-rename-closeicon`
 
@@ -148,10 +148,10 @@ Renames `Autocomplete`'s `closeIcon` prop to `clearIcon`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/autocomplete-rename-closeicon  <path>
+npx @mui/codemod v5.0.0/autocomplete-rename-closeicon  <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#autocomplete).
 
 #### `autocomplete-rename-option`
 
@@ -167,10 +167,10 @@ Renames `Autocomplete`'s `getOptionSelected` to `isOptionEqualToValue`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/autocomplete-rename-option  <path>
+npx @mui/codemod v5.0.0/autocomplete-rename-option  <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#autocomplete).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#autocomplete).
 
 #### `avatar-circle-circular`
 
@@ -186,10 +186,10 @@ Updates the `Avatar`'s `variant` value and `classes` key from 'circle' to 'circu
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/avatar-circle-circular <path>
+npx @mui/codemod v5.0.0/avatar-circle-circular <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#avatar).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#avatar).
 
 #### `badge-overlap-value`
 
@@ -221,10 +221,10 @@ Renames the badge's props.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/badge-overlap-value <path>
+npx @mui/codemod v5.0.0/badge-overlap-value <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#badge).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#badge).
 
 #### `box-borderradius-values`
 
@@ -240,10 +240,10 @@ Updates the Box API from separate system props to `sx`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/box-borderradius-values <path>
+npx @mui/codemod v5.0.0/box-borderradius-values <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#box).
 
 #### `box-rename-css`
 
@@ -255,10 +255,10 @@ Renames the Box `css` prop to `sx`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/box-rename-css <path>
+npx @mui/codemod v5.0.0/box-rename-css <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#box).
 
 #### `box-rename-gap`
 
@@ -276,10 +276,10 @@ Renames the Box `grid*Gap` props.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/box-rename-gap <path>
+npx @mui/codemod v5.0.0/box-rename-gap <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#box).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#box).
 
 #### `button-color-prop`
 
@@ -293,10 +293,10 @@ Removes the outdated `color` prop values.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/button-color-prop <path>
+npx @mui/codemod v5.0.0/button-color-prop <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#button).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#button).
 
 #### `chip-variant-prop`
 
@@ -310,10 +310,10 @@ Removes the Chip `variant` prop if the value is `"default"`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/chip-variant-prop <path>
+npx @mui/codemod v5.0.0/chip-variant-prop <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#chip).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#chip).
 
 #### `circularprogress-variant`
 
@@ -327,10 +327,10 @@ Renames the CircularProgress `static` variant to `determinate`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/circularprogress-variant <path>
+npx @mui/codemod v5.0.0/circularprogress-variant <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#circularprogress).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#circularprogress).
 
 #### `collapse-rename-collapsedheight`
 
@@ -346,10 +346,10 @@ Renames `Collapse`'s `collapsedHeight` prop to `collapsedSize`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/collapse-rename-collapsedheight <path>
+npx @mui/codemod v5.0.0/collapse-rename-collapsedheight <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#collapse).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#collapse).
 
 #### `component-rename-prop`
 
@@ -365,7 +365,7 @@ A generic codemod to rename any component prop.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/component-rename-prop <path> -- --component=Grid --from=prop --to=newProp
+npx @mui/codemod v5.0.0/component-rename-prop <path> -- --component=Grid --from=prop --to=newProp
 ```
 
 #### `core-styles-import`
@@ -378,7 +378,7 @@ Renames private import from `core/styles/*` to `core/styles`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/core-styles-import <path>
+npx @mui/codemod v5.0.0/core-styles-import <path>
 ```
 
 #### `create-theme`
@@ -391,7 +391,7 @@ Renames the function `createMuiTheme` to `createTheme`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/create-theme <path>
+npx @mui/codemod v5.0.0/create-theme <path>
 ```
 
 #### `dialog-props`
@@ -404,10 +404,10 @@ Remove `disableBackdropClick` prop from `<Dialog>`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/dialog-props <path>
+npx @mui/codemod v5.0.0/dialog-props <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#dialog).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#dialog).
 
 #### `dialog-title-props`
 
@@ -419,10 +419,10 @@ Remove `disableTypography` prop from `<DialogTitle>`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/dialog-title-props <path>
+npx @mui/codemod v5.0.0/dialog-title-props <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#dialog).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#dialog).
 
 #### `emotion-prepend-cache`
 
@@ -436,7 +436,7 @@ const cache = emotionCreateCache({
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/create-theme <path>
+npx @mui/codemod v5.0.0/create-theme <path>
 ```
 
 #### `expansion-panel-component`
@@ -444,10 +444,10 @@ npx @mui/codemod@next v5.0.0/create-theme <path>
 Renames `ExpansionPanel*` to `Accordion*`
 
 ```sh
-npx @mui/codemod@next v5.0.0/expansion-panel-component <path>
+npx @mui/codemod v5.0.0/expansion-panel-component <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#expansionpanel).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#expansionpanel).
 
 #### `fab-variant`
 
@@ -457,10 +457,10 @@ You can find more details about this breaking change in [the migration guide](ht
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/fab-variant <path>
+npx @mui/codemod v5.0.0/fab-variant <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#fab).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#fab).
 
 #### `fade-rename-alpha`
 
@@ -477,10 +477,10 @@ Renames the `fade` style utility import and calls to `alpha`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/fade-rename-alpha <path>
+npx @mui/codemod v5.0.0/fade-rename-alpha <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#styles).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#styles).
 
 #### `grid-justify-justifycontent`
 
@@ -494,20 +494,20 @@ Renames `Grid`'s `justify` prop to `justifyContent`.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/grid-justify-justifycontent <path>
+npx @mui/codemod v5.0.0/grid-justify-justifycontent <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#grid).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#grid).
 
 #### `grid-list-component`
 
 Renames `GridList*` to `ImageList*`
 
 ```sh
-npx @mui/codemod@next v5.0.0/grid-list-component <path>
+npx @mui/codemod v5.0.0/grid-list-component <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#gridlist).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#gridlist).
 
 #### `icon-button-size`
 
@@ -521,10 +521,10 @@ Adds `size="large"` if `size` is not defined to get the same appearance as v4.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/icon-button-size <path>
+npx @mui/codemod v5.0.0/icon-button-size <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#iconbutton).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#iconbutton).
 
 #### `jss-to-styled`
 
@@ -586,13 +586,13 @@ export const MyCard = () => {
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/jss-to-styled <path>
+npx @mui/codemod v5.0.0/jss-to-styled <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#1-use-styled-or-sx-api).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#1-use-styled-or-sx-api).
 
 > **Note:** This approach converts the first element in the return statement into styled component but also increases CSS specificity to override nested children.
-> This codemod should be adopted after handling all breaking changes, [check out the migration documentation](https://next.material-ui.com/guides/migration-v4/)
+> This codemod should be adopted after handling all breaking changes, [check out the migration documentation](https://material-ui.com/guides/migration-v4/)
 
 #### `link-underline-hover`
 
@@ -604,10 +604,10 @@ Apply `underline="hover"` to `<Link />` that does not define `underline` prop (t
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/icon-button-size <path>
+npx @mui/codemod v5.0.0/icon-button-size <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#link).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#link).
 
 #### `material-ui-styles`
 
@@ -642,7 +642,7 @@ import mergeClasses from '@material-ui/styles/mergeClasses';
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/material-ui-styles <path>
+npx @mui/codemod v5.0.0/material-ui-styles <path>
 ```
 
 #### `material-ui-types`
@@ -655,10 +655,10 @@ Renames `Omit` import from `@material-ui/types` to `DistributiveOmit`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/material-ui-types <path>
+npx @mui/codemod v5.0.0/material-ui-types <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#material-ui-types).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#material-ui-types).
 
 #### `modal-props`
 
@@ -672,10 +672,10 @@ Removes `disableBackdropClick` and `onEscapeKeyDown` from `<Modal>`
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/modal-props <path>
+npx @mui/codemod v5.0.0/modal-props <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#modal).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#modal).
 
 #### `moved-lab-modules`
 
@@ -696,18 +696,18 @@ or
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/moved-lab-modules <path>
+npx @mui/codemod v5.0.0/moved-lab-modules <path>
 ```
 
 You can find more details about this breaking change in the migration guide.
 
-- [Alert](https://next.material-ui.com/guides/migration-v4/#alert)
-- [Autocomplete](https://next.material-ui.com/guides/migration-v4/#autocomplete)
-- [AvatarGroup](https://next.material-ui.com/guides/migration-v4/#avatar)
-- [Pagination](https://next.material-ui.com/guides/migration-v4/#pagination)
-- [Skeleton](https://next.material-ui.com/guides/migration-v4/#skeleton)
-- [SpeedDial](https://next.material-ui.com/guides/migration-v4/#speeddial)
-- [ToggleButton](https://next.material-ui.com/guides/migration-v4/#togglebutton)
+- [Alert](https://material-ui.com/guides/migration-v4/#alert)
+- [Autocomplete](https://material-ui.com/guides/migration-v4/#autocomplete)
+- [AvatarGroup](https://material-ui.com/guides/migration-v4/#avatar)
+- [Pagination](https://material-ui.com/guides/migration-v4/#pagination)
+- [Skeleton](https://material-ui.com/guides/migration-v4/#skeleton)
+- [SpeedDial](https://material-ui.com/guides/migration-v4/#speeddial)
+- [ToggleButton](https://material-ui.com/guides/migration-v4/#togglebutton)
 
 #### `pagination-round-circular`
 
@@ -721,10 +721,10 @@ Renames `Pagination*`'s `shape` values from 'round' to 'circular'.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/pagination-round-circular <path>
+npx @mui/codemod v5.0.0/pagination-round-circular <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#pagination).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#pagination).
 
 #### `optimal-imports`
 
@@ -740,7 +740,7 @@ Fix private import paths.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/optimal-imports <path>
+npx @mui/codemod v5.0.0/optimal-imports <path>
 ```
 
 #### `root-ref`
@@ -748,10 +748,10 @@ npx @mui/codemod@next v5.0.0/optimal-imports <path>
 Removes `RootRef` from the codebase.
 
 ```sh
-npx @mui/codemod@next v5.0.0/root-ref <path>
+npx @mui/codemod v5.0.0/root-ref <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#rootref).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#rootref).
 
 #### `skeleton-variant`
 
@@ -763,20 +763,20 @@ You can find more details about this breaking change in [the migration guide](ht
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/skeleton-variant <path>
+npx @mui/codemod v5.0.0/skeleton-variant <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#skeleton).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#skeleton).
 
 #### `styled-engine-provider`
 
 Applies `StyledEngineProvider` to the files that contains `ThemeProvider`.
 
 ```sh
-npx @mui/codemod@next v5.0.0/styled-engine-provider <path>
+npx @mui/codemod v5.0.0/styled-engine-provider <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#style-library).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#style-library).
 
 #### `table-props`
 
@@ -799,10 +799,10 @@ Renames props in `Table*` components.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/table-props <path>
+npx @mui/codemod v5.0.0/table-props <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#table).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#table).
 
 #### `tabs-scroll-buttons`
 
@@ -818,10 +818,10 @@ Renames the `Tabs`'s `scrollButtons` prop values.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/tabs-scroll-buttons <path>
+npx @mui/codemod v5.0.0/tabs-scroll-buttons <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#tabs).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#tabs).
 
 #### `textarea-minmax-rows`
 
@@ -837,23 +837,23 @@ Renames `TextField`'s rows props.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/textarea-minmax-rows <path>
+npx @mui/codemod v5.0.0/textarea-minmax-rows <path>
 ```
 
 You can find more details about this breaking change in the migration guide.
 
-- [TextareaAutosize](https://next.material-ui.com/guides/migration-v4/#textareaautoresize)
-- [TextField](https://next.material-ui.com/guides/migration-v4/#textfield)
+- [TextareaAutosize](https://material-ui.com/guides/migration-v4/#textareaautoresize)
+- [TextField](https://material-ui.com/guides/migration-v4/#textfield)
 
 #### `theme-augment`
 
 Adds `DefaultTheme` module augmentation to typescript projects.
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-augment <path>
+npx @mui/codemod v5.0.0/theme-augment <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#material-ui-styles).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#material-ui-styles).
 
 #### `theme-breakpoints`
 
@@ -869,20 +869,20 @@ Updates breakpoint values to match new logic. ⚠️ This mod is not idempotent,
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-breakpoints <path>
+npx @mui/codemod v5.0.0/theme-breakpoints <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#theme).
 
 #### `theme-breakpoints-width`
 
 Renames `theme.breakpoints.width('md')` to `theme.breakpoints.values.md`.
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-breakpoints-width <path>
+npx @mui/codemod v5.0.0/theme-breakpoints-width <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#theme).
 
 #### `theme-options`
 
@@ -892,7 +892,7 @@ You can find more details about this breaking change in [the migration guide](ht
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-options <path>
+npx @mui/codemod v5.0.0/theme-options <path>
 ```
 
 #### `theme-palette-mode`
@@ -907,20 +907,20 @@ Renames `type` to `mode`.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-palette-mode <path>
+npx @mui/codemod v5.0.0/theme-palette-mode <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#theme).
 
 #### `theme-provider`
 
 Renames `MuiThemeProvider` to `ThemeProvider`.
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-provider <path>
+npx @mui/codemod v5.0.0/theme-provider <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#material-ui-core-styles).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#material-ui-core-styles).
 
 #### `theme-spacing`
 
@@ -936,10 +936,10 @@ Removes the 'px' suffix from some template strings.
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-spacing <path>
+npx @mui/codemod v5.0.0/theme-spacing <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#theme).
 
 #### `theme-typography-round`
 
@@ -951,17 +951,17 @@ Renames `theme.typography.round($number)` to `Math.round($number * 1e5) / 1e5`.
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/theme-typography-round <path>
+npx @mui/codemod v5.0.0/theme-typography-round <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#theme).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#theme).
 
 #### `transitions`
 
 Renames import `transitions` to `createTransitions`
 
 ```sh
-npx @mui/codemod@next v5.0.0/transitions <path>
+npx @mui/codemod v5.0.0/transitions <path>
 ```
 
 #### `use-autocomplete`
@@ -974,7 +974,7 @@ Renames `useAutocomplete` related import from lab to core
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/use-autocomplete <path>
+npx @mui/codemod v5.0.0/use-autocomplete <path>
 ```
 
 #### `use-transitionprops`
@@ -1003,7 +1003,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/use-transitionprops <path>
+npx @mui/codemod v5.0.0/use-transitionprops <path>
 ```
 
 You can find more details about this breaking change in [the migration guide](/guides/migration-v4/#dialog).
@@ -1033,7 +1033,7 @@ The diff should look like this:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v5.0.0/variant-prop <path>
+npx @mui/codemod v5.0.0/variant-prop <path>
 ```
 
 #### `with-mobile-dialog`
@@ -1042,15 +1042,15 @@ Removes imported `withMobileDialog`, and inserts hardcoded version to prevent ap
 
 ```diff
 - import withMobileDialog from '@material-ui/core/withMobileDialog';
-+ // FIXME checkout https://next.material-ui.com/guides/migration-v4/#dialog
++ // FIXME checkout https://material-ui.com/guides/migration-v4/#dialog
 + const withMobileDialog = () => (WrappedComponent) => (props) => <WrappedComponent {...props} width="lg" fullScreen={false} />;
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/with-mobile-dialog <path>
+npx @mui/codemod v5.0.0/with-mobile-dialog <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#dialog).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#dialog).
 
 #### `with-width`
 
@@ -1063,10 +1063,10 @@ Removes `withWidth` import, and inserts hardcoded version to prevent application
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/with-width <path>
+npx @mui/codemod v5.0.0/with-width <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#material-ui-core-styles).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#material-ui-core-styles).
 
 #### `mui-replace`
 
@@ -1124,10 +1124,10 @@ Replace every occurrence of `material-ui` related package with the new package n
 ```
 
 ```sh
-npx @mui/codemod@next v5.0.0/mui-replace <path>
+npx @mui/codemod v5.0.0/mui-replace <path>
 ```
 
-You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#update-material-ui-version).
+You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#update-material-ui-version).
 
 ### v4.0.0
 
@@ -1144,7 +1144,7 @@ The diff should look like this:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v4.0.0/theme-spacing-api <path>
+npx @mui/codemod v4.0.0/theme-spacing-api <path>
 ```
 
 This codemod tries to perform a basic expression simplification which can be improved for expressions that use more than one operation.
@@ -1171,7 +1171,7 @@ Converts all `@material-ui/core` imports more than 1 level deep to the optimal f
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v4.0.0/optimal-imports <path>
+npx @mui/codemod v4.0.0/optimal-imports <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -1189,7 +1189,7 @@ Converts all `@material-ui/core` submodule imports to the root module:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v4.0.0/top-level-imports <path>
+npx @mui/codemod v4.0.0/top-level-imports <path>
 ```
 
 Head to https://material-ui.com/guides/minimizing-bundle-size/ to understand when it's useful.
@@ -1210,7 +1210,7 @@ The diff should look like this:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v1.0.0/import-path <path>
+npx @mui/codemod v1.0.0/import-path <path>
 ```
 
 **Notice**: if you are migrating from pre-v1.0, and your imports use `material-ui`, you will need to manually find and replace all references to `material-ui` in your code to `@material-ui/core`. E.g.:
@@ -1237,7 +1237,7 @@ The diff should look like this:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v1.0.0/color-imports <path>
+npx @mui/codemod v1.0.0/color-imports <path>
 ```
 
 **additional options**
@@ -1245,7 +1245,7 @@ npx @mui/codemod@next v1.0.0/color-imports <path>
 <!-- #default-branch-switch -->
 
 ```
-npx @mui/codemod@next v1.0.0/color-imports <path> -- --importPath='mui/styles/colors' --targetPath='mui/colors'
+npx @mui/codemod v1.0.0/color-imports <path> -- --importPath='mui/styles/colors' --targetPath='mui/colors'
 ```
 
 #### `svg-icon-imports`
@@ -1263,7 +1263,7 @@ The diff should look like this:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v1.0.0/svg-icon-imports <path>
+npx @mui/codemod v1.0.0/svg-icon-imports <path>
 ```
 
 ### v0.15.0
@@ -1287,5 +1287,5 @@ The diff should look like this:
 <!-- #default-branch-switch -->
 
 ```sh
-npx @mui/codemod@next v0.15.0/import-path <path>
+npx @mui/codemod v0.15.0/import-path <path>
 ```

--- a/packages/mui-codemod/package.json
+++ b/packages/mui-codemod/package.json
@@ -16,7 +16,7 @@
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-codemod/**/*.test.js'",
     "prebuild": "rimraf build",
     "build": "node ../../scripts/build node --out-dir ./build && cpy README.md build && cpy package.json build && cpy codemod.js build",
-    "release": "yarn build && npm publish --tag next"
+    "release": "yarn build && npm publish"
   },
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "directory": "packages/mui-codemod"
   },
   "license": "MIT",
-  "homepage": "https://github.com/mui-org/material-ui/tree/next/packages/mui-codemod",
+  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/mui-codemod",
   "dependencies": {
     "@babel/core": "^7.15.0",
     "@babel/runtime": "^7.14.8",

--- a/packages/mui-codemod/src/v5.0.0/modal-props.js
+++ b/packages/mui-codemod/src/v5.0.0/modal-props.js
@@ -35,7 +35,7 @@ export default function transformer(file, api, options) {
   if (hasDisableBackdropClick || hasDisableBackdropClick) {
     source = source.replace(
       /(<Modal)([\s\S]*>)/gm,
-      `$1// You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#modal)${EOL}$2`,
+      `$1// You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#modal)${EOL}$2`,
     );
   }
 

--- a/packages/mui-codemod/src/v5.0.0/modal-props.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/modal-props.test/expected.js
@@ -1,5 +1,5 @@
 <Modal
 // `handleOnEscapeKeyDown` is removed by codemod.
 // `disableBackdropClick` is removed by codemod.
-// You can find more details about this breaking change in [the migration guide](https://next.material-ui.com/guides/migration-v4/#modal)
+// You can find more details about this breaking change in [the migration guide](https://material-ui.com/guides/migration-v4/#modal)
  onClose={handleClose} />;

--- a/packages/mui-core/README.md
+++ b/packages/mui-core/README.md
@@ -8,14 +8,14 @@ Install the package in your project directory with:
 
 ```sh
 // with npm
-npm install @mui/core@next
+npm install @mui/core
 
 // with yarn
-yarn add @mui/core@next
+yarn add @mui/core
 ```
 
 ## Documentation
 
 <!-- #default-branch-switch -->
 
-[The documentation](https://next.material-ui.com/customization/unstyled-components/)
+[The documentation](https://material-ui.com/customization/unstyled-components/)

--- a/packages/mui-core/package.json
+++ b/packages/mui-core/package.json
@@ -31,7 +31,7 @@
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-core/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"

--- a/packages/mui-core/package.json
+++ b/packages/mui-core/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/customization/unstyled-components/",
+  "homepage": "https://material-ui.com/customization/unstyled-components/",
   "scripts": {
     "build": "yarn build:legacy && yarn build:modern && yarn build:node && yarn build:stable && yarn build:types && yarn build:copy-files",
     "build:legacy": "node ../../scripts/build legacy",

--- a/packages/mui-docs/README.md
+++ b/packages/mui-docs/README.md
@@ -8,10 +8,10 @@ Install the package in your project directory with:
 
 ```sh
 // with npm
-npm install @mui/docs@next
+npm install @mui/docs
 
 // with yarn
-yarn add @mui/docs@next
+yarn add @mui/docs
 ```
 
 The docs has a peer dependency on the core components.
@@ -19,10 +19,10 @@ If you are not already using Material-UI in your project, you can add it with:
 
 ```sh
 // with npm
-npm install @mui/material@next
+npm install @mui/material
 
 // with yarn
-yarn add @mui/material@next
+yarn add @mui/material
 ```
 
 ## Documentation

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/next/packages/mui-docs",
+  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/mui-docs",
   "scripts": {
     "build": "yarn build:legacy && yarn build:modern && yarn build:node && yarn build:stable && yarn build:copy-files",
     "build:legacy": "node ../../scripts/build legacy",
@@ -30,7 +30,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "exit 0"
   },
   "peerDependencies": {

--- a/packages/mui-icons-material/README.md
+++ b/packages/mui-icons-material/README.md
@@ -6,30 +6,34 @@ This package provides the Google [Material icons](https://fonts.google.com/icons
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```sh
 // with npm
-npm install @mui/icons-material@next
+npm install @mui/icons-material
 
 // with yarn
-yarn add @mui/icons-material@next
+yarn add @mui/icons-material
 ```
 
+<!-- #default-branch-switch -->
+
 These components use the Material-UI [SvgIcon](https://material-ui.com/api/svg-icon/) component to
-render the SVG path for each icon, and so a have a peer-dependency on the `next` release of Material-UI.
+render the SVG path for each icon.
 
 If you are not already using Material-UI in your project, you can add it with:
 
 ```sh
 // with npm
-npm install @mui/material@next
+npm install @mui/material
 
 // with yarn
-yarn add @mui/material@next
+yarn add @mui/material
 ```
 
 ## Documentation
 
 <!-- #default-branch-switch -->
 
-- [The documentation](https://next.material-ui.com/components/icons/#svg-material-icons)
-- [The icons search](https://next.material-ui.com/components/material-icons/)
+- [The documentation](https://material-ui.com/components/icons/#svg-material-icons)
+- [The icons search](https://material-ui.com/components/material-icons/)

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/components/material-icons/",
+  "homepage": "https://material-ui.com/components/material-icons/",
   "scripts": {
     "build": "cp -r lib/ build/ && yarn build:typings && yarn build:copy-files",
     "build:lib": "yarn build:node && yarn build:stable",

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -33,7 +33,7 @@
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:typings": "babel-node --config-file ../../babel.config.js ./scripts/create-typings.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "src:download": "cd ../../ && babel-node --config-file ./babel.config.js packages/mui-icons-material/scripts/download.js",
     "src:icons": "cd ../../ && UV_THREADPOOL_SIZE=64 babel-node --config-file ./babel.config.js packages/mui-icons-material/builder.js --output-dir packages/mui-icons-material/src --svg-dir packages/mui-icons-material/material-icons --renameFilter ./renameFilters/material-design-icons.js && cd packages/mui-icons-material && yarn build:lib:clean",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-icons-material/**/*.test.{js,ts,tsx}'",

--- a/packages/mui-lab/README.md
+++ b/packages/mui-lab/README.md
@@ -6,27 +6,31 @@ This package hosts the incubator components that are not yet ready to move to `c
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```sh
 // with npm
-npm install @mui/lab@next
+npm install @mui/lab
 
 // with yarn
-yarn add @mui/lab@next
+yarn add @mui/lab
 ```
 
-The lab has a peer dependency on the core components.
+The lab has a peer dependency on the Material Design components.
 If you are not already using Material-UI in your project, you can install it with:
+
+<!-- #default-branch-switch -->
 
 ```sh
 // with npm
-npm install @mui/material@next
+npm install @mui/material
 
 // with yarn
-yarn add @mui/material@next
+yarn add @mui/material
 ```
 
 ## Documentation
 
 <!-- #default-branch-switch -->
 
-[The documentation](https://next.material-ui.com/components/about-the-lab/)
+[The documentation](https://material-ui.com/components/about-the-lab/)

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/components/about-the-lab/",
+  "homepage": "https://material-ui.com/components/about-the-lab/",
   "scripts": {
     "build": "yarn build:legacy && yarn build:modern && yarn build:node && yarn build:stable && yarn build:types && yarn build:copy-files ",
     "build:legacy": "node ../../scripts/build legacy",

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -31,7 +31,7 @@
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-lab/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },

--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -33,7 +33,7 @@
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-material-next/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"

--- a/packages/mui-material/README.md
+++ b/packages/mui-material/README.md
@@ -8,10 +8,10 @@ Install the package in your project directory with:
 
 ```sh
 // with npm
-npm install @mui/material@next
+npm install @mui/material
 
 // with yarn
-yarn add @mui/material@next
+yarn add @mui/material
 ```
 
 ## Documentation

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -35,7 +35,7 @@
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-material/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"

--- a/packages/mui-material/test/umd/run.js
+++ b/packages/mui-material/test/umd/run.js
@@ -47,7 +47,7 @@ async function createApp() {
 
   let index = await fse.readFile(path.join(rootPath, 'examples/cdn/index.html'), 'utf8');
   index = index.replace(
-    'https://unpkg.com/@mui/material@next/umd/material-ui.development.js',
+    'https://unpkg.com/@mui/material@latest/umd/material-ui.development.js',
     umdPath,
   );
   index = index.replace(

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/",
+  "homepage": "https://material-ui.com/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -33,7 +33,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-private-theming/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },

--- a/packages/mui-styled-engine-sc/README.md
+++ b/packages/mui-styled-engine-sc/README.md
@@ -7,4 +7,4 @@ It's designed for developers who would like to use `styled-components` as the ma
 
 <!-- #default-branch-switch -->
 
-[The documentation](https://next.material-ui.com/guides/styled-engine/)
+[The documentation](https://material-ui.com/guides/styled-engine/)

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/guides/styled-engine/",
+  "homepage": "https://material-ui.com/guides/styled-engine/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -33,7 +33,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-styled-engine-sc/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },

--- a/packages/mui-styled-engine/README.md
+++ b/packages/mui-styled-engine/README.md
@@ -8,4 +8,4 @@ It is used internally in the `@mui/system` package.
 
 <!-- #default-branch-switch -->
 
-[The documentation](https://next.material-ui.com/guides/styled-engine/)
+[The documentation](https://material-ui.com/guides/styled-engine/)

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -33,7 +33,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-styled-engine/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/guides/styled-engine/",
+  "homepage": "https://material-ui.com/guides/styled-engine/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -33,7 +33,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-styles/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/styles/basics/",
+  "homepage": "https://material-ui.com/styles/basics/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/mui-styles/src/makeStyles/makeStyles.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.js
@@ -269,8 +269,7 @@ export default function makeStyles(stylesOrCreator, options = {}) {
         console.error(
           [
             `Material-UI: You are using a variant value \`${props.variant}\` for which you didn't define styles.`,
-            // TODO: switch to material-ui.com when v5 is released
-            `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://next.material-ui.com/r/custom-component-variants.`,
+            `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://material-ui.com/r/custom-component-variants.`,
           ].join('\n'),
         );
       }

--- a/packages/mui-styles/src/useThemeVariants/useThemeVariants.test.js
+++ b/packages/mui-styles/src/useThemeVariants/useThemeVariants.test.js
@@ -137,12 +137,12 @@ describe('useThemeVariants', () => {
     ).toErrorDev([
       [
         `Material-UI: You are using a variant value \`test\` for which you didn't define styles.`,
-        `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://next.material-ui.com/r/custom-component-variants.`,
+        `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://material-ui.com/r/custom-component-variants.`,
       ].join('\n'),
       !strictModeDoubleLoggingSupressed &&
         [
           `Material-UI: You are using a variant value \`test\` for which you didn't define styles.`,
-          `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://next.material-ui.com/r/custom-component-variants.`,
+          `Please create a new variant matcher in your theme for this variant. To learn more about matchers visit https://material-ui.com/r/custom-component-variants.`,
         ].join('\n'),
     ]);
   });

--- a/packages/mui-system/README.md
+++ b/packages/mui-system/README.md
@@ -10,14 +10,14 @@ Install the package in your project directory with:
 
 ```sh
 // with npm
-npm install @mui/system@next @emotion/react @emotion/styled
+npm install @mui/system @emotion/react @emotion/styled
 
 // with yarn
-yarn add @mui/system@next @emotion/react @emotion/styled
+yarn add @mui/system @emotion/react @emotion/styled
 ```
 
 ## Documentation
 
 <!-- #default-branch-switch -->
 
-[The documentation](https://next.material-ui.com/system/basics/)
+[The documentation](https://material-ui.com/system/basics/)

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://next.material-ui.com/system/basics/",
+  "homepage": "https://material-ui.com/system/basics/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/material-ui"

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -33,7 +33,7 @@
     "build:stable": "node ../../scripts/build stable",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-system/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },

--- a/packages/mui-types/package.json
+++ b/packages/mui-types/package.json
@@ -23,12 +23,12 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/next/packages/mui-types",
+  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/mui-types",
   "scripts": {
     "build": "mkdir build && cpy index.d.ts build/ && yarn build:copy-files",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "echo 'No runtime test. Type tests are run with the `typescript` script.'",
     "typescript": "tslint -p tsconfig.json \"*.{ts,tsx}\""
   },

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/mui-org/material-ui/tree/next/packages/mui-utils",
+  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/mui-utils",
   "scripts": {
     "build": "yarn build:legacy && yarn build:modern && yarn build:node && yarn build:stable && yarn build:copy-files && yarn build:types",
     "build:legacy": "node ../../scripts/build legacy",
@@ -30,7 +30,7 @@
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:types": "node ../../scripts/buildTypes",
     "prebuild": "rimraf build",
-    "release": "yarn build && npm publish build --tag next",
+    "release": "yarn build && npm publish build",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-utils/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },


### PR DESCRIPTION
List of changes:
- [x] Handle all `#default-branch-switch` comments
- [x] Replace next.material-ui.com with material-ui.com
- [x] Replace the @mui/*@next with @mui/*
- [x] Add redirects from next.material-ui.com -> material-ui.com
- [x] Change the tag from next to latest