### PR TITLE
[test] Recommend yarn t over test:watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "test:regressions:server": "serve test/regressions",
     "test:umd": "node packages/mui-material/test/umd/run.js",
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
-    "test:watch": "yarn test:unit --watch",
     "test:argos": "node ./scripts/pushArgos.js",
     "typescript": "lerna run --no-bail --parallel typescript",
     "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript"

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@ Thanks for writing tests! Here's a quick run-down on our current setup.
 ## Getting started
 
 1. Add a unit test to `packages/*/src/TheUnitInQuestion/TheUnitInQuestion.test.js` or an integration test `packages/*/test/`.
-2. Run `yarn test:watch`.
+2. Run `yarn t TheUnitInQuestion`.
 3. Implement the tested behavior
 4. Open a PR once the test passes or you want somebody to review your work
 
@@ -116,11 +116,11 @@ trade-off, mainly completeness vs. speed.
 
 To run all of the unit and integration tests run `yarn test:unit`
 
-If you want to `grep` for certain tests add `-g STRING_TO_GREP`.
+If you want to `grep` for certain tests add `-g STRING_TO_GREP` though for development we recommend `yarn t <testFilePattern>`.
 
 #### Watch the core mocha unit/integration test suite.
 
-`yarn test:watch`
+`yarn t <testFilePattern>`
 
 First, we have the **unit test** suite.
 It uses [mocha](https://mochajs.org) and a thin wrapper around `@testing-library/react`.

--- a/test/cli.js
+++ b/test/cli.js
@@ -35,7 +35,7 @@ async function run(argv) {
   if (argv.bail) {
     args.push('--bail');
   }
-  if (argv.inspectBrk) {
+  if (argv.debug) {
     args.push('--inspect-brk');
   }
   if (!argv.single) {
@@ -79,11 +79,6 @@ yargs
         })
         .option('bail', {
           alias: 'b',
-          description: 'Stop on first error.',
-          type: 'boolean',
-        })
-        .option('inspect-brk', {
-          alias: 'd',
           description: 'Stop on first error.',
           type: 'boolean',
         })


### PR DESCRIPTION
`yarn test:watch` is really not suitable for 99% of the use cases. The one-off tasks can use `yarn test:unit --watch`.

Also removes the `--inspect-brk` flag from the experimental CLI since it's not straight forward to use. If you need it, and know what you're doing, you're better off editing the CLI locally.