### PR TITLE
[docs] Update redirects to X's docs

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -159,9 +159,9 @@ https://v3-9-0.material-ui.com/* https://v3.material-ui.com/:splat 301!
 ## material-ui-x
 ## Unlike the store that expect to be hosted under a subfolder,
 ## material-ui-x is configured to be hosted at the root.
-/api/*/ https://next--material-ui-x.netlify.app/api/:splat/ 200
-/:lang/api/*/ https://next--material-ui-x.netlify.app/:lang/api/:splat/ 200
-/components/* https://next--material-ui-x.netlify.app/components/:splat 200
-/:lang/components/* https://next--material-ui-x.netlify.app/:lang/components/:splat 200
-/_next/* https://next--material-ui-x.netlify.app/_next/:splat 200
-/static/x/* https://next--material-ui-x.netlify.app/static/x/:splat 200
+/api/*/ https://docs-v5--material-ui-x.netlify.app/api/:splat/ 200
+/:lang/api/*/ https://docs-v5--material-ui-x.netlify.app/:lang/api/:splat/ 200
+/components/* https://docs-v5--material-ui-x.netlify.app/components/:splat 200
+/:lang/components/* https://docs-v5--material-ui-x.netlify.app/:lang/components/:splat 200
+/_next/* https://docs-v5--material-ui-x.netlify.app/_next/:splat 200
+/static/x/* https://docs-v5--material-ui-x.netlify.app/static/x/:splat 200


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://next.material-ui.com/components/data-grid is pointing to `next`, which is the development branch of the v5 version. I've created the `docs-v5` branch to deploy the v5 docs. This new branch was created based on `master`.

Before: https://next.material-ui.com/api/data-grid/data-grid/#css

<img width="500" src="https://user-images.githubusercontent.com/42154031/132921559-dd562952-2915-4a2a-bb5e-4f409b067742.png" alt="image" style="max-width: 100%;">

After: https://deploy-preview-28263--material-ui.netlify.app/api/data-grid/data-grid/#css

<img width="500" src="https://user-images.githubusercontent.com/42154031/132921606-dcf9b595-0aae-40a8-bdc9-bca4873c39e0.png" alt="image" style="max-width: 100%;">

