### PR TITLE
[core] Support release:build with cmd.exe

### DIFF
--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://material-ui.com/components/material-icons/",
   "scripts": {
-    "build": "cp -r lib/ build/ && yarn build:typings && yarn build:copy-files",
+    "build": "shx cp -r lib/ build/ && yarn build:typings && yarn build:copy-files",
     "build:lib": "yarn build:node && yarn build:stable",
     "build:lib:clean": "rimraf lib/ && yarn build:lib",
     "build:legacy": "echo 'Skip legacy build'",
@@ -56,6 +56,7 @@
   "devDependencies": {
     "fs-extra": "^10.0.0",
     "mustache": "^4.2.0",
+    "shx": "^0.3.3",
     "svgo": "^2.4.0",
     "yargs": "^17.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14860,7 +14860,7 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.3:
+shelljs@^0.8.3, shelljs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -14868,6 +14868,14 @@ shelljs@^0.8.3:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shx@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.3.tgz#681a88c7c10db15abe18525349ed474f0f1e7b9f"
+  integrity sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.4"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Makes building `@mui/icons-material` (and, therefore, running `yarn release:build` in the repository root) succeed on Windows.