### PR TITLE
[core] Add `clean` yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "release:publish": "lerna publish from-package --dist-tag next --contents build",
     "release:publish:dry-run": "lerna publish from-package --dist-tag next --contents build --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag",
+    "clean": "lerna run --parallel --scope \"@mui/*\" prebuild",
     "docs:api": "rimraf ./docs/pages/api-docs && yarn docs:api:build",
     "docs:api:build": "cross-env BABEL_ENV=development __NEXT_EXPORT_TRAILING_SLASH=true babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/buildApi.ts  ./docs/pages/api-docs ./packages/mui-core/src ./packages/mui-material/src ./packages/mui-lab/src --apiPagesManifestPath ./docs/src/pagesApi.js",
     "docs:build": "yarn workspace docs build",


### PR DESCRIPTION
This PR adds a `clean` yarn script to the root package.json.

Quite often when building projects I encountered a Typescript error stating that some modules were built using different sources. Cleaning the remains of previous builds solves the problem.