### PR TITLE
[docs] No import from `react-router`

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -102,7 +102,6 @@
     "react-intersection-observer": "^8.32.1",
     "react-is": "^17.0.2",
     "react-number-format": "^4.7.3",
-    "react-router": "^5.0.0",
     "react-router-dom": "^5.0.1",
     "react-spring": "^8.0.27",
     "react-swipeable-views": "^0.14.0",

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
@@ -10,8 +10,7 @@ import Typography from '@mui/material/Typography';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
-import { Route, MemoryRouter } from 'react-router';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, Route, MemoryRouter } from 'react-router-dom';
 
 const breadcrumbNameMap = {
   '/inbox': 'Inbox',

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
@@ -9,8 +9,7 @@ import Typography from '@mui/material/Typography';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
-import { Route, MemoryRouter } from 'react-router';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, Route, MemoryRouter } from 'react-router-dom';
 
 interface ListItemLinkProps extends ListItemProps {
   to: string;

--- a/docs/src/pages/components/pagination/PaginationLink.js
+++ b/docs/src/pages/components/pagination/PaginationLink.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { MemoryRouter, Route } from 'react-router';
-import { Link } from 'react-router-dom';
+import { Link, MemoryRouter, Route } from 'react-router-dom';
 import Pagination from '@mui/material/Pagination';
 import PaginationItem from '@mui/material/PaginationItem';
 

--- a/docs/src/pages/components/pagination/PaginationLink.tsx
+++ b/docs/src/pages/components/pagination/PaginationLink.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { MemoryRouter, Route } from 'react-router';
-import { Link } from 'react-router-dom';
+import { Link, MemoryRouter, Route } from 'react-router-dom';
 import Pagination from '@mui/material/Pagination';
 import PaginationItem from '@mui/material/PaginationItem';
 

--- a/docs/src/pages/guides/routing/ButtonRouter.js
+++ b/docs/src/pages/guides/routing/ButtonRouter.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { MemoryRouter as Router } from 'react-router';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, MemoryRouter as Router } from 'react-router-dom';
 import Button from '@mui/material/Button';
 
 const LinkBehavior = React.forwardRef((props, ref) => (

--- a/docs/src/pages/guides/routing/ButtonRouter.tsx
+++ b/docs/src/pages/guides/routing/ButtonRouter.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
-import { MemoryRouter as Router } from 'react-router';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+  MemoryRouter as Router,
+} from 'react-router-dom';
 import Button from '@mui/material/Button';
 
 const LinkBehavior = React.forwardRef<any, Omit<RouterLinkProps, 'to'>>(

--- a/docs/src/pages/guides/routing/LinkRouter.js
+++ b/docs/src/pages/guides/routing/LinkRouter.js
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { MemoryRouter as Router } from 'react-router';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, MemoryRouter as Router } from 'react-router-dom';
 import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';
 

--- a/docs/src/pages/guides/routing/LinkRouter.tsx
+++ b/docs/src/pages/guides/routing/LinkRouter.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { MemoryRouter as Router } from 'react-router';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+  MemoryRouter as Router,
+} from 'react-router-dom';
 import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';
 

--- a/docs/src/pages/guides/routing/LinkRouterWithTheme.js
+++ b/docs/src/pages/guides/routing/LinkRouterWithTheme.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { MemoryRouter as Router } from 'react-router';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, MemoryRouter as Router } from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';

--- a/docs/src/pages/guides/routing/LinkRouterWithTheme.tsx
+++ b/docs/src/pages/guides/routing/LinkRouterWithTheme.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
-import { MemoryRouter as Router } from 'react-router';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+  MemoryRouter as Router,
+} from 'react-router-dom';
 import { Theme, ThemeProvider, createTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';

--- a/docs/src/pages/guides/routing/ListRouter.js
+++ b/docs/src/pages/guides/routing/ListRouter.js
@@ -10,8 +10,7 @@ import Divider from '@mui/material/Divider';
 import InboxIcon from '@mui/icons-material/Inbox';
 import DraftsIcon from '@mui/icons-material/Drafts';
 import Typography from '@mui/material/Typography';
-import { Route, MemoryRouter } from 'react-router';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, Route, MemoryRouter } from 'react-router-dom';
 
 function ListItemLink(props) {
   const { icon, primary, to } = props;

--- a/docs/src/pages/guides/routing/ListRouter.tsx
+++ b/docs/src/pages/guides/routing/ListRouter.tsx
@@ -9,8 +9,12 @@ import Divider from '@mui/material/Divider';
 import InboxIcon from '@mui/icons-material/Inbox';
 import DraftsIcon from '@mui/icons-material/Drafts';
 import Typography from '@mui/material/Typography';
-import { Route, MemoryRouter } from 'react-router';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+  Route,
+  MemoryRouter,
+} from 'react-router-dom';
 
 interface ListItemLinkProps {
   icon?: React.ReactElement;

--- a/packages/mui-material/test/typescript/hoc-interop.spec.tsx
+++ b/packages/mui-material/test/typescript/hoc-interop.spec.tsx
@@ -13,7 +13,7 @@ import { createStyles, withStyles } from '@mui/styles';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import emotionStyled from '@emotion/styled';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
 const filledProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13723,7 +13723,7 @@ react-router-dom@^5.0.1, react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.2.0, react-router@^5.0.0:
+react-router@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
   integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==


### PR DESCRIPTION
In an application only a single version of `react-router` can exist (https://github.com/remix-run/react-router/releases/tag/v5.0.0).

Since `react-router-dom` exports everything from `react-router` we can automatically ensure this by not directly importing from `react-router`. Otherwise we get failures such as https://app.netlify.com/sites/material-ui/deploys/613d60a8b0b0ad00075eb389

Closes https://github.com/mui-org/material-ui/pull/28282