### PR TITLE
[docs] Remove job ad on the website

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import throttle from 'lodash/throttle';
 import clsx from 'clsx';
 import { useSelector } from 'react-redux';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import NoSsr from '@material-ui/core/NoSsr';
+// import NoSsr from '@material-ui/core/NoSsr';
 import { BANNER_HEIGHT } from 'docs/src/modules/constants';
 import Link from 'docs/src/modules/components/Link';
 import PageContext from 'docs/src/modules/components/PageContext';
@@ -119,7 +119,7 @@ export default function AppTableOfContents(props) {
   const { items } = props;
   const classes = useStyles();
   const t = useSelector((state) => state.options.t);
-  const theme = useTheme();
+  // const theme = useTheme();
 
   const itemsWithNodeRef = React.useRef([]);
   React.useEffect(() => {
@@ -241,26 +241,30 @@ export default function AppTableOfContents(props) {
           </Typography>
         </div>
       ) : null}
-      <NoSsr>
-        <Link href="/company/careers/" underline="none" className={classes.hiring}>
-          <img
-            src={`/static/hiring-toc-${theme.palette.type}.png`}
-            alt=""
-            loading="lazy"
-            width={175}
-            height={119}
-          />
-          {"We're hiring a "}
-          {
-            ['React engineer', 'Full-stack engineer', 'Product manager', 'Dev. Advocate'][
-              Math.round(Math.random() * 3)
-            ]
-          }
-          {' and more roles.'}
-          {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-          <span className={classes.hiringLearn}>Learn more &rarr;</span>
-        </Link>
-      </NoSsr>
+      {/**
+        <NoSsr>
+          <Link href="/company/careers/" underline="none" className={classes.hiring}>
+            <img
+              src={`/static/hiring-toc-${theme.palette.type}.png`}
+              alt=""
+              loading="lazy"
+              width={175}
+              height={119}
+            />
+            {"We're hiring a "}
+            {
+              ['React engineer', 'Full-stack engineer', 'Product manager', 'Dev. Advocate'][
+                Math.round(Math.random() * 3)
+              ]
+            }
+            {' and more roles.'}
+          */}
+      {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
+      {/**
+            <span className={classes.hiringLearn}>Learn more &rarr;</span>
+          </Link>
+        </NoSsr>
+        */}
     </nav>
   );
 }

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -259,7 +259,6 @@ export default function AppTableOfContents(props) {
             }
             {' and more roles.'}
           */}
-      {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
       {/**
             <span className={classes.hiringLearn}>Learn more &rarr;</span>
           </Link>

--- a/docs/src/pages/company/careers/developer-advocate.md
+++ b/docs/src/pages/company/careers/developer-advocate.md
@@ -53,7 +53,7 @@ We are looking for a dedicated educator and experienced developer to join us as 
 
 ## Compensation
 
-Competitive compensation, depending on the profile. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
+Competitive compensation of up to \$140,000 USD/year, depending on the profile. It could go higher for a person that can significantly push the mission forward. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
 
 ## Apply
 

--- a/docs/src/pages/company/careers/full-stack-engineer.md
+++ b/docs/src/pages/company/careers/full-stack-engineer.md
@@ -64,7 +64,7 @@ You are curious, you enjoy taking risks, and learning.
 
 ## Compensation
 
-Competitive compensation, depending on the profile. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
+Competitive compensation of up to \$140,000 USD/year, depending on the profile. It could go higher for a person that can significantly push the mission forward. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
 
 ## Apply
 

--- a/docs/src/pages/company/careers/product-manager.md
+++ b/docs/src/pages/company/careers/product-manager.md
@@ -60,7 +60,7 @@ You will be joining the advanced components team.
 
 ## Compensation
 
-Competitive compensation, depending on the profile. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
+Competitive compensation of up to \$140,000 USD/year, depending on the profile. It could go higher for a person that can significantly push the mission forward. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
 
 ## Apply
 

--- a/docs/src/pages/company/careers/react-engineer.md
+++ b/docs/src/pages/company/careers/react-engineer.md
@@ -109,7 +109,7 @@ We're looking for someone with strong front-end skills. More important than spec
 
 ## Compensation
 
-Competitive compensation, depending on the profile. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
+Competitive compensation of up to \$140,000 USD/year, depending on the profile. It could go higher for a person that can significantly push the mission forward. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
 
 ## Apply
 

--- a/docs/src/pages/company/careers/technical-product-manager.md
+++ b/docs/src/pages/company/careers/technical-product-manager.md
@@ -60,7 +60,7 @@ You will be joining the advanced components team.
 
 ## Compensation
 
-Competitive compensation, depending on the profile. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
+Competitive compensation of up to \$140,000 USD/year, depending on the profile. It could go higher for a person that can significantly push the mission forward. You can find the other perks & benefits in the [careers](/company/careers/#perks-amp-benefits) page.
 
 ## Apply
 


### PR DESCRIPTION
cd8aeb64a9038ae9cb8ecf1cd7fd8a2bfea2d6b6 was the last commit on `master` before we merged `next` and since we had commits on v4.x that weren't on `master` we can't just `git merge --ff-only master`. So I'm just cherry-picking cd8aeb64a9038ae9cb8ecf1cd7fd8a2bfea2d6b6.

Original commit description:
Too many inbound applications than we can handle.

This reverts commit 120c564109245a3b070b1cbaf2c9f3f8659fd9fa.