### PR TITLE
[docs] Replace remaining unstyled package reference

### DIFF
--- a/docs/src/pages/customization/unstyled-components/unstyled-components.md
+++ b/docs/src/pages/customization/unstyled-components/unstyled-components.md
@@ -18,7 +18,7 @@ If you:
 - need precise control over the rendered HTML of the components,
 - or need to implement custom components but don't want to deal with accessibility features on your own,
 
-then you will find `material-ui/unstyled` useful.
+then you will find `@mui/core` useful.
 
 If, however, you:
 


### PR DESCRIPTION
Found one stray occurrence of the old `material/unstyled`