### PR TITLE
[docs] Fix failing client-side navigation for /api routes

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -165,7 +165,6 @@ module.exports = {
       },
     };
   },
-  trailingSlash: true,
   env: {
     COMMIT_REF: process.env.COMMIT_REF,
     ENABLE_AD: process.env.ENABLE_AD,
@@ -223,8 +222,13 @@ module.exports = {
     return map;
   },
   reactStrictMode,
+  trailingSlash: true,
   async rewrites() {
-    return [{ source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' }];
+    return [
+      { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
+      // Make sure to include the trailing slash if `trailingSlash` option is set
+      { source: '/api/:rest*/', destination: '/api-docs/:rest*/' },
+    ];
   },
   // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
   optimizeFonts: false,

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -51,15 +51,12 @@ function handleClick(event) {
   handleEvent(event, activeElement.getAttribute('href'));
 }
 
-let bound = false;
-
 export default function MarkdownLinks() {
   React.useEffect(() => {
-    if (bound) {
-      return;
-    }
-    bound = true;
     document.addEventListener('click', handleClick);
+    return () => {
+      document.addEventListener('click', handleClick);
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
Next.js previously fell back to basic URL navigation (opposed to client-side routing) for links to `/api` routes that were rendered via markdown.

Compare clicking on the "InputBase" link in "Props of the InputBase component are also available." on https://613f2e53d5823400073263e4--material-ui.netlify.app/api/outlined-input/ vs https://deploy-preview-28356--material-ui.netlify.app//api/outlined-input/

I previously thought `rewrites` was just not working for client-side navigation (https://github.com/mui-org/material-ui/pull/23586). Turns out it's just bugged when the rewrite doesn't have a trailing slash with `trailingSlash: true` (https://github.com/vercel/next.js/issues/25673, https://github.com/vercel/next.js/issues/25104, https://github.com/vercel/next.js/issues/20984).

We can probably revert most https://github.com/mui-org/material-ui/pull/23586 but I'm not sure how the data-grid `api-docs` rewrites work so I'm rather not touch it.


