### PR TITLE
[docs] Fix various broken master links

### DIFF
--- a/docs/pages/api-docs/accordion-actions.md
+++ b/docs/pages/api-docs/accordion-actions.md
@@ -49,7 +49,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/AccordionActions/AccordionActions.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/AccordionActions/AccordionActions.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/accordion-details.md
+++ b/docs/pages/api-docs/accordion-details.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/AccordionDetails/AccordionDetails.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/AccordionDetails/AccordionDetails.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/accordion-summary.md
+++ b/docs/pages/api-docs/accordion-summary.md
@@ -56,7 +56,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/AccordionSummary/AccordionSummary.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/AccordionSummary/AccordionSummary.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/accordion.md
+++ b/docs/pages/api-docs/accordion.md
@@ -57,7 +57,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Accordion/Accordion.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Accordion/Accordion.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/alert-title.md
+++ b/docs/pages/api-docs/alert-title.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/AlertTitle/AlertTitle.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/AlertTitle/AlertTitle.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/alert.md
+++ b/docs/pages/api-docs/alert.md
@@ -71,7 +71,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Alert/Alert.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/Alert/Alert.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/app-bar.md
+++ b/docs/pages/api-docs/app-bar.md
@@ -59,7 +59,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/AppBar/AppBar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/AppBar/AppBar.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/autocomplete.md
+++ b/docs/pages/api-docs/autocomplete.md
@@ -127,7 +127,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Autocomplete/Autocomplete.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/Autocomplete/Autocomplete.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/avatar-group.md
+++ b/docs/pages/api-docs/avatar-group.md
@@ -50,7 +50,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/avatar.md
+++ b/docs/pages/api-docs/avatar.md
@@ -61,7 +61,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Avatar/Avatar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Avatar/Avatar.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/backdrop.md
+++ b/docs/pages/api-docs/backdrop.md
@@ -51,7 +51,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Backdrop/Backdrop.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Backdrop/Backdrop.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/badge.md
+++ b/docs/pages/api-docs/badge.md
@@ -78,7 +78,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Badge/Badge.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Badge/Badge.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/bottom-navigation-action.md
+++ b/docs/pages/api-docs/bottom-navigation-action.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/bottom-navigation.md
+++ b/docs/pages/api-docs/bottom-navigation.md
@@ -51,7 +51,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/BottomNavigation/BottomNavigation.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/BottomNavigation/BottomNavigation.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/breadcrumbs.md
+++ b/docs/pages/api-docs/breadcrumbs.md
@@ -56,7 +56,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/button-base.md
+++ b/docs/pages/api-docs/button-base.md
@@ -61,7 +61,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/ButtonBase.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ButtonBase/ButtonBase.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/button-group.md
+++ b/docs/pages/api-docs/button-group.md
@@ -80,7 +80,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonGroup/ButtonGroup.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ButtonGroup/ButtonGroup.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/button.md
+++ b/docs/pages/api-docs/button.md
@@ -87,7 +87,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Button/Button.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Button/Button.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/card-action-area.md
+++ b/docs/pages/api-docs/card-action-area.md
@@ -49,7 +49,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardActionArea/CardActionArea.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CardActionArea/CardActionArea.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/card-actions.md
+++ b/docs/pages/api-docs/card-actions.md
@@ -49,7 +49,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardActions/CardActions.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CardActions/CardActions.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/card-content.md
+++ b/docs/pages/api-docs/card-content.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardContent/CardContent.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CardContent/CardContent.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/card-header.md
+++ b/docs/pages/api-docs/card-header.md
@@ -59,7 +59,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardHeader/CardHeader.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CardHeader/CardHeader.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/card-media.md
+++ b/docs/pages/api-docs/card-media.md
@@ -52,7 +52,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardMedia/CardMedia.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CardMedia/CardMedia.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/card.md
+++ b/docs/pages/api-docs/card.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Card/Card.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Card/Card.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/checkbox.md
+++ b/docs/pages/api-docs/checkbox.md
@@ -66,7 +66,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Checkbox/Checkbox.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Checkbox/Checkbox.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/chip.md
+++ b/docs/pages/api-docs/chip.md
@@ -87,7 +87,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Chip/Chip.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Chip/Chip.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/circular-progress.md
+++ b/docs/pages/api-docs/circular-progress.md
@@ -67,7 +67,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CircularProgress/CircularProgress.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CircularProgress/CircularProgress.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/collapse.md
+++ b/docs/pages/api-docs/collapse.md
@@ -59,7 +59,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Collapse/Collapse.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Collapse/Collapse.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/container.md
+++ b/docs/pages/api-docs/container.md
@@ -57,7 +57,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Container/Container.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Container/Container.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/css-baseline.md
+++ b/docs/pages/api-docs/css-baseline.md
@@ -46,7 +46,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CssBaseline/CssBaseline.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/CssBaseline/CssBaseline.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/dialog-actions.md
+++ b/docs/pages/api-docs/dialog-actions.md
@@ -49,7 +49,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogActions/DialogActions.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/DialogActions/DialogActions.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/dialog-content-text.md
+++ b/docs/pages/api-docs/dialog-content-text.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogContentText/DialogContentText.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/DialogContentText/DialogContentText.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/dialog-content.md
+++ b/docs/pages/api-docs/dialog-content.md
@@ -49,7 +49,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogContent/DialogContent.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/DialogContent/DialogContent.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/dialog-title.md
+++ b/docs/pages/api-docs/dialog-title.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogTitle/DialogTitle.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/DialogTitle/DialogTitle.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/dialog.md
+++ b/docs/pages/api-docs/dialog.md
@@ -84,7 +84,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Dialog/Dialog.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Dialog/Dialog.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/divider.md
+++ b/docs/pages/api-docs/divider.md
@@ -58,7 +58,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Divider/Divider.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Divider/Divider.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/drawer.md
+++ b/docs/pages/api-docs/drawer.md
@@ -68,7 +68,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Drawer/Drawer.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Drawer/Drawer.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/expansion-panel-actions.md
+++ b/docs/pages/api-docs/expansion-panel-actions.md
@@ -52,5 +52,5 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.js) for more detail.
 

--- a/docs/pages/api-docs/expansion-panel-details.md
+++ b/docs/pages/api-docs/expansion-panel-details.md
@@ -50,5 +50,5 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.js) for more detail.
 

--- a/docs/pages/api-docs/expansion-panel-summary.md
+++ b/docs/pages/api-docs/expansion-panel-summary.md
@@ -58,7 +58,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/expansion-panel.md
+++ b/docs/pages/api-docs/expansion-panel.md
@@ -60,7 +60,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/fab.md
+++ b/docs/pages/api-docs/fab.md
@@ -64,7 +64,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Fab/Fab.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Fab/Fab.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/filled-input.md
+++ b/docs/pages/api-docs/filled-input.md
@@ -86,7 +86,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FilledInput/FilledInput.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/FilledInput/FilledInput.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/form-control-label.md
+++ b/docs/pages/api-docs/form-control-label.md
@@ -60,7 +60,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormControlLabel/FormControlLabel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/FormControlLabel/FormControlLabel.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/form-control.md
+++ b/docs/pages/api-docs/form-control.md
@@ -81,7 +81,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormControl/FormControl.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/FormControl/FormControl.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/form-group.md
+++ b/docs/pages/api-docs/form-group.md
@@ -51,7 +51,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormGroup/FormGroup.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/FormGroup/FormGroup.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/form-helper-text.md
+++ b/docs/pages/api-docs/form-helper-text.md
@@ -62,7 +62,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormHelperText/FormHelperText.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/FormHelperText/FormHelperText.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/form-label.md
+++ b/docs/pages/api-docs/form-label.md
@@ -61,7 +61,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/FormLabel/FormLabel.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/grid-list-tile-bar.md
+++ b/docs/pages/api-docs/grid-list-tile-bar.md
@@ -64,5 +64,5 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridListTileBar/GridListTileBar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/GridListTileBar/GridListTileBar.js) for more detail.
 

--- a/docs/pages/api-docs/grid-list-tile.md
+++ b/docs/pages/api-docs/grid-list-tile.md
@@ -56,5 +56,5 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridListTile/GridListTile.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/GridListTile/GridListTile.js) for more detail.
 

--- a/docs/pages/api-docs/grid-list.md
+++ b/docs/pages/api-docs/grid-list.md
@@ -54,5 +54,5 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridList/GridList.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/GridList/GridList.js) for more detail.
 

--- a/docs/pages/api-docs/grid.md
+++ b/docs/pages/api-docs/grid.md
@@ -109,7 +109,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Grid/Grid.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Grid/Grid.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/icon-button.md
+++ b/docs/pages/api-docs/icon-button.md
@@ -62,7 +62,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/IconButton/IconButton.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/IconButton/IconButton.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/icon.md
+++ b/docs/pages/api-docs/icon.md
@@ -58,7 +58,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Icon/Icon.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Icon/Icon.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/image-list-item-bar.md
+++ b/docs/pages/api-docs/image-list-item-bar.md
@@ -62,7 +62,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ImageListItemBar/ImageListItemBar.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/image-list-item.md
+++ b/docs/pages/api-docs/image-list-item.md
@@ -53,7 +53,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ImageListItem/ImageListItem.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ImageListItem/ImageListItem.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/image-list.md
+++ b/docs/pages/api-docs/image-list.md
@@ -53,7 +53,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ImageList/ImageList.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ImageList/ImageList.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/input-adornment.md
+++ b/docs/pages/api-docs/input-adornment.md
@@ -58,7 +58,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputAdornment/InputAdornment.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/InputAdornment/InputAdornment.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/input-base.md
+++ b/docs/pages/api-docs/input-base.md
@@ -94,7 +94,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputBase/InputBase.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/InputBase/InputBase.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/input-label.md
+++ b/docs/pages/api-docs/input-label.md
@@ -67,7 +67,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputLabel/InputLabel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/InputLabel/InputLabel.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/input.md
+++ b/docs/pages/api-docs/input.md
@@ -84,7 +84,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Input/Input.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Input/Input.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/linear-progress.md
+++ b/docs/pages/api-docs/linear-progress.md
@@ -71,7 +71,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/LinearProgress/LinearProgress.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/LinearProgress/LinearProgress.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/link.md
+++ b/docs/pages/api-docs/link.md
@@ -57,7 +57,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Link/Link.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Link/Link.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/list-item-avatar.md
+++ b/docs/pages/api-docs/list-item-avatar.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/list-item-icon.md
+++ b/docs/pages/api-docs/list-item-icon.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemIcon/ListItemIcon.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ListItemIcon/ListItemIcon.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/list-item-secondary-action.md
+++ b/docs/pages/api-docs/list-item-secondary-action.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/list-item-text.md
+++ b/docs/pages/api-docs/list-item-text.md
@@ -58,7 +58,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemText/ListItemText.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ListItemText/ListItemText.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/list-item.md
+++ b/docs/pages/api-docs/list-item.md
@@ -68,7 +68,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItem/ListItem.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ListItem/ListItem.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/list-subheader.md
+++ b/docs/pages/api-docs/list-subheader.md
@@ -57,7 +57,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListSubheader/ListSubheader.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ListSubheader/ListSubheader.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/list.md
+++ b/docs/pages/api-docs/list.md
@@ -54,7 +54,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/List/List.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/List/List.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/menu-item.md
+++ b/docs/pages/api-docs/menu-item.md
@@ -54,7 +54,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/MenuItem/MenuItem.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/MenuItem/MenuItem.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/menu.md
+++ b/docs/pages/api-docs/menu.md
@@ -64,7 +64,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Menu/Menu.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Menu/Menu.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/mobile-stepper.md
+++ b/docs/pages/api-docs/mobile-stepper.md
@@ -60,7 +60,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/MobileStepper/MobileStepper.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/MobileStepper/MobileStepper.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/native-select.md
+++ b/docs/pages/api-docs/native-select.md
@@ -63,7 +63,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/NativeSelect/NativeSelect.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/NativeSelect/NativeSelect.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/outlined-input.md
+++ b/docs/pages/api-docs/outlined-input.md
@@ -87,7 +87,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/OutlinedInput/OutlinedInput.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/OutlinedInput/OutlinedInput.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/pagination-item.md
+++ b/docs/pages/api-docs/pagination-item.md
@@ -68,7 +68,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/PaginationItem/PaginationItem.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/PaginationItem/PaginationItem.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/pagination.md
+++ b/docs/pages/api-docs/pagination.md
@@ -64,7 +64,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Pagination/Pagination.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/Pagination/Pagination.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/paper.md
+++ b/docs/pages/api-docs/paper.md
@@ -78,7 +78,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Paper/Paper.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Paper/Paper.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/popover.md
+++ b/docs/pages/api-docs/popover.md
@@ -70,7 +70,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Popover/Popover.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Popover/Popover.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/radio.md
+++ b/docs/pages/api-docs/radio.md
@@ -64,7 +64,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Radio/Radio.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Radio/Radio.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/rating.md
+++ b/docs/pages/api-docs/rating.md
@@ -76,7 +76,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Rating/Rating.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/Rating/Rating.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/scoped-css-baseline.md
+++ b/docs/pages/api-docs/scoped-css-baseline.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/ScopedCssBaseline/ScopedCssBaseline.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/select.md
+++ b/docs/pages/api-docs/select.md
@@ -78,7 +78,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Select/Select.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Select/Select.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/skeleton.md
+++ b/docs/pages/api-docs/skeleton.md
@@ -60,7 +60,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Skeleton/Skeleton.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/Skeleton/Skeleton.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/slider.md
+++ b/docs/pages/api-docs/slider.md
@@ -89,7 +89,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Slider/Slider.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Slider/Slider.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/snackbar-content.md
+++ b/docs/pages/api-docs/snackbar-content.md
@@ -51,7 +51,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/SnackbarContent/SnackbarContent.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/SnackbarContent/SnackbarContent.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/snackbar.md
+++ b/docs/pages/api-docs/snackbar.md
@@ -73,7 +73,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Snackbar/Snackbar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Snackbar/Snackbar.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/speed-dial-action.md
+++ b/docs/pages/api-docs/speed-dial-action.md
@@ -61,7 +61,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/speed-dial-icon.md
+++ b/docs/pages/api-docs/speed-dial-icon.md
@@ -53,7 +53,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/speed-dial.md
+++ b/docs/pages/api-docs/speed-dial.md
@@ -66,7 +66,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDial/SpeedDial.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/SpeedDial/SpeedDial.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/step-button.md
+++ b/docs/pages/api-docs/step-button.md
@@ -52,7 +52,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepButton/StepButton.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/StepButton/StepButton.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/step-connector.md
+++ b/docs/pages/api-docs/step-connector.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepConnector/StepConnector.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/StepConnector/StepConnector.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/step-content.md
+++ b/docs/pages/api-docs/step-content.md
@@ -52,7 +52,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepContent/StepContent.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/StepContent/StepContent.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/step-icon.md
+++ b/docs/pages/api-docs/step-icon.md
@@ -54,7 +54,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepIcon/StepIcon.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/StepIcon/StepIcon.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/step-label.md
+++ b/docs/pages/api-docs/step-label.md
@@ -63,7 +63,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepLabel/StepLabel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/StepLabel/StepLabel.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/step.md
+++ b/docs/pages/api-docs/step.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Step/Step.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Step/Step.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/stepper.md
+++ b/docs/pages/api-docs/stepper.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Stepper/Stepper.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Stepper/Stepper.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/svg-icon.md
+++ b/docs/pages/api-docs/svg-icon.md
@@ -62,7 +62,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/SvgIcon/SvgIcon.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/SvgIcon/SvgIcon.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/switch.md
+++ b/docs/pages/api-docs/switch.md
@@ -71,7 +71,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Switch/Switch.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Switch/Switch.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/tab-panel.md
+++ b/docs/pages/api-docs/tab-panel.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TabPanel/TabPanel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TabPanel/TabPanel.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/tab-scroll-button.md
+++ b/docs/pages/api-docs/tab-scroll-button.md
@@ -52,7 +52,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TabScrollButton/TabScrollButton.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TabScrollButton/TabScrollButton.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/tab.md
+++ b/docs/pages/api-docs/tab.md
@@ -63,7 +63,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tab/Tab.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Tab/Tab.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/table-body.md
+++ b/docs/pages/api-docs/table-body.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableBody/TableBody.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableBody/TableBody.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/table-cell.md
+++ b/docs/pages/api-docs/table-cell.md
@@ -66,7 +66,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableCell/TableCell.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableCell/TableCell.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/table-container.md
+++ b/docs/pages/api-docs/table-container.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableContainer/TableContainer.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableContainer/TableContainer.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/table-footer.md
+++ b/docs/pages/api-docs/table-footer.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableFooter/TableFooter.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableFooter/TableFooter.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/table-head.md
+++ b/docs/pages/api-docs/table-head.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableHead/TableHead.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableHead/TableHead.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/table-pagination.md
+++ b/docs/pages/api-docs/table-pagination.md
@@ -72,7 +72,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TablePagination/TablePagination.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TablePagination/TablePagination.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/table-row.md
+++ b/docs/pages/api-docs/table-row.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableRow/TableRow.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableRow/TableRow.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/table-sort-label.md
+++ b/docs/pages/api-docs/table-sort-label.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableSortLabel/TableSortLabel.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TableSortLabel/TableSortLabel.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/table.md
+++ b/docs/pages/api-docs/table.md
@@ -52,7 +52,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Table/Table.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Table/Table.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/tabs.md
+++ b/docs/pages/api-docs/tabs.md
@@ -73,7 +73,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tabs/Tabs.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Tabs/Tabs.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/text-field.md
+++ b/docs/pages/api-docs/text-field.md
@@ -106,7 +106,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TextField/TextField.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/TextField/TextField.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/timeline-connector.md
+++ b/docs/pages/api-docs/timeline-connector.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TimelineConnector/TimelineConnector.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/timeline-content.md
+++ b/docs/pages/api-docs/timeline-content.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TimelineContent/TimelineContent.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TimelineContent/TimelineContent.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/timeline-dot.md
+++ b/docs/pages/api-docs/timeline-dot.md
@@ -55,7 +55,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TimelineDot/TimelineDot.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TimelineDot/TimelineDot.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/timeline-item.md
+++ b/docs/pages/api-docs/timeline-item.md
@@ -53,7 +53,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TimelineItem/TimelineItem.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TimelineItem/TimelineItem.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/timeline-opposite-content.md
+++ b/docs/pages/api-docs/timeline-opposite-content.md
@@ -48,7 +48,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/timeline-separator.md
+++ b/docs/pages/api-docs/timeline-separator.md
@@ -47,7 +47,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TimelineSeparator/TimelineSeparator.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/timeline.md
+++ b/docs/pages/api-docs/timeline.md
@@ -51,7 +51,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Timeline/Timeline.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/Timeline/Timeline.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/toggle-button-group.md
+++ b/docs/pages/api-docs/toggle-button-group.md
@@ -56,7 +56,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/toggle-button.md
+++ b/docs/pages/api-docs/toggle-button.md
@@ -57,7 +57,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/ToggleButton/ToggleButton.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/ToggleButton/ToggleButton.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api-docs/toolbar.md
+++ b/docs/pages/api-docs/toolbar.md
@@ -53,7 +53,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Toolbar/Toolbar.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Toolbar/Toolbar.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/tooltip.md
+++ b/docs/pages/api-docs/tooltip.md
@@ -77,7 +77,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Tooltip/Tooltip.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/tree-item.md
+++ b/docs/pages/api-docs/tree-item.md
@@ -63,7 +63,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TreeItem/TreeItem.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TreeItem/TreeItem.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/tree-view.md
+++ b/docs/pages/api-docs/tree-view.md
@@ -59,7 +59,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TreeView/TreeView.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-lab/src/TreeView/TreeView.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/typography.md
+++ b/docs/pages/api-docs/typography.md
@@ -85,7 +85,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Typography/Typography.js) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Typography/Typography.js) for more detail.
 
 ## Demos
 

--- a/docs/pages/blog/december-2019-update.md
+++ b/docs/pages/blog/december-2019-update.md
@@ -26,7 +26,7 @@ Here are the most significant improvements in December:
 
   ![Vertical button](/static/blog/december-2019-update/vertical-buttons.png)
 
-- 🌎 We have almost doubled the number of supported [locales](/guides/localization/#localization) from 13 to 22, thanks to our awesome contributors. [Help us](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/locale/index.js) double this number next month 🚀!
+- 🌎 We have almost doubled the number of supported [locales](/guides/localization/#localization) from 13 to 22, thanks to our awesome contributors. [Help us](https://github.com/mui-org/material-ui/blob/master/packages/mui-material/src/locale/index.ts) double this number next month 🚀!
 
 But this summary is just scratching the surface. We have accepted 168 commits from 73 different contributors. We have changed 1,059 files with 13,468 additions and 8,584 deletions.
 

--- a/docs/src/modules/constants.js
+++ b/docs/src/modules/constants.js
@@ -54,7 +54,8 @@ const LANGUAGES_LABEL = [
 ];
 
 const SOURCE_CODE_ROOT_URL =
-  process.env.SOURCE_CODE_ROOT_URL || 'https://github.com/mui-org/material-ui/blob/master';
+  // #default-branch-switch
+  process.env.SOURCE_CODE_ROOT_URL || 'https://github.com/mui-org/material-ui/blob/v4.x';
 const SOURCE_CODE_REPO = process.env.SOURCE_CODE_REPO || 'https://github.com/mui-org/material-ui';
 
 const BANNER_HEIGHT = 36;

--- a/docs/src/pages/customization/default-theme/default-theme.md
+++ b/docs/src/pages/customization/default-theme/default-theme.md
@@ -12,5 +12,5 @@ Explore the default theme object:
 > as the `theme` variable is exposed on all the documentation pages.
 > Please note that **the documentation site is using a custom theme**.
 
-If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/styles/createTheme.js),
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/styles/createTheme.js),
 and the related imports which `createTheme` uses.

--- a/docs/src/pages/customization/globals/globals.md
+++ b/docs/src/pages/customization/globals/globals.md
@@ -27,7 +27,7 @@ const theme = createTheme({
 
 The list of these customization points for each component is documented under the **Component API** section.
 For instance, you can have a look at the [Button](/api/button/#css).
-Alternatively, you can always have a look at the [implementation](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Button/Button.js).
+Alternatively, you can always have a look at the [implementation](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Button/Button.js).
 
 ## Global CSS
 

--- a/docs/src/pages/customization/z-index/z-index.md
+++ b/docs/src/pages/customization/z-index/z-index.md
@@ -5,7 +5,7 @@
 Several Material-UI components utilize `z-index`, employing a default z-index scale in Material-UI
 that has been designed to properly layer drawers, modals, snackbars, tooltips, and more.
 
-[These values](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/styles/zIndex.js) start at an arbitrary number, high and specific enough to ideally avoid conflicts.
+[These values](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/styles/zIndex.js) start at an arbitrary number, high and specific enough to ideally avoid conflicts.
 
 - mobile stepper: 1000
 - speed dial: 1050

--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -61,7 +61,7 @@ Two Universal Module Definition (**UMD**) files are provided:
 - one for development: https://unpkg.com/@material-ui/core@latest/umd/material-ui.development.js
 - one for production: https://unpkg.com/@material-ui/core@latest/umd/material-ui.production.min.js
 
-You can follow [this CDN example](https://github.com/mui-org/material-ui/tree/master/examples/cdn) to quickly get started.
+You can follow [this CDN example](https://github.com/mui-org/material-ui/tree/v4.x/examples/cdn) to quickly get started.
 
 ⚠️ Using this approach in **production** is **discouraged** though -
 the client has to download the entire library, regardless of which components are actually used,

--- a/docs/src/pages/getting-started/templates/Templates.js
+++ b/docs/src/pages/getting-started/templates/Templates.js
@@ -37,7 +37,7 @@ function layouts(t) {
       src: '/static/images/templates/dashboard.png',
       href: '/getting-started/templates/dashboard/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/dashboard',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/dashboard',
     },
     {
       title: t('signInTitle'),
@@ -45,7 +45,7 @@ function layouts(t) {
       src: '/static/images/templates/sign-in.png',
       href: '/getting-started/templates/sign-in/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sign-in',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/sign-in',
     },
     {
       title: t('signInSideTitle'),
@@ -53,7 +53,7 @@ function layouts(t) {
       src: '/static/images/templates/sign-in-side.png',
       href: '/getting-started/templates/sign-in-side/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sign-in-side',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/sign-in-side',
     },
     {
       title: t('signUpTitle'),
@@ -61,7 +61,7 @@ function layouts(t) {
       src: '/static/images/templates/sign-up.png',
       href: '/getting-started/templates/sign-up/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sign-up',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/sign-up',
     },
     {
       title: t('blogTitle'),
@@ -69,7 +69,7 @@ function layouts(t) {
       src: '/static/images/templates/blog.png',
       href: '/getting-started/templates/blog/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/blog',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/blog',
     },
     {
       title: t('checkoutTitle'),
@@ -77,7 +77,7 @@ function layouts(t) {
       src: '/static/images/templates/checkout.png',
       href: '/getting-started/templates/checkout/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/checkout',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/checkout',
     },
     {
       title: t('albumTitle'),
@@ -85,7 +85,7 @@ function layouts(t) {
       src: '/static/images/templates/album.png',
       href: '/getting-started/templates/album/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/album',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/album',
     },
     {
       title: t('pricingTitle'),
@@ -93,7 +93,7 @@ function layouts(t) {
       src: '/static/images/templates/pricing.png',
       href: '/getting-started/templates/pricing/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/pricing',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/pricing',
     },
     {
       title: t('stickyFooterTitle'),
@@ -101,7 +101,7 @@ function layouts(t) {
       src: '/static/images/templates/sticky-footer.png',
       href: '/getting-started/templates/sticky-footer/',
       source:
-        'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sticky-footer',
+        'https://github.com/mui-org/material-ui/tree/v4.x/docs/src/pages/getting-started/templates/sticky-footer',
     },
   ];
 }

--- a/docs/src/pages/guides/localization/localization.md
+++ b/docs/src/pages/guides/localization/localization.md
@@ -64,7 +64,7 @@ const theme = createTheme({
 | Ukrainian | uk-UA | `ukUA` |
 | Vietnamese | vi-VN | `viVN` |
 
-You can [find the source](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/locale/index.ts) in the GitHub repository.
+You can [find the source](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/locale/index.ts) in the GitHub repository.
 
 To create your own translation, or to customise the English text, copy this file to your project, make any changes needed and import the locale from there.
 

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -213,7 +213,7 @@ If you are using Create React App, you will need to use a couple of projects tha
 
 #### 2. Convert all your imports
 
-Finally, you can convert your existing codebase to this option with this [top-level-imports](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-codemod/README.md#top-level-imports) codemod.
+Finally, you can convert your existing codebase to this option with this [top-level-imports](https://github.com/mui-org/material-ui/blob/master/packages/mui-codemod/README.md#top-level-imports) codemod.
 It will perform the following diffs:
 
 ```diff

--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -187,11 +187,11 @@ ReactDOM.hydrate(<Main />, document.querySelector('#root'));
 
 ## Reference implementations
 
-We host different reference implementations which you can find in the [GitHub repository](https://github.com/mui-org/material-ui) under the [`/examples`](https://github.com/mui-org/material-ui/tree/master/examples) folder:
+We host different reference implementations which you can find in the [GitHub repository](https://github.com/mui-org/material-ui) under the [`/examples`](https://github.com/mui-org/material-ui/tree/v4.x/examples) folder:
 
-- [The reference implementation of this tutorial](https://github.com/mui-org/material-ui/tree/master/examples/ssr)
-- [Gatsby](https://github.com/mui-org/material-ui/tree/master/examples/gatsby)
-- [Next.js](https://github.com/mui-org/material-ui/tree/master/examples/nextjs)
+- [The reference implementation of this tutorial](https://github.com/mui-org/material-ui/tree/v4.x/examples/ssr)
+- [Gatsby](https://github.com/mui-org/material-ui/tree/v4.x/examples/gatsby)
+- [Next.js](https://github.com/mui-org/material-ui/tree/v4.x/examples/nextjs)
 
 ## Troubleshooting
 

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -4,7 +4,7 @@
 
 Material-UI requires a minimum version of TypeScript 3.2.
 
-Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example.
+Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/v4.x/examples/create-react-app-with-typescript) example.
 
 In order for types to work, you have to at least have the following options enabled
 in your `tsconfig.json`:

--- a/docs/src/pages/styles/advanced/advanced.md
+++ b/docs/src/pages/styles/advanced/advanced.md
@@ -401,13 +401,13 @@ You can [follow the server side guide](/guides/server-rendering/) for a more det
 There is [an official Gatsby plugin](https://github.com/hupe1980/gatsby-plugin-material-ui) that enables server-side rendering for `@material-ui/styles`.
 Refer to the plugin's page for setup and usage instructions.
 
-Refer to [this example Gatsby project](https://github.com/mui-org/material-ui/blob/master/examples/gatsby) for an up-to-date usage example.
+Refer to [this example Gatsby project](https://github.com/mui-org/material-ui/blob/v4.x/examples/gatsby) for an up-to-date usage example.
 
 ### Next.js
 
-You need to have a custom `pages/_document.js`, then copy [this logic](https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_document.js) to inject the server-side rendered styles into the `<head>` element.
+You need to have a custom `pages/_document.js`, then copy [this logic](https://github.com/mui-org/material-ui/blob/v4.x/examples/nextjs/pages/_document.js) to inject the server-side rendered styles into the `<head>` element.
 
-Refer to [this example project](https://github.com/mui-org/material-ui/blob/master/examples/nextjs) for an up-to-date usage example.
+Refer to [this example project](https://github.com/mui-org/material-ui/blob/v4.x/examples/nextjs) for an up-to-date usage example.
 
 ## Class names
 

--- a/docs/src/pages/styles/basics/basics.md
+++ b/docs/src/pages/styles/basics/basics.md
@@ -15,7 +15,7 @@ and **unlocks many great features** (theme nesting, dynamic styles, self-support
 Material-UI's styling solution is inspired by many other styling libraries such as [styled-components](https://www.styled-components.com/) and [emotion](https://emotion.sh/).
 
 - 💅 You can expect [the same advantages](https://www.styled-components.com/docs/basics#motivation) as styled-components.
-- 🚀 It's [blazing fast](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-benchmark/README.md#material-uistyles).
+- 🚀 It's [blazing fast](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-benchmark/README.md#material-uistyles).
 - 🧩 It's extensible via a [plugin](https://github.com/cssinjs/jss/blob/master/docs/plugins.md) API.
 - ⚡️ It uses [JSS](https://github.com/cssinjs/jss) at its core – a [high performance](https://github.com/cssinjs/jss/blob/master/docs/performance.md) JavaScript to CSS compiler which works at runtime and server-side.
 - 📦 Less than [15 KB gzipped](https://bundlephobia.com/result?p=@material-ui/styles); and no bundle size increase if used alongside Material-UI.

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -12,7 +12,7 @@
 - 🦎 Work with any theme object.
 - 💅 Work with the most popular CSS-in-JS solutions.
 - 📦 Less than [4 KB gzipped](https://bundlephobia.com/result?p=@material-ui/system).
-- 🚀 [Fast enough](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-benchmark/README.md#material-uisystem) not to be a bottleneck at runtime.
+- 🚀 [Fast enough](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui-benchmark/README.md#material-uisystem) not to be a bottleneck at runtime.
 
 It's important to understand that this package exposes pure (side-effect free) style functions with this signature: `({ theme, ...style }) => style`, **that's it**.
 

--- a/examples/create-react-app-with-typescript/README.md
+++ b/examples/create-react-app-with-typescript/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/create-react-app-with-typescript
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2 material-ui-master/examples/create-react-app-with-typescript
 cd create-react-app-with-typescript
 ```
 
@@ -18,7 +18,7 @@ npm start
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/create-react-app-with-typescript)
 
 ## The idea behind the example
 

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/create-react-app
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2 material-ui-master/examples/create-react-app
 cd create-react-app
 ```
 
@@ -18,7 +18,7 @@ npm start
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/create-react-app)
 
 ## The idea behind the example
 

--- a/examples/gatsby-theme/README.md
+++ b/examples/gatsby-theme/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/gatsby-theme
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2  material-ui-master/examples/gatsby-theme
 cd gatsby-theme
 ```
 
@@ -18,10 +18,10 @@ npm run develop
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/gatsby-theme)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/gatsby-theme)
 
 ## The idea behind the example
 
-This is an alternative example to [`/examples/gatsby`](https://github.com/mui-org/material-ui/tree/master/examples/gatsby) leveraging [gatsby-theme-material-ui](https://github.com/hupe1980/gatsby-theme-material-ui/tree/master/packages/gatsby-theme-material-ui).
+This is an alternative example to [`/examples/gatsby`](https://github.com/mui-org/material-ui/tree/v4.x/examples/gatsby) leveraging [gatsby-theme-material-ui](https://github.com/hupe1980/gatsby-theme-material-ui/tree/v4.x/packages/gatsby-theme-material-ui).
 The example bundles different Gatsby plugins into a single Gatsby theme.
 It trades less freedom for fewer boilerplate.

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/gatsby
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2  material-ui-master/examples/gatsby
 cd gatsby
 ```
 
@@ -18,7 +18,7 @@ npm run develop
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/gatsby)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/gatsby)
 
 ## The idea behind the example
 
@@ -27,4 +27,4 @@ or:
 ## gatsby-theme-material-ui
 
 Looking for an example with less boilerplate but also less freedom?
-Check [`/examples/gatsby-theme`](https://github.com/mui-org/material-ui/tree/master/examples/gatsby-theme) out.
+Check [`/examples/gatsby-theme`](https://github.com/mui-org/material-ui/tree/v4.x/examples/gatsby-theme) out.

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs-with-typescript
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2  material-ui-master/examples/nextjs-with-typescript
 cd nextjs-with-typescript
 ```
 
@@ -18,7 +18,7 @@ npm run dev
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs-with-typescript)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/nextjs-with-typescript)
 
 ## The idea behind the example
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2  material-ui-master/examples/nextjs
 cd nextjs
 ```
 
@@ -18,7 +18,7 @@ npm run dev
 
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/nextjs)
 
 ## The idea behind the example
 

--- a/examples/preact/README.md
+++ b/examples/preact/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/preact
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v4.x | tar -xz --strip=2  material-ui-master/examples/preact
 cd preact
 ```
 
@@ -17,7 +17,7 @@ npm run start
 ```
 or:
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/preact)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/v4.x/examples/preact)
 
 ## The idea behind the example
 

--- a/framer/Material-UI.framerfx/README.md
+++ b/framer/Material-UI.framerfx/README.md
@@ -55,7 +55,7 @@ If multiple options are supplied, they take the following priority:
 ## Resources
 
 - [Material-UI documentation](https://material-ui.com/)
-- [GitHub repo](https://github.com/mui-org/material-ui/tree/master/framer)
+- [GitHub repo](https://github.com/mui-org/material-ui/tree/v4.x/framer)
 
 ## Releases
 

--- a/test/README.md
+++ b/test/README.md
@@ -68,11 +68,11 @@ If you want to `grep` for certain tests add `-g STRING_TO_GREP`.
 
 First, we have the **unit test** suite.
 It uses [mocha](https://mochajs.org) and a thin wrapper around `@testing-library/react`.
-Here is an [example](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Dialog/Dialog.test.js#L87) with the `Dialog` component.
+Here is an [example](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/src/Dialog/Dialog.test.js#L87) with the `Dialog` component.
 
 Next, we have the **integration** tests. They are mostly used for components that
 act as composite widgets like `Select` or `Menu`.
-Here is an [example](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/test/integration/Menu.test.js#L28) with the `Menu` component.
+Here is an [example](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/test/integration/Menu.test.js#L28) with the `Menu` component.
 
 #### Create HTML coverage reports
 
@@ -110,7 +110,7 @@ Next, we are using [docker](https://github.com/docker/docker) to take screenshot
 ![before](/test/docs-regressions-before.png)
 ![diff](/test/docs-regressions-diff.png)
 
-Here is an [example](https://github.com/mui-org/material-ui/blob/master/test/regressions/tests/Menu/SimpleMenuList.js#L6) with the `Menu` component.
+Here is an [example](https://github.com/mui-org/material-ui/blob/v4.x/test/regressions/tests/Menu/SimpleMenuList.js#L6) with the `Menu` component.
 
 #### Installation
 


### PR DESCRIPTION
Looked through the codebase for usage of the word `master` and tried to fix them. This was a best effort attempt so I may have missed some.

The takeaway is repeating to "not link source code". The source must be irrelevant for user-facing documentation.

Closes https://github.com/mui-org/material-ui/issues/28345