### PR TITLE
[Tooltip] Ensure `user-select` CSS property is reverted after touch end

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -459,7 +459,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       children.props.onTouchEnd(event);
     }
 
-    clearTimeout(touchTimer.current);
+    stopTouchInteraction();
     clearTimeout(leaveTimer.current);
     leaveTimer.current = setTimeout(() => {
       handleClose(event);

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -1130,6 +1130,26 @@ describe('<Tooltip />', () => {
       expect(document.body.style.WebkitUserSelect.toLowerCase()).to.equal('revert');
     });
 
+    it('ensures text-selection is reset after single press', () => {
+
+      const { getByRole } = render(
+        <Tooltip
+          title="Hello World"
+        >
+          <button type="submit">Hello World</button>
+        </Tooltip>,
+      );
+      document.body.style.WebkitUserSelect = 'revert';
+
+      fireEvent.touchStart(getByRole('button'));
+
+      expect(document.body.style.WebkitUserSelect).to.equal('none');
+
+      fireEvent.touchEnd(getByRole('button'));
+
+      expect(document.body.style.WebkitUserSelect).to.equal('revert');
+    });
+
     it('restores user-select when unmounted during longpress', () => {
       const enterTouchDelay = 700;
       const enterDelay = 100;

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -1131,7 +1131,6 @@ describe('<Tooltip />', () => {
     });
 
     it('ensures text-selection is reset after single press', () => {
-
       const { getByRole } = render(
         <Tooltip title="Hello World">
           <button type="submit">Hello World</button>

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -1133,9 +1133,7 @@ describe('<Tooltip />', () => {
     it('ensures text-selection is reset after single press', () => {
 
       const { getByRole } = render(
-        <Tooltip
-          title="Hello World"
-        >
+        <Tooltip title="Hello World">
           <button type="submit">Hello World</button>
         </Tooltip>,
       );


### PR DESCRIPTION
Currently if you tap on a button within a tooltip on mobile (safari/chrome) the user select will be set to 'none', the `handleTouchEnd` function will remove the touchtimer from the touch start, so the user select ‘none’ will now be left on for the rest of the session.

Demo of the bug here (bug exists in current mui and 5 rc), https://codesandbox.io/s/usage-forked-vow1z?file=/index.js ... if you go to the resolved window on chrome and use a mobile view to trigger event by "tapping" the button, you will see that you can no longer select the text in the document. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
