### PR TITLE
[docs] Use the legacy domain for v0

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -9,12 +9,14 @@
 # To add when we finish work on v5
 https://next.material-ui.com/* https://mui.com/:splat 301!
 
-# Support multiple domains
+# Support multiple domains expect for v0
 https://material-ui.dev/* https://mui.com/:splat 301!
-https://v0.material-ui.com/* https://v0.mui.com/:splat 301!
 https://v1.material-ui.com/* https://v1.mui.com/:splat 301!
 https://v3.material-ui.com/* https://v3.mui.com/:splat 301!
 https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
+
+# Temporarily access the v0 docs from the legacy domain
+https://v0.mui.com/* https://v0.material-ui.com/:splat 302!
 
 # Redirect all except the store
 https://material-ui.com https://mui.com 301!
@@ -54,76 +56,76 @@ https://mui.com/store/* https://material-ui.com/store/:splat 302!
 # Legacy redirection
 # Added in chronological order
 # To be removed at some point
-/v0.20.0 https://v0.mui.com/v0.20.0
-/v0.19.4 https://v0.mui.com/v0.19.4
-/v0.19.3 https://v0.mui.com/v0.19.3
-/v0.19.2 https://v0.mui.com/v0.19.2
-/v0.19.1 https://v0.mui.com/v0.19.1
-/v0.19.0 https://v0.mui.com/v0.19.0
-/v0.18.7 https://v0.mui.com/v0.18.7
-/v0.18.6 https://v0.mui.com/v0.18.6
-/v0.18.5 https://v0.mui.com/v0.18.5
-/v0.18.4 https://v0.mui.com/v0.18.4
-/v0.18.3 https://v0.mui.com/v0.18.3
-/v0.18.2 https://v0.mui.com/v0.18.2
-/v0.18.1 https://v0.mui.com/v0.18.1
-/v0.18.0 https://v0.mui.com/v0.18.0
-/v0.17.2 https://v0.mui.com/v0.17.2
-/v0.17.1 https://v0.mui.com/v0.17.1
-/v0.17.0 https://v0.mui.com/v0.17.0
-/v0.16.7 https://v0.mui.com/v0.16.7
-/v0.16.6 https://v0.mui.com/v0.16.6
-/v0.16.5 https://v0.mui.com/v0.16.5
-/v0.16.2 https://v0.mui.com/v0.16.2
-/v0.16.1 https://v0.mui.com/v0.16.1
-/v0.16.0 https://v0.mui.com/v0.16.0
-/v0.15.4 https://v0.mui.com/v0.15.4
-/v0.15.3 https://v0.mui.com/v0.15.3
-/v0.15.2 https://v0.mui.com/v0.15.2
-/v0.15.1 https://v0.mui.com/v0.15.1
-/v0.15.0 https://v0.mui.com/v0.15.0
-/v0.14.4 https://v0.mui.com/v0.14.4
-/v0.14.3 https://v0.mui.com/v0.14.3
-/v0.14.2 https://v0.mui.com/v0.14.2
-/v0.14.1 https://v0.mui.com/v0.14.1
-/v0.14.0 https://v0.mui.com/v0.14.0
-/v0.13.4 https://v0.mui.com/v0.13.4
-/v0.13.3 https://v0.mui.com/v0.13.3
-/v0.13.2 https://v0.mui.com/v0.13.2
-/v0.13.1 https://v0.mui.com/v0.13.1
-/v0.13.0 https://v0.mui.com/v0.13.0
-/v0.12.5 https://v0.mui.com/v0.12.5
-/v0.12.4 https://v0.mui.com/v0.12.4
-/v0.12.3 https://v0.mui.com/v0.12.3
-/v0.12.2 https://v0.mui.com/v0.12.2
-/v0.12.1 https://v0.mui.com/v0.12.1
-/v0.12.0 https://v0.mui.com/v0.12.0
-/v0.11.1 https://v0.mui.com/v0.11.1
-/v0.11.0 https://v0.mui.com/v0.11.0
-/v0.10.4 https://v0.mui.com/v0.10.4
-/v0.10.3 https://v0.mui.com/v0.10.3
-/v0.10.2 https://v0.mui.com/v0.10.2
-/v0.10.1 https://v0.mui.com/v0.10.1
-/v0.10.0 https://v0.mui.com/v0.10.0
-/v0.9.2 https://v0.mui.com/v0.9.2
-/v0.9.1 https://v0.mui.com/v0.9.1
-/v0.9.0 https://v0.mui.com/v0.9.0
-/v0.8.0 https://v0.mui.com/v0.8.0
-/v0.7.5 https://v0.mui.com/v0.7.5
-/v0.7.2 https://v0.mui.com/v0.7.2
-/v0.7.1 https://v0.mui.com/v0.7.1
-/v0.5.0 https://v0.mui.com/v0.5.0
-/v0.7.4 https://v0.mui.com/v0.7.4
-/v0.7.3 https://v0.mui.com/v0.7.3
-/v0.7.0 https://v0.mui.com/v0.7.0
-/v0.6.1 https://v0.mui.com/v0.6.1
-/v0.6.0 https://v0.mui.com/v0.6.0
-/v0.4.1 https://v0.mui.com/v0.4.1
-/v0.4.0 https://v0.mui.com/v0.4.0
-/v0.3.3 https://v0.mui.com/v0.3.3
-/v0.3.2 https://v0.mui.com/v0.3.2
-/v0.3.1 https://v0.mui.com/v0.3.1
-/v0.3.0 https://v0.mui.com/v0.3.0
+/v0.20.0 https://v0.material-ui.com/v0.20.0
+/v0.19.4 https://v0.material-ui.com/v0.19.4
+/v0.19.3 https://v0.material-ui.com/v0.19.3
+/v0.19.2 https://v0.material-ui.com/v0.19.2
+/v0.19.1 https://v0.material-ui.com/v0.19.1
+/v0.19.0 https://v0.material-ui.com/v0.19.0
+/v0.18.7 https://v0.material-ui.com/v0.18.7
+/v0.18.6 https://v0.material-ui.com/v0.18.6
+/v0.18.5 https://v0.material-ui.com/v0.18.5
+/v0.18.4 https://v0.material-ui.com/v0.18.4
+/v0.18.3 https://v0.material-ui.com/v0.18.3
+/v0.18.2 https://v0.material-ui.com/v0.18.2
+/v0.18.1 https://v0.material-ui.com/v0.18.1
+/v0.18.0 https://v0.material-ui.com/v0.18.0
+/v0.17.2 https://v0.material-ui.com/v0.17.2
+/v0.17.1 https://v0.material-ui.com/v0.17.1
+/v0.17.0 https://v0.material-ui.com/v0.17.0
+/v0.16.7 https://v0.material-ui.com/v0.16.7
+/v0.16.6 https://v0.material-ui.com/v0.16.6
+/v0.16.5 https://v0.material-ui.com/v0.16.5
+/v0.16.2 https://v0.material-ui.com/v0.16.2
+/v0.16.1 https://v0.material-ui.com/v0.16.1
+/v0.16.0 https://v0.material-ui.com/v0.16.0
+/v0.15.4 https://v0.material-ui.com/v0.15.4
+/v0.15.3 https://v0.material-ui.com/v0.15.3
+/v0.15.2 https://v0.material-ui.com/v0.15.2
+/v0.15.1 https://v0.material-ui.com/v0.15.1
+/v0.15.0 https://v0.material-ui.com/v0.15.0
+/v0.14.4 https://v0.material-ui.com/v0.14.4
+/v0.14.3 https://v0.material-ui.com/v0.14.3
+/v0.14.2 https://v0.material-ui.com/v0.14.2
+/v0.14.1 https://v0.material-ui.com/v0.14.1
+/v0.14.0 https://v0.material-ui.com/v0.14.0
+/v0.13.4 https://v0.material-ui.com/v0.13.4
+/v0.13.3 https://v0.material-ui.com/v0.13.3
+/v0.13.2 https://v0.material-ui.com/v0.13.2
+/v0.13.1 https://v0.material-ui.com/v0.13.1
+/v0.13.0 https://v0.material-ui.com/v0.13.0
+/v0.12.5 https://v0.material-ui.com/v0.12.5
+/v0.12.4 https://v0.material-ui.com/v0.12.4
+/v0.12.3 https://v0.material-ui.com/v0.12.3
+/v0.12.2 https://v0.material-ui.com/v0.12.2
+/v0.12.1 https://v0.material-ui.com/v0.12.1
+/v0.12.0 https://v0.material-ui.com/v0.12.0
+/v0.11.1 https://v0.material-ui.com/v0.11.1
+/v0.11.0 https://v0.material-ui.com/v0.11.0
+/v0.10.4 https://v0.material-ui.com/v0.10.4
+/v0.10.3 https://v0.material-ui.com/v0.10.3
+/v0.10.2 https://v0.material-ui.com/v0.10.2
+/v0.10.1 https://v0.material-ui.com/v0.10.1
+/v0.10.0 https://v0.material-ui.com/v0.10.0
+/v0.9.2 https://v0.material-ui.com/v0.9.2
+/v0.9.1 https://v0.material-ui.com/v0.9.1
+/v0.9.0 https://v0.material-ui.com/v0.9.0
+/v0.8.0 https://v0.material-ui.com/v0.8.0
+/v0.7.5 https://v0.material-ui.com/v0.7.5
+/v0.7.2 https://v0.material-ui.com/v0.7.2
+/v0.7.1 https://v0.material-ui.com/v0.7.1
+/v0.5.0 https://v0.material-ui.com/v0.5.0
+/v0.7.4 https://v0.material-ui.com/v0.7.4
+/v0.7.3 https://v0.material-ui.com/v0.7.3
+/v0.7.0 https://v0.material-ui.com/v0.7.0
+/v0.6.1 https://v0.material-ui.com/v0.6.1
+/v0.6.0 https://v0.material-ui.com/v0.6.0
+/v0.4.1 https://v0.material-ui.com/v0.4.1
+/v0.4.0 https://v0.material-ui.com/v0.4.0
+/v0.3.3 https://v0.material-ui.com/v0.3.3
+/v0.3.2 https://v0.material-ui.com/v0.3.2
+/v0.3.1 https://v0.material-ui.com/v0.3.1
+/v0.3.0 https://v0.material-ui.com/v0.3.0
 /css-in-js/* /styles/:splat 301
 /customization/css-in-js/ /styles/basics/ 301
 /customization/overrides/ /customization/components/ 301


### PR DESCRIPTION
For some reason, yet to be determined, the https://v0.mui.com is not working. Because of this, I am reverting the changes for the v0 redirects, and I am adding a temporary redirect from https://v0.mui.com to https://v0.material-ui.com