### PR TITLE
[test] Assert on user-select that has the same value across browsers

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -1118,7 +1118,7 @@ describe('<Tooltip />', () => {
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-      document.body.style.WebkitUserSelect = 'revert';
+      document.body.style.WebkitUserSelect = 'text';
 
       fireEvent.touchStart(getByRole('button'));
 
@@ -1127,7 +1127,7 @@ describe('<Tooltip />', () => {
       act(() => {
         clock.tick(enterTouchDelay + enterDelay);
       });
-      expect(document.body.style.WebkitUserSelect.toLowerCase()).to.equal('revert');
+      expect(document.body.style.WebkitUserSelect).to.equal('text');
     });
 
     it('ensures text-selection is reset after single press', () => {
@@ -1136,7 +1136,7 @@ describe('<Tooltip />', () => {
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-      document.body.style.WebkitUserSelect = 'revert';
+      document.body.style.WebkitUserSelect = 'text';
 
       fireEvent.touchStart(getByRole('button'));
 
@@ -1144,7 +1144,7 @@ describe('<Tooltip />', () => {
 
       fireEvent.touchEnd(getByRole('button'));
 
-      expect(document.body.style.WebkitUserSelect).to.equal('revert');
+      expect(document.body.style.WebkitUserSelect).to.equal('text');
     });
 
     it('restores user-select when unmounted during longpress', () => {
@@ -1164,14 +1164,14 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      document.body.style.WebkitUserSelect = 'revert';
+      document.body.style.WebkitUserSelect = 'text';
       // Let updates flush before unmounting
       act(() => {
         fireEvent.touchStart(getByRole('button'));
       });
       unmount();
 
-      expect(document.body.style.WebkitUserSelect.toLowerCase()).to.equal('revert');
+      expect(document.body.style.WebkitUserSelect).to.equal('text');
     });
   });
 });


### PR DESCRIPTION
Safari normalizes `revert` to `Revert` but not `text`. So let's just use a value that's invariant across browsers. The test just needs a valid value anyway.

Fixes https://app.circleci.com/pipelines/github/mui-org/material-ui/52440/workflows/66f0e1ec-17e3-4ab1-b0f1-b703d0d6a35a/jobs/297054 which broke in https://github.com/mui-org/material-ui/pull/28372

Browser run: https://app.circleci.com/pipelines/github/mui-org/material-ui/52442/workflows/6a90301d-e8f1-4a1c-b6c5-4a7190382b9d/jobs/297071