### PR TITLE
[docs] Fix the notification display logic

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -11,6 +11,6 @@
   },
   {
     "id": 54,
-    "text": "<a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://twitter.com/MaterialUI/status/1438518915236126723\">MUI Core v5 is out 🎉</a>"
+    "text": "<a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://twitter.com/MaterialUI/status/1438518915236126723\">MUI Core v5</a> is out 🎉"
   }
 ]

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -103,7 +103,7 @@ export default function Notifications() {
         .then((newMessages) => {
           if (active) {
             const seen = getCookie('lastSeenNotification');
-            const lastSeenNotification = seen === '' ? 0 : parseInt(seen, 10);
+            const lastSeenNotification = seen === undefined ? 0 : parseInt(seen, 10);
             setNotifications({
               messages: newMessages || [],
               lastSeen: lastSeenNotification,

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -226,8 +226,6 @@ export function getDependencies(
  * @return The cookie value
  */
 export function getCookie(name: string): string | undefined {
-  // `process.browser` is set by nextjs where we only use `getCookie`
-  // but this file is imported from nodejs scripts so TypeScript complains for that environment.
   if (typeof document !== 'undefined') {
     const value = `; ${document.cookie}`;
     const parts = value.split(`; ${name}=`);

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -228,7 +228,7 @@ export function getDependencies(
 export function getCookie(name: string): string | undefined {
   // `process.browser` is set by nextjs where we only use `getCookie`
   // but this file is imported from nodejs scripts so TypeScript complains for that environment.
-  if ((process as any).browser) {
+  if (typeof document !== 'undefined') {
     const value = `; ${document.cookie}`;
     const parts = value.split(`; ${name}=`);
     if (parts.length === 2) {


### PR DESCRIPTION
The issue: open https://mui.com/components/alert/ without any cookies and notice how the notifications are not displayed. The reason is that `getCookie` returned undefined when there is no match, not an empty string as the notification expects