### PR TITLE
[codemod] Cover edge case for theme-spacing

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.js
@@ -5,7 +5,7 @@ export default function transformer(file) {
   return (
     file.source
       // `${theme.spacing(2)}px` -> theme.spacing(2)
-      .replace(/`\${((theme\.spacing|spacing)\([^{}]*\))}px`/gm, '$1')
+      .replace(/`(-?)\${(-?)(theme\.spacing|spacing)\(([^{}]*)\)}px`/gm, '$3($1$2$4)')
       // `${theme.spacing(2)}px ${theme.spacing(4)}px` -> `${theme.spacing(2)} ${theme.spacing(4)}`
       .replace(/(?<={(theme\.spacing|spacing)\(.*\)})px/gm, '')
       .replace(/((theme\.spacing|spacing)\(.*\))\s*\+\s*'px'/gm, '$1')

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/actual.js
@@ -9,3 +9,5 @@ spacing(gap) + 'px'
 `calc(100% - ${theme.spacing(itemHorzPadding * 2)}px)`
 padding: `${theme.spacing(2) - 1}px 0`
 `calc(100% - ${theme.spacing(itemHorzPadding) * 0.3}px)`
+`${-theme.spacing(1)}px`
+`-${theme.spacing(1)}px`

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/expected.js
@@ -9,3 +9,5 @@ spacing(gap)
 `calc(100% - ${theme.spacing(itemHorzPadding * 2)})`
 padding: `calc(${theme.spacing(2)} - 1px) 0`
 `calc(100% - calc(${theme.spacing(itemHorzPadding)} * 0.3))`
+theme.spacing(-1)
+theme.spacing(-1)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR should prevent the bug from https://github.com/mui-org/mui-store/commit/9c1da0176ec2de1c24e2047c9e76371da185a374 to support this transformation

```js
`-${theme.spacing(1)}px` => theme.spacing(-1) // 1st case
`${-theme.spacing(1)}px` => theme.spacing(-1) // 2nd case
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
