### PR TITLE
[website] Fix 40x links

### DIFF
--- a/docs/pages/blog/2021-q1-update.md
+++ b/docs/pages/blog/2021-q1-update.md
@@ -197,7 +197,7 @@ We will cross the ten-person milestone in the coming weeks (11).
 
 We have the following objectives:
 
-- Finish the implementation of the rebranding. A preview, the [about](https://mui.com/branding/about/) and [pricing](https://mui.com/branding/pricing/) pages.
+- Finish the implementation of the rebranding. A preview, the [about](/about/) and [pricing](/pricing/) pages.
 - Onboard the new members and scale our processes as we double the size of the organization this quarter.
 
 ### Core components

--- a/docs/src/pages/company/careers/developer-advocate.md
+++ b/docs/src/pages/company/careers/developer-advocate.md
@@ -12,7 +12,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://mui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/company/careers/full-stack-engineer.md
+++ b/docs/src/pages/company/careers/full-stack-engineer.md
@@ -13,7 +13,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://mui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/company/careers/react-engineer.md
+++ b/docs/src/pages/company/careers/react-engineer.md
@@ -13,7 +13,7 @@
 
 ## About us
 
-See the [careers](/company/careers/) and [about us](https://mui.com/branding/about/) pages.
+See the [careers](/company/careers/) and [about us](/about/) pages.
 
 ### Why we're hiring
 

--- a/docs/src/pages/guides/routing/routing-de.md
+++ b/docs/src/pages/guides/routing/routing-de.md
@@ -4,7 +4,7 @@
 
 ## Navigation components
 
-There are two main components available to perform navigations. The most common one is the [`Link`](/components/link/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
+There are two main components available to perform navigations. The most common one is the [`Link`](/components/links/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
 
 {{"demo": "pages/guides/routing/LinkDemo.js"}}
 

--- a/docs/src/pages/guides/routing/routing-es.md
+++ b/docs/src/pages/guides/routing/routing-es.md
@@ -4,7 +4,7 @@
 
 ## Navigation components
 
-There are two main components available to perform navigations. The most common one is the [`Link`](/components/link/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
+There are two main components available to perform navigations. The most common one is the [`Link`](/components/links/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
 
 {{"demo": "pages/guides/routing/LinkDemo.js"}}
 

--- a/docs/src/pages/guides/routing/routing-fr.md
+++ b/docs/src/pages/guides/routing/routing-fr.md
@@ -4,7 +4,7 @@
 
 ## Navigation components
 
-There are two main components available to perform navigations. The most common one is the [`Link`](/components/link/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
+There are two main components available to perform navigations. The most common one is the [`Link`](/components/links/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
 
 {{"demo": "pages/guides/routing/LinkDemo.js"}}
 

--- a/docs/src/pages/guides/routing/routing-ja.md
+++ b/docs/src/pages/guides/routing/routing-ja.md
@@ -4,7 +4,7 @@
 
 ## Navigation components
 
-There are two main components available to perform navigations. The most common one is the [`Link`](/components/link/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
+There are two main components available to perform navigations. The most common one is the [`Link`](/components/links/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
 
 {{"demo": "pages/guides/routing/LinkDemo.js"}}
 

--- a/docs/src/pages/guides/routing/routing-pt.md
+++ b/docs/src/pages/guides/routing/routing-pt.md
@@ -4,7 +4,7 @@
 
 ## Navigation components
 
-There are two main components available to perform navigations. The most common one is the [`Link`](/components/link/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
+There are two main components available to perform navigations. The most common one is the [`Link`](/components/links/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
 
 {{"demo": "pages/guides/routing/LinkDemo.js"}}
 

--- a/docs/src/pages/guides/routing/routing-zh.md
+++ b/docs/src/pages/guides/routing/routing-zh.md
@@ -4,7 +4,7 @@
 
 ## Navigation components
 
-There are two main components available to perform navigations. The most common one is the [`Link`](/components/link/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
+There are two main components available to perform navigations. The most common one is the [`Link`](/components/links/) as its name might suggest. It renders a native `<a>` element and applies the `href` as an attribute.
 
 {{"demo": "pages/guides/routing/LinkDemo.js"}}
 


### PR DESCRIPTION
Fixing some dead links reported by moz.com

---

~The ones left are related to the API pages of the DataGrid. Looks like the URLs for the API pages changed. The SideBar references URLs starting with `/api-docs/data-grid/*`, but the valid links are actually starting with `/api/data-grid/*`. We should either change the _redirecs:~

```diff
diff --git a/docs/public/_redirects b/docs/public/_redirects
index 9678655950..65243167a0 100644
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -184,7 +184,7 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 ## material-ui-x
 ## Unlike the store that expect to be hosted under a subfolder,
 ## material-ui-x is configured to be hosted at the root.
-/api/*/ https://docs-v5--material-ui-x.netlify.app/api/:splat/ 200
+/api-docs/*/ https://docs-v5--material-ui-x.netlify.app/api/:splat/ 200
 /:lang/api/*/ https://docs-v5--material-ui-x.netlify.app/:lang/api/:splat/ 200
 /components/* https://docs-v5--material-ui-x.netlify.app/components/:splat 200
 /:lang/components/* https://docs-v5--material-ui-x.netlify.app/:lang/components/:splat 200
```

~Or fix the links in the Sidebar. Probably @m4theushw can give us more details.~

Edit: this is being handled in https://github.com/mui-org/material-ui/pull/28176