### PR TITLE
[core] Ensure both docs bundles are analyzeable

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -42,8 +42,9 @@ module.exports = {
           analyzerMode: 'server',
           generateStatsFile: true,
           analyzerPort: options.isServer ? 8888 : 8889,
-          // Will be available at `.next/stats.json`
-          statsFilename: 'stats.json',
+          reportTitle: `${options.isServer ? 'server' : 'client'} docs bundle`,
+          // Will be available at `.next/${statsFilename}`
+          statsFilename: `stats-${options.isServer ? 'server' : 'client'}.json`,
         }),
       );
     }


### PR DESCRIPTION
Adds stats and page titles for client and server bundle. Previously you'd only get one.