### PR TITLE
[docs] Fix broken/incorrect attributes links in Avatar and NativeSelect API pages

### DIFF
--- a/docs/translations/api-docs/avatar/avatar.json
+++ b/docs/translations/api-docs/avatar/avatar.json
@@ -5,7 +5,7 @@
     "children": "Used to render icon or text elements inside the Avatar if <code>src</code> is not set. This can be an element, or just a string.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
-    "imgProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>img</code> element if the component is used to display an image. It can be used to listen for the loading error event.",
+    "imgProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes\">Attributes</a> applied to the <code>img</code> element if the component is used to display an image. It can be used to listen for the loading error event.",
     "sizes": "The <code>sizes</code> attribute for the <code>img</code> element.",
     "src": "The <code>src</code> attribute for the <code>img</code> element.",
     "srcSet": "The <code>srcSet</code> attribute for the <code>img</code> element. Use this attribute for responsive image display.",

--- a/docs/translations/api-docs/avatar/avatar.json
+++ b/docs/translations/api-docs/avatar/avatar.json
@@ -5,7 +5,7 @@
     "children": "Used to render icon or text elements inside the Avatar if <code>src</code> is not set. This can be an element, or just a string.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
-    "imgProps": "&lt;a href=&quot;<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes&quot;&gt;Attributes&lt;/a&gt;\">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes&quot;&gt;Attributes&lt;/a&gt;</a> applied to the <code>img</code> element if the component is used to display an image. It can be used to listen for the loading error event.",
+    "imgProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>img</code> element if the component is used to display an image. It can be used to listen for the loading error event.",
     "sizes": "The <code>sizes</code> attribute for the <code>img</code> element.",
     "src": "The <code>src</code> attribute for the <code>img</code> element.",
     "srcSet": "The <code>srcSet</code> attribute for the <code>img</code> element. Use this attribute for responsive image display.",

--- a/docs/translations/api-docs/native-select/native-select.json
+++ b/docs/translations/api-docs/native-select/native-select.json
@@ -5,7 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "IconComponent": "The icon that displays the arrow.",
     "input": "An <code>Input</code> element; does not have to be a material-ui specific <code>Input</code>.",
-    "inputProps": "&lt;a href=&quot;<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes&quot;&gt;Attributes&lt;/a&gt;\">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes&quot;&gt;Attributes&lt;/a&gt;</a> applied to the <code>select</code> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>select</code> element.",
     "onChange": "Callback fired when a menu item is selected.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLSelectElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "value": "The <code>input</code> value. The DOM API casts this to a string.",

--- a/docs/translations/api-docs/native-select/native-select.json
+++ b/docs/translations/api-docs/native-select/native-select.json
@@ -5,7 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "IconComponent": "The icon that displays the arrow.",
     "input": "An <code>Input</code> element; does not have to be a material-ui specific <code>Input</code>.",
-    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>select</code> element.",
+    "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes\">Attributes</a> applied to the <code>select</code> element.",
     "onChange": "Callback fired when a menu item is selected.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLSelectElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "value": "The <code>input</code> value. The DOM API casts this to a string.",

--- a/packages/mui-material/src/Avatar/Avatar.d.ts
+++ b/packages/mui-material/src/Avatar/Avatar.d.ts
@@ -24,7 +24,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     classes?: Partial<AvatarClasses>;
     /**
-     * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `img` element if the component is used to display an image.
+     * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes) applied to the `img` element if the component is used to display an image.
      * It can be used to listen for the loading error event.
      */
     imgProps?: React.ImgHTMLAttributes<HTMLImageElement>;

--- a/packages/mui-material/src/Avatar/Avatar.d.ts
+++ b/packages/mui-material/src/Avatar/Avatar.d.ts
@@ -24,7 +24,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     classes?: Partial<AvatarClasses>;
     /**
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes">Attributes</a> applied to the `img` element if the component is used to display an image.
+     * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `img` element if the component is used to display an image.
      * It can be used to listen for the loading error event.
      */
     imgProps?: React.ImgHTMLAttributes<HTMLImageElement>;

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -215,7 +215,7 @@ Avatar.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes">Attributes</a> applied to the `img` element if the component is used to display an image.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `img` element if the component is used to display an image.
    * It can be used to listen for the loading error event.
    */
   imgProps: PropTypes.object,

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -215,7 +215,7 @@ Avatar.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
-   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `img` element if the component is used to display an image.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes) applied to the `img` element if the component is used to display an image.
    * It can be used to listen for the loading error event.
    */
   imgProps: PropTypes.object,

--- a/packages/mui-material/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.d.ts
@@ -28,7 +28,7 @@ export interface NativeSelectProps
    */
   input?: React.ReactElement<any, any>;
   /**
-   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `select` element.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes) applied to the `select` element.
    */
   inputProps?: Partial<NativeSelectInputProps>;
   /**

--- a/packages/mui-material/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.d.ts
@@ -28,7 +28,7 @@ export interface NativeSelectProps
    */
   input?: React.ReactElement<any, any>;
   /**
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes">Attributes</a> applied to the `select` element.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `select` element.
    */
   inputProps?: Partial<NativeSelectInputProps>;
   /**

--- a/packages/mui-material/src/NativeSelect/NativeSelect.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.js
@@ -97,7 +97,7 @@ NativeSelect.propTypes /* remove-proptypes */ = {
    */
   input: PropTypes.element,
   /**
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes">Attributes</a> applied to the `select` element.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `select` element.
    */
   inputProps: PropTypes.object,
   /**

--- a/packages/mui-material/src/NativeSelect/NativeSelect.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.js
@@ -97,7 +97,7 @@ NativeSelect.propTypes /* remove-proptypes */ = {
    */
   input: PropTypes.element,
   /**
-   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `select` element.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes) applied to the `select` element.
    */
   inputProps: PropTypes.object,
   /**


### PR DESCRIPTION
I noticed some broken attributes links in the API docs for Avatar and NativeSelect. It also seems like the attributes links were pointing to the completely incorrect page in addition to being broken. Avatar was pointing to Input element attributes on MDN, and NativeSelect was pointing to the same as well. I change them to point to image and select attributes respectively.

This is my first PR here so let me know if I did anything wrong.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
