### PR TITLE
[DatePicker] Removing the inputFormat and renderInput from props

### DIFF
--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -31,6 +31,7 @@ export interface MonthPickerProps<TDate> {
   disablePast?: boolean | null;
   /** If `true` future days are disabled. */
   disableFuture?: boolean | null;
+  inputFormat?: string;
   /** Minimal selectable date. */
   minDate: TDate;
   /** Maximal selectable date. */
@@ -41,6 +42,7 @@ export interface MonthPickerProps<TDate> {
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
+  renderInput?: () => void;
   sx?: SxProps<Theme>;
 }
 
@@ -79,8 +81,9 @@ const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
   inProps: MonthPickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
+  const { inputFormat, renderInput, ...rest } = inProps;
   const props = useThemeProps<Theme, MonthPickerProps<TDate>, 'MuiMonthPicker'>({
-    props: inProps,
+    props: rest,
     name: 'MuiMonthPicker',
   });
 

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -31,7 +31,6 @@ export interface MonthPickerProps<TDate> {
   disablePast?: boolean | null;
   /** If `true` future days are disabled. */
   disableFuture?: boolean | null;
-  inputFormat?: string;
   /** Minimal selectable date. */
   minDate: TDate;
   /** Maximal selectable date. */
@@ -42,7 +41,6 @@ export interface MonthPickerProps<TDate> {
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
-  renderInput?: () => void;
   sx?: SxProps<Theme>;
 }
 
@@ -81,9 +79,8 @@ const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
   inProps: MonthPickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const { inputFormat, renderInput, ...rest } = inProps;
   const props = useThemeProps<Theme, MonthPickerProps<TDate>, 'MuiMonthPicker'>({
-    props: rest,
+    props: inProps,
     name: 'MuiMonthPicker',
   });
 

--- a/packages/mui-lab/src/internal/pickers/Picker/Picker.tsx
+++ b/packages/mui-lab/src/internal/pickers/Picker/Picker.tsx
@@ -38,6 +38,7 @@ export interface PickerProps<TDateValue = any> extends ExportedPickerProps {
     currentWrapperVariant: WrapperVariant,
     isFinish?: PickerSelectionState,
   ) => void;
+  renderInput?: (...args: any) => JSX.Element;
   toggleMobileKeyboardView: () => void;
 }
 
@@ -84,6 +85,8 @@ function Picker(props: PickerProps) {
   } = props;
   const isLandscape = useIsLandscape(views, orientation);
   const wrapperVariant = React.useContext(WrapperVariantContext);
+
+  const { renderInput, inputFormat, ...rest } = other;
 
   const toShowToolbar =
     typeof showToolbar === 'undefined' ? wrapperVariant !== 'desktop' : showToolbar;
@@ -148,7 +151,7 @@ function Picker(props: PickerProps) {
                 onChange={handleChangeAndOpenNext}
                 view={openView}
                 views={views.filter(isDatePickerView)}
-                {...other}
+                {...rest}
               />
             )}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The inProps passed to MonthPicker contain the inputFormat and renderInput.

![image](https://user-images.githubusercontent.com/49247431/133890278-cb493e22-6574-466d-a872-e87b7e70694c.png)

In component MonthPicker, put the inputFormat and renderInput in the interface to can remove it before passing the inProps to props.

closes #28352