### PR TITLE
[Checkbox] Fix form submission with empty value

### DIFF
--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -168,7 +168,7 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
         ownerState={ownerState}
         tabIndex={tabIndex}
         type={type}
-        value={value}
+        {...(type === 'checkbox' && value === undefined ? {} : { value })}
         {...inputProps}
       />
       {checked ? checkedIcon : icon}

--- a/packages/mui-material/src/internal/SwitchBase.test.js
+++ b/packages/mui-material/src/internal/SwitchBase.test.js
@@ -441,7 +441,7 @@ describe('<SwitchBase />', () => {
         <SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />,
       );
 
-      expect(getByRole('checkbox')).to.not.have.property('value', '');
+      expect(getByRole('checkbox')).not.to.have.property('value', '');
     });
 
     it('allows to overwrite value', () => {

--- a/packages/mui-material/src/internal/SwitchBase.test.js
+++ b/packages/mui-material/src/internal/SwitchBase.test.js
@@ -434,4 +434,22 @@ describe('<SwitchBase />', () => {
       ]);
     });
   });
+
+  describe('checkbox form submission', () => {
+    it('dont set a void string as value', () => {
+      const { getByRole } = render(
+        <SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />,
+      );
+
+      expect(getByRole('checkbox')).to.not.have.property('value', '');
+    });
+
+    it('allows to overwrite value', () => {
+      const { getByRole } = render(
+        <SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" value="off" />,
+      );
+
+      expect(getByRole('checkbox')).to.have.property('value', 'off');
+    });
+  });
 });


### PR DESCRIPTION
Hello,  

Mui checkboxes, when used in a `<form>`, don't submit their values.  

https://user-images.githubusercontent.com/6702424/133891709-41dea162-1130-42f7-91ea-5040ea2c4f16.mov

[Playground link](https://stackblitz.com/edit/tss-react-sedypu?devtoolsheight=33&file=index.tsx)

This is due to the fact that, if we [put a `value` prop to the `<input />`](https://github.com/mui-org/material-ui/blob/aa8ab172aaaf49a142cb062984deec480c49c0d4/packages/mui-material/src/internal/SwitchBase.js#L171), even if it's `undefined`, it ends up as an [html property](https://user-images.githubusercontent.com/6702424/133891848-2d2f5453-c680-430c-9723-b0cfd7426027.png) and at the time of submiting the form will be interpreted as a void string overriding the checked value.  

This PR fixes it but maybe it would be better to fix it upstream. 

Best regards,  

PS: [The new landing page](https://mui.com) is very cool. 

 