### PR TITLE
[docs] Update caret position in comments to match npm scope

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -60,16 +60,16 @@ Anything deeper is considered private and can cause issues, such as module dupli
 // ✅ OK
 import { Add as AddIcon } from '@mui/icons-material';
 import { Tabs } from '@mui/material';
-//                                 ^^^^ 1st or top-level
+//                         ^^^^^^^^ 1st or top-level
 
 // ✅ OK
 import AddIcon from '@mui/icons-material/Add';
 import Tabs from '@mui/material/Tabs';
-//                                  ^^^^ 2nd level
+//                              ^^^^ 2nd level
 
 // ❌ NOT OK
 import TabIndicator from '@mui/material/Tabs/TabIndicator';
-//                                               ^^^^^^^^^^^^ 3rd level
+//                                           ^^^^^^^^^^^^ 3rd level
 ```
 
 If you're using `eslint` you can catch problematic imports with the [`no-restricted-imports` rule](https://eslint.org/docs/rules/no-restricted-imports). The following `.eslintrc` configuration will highlight problematic imports from `@mui` packages:


### PR DESCRIPTION
Caret positions were still assuming `@material-ui`

Preview: https://deploy-preview-28426--material-ui.netlify.app/guides/minimizing-bundle-size/#option-1