### PR TITLE
[website] Fix crash

### DIFF
--- a/docs/src/components/productCore/CoreComponents.tsx
+++ b/docs/src/components/productCore/CoreComponents.tsx
@@ -177,15 +177,11 @@ export default function CoreComponents() {
               >
                 {demo === 'Button' && (
                   <Stack
-                    gap={2}
+                    spacing={2}
+                    direction={{ xs: 'column', sm: 'row' }}
                     sx={{
                       height: '100%',
                       py: 5,
-                      display: 'flex',
-                      flexDirection: {
-                        xs: 'column',
-                        sm: 'row',
-                      },
                       justifyContent: 'center',
                       alignItems: 'center',
                       flexWrap: 'wrap',
@@ -232,13 +228,7 @@ export default function CoreComponents() {
                         },
                     }}
                   >
-                    <Table
-                      aria-label="demo table"
-                      sx={{
-                        backgroundColor: (theme) =>
-                          theme.palette.mode === 'dark' ? theme.palette.primaryDark[800] : '#fff',
-                      }}
-                    >
+                    <Table aria-label="demo table">
                       <TableHead>
                         <TableRow>
                           <TableCell>Dessert</TableCell>

--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { styled, alpha } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import NoSsr from '@mui/material/NoSsr';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import SvgMuiLogo from 'docs/src/icons/SvgMuiLogo';
@@ -14,11 +13,9 @@ import Link from 'docs/src/modules/components/Link';
 import { DeferredAppSearch } from 'docs/src/modules/components/AppFrame';
 import ROUTES from 'docs/src/route';
 
-const Header = styled('header', {
-  shouldForwardProp: (prop) => prop !== 'trigger',
-})<{ trigger: boolean }>(({ theme, trigger }) => ({
+const Header = styled('header')(({ theme }) => ({
   position: 'sticky',
-  top: trigger ? -80 : 0,
+  top: 0,
   transition: theme.transitions.create('top'),
   zIndex: theme.zIndex.appBar,
   backdropFilter: 'blur(20px)',
@@ -33,9 +30,13 @@ const Header = styled('header', {
 
 export default function AppHeader() {
   const changeTheme = useChangeTheme();
-  const [mode, setMode] = React.useState(getCookie('paletteMode') || 'system');
+  const [mode, setMode] = React.useState<string | null>(null);
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
+
+  React.useEffect(() => {
+    setMode(getCookie('paletteMode') || 'system');
+  }, [setMode]);
 
   const handleChangeThemeMode = (checked: boolean) => {
     let paletteMode = 'system';
@@ -55,12 +56,12 @@ export default function AppHeader() {
     }
   };
   return (
-    <Header trigger={false}>
+    <Header>
       <Container sx={{ display: 'flex', alignItems: 'center', minHeight: 64 }}>
         <Box
           component={Link}
           href={ROUTES.home}
-          aria-label="Goto homepage"
+          aria-label="Go to homepage"
           sx={{ lineHeight: 0, mr: 2 }}
         >
           <SvgMuiLogo width={32} />
@@ -75,12 +76,12 @@ export default function AppHeader() {
         <Box sx={{ display: { md: 'none' }, mr: 1 }}>
           <HeaderNavDropdown />
         </Box>
-        <NoSsr>
+        {mode !== null ? (
           <ThemeModeToggle
             checked={mode === 'system' ? prefersDarkMode : mode === 'dark'}
             onChange={handleChangeThemeMode}
           />
-        </NoSsr>
+        ) : null}
       </Container>
     </Header>
   );

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -38,9 +38,13 @@ function AppSettingsDrawer(props) {
   const t = useTranslate();
   const theme = useTheme();
   const changeTheme = useChangeTheme();
-  const [mode, setMode] = React.useState(getCookie('paletteMode') || 'system');
+  const [mode, setMode] = React.useState(null);
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
+
+  React.useEffect(() => {
+    setMode(getCookie('paletteMode') || 'system');
+  }, [setMode]);
 
   const handleChangeThemeMode = (event, paletteMode) => {
     if (paletteMode === null) {

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -226,13 +226,16 @@ export function getDependencies(
  * @return The cookie value
  */
 export function getCookie(name: string): string | undefined {
-  if (typeof document !== 'undefined') {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) {
-      return parts[1].split(';').shift();
-    }
+  if (typeof document === 'undefined') {
+    throw new Error('Your logic is not SSR mode safe');
   }
+
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    return parts[1].split(';').shift();
+  }
+
   return undefined;
 }
 

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -227,7 +227,7 @@ export function getDependencies(
  */
 export function getCookie(name: string): string | undefined {
   if (typeof document === 'undefined') {
-    throw new Error('Your logic is not SSR mode safe');
+    throw new Error('getCookie() is not supported on the server. Fallback to a different value when rendering on the server.');
   }
 
   const value = `; ${document.cookie}`;

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -227,7 +227,9 @@ export function getDependencies(
  */
 export function getCookie(name: string): string | undefined {
   if (typeof document === 'undefined') {
-    throw new Error('getCookie() is not supported on the server. Fallback to a different value when rendering on the server.');
+    throw new Error(
+      'getCookie() is not supported on the server. Fallback to a different value when rendering on the server.',
+    );
   }
 
   const value = `; ${document.cookie}`;


### PR DESCRIPTION
Initially, I wanted to fix https://twitter.com/sairaj2119/status/1439453551944552448. Open https://mui.com/core/ and click on "Table", it crashes

<img width="754" alt="Screenshot 2021-09-19 at 13 43 53" src="https://user-images.githubusercontent.com/3165635/133926344-953352d2-b07b-4ccf-80fb-17bac2ca5fdb.png">

but then I also noticed:

- We were using flex gap -> removed it
- We were having a dead prop -> removed it
- getCookie silently returns undefined if read on the server -> throw to force making it the SSR handling safer

Fixes https://github.com/mui-org/material-ui/issues/28487