### PR TITLE
[test] Increase BS timeout for Firefox

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -22,7 +22,8 @@ const browserStack = {
   // Since we have limited ressources on BrowserStack we often time out on PRs.
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
-  enabled: !CI || !isPR || process.env.BROWSERSTACK_FORCE === 'true',
+  // enabled: !CI || !isPR || process.env.BROWSERSTACK_FORCE === 'true',
+  enabled: true,
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
@@ -190,7 +191,7 @@ module.exports = function setKarmaConfig(config) {
           os: 'Windows',
           os_version: '10',
           browser: 'firefox',
-          browser_version: '78.0',
+          browser_version: '92.0',
         },
         safari: {
           base: 'BrowserStack',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -22,13 +22,12 @@ const browserStack = {
   // Since we have limited ressources on BrowserStack we often time out on PRs.
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
-  // enabled: !CI || !isPR || process.env.BROWSERSTACK_FORCE === 'true',
-  enabled: true,
+  enabled: !CI || !isPR || process.env.BROWSERSTACK_FORCE === 'true',
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 6 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 10 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();
@@ -191,7 +190,7 @@ module.exports = function setKarmaConfig(config) {
           os: 'Windows',
           os_version: '10',
           browser: 'firefox',
-          browser_version: '92.0',
+          browser_version: '78.0',
         },
         safari: {
           base: 'BrowserStack',


### PR DESCRIPTION
The tests with Firefox 78 are frequently hitting the timeout. It's much slower than the other browsers. 

<img width="946" alt="Screenshot 2021-09-19 at 13 58 55" src="https://user-images.githubusercontent.com/3165635/133926700-3d4936f2-560e-4521-a1c6-966b2eedb48a.png">

~This PR aims to evaluate how much faster the latest version of Firefox is in BrowserStack.~ didn't work