### PR TITLE
[website] Add components index page

### DIFF
--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -32,7 +32,7 @@ export default function Home() {
           sx={{
             fontWeight: 500,
             bgcolor: 'transparent',
-            color: (theme) => (theme.palette.mode === 'dark' ? '' : 'grey.600'),
+            color: 'grey.600',
             px: 1,
           }}
         >
@@ -79,7 +79,7 @@ export default function Home() {
       <AppHeader />
       <main>
         <Section bg="gradient" sx={{ py: { xs: 2, sm: 4 } }}>
-          <Typography component="h1" variant="h2" sx={{ mb: 3 }}>
+          <Typography component="h1" variant="h2" sx={{ mb: 4, pl: 1 }}>
             All Components
           </Typography>
           <Masonry

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import Head from 'docs/src/modules/components/Head';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import Typography from '@mui/material/Typography';
+import Divider from '@mui/material/Divider';
+import Masonry from '@mui/lab/Masonry';
+import MasonryItem from '@mui/lab/MasonryItem';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+import AppHeader from 'docs/src/layouts/AppHeader';
+import AppFooter from 'docs/src/layouts/AppFooter';
+import BrandingProvider from 'docs/src/BrandingProvider';
+import Section from 'docs/src/layouts/Section';
+import PageContext from 'docs/src/modules/components/PageContext';
+import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
+import { useTranslate } from 'docs/src/modules/utils/i18n';
+import Link from 'docs/src/modules/components/Link';
+import { MuiPage } from 'docs/src/pages';
+
+export default function Home() {
+  const { pages } = React.useContext(PageContext);
+  const t = useTranslate();
+  const componentPageData = pages.find(({ pathname }) => pathname === '/components');
+  function renderCategory(page: MuiPage) {
+    return (
+      <Box key={page.pathname}>
+        <Typography
+          component="h2"
+          variant="body2"
+          sx={{
+            fontWeight: 500,
+            bgcolor: 'transparent',
+            color: (theme) => (theme.palette.mode === 'dark' ? '' : 'grey.600'),
+            px: 1,
+          }}
+        >
+          {pageToTitleI18n(page, t)}
+        </Typography>
+        <List>
+          {(page.children || []).map((nestedPage) => (
+            <ListItem key={nestedPage.pathname} disablePadding>
+              <ListItemButton
+                component={Link}
+                noLinkStyle
+                href={nestedPage.pathname}
+                sx={{
+                  px: 1,
+                  py: 0.5,
+                  fontSize: '0.84375rem',
+                  fontWeight: 500,
+                  '&:hover, &:focus': { '& svg': { opacity: 1 } },
+                }}
+              >
+                {pageToTitleI18n(nestedPage, t) || ''}
+                <KeyboardArrowRightRounded
+                  sx={{
+                    ml: 'auto',
+                    fontSize: '1.125rem',
+                    opacity: 0,
+                    color: 'primary.main',
+                  }}
+                />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+        <Box sx={{ height: 20 }} />
+      </Box>
+    );
+  }
+  return (
+    <BrandingProvider>
+      <Head
+        title="MUI: The React component library you always wanted"
+        description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design. You will develop React applications faster."
+      />
+      <AppHeader />
+      <main>
+        <Section bg="gradient" sx={{ py: { xs: 2, sm: 4 } }}>
+          <Typography component="h1" variant="h2" sx={{ mb: 3 }}>
+            All Components
+          </Typography>
+          <Masonry
+            columns={{ sm: 3, md: 4 }}
+            spacing={2}
+            sx={{
+              display: { xs: 'none', sm: 'grid' },
+            }}
+          >
+            {(componentPageData?.children || []).map((page) => {
+              return <MasonryItem key={page.pathname}>{renderCategory(page)}</MasonryItem>;
+            })}
+          </Masonry>
+          <Box
+            sx={{
+              display: { xs: 'grid', sm: 'none' },
+              gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+            }}
+          >
+            {(componentPageData?.children || []).map((page) => renderCategory(page))}
+          </Box>
+        </Section>
+      </main>
+      <Divider />
+      <AppFooter />
+    </BrandingProvider>
+  );
+}

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -19,6 +19,15 @@ import { useTranslate } from 'docs/src/modules/utils/i18n';
 import Link from 'docs/src/modules/components/Link';
 import { MuiPage } from 'docs/src/pages';
 
+function getMasonryItemHeight(menuLenght: number) {
+  return (
+    21 + // category header
+    16 + // list padding top, bottom
+    20 + // bottom box
+    menuLenght * 30 // each menu is 30px
+  );
+}
+
 export default function Home() {
   const { pages } = React.useContext(PageContext);
   const t = useTranslate();
@@ -90,7 +99,14 @@ export default function Home() {
             }}
           >
             {(componentPageData?.children || []).map((page) => {
-              return <MasonryItem key={page.pathname}>{renderCategory(page)}</MasonryItem>;
+              return (
+                <MasonryItem
+                  key={page.pathname}
+                  defaultHeight={getMasonryItemHeight((page.children || []).length)}
+                >
+                  {renderCategory(page)}
+                </MasonryItem>
+              );
             })}
           </Masonry>
           <Box

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -16,7 +16,7 @@ import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import Link from 'docs/src/modules/components/Link';
 
-export default function Home() {
+export default function Components() {
   const { pages } = React.useContext(PageContext);
   const t = useTranslate();
   const componentPageData = pages.find(({ pathname }) => pathname === '/components');

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -15,11 +15,40 @@ import PageContext from 'docs/src/modules/components/PageContext';
 import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import Link from 'docs/src/modules/components/Link';
+import { MuiPage } from 'docs/src/pages';
 
 export default function Components() {
   const { pages } = React.useContext(PageContext);
   const t = useTranslate();
   const componentPageData = pages.find(({ pathname }) => pathname === '/components');
+  function renderItem(aPage: MuiPage) {
+    return (
+      <ListItem key={aPage.pathname} disablePadding>
+        <ListItemButton
+          component={Link}
+          noLinkStyle
+          href={aPage.pathname}
+          sx={{
+            px: 1,
+            py: 0.5,
+            fontSize: '0.84375rem',
+            fontWeight: 500,
+            '&:hover, &:focus': { '& svg': { opacity: 1 } },
+          }}
+        >
+          {pageToTitleI18n(aPage, t) || ''}
+          <KeyboardArrowRightRounded
+            sx={{
+              ml: 'auto',
+              fontSize: '1.125rem',
+              opacity: 0,
+              color: 'primary.main',
+            }}
+          />
+        </ListItemButton>
+      </ListItem>
+    );
+  }
   return (
     <BrandingProvider>
       <Head
@@ -45,7 +74,6 @@ export default function Components() {
                   variant="body2"
                   sx={{
                     fontWeight: 500,
-                    bgcolor: 'transparent',
                     color: 'grey.600',
                     px: 1,
                   }}
@@ -53,32 +81,28 @@ export default function Components() {
                   {pageToTitleI18n(page, t)}
                 </Typography>
                 <List>
-                  {(page.children || []).map((nestedPage) => (
-                    <ListItem key={nestedPage.pathname} disablePadding>
-                      <ListItemButton
-                        component={Link}
-                        noLinkStyle
-                        href={nestedPage.pathname}
-                        sx={{
-                          px: 1,
-                          py: 0.5,
-                          fontSize: '0.84375rem',
-                          fontWeight: 500,
-                          '&:hover, &:focus': { '& svg': { opacity: 1 } },
-                        }}
-                      >
-                        {pageToTitleI18n(nestedPage, t) || ''}
-                        <KeyboardArrowRightRounded
-                          sx={{
-                            ml: 'auto',
-                            fontSize: '1.125rem',
-                            opacity: 0,
-                            color: 'primary.main',
-                          }}
-                        />
-                      </ListItemButton>
-                    </ListItem>
-                  ))}
+                  {(page.children || []).map((nestedPage) => {
+                    if (nestedPage.children) {
+                      return (
+                        <ListItem key={nestedPage.pathname} sx={{ py: 0, px: 1 }}>
+                          <Box sx={{ width: '100%', pt: 1 }}>
+                            <Typography
+                              component="div"
+                              variant="body2"
+                              sx={{
+                                fontWeight: 500,
+                                color: 'grey.600',
+                              }}
+                            >
+                              {pageToTitleI18n(nestedPage, t) || ''}
+                            </Typography>
+                            <List>{nestedPage.children.map(renderItem)}</List>
+                          </Box>
+                        </ListItem>
+                      );
+                    }
+                    return renderItem(nestedPage);
+                  })}
                 </List>
               </Box>
             ))}

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -23,7 +23,7 @@ export default function Home() {
   return (
     <BrandingProvider>
       <Head
-        title="MUI: The React component library you always wanted"
+        title="Components - MUI"
         description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design. You will develop React applications faster."
       />
       <AppHeader />

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -6,8 +6,6 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
-import Masonry from '@mui/lab/Masonry';
-import MasonryItem from '@mui/lab/MasonryItem';
 import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
 import AppHeader from 'docs/src/layouts/AppHeader';
 import AppFooter from 'docs/src/layouts/AppFooter';
@@ -17,68 +15,11 @@ import PageContext from 'docs/src/modules/components/PageContext';
 import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import Link from 'docs/src/modules/components/Link';
-import { MuiPage } from 'docs/src/pages';
-
-function getMasonryItemHeight(menuLenght: number) {
-  return (
-    21 + // category header
-    16 + // list padding top, bottom
-    20 + // bottom box
-    menuLenght * 30 // each menu is 30px
-  );
-}
 
 export default function Home() {
   const { pages } = React.useContext(PageContext);
   const t = useTranslate();
   const componentPageData = pages.find(({ pathname }) => pathname === '/components');
-  function renderCategory(page: MuiPage) {
-    return (
-      <Box key={page.pathname}>
-        <Typography
-          component="h2"
-          variant="body2"
-          sx={{
-            fontWeight: 500,
-            bgcolor: 'transparent',
-            color: 'grey.600',
-            px: 1,
-          }}
-        >
-          {pageToTitleI18n(page, t)}
-        </Typography>
-        <List>
-          {(page.children || []).map((nestedPage) => (
-            <ListItem key={nestedPage.pathname} disablePadding>
-              <ListItemButton
-                component={Link}
-                noLinkStyle
-                href={nestedPage.pathname}
-                sx={{
-                  px: 1,
-                  py: 0.5,
-                  fontSize: '0.84375rem',
-                  fontWeight: 500,
-                  '&:hover, &:focus': { '& svg': { opacity: 1 } },
-                }}
-              >
-                {pageToTitleI18n(nestedPage, t) || ''}
-                <KeyboardArrowRightRounded
-                  sx={{
-                    ml: 'auto',
-                    fontSize: '1.125rem',
-                    opacity: 0,
-                    color: 'primary.main',
-                  }}
-                />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-        <Box sx={{ height: 20 }} />
-      </Box>
-    );
-  }
   return (
     <BrandingProvider>
       <Head
@@ -91,31 +32,56 @@ export default function Home() {
           <Typography component="h1" variant="h2" sx={{ mb: 4, pl: 1 }}>
             All Components
           </Typography>
-          <Masonry
-            columns={{ sm: 3, md: 4 }}
-            spacing={2}
-            sx={{
-              display: { xs: 'none', sm: 'grid' },
-            }}
-          >
-            {(componentPageData?.children || []).map((page) => {
-              return (
-                <MasonryItem
-                  key={page.pathname}
-                  defaultHeight={getMasonryItemHeight((page.children || []).length)}
-                >
-                  {renderCategory(page)}
-                </MasonryItem>
-              );
-            })}
-          </Masonry>
           <Box
             sx={{
-              display: { xs: 'grid', sm: 'none' },
+              display: 'grid',
               gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
             }}
           >
-            {(componentPageData?.children || []).map((page) => renderCategory(page))}
+            {(componentPageData?.children || []).map((page) => (
+              <Box key={page.pathname} sx={{ pb: 2 }}>
+                <Typography
+                  component="h2"
+                  variant="body2"
+                  sx={{
+                    fontWeight: 500,
+                    bgcolor: 'transparent',
+                    color: 'grey.600',
+                    px: 1,
+                  }}
+                >
+                  {pageToTitleI18n(page, t)}
+                </Typography>
+                <List>
+                  {(page.children || []).map((nestedPage) => (
+                    <ListItem key={nestedPage.pathname} disablePadding>
+                      <ListItemButton
+                        component={Link}
+                        noLinkStyle
+                        href={nestedPage.pathname}
+                        sx={{
+                          px: 1,
+                          py: 0.5,
+                          fontSize: '0.84375rem',
+                          fontWeight: 500,
+                          '&:hover, &:focus': { '& svg': { opacity: 1 } },
+                        }}
+                      >
+                        {pageToTitleI18n(nestedPage, t) || ''}
+                        <KeyboardArrowRightRounded
+                          sx={{
+                            ml: 'auto',
+                            fontSize: '1.125rem',
+                            opacity: 0,
+                            color: 'primary.main',
+                          }}
+                        />
+                      </ListItemButton>
+                    </ListItem>
+                  ))}
+                </List>
+              </Box>
+            ))}
           </Box>
         </Section>
       </main>

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -374,6 +374,16 @@ export function getThemedComponents(theme: Theme) {
           },
         },
       },
+      MuiListItemButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 5,
+            '&:hover, &:focus': {
+              backgroundColor: theme.palette.mode === 'dark' ? '' : theme.palette.grey[100],
+            },
+          },
+        },
+      },
       MuiSelect: {
         defaultProps: {
           IconComponent: ArrowDropDownRounded,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Preview**: https://deploy-preview-28485--material-ui.netlify.app/components/

This page is essential for setting `page_rank` of all components to appear first in docsearch. According to #28333 

<img width="1079" alt="Screen Shot 2564-09-20 at 14 31 43" src="https://user-images.githubusercontent.com/18292247/133969120-f6c44d09-bbec-48ab-9e57-f942b1f4647c.png">


- For the design, I make it similar to Navigation drawer but with our Masonry component! (I think we can go with this simple design at first to unblock the docsearch improvement because it can only be access directly from the url and later improve with fancy design)
- Same pages data as in navigation 

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
