### PR TITLE
[docs] Avoid re-mounting the whole tree when switching theme direction

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -14,7 +14,6 @@ import PropTypes from 'prop-types';
 import acceptLanguage from 'accept-language';
 import { create } from 'jss';
 import jssRtl from 'jss-rtl';
-import { CacheProvider } from '@emotion/react';
 import { useRouter } from 'next/router';
 import { StylesProvider, jssPreset } from '@mui/styles';
 import pages from 'docs/src/pages';
@@ -306,7 +305,7 @@ function findActivePage(currentPages, pathname) {
 }
 
 function AppWrapper(props) {
-  const { children, pageProps } = props;
+  const { children, emotionCache, pageProps } = props;
 
   const router = useRouter();
 
@@ -342,7 +341,9 @@ function AppWrapper(props) {
           <PageContext.Provider value={{ activePage, pages }}>
             <StylesProvider jss={jss}>
               <ThemeProvider>
-                <DocsStyledEngineProvider>{children}</DocsStyledEngineProvider>
+                <DocsStyledEngineProvider cacheLtr={emotionCache}>
+                  {children}
+                </DocsStyledEngineProvider>
               </ThemeProvider>
             </StylesProvider>
           </PageContext.Provider>
@@ -357,6 +358,7 @@ function AppWrapper(props) {
 
 AppWrapper.propTypes = {
   children: PropTypes.node.isRequired,
+  emotionCache: PropTypes.object.isRequired,
   pageProps: PropTypes.object.isRequired,
 };
 
@@ -364,11 +366,9 @@ export default function MyApp(props) {
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
 
   return (
-    <CacheProvider value={emotionCache}>
-      <AppWrapper pageProps={pageProps}>
-        <Component {...pageProps} />
-      </AppWrapper>
-    </CacheProvider>
+    <AppWrapper emotionCache={emotionCache} pageProps={pageProps}>
+      <Component {...pageProps} />
+    </AppWrapper>
   );
 }
 

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -15,27 +15,20 @@ const cacheRtl = createCache({
 });
 
 export default function StyledEngineProvider(props) {
+  const { children, cacheLtr } = props;
   const theme = useTheme();
 
   const rtl = theme.direction === 'rtl';
-  let Wrapper = React.Fragment;
-  let wraperProps = {};
-
-  // Only happens client-side after the hydration
-  if (rtl) {
-    Wrapper = CacheProvider;
-    wraperProps = {
-      value: cacheRtl,
-    };
-  }
+  const emotionCache = theme.direction === 'rtl' ? cacheRtl : cacheLtr;
 
   return (
     <StyleSheetManager stylisPlugins={rtl ? [rtlPluginSc] : []}>
-      <Wrapper {...wraperProps}>{props.children}</Wrapper>
+      <CacheProvider value={emotionCache}>{children}</CacheProvider>
     </StyleSheetManager>
   );
 }
 
 StyledEngineProvider.propTypes = {
+  cacheLtr: PropTypes.object.isRequired,
   children: PropTypes.node,
 };


### PR DESCRIPTION
Switching between right-to-left and left-to-right currently re-mounts the whole tree since we inject an additional CacheProvider for right-to-left. It's unclear why. Instead, we use a single CacheProvider and just pass a different value. 

This also helps identifying where a cache is coming from.