### PR TITLE
[website] Update /company pages to use marketing website Header and Footer

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -391,24 +391,16 @@ function CareersContent() {
       </div>
       {/* Open roles */}
       <Container sx={{ py: { xs: 4, md: 8 } }}>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <div id="#open-roles">
-            <Typography variant="h2" sx={{ my: 1 }} id="open-roles">
-              Open roles
-            </Typography>
-            <Typography color="text.secondary" sx={{ mb: 2, maxWidth: 450 }}>
-              The company is bootstrapped (so far). It was incorporated in mid-2019 and yet growing
-              fast (x2-3 YoY). We doubled the team in 2020 and are on track to do the same in 2021.
-              We&apos;re looking for help keep growing in the following areas:
-            </Typography>
-          </div>
-        </Box>
+        <div>
+          <Typography variant="h2" sx={{ my: 1 }} id="open-roles">
+            Open roles
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 2, maxWidth: 450 }}>
+            The company is bootstrapped (so far). It was incorporated in mid-2019 and yet growing
+            fast (x2-3 YoY). We doubled the team in 2020 and are on track to do the same in 2021.
+            We&apos;re looking for help keep growing in the following areas:
+          </Typography>
+        </div>
         <Divider
           sx={{
             my: { xs: 2, sm: 4 },

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -398,7 +398,7 @@ function CareersContent() {
             alignItems: 'center',
           }}
         >
-          <div>
+          <div id="#open-roles">
             <Typography variant="h2" sx={{ my: 1 }} id="open-roles">
               Open roles
             </Typography>

--- a/docs/src/modules/components/TopLayoutCompany.js
+++ b/docs/src/modules/components/TopLayoutCompany.js
@@ -1,52 +1,42 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@mui/styles';
-import { createTheme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Head from 'docs/src/modules/components/Head';
-import { BANNER_HEIGHT } from 'docs/src/modules/constants';
 import AppContainer from 'docs/src/modules/components/AppContainer';
 import AppFooter from 'docs/src/layouts/AppFooter';
-import MarkdownElement from './MarkdownElement';
 import Divider from '@mui/material/Divider';
-import Link from '@mui/material/Link';
 import AppHeader from 'docs/src/layouts/AppHeader';
 import BrandingProvider from 'docs/src/BrandingProvider';
+import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
+import Link from 'docs/src/modules/components/Link';
 
-const styles = (theme) => ({
-  root: {
-    flex: '1 0 100%',
-  },
-  back: {
-    display: 'block',
-    marginBottom: theme.spacing(4),
-  },
-  container: {
-    marginBottom: theme.spacing(15),
-    maxWidth: `calc(680px + ${theme.spacing(12)})`,
-    '& .markdownElement': {
-      [theme.breakpoints.up('md')]: {
-        paddingRight: theme.spacing(4),
-      },
+const StyledDiv = styled('div')(() => ({
+  flex: '1 0 100%',
+}));
+
+const StyledAppContainer = styled(AppContainer)(({ theme }) => ({
+  '& .markdownElement': {
+    [theme.breakpoints.up('md')]: {
+      paddingRight: theme.spacing(4),
     },
   },
-});
+}));
 
 function TopLayoutCompany(props) {
-  const { classes, docs } = props;
+  const { docs } = props;
   const { description, rendered, title } = docs.en;
 
   return (
     <BrandingProvider>
       <AppHeader />
       <Head title={`${title} - MUI`} description={description} />
-      <div className={classes.root}>
-        <AppContainer component="main" className={classes.container}>
+      <StyledDiv>
+        <StyledAppContainer component="main" sx={{ py: { xs: 3, sm: 4, md: 8 } }}>
           <Link
             href="/careers/#open-roles"
             rel="nofollow"
-            color="text.secondary"
             variant="body2"
-            className={classes.back}
+            sx={{ display: 'block', mb: 2 }}
           >
             {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
             {'< Back to open roles'}
@@ -54,18 +44,16 @@ function TopLayoutCompany(props) {
           {rendered.map((chunk, index) => {
             return <MarkdownElement key={index} renderedMarkdown={chunk} />;
           })}
-        </AppContainer>
+        </StyledAppContainer>
         <Divider />
         <AppFooter />
-      </div>
+      </StyledDiv>
     </BrandingProvider>
   );
 }
 
 TopLayoutCompany.propTypes = {
-  classes: PropTypes.object.isRequired,
   docs: PropTypes.object.isRequired,
 };
 
-const defaultTheme = createTheme();
-export default withStyles(styles, { defaultTheme })(TopLayoutCompany);
+export default TopLayoutCompany;

--- a/docs/src/modules/components/TopLayoutCompany.js
+++ b/docs/src/modules/components/TopLayoutCompany.js
@@ -3,20 +3,25 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@mui/styles';
 import { createTheme } from '@mui/material/styles';
 import Head from 'docs/src/modules/components/Head';
-import AppFrame from 'docs/src/modules/components/AppFrame';
 import { BANNER_HEIGHT } from 'docs/src/modules/constants';
 import AppContainer from 'docs/src/modules/components/AppContainer';
-import AppFooter from 'docs/src/modules/components/AppFooter';
+import AppFooter from 'docs/src/layouts/AppFooter';
 import MarkdownElement from './MarkdownElement';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+import AppHeader from 'docs/src/layouts/AppHeader';
+import BrandingProvider from 'docs/src/BrandingProvider';
 
 const styles = (theme) => ({
   root: {
     flex: '1 0 100%',
-    // Adding top buffer because of the v5 banner
-    marginTop: BANNER_HEIGHT,
+  },
+  back: {
+    display: 'block',
+    marginBottom: theme.spacing(4),
   },
   container: {
-    marginBottom: theme.spacing(20),
+    marginBottom: theme.spacing(15),
     maxWidth: `calc(680px + ${theme.spacing(12)})`,
     '& .markdownElement': {
       [theme.breakpoints.up('md')]: {
@@ -31,17 +36,29 @@ function TopLayoutCompany(props) {
   const { description, rendered, title } = docs.en;
 
   return (
-    <AppFrame disableDrawer>
+    <BrandingProvider>
+      <AppHeader />
       <Head title={`${title} - MUI`} description={description} />
       <div className={classes.root}>
         <AppContainer component="main" className={classes.container}>
+          <Link
+            href="/careers/#open-roles"
+            rel="nofollow"
+            color="text.secondary"
+            variant="body2"
+            className={classes.back}
+          >
+            {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
+            {'< Back to open roles'}
+          </Link>
           {rendered.map((chunk, index) => {
             return <MarkdownElement key={index} renderedMarkdown={chunk} />;
           })}
         </AppContainer>
+        <Divider />
         <AppFooter />
       </div>
-    </AppFrame>
+    </BrandingProvider>
   );
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- Updated the file `TopLayoutCompany` to use the AppHeader and AppFooter used in the marketing pages instead of the documentation ones (footer was already outdated though). 
- Added a link to the role pages linking back to the Open Roles section on the Careers page. 

[Deploy preview →](https://deploy-preview-28498--material-ui.netlify.app/company/product-manager/)