### PR TITLE
[test] Make `seconds` `views` test pass in browsers

### DIFF
--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import DateTimePicker from '@mui/lab/DateTimePicker';
-import { expect } from 'chai';
-import { createPickerRender, getByMuiTest } from '../internal/pickers/test-utils';
+import { createPickerRender } from '../internal/pickers/test-utils';
 
 describe('<DateTimePicker />', () => {
   const render = createPickerRender();
@@ -16,48 +15,5 @@ describe('<DateTimePicker />', () => {
         value={null}
       />,
     );
-  });
-
-  it('should be render seconds on view', () => {
-    const date = new Date(2021, 10, 20, 10, 1, 22);
-    render(
-      <DateTimePicker
-        renderInput={(params) => <TextField {...params} />}
-        onChange={() => {}}
-        open={Boolean(true)}
-        views={['seconds']}
-        value={date}
-      />,
-    );
-    expect(getByMuiTest('seconds')).to.have.text('22');
-  });
-
-  it('should not be render seconds by default', () => {
-    const date = new Date(2021, 10, 20, 10, 1, 22);
-    render(
-      <DateTimePicker
-        renderInput={(params) => <TextField {...params} />}
-        onChange={() => {}}
-        open={Boolean(true)}
-        value={date}
-      />,
-    );
-    expect(() => getByMuiTest('seconds')).throw('Unable to find an element');
-  });
-
-  it('should be render date and time by default', () => {
-    const date = new Date(2021, 10, 20, 10, 1, 22);
-    render(
-      <DateTimePicker
-        renderInput={(params) => <TextField {...params} />}
-        onChange={() => {}}
-        open={Boolean(true)}
-        value={date}
-      />,
-    );
-    expect(getByMuiTest('hours')).to.have.text('10');
-    expect(getByMuiTest('minutes')).to.have.text('01');
-    expect(getByMuiTest('datetimepicker-toolbar-year')).to.have.text('2021');
-    expect(getByMuiTest('datetimepicker-toolbar-day')).to.have.text('Nov 20');
   });
 });

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -4,7 +4,12 @@ import { expect } from 'chai';
 import { spy, useFakeTimers, SinonSpy, SinonFakeTimers } from 'sinon';
 import { fireEvent, fireTouchChangedEvent, screen } from 'test/utils';
 import MobileDateTimePicker from '@mui/lab/MobileDateTimePicker';
-import { adapterToUse, getByMuiTest, createPickerRender } from '../internal/pickers/test-utils';
+import {
+  adapterToUse,
+  getByMuiTest,
+  queryByMuiTest,
+  createPickerRender,
+} from '../internal/pickers/test-utils';
 
 describe('<MobileDateTimePicker />', () => {
   let clock: SinonFakeTimers;
@@ -127,5 +132,35 @@ describe('<MobileDateTimePicker />', () => {
 
     fireEvent.click(screen.getByText('Cancel'));
     expect(onCloseMock.callCount).to.equal(1);
+  });
+
+  it('should render date and time by default', () => {
+    render(
+      <MobileDateTimePicker
+        renderInput={(params) => <TextField {...params} />}
+        onChange={() => {}}
+        open
+        value={adapterToUse.date('2021-11-20T10:01:22.000')}
+      />,
+    );
+
+    expect(queryByMuiTest(document.body, 'seconds')).to.equal(null);
+    expect(getByMuiTest('hours')).to.have.text('10');
+    expect(getByMuiTest('minutes')).to.have.text('01');
+    expect(getByMuiTest('datetimepicker-toolbar-year')).to.have.text('2021');
+    expect(getByMuiTest('datetimepicker-toolbar-day')).to.have.text('Nov 20');
+  });
+
+  it('can render seconds on view', () => {
+    render(
+      <MobileDateTimePicker
+        renderInput={(params) => <TextField {...params} />}
+        onChange={() => {}}
+        open
+        views={['seconds']}
+        value={adapterToUse.date('2021-11-20T10:01:22.000')}
+      />,
+    );
+    expect(getByMuiTest('seconds')).to.have.text('22');
   });
 });


### PR DESCRIPTION
The tests added in https://github.com/mui-org/material-ui/pull/25095 assumed `DatePicker` would render a `MobileDatePicker`. But that depends on the environment. For us that meant that browser tests were failing while headless tests were passing (because different components were rendered). The actual feature is only supported by the `MobileDatePicker` so let's just test it for that component.


Browser pass: https://app.circleci.com/pipelines/github/mui-org/material-ui/52746/workflows/6ae67665-93b2-404e-a3ab-b01acc38b759/jobs/299238 (failures are unrelated)