### PR TITLE
[docs] Fix wrong name for zIndex's property example in /system/

### DIFF
--- a/docs/src/pages/system/the-sx-prop/the-sx-prop.md
+++ b/docs/src/pages/system/the-sx-prop/the-sx-prop.md
@@ -86,7 +86,7 @@ The `zIndex` property maps its value to the `theme.zIndex` value.
 
 ```jsx
 <Box sx={{ zIndex: 'tooltip' }} />
-// equivalent to backgroundColor: theme => theme.zIndex.tooltip
+// equivalent to zIndex: theme => theme.zIndex.tooltip
 ```
 
 _Head to the [positions page](/system/positions/) for more details._


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
