### PR TITLE
[Switch] Fix style overrides on input

### DIFF
--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -92,7 +92,7 @@ const SwitchSwitchBase = styled(SwitchBase, {
 
     return [
       styles.switchBase,
-      styles.input,
+      { [`& .${switchClasses.input}`]: styles.input },
       ownerState.color !== 'default' && styles[`color${capitalize(ownerState.color)}`],
     ];
   },

--- a/packages/mui-material/src/Switch/Switch.test.js
+++ b/packages/mui-material/src/Switch/Switch.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import Switch, { switchClasses as classes } from '@mui/material/Switch';
 import FormControl from '@mui/material/FormControl';
@@ -49,6 +50,34 @@ describe('<Switch />', () => {
     const { getByRole } = render(<Switch defaultChecked />);
 
     expect(getByRole('checkbox')).to.have.property('checked', true);
+  });
+
+  it('slots overrides should work', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const inputStyle = {
+      marginTop: '13px',
+    };
+
+    const theme = createTheme({
+      components: {
+        MuiSwitch: {
+          styleOverrides: {
+            input: inputStyle,
+          },
+        },
+      },
+    });
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Switch />
+      </ThemeProvider>,
+    );
+
+    expect(container.getElementsByClassName(classes.input)[0]).to.toHaveComputedStyle(inputStyle);
   });
 
   specify('the switch can be disabled', () => {

--- a/packages/mui-material/src/Switch/Switch.test.js
+++ b/packages/mui-material/src/Switch/Switch.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { describeConformance, act, createClientRender, fireEvent } from 'test/utils';
 import Switch, { switchClasses as classes } from '@mui/material/Switch';
 import FormControl from '@mui/material/FormControl';
@@ -12,7 +11,10 @@ describe('<Switch />', () => {
     classes,
     render,
     muiName: 'MuiSwitch',
-    testDeepOverrides: { slotName: 'track', slotClassName: classes.track },
+    testDeepOverrides: [
+      { slotName: 'track', slotClassName: classes.track },
+      { slotName: 'input', slotClassName: classes.input },
+    ],
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp', 'componentsProp', 'propsSpread', 'themeDefaultProps', 'themeVariants'],
   }));
@@ -50,34 +52,6 @@ describe('<Switch />', () => {
     const { getByRole } = render(<Switch defaultChecked />);
 
     expect(getByRole('checkbox')).to.have.property('checked', true);
-  });
-
-  it('slots overrides should work', function test() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      this.skip();
-    }
-
-    const inputStyle = {
-      marginTop: '13px',
-    };
-
-    const theme = createTheme({
-      components: {
-        MuiSwitch: {
-          styleOverrides: {
-            input: inputStyle,
-          },
-        },
-      },
-    });
-
-    const { container } = render(
-      <ThemeProvider theme={theme}>
-        <Switch />
-      </ThemeProvider>,
-    );
-
-    expect(container.getElementsByClassName(classes.input)[0]).to.toHaveComputedStyle(inputStyle);
   });
 
   specify('the switch can be disabled', () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does it do?

Overrides theme styles applied on input.

### Why is it needed?

Fixes style overrides on checkbox input in SwitchBase.

### Related issue(s)/PR(s)

Closes #28555 