### PR TITLE
[docs] Mention Premium pricing cap

### DIFF
--- a/docs/src/components/pricing/EarlyBird.tsx
+++ b/docs/src/components/pricing/EarlyBird.tsx
@@ -9,7 +9,7 @@ import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRou
 
 export default function EarlyBird() {
   return (
-    <Container sx={{ pt: 2, pb: { xs: 2, sm: 4, md: 8 } }} id="EarlyBird">
+    <Container sx={{ pt: 2, pb: { xs: 2, sm: 4, md: 8 } }} id="early-bird">
       <Stack
         sx={{
           borderRadius: 1,

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -71,7 +71,13 @@ export function PlanName({
   );
 }
 
-export function PlanPrice({ plan }: { plan: 'community' | 'pro' | 'premium' }) {
+interface PlanPriceProps {
+  plan: 'community' | 'pro' | 'premium';
+}
+
+export function PlanPrice(props: PlanPriceProps) {
+  const { plan } = props;
+
   if (plan === 'community') {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', mt: 1, mb: 2 }}>
@@ -132,7 +138,7 @@ export function PlanPrice({ plan }: { plan: 'community' | 'pro' | 'premium' }) {
     );
   }
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', mt: 1, mb: 2 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
       <Typography variant="h4" component="div" fontWeight="bold" color="grey.600">
         $599
       </Typography>
@@ -836,9 +842,7 @@ export default function PricingTable({
             Plans
           </Typography>
           <Box sx={{ display: 'flex', flexDirection: 'column', p: 2 }}>
-            <div>
-              <PlanName plan="community" />
-            </div>
+            <PlanName plan="community" />
             <PlanPrice plan="community" />
             <Button
               component={Link}
@@ -854,9 +858,7 @@ export default function PricingTable({
           </Box>
           <ColumnHeadHighlight>
             <Recommended />
-            <div>
-              <PlanName plan="pro" />
-            </div>
+            <PlanName plan="pro" />
             <PlanPrice plan="pro" />
             <Button
               component={Link}
@@ -874,6 +876,9 @@ export default function PricingTable({
             <Box sx={{ opacity: 0.5 }}>
               <PlanName plan="premium" />
               <PlanPrice plan="premium" />
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: 13 }}>
+                Price capped at 10 developers per application
+              </Typography>
             </Box>
             <Button
               variant="outlined"

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -102,7 +102,6 @@ export function PlanPrice(props: PlanPriceProps) {
             sx={{
               borderRadius: 0.5,
               bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'error.900' : 'error.100'),
-              // bgcolor: 'error.200',
               textDecoration: 'line-through',
               p: '4px',
             }}

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -127,26 +127,29 @@ export function PlanPrice(props: PlanPriceProps) {
             / developer.
           </Typography>
         </Box>
-        <div>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            <Link href="#EarlyBird">* Early bird special.</Link>
-            <br />
-            Price capped at 10 developers.
-          </Typography>
-        </div>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          <Link href="#early-bird">* Early bird special.</Link>
+          <br />
+          Price capped at 10 developers.
+        </Typography>
       </div>
     );
   }
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
-      <Typography variant="h4" component="div" fontWeight="bold" color="grey.600">
-        $599
+    <div>
+      <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
+        <Typography variant="h4" component="div" fontWeight="bold" color="grey.600">
+          $599
+        </Typography>
+        <Box sx={{ width: 5 }} />
+        <Typography variant="body2" color="text.secondary">
+          / developer.
+        </Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+        Price capped at 10 developers per application
       </Typography>
-      <Box sx={{ width: 5 }} />
-      <Typography variant="body2" color="text.secondary">
-        / developer.
-      </Typography>
-    </Box>
+    </div>
   );
 }
 
@@ -876,9 +879,6 @@ export default function PricingTable({
             <Box sx={{ opacity: 0.5 }}>
               <PlanName plan="premium" />
               <PlanPrice plan="premium" />
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: 13 }}>
-                Price capped at 10 developers per application
-              </Typography>
             </Box>
             <Button
               variant="outlined"

--- a/docs/src/components/productDesignKit/DesignKitFAQ.tsx
+++ b/docs/src/components/productDesignKit/DesignKitFAQ.tsx
@@ -25,6 +25,16 @@ const faqData = [
     ),
   },
   {
+    summary: 'How many licenses do I need?',
+    detail: (
+      <React.Fragment>
+        The number of licenses purchased must correspond to the maximum number of editors working
+        concurrently in a 24 hour period. An editor is somebody contributing changes to the designed
+        screens that use the UI kits. No licenses are required for viewing the designs.
+      </React.Fragment>
+    ),
+  },
+  {
     summary: 'The UI kit got an update. How do I get it?',
     detail: (
       <React.Fragment>
@@ -101,10 +111,10 @@ const AccordionDetails = styled(MuiAccordionDetail)(({ theme }) => ({
 }));
 
 export default function DesignKitFAQ() {
-  function renderItem(index: number, defaultExpanded?: boolean) {
+  function renderItem(index: number) {
     const faq = faqData[index];
     return (
-      <Accordion variant="outlined" defaultExpanded={defaultExpanded}>
+      <Accordion variant="outlined">
         <AccordionSummary
           expandIcon={<KeyboardArrowDownRounded sx={{ fontSize: 20, color: 'primary.main' }} />}
         >
@@ -132,12 +142,13 @@ export default function DesignKitFAQ() {
       </Typography>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          {renderItem(0, true)}
+          {renderItem(0)}
           {renderItem(1)}
+          {renderItem(2)}
         </Grid>
         <Grid item xs={12} md={6}>
-          {renderItem(2)}
           {renderItem(3)}
+          {renderItem(4)}
           <Paper
             variant="outlined"
             sx={{

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -128,7 +128,7 @@ export const getDesignTokens = (mode: 'light' | 'dark') =>
       ...(mode === 'light' && {
         text: {
           primary: grey[900],
-          secondary: grey[800],
+          secondary: grey[700],
         },
       }),
       ...(mode === 'dark' && {

--- a/docs/src/modules/components/AppTheme.js
+++ b/docs/src/modules/components/AppTheme.js
@@ -16,5 +16,5 @@ export default function AppTheme(props) {
 }
 
 AppTheme.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
 };

--- a/docs/src/modules/components/ad.styles.js
+++ b/docs/src/modules/components/ad.styles.js
@@ -35,7 +35,7 @@ const adBodyImageStyles = (theme) => ({
     color: theme.palette.text.secondary,
     display: 'block',
     marginTop: theme.spacing(0.5),
-    fontWeight: 500,
+    fontWeight: theme.typography.fontWeightRegular,
   },
 });
 

--- a/docs/src/pages/components/buttons/buttons.md
+++ b/docs/src/pages/components/buttons/buttons.md
@@ -19,13 +19,13 @@ Buttons communicate actions that users can take. They are typically placed throu
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-## Basic Button
+## Basic button
 
 The `Button` comes with three variants: text (default), contained, and outlined.
 
 {{"demo": "pages/components/buttons/BasicButtons.js"}}
 
-### Text buttons
+### Text button
 
 [Text buttons](https://material.io/components/buttons#text-button)
 are typically used for less-pronounced actions, including those located: in dialogs, in cards.
@@ -33,7 +33,7 @@ In cards, text buttons help maintain an emphasis on card content.
 
 {{"demo": "pages/components/buttons/TextButtons.js"}}
 
-### Contained buttons
+### Contained button
 
 [Contained buttons](https://material.io/components/buttons#contained-button)
 are high-emphasis, distinguished by their use of elevation and fill.
@@ -45,7 +45,7 @@ You can remove the elevation with the `disableElevation` prop.
 
 {{"demo": "pages/components/buttons/DisableElevation.js"}}
 
-### Outlined buttons
+### Outlined button
 
 [Outlined buttons](https://material.io/components/buttons#outlined-button) are medium-emphasis buttons.
 They contain actions that are important but aren't the primary action in an app.
@@ -123,7 +123,7 @@ You can learn more about this in the [overrides documentation page](/customizati
 
 🎨 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/styles/button).
 
-## Loading buttons
+## Loading button
 
 The loading buttons can show loading state and disable interactions.
 
@@ -133,7 +133,7 @@ Toggle the loading switch to see the transition between the different states.
 
 {{"demo": "pages/components/buttons/LoadingButtonsTransition.js"}}
 
-## Complex buttons
+## Complex button
 
 The Text Buttons, Contained Buttons, Floating Action Buttons and Icon Buttons are built on top of the same component: the `ButtonBase`.
 You can take advantage of this lower-level component to build custom interactions.


### PR DESCRIPTION
This PR batches a few small changes:

- Add the missing pricing cap "Price capped at 10 developers per application"
- Fix anchor naming convention: kebab case, as the other parts of the URL: EarlyBird -> early-bird
- Remove unnecessary div
- Increase the contrast between `palette.text.primary` and `palette.text.secondary`. I'm not so sure about this one. I was personally struggling to see a difference in the text between the two
- Make the Ad "powered by" mention less visible
- Update a few headers to match the convention
- Add a new FAQ for the design kits, related to https://github.com/mui-org/mui-store/pull/70

Preview: https://deploy-preview-28581--material-ui.netlify.app/