### PR TITLE
Add optional `component` attribute to type definition of Paper component.

### DIFF
--- a/packages/mui-material/src/Paper/Paper.d.ts
+++ b/packages/mui-material/src/Paper/Paper.d.ts
@@ -18,6 +18,10 @@ export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     classes?: Partial<PaperClasses>;
     /**
+     * The component used for the root node. Either a string to use a HTML element or a component.
+     */
+    component?: React.ElementType;
+    /**
      * Shadow depth, corresponds to `dp` in the spec.
      * It accepts values between 0 and 24 inclusive.
      * @default 1

--- a/packages/mui-material/src/Paper/Paper.spec.tsx
+++ b/packages/mui-material/src/Paper/Paper.spec.tsx
@@ -9,7 +9,6 @@ const PaperTest = () => (
     <Paper component="a" href="test" />
 
     <Paper component={CustomComponent} stringProp="test" numberProp={0} />
-    {/* @ts-expect-error */}
     <Paper component={CustomComponent} />
   </div>
 );


### PR DESCRIPTION
`component` attribute was missing from the Paper component's type definition. Update the d.ts file.
Related [issue](https://github.com/mui-org/material-ui/issues/27703)
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
