### PR TITLE
[TouchRipple] Remove MuiTouchRipple from the theme

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2207,6 +2207,10 @@ As the core components use emotion as their style engine, the props used by emot
   +<Tooltip>
   ```
 
+### TouchRipple
+
+`@mui/material/ButtonBase/TouchRipple` is now considered private and has therefore been removed from the `ThemeOptions` object. Customization can still be done via the `ButtonBase.TouchRippleProps` property.
+
 ### Typography
 
 - Remove the `srOnly` variant. You can use the `visuallyHidden` utility in conjunction with the `sx` prop instead.

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -396,6 +396,14 @@ The following changes are supported by the adapter:
   +  palette: { text: { hint: 'rgba(0, 0, 0, 0.38)' } },
   +});
   ```
+  TypeScript: You can add it to the palette using [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)
+  ```ts
+  declare module '@mui/material/styles/createPalette' {
+    interface TypeText {
+      hint: string;
+    }
+  }
+  ```
 
 - The components' definitions in the theme were restructured under the `components` key, to allow for easier discoverability of the definitions related to any one component.
 

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -4,7 +4,6 @@ import { TransitionGroup } from 'react-transition-group';
 import clsx from 'clsx';
 import { keyframes } from '@mui/system';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
 import Ripple from './Ripple';
 import touchRippleClasses from './touchRippleClasses';
 
@@ -118,9 +117,7 @@ export const TouchRippleRipple = styled(Ripple, {
  *
  * TODO v5: Make private
  */
-const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTouchRipple' });
-
+const TouchRipple = React.forwardRef(function TouchRipple(props, ref) {
   const { center: centerProp = false, classes = {}, className, ...other } = props;
   const [ripples, setRipples] = React.useState([]);
   const nextKey = React.useRef(0);

--- a/packages/mui-material/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.test.js
@@ -52,6 +52,7 @@ describe('<TouchRipple />', () => {
       'componentProp',
       'componentsProp',
       'refForwarding',
+      'themeDefaultProps',
       'themeStyleOverrides',
       'themeVariants',
     ],

--- a/packages/mui-material/src/styles/components.d.ts
+++ b/packages/mui-material/src/styles/components.d.ts
@@ -556,11 +556,6 @@ export interface Components {
     styleOverrides?: ComponentsOverrides['MuiTooltip'];
     variants?: ComponentsVariants['MuiTooltip'];
   };
-  MuiTouchRipple?: {
-    defaultProps?: ComponentsProps['MuiTouchRipple'];
-    styleOverrides?: ComponentsOverrides['MuiTouchRipple'];
-    variants?: ComponentsVariants['MuiTouchRipple'];
-  };
   MuiTypography?: {
     defaultProps?: ComponentsProps['MuiTypography'];
     styleOverrides?: ComponentsOverrides['MuiTypography'];

--- a/packages/mui-material/src/styles/props.d.ts
+++ b/packages/mui-material/src/styles/props.d.ts
@@ -112,7 +112,6 @@ import { ToggleButtonProps } from '../ToggleButton';
 import { ToggleButtonGroupProps } from '../ToggleButtonGroup';
 import { ToolbarProps } from '../Toolbar';
 import { TooltipProps } from '../Tooltip';
-import { TouchRippleProps } from '../ButtonBase/TouchRipple';
 import { TypographyProps } from '../Typography';
 
 export type ComponentsProps = {
@@ -233,7 +232,6 @@ export interface ComponentsPropsList {
   MuiToggleButtonGroup: ToggleButtonGroupProps;
   MuiToolbar: ToolbarProps;
   MuiTooltip: TooltipProps;
-  MuiTouchRipple: TouchRippleProps;
   MuiTypography: TypographyProps;
   MuiUseMediaQuery: useMediaQueryOptions;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Removing MuiTouchRipple from the theme since it's now considered private.
Also added a TypeScript example in the v4 migration for adding hint text to the theme.

Closes: #28551