### PR TITLE
[docs] Fix title MUI x2

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -262,7 +262,7 @@ function ApiDocs(props) {
       disableAd={false}
       disableToc={false}
       location={apiSourceLocation}
-      title={`${componentName} API – MUI`}
+      title={`${componentName} API`}
       toc={toc}
     >
       <MarkdownElement>


### PR DESCRIPTION
https://mui.com/api/alert/

<img width="256" alt="Screenshot 2021-09-26 at 23 49 31" src="https://user-images.githubusercontent.com/3165635/134825351-543c9912-8579-4ee5-b4b6-e99849edcb27.png">

Found that looking into a quick video @zromick did (https://www.youtube.com/watch?v=7RqVQ0Zn6-E)

https://deploy-preview-28634--material-ui.netlify.app/api/alert/