### PR TITLE
[docs] Improve old doc versions discoverability

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -186,11 +186,17 @@ function AppNavDrawer(props) {
                   variant="outlined"
                   endIcon={<ArrowDropDownRoundedIcon fontSize="small" />}
                   sx={{
+                    border: (theme) =>
+                      `1px solid  ${
+                        theme.palette.mode === 'dark'
+                          ? theme.palette.primaryDark[600]
+                          : theme.palette.grey[200]
+                      }`,
                     color: (theme) =>
                       theme.palette.mode === 'dark'
                         ? theme.palette.primary[300]
                         : theme.palette.primary[500],
-                    mr: 3,
+                    mr: 2,
                   }}
                 >
                   {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
-import { styled } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import List from '@mui/material/List';
 import Drawer from '@mui/material/Drawer';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Box from '@mui/material/Box';
@@ -17,6 +19,7 @@ import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import PageContext from 'docs/src/modules/components/PageContext';
 import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
+import DoneRounded from '@mui/icons-material/DoneRounded';
 
 const savedScrollTop = {};
 
@@ -155,6 +158,7 @@ const iOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigato
 function AppNavDrawer(props) {
   const { className, disablePermanent, mobileOpen, onClose, onOpen } = props;
   const { activePage, pages } = React.useContext(PageContext);
+  const [anchorEl, setAnchorEl] = React.useState(null);
   const userLanguage = useUserLanguage();
   const languagePrefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
   const t = useTranslate();
@@ -173,24 +177,77 @@ function AppNavDrawer(props) {
               </Box>
             </NextLink>
             {process.env.LIB_VERSION ? (
-              <Button
-                component="a"
-                href={`https://mui.com${languagePrefix}/versions/`}
-                onClick={onClose}
-                size="small"
-                variant="outlined"
-                endIcon={<ArrowDropDownRoundedIcon fontSize="small" />}
-                sx={{
-                  color: (theme) =>
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.primary[300]
-                      : theme.palette.primary[500],
-                  mr: 3,
-                }}
-              >
-                {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
-                {`v${process.env.LIB_VERSION}`}
-              </Button>
+              <React.Fragment>
+                <Button
+                  onClick={(event) => {
+                    setAnchorEl(event.currentTarget);
+                  }}
+                  size="small"
+                  variant="outlined"
+                  endIcon={<ArrowDropDownRoundedIcon fontSize="small" />}
+                  sx={{
+                    color: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.primary[300]
+                        : theme.palette.primary[500],
+                    mr: 3,
+                  }}
+                >
+                  {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
+                  {`v${process.env.LIB_VERSION}`}
+                </Button>
+                <Menu
+                  anchorEl={anchorEl}
+                  open={Boolean(anchorEl)}
+                  onClose={() => setAnchorEl(null)}
+                  PaperProps={{
+                    variant: 'outlined',
+                    sx: {
+                      mt: 0.5,
+                      minWidth: 160,
+                      borderColor: (theme) =>
+                        theme.palette.mode === 'dark' ? 'primaryDark.700' : 'grey.200',
+                      bgcolor: (theme) =>
+                        theme.palette.mode === 'dark' ? 'primaryDark.900' : 'background.paper',
+                      boxShadow: (theme) =>
+                        `0px 4px 20px ${
+                          theme.palette.mode === 'dark'
+                            ? alpha(theme.palette.background.paper, 0.72)
+                            : 'rgba(170, 180, 190, 0.3)'
+                        }`,
+                      '& .MuiMenuItem-root': {
+                        fontSize: '0.875rem',
+                        fontWeight: 500,
+                        '&.Mui-selected': {
+                          color: 'primary.main',
+                        },
+                      },
+                    },
+                  }}
+                >
+                  <MenuItem selected>
+                    {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
+                    {`v${process.env.LIB_VERSION}`} <DoneRounded sx={{ fontSize: 16, ml: 0.25 }} />
+                  </MenuItem>
+                  <MenuItem
+                    component="a"
+                    href={`https://v4.mui.com${languagePrefix}/`}
+                    onClick={onClose}
+                  >
+                    {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
+                    {`v4`}
+                  </MenuItem>
+                  <Divider />
+                  <MenuItem
+                    component="a"
+                    href={`https://mui.com${languagePrefix}/versions/`}
+                    onClick={onClose}
+                  >
+                    {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
+                    {`View all versions`}
+                  </MenuItem>
+                </Menu>
+              </React.Fragment>
             ) : null}
           </ToolbarDiv>
         </ToolbarIE11>
@@ -201,7 +258,7 @@ function AppNavDrawer(props) {
         <Box sx={{ height: 40 }} />
       </React.Fragment>
     );
-  }, [activePage, pages, onClose, t, languagePrefix]);
+  }, [activePage, pages, onClose, languagePrefix, t, anchorEl, setAnchorEl]);
 
   return (
     <nav className={className} aria-label={t('mainNavigation')}>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -222,7 +222,7 @@ function AppNavDrawer(props) {
                             : 'rgba(170, 180, 190, 0.3)'
                         }`,
                       '& .MuiMenuItem-root': {
-                        fontSize: '0.875rem',
+                        fontSize: theme.typography.pxToRem(14),
                         fontWeight: 500,
                         '&.Mui-selected': {
                           color: 'primary.main',

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -222,7 +222,7 @@ function AppNavDrawer(props) {
                             : 'rgba(170, 180, 190, 0.3)'
                         }`,
                       '& .MuiMenuItem-root': {
-                        fontSize: theme.typography.pxToRem(14),
+                        fontSize: (theme) => theme.typography.pxToRem(14),
                         fontWeight: 500,
                         '&.Mui-selected': {
                           color: 'primary.main',

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -16,6 +16,7 @@ import AppNavDrawerItem from 'docs/src/modules/components/AppNavDrawerItem';
 import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import PageContext from 'docs/src/modules/components/PageContext';
 import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
+import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
 
 const savedScrollTop = {};
 
@@ -177,6 +178,8 @@ function AppNavDrawer(props) {
                 href={`https://mui.com${languagePrefix}/versions/`}
                 onClick={onClose}
                 size="small"
+                variant="outlined"
+                endIcon={<ArrowDropDownRoundedIcon fontSize="small" />}
                 sx={{
                   color: (theme) =>
                     theme.palette.mode === 'dark'

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -225,7 +225,7 @@ function AppNavDrawer(props) {
                     },
                   }}
                 >
-                  <MenuItem selected>
+                  <MenuItem selected onClick={() => setAnchorEl(null)}>
                     {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
                     {`v${process.env.LIB_VERSION}`} <DoneRounded sx={{ fontSize: 16, ml: 0.25 }} />
                   </MenuItem>

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -7,7 +7,7 @@ import { useTheme, styled } from '@mui/material/styles';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 
 const Root = styled('div')(({ theme }) => ({
-  margin: theme.spacing(2, 3),
+  margin: theme.spacing(2, 2),
   '& img': {
     display: 'inline-block',
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://deploy-preview-28651--material-ui.netlify.app/getting-started/usage/

### Problem
I've seen some users, after v5 release, struggling to find v4 documentation. Friends even came to me asking for it. This indicates that the version button on the top left near the logo doesn't have enough affordance. If it had, people would be able to go to the _**/versions**_ page where they would find every version documentation.

### Proposed design
In order to facilitate accessing v4 documentation and increase discoverability of older versions in general, here's the proposed design prototype where I'm first using the outlined variant plus and arrow icon to clarify it's a button. Then, I'm actually turning it into a menu with only two options (could be more, no strong opinions) being the first the current lib version and the second the previous major. At the end of the menu, there's a button to access the _**/versions**_ page.

![version button](https://user-images.githubusercontent.com/67129314/134947640-9dc6e676-f409-495d-a307-9d1abcad4c71.gif)

Menu items go to: 
- v5.0.1 → https://mui.com/
- v4 → https://v4.mui.com/
- View all versions → https://mui.com/versions