### PR TITLE
[docs] Make the Toggle Button size demo use default icon size

### DIFF
--- a/docs/src/pages/components/toggle-button/ToggleButtonSizes.js
+++ b/docs/src/pages/components/toggle-button/ToggleButtonSizes.js
@@ -16,16 +16,16 @@ export default function ToggleButtonSizes() {
 
   const children = [
     <ToggleButton value="left" key="left">
-      <FormatAlignLeftIcon fontSize="small" />
+      <FormatAlignLeftIcon />
     </ToggleButton>,
     <ToggleButton value="center" key="center">
-      <FormatAlignCenterIcon fontSize="small" />
+      <FormatAlignCenterIcon />
     </ToggleButton>,
     <ToggleButton value="right" key="right">
-      <FormatAlignRightIcon fontSize="small" />
+      <FormatAlignRightIcon />
     </ToggleButton>,
     <ToggleButton value="justify" key="justify">
-      <FormatAlignJustifyIcon fontSize="small" />
+      <FormatAlignJustifyIcon />
     </ToggleButton>,
   ];
 

--- a/docs/src/pages/components/toggle-button/ToggleButtonSizes.tsx
+++ b/docs/src/pages/components/toggle-button/ToggleButtonSizes.tsx
@@ -19,16 +19,16 @@ export default function ToggleButtonSizes() {
 
   const children = [
     <ToggleButton value="left" key="left">
-      <FormatAlignLeftIcon fontSize="small" />
+      <FormatAlignLeftIcon />
     </ToggleButton>,
     <ToggleButton value="center" key="center">
-      <FormatAlignCenterIcon fontSize="small" />
+      <FormatAlignCenterIcon />
     </ToggleButton>,
     <ToggleButton value="right" key="right">
-      <FormatAlignRightIcon fontSize="small" />
+      <FormatAlignRightIcon />
     </ToggleButton>,
     <ToggleButton value="justify" key="justify">
-      <FormatAlignJustifyIcon fontSize="small" />
+      <FormatAlignJustifyIcon />
     </ToggleButton>,
   ];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What's in this PR?
- Removed the `fontSize="small"` of the icons used in the [Toggle Button size demo](https://mui.com/components/toggle-button/#size). Doing so, Figma and code will match, which closes https://github.com/mui-org/material-ui/issues/28654.
- This accidentally helps with making this component demos be more consistent/simpler since this was the only instance where the icons didn't render at their default size.
