### PR TITLE
[examples] Nextjs Link missing passHref #28588

### DIFF
--- a/examples/nextjs-with-styled-components-typescript/src/Link.tsx
+++ b/examples/nextjs-with-styled-components-typescript/src/Link.tsx
@@ -28,6 +28,7 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         replace={replace}
         scroll={scroll}
         shallow={shallow}
+        passHref
         locale={locale}
       >
         <Anchor ref={ref} {...other} />

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -28,6 +28,7 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         replace={replace}
         scroll={scroll}
         shallow={shallow}
+        passHref
         locale={locale}
       >
         <Anchor ref={ref} {...other} />

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -20,6 +20,7 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
       replace={replace}
       scroll={scroll}
       shallow={shallow}
+      passHref
       locale={locale}
     >
       <Anchor ref={ref} {...other} />

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -20,7 +20,7 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
       replace={replace}
       scroll={scroll}
       shallow={shallow}
-      passHref
+      passHref // test
       locale={locale}
     >
       <Anchor ref={ref} {...other} />

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -20,7 +20,7 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
       replace={replace}
       scroll={scroll}
       shallow={shallow}
-      passHref // test
+      passHref
       locale={locale}
     >
       <Anchor ref={ref} {...other} />


### PR DESCRIPTION
Closes #28588 `passHref` was added to all three of the nextjs examples. 

- /examples/nextjs
- /examples/nextjs-with-styled-components-typescript
- /examples/nextjs-with-typescript

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
