### PR TITLE
#28117 [docs] Dark mode conditional content rendering

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -7,6 +7,7 @@ import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import { getMetaThemeColor } from 'docs/src/modules/brandingTheme';
+import { GlobalStyles } from '@mui/styled-engine';
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -112,6 +113,22 @@ export default class MyDocument extends Document {
             dangerouslySetInnerHTML={{
               __html: `@font-face{font-family:'IBM Plex Sans';src:url(/static/fonts/IBMPlexSans-Regular.woff2) format('woff2'),url(/static/fonts/IBMPlexSans-Regular.woff) format('woff'),url(/static/fonts/IBMPlexSans-Regular.ttf) format('truetype');font-weight:400;font-style:normal;font-display:swap}@font-face{font-family:'IBM Plex Sans';src:url(/static/fonts/IBMPlexSans-Medium.woff2) format('woff2'),url(/static/fonts/IBMPlexSans-Medium.woff) format('woff'),url(/static/fonts/IBMPlexSans-Medium.ttf) format('truetype');font-weight:500;font-style:normal;font-display:swap}@font-face{font-family:'IBM Plex Sans';src:url(/static/fonts/IBMPlexSans-Bold.woff2) format('woff2'),url(/static/fonts/IBMPlexSans-Bold.woff) format('woff'),url(/static/fonts/IBMPlexSans-Bold.ttf) format('truetype');font-weight:700;font-style:normal;font-display:swap}@font-face{font-family:'IBM Plex Mono';src:url(/static/fonts/IBMPlexMono-Regular.woff2) format('woff2'),url(/static/fonts/IBMPlexMono-Regular.woff) format('woff'),url(/static/fonts/IBMPlexMono-Regular.ttf) format('truetype');font-weight:400;font-style:normal;font-display:swap}@font-face{font-family:'IBM Plex Mono';src:url(/static/fonts/IBMPlexMono-SemiBold.woff2) format('woff2'),url(/static/fonts/IBMPlexMono-SemiBold.woff) format('woff'),url(/static/fonts/IBMPlexMono-SemiBold.ttf) format('truetype');font-weight:600;font-style:normal;font-display:swap}`,
             }}
+          />
+          <GlobalStyles
+            styles={`
+              .only-light-mode {
+                display: none;
+              }
+              .mode-light .only-light-mode {
+                display: block;
+              }
+              .only-dark-mode {
+                display: none;
+              }
+              .mode-dark .only-dark-mode {
+                display: block;
+              }
+            `}
           />
         </Head>
         <body>

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -42,9 +42,21 @@ function AppSettingsDrawer(props) {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
 
+  const updateBodyClass = (currentMode) => {
+    if (currentMode === 'dark') {
+      document.body.classList.remove('mode-light');
+      document.body.classList.add('mode-dark');
+    } else {
+      document.body.classList.remove('mode-dark');
+      document.body.classList.add('mode-light');
+    }
+  };
+
   React.useEffect(() => {
-    setMode(getCookie('paletteMode') || 'system');
-  }, [setMode]);
+    const initialMode = getCookie('paletteMode') || 'system';
+    setMode(initialMode);
+    updateBodyClass(initialMode === 'system' ? preferredMode : initialMode);
+  }, [setMode, preferredMode]);
 
   const handleChangeThemeMode = (event, paletteMode) => {
     if (paletteMode === null) {
@@ -56,9 +68,11 @@ function AppSettingsDrawer(props) {
     if (paletteMode === 'system') {
       document.cookie = `paletteMode=;path=/;max-age=31536000`;
       changeTheme({ paletteMode: preferredMode });
+      updateBodyClass(preferredMode);
     } else {
       document.cookie = `paletteMode=${paletteMode};path=/;max-age=31536000`;
       changeTheme({ paletteMode });
+      updateBodyClass(paletteMode);
     }
   };
 


### PR DESCRIPTION
Closes #28117.

Example usage:

```markdown
# Example

<div class="only-dark-mode">
  dark mode
</div>
<div class="only-light-mode">
  light mode
</div>
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
