### PR TITLE
[codemod] Update the generated imports in `jss-to-styled` codemod to match the new package names

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.js
@@ -513,7 +513,7 @@ export default function transformer(file, api, options) {
         path.insertAfter(
           j.importDeclaration(
             [j.importSpecifier(j.identifier('styled'))],
-            j.literal('@material-ui/core/styles'),
+            j.literal('@mui/material/styles'),
           ),
         ),
       );

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/Anonymous.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/Anonymous.expected.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'Anonymous';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/eighth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/eighth.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import Typography from '@material-ui/core/Typography';
 import MuiLink from '@material-ui/core/Link';
 import Container from 'modules/components/Container';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/eleventh.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/eleventh.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import SomeNamespace from 'SomeNamespace';
 const PREFIX = 'eleventh';
 

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/exportClass.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/exportClass.expected.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'Test';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/exportFunction.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/exportFunction.expected.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'Test';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/fifth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/fifth.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import Typography from '@material-ui/core/Typography';
 import Container from 'modules/components/Container';
 import Button from 'modules/components/Button';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { connect } from 'react-redux';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/fourth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/fourth.expected.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/nineth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/nineth.expected.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'nineth';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/second.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/second.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import Typography from '@material-ui/core/Typography';
 import Container from 'modules/components/Container';
 import Button from 'modules/components/Button';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/seventh.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/seventh.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { withPrefix, navigate } from 'gatsby';
 

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import IconButton from '@material-ui/core/IconButton';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/tenth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/tenth.expected.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'tenth';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/third.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/third.expected.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles.expected.tsx
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles.expected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'MyComponent';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles1.expected.tsx
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles1.expected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'withCreateStyles1';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles2.expected.tsx
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles2.expected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'withCreateStyles2';
 
 const classes = {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles3.expected.tsx
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/withCreateStyles3.expected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/material/styles';
 const PREFIX = 'MyComponent';
 
 const classes = {


### PR DESCRIPTION
Changes done in the generated files:

```diff
-import { styled } from '@material-ui/core/styles';
+import { styled } from '@mui/styled/styles';
```

The codemod could be run after the codemod for the rename of the packages, so it could create wrong paths. 