### PR TITLE
[Tooltip] Allow overriding internal components and their props

### DIFF
--- a/docs/pages/api-docs/tooltip.json
+++ b/docs/pages/api-docs/tooltip.json
@@ -4,6 +4,14 @@
     "title": { "type": { "name": "node" }, "required": true },
     "arrow": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
+    "components": {
+      "type": {
+        "name": "shape",
+        "description": "{ Arrow?: elementType, Popper?: elementType, Tooltip?: elementType, Transition?: elementType }"
+      },
+      "default": "{}"
+    },
+    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
     "describeChild": { "type": { "name": "bool" } },
     "disableFocusListener": { "type": { "name": "bool" } },
     "disableHoverListener": { "type": { "name": "bool" } },

--- a/docs/translations/api-docs/tooltip/tooltip.json
+++ b/docs/translations/api-docs/tooltip/tooltip.json
@@ -4,6 +4,8 @@
     "arrow": "If <code>true</code>, adds an arrow to the tooltip.",
     "children": "Tooltip reference element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "components": "The components used for each slot inside the Tooltip. Either a string to use a HTML element or a component.",
+    "componentsProps": "The props used for each slot inside the Tooltip.",
     "describeChild": "Set to <code>true</code> if the <code>title</code> acts as an accessible description. By default the <code>title</code> acts as an accessible label for the child.",
     "disableFocusListener": "Do not respond to focus-visible events.",
     "disableHoverListener": "Do not respond to hover events.",

--- a/packages/mui-material/src/Tooltip/Tooltip.d.ts
+++ b/packages/mui-material/src/Tooltip/Tooltip.d.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
+import { MUIStyledCommonProps, SxProps } from '@mui/system';
 import { InternalStandardProps as StandardProps, Theme } from '..';
 import { TransitionProps } from '../transitions/transition';
 import { PopperProps } from '../Popper/Popper';
 import { TooltipClasses } from './tooltipClasses';
+
+export interface TooltipComponentsPropsOverrides {}
 
 export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   /**
@@ -19,6 +21,31 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<TooltipClasses>;
+  /**
+   * The components used for each slot inside the Tooltip.
+   * Either a string to use a HTML element or a component.
+   * @default {}
+   */
+  components?: {
+    Popper?: React.ElementType;
+    Transition?: React.ElementType;
+    Tooltip?: React.ElementType;
+    Arrow?: React.ElementType;
+  };
+  /**
+   * The props used for each slot inside the Tooltip.
+   * @default {}
+   */
+  componentsProps?: {
+    popper?: PopperProps & TooltipComponentsPropsOverrides;
+    transition?: TransitionProps & TooltipComponentsPropsOverrides;
+    tooltip?: React.HTMLProps<HTMLDivElement> &
+      MUIStyledCommonProps &
+      TooltipComponentsPropsOverrides;
+    arrow?: React.HTMLProps<HTMLSpanElement> &
+      MUIStyledCommonProps &
+      TooltipComponentsPropsOverrides;
+  };
   /**
    * Set to `true` if the `title` acts as an accessible description.
    * By default the `title` acts as an accessible label for the child.

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -1092,6 +1092,96 @@ describe('<Tooltip />', () => {
     });
   });
 
+  describe('prop: components', () => {
+    it('can render a different Popper component', () => {
+      const CustomPopper = () => <div data-testid="CustomPopper" />;
+      const { getByTestId } = render(
+        <Tooltip title="Hello World" open components={{ Popper: CustomPopper }}>
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(getByTestId('CustomPopper')).toBeVisible();
+    });
+
+    it('can render a different Tooltip component', () => {
+      const CustomTooltip = React.forwardRef((props, ref) => (
+        <div data-testid="CustomTooltip" ref={ref} />
+      ));
+      const { getByTestId } = render(
+        <Tooltip title="Hello World" open components={{ Tooltip: CustomTooltip }}>
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(getByTestId('CustomTooltip')).toBeVisible();
+    });
+
+    it('can render a different Arrow component', () => {
+      const CustomArrow = React.forwardRef((props, ref) => (
+        <div data-testid="CustomArrow" ref={ref} />
+      ));
+      const { getByTestId } = render(
+        <Tooltip title="Hello World" open arrow components={{ Arrow: CustomArrow }}>
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(getByTestId('CustomArrow')).toBeVisible();
+    });
+  });
+
+  describe('prop: componentsProps', () => {
+    it('can provide custom props for the inner Popper component', () => {
+      const { getByTestId } = render(
+        <Tooltip
+          title="Hello World"
+          open
+          componentsProps={{ popper: { 'data-testid': 'CustomPopper' } }}
+        >
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(getByTestId('CustomPopper')).toBeVisible();
+    });
+
+    it('can provide custom props for the inner Tooltip component', () => {
+      const { getByTestId } = render(
+        <Tooltip
+          title="Hello World"
+          open
+          componentsProps={{ tooltip: { 'data-testid': 'CustomTooltip' } }}
+        >
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(getByTestId('CustomTooltip')).toBeVisible();
+    });
+
+    it('can provide custom props for the inner Arrow component', () => {
+      const { getByTestId } = render(
+        <Tooltip
+          title="Hello World"
+          open
+          arrow
+          componentsProps={{ arrow: { 'data-testid': 'CustomArrow' } }}
+        >
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(getByTestId('CustomArrow')).toBeVisible();
+    });
+  });
+
   describe('user-select state', () => {
     let prevWebkitUserSelect;
     beforeEach(() => {

--- a/packages/mui-system/src/createStyled.d.ts
+++ b/packages/mui-system/src/createStyled.d.ts
@@ -140,6 +140,12 @@ export interface CreateStyledComponent<
   ): StyledComponent<ComponentProps & AdditionalProps, SpecificComponentProps, JSXProps>;
 }
 
+export interface MUIStyledCommonProps<Theme extends object = DefaultTheme> {
+  theme?: Theme;
+  as?: React.ElementType;
+  sx?: SxProps<Theme>;
+}
+
 export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
@@ -148,11 +154,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
   ): CreateStyledComponent<
-    Pick<PropsOf<C>, ForwardedProps> & {
-      theme?: Theme;
-      as?: React.ElementType;
-      sx?: SxProps<Theme>;
-    },
+    Pick<PropsOf<C>, ForwardedProps> & MUIStyledCommonProps<Theme>,
     {},
     {
       ref?: React.Ref<InstanceType<C>>;
@@ -163,11 +165,7 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     component: C,
     options?: StyledOptions & MuiStyledOptions,
   ): CreateStyledComponent<
-    PropsOf<C> & {
-      theme?: Theme;
-      as?: React.ElementType;
-      sx?: SxProps<Theme>;
-    },
+    PropsOf<C> & MUIStyledCommonProps<Theme>,
     {},
     {
       ref?: React.Ref<InstanceType<C>>;
@@ -180,24 +178,12 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
-  ): CreateStyledComponent<
-    Pick<PropsOf<C>, ForwardedProps> & {
-      theme?: Theme;
-      as?: React.ElementType;
-      sx?: SxProps<Theme>;
-    }
-  >;
+  ): CreateStyledComponent<Pick<PropsOf<C>, ForwardedProps> & MUIStyledCommonProps<Theme>>;
 
   <C extends React.JSXElementConstructor<React.ComponentProps<C>>>(
     component: C,
     options?: StyledOptions & MuiStyledOptions,
-  ): CreateStyledComponent<
-    PropsOf<C> & {
-      theme?: Theme;
-      as?: React.ElementType;
-      sx?: SxProps<Theme>;
-    }
-  >;
+  ): CreateStyledComponent<PropsOf<C> & MUIStyledCommonProps<Theme>>;
 
   <
     Tag extends keyof JSX.IntrinsicElements,
@@ -206,25 +192,14 @@ export interface CreateMUIStyled<Theme extends object = DefaultTheme> {
     tag: Tag,
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
   ): CreateStyledComponent<
-    {
-      theme?: Theme;
-      as?: React.ElementType;
-      sx?: SxProps<Theme>;
-    },
+    MUIStyledCommonProps<Theme>,
     Pick<JSX.IntrinsicElements[Tag], ForwardedProps>
   >;
 
   <Tag extends keyof JSX.IntrinsicElements>(
     tag: Tag,
     options?: StyledOptions & MuiStyledOptions,
-  ): CreateStyledComponent<
-    {
-      theme?: Theme;
-      as?: React.ElementType;
-      sx?: SxProps<Theme>;
-    },
-    JSX.IntrinsicElements[Tag]
-  >;
+  ): CreateStyledComponent<MUIStyledCommonProps<Theme>, JSX.IntrinsicElements[Tag]>;
 }
 
 export function shouldForwardProp(propName: PropertyKey): boolean;


### PR DESCRIPTION
First discussed in https://github.com/mui-org/material-ui/issues/28679#issuecomment-930047738

Adds `components` and `componentProps` props to the Tooltip component.
For slots that were customizable before (Transition, Popper), the old props (`TransitionComponent`, `TransitionProps`, `PopperComponent`, `PopperProps`) take precedence over the new ones.

