### PR TITLE
[docs] Only add JSS to demos

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -12,10 +12,7 @@ import { loadCSS } from 'fg-loadcss/src/loadCSS';
 import NextHead from 'next/head';
 import PropTypes from 'prop-types';
 import acceptLanguage from 'accept-language';
-import { create } from 'jss';
-import jssRtl from 'jss-rtl';
 import { useRouter } from 'next/router';
-import { StylesProvider, jssPreset } from '@mui/styles';
 import pages from 'docs/src/pages';
 import PageContext from 'docs/src/modules/components/PageContext';
 import GoogleAnalytics from 'docs/src/modules/components/GoogleAnalytics';
@@ -38,12 +35,6 @@ import createEmotionCache from 'docs/src/createEmotionCache';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
-
-// Configure JSS
-const jss = create({
-  plugins: [...jssPreset().plugins, jssRtl()],
-  insertionPoint: process.browser ? document.querySelector('#insertion-point-jss') : null,
-});
 
 function useFirstRender() {
   const firstRenderRef = React.useRef(true);
@@ -339,13 +330,11 @@ function AppWrapper(props) {
       <UserLanguageProvider defaultUserLanguage={pageProps.userLanguage}>
         <CodeVariantProvider>
           <PageContext.Provider value={{ activePage, pages }}>
-            <StylesProvider jss={jss}>
-              <ThemeProvider>
-                <DocsStyledEngineProvider cacheLtr={emotionCache}>
-                  {children}
-                </DocsStyledEngineProvider>
-              </ThemeProvider>
-            </StylesProvider>
+            <ThemeProvider>
+              <DocsStyledEngineProvider cacheLtr={emotionCache}>
+                {children}
+              </DocsStyledEngineProvider>
+            </ThemeProvider>
           </PageContext.Provider>
           <LanguageNegotiation />
           <Analytics />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ServerStyleSheets } from '@mui/styles';
+import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import { ServerStyleSheet } from 'styled-components';
 import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
@@ -158,7 +158,7 @@ MyDocument.getInitialProps = async (ctx) => {
   // 4. page.render
 
   // Render app and page and get the context of the page with collected side effects.
-  const materialSheets = new ServerStyleSheets();
+  const jssSheets = new JSSServerStyleSheets();
   const styledComponentsSheet = new ServerStyleSheet();
   const originalRenderPage = ctx.renderPage;
 
@@ -170,7 +170,7 @@ MyDocument.getInitialProps = async (ctx) => {
       originalRenderPage({
         enhanceApp: (App) => (props) =>
           styledComponentsSheet.collectStyles(
-            materialSheets.collect(<App emotionCache={cache} {...props} />),
+            jssSheets.collect(<App emotionCache={cache} {...props} />),
           ),
       });
 
@@ -185,7 +185,7 @@ MyDocument.getInitialProps = async (ctx) => {
       />
     ));
 
-    let css = materialSheets.toString();
+    let css = jssSheets.toString();
     // It might be undefined, e.g. after an error.
     if (css && process.env.NODE_ENV === 'production') {
       const result1 = await prefixer.process(css, { from: undefined });

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -127,6 +127,12 @@ const getTheme = (outerTheme) => {
   return resultTheme;
 };
 
+// TODO: Let demos decide whether they need JSS
+const jss = create({
+  plugins: [...jssPreset().plugins, rtl()],
+  insertionPoint: process.browser ? document.querySelector('#insertion-point-jss') : null,
+});
+
 /**
  * Isolates the demo component as best as possible. Additional props are spread
  * to an `iframe` if `iframe={true}`.
@@ -140,12 +146,14 @@ function DemoSandboxed(props) {
 
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
-      <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
-        <Sandbox {...sandboxProps}>
-          {/* WARNING: `<Component />` needs to be a child of `Sandbox` since certain implementations rely on `cloneElement` */}
-          <Component />
-        </Sandbox>
-      </ThemeProvider>
+      <StylesProvider jss={jss}>
+        <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
+          <Sandbox {...sandboxProps}>
+            {/* WARNING: `<Component />` needs to be a child of `Sandbox` since certain implementations rely on `cloneElement` */}
+            <Component />
+          </Sandbox>
+        </ThemeProvider>
+      </StylesProvider>
     </DemoErrorBoundary>
   );
 }


### PR DESCRIPTION
We only need JSS for the demos now since the migration to Emotion is complete. So we might as well move it to the demos. This removes JSS from the bundle of the landing page.

Though now we have one JSS instance per demo so I'm not sure if this works. 

Might need to work on conditionally applying JSS to `MarkdownDocs` if at least one of the demos needs it.

```diff
-├ chunks/pages/_app.e18b17.js                116 kB
+├ chunks/pages/_app.cd857f.js                103 kB
```

master deploy logs: https://app.netlify.com/sites/material-ui/deploys/61544df498787c0008a68275
PR deploy logs: https://app.netlify.com/sites/material-ui/deploys/61548b3b26ce69000ab2341d