### PR TITLE
[InputLabel] Fix condition for applying `formControl` overrides

### DIFF
--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -39,7 +39,7 @@ const InputLabelRoot = styled(FormLabel, {
     return [
       { [`& .${formLabelClasses.asterisk}`]: styles.asterisk },
       styles.root,
-      !ownerState.formControl && styles.formControl,
+      ownerState.formControl && styles.formControl,
       ownerState.size === 'small' && styles.sizeSmall,
       ownerState.shrink && styles.shrink,
       !ownerState.disableAnimation && styles.animated,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Revert the condition to correctly apply formControl styles when formControl=true
Fixes https://github.com/mui-org/material-ui/issues/28686
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
