### PR TITLE
[core] Disable running release:tag script on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: yarn release:tag
+        if: github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'mui-org/material-ui')
         run: |
           git remote -v
           yarn release:tag --dryRun


### PR DESCRIPTION
The CI action fails while running on forks. Specifically, the `yarn release:tag` step crashes as it doesn't have the correct git remotes set.
AFAIK, this step is not crucial on the forks, so this PR disables it on repositories other than `mui-org/material-ui`.

---

@eps1lon Are you aware of anything that could depend on this step being run on forks? And what's the point of actually running this command on CI? We do add tags manually after releases, don't we?