### PR TITLE
[docs] Fix typo in Mui CSS classname

### DIFF
--- a/docs/src/pages/components/dialogs/CustomizedDialogs.js
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.js
@@ -11,10 +11,10 @@ import CloseIcon from '@mui/icons-material/Close';
 import Typography from '@mui/material/Typography';
 
 const BootstrapDialog = styled(Dialog)(({ theme }) => ({
-  '& .MuDialogContent-root': {
+  '& .MuiDialogContent-root': {
     padding: theme.spacing(2),
   },
-  '& .MuDialogActions-root': {
+  '& .MuiDialogActions-root': {
     padding: theme.spacing(1),
   },
 }));

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
@@ -10,10 +10,10 @@ import CloseIcon from '@mui/icons-material/Close';
 import Typography from '@mui/material/Typography';
 
 const BootstrapDialog = styled(Dialog)(({ theme }) => ({
-  '& .MuDialogContent-root': {
+  '& .MuiDialogContent-root': {
     padding: theme.spacing(2),
   },
-  '& .MuDialogActions-root': {
+  '& .MuiDialogActions-root': {
     padding: theme.spacing(1),
   },
 }));


### PR DESCRIPTION
Fix names of global classes

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
