### PR TITLE
using context value after props to accomodate nesting of grid container in grid item along with the breakpoint default fix

### DIFF
--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -246,7 +246,7 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
   const props = extendSxProp(themeProps);
   const {
     className,
-    columns: columnsProp = 12,
+    columns: columnsProp,
     columnSpacing: columnSpacingProp,
     component = 'div',
     container = false,
@@ -267,7 +267,13 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
   const rowSpacing = rowSpacingProp || spacing;
   const columnSpacing = columnSpacingProp || spacing;
 
-  const columns = React.useContext(GridContext) || columnsProp;
+  const columnsContext = React.useContext(GridContext);
+
+  // setting prop before context to accomodate nesting
+  const columnSet = columnsProp || columnsContext || 12;
+
+  // colums set with default breakpoint unit of 12
+  const columns = columnSet || 12;
 
   const ownerState = {
     ...props,


### PR DESCRIPTION
in reference to issue https://github.com/mui-org/material-ui/issues/28554

A better representation of the above issue would be this
It can be clearly seen from the below image that the container inside the item uses the spacing props of the parent 

![image](https://user-images.githubusercontent.com/59202075/135596253-968c6e53-171a-4891-8841-f7699c3d19f6.png)

The correct case should have been this

![image](https://user-images.githubusercontent.com/59202075/135596549-45b9dafc-4a22-4924-a6bc-3ee6d32f4d6d.png)



This can be fixed by just some boolean fixes
The prop had to be put before the value obtained for *Gridcontext* in the *OR* operation for it to be used first
The breakpoint unit 12 had to be set later so that it can be used as a default provided the earlier two parameters are null


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
