### PR TITLE
[docs] Fix various links in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please read [the full text](/CODE_OF_CONDUCT.md) so that you can understand what
 
 ## A large spectrum of contributions
 
-There are [many ways](https://mui.com/getting-started/faq/#material-ui-is-awesome-how-can-i-support-the-project) to contribute to MUI, code contribution is one aspect of it. For instance, documentation improvements are as important as code changes.
+There are [many ways](https://mui.com/getting-started/faq/#mui-is-awesome-how-can-i-support-the-project) to contribute to MUI, code contribution is one aspect of it. For instance, documentation improvements are as important as code changes.
 
 ## Your first Pull Request
 
@@ -294,4 +294,4 @@ To get a sense of where MUI is heading, or for ideas on where you could contribu
 
 ## License
 
-By contributing your code to the mui-org/material-ui GitHub repository, you agree to license your contribution under the MIT license.
+By contributing your code to the [mui-org/material-ui](https://github.com/mui-org/material-ui) GitHub repository, you agree to license your contribution under the [MIT license](/LICENSE).


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- update ID link to docs with proper heading
- Add links to LICENSE file and repo
---

- Is is okay that some of the links to file are to HEAD of the repo?