### PR TITLE
[MenuList] Fix `textCriteriaRef` and invalid value comparisons (#28704)

### DIFF
--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -110,8 +110,8 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
   const listRef = React.useRef(null);
   const textCriteriaRef = React.useRef({
     keys: [],
-    repeating: true,
-    previousKeyMatched: true,
+    repeating: false,
+    previousKeyMatched: false,
     lastTime: null,
   });
 
@@ -169,17 +169,20 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
       const lowerKey = key.toLowerCase();
       const currTime = performance.now();
       if (criteria.keys.length > 0) {
-        // Reset
-        if (currTime - criteria.lastTime > 500) {
-          criteria.keys = [];
-          criteria.repeating = true;
-          criteria.previousKeyMatched = true;
-        } else if (criteria.repeating && lowerKey !== criteria.keys[0]) {
-          criteria.repeating = false;
+        if (criteria.lastTime) {
+          // Reset
+          if (currTime - criteria.lastTime > 500) {
+            criteria.keys = [];
+            criteria.repeating = false;
+            criteria.previousKeyMatched = false;
+          } else if (criteria.repeating && lowerKey !== criteria.keys[0]) {
+            criteria.repeating = false;
+          }
         }
       }
       criteria.lastTime = currTime;
       criteria.keys.push(lowerKey);
+
       const keepFocusOnCurrent =
         currentFocus && !criteria.repeating && textCriteriaMatches(currentFocus, criteria);
       if (


### PR DESCRIPTION
- Initial values of `repeating` and `previousKeyMatched` should be `false` instead of `true` because there are no comparisons initially.
- Also, when `handleKeyDown` is called for the first time, there is a comparison between `currTime` (which is always a number) and `criteria.lastTime` (which is initially `null`) causing the code inside `if` statement to execute which might have not been anticipated by the author in this [PR](https://github.com/mui-org/material-ui/pull/15495).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
