### PR TITLE
[CalendarPicker] Set week day label margin depending on  renderDay function prop

### DIFF
--- a/packages/mui-lab/src/CalendarPicker/PickersCalendar.tsx
+++ b/packages/mui-lab/src/CalendarPicker/PickersCalendar.tsx
@@ -62,10 +62,10 @@ const PickersCalendarDayHeader = styled('div', { skipSx: true })({
   alignItems: 'center',
 });
 
-const PickersCalendarWeekDayLabel = styled(Typography, { skipSx: true })(({ theme }) => ({
+const PickersCalendarWeekDayLabel = styled(Typography, { skipSx: true })(({ theme, margin }) => ({
   width: 36,
   height: 40,
-  margin: '0 2px',
+  margin: `${margin}px`,
   textAlign: 'center',
   display: 'flex',
   justifyContent: 'center',
@@ -144,7 +144,7 @@ function PickersCalendar<TDate>(props: PickersCalendarProps<TDate>) {
     <React.Fragment>
       <PickersCalendarDayHeader>
         {utils.getWeekdays().map((day, i) => (
-          <PickersCalendarWeekDayLabel aria-hidden key={day + i.toString()} variant="caption">
+          <PickersCalendarWeekDayLabel aria-hidden key={day + i.toString()} variant="caption" margin={renderDay ? '0' : '0 2'}>
             {day.charAt(0).toUpperCase()}
           </PickersCalendarWeekDayLabel>
         ))}


### PR DESCRIPTION
Related to issue: https://github.com/mui-org/material-ui/issues/28688

Possibly not the most elegant solution, but fixes the issue with the weekday label's being misaligned when the renderDay function prop is being used and disableMargin is true.

<img width="323" alt="Screen Shot 2021-10-02 at 7 27 19 PM" src="https://user-images.githubusercontent.com/39945540/135706424-c641ef78-f6e8-4329-ae78-c1ebf952ce7e.png">

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
