### PR TITLE
[TimePicker] Add autoFocus 

### DIFF
--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -95,6 +95,10 @@ TimePicker.propTypes /* remove-proptypes */ = {
    */
   ampmInClock: PropTypes.bool,
   /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Cancel text message.
    * @default 'Cancel'
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `autoFocus` prop is available for the [DatePicker](https://github.com/mui-org/material-ui/blob/master/packages/mui-lab/src/DatePicker/DatePicker.tsx#L95), the [DateTimePicker](https://github.com/mui-org/material-ui/blob/master/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx#L105) and the [DateRangePicker](https://github.com/mui-org/material-ui/blob/master/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx#L190), but not for the TimePicker. This PR tries to solve that. 