### PR TITLE
[docs] AdapterDayJS -> AdapterDayjs

### DIFF
--- a/docs/src/pages/components/date-picker/date-picker.md
+++ b/docs/src/pages/components/date-picker/date-picker.md
@@ -24,7 +24,7 @@ This component relies on the date management library of your choice. It supports
 Please install any of these libraries and set up the right date engine by wrapping your root (or the highest level you wish the pickers to be available) with `LocalizationProvider`:
 
 ```jsx
-// or @mui/lab/Adapter{DayJS,Luxon,Moment} or any valid date-io adapter
+// or @mui/lab/Adapter{Dayjs,Luxon,Moment} or any valid date-io adapter
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 


### PR DESCRIPTION
Changed DayJS to Dayjs in documentation, as there is not DayJS folder in node_modules. On importing as DayJS I am getting a error `'index.js' does not match the corresponding name on disk: '.\node_modules\@mui\lab\AdapterDayJS\AdapterDayjs'.` so based on node_modules structure I changed the import file name to Dayjs and it worked.

![image](https://user-images.githubusercontent.com/59141533/135733025-0615c585-4fc2-413c-b004-cc04b158b842.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
