### PR TITLE
[test] Fix instances where type tests were only passing due to object being part of ReactNode

### DIFF
--- a/packages/mui-material/src/Button/Button.spec.tsx
+++ b/packages/mui-material/src/Button/Button.spec.tsx
@@ -80,8 +80,8 @@ const ButtonTest = () => (
         TestOverride
       </Button>
     }
-    <Button startIcon={FakeIcon}>Start Icon</Button>
-    <Button endIcon={FakeIcon}>endIcon</Button>
+    <Button startIcon={<FakeIcon />}>Start Icon</Button>
+    <Button endIcon={<FakeIcon />}>endIcon</Button>
   </div>
 );
 


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026