### PR TITLE
[docs] Theme documentation, typo fix

### DIFF
--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -102,7 +102,7 @@ Generate a theme base on the options received.
 1. `options` (_object_): Takes an incomplete theme object and adds the missing parts.
 2. `...args` (_object[]_): Deep merge the arguments with the about to be returned theme.
 
-> Note: Only the first argument (`options`) is being processed by the `createdTheme` function.
+> Note: Only the first argument (`options`) is being processed by the `createTheme` function.
 > If you want to actually merge two themes' options and create a new one based on them, you may want to deep merge the two options and provide them as a first argument to the `createTheme` function.
 
 ```js


### PR DESCRIPTION
Typo has fixed in theme documentation.
"createdTheme" => "createTheme"

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
