### PR TITLE
[codemod] Fix `optimal-imports` to support v4 and v5-alpha, beta

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/optimal-imports.js
+++ b/packages/mui-codemod/src/v5.0.0/optimal-imports.js
@@ -6,7 +6,11 @@ import getJSExports from '../util/getJSExports';
 if (process.env.NODE_ENV === 'test') {
   const resolve = require.resolve;
   require.resolve = (source) =>
-    resolve(source.replace(/^@material-ui\/core\/es/, '../../../mui-material/src'));
+    resolve(
+      source
+        .replace(/^@material-ui\/core\/es/, '../../../mui-material/src')
+        .replace(/^@material-ui\/core\/modern/, '../../../mui-material/src'),
+    );
 }
 
 export default function transformer(fileInfo, api, options) {
@@ -47,11 +51,18 @@ export default function transformer(fileInfo, api, options) {
     }
     const targetImportPath = `${targetModule}/${subpath}`;
 
-    const whitelist = getJSExports(
-      require.resolve(`${importModule}/es/${subpath}`, {
+    let loader;
+    try {
+      loader = require.resolve(`${importModule}/modern/${subpath}`, {
         paths: [dirname(fileInfo.path)],
-      }),
-    );
+      });
+    } catch (error) {
+      loader = require.resolve(`${importModule}/es/${subpath}`, {
+        paths: [dirname(fileInfo.path)],
+      });
+    }
+
+    const whitelist = getJSExports(loader);
 
     path.node.specifiers.forEach((specifier, index) => {
       if (!path.node.specifiers.length) {

--- a/packages/mui-codemod/src/v5.0.0/optimal-imports.js
+++ b/packages/mui-codemod/src/v5.0.0/optimal-imports.js
@@ -6,7 +6,7 @@ import getJSExports from '../util/getJSExports';
 if (process.env.NODE_ENV === 'test') {
   const resolve = require.resolve;
   require.resolve = (source) =>
-    resolve(source.replace(/^@material-ui\/core\/modern/, '../../../mui-material/src'));
+    resolve(source.replace(/^@material-ui\/core\/es/, '../../../mui-material/src'));
 }
 
 export default function transformer(fileInfo, api, options) {
@@ -48,7 +48,7 @@ export default function transformer(fileInfo, api, options) {
     const targetImportPath = `${targetModule}/${subpath}`;
 
     const whitelist = getJSExports(
-      require.resolve(`${importModule}/modern/${subpath}`, {
+      require.resolve(`${importModule}/es/${subpath}`, {
         paths: [dirname(fileInfo.path)],
       }),
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Open as draft to discuss about this change. I can reproduce with `@material-ui/core` latest(4.12.3) that codemod cannot transform `import blueGrey from "@material-ui/core/colors/blueGrey";`

Got the same error as in #28542 

```
 ERR /Users/siriwatknp/practice-repos/mui-colors-codemod/src/App.js Transformation error (Cannot find module '@material-ui/core/modern/colors' Require stack: - /Users/siriwatknp/Personal-Repos/material-ui/packages/mui-codemod/src/v5.0.0/optimal-imports.js - /Users/siriwatknp/Personal-Repos/material-ui/packages/mui-codemod/src/v5.0.0/preset-safe.js - /Users/siriwatknp/Personal-Repos/material-ui/node_modules/jscodeshift/src/Worker.js)
Error: Cannot find module '@material-ui/core/modern/colors'
```

but by using `/es/` folder, it works. @mnajdova what is the reason to use `/modern/` at [that time](https://github.com/mui-org/material-ui/pull/27404)?

> Note: in `node_modules`, I only see folder `es` and `esm` but no sign of `modern`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
