### PR TITLE
[website] Hide 'become a diamond sponsor' box on landing page

### DIFF
--- a/docs/src/components/home/DiamondSponsors.tsx
+++ b/docs/src/components/home/DiamondSponsors.tsx
@@ -62,7 +62,8 @@ export default function DiamondSponsors() {
             <SponsorCard logoSize={64} inView={inView} item={item} />
           </Grid>
         ))}
-        <Grid item xs={12} sm={6} md={4}>
+        {/* Display this once a spot for diamond sponsor is available */}
+        <Grid item xs={12} sm={6} md={4} sx={{ display: 'none' }}>
           <Paper
             variant="outlined"
             sx={{

--- a/docs/src/components/home/DiamondSponsors.tsx
+++ b/docs/src/components/home/DiamondSponsors.tsx
@@ -39,6 +39,8 @@ export default function DiamondSponsors() {
     threshold: 0,
     rootMargin: '500px',
   });
+  const maxNumberOfDiamondSponsors = 3;
+  const allSpotsAreFilled = maxNumberOfDiamondSponsors <= DIAMONDs.length;
   return (
     <Box ref={ref}>
       <Box sx={{ mb: 2 }}>
@@ -62,8 +64,7 @@ export default function DiamondSponsors() {
             <SponsorCard logoSize={64} inView={inView} item={item} />
           </Grid>
         ))}
-        {/* Display this once a spot for diamond sponsor is available */}
-        <Grid item xs={12} sm={6} md={4} sx={{ display: 'none' }}>
+        <Grid item xs={12} sm={6} md={4} sx={{ ...(allSpotsAreFilled && { display: 'none' }) }}>
           <Paper
             variant="outlined"
             sx={{

--- a/docs/src/components/home/DiamondSponsors.tsx
+++ b/docs/src/components/home/DiamondSponsors.tsx
@@ -40,7 +40,7 @@ export default function DiamondSponsors() {
     rootMargin: '500px',
   });
   const maxNumberOfDiamondSponsors = 3;
-  const allSpotsAreFilled = maxNumberOfDiamondSponsors <= DIAMONDs.length;
+  const spotIsAvailable = maxNumberOfDiamondSponsors > DIAMONDs.length;
   return (
     <Box ref={ref}>
       <Box sx={{ mb: 2 }}>
@@ -64,49 +64,51 @@ export default function DiamondSponsors() {
             <SponsorCard logoSize={64} inView={inView} item={item} />
           </Grid>
         ))}
-        <Grid item xs={12} sm={6} md={4} sx={{ ...(allSpotsAreFilled && { display: 'none' }) }}>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              display: 'flex',
-              alignItems: 'center',
-              height: '100%',
-              borderStyle: 'dashed',
-              borderColor: (theme) =>
-                theme.palette.mode === 'dark' ? 'primaryDark.400' : 'grey.300',
-            }}
-          >
-            <IconButton
-              aria-label="Become MUI sponsor"
-              component="a"
-              href="mailto:diamond@mui.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              color="primary"
+        {spotIsAvailable && (
+          <Grid item xs={12} sm={6} md={4}>
+            <Paper
+              variant="outlined"
               sx={{
-                mr: 2,
-                border: '1px solid',
+                p: 2,
+                display: 'flex',
+                alignItems: 'center',
+                height: '100%',
+                borderStyle: 'dashed',
                 borderColor: (theme) =>
                   theme.palette.mode === 'dark' ? 'primaryDark.400' : 'grey.300',
               }}
             >
-              <AddRounded />
-            </IconButton>
-            <div>
-              <Typography variant="body2" color="text.primary" fontWeight="bold">
-                Become our sponsor!
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                To join us, contact us at{' '}
-                <Link href="mailto:diamond@mui.com" target="_blank" rel="noopener noreferrer">
-                  diamond@mui.com
-                </Link>{' '}
-                for pre-approval.
-              </Typography>
-            </div>
-          </Paper>
-        </Grid>
+              <IconButton
+                aria-label="Become MUI sponsor"
+                component="a"
+                href="mailto:diamond@mui.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                color="primary"
+                sx={{
+                  mr: 2,
+                  border: '1px solid',
+                  borderColor: (theme) =>
+                    theme.palette.mode === 'dark' ? 'primaryDark.400' : 'grey.300',
+                }}
+              >
+                <AddRounded />
+              </IconButton>
+              <div>
+                <Typography variant="body2" color="text.primary" fontWeight="bold">
+                  Become our sponsor!
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  To join us, contact us at{' '}
+                  <Link href="mailto:diamond@mui.com" target="_blank" rel="noopener noreferrer">
+                    diamond@mui.com
+                  </Link>{' '}
+                  for pre-approval.
+                </Typography>
+              </div>
+            </Paper>
+          </Grid>
+        )}
       </Grid>
     </Box>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Since all 3 spots for diamond sponsors are filled, we can disable the "Become a sponsor" box on landing page.

Request: https://github.com/mui-org/material-ui/pull/28737#issuecomment-933188757