### PR TITLE
[docs] Use HTML standards for autocomplete attributes

### DIFF
--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.js
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.js
@@ -61,7 +61,7 @@ export default function SignUp() {
             <Grid container spacing={2}>
               <Grid item xs={12} sm={6}>
                 <TextField
-                  autoComplete="fname"
+                  autoComplete="given-name"
                   name="firstName"
                   required
                   fullWidth
@@ -77,7 +77,7 @@ export default function SignUp() {
                   id="lastName"
                   label="Last Name"
                   name="lastName"
-                  autoComplete="lname"
+                  autoComplete="family-name"
                 />
               </Grid>
               <Grid item xs={12}>

--- a/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/src/pages/getting-started/templates/sign-up/SignUp.tsx
@@ -61,7 +61,7 @@ export default function SignUp() {
             <Grid container spacing={2}>
               <Grid item xs={12} sm={6}>
                 <TextField
-                  autoComplete="fname"
+                  autoComplete="given-name"
                   name="firstName"
                   required
                   fullWidth
@@ -77,7 +77,7 @@ export default function SignUp() {
                   id="lastName"
                   label="Last Name"
                   name="lastName"
-                  autoComplete="lname"
+                  autoComplete="family-name"
                 />
               </Grid>
               <Grid item xs={12}>

--- a/docs/src/pages/premium-themes/onepirate/SignUp.js
+++ b/docs/src/pages/premium-themes/onepirate/SignUp.js
@@ -60,7 +60,7 @@ function SignUp() {
                     autoFocus
                     component={RFTextField}
                     disabled={submitting || sent}
-                    autoComplete="fname"
+                    autoComplete="given-name"
                     fullWidth
                     label="First name"
                     name="firstName"
@@ -71,7 +71,7 @@ function SignUp() {
                   <Field
                     component={RFTextField}
                     disabled={submitting || sent}
-                    autoComplete="lname"
+                    autoComplete="family-name"
                     fullWidth
                     label="Last name"
                     name="lastName"

--- a/docs/src/pages/premium-themes/onepirate/SignUp.tsx
+++ b/docs/src/pages/premium-themes/onepirate/SignUp.tsx
@@ -60,7 +60,7 @@ function SignUp() {
                     autoFocus
                     component={RFTextField}
                     disabled={submitting || sent}
-                    autoComplete="fname"
+                    autoComplete="given-name"
                     fullWidth
                     label="First name"
                     name="firstName"
@@ -71,7 +71,7 @@ function SignUp() {
                   <Field
                     component={RFTextField}
                     disabled={submitting || sent}
-                    autoComplete="lname"
+                    autoComplete="family-name"
                     fullWidth
                     label="Last name"
                     name="lastName"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The standard in HTML for autocomplete attributes for first or last names is to use `given-name` or `family-name`, respectively. By having examples which use incorrect standards, many developers will simply use these incorrect attributes. This pull request updates the `SignUp` examples in MUI to use the proper attributes for HTML autocomplete according to the following standards:

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

> "name"
The field expects the value to be a person's full name. Using "name" rather than breaking the name down into its components is generally preferred because it avoids dealing with the wide diversity of human names and how they are structured; however, you can use the following autocomplete values if you do need to break the name down into its components:
[...]
> "given-name"
The given (or "first") name.
[...]
> "family-name"
The family (or "last") name.

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute

> "name"
"honorific-prefix"
"given-name"
"additional-name"
"family-name"
"honorific-suffix"
