### PR TITLE
[website] Add "React" to the /x page hero description

### DIFF
--- a/docs/pages/x.tsx
+++ b/docs/pages/x.tsx
@@ -16,7 +16,7 @@ export default function Home() {
     <BrandingProvider>
       <Head
         title="MUI X: Performant advanced components"
-        description="We are kicking it off with the most powerful Data Grid on the market and there's a lot more to come. Build complex applications with our advanced components."
+        description="We are kicking it off with the most powerful Data Grid on the market and there's a lot more to come. Build complex applications with our advanced React components."
         card="/static/social-previews/x-preview.jpg"
       />
       <CssBaseline />

--- a/docs/src/components/productX/XHero.tsx
+++ b/docs/src/components/productX/XHero.tsx
@@ -55,8 +55,8 @@ export default function XHero() {
             <br /> components
           </Typography>
           <Typography color="text.secondary" sx={{ mb: 3, maxWidth: 500 }}>
-            Build complex and data-rich applications using a growing list of advanced components.
-            We&apos;re kicking it off with the most powerful Data Grid on the market.
+            Build complex and data-rich applications using a growing list of advanced React
+            components. We&apos;re kicking it off with the most powerful Data Grid on the market.
           </Typography>
           <GetStartedButtons
             installation="npm install @mui/x-data-grid"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adding the "React" word to the /x page hero and SEO description. This is an iteration after one customer bought MUI X Pro thinking it was actually buying the Design Kits. We weren't mentioning that the /x page as about React components as well so maybe this helps to avoid this same confusion happening again.

Preview: https://deploy-preview-28830--material-ui.netlify.app/x/