### PR TITLE
[core] Remove `--exact` from `release:version`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "deduplicate": "node scripts/deduplicate.js",
     "benchmark:browser": "yarn workspace benchmark browser",
     "build:codesandbox": "lerna run --parallel --scope \"@mui/*\" build",
-    "release:version": "lerna version --exact --no-changelog --no-push --no-git-tag-version",
+    "release:version": "lerna version --no-changelog --no-push --no-git-tag-version",
     "release:build": "lerna run --parallel --scope \"@mui/*\" build",
     "release:changelog": "node scripts/releaseChangelog",
     "release:publish": "lerna publish from-package --dist-tag latest --contents build",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ The following steps must be proposed as a pull request.
 
 1. Clean the generated changelog, to match the format of https://github.com/mui-org/material-ui/releases.
 1. Update the root `/package.json`'s version
-1. `yarn release:version` (🔔 remove `^` from packages with prerelease versio, eg. `-alpha`)
+1. `yarn release:version` (🔔 remove `^` from packages with prerelease version, eg. `-alpha`)
 1. Open PR with changes and wait for review and green CI
 1. Merge PR once CI is green and it has been approved
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ The following steps must be proposed as a pull request.
 
 1. Clean the generated changelog, to match the format of https://github.com/mui-org/material-ui/releases.
 1. Update the root `/package.json`'s version
-1. `yarn release:version` (🔔 remove `^` from packages with prerelease version, eg. `-alpha`)
+1. `yarn release:version` (🔔 manually remove `^` from packages with prerelease version, eg. `-alpha`)
 1. Open PR with changes and wait for review and green CI
 1. Merge PR once CI is green and it has been approved
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ The following steps must be proposed as a pull request.
 
 1. Clean the generated changelog, to match the format of https://github.com/mui-org/material-ui/releases.
 1. Update the root `/package.json`'s version
-1. `yarn release:version`
+1. `yarn release:version` (🔔 remove `^` from packages with prerelease versio, eg. `-alpha`)
 1. Open PR with changes and wait for review and green CI
 1. Merge PR once CI is green and it has been approved
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This will help us not to manually update the version with `^` when doing release. @michaldudak please try it out in this release and see if there is any error with this change.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
