### PR TITLE
[Stacl] Add props & variants types in the theme

### DIFF
--- a/packages/mui-material/src/styles/components.d.ts
+++ b/packages/mui-material/src/styles/components.d.ts
@@ -431,6 +431,10 @@ export interface Components {
     styleOverrides?: ComponentsOverrides['MuiSpeedDialIcon'];
     variants?: ComponentsVariants['MuiSpeedDialIcon'];
   };
+  MuiStack?: {
+    defaultProps?: ComponentsProps['MuiStack'];
+    variants?: ComponentsVariants['MuiStack'];
+  };
   MuiStep?: {
     defaultProps?: ComponentsProps['MuiStep'];
     styleOverrides?: ComponentsOverrides['MuiStep'];

--- a/packages/mui-material/src/styles/props.d.ts
+++ b/packages/mui-material/src/styles/props.d.ts
@@ -86,6 +86,7 @@ import { SnackbarProps } from '../Snackbar';
 import { SpeedDialProps } from '../SpeedDial';
 import { SpeedDialActionProps } from '../SpeedDialAction';
 import { SpeedDialIconProps } from '../SpeedDialIcon';
+import { StackProps } from '../Stack';
 import { StepButtonProps } from '../StepButton';
 import { StepConnectorProps } from '../StepConnector';
 import { StepContentProps } from '../StepContent';
@@ -207,6 +208,7 @@ export interface ComponentsPropsList {
   MuiSpeedDial: SpeedDialProps;
   MuiSpeedDialAction: SpeedDialActionProps;
   MuiSpeedDialIcon: SpeedDialIconProps;
+  MuiStack: StackProps;
   MuiStep: StepProps;
   MuiStepButton: StepButtonProps;
   MuiStepConnector: StepConnectorProps;


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/28838

Adds components's props and variants types for the `Stack` component