### PR TITLE
updated default LockOpen icon to correctly be the filled variant

### DIFF
--- a/packages/mui-icons-material/lib/LockOpen.js
+++ b/packages/mui-icons-material/lib/LockOpen.js
@@ -1,18 +1,21 @@
-"use strict";
+'use strict';
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault');
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+Object.defineProperty(exports, '__esModule', {
+  value: true,
 });
 exports.default = void 0;
 
-var _createSvgIcon = _interopRequireDefault(require("./utils/createSvgIcon"));
+var _createSvgIcon = _interopRequireDefault(require('./utils/createSvgIcon'));
 
-var _jsxRuntime = require("react/jsx-runtime");
+var _jsxRuntime = require('react/jsx-runtime');
 
-var _default = (0, _createSvgIcon.default)( /*#__PURE__*/(0, _jsxRuntime.jsx)("path", {
-  d: "M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z"
-}), 'LockOpen');
+var _default = (0, _createSvgIcon.default)(
+  /*#__PURE__*/ (0, _jsxRuntime.jsx)('path', {
+    d: 'M6 20zm6-7c1.1 0 2 .9 2 2s-.9 2-2 2s-2-.9-2-2s.9-2 2-2zM18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h2c0-1.66 1.34-3 3-3s3 1.34 3 3v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zzz',
+  }),
+  'LockOpen',
+);
 
 exports.default = _default;

--- a/packages/mui-icons-material/lib/esm/LockOpen.js
+++ b/packages/mui-icons-material/lib/esm/LockOpen.js
@@ -1,5 +1,8 @@
 import createSvgIcon from './utils/createSvgIcon';
-import { jsx as _jsx } from "react/jsx-runtime";
-export default createSvgIcon( /*#__PURE__*/_jsx("path", {
-  d: "M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z"
-}), 'LockOpen');
+import { jsx as _jsx } from 'react/jsx-runtime';
+export default createSvgIcon(
+  /*#__PURE__*/ _jsx('path', {
+    d: 'M6 20zm6-7c1.1 0 2 .9 2 2s-.9 2-2 2s-2-.9-2-2s.9-2 2-2zM18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h2c0-1.66 1.34-3 3-3s3 1.34 3 3v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zzz',
+  }),
+  'LockOpen',
+);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The LockOpen icon was missing its filled variant. Updated the default (filled) SVG to be the correct variant.
![image](https://user-images.githubusercontent.com/8363569/136152227-bb5a58d9-281f-4cc0-8e9e-05d674fc38c9.png)
 

Addresses #28858

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
