### PR TITLE
[test] Add a test for not allowing styled-components' APIs on mui `styled` function

### DIFF
--- a/packages/mui-styled-engine-sc/src/styled.test.js
+++ b/packages/mui-styled-engine-sc/src/styled.test.js
@@ -35,15 +35,7 @@ describe('styled', () => {
     expect(container.querySelector('[class^=TestComponent]')).not.to.equal(null);
   });
 
-  it("should not allow styled-components's APIs", () => {
-    expect(() => {
-      const StyledComponent = styled('span').attrs();
-      render(<StyledComponent />);
-    }).to.throw();
-
-    expect(() => {
-      const StyledComponent = styled('span').withComponent();
-      render(<StyledComponent />);
-    }).to.throw();
+  it("should not allow styled-components's APIs: .attrs", () => {
+    expect(typeof styled('span').attrs).to.equal('undefined');
   });
 });

--- a/packages/mui-styled-engine-sc/src/styled.test.js
+++ b/packages/mui-styled-engine-sc/src/styled.test.js
@@ -34,4 +34,16 @@ describe('styled', () => {
     expect(container.firstChild).not.to.have.attribute('color');
     expect(container.querySelector('[class^=TestComponent]')).not.to.equal(null);
   });
+
+  it("should not allow styled-components's APIs", () => {
+    expect(() => {
+      const StyledComponent = styled('span').attrs();
+      render(<StyledComponent />);
+    }).to.throw();
+
+    expect(() => {
+      const StyledComponent = styled('span').withComponent();
+      render(<StyledComponent />);
+    }).to.throw();
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
