### PR TITLE
[DesktopDatePicker] add Paper props to pass down to Paper component

### DIFF
--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -303,6 +303,24 @@ describe('<DesktopDatePicker />', () => {
     });
   });
 
+  describe('prop: PaperProps', () => {
+    it('forwards data-testid prop', () => {
+      render(
+        <DesktopDatePicker
+          open
+          onChange={() => {}}
+          PaperProps={{
+            // @ts-expect-error `data-*` attributes are not recognized in props objects
+            'data-testid': 'paper',
+          }}
+          renderInput={(params) => <TextField {...params} />}
+          value={null}
+        />,
+      );
+      expect(screen.queryByTestId('paper')).toBeVisible();
+    });
+  });
+
   describe('scroll', () => {
     const NoTransition = React.forwardRef(function NoTransition(
       props: TransitionProps & { children?: React.ReactNode },

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -50,6 +50,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   const {
     onChange,
     PopperProps,
+    PaperProps,
     ToolbarComponent = DatePickerToolbar,
     TransitionComponent,
     value,
@@ -63,6 +64,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
       PopperProps={PopperProps}
+      PaperProps={PaperProps}
       TransitionComponent={TransitionComponent}
     >
       <Picker

--- a/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
@@ -196,6 +196,7 @@ const PickersPopper = (props: PickerPopperProps) => {
     role,
     TransitionComponent = Grow,
     TrapFocusProps,
+    ...paperProps
   } = props;
 
   React.useEffect(() => {
@@ -255,8 +256,9 @@ const PickersPopper = (props: PickerPopperProps) => {
         >
           <TransitionComponent {...TransitionProps}>
             <PickersPopperPaper
-              tabIndex={-1}
               elevation={8}
+              {...paperProps}
+              tabIndex={-1}
               ref={handlePaperRef}
               onClick={onPaperClick}
               onTouchStart={onPaperTouchStart}

--- a/packages/mui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
+++ b/packages/mui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
@@ -1,10 +1,20 @@
 import * as React from 'react';
 import { useForkRef } from '@mui/material/utils';
+import { PaperProps as MuiPaperProps } from '@mui/material/Paper';
 import { WrapperVariantContext } from './WrapperVariantContext';
 import PickersPopper, { ExportedPickerPopperProps } from '../PickersPopper';
 import { DateInputPropsLike, PrivateWrapperProps } from './WrapperProps';
 
-export interface DesktopWrapperProps extends ExportedPickerPopperProps {
+interface ExportedPickerPaperProps {
+  /**
+   * Paper props passed down to [Paper](https://mui.com/api/paper/) component.
+   */
+  PaperProps?: Partial<
+    Omit<MuiPaperProps, 'role' | 'tabIndex' | 'ref' | 'onClick' | 'onTouchStart' | 'ownerState'>
+  >;
+}
+
+export interface DesktopWrapperProps extends ExportedPickerPopperProps, ExportedPickerPaperProps {
   children?: React.ReactNode;
 }
 
@@ -23,6 +33,7 @@ function DesktopWrapper(props: InternalDesktopWrapperProps) {
     onDismiss,
     open,
     PopperProps,
+    PaperProps,
     TransitionComponent,
   } = props;
   const ownInputRef = React.useRef<HTMLInputElement>(null);
@@ -38,6 +49,7 @@ function DesktopWrapper(props: InternalDesktopWrapperProps) {
         TransitionComponent={TransitionComponent}
         PopperProps={PopperProps}
         onClose={onDismiss}
+        {...PaperProps}
       >
         {children}
       </PickersPopper>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In order to be able to customize the DesktopDatePicker Paper component, we must pass down the PaperProps to the Paper component.

## Customized Paper:
<img width="404" alt="Capture d’écran 2021-10-06 à 10 12 02" src="https://user-images.githubusercontent.com/48829921/136165254-8efd86f5-9aa8-4bf5-8b7a-616a60f32c53.png">


