### PR TITLE
[system] Add posibility to use props in style overrides

### DIFF
--- a/packages/mui-material/src/styles/overrides.d.ts
+++ b/packages/mui-material/src/styles/overrides.d.ts
@@ -110,15 +110,16 @@ import { ToolbarClassKey } from '../Toolbar';
 import { TooltipClassKey } from '../Tooltip';
 import { TouchRippleClassKey } from '../ButtonBase/TouchRipple';
 import { TypographyClassKey } from '../Typography';
+import { ComponentsProps, ComponentsPropsList } from './props';
 
-export type OverridesStyleRules<ClassKey extends string = string> = Record<
+export type OverridesStyleRules<Name extends keyof ComponentsPropsList, ClassKey extends string = string> = Record<
   ClassKey,
-  CSSInterpolation
+  CSSInterpolation | ((props: ComponentsProps[Name]) => CSSInterpolation)
 >;
 
 export type ComponentsOverrides = {
   [Name in keyof ComponentNameToClassKey]?: Partial<
-    OverridesStyleRules<ComponentNameToClassKey[Name]>
+    OverridesStyleRules<Name, ComponentNameToClassKey[Name]>
   >;
 } & {
   MuiCssBaseline?: CSSObject | string;

--- a/packages/mui-system/src/createStyled.d.ts
+++ b/packages/mui-system/src/createStyled.d.ts
@@ -88,7 +88,10 @@ export interface StyledOptions {
 export interface MuiStyledOptions {
   name?: string;
   slot?: string;
-  overridesResolver?: (props: any, styles: Record<string, CSSInterpolation>) => CSSInterpolation;
+  overridesResolver?: <Props>(
+    props: Props,
+    styles: Record<string, CSSInterpolation | ((props: Props) => CSSInterpolation)>,
+  ) => CSSInterpolation;
   skipVariantsResolver?: boolean;
   skipSx?: boolean;
 }

--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -57,6 +57,7 @@ export function shouldForwardProp(prop) {
   return prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as';
 }
 
+
 export const systemDefaultTheme = createTheme();
 
 const lowercaseFirstLetter = (string) => {
@@ -131,7 +132,12 @@ export default function createStyled(input = {}) {
           const styleOverrides = getStyleOverrides(componentName, theme);
 
           if (styleOverrides) {
-            return overridesResolver(props, styleOverrides);
+            let overrides = overridesResolver(props, styleOverrides);
+            if (!Array.isArray(overrides)) {
+              overrides = [overrides];
+            }
+
+            return overrides.map(override => typeof override === 'function' ? override(props) : override);
           }
 
           return null;

--- a/packages/mui-system/src/createStyled.test.js
+++ b/packages/mui-system/src/createStyled.test.js
@@ -100,13 +100,13 @@ describe('createStyled', () => {
       });
     });
 
-    it('Accepts function with props as override', () => {
+    it('Accepts function as override', () => {
       const theme = createTheme({
         components: {
           MuiButton: {
             styleOverrides: {
-              root: (props) => ({ ...(props.color === 'primary' && { color: 'pink' }) })
-            }
+              root: (props) => ({ ...(props.color === 'primary' && { color: 'pink' }) }),
+            },
           },
         },
       });
@@ -131,6 +131,44 @@ describe('createStyled', () => {
 
       expect(container.getElementsByTagName('button')[0]).toHaveComputedStyle({
         color: 'pink',
+      });
+    });
+
+    it('Accepts function and object as override', () => {
+      const theme = createTheme({
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              root: (props) => ({ ...(props.color === 'primary' && { color: 'pink' }) }),
+              test: {
+                background: 'black'
+              },
+            },
+          },
+        },
+      });
+
+      const styled = createStyled({});
+      const Button = styled('button', {
+        shouldForwardProp: (prop) => prop !== 'color' && prop !== 'contained',
+        name: 'MuiButton',
+        slot: 'Root',
+        overridesResolver: (props, styles) => [styles.root, styles.test],
+      })({
+        display: 'flex',
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Button color="primary" variant="contained" className="Mui-disabled">
+            Hello
+          </Button>
+        </ThemeProvider>,
+      );
+
+      expect(container.getElementsByTagName('button')[0]).toHaveComputedStyle({
+        color: 'pink',
+        background: 'black'
       });
     });
   });

--- a/packages/mui-system/src/createStyled.test.js
+++ b/packages/mui-system/src/createStyled.test.js
@@ -99,5 +99,39 @@ describe('createStyled', () => {
         height: '200px',
       });
     });
+
+    it('Accepts function with props as override', () => {
+      const theme = createTheme({
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              root: (props) => ({ ...(props.color === 'primary' && { color: 'pink' }) })
+            }
+          },
+        },
+      });
+
+      const styled = createStyled({});
+      const Button = styled('button', {
+        shouldForwardProp: (prop) => prop !== 'color' && prop !== 'contained',
+        name: 'MuiButton',
+        slot: 'Root',
+        overridesResolver: (props, styles) => styles.root,
+      })({
+        display: 'flex',
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Button color="primary" variant="contained" className="Mui-disabled">
+            Hello
+          </Button>
+        </ThemeProvider>,
+      );
+
+      expect(container.getElementsByTagName('button')[0]).toHaveComputedStyle({
+        color: 'pink',
+      });
+    });
   });
 });


### PR DESCRIPTION
This change introduces posibility to use props inside theme components style overrides.

## Example

```jsx
const theme = createTheme({
  components: {
    MuiButton: {
      styleOverrides: {
        root: (props) => ({ ...(props.color === 'primary' && { color: 'pink' }) })
      }
    }
  }
})
```

This change is tested and typed and should not break previous behavior

closes #27415 

