### PR TITLE
[SliderUnstyled] Prevent unknown-prop error when using `marks` prop

### DIFF
--- a/packages/mui-core/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-core/src/SliderUnstyled/SliderUnstyled.js
@@ -681,8 +681,8 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
               {...markProps}
               {...(!isHostComponent(Mark) && {
                 ownerState: { ...ownerState, ...markProps.ownerState },
+                markActive,
               })}
-              markActive={markActive}
               style={{ ...style, ...markProps.style }}
               className={clsx(classes.mark, markProps.className, {
                 [classes.markActive]: markActive,

--- a/packages/mui-core/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/mui-core/src/SliderUnstyled/SliderUnstyled.test.js
@@ -1,5 +1,6 @@
-import * as React from 'react';
+import SliderUnstyled, { sliderUnstyledClasses as classes } from '@mui/core/SliderUnstyled';
 import { expect } from 'chai';
+import * as React from 'react';
 import { spy, stub } from 'sinon';
 import {
   createClientRender,
@@ -8,7 +9,6 @@ import {
   fireEvent,
   screen,
 } from 'test/utils';
-import SliderUnstyled, { sliderUnstyledClasses as classes } from '@mui/core/SliderUnstyled';
 
 describe('<SliderUnstyled />', () => {
   before(function beforeHook() {
@@ -66,6 +66,19 @@ describe('<SliderUnstyled />', () => {
     const { current: element } = elementRef;
     expect(element.getAttribute('ownerState')).to.equal(null);
     expect(element.getAttribute('theme')).to.equal(null);
+  });
+
+  describe('prop: marks', () => {
+    it('does not cause unknown-prop error', () => {
+      const marks = [
+        {
+          value: 33,
+        },
+      ];
+      expect(() => {
+        render(<SliderUnstyled marks={marks} />);
+      }).not.to.throw();
+    });
   });
 
   describe('prop: orientation', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/28500

When using the `SliderUnstyled` with the `marks` property set, I get this error:
```
react-dom.development.js:67 Warning: React does not recognize the `markActive` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `markactive` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at span
    at span
    at SliderUnstyled
...
```