### PR TITLE
Fix usage of URL types in Typescript examples

### DIFF
--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -58,22 +58,28 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     ...other
   } = props;
 
+  let hrefUrl: URL;
   let isExternal: boolean;
   let pathname: string;
   let hrefString: string;
-  if (typeof href === 'string') {
-    pathname = href;
-    hrefString = href;
-    try {
-      new URL(href); // Throws TypeError if input is invalid, e.g., having no protocol.
-      isExternal = true;
-    } catch {
-      isExternal = false;
+
+  try {
+    // The UrlObject type does not guarantee any fields are set.
+    hrefUrl = new URL(typeof href === 'string' ? href : href.href ?? '');
+    isExternal = true;
+    pathname = hrefUrl.pathname;
+    hrefString = hrefUrl.href;
+  } catch {
+    // If URL construction failed, then absence of protocol can be assumed,
+    // so this is likely a relative path.
+    isExternal = false;
+    if (typeof href === 'string') {
+      pathname = href;
+      hrefString = href;
+    } else {
+      pathname = href.pathname ?? '';
+      hrefString = href.href ?? '';
     }
-  } else {
-    pathname = href.pathname ?? '';
-    hrefString = href.href ?? '';
-    isExternal = href.protocol != null && href.protocol.length > 0;
   }
 
   const router = useRouter();


### PR DESCRIPTION
- Previously may not compile due to LinkProps.href being `string | UrlObject` and the type not strictly checked when used as parameters that were either `string` or `Url`, but not both.
- Relies upon the newer Node WHATWG URL API for parsing to check if protocol is present in the `href` value, if not relying upon `new URL(...)` to throw.
- Fixes #28880
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
