### PR TITLE
[docs] Improve visibility of styled engine configuration section in installation guide (#28903)

### DIFF
--- a/docs/src/pages/getting-started/installation/installation-pt.md
+++ b/docs/src/pages/getting-started/installation/installation-pt.md
@@ -30,7 +30,7 @@ npm install @material-ui/core@next @material-ui/styled-engine-sc@next styled-com
 yarn add @material-ui/core@next @material-ui/styled-engine-sc@next styled-components
 ```
 
-Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
+> 💡 Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
 
 ## Fonte Roboto
 

--- a/docs/src/pages/getting-started/installation/installation-zh.md
+++ b/docs/src/pages/getting-started/installation/installation-zh.md
@@ -30,7 +30,7 @@ npm install @material-ui/core@next @material-ui/styled-engine-sc@next styled-com
 yarn add @material-ui/core@next @material-ui/styled-engine-sc@next styled-components
 ```
 
-Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
+> 💡 Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
 
 ## Roboto 字体
 

--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -30,7 +30,7 @@ npm install @mui/material @mui/styled-engine-sc styled-components
 yarn add @mui/material @mui/styled-engine-sc styled-components
 ```
 
-Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
+> 💡 Take a look at the [Styled Engine guide](/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
 
 ## Roboto font
 


### PR DESCRIPTION
### Summary

As per discussion in #28898, the instructions required for setting up `styled-components` style engine is easily overlooked because it seems like it is optional. 

As an improvement, I am just adding a minor change to convert the text into a blockquote to make it more apparent to the person setting up the package.

### Changes
- Convert the text into a blockquote (in all languages - en, pt, zh)


**Note:** For existing documentation please see [Getting Started > Installation#npm](https://mui.com/getting-started/installation/#npm)

### Preview (with changes):
<img width="821" alt="Screen Shot 2021-10-07 at 1 53 50 PM" src="https://user-images.githubusercontent.com/9851316/136461848-98775eda-e47e-4d5e-a86b-9b59f95430da.png">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
