### PR TITLE
[core] Remove unnecessary usages of `useEventCallback`

### DIFF
--- a/packages/mui-core/src/ButtonUnstyled/useButton.ts
+++ b/packages/mui-core/src/ButtonUnstyled/useButton.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   unstable_setRef as setRef,
-  unstable_useEventCallback as useEventCallback,
   unstable_useForkRef as useForkRef,
   unstable_useIsFocusVisible as useIsFocusVisible,
 } from '@mui/utils';
@@ -31,7 +30,7 @@ export default function useButton(props: UseButtonProps) {
     isFocusVisibleRef.current = focusVisible;
   }, [focusVisible, isFocusVisibleRef]);
 
-  const handleMouseLeave =
+  const createHandleMouseLeave =
     (otherHandlers: Record<string, React.EventHandler<any>>) => (event: React.MouseEvent) => {
       if (focusVisible) {
         event.preventDefault();
@@ -40,7 +39,7 @@ export default function useButton(props: UseButtonProps) {
       otherHandlers.onMouseLeave?.(event);
     };
 
-  const handleBlur =
+  const createHandleBlur =
     (otherHandlers: Record<string, React.EventHandler<any>>) => (event: React.FocusEvent) => {
       handleBlurVisible(event);
 
@@ -51,23 +50,22 @@ export default function useButton(props: UseButtonProps) {
       otherHandlers.onBlur?.(event);
     };
 
-  const handleFocus = useEventCallback(
+  const createHandleFocus =
     (otherHandlers: Record<string, React.EventHandler<any>>) =>
-      (event: React.FocusEvent<HTMLButtonElement>) => {
-        // Fix for https://github.com/facebook/react/issues/7769
-        if (!buttonRef.current) {
-          buttonRef.current = event.currentTarget;
-        }
+    (event: React.FocusEvent<HTMLButtonElement>) => {
+      // Fix for https://github.com/facebook/react/issues/7769
+      if (!buttonRef.current) {
+        buttonRef.current = event.currentTarget;
+      }
 
-        handleFocusVisible(event);
-        if (isFocusVisibleRef.current === true) {
-          setFocusVisible(true);
-          otherHandlers.onFocusVisible?.(event);
-        }
+      handleFocusVisible(event);
+      if (isFocusVisibleRef.current === true) {
+        setFocusVisible(true);
+        otherHandlers.onFocusVisible?.(event);
+      }
 
-        otherHandlers.onFocus?.(event);
-      },
-  );
+      otherHandlers.onFocus?.(event);
+    };
 
   const elementType = component ?? components.Root ?? 'button';
 
@@ -78,7 +76,7 @@ export default function useButton(props: UseButtonProps) {
     );
   };
 
-  const handleMouseDown =
+  const createHandleMouseDown =
     (otherHandlers: Record<string, React.EventHandler<any>>) =>
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (event.target === event.currentTarget && !disabled) {
@@ -88,7 +86,7 @@ export default function useButton(props: UseButtonProps) {
       otherHandlers.onMouseDown?.(event);
     };
 
-  const handleMouseUp =
+  const createHandleMouseUp =
     (otherHandlers: Record<string, React.EventHandler<any>>) =>
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (event.target === event.currentTarget) {
@@ -98,7 +96,7 @@ export default function useButton(props: UseButtonProps) {
       otherHandlers.onMouseUp?.(event);
     };
 
-  const handleKeyDown = useEventCallback(
+  const createHandleKeyDown =
     (otherHandlers: Record<string, React.EventHandler<any>>) => (event: React.KeyboardEvent) => {
       if (event.target === event.currentTarget && isNonNativeButton() && event.key === ' ') {
         event.preventDefault();
@@ -120,10 +118,9 @@ export default function useButton(props: UseButtonProps) {
         event.preventDefault();
         otherHandlers.onClick?.(event);
       }
-    },
-  );
+    };
 
-  const handleKeyUp = useEventCallback(
+  const createHandleKeyUp =
     (otherHandlers: Record<string, React.EventHandler<any>>) => (event: React.KeyboardEvent) => {
       // calling preventDefault in keyUp on a <button> will not dispatch a click event if Space is pressed
       // https://codesandbox.io/s/button-keyup-preventdefault-dn7f0
@@ -143,8 +140,7 @@ export default function useButton(props: UseButtonProps) {
       ) {
         otherHandlers.onClick?.(event);
       }
-    },
-  );
+    };
 
   const handleOwnRef = useForkRef(focusVisibleRef, buttonRef);
   const handleRef = useForkRef(ref, handleOwnRef);
@@ -174,13 +170,13 @@ export default function useButton(props: UseButtonProps) {
     const externalEventHandlers = { ...propsEventHandlers, ...otherHandlers };
 
     const ownEventHandlers = {
-      onBlur: handleBlur(externalEventHandlers),
-      onFocus: handleFocus(externalEventHandlers),
-      onKeyDown: handleKeyDown(externalEventHandlers),
-      onKeyUp: handleKeyUp(externalEventHandlers),
-      onMouseDown: handleMouseDown(externalEventHandlers),
-      onMouseLeave: handleMouseLeave(externalEventHandlers),
-      onMouseUp: handleMouseUp(externalEventHandlers),
+      onBlur: createHandleBlur(externalEventHandlers),
+      onFocus: createHandleFocus(externalEventHandlers),
+      onKeyDown: createHandleKeyDown(externalEventHandlers),
+      onKeyUp: createHandleKeyUp(externalEventHandlers),
+      onMouseDown: createHandleMouseDown(externalEventHandlers),
+      onMouseLeave: createHandleMouseLeave(externalEventHandlers),
+      onMouseUp: createHandleMouseUp(externalEventHandlers),
     };
 
     const mergedEventHandlers: Record<string, React.EventHandler<any>> = {

--- a/packages/mui-core/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-core/src/SliderUnstyled/SliderUnstyled.js
@@ -271,21 +271,21 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
   const handleFocusRef = useForkRef(focusVisibleRef, sliderRef);
   const handleRef = useForkRef(ref, handleFocusRef);
 
-  const handleFocus = useEventCallback((event) => {
+  const handleFocus = (event) => {
     const index = Number(event.currentTarget.getAttribute('data-index'));
     handleFocusVisible(event);
     if (isFocusVisibleRef.current === true) {
       setFocusVisible(index);
     }
     setOpen(index);
-  });
-  const handleBlur = useEventCallback((event) => {
+  };
+  const handleBlur = (event) => {
     handleBlurVisible(event);
     if (isFocusVisibleRef.current === false) {
       setFocusVisible(-1);
     }
     setOpen(-1);
-  });
+  };
   const handleMouseOver = useEventCallback((event) => {
     const index = Number(event.currentTarget.getAttribute('data-index'));
     setOpen(index);
@@ -310,7 +310,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
     setFocusVisible(-1);
   }
 
-  const handleHiddenInputChange = useEventCallback((event) => {
+  const handleHiddenInputChange = (event) => {
     const index = Number(event.currentTarget.getAttribute('data-index'));
     const value = values[index];
     const marksValues = marks.map((mark) => mark.value);
@@ -367,7 +367,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
     if (onChangeCommitted) {
       onChangeCommitted(event, newValue);
     }
-  });
+  };
 
   const previousIndex = React.useRef();
   let axis = orientation;

--- a/packages/mui-core/src/SwitchUnstyled/useSwitch.ts
+++ b/packages/mui-core/src/SwitchUnstyled/useSwitch.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   unstable_useControlled as useControlled,
-  unstable_useEventCallback as useEventCallback,
   unstable_useForkRef as useForkRef,
   unstable_useIsFocusVisible as useIsFocusVisible,
 } from '@mui/utils';
@@ -96,18 +95,19 @@ export default function useSwitch(props: UseSwitchProps) {
     state: 'checked',
   });
 
-  const handleInputChange = useEventCallback(
-    (event: React.ChangeEvent<HTMLInputElement>, otherHandler?: React.FormEventHandler) => {
-      // Workaround for https://github.com/facebook/react/issues/9023
-      if (event.nativeEvent.defaultPrevented) {
-        return;
-      }
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    otherHandler?: React.FormEventHandler,
+  ) => {
+    // Workaround for https://github.com/facebook/react/issues/9023
+    if (event.nativeEvent.defaultPrevented) {
+      return;
+    }
 
-      setCheckedState(event.target.checked);
-      onChange?.(event);
-      otherHandler?.(event);
-    },
-  );
+    setCheckedState(event.target.checked);
+    onChange?.(event);
+    otherHandler?.(event);
+  };
 
   const {
     isFocusVisibleRef,
@@ -127,36 +127,32 @@ export default function useSwitch(props: UseSwitchProps) {
 
   const inputRef = React.useRef<any>(null);
 
-  const handleFocus = useEventCallback(
-    (event: React.FocusEvent, otherHandler?: React.FocusEventHandler) => {
-      // Fix for https://github.com/facebook/react/issues/7769
-      if (!inputRef.current) {
-        inputRef.current = event.currentTarget;
-      }
+  const handleFocus = (event: React.FocusEvent, otherHandler?: React.FocusEventHandler) => {
+    // Fix for https://github.com/facebook/react/issues/7769
+    if (!inputRef.current) {
+      inputRef.current = event.currentTarget;
+    }
 
-      handleFocusVisible(event);
-      if (isFocusVisibleRef.current === true) {
-        setFocusVisible(true);
-        onFocusVisible?.(event);
-      }
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
+      setFocusVisible(true);
+      onFocusVisible?.(event);
+    }
 
-      onFocus?.(event);
-      otherHandler?.(event);
-    },
-  );
+    onFocus?.(event);
+    otherHandler?.(event);
+  };
 
-  const handleBlur = useEventCallback(
-    (event: React.FocusEvent, otherHandler?: React.FocusEventHandler) => {
-      handleBlurVisible(event);
+  const handleBlur = (event: React.FocusEvent, otherHandler?: React.FocusEventHandler) => {
+    handleBlurVisible(event);
 
-      if (isFocusVisibleRef.current === false) {
-        setFocusVisible(false);
-      }
+    if (isFocusVisibleRef.current === false) {
+      setFocusVisible(false);
+    }
 
-      onBlur?.(event);
-      otherHandler?.(event);
-    },
-  );
+    onBlur?.(event);
+    otherHandler?.(event);
+  };
 
   const handleRefChange = useForkRef(focusVisibleRef, inputRef);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

It's best to review this PR [without whitespace changes](https://github.com/mui-org/material-ui/pull/28910/files?w=1).

I've removed references to `useEventCallback` where as far as I can tell, there would be no difference from the way it's currently used:

- in `useButton`, it was applied to functions that would create event handlers, but then these "factory" functions are called inside this file, so there's no need to maintain a stable reference to them. I've also added a `create` prefix to them to match the naming convention used in  https://github.com/mui-org/material-ui/blob/e0cdcd130db60d252c4382570844ea7278649a08/packages/mui-material/src/ClickAwayListener/ClickAwayListener.tsx#L149 for clarity.
- in `useSwitch` again the functions were not passed outside of the hook and only called inside this file, so there's no point in maintaining a stable reference
- in `SliderUnstyled` the event handlers that I've removed it from, were passed directly to `<input>` and React doesn't require them to have a stable reference: https://twitter.com/dan_abramov/status/1102708434821173249
