### PR TITLE
[docs] Update Getting Started Templates' Source URIs

### DIFF
--- a/docs/src/pages/getting-started/templates/Templates.js
+++ b/docs/src/pages/getting-started/templates/Templates.js
@@ -16,6 +16,7 @@ function layouts(t) {
       src: '/static/images/templates/dashboard.png',
       href: '/getting-started/templates/dashboard/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/dashboard',
     },
     {
@@ -24,6 +25,7 @@ function layouts(t) {
       src: '/static/images/templates/sign-in.png',
       href: '/getting-started/templates/sign-in/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sign-in',
     },
     {
@@ -32,6 +34,7 @@ function layouts(t) {
       src: '/static/images/templates/sign-in-side.png',
       href: '/getting-started/templates/sign-in-side/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sign-in-side',
     },
     {
@@ -40,6 +43,7 @@ function layouts(t) {
       src: '/static/images/templates/sign-up.png',
       href: '/getting-started/templates/sign-up/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sign-up',
     },
     {
@@ -48,6 +52,7 @@ function layouts(t) {
       src: '/static/images/templates/blog.png',
       href: '/getting-started/templates/blog/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/blog',
     },
     {
@@ -56,6 +61,7 @@ function layouts(t) {
       src: '/static/images/templates/checkout.png',
       href: '/getting-started/templates/checkout/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/checkout',
     },
     {
@@ -64,6 +70,7 @@ function layouts(t) {
       src: '/static/images/templates/album.png',
       href: '/getting-started/templates/album/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/album',
     },
     {
@@ -72,6 +79,7 @@ function layouts(t) {
       src: '/static/images/templates/pricing.png',
       href: '/getting-started/templates/pricing/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/pricing',
     },
     {
@@ -80,6 +88,7 @@ function layouts(t) {
       src: '/static/images/templates/sticky-footer.png',
       href: '/getting-started/templates/sticky-footer/',
       source:
+        // #default-branch-switch
         'https://github.com/mui-org/material-ui/tree/master/docs/src/pages/getting-started/templates/sticky-footer',
     },
   ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I recently merged #28827 which fixed the autocomplete attributes in some of the templates. However, the link to the source code for these templates is referring to the `next` branch which is way behind `master`.

This pull request updates the source URIs for the templates on the getting started page to use the `master` branch.