### PR TITLE
[docs] Update box example to use 'backgroundColor' rather than 'bgColor'

### DIFF
--- a/docs/src/pages/components/box/BoxSx.js
+++ b/docs/src/pages/components/box/BoxSx.js
@@ -7,7 +7,7 @@ export default function BoxSx() {
       sx={{
         width: 300,
         height: 300,
-        bgcolor: 'primary.dark',
+        backgroundColor: 'primary.dark',
         '&:hover': {
           backgroundColor: 'primary.main',
           opacity: [0.9, 0.8, 0.7],

--- a/docs/src/pages/components/box/BoxSx.tsx
+++ b/docs/src/pages/components/box/BoxSx.tsx
@@ -7,7 +7,7 @@ export default function BoxSx() {
       sx={{
         width: 300,
         height: 300,
-        bgcolor: 'primary.dark',
+        backgroundColor: 'primary.dark',
         '&:hover': {
           backgroundColor: 'primary.main',
           opacity: [0.9, 0.8, 0.7],

--- a/docs/src/pages/components/box/BoxSx.tsx.preview
+++ b/docs/src/pages/components/box/BoxSx.tsx.preview
@@ -2,7 +2,7 @@
   sx={{
     width: 300,
     height: 300,
-    bgcolor: 'primary.dark',
+    backgroundColor: 'primary.dark',
     '&:hover': {
       backgroundColor: 'primary.main',
       opacity: [0.9, 0.8, 0.7],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Summary

Correct the `sx` prop for background color in the example  `<BoxSx />`.

### Changes
- Update the background prop key in the `sx` prop from `bgColor` to `backgroundColor`

**Note:** checkout [The `sx` prop](https://mui.com/components/box/#the-sx-prop) for more information and working example in [codesandbox](https://codesandbox.io/s/22g0r?file=/demo.js:185-200)

### Preview (with changes):
<img width="820" alt="Screen Shot 2021-10-09 at 9 33 37 PM" src="https://user-images.githubusercontent.com/9851316/136682261-37abd139-b489-45c6-9299-e4aa5cc84e15.png">



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).