### PR TITLE
[Tabs] Alternative way to disable ":first-child is unsafe" error

### DIFF
--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -145,7 +145,7 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
   const icon =
     iconProp && label && React.isValidElement(iconProp)
       ? React.cloneElement(iconProp, {
-          className: classes.iconWrapper,
+          className: clsx(classes.iconWrapper, iconProp.props.className),
         })
       : iconProp;
   const handleClick = (event) => {

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -122,13 +122,14 @@ describe('<Tab />', () => {
     });
 
     it('should add a classname when passed together with label', () => {
-      const { getByRole } = render(<Tab icon={<div data-testid="icon" />} label="foo" />);
+      const { getByRole } = render(<Tab icon={<div className="test-icon" />} label="foo" />);
       const wrapper = getByRole('tab').children[0];
       expect(wrapper).to.have.class(classes.iconWrapper);
+      expect(wrapper).to.have.class('test-icon');
     });
 
     it('should have bottom margin when passed together with label', () => {
-      const { getByRole } = render(<Tab icon={<div data-testid="icon" />} label="foo" />);
+      const { getByRole } = render(<Tab icon={<div />} label="foo" />);
       const wrapper = getByRole('tab').children[0];
       expect(wrapper).toHaveComputedStyle({ marginBottom: '6px' });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


This PR introduces 2 alternatives to disable the **":first-child is unsafe"** error:
- Source of error: 
```
...(ownerState.icon &&
    ownerState.label && {
      ...,
      [`& > *:first-child`]: {
        marginBottom: 6,
      },
    }),
```
- https://github.com/mui-org/material-ui/pull/28890 was the first iteration. Its solution was wrapping `icon` with a `span` with a classname and target the classname for styling:
```diff
@@ -176,7 +183,8 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
       tabIndex={selected ? 0 : -1}
       {...other}
     >
-      {icon}
+      {icon && <span className={classes.icon}>{icon}</span>}
```

Since the first iteration changes the DOM rendered, I prepared two alternatives:
(1) Use `'/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */'`
- Reference: https://github.com/emotion-js/emotion/blob/main/packages/react/__tests__/warnings.js#L87
```diff
@@ -59,8 +62,10 @@ const TabRoot = styled(ButtonBase, {
        ...,
-      [`& > *:first-child`]: {
-        marginBottom: 6,
+      [`& > *`]: {
+        [`:first-child ${ignoreSsrFlag}`]: {
+          marginBottom: 6,
+        },
       },
     }),
```
- most concise solution but not supporting zero SSR configuration might not be a good idea

(2) Clone `icon` with a classname and target the classname for styling:
```diff
@@ -148,7 +148,12 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
   };
 
   const classes = useUtilityClasses(ownerState);
-
+  const icon =
+    iconProp && label && typeof iconProp !== 'string'
+      ? React.cloneElement(iconProp, {
+          className: classes.iconWrapper,
+        })
+      : iconProp;
```
- code sandbox: https://codesandbox.io/s/ecstatic-mendel-i8c43?file=/src/App.js