### PR TITLE
[Autocomplete] Don't crash during keyboard navigation when renderTags returns nothing

### DIFF
--- a/packages/mui-core/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-core/src/AutocompleteUnstyled/useAutocomplete.js
@@ -257,7 +257,7 @@ export default function useAutocomplete(props) {
     if (tagToFocus === -1) {
       inputRef.current.focus();
     } else {
-      anchorEl.querySelector(`[data-tag-index="${tagToFocus}"]`).focus();
+      anchorEl.querySelector(`[data-tag-index="${tagToFocus}"]`)?.focus();
     }
   });
 


### PR DESCRIPTION
Closes #27933 
Closes https://github.com/mui-org/material-ui/pull/27949

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
