### PR TITLE
[docs] Minor typo in v4-v5 migration docs

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2436,7 +2436,7 @@ npx @mui/codemod v5.0.0/jss-to-styled <path>
 -    backgroundColor: theme.palette.primary.main
 -  },
 -  cta: {
--    borderRadius: theme.shape.radius.
+-    borderRadius: theme.shape.radius
 -  },
 -  content: {
 -    color: theme.palette.common.white,
@@ -2457,7 +2457,7 @@ npx @mui/codemod v5.0.0/jss-to-styled <path>
 +    backgroundColor: theme.palette.primary.main
 +  },
 +  [`& .${classes.cta}`]: {
-+    borderRadius: theme.shape.radius.
++    borderRadius: theme.shape.radius
 +  },
 +  [`& .${classes.content}`]: {
 +    color: theme.palette.common.white,

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -542,7 +542,7 @@ import Typography from '@material-ui/core/Typography';
 -    backgroundColor: theme.palette.primary.main
 -  },
 -  cta: {
--    borderRadius: theme.shape.radius.
+-    borderRadius: theme.shape.radius
 -  },
 -  content: {
 -    color: theme.palette.common.white,
@@ -563,7 +563,7 @@ import Typography from '@material-ui/core/Typography';
 +    backgroundColor: theme.palette.primary.main
 +  },
 +  [`& .${classes.cta}`]: {
-+    borderRadius: theme.shape.radius.
++    borderRadius: theme.shape.radius
 +  },
 +  [`& .${classes.content}`]: {
 +    color: theme.palette.common.white,


### PR DESCRIPTION
There is a minor typo in the [JSS section of the Migration from v4 to v5](https://mui.com/guides/migration-v4/#migrate-from-jss) docs.  

The code blocks have a line ending in a dot:

```diff
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    alignItems: 'center',
-    backgroundColor: theme.palette.primary.main
-  },
-  cta: {
-    borderRadius: theme.shape.radius. // <--- here
-  },
-  content: {
-    color: theme.palette.common.white,
-    fontSize: 16,
-    lineHeight: 1.7
-  },
-}))
+const PREFIX = 'MyCard';
+const classes = {
+  root: `${PREFIX}-root`,
+  cta: `${PREFIX}-cta`,
+  content: `${PREFIX}-content`,
+}
+const Root = styled('div')(({ theme }) => ({
+  [`&.${classes.root}`]: {
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: theme.palette.primary.main
+  },
+  [`& .${classes.cta}`]: {
+    borderRadius: theme.shape.radius. // <--- here
+  },
+  [`& .${classes.content}`]: {
+    color: theme.palette.common.white, 
+    fontSize: 16,
+    lineHeight: 1.7
+  },
+}))
```

It occurs in two places and I've corrected both.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
