### PR TITLE
[core] Update `peerDependencies` to require `latest` instead of `next`

### DIFF
--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -34,7 +34,7 @@
     "test": "exit 0"
   },
   "peerDependencies": {
-    "@mui/material": "^5.0.0-rc.0",
+    "@mui/material": "^5.0.0",
     "@types/react": "^16.8.6 || ^17.0.0",
     "react": "^17.0.2"
   },

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -41,7 +41,7 @@
     "typescript": "tslint -p tsconfig.json \"src/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
-    "@mui/material": "^5.0.0-rc.0",
+    "@mui/material": "^5.0.0",
     "@types/react": "^16.8.6 || ^17.0.0",
     "react": "^17.0.2"
   },

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -36,7 +36,7 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },
   "peerDependencies": {
-    "@mui/material": "^5.0.0-rc.0",
+    "@mui/material": "^5.0.0",
     "@types/react": "^16.8.6 || ^17.0.0",
     "date-fns": "^2.25.0",
     "dayjs": "^1.10.7",


### PR DESCRIPTION
`peerDependencies` were still listing `-rc.0` instead of `latest`.