### PR TITLE
[transitions] Mark `children` as required where nullish `children` would crash at runtime

### DIFF
--- a/docs/pages/api-docs/fade.json
+++ b/docs/pages/api-docs/fade.json
@@ -1,8 +1,8 @@
 {
   "props": {
+    "children": { "type": { "name": "custom", "description": "element" }, "required": true },
     "addEndListener": { "type": { "name": "func" } },
     "appear": { "type": { "name": "bool" }, "default": "true" },
-    "children": { "type": { "name": "custom", "description": "element" } },
     "easing": {
       "type": {
         "name": "union",

--- a/docs/pages/api-docs/grow.json
+++ b/docs/pages/api-docs/grow.json
@@ -1,8 +1,8 @@
 {
   "props": {
+    "children": { "type": { "name": "custom", "description": "element" }, "required": true },
     "addEndListener": { "type": { "name": "func" } },
     "appear": { "type": { "name": "bool" }, "default": "true" },
-    "children": { "type": { "name": "custom", "description": "element" } },
     "easing": {
       "type": {
         "name": "union",

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -1,8 +1,8 @@
 {
   "props": {
+    "children": { "type": { "name": "custom", "description": "element" }, "required": true },
     "addEndListener": { "type": { "name": "func" } },
     "appear": { "type": { "name": "bool" }, "default": "true" },
-    "children": { "type": { "name": "custom", "description": "element" } },
     "container": {
       "type": { "name": "custom", "description": "HTML element<br>&#124;&nbsp;func" }
     },

--- a/docs/pages/api-docs/zoom.json
+++ b/docs/pages/api-docs/zoom.json
@@ -1,8 +1,8 @@
 {
   "props": {
+    "children": { "type": { "name": "custom", "description": "element" }, "required": true },
     "addEndListener": { "type": { "name": "func" } },
     "appear": { "type": { "name": "bool" }, "default": "true" },
-    "children": { "type": { "name": "custom", "description": "element" } },
     "easing": {
       "type": {
         "name": "union",

--- a/docs/src/pages/components/dialogs/AlertDialogSlide.tsx
+++ b/docs/src/pages/components/dialogs/AlertDialogSlide.tsx
@@ -10,7 +10,7 @@ import { TransitionProps } from '@mui/material/transitions';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
-    children?: React.ReactElement<any, any>;
+    children: React.ReactElement<any, any>;
   },
   ref: React.Ref<unknown>,
 ) {

--- a/docs/src/pages/components/dialogs/FullScreenDialog.tsx
+++ b/docs/src/pages/components/dialogs/FullScreenDialog.tsx
@@ -15,7 +15,7 @@ import { TransitionProps } from '@mui/material/transitions';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
-    children?: React.ReactElement;
+    children: React.ReactElement;
   },
   ref: React.Ref<unknown>,
 ) {

--- a/docs/src/pages/components/snackbars/TransitionsSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/TransitionsSnackbar.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import Button from '@mui/material/Button';
 import Snackbar from '@mui/material/Snackbar';
 import Fade from '@mui/material/Fade';
-import Slide from '@mui/material/Slide';
-import Grow from '@mui/material/Grow';
+import Slide, { SlideProps } from '@mui/material/Slide';
+import Grow, { GrowProps } from '@mui/material/Grow';
 import { TransitionProps } from '@mui/material/transitions';
 
-function SlideTransition(props: TransitionProps) {
+function SlideTransition(props: SlideProps) {
   return <Slide {...props} direction="up" />;
 }
 
-function GrowTransition(props: TransitionProps) {
+function GrowTransition(props: GrowProps) {
   return <Grow {...props} />;
 }
 
@@ -19,7 +19,7 @@ export default function TransitionsSnackbar() {
     open: boolean;
     Transition: React.ComponentType<
       TransitionProps & {
-        children?: React.ReactElement<any, any>;
+        children: React.ReactElement<any, any>;
       }
     >;
   }>({
@@ -31,7 +31,7 @@ export default function TransitionsSnackbar() {
     (
       Transition: React.ComponentType<
         TransitionProps & {
-          children?: React.ReactElement<any, any>;
+          children: React.ReactElement<any, any>;
         }
       >,
     ) =>

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Snackbar.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Snackbar.tsx
@@ -38,7 +38,9 @@ const styles = (theme: Theme) =>
     },
   } as const);
 
-function Transition(props: TransitionProps) {
+function Transition(
+  props: TransitionProps & { children: React.ReactElement<any, any> },
+) {
   return <Slide {...props} direction="down" />;
 }
 

--- a/packages/mui-core/src/Unstable_TrapFocus/Unstable_TrapFocus.d.ts
+++ b/packages/mui-core/src/Unstable_TrapFocus/Unstable_TrapFocus.d.ts
@@ -25,7 +25,7 @@ export interface TrapFocusProps {
   /**
    * A single child content element.
    */
-  children?: React.ReactElement<any, any>;
+  children: React.ReactElement<any, any>;
   /**
    * If `true`, the trap focus will not automatically shift focus to itself when it opens, and
    * replace it to the last focused element when it closes.

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -87,7 +87,7 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
    * @default Fade
    */
   TransitionComponent?: React.JSXElementConstructor<
-    TransitionProps & { children?: React.ReactElement<any, any> }
+    TransitionProps & { children: React.ReactElement<any, any> }
   >;
   /**
    * The duration for the transition, in milliseconds.

--- a/packages/mui-material/src/Fade/Fade.d.ts
+++ b/packages/mui-material/src/Fade/Fade.d.ts
@@ -11,7 +11,7 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
   /**
    * A single child content element.
    */
-  children?: React.ReactElement<any, any>;
+  children: React.ReactElement<any, any>;
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.

--- a/packages/mui-material/src/Fade/Fade.js
+++ b/packages/mui-material/src/Fade/Fade.js
@@ -165,7 +165,7 @@ Fade.propTypes /* remove-proptypes */ = {
   /**
    * A single child content element.
    */
-  children: elementAcceptingRef,
+  children: elementAcceptingRef.isRequired,
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.

--- a/packages/mui-material/src/Grow/Grow.d.ts
+++ b/packages/mui-material/src/Grow/Grow.d.ts
@@ -11,7 +11,7 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
   /**
    * A single child content element.
    */
-  children?: React.ReactElement<any, any>;
+  children: React.ReactElement<any, any>;
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.

--- a/packages/mui-material/src/Grow/Grow.js
+++ b/packages/mui-material/src/Grow/Grow.js
@@ -222,7 +222,7 @@ Grow.propTypes /* remove-proptypes */ = {
   /**
    * A single child content element.
    */
-  children: elementAcceptingRef,
+  children: elementAcceptingRef.isRequired,
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.

--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -114,7 +114,7 @@ export interface PopoverProps extends StandardProps<ModalProps, 'children'> {
    * @default Grow
    */
   TransitionComponent?: React.JSXElementConstructor<
-    TransitionProps & { children?: React.ReactElement<any, any> }
+    TransitionProps & { children: React.ReactElement<any, any> }
   >;
   /**
    * Set to 'auto' to automatically calculate transition time based on height.

--- a/packages/mui-material/src/Slide/Slide.d.ts
+++ b/packages/mui-material/src/Slide/Slide.d.ts
@@ -11,7 +11,7 @@ export interface SlideProps extends TransitionProps {
   /**
    * A single child content element.
    */
-  children?: React.ReactElement<any, any>;
+  children: React.ReactElement<any, any>;
   /**
    * An HTML element, or a function that returns one.
    * It's used to set the container the Slide is transitioning from.

--- a/packages/mui-material/src/Slide/Slide.js
+++ b/packages/mui-material/src/Slide/Slide.js
@@ -285,7 +285,7 @@ Slide.propTypes /* remove-proptypes */ = {
   /**
    * A single child content element.
    */
-  children: elementAcceptingRef,
+  children: elementAcceptingRef.isRequired,
   /**
    * An HTML element, or a function that returns one.
    * It's used to set the container the Slide is transitioning from.

--- a/packages/mui-material/src/Snackbar/Snackbar.d.ts
+++ b/packages/mui-material/src/Snackbar/Snackbar.d.ts
@@ -98,7 +98,7 @@ export interface SnackbarProps extends StandardProps<React.HTMLAttributes<HTMLDi
    * @default Grow
    */
   TransitionComponent?: React.JSXElementConstructor<
-    TransitionProps & { children?: React.ReactElement<any, any> }
+    TransitionProps & { children: React.ReactElement<any, any> }
   >;
   /**
    * The duration for the transition, in milliseconds.

--- a/packages/mui-material/src/Tooltip/Tooltip.d.ts
+++ b/packages/mui-material/src/Tooltip/Tooltip.d.ts
@@ -167,7 +167,7 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
    * @default Grow
    */
   TransitionComponent?: React.JSXElementConstructor<
-    TransitionProps & { children?: React.ReactElement<any, any> }
+    TransitionProps & { children: React.ReactElement<any, any> }
   >;
   /**
    * Props applied to the transition element.

--- a/packages/mui-material/src/Zoom/Zoom.d.ts
+++ b/packages/mui-material/src/Zoom/Zoom.d.ts
@@ -11,7 +11,7 @@ export interface ZoomProps extends TransitionProps {
   /**
    * A single child content element.
    */
-  children?: React.ReactElement<any, any>;
+  children: React.ReactElement<any, any>;
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.

--- a/packages/mui-material/src/Zoom/Zoom.js
+++ b/packages/mui-material/src/Zoom/Zoom.js
@@ -166,7 +166,7 @@ Zoom.propTypes /* remove-proptypes */ = {
   /**
    * A single child content element.
    */
-  children: elementAcceptingRef,
+  children: elementAcceptingRef.isRequired,
   /**
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.


### PR DESCRIPTION
Affects:
- `Fade` 
- `Grow`
- `Slide`
- `Zoom`

`Collapse` is unaffected since it actually accepts `ReactNode` due to using a wrapper div.

Closes https://github.com/mui-org/material-ui/issues/28075