### PR TITLE
docs(faq): `ThemeProvider` has no effect without `@emotion/styled`

### DIFF
--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -443,3 +443,8 @@ return (
   />
 );
 ```
+
+## I added a `ThemeProvider`. Why does the styling not change accordingly?
+
+Styling the components per [`ThemeProvider`](https://mui.com/customization/theming/#theme-provider) requires [`@emotion/styled`](https://www.npmjs.com/package/@emotion/styled).
+If the package is missing, all components render with the default theme.


### PR DESCRIPTION
I've stumbled upon this when adding storybook to a component library.
`@emotion/styled` is not required to use and reexport the `@mui/material` components. So when it is included as dependency of consuming projects everything works fine there.
But in the component library decorating with a `ThemeProvider` "obviously" has no effect.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
