### PR TITLE
[chip] disable ripple only if onDelete is present.

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -376,7 +376,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
       ? {
           component: ComponentProp || 'div',
           focusVisibleClassName: classes.focusVisible,
-          ...onDelete && { disableRipple: true },
+          ...(onDelete && { disableRipple: true }),
         }
       : {};
 

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -376,7 +376,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
       ? {
           component: ComponentProp || 'div',
           focusVisibleClassName: classes.focusVisible,
-          disableRipple: Boolean(onDelete) || undefined,
+          ...onDelete && { disableRipple: true },
         }
       : {};
 

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -376,7 +376,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
       ? {
           component: ComponentProp || 'div',
           focusVisibleClassName: classes.focusVisible,
-          disableRipple: Boolean(onDelete),
+          disableRipple: Boolean(onDelete) || undefined,
         }
       : {};
 

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -12,6 +12,7 @@ import {
 } from 'test/utils';
 import Avatar from '@mui/material/Avatar';
 import Chip, { chipClasses as classes } from '@mui/material/Chip';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CheckBox from '../internal/svg-icons/CheckBox';
 
 describe('<Chip />', () => {
@@ -86,6 +87,28 @@ describe('<Chip />', () => {
 
       expect(container.firstChild).to.have.class('MuiButtonBase-root');
       expect(container.firstChild).to.have.tagName('a');
+      expect(container.firstChild.querySelector('.MuiTouchRipple-root')).not.to.equal(null);
+    });
+
+    it('should disable ripple when MuiButtonBase has disableRipple in theme', () => {
+      const theme = createTheme({
+        components: {
+          MuiButtonBase: {
+            defaultProps: {
+              disableRipple: true,
+            },
+          },
+        },
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Chip clickable label="My Chip" />
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).to.have.class('MuiButtonBase-root');
+      expect(container.firstChild.querySelector('.MuiTouchRipple-root')).to.equal(null);
     });
 
     it('should apply user value of tabIndex', () => {
@@ -151,6 +174,14 @@ describe('<Chip />', () => {
 
       expect(getByRole('button')).to.have.property('tabIndex', 0);
       expect(container.querySelector('#avatar')).not.to.equal(null);
+    });
+
+    it('should not create ripples', () => {
+      const { container } = render(
+        <Chip avatar={<Avatar id="avatar">MB</Avatar>} onDelete={() => {}} />,
+      );
+
+      expect(container.firstChild.querySelector('.MuiTouchRipple-root')).to.equal(null);
     });
 
     it('should apply user value of tabIndex', () => {


### PR DESCRIPTION
close #29033

I pass `disableRipple` props to ButtonBase only when `onDelete` props exists. 
This will allow you to disable Ripple in clickable Chip.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
