### PR TITLE
[docs] Add JSDoc to `theme.breakpoints`

### DIFF
--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -70,8 +70,9 @@ You define your project's breakpoints in the `theme.breakpoints` section of your
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
 
 - [`theme.breakpoints.values`](/customization/default-theme/?expand-path=$.breakpoints.values): Default to the [above values](#default-breakpoints). The keys are your screen names, and the values are the min-width where that breakpoint should start.
-- `theme.breakpoints.unit`: Default to `px`. The unit used for the breakpoint's values.
-- `theme.breakpoints.step`: Default to 5 (`0.05px`). The increment used to implement exclusive breakpoints.
+- `theme.breakpoints.unit`: Default to `'px'`. The unit used for the breakpoint's values.
+- `theme.breakpoints.step`: Default to `5`. The increment divided by 100 used to implement exclusive breakpoints.
+  For example, `{ step: 5 }` means that `down(500)` will result in `'(max-width: 499.95px)'`.
 
 If you change the default breakpoints's values, you need to provide them all:
 

--- a/packages/mui-system/src/createTheme/createBreakpoints.d.ts
+++ b/packages/mui-system/src/createTheme/createBreakpoints.d.ts
@@ -59,10 +59,11 @@ export interface Breakpoints {
 
 export interface BreakpointsOptions extends Partial<Breakpoints> {
   /**
-   * The increment used to implement exclusive breakpoints.
-   * @default '0.05px'
+   * The increment divided by 100 used to implement exclusive breakpoints.
+   * For example, `step: 5` means that `down(500)` will result in `'(max-width: 499.95px)'`.
+   * @default 5
    */
-  step?: string | undefined;
+  step?: number | undefined;
   /**
    * The unit used for the breakpoint's values.
    * @default 'px'


### PR DESCRIPTION
Helps discoverability of APIs available in `theme.breakpoints` in response to feedback received in https://github.com/mui-org/material-ui/issues/29037.

This includes a type change to `createTheme({ breakpoints: { step }})` where `step` previously accepted a `string` even though we implicitly convert it to a `number` in https://github.com/mui-org/material-ui/blob/49b3469442d45329df59e524fd31a2ce6ff311cc/packages/mui-system/src/createTheme/createBreakpoints.js#L31


https://user-images.githubusercontent.com/12292047/137282208-232892b1-af98-4208-8b93-3ad6938b664d.mp4