### PR TITLE
[ListItemButton] Using link component when `href` or `to` prop passed

### DIFF
--- a/docs/pages/api-docs/list-item-button.json
+++ b/docs/pages/api-docs/list-item-button.json
@@ -13,6 +13,7 @@
     "disableGutters": { "type": { "name": "bool" } },
     "divider": { "type": { "name": "bool" } },
     "focusVisibleClassName": { "type": { "name": "string" } },
+    "LinkComponent": { "type": { "name": "elementType" }, "default": "'a'" },
     "selected": { "type": { "name": "bool" } },
     "sx": { "type": { "name": "object" } }
   },

--- a/docs/translations/api-docs/list-item-button/list-item-button.json
+++ b/docs/translations/api-docs/list-item-button/list-item-button.json
@@ -11,6 +11,7 @@
     "disableGutters": "If <code>true</code>, the left and right padding is removed.",
     "divider": "If <code>true</code>, a 1px light border is added to the bottom of the list item.",
     "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/master/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed.",
+    "LinkComponent": "The component used to render a link when the <code>href</code> prop is provided.",
     "selected": "Use to apply selected styling.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
   },

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -127,7 +127,6 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     divider = false,
     focusVisibleClassName,
     selected = false,
-    LinkComponent = 'a',
     ...other
   } = props;
 
@@ -169,7 +168,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
       <ListItemButtonRoot
         ref={handleRef}
         component={
-          component === 'div' && (other.href || other.to) ? LinkComponent : component
+          component === 'div' && (other.href || other.to) ? other.LinkComponent || 'a' : component
         }
         focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
         ownerState={ownerState}

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -127,6 +127,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     divider = false,
     focusVisibleClassName,
     selected = false,
+    LinkComponent = 'a',
     ...other
   } = props;
 
@@ -168,7 +169,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
       <ListItemButtonRoot
         ref={handleRef}
         component={
-          component === 'div' && (other.href || other.to) ? other.LinkComponent || 'a' : component
+          component === 'div' && (other.href || other.to) ? LinkComponent : component
         }
         focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
         ownerState={ownerState}
@@ -241,6 +242,15 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * if needed.
    */
   focusVisibleClassName: PropTypes.string,
+  /**
+   * @ignore
+   */
+  href: PropTypes.string,
+  /**
+   * The component used to render a link when the `href` prop is provided.
+   * @default 'a'
+   */
+  LinkComponent: PropTypes.elementType,
   /**
    * Use to apply selected styling.
    * @default false

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -167,7 +167,9 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     <ListContext.Provider value={childContext}>
       <ListItemButtonRoot
         ref={handleRef}
-        component={component}
+        component={
+          component === 'div' && (other.href || other.to) ? other.LinkComponent || 'a' : component
+        }
         focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
         ownerState={ownerState}
         {...other}

--- a/packages/mui-material/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.test.js
@@ -68,4 +68,14 @@ describe('<ListItemButton />', () => {
       expect(button).to.have.class(classes.focusVisible);
     });
   });
+
+  it('should automatically change it to an anchor element when href is provided', () => {
+    const { container } = render(<ListItemButton href="https://google.com">Hello</ListItemButton>);
+    const button = container.firstChild;
+
+    expect(button).to.have.property('nodeName', 'A');
+    expect(button).not.to.have.attribute('role');
+    expect(button).not.to.have.attribute('type');
+    expect(button).to.have.attribute('href', 'https://google.com');
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui-org/material-ui/issues/29030
