### PR TITLE
[docs] Update module augmentation reference url

### DIFF
--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -44,7 +44,7 @@ const theme = createTheme({
 });
 ```
 
-If you are using TypeScript, you would also need to use [module augmentation](/guides/typescript/#customization-of-theme) for the theme to accept the above values.
+If you are using TypeScript, you would also need to use [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) for the theme to accept the above values.
 
 ```tsx
 declare module '@mui/material/styles' {


### PR DESCRIPTION
The existing URL for Module Augmentation just took you back to the section "Customization of Theme" on the TypeScript page, which only contained a link to this page, in essence a self-reference loop that added no value. I've changed the URL to the Module Augmentation section of the Declaration Merging page of the TypeScript Documentation, which is instructive as to what Module Augmentation is. I believe this link will help future MUI advanced themers understand the concept of Module Augmentation and how it relates to custom theming.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
