### PR TITLE
[DateRangePicker] Fix `DateRangePickerDayProps` interface

### DIFF
--- a/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -41,7 +41,7 @@ export interface DateRangePickerDayClasses {
 
 export type DateRangePickerDayClassKey = keyof DateRangePickerDayClasses;
 
-export interface DateRangePickerDayProps<TDate> extends Omit<PickersDayProps<TDate>, 'classes'> {
+export interface DateRangePickerDayProps<TDate = unknown> extends Omit<PickersDayProps<TDate>, 'classes'> {
   /**
    * Set to `true` if the `day` is in a highlighted date range.
    */

--- a/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -41,7 +41,8 @@ export interface DateRangePickerDayClasses {
 
 export type DateRangePickerDayClassKey = keyof DateRangePickerDayClasses;
 
-export interface DateRangePickerDayProps<TDate = unknown> extends Omit<PickersDayProps<TDate>, 'classes'> {
+export interface DateRangePickerDayProps<TDate = unknown>
+  extends Omit<PickersDayProps<TDate>, 'classes'> {
   /**
    * Set to `true` if the `day` is in a highlighted date range.
    */

--- a/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -41,8 +41,7 @@ export interface DateRangePickerDayClasses {
 
 export type DateRangePickerDayClassKey = keyof DateRangePickerDayClasses;
 
-export interface DateRangePickerDayProps<TDate = unknown>
-  extends Omit<PickersDayProps<TDate>, 'classes'> {
+export interface DateRangePickerDayProps<TDate> extends Omit<PickersDayProps<TDate>, 'classes'> {
   /**
    * Set to `true` if the `day` is in a highlighted date range.
    */

--- a/packages/mui-lab/src/themeAugmentation/props.d.ts
+++ b/packages/mui-lab/src/themeAugmentation/props.d.ts
@@ -36,7 +36,7 @@ export interface LabComponentsPropsList {
   MuiCalendarPickerSkeleton: CalendarPickerSkeletonProps;
   MuiClockPicker: ClockPickerProps<unknown>;
   MuiDatePicker: DatePickerProps;
-  MuiDateRangePickerDay: DateRangePickerDayProps;
+  MuiDateRangePickerDay: DateRangePickerDayProps<unknown>;
   MuiDateTimePicker: DateTimePickerProps;
   MuiDesktopDateTimePicker: DesktopDateTimePickerProps;
   MuiDesktopTimePicker: DesktopTimePickerProps;


### PR DESCRIPTION
Fix for #28373.

Problem:
- npm build with tsc fails with a typescript throw

Solution:
- Follow the existing pattern of other lab components (`MuiDatePicker`, `MuiDateTimePicker`, etc…) of providing `unknown` as a default value for `TDate`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
