### PR TITLE
[CSSBaseline] Remove incorrect @deprecated annotation

### DIFF
--- a/packages/mui-material/src/styles/components.d.ts
+++ b/packages/mui-material/src/styles/components.d.ts
@@ -128,9 +128,6 @@ export interface Components {
     styleOverrides?: ComponentsOverrides['MuiContainer'];
     variants?: ComponentsVariants['MuiContainer'];
   };
-  /**
-   * @deprecated See CssBaseline.d.ts
-   */
   MuiCssBaseline?: {
     defaultProps?: ComponentsProps['MuiCssBaseline'];
     styleOverrides?: ComponentsOverrides['MuiCssBaseline'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Removes the deprecated tag as discussed in #29015

If we decided that this was intentional let me know and I can close this!

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
