### PR TITLE
[DatePicker] Fix Input not clear for invalid date

### DIFF
--- a/packages/mui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
+++ b/packages/mui-lab/src/internal/pickers/hooks/useMaskedInput.tsx
@@ -62,13 +62,25 @@ export function useMaskedInput({
   const currentInputValue = getDisplayDate(utils, rawValue, inputFormat);
   const [innerInputValue, setInnerInputValue] = React.useState(currentInputValue);
   const previousInputValueRef = React.useRef(currentInputValue);
+  const previousRawValueRef = React.useRef(rawValue);
+
   React.useEffect(() => {
     previousInputValueRef.current = currentInputValue;
   }, [currentInputValue]);
+
+  React.useEffect(() => {
+    previousRawValueRef.current = rawValue;
+  }, [rawValue]);
+
   const notTyping = !isFocused;
   const valueChanged = previousInputValueRef.current !== currentInputValue;
+  const rawValueChanged = previousRawValueRef.current !== rawValue;
   // Update the input value only if the value changed outside of typing
-  if (notTyping && valueChanged && (rawValue === null || utils.isValid(rawValue))) {
+  if (
+    notTyping &&
+    (valueChanged || rawValueChanged) &&
+    (rawValue === null || utils.isValid(rawValue))
+  ) {
     if (currentInputValue !== innerInputValue) {
       setInnerInputValue(currentInputValue);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: #29001 

In `useMaskedInput hook` when there is invalid date so current value is set to empty `""` string. then it check is valid changed or not. that's why value is not set to clear after invalid date.

I added another check for `rawValue` and check if rawValue change or not. If yes then set new value.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
