### PR TITLE
(LoadingButton) Improve spacing for text variant in ButtonStartIcon/ButtonEndIcon

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -256,6 +256,9 @@ const ButtonStartIcon = styled('span', {
   ...(ownerState.size === 'small' && {
     marginLeft: -2,
   }),
+  ...(ownerState.variant === 'text' && {
+    marginRight: 16,
+  }),
   ...commonIconStyles(ownerState),
 }));
 
@@ -273,6 +276,9 @@ const ButtonEndIcon = styled('span', {
   marginLeft: 8,
   ...(ownerState.size === 'small' && {
     marginRight: -2,
+  }),
+  ...(ownerState.variant === 'text' && {
+    marginLeft: 16,
   }),
   ...commonIconStyles(ownerState),
 }));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29066 