### PR TITLE
Fix the position of the CodeRounded icon to the center.

### DIFF
--- a/docs/src/components/showcase/TaskCard.tsx
+++ b/docs/src/components/showcase/TaskCard.tsx
@@ -112,7 +112,13 @@ export default function TaskCard() {
                 p: '2px',
               }}
             >
-              <CodeRounded color="primary" />
+              <CodeRounded
+                color="primary"
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                }}
+              />
             </Box>
             <Typography variant="h6" component="div" sx={{ mt: 1.5, fontWeight: 500 }}>
               Check the docs for getting every component API


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The CodeRounded icon on the TaskCard of the hero of https://mui.com/ was off-centered in the lower left corner, and has been fixed as shown in the image
## before 

<img width="383" alt="screenshot 2021-10-15 18 34 29" src="https://user-images.githubusercontent.com/44772513/137466446-7a13f023-905a-41ce-bf05-77c1308115cd.png">


## after

<img width="376" alt="screenshot 2021-10-15 18 34 05" src="https://user-images.githubusercontent.com/44772513/137466402-8f86ccc7-9f6e-4aa9-a9c4-3b4300cdabe7.png">
