### PR TITLE
[LoadingButton] Improve spacing for text variant in ButtonStartIcon/ButtonEndIcon

### DIFF
--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -101,9 +101,14 @@ const LoadingButtonLoadingIndicator = styled('div', {
   position: 'absolute',
   visibility: 'visible',
   display: 'flex',
-  ...(ownerState.loadingPosition === 'start' && {
-    left: 14,
-  }),
+  ...(ownerState.loadingPosition === 'start' &&
+    (ownerState.variant === 'outlined' || ownerState.variant === 'contained') && {
+      left: 14,
+    }),
+  ...(ownerState.loadingPosition === 'start' &&
+    (ownerState.variant === 'text' || !ownerState.variant) && {
+      left: 6,
+    }),
   ...(ownerState.loadingPosition === 'center' && {
     left: '50%',
     transform: 'translate(-50%)',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29066
