### PR TITLE
[TextField] Fix invisible wrap within notched inputs

### DIFF
--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -40,6 +40,7 @@ const NotchedOutlineLegend = styled('legend', { skipSx: true })(({ ownerState, t
       duration: 50,
       easing: theme.transitions.easing.easeOut,
     }),
+    whiteSpace: 'nowrap',
     '& > span': {
       paddingLeft: 5,
       paddingRight: 5,


### PR DESCRIPTION
For a while, there exists a bug in notched inputs, when the label consists of more than three words. Basically, the `legend` in the `fieldset` is, when not in notched state, set to a width of `0.01px`. This leads to the invisible text wrapping around multiple lines, specifically out of the text field.

The effect can be clearly seen when the input is in a dialog, as demonstrated here:
https://codesandbox.io/s/blissful-swartz-di456?file=/src/App.js

This PR sets the label `white-space` to `nowrap`, so that the invisible label is no more overflowing out of the input.
