### PR TITLE
[docs] Add next.js styled-component guide and update links to example

### DIFF
--- a/docs/src/pages/guides/styled-engine/styled-engine.md
+++ b/docs/src/pages/guides/styled-engine/styled-engine.md
@@ -97,6 +97,7 @@ If you are using create-react-app, there is a ready-to-use template in the examp
 You can use these `styled-component` examples as a reference:
 
 <!-- #default-branch-switch -->
+
 - [create-react-app](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-styled-components)
 - [create-react-app with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript)
 - [Next.js](https://github.com/mui-org/material-ui/tree/master/examples/nextjs-with-styled-components-typescript)


### PR DESCRIPTION
### Summary

Add information about adding support for `styled-components` using `next.js`.

I think given the configuration is more involved when using Next.js, It makes sense to add a bit more information about it.


### Changes

- Add a `Next.js` section to the styled engine guide
- Touch up “Ready-to-use examples“ example section and update links

### Preview


<img width="828" alt="Screen Shot 2021-10-17 at 11 43 43 AM" src="https://user-images.githubusercontent.com/9851316/137640650-96c6b2e2-62f7-4d80-a18f-511e4c3b11e4.png">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
