### PR TITLE
[docs] Add AppBar demo for enable color on dark

### DIFF
--- a/docs/src/pages/components/app-bar/ColorAppBarOnDark.js
+++ b/docs/src/pages/components/app-bar/ColorAppBarOnDark.js
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import SearchIcon from '@mui/icons-material/Search';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import MoreIcon from '@mui/icons-material/MoreVert';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export default function ColorAppBarOnDark() {
+  return (
+    <ThemeProvider
+      theme={createTheme({
+        components: {
+          MuiAppBar: {
+            defaultProps: {
+              enableColorOnDark: true,
+            },
+          },
+        },
+      })}
+    >
+      <Box sx={{ flexGrow: 1 }}>
+        <AppBar position="static" color="primary">
+          <Toolbar>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              MUI
+            </Typography>
+            <IconButton size="large" aria-label="search" color="inherit">
+              <SearchIcon />
+            </IconButton>
+            <IconButton
+              size="large"
+              aria-label="display more actions"
+              edge="end"
+              color="inherit"
+            >
+              <MoreIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/docs/src/pages/components/app-bar/ColorAppBarOnDark.tsx
+++ b/docs/src/pages/components/app-bar/ColorAppBarOnDark.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import SearchIcon from '@mui/icons-material/Search';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import MoreIcon from '@mui/icons-material/MoreVert';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export default function ColorAppBarOnDark() {
+  return (
+    <ThemeProvider
+      theme={createTheme({
+        components: {
+          MuiAppBar: {
+            defaultProps: {
+              enableColorOnDark: true,
+            },
+          },
+        },
+      })}
+    >
+      <Box sx={{ flexGrow: 1 }}>
+        <AppBar position="static" color="primary">
+          <Toolbar>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              MUI
+            </Typography>
+            <IconButton size="large" aria-label="search" color="inherit">
+              <SearchIcon />
+            </IconButton>
+            <IconButton
+              size="large"
+              aria-label="display more actions"
+              edge="end"
+              color="inherit"
+            >
+              <MoreIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/docs/src/pages/components/app-bar/app-bar.md
+++ b/docs/src/pages/components/app-bar/app-bar.md
@@ -142,11 +142,15 @@ function HideOnScroll(props) {
 Following the [Material Design guidelines](https://material.io/design/color/dark-theme.html), the `color` prop has no effect on the appearance of the AppBar in dark mode.
 You can override this behavior by setting the `enableColorOnDark` prop to `true`.
 
-```jsx
-// Specific element via prop
-<AppBar enableColorOnDark />
+Enable color on dark for specific elements via prop
 
-// Affect all AppBars via theme
+```jsx
+<AppBar enableColorOnDark />
+```
+
+Affect all AppBars via theme
+
+```jsx
 <ThemeProvider
   theme={createTheme({
     components: {
@@ -161,3 +165,5 @@ You can override this behavior by setting the `enableColorOnDark` prop to `true`
   <AppBar />
 </ThemeProvider>
 ```
+
+{{"demo": "pages/components/app-bar/ColorAppBarOnDark.js", "bg": true}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

A showcase on how to enable AppBar color on dark mode 
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

@siriwatknp Please can you review 