### PR TITLE
[Button] Fix loading indicator position when using 'medium' size 'text' variant button

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -158,7 +158,7 @@ const ButtonRoot = styled(ButtonBase, {
       }),
     },
     ...(ownerState.variant === 'text' && {
-      padding: '6px 8px',
+      padding: '5px 15px',
     }),
     ...(ownerState.variant === 'text' &&
       ownerState.color !== 'inherit' && {


### PR DESCRIPTION
close #29066 

Before:
<img width="170" alt="Screen Shot 2021-10-18 at 12 41 49 PM" src="https://user-images.githubusercontent.com/11153775/137781842-9829a664-a7c9-47f0-ac11-dc9d053a7a33.png">

After:
<img width="133" alt="Screen Shot 2021-10-18 at 12 42 26 PM" src="https://user-images.githubusercontent.com/11153775/137781845-b9e024ac-1d50-475c-87d9-ce1aff6f6094.png">

