### PR TITLE
Fix status label overflow in AdvancedShowcase

### DIFF
--- a/docs/src/components/x-grid/EditStatus.tsx
+++ b/docs/src/components/x-grid/EditStatus.tsx
@@ -66,7 +66,7 @@ export default function EditStatus(props: GridRenderEditCellParams) {
             <ListItemIcon>
               <IconComponent />
             </ListItemIcon>
-            <ListItemText primary={label} />
+            <ListItemText primary={label} sx={{ overflow: 'hidden' }} />
           </MenuItem>
         );
       })}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Closes #28723.

I went with hiding the overflow since it's the least intrusive (compared to e.g. adjusting the width of the data-grid) and shows the most content (compared to e.g. using `text-overflow: "ellipsis"`).
