### PR TITLE
[docs] Set default value for filterOptions

### DIFF
--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -30,7 +30,7 @@
     "disabledItemsFocusable": { "type": { "name": "bool" } },
     "disableListWrap": { "type": { "name": "bool" } },
     "disablePortal": { "type": { "name": "bool" } },
-    "filterOptions": { "type": { "name": "func" } },
+    "filterOptions": { "type": { "name": "func" }, "default": "fuzzy text match" },
     "filterSelectedOptions": { "type": { "name": "bool" } },
     "forcePopupIcon": {
       "type": { "name": "union", "description": "'auto'<br>&#124;&nbsp;bool" },


### PR DESCRIPTION
By [default](https://github.com/mui-org/material-ui/blob/512896973499adbbda057e7f3685d1b23cc02de9/packages/mui-core/src/AutocompleteUnstyled/useAutocomplete.js#L64), options are filtered through fuzzy match. This is confusing when the docs don't have any default, setting the expectation that the options provided should not be filtered based on the value.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
