### PR TITLE
[internal] Order repro methods by preference

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -27,10 +27,11 @@ labels: 'status: needs triage'
 ## Steps to Reproduce 🕹
 
 <!--
-  Provide a link to a live example (you can use codesandbox.io) and an unambiguous set of steps to reproduce this bug.
-  Include code to reproduce, if relevant (which it most likely is).
-
   You should use the official codesandbox template as a starting point: https://mui.com/r/issue-template-next
+
+  If that's not sufficient, please create a cloneable repository.
+
+  Pieces of code will result in a slower response time since a maintainer has to do additional work to reproduce the problem.
 
   If you have an issue concerning TypeScript please start from this TypeScript playground: https://mui.com/r/ts-issue-template
 


### PR DESCRIPTION
1. codesandbox
2. cloneable repo
3. code

And explain why bits of code are bad.
