### PR TITLE
[InputBase] Remove wrong theme overriding with MUI's default theme

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -9,7 +9,6 @@ import FormControlContext from '../FormControl/FormControlContext';
 import useFormControl from '../FormControl/useFormControl';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
-import useTheme from '../styles/useTheme';
 import capitalize from '../utils/capitalize';
 import useForkRef from '../utils/useForkRef';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
@@ -268,8 +267,6 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
     ...other
   } = props;
 
-  const theme = useTheme();
-
   const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
   const { current: isControlled } = React.useRef(value != null);
 
@@ -498,7 +495,6 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
         {...rootProps}
         {...(!isHostComponent(Root) && {
           ownerState: { ...ownerState, ...rootProps.ownerState },
-          theme,
         })}
         ref={ref}
         onClick={handleClick}
@@ -530,7 +526,6 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
             {...(!isHostComponent(Input) && {
               as: InputComponent,
               ownerState: { ...ownerState, ...inputProps.ownerState },
-              theme,
             })}
             ref={handleInputRef}
             className={clsx(classes.input, inputProps.className, inputPropsProp.className)}

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -8,6 +8,8 @@ import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 import Select from '@mui/material/Select';
 import InputBase, { inputBaseClasses as classes } from '@mui/material/InputBase';
+import { createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@emotion/react';
 
 describe('<InputBase />', () => {
   const render = createClientRender();
@@ -655,6 +657,28 @@ describe('<InputBase />', () => {
       const inputRef = React.createRef();
       const { container } = render(<InputBase multiline inputRef={inputRef} />);
       expect(inputRef.current).to.equal(container.querySelector('textarea'));
+    });
+  });
+
+  describe('prop: focused', () => {
+    it('should render correct border color with `ThemeProvider` imported from `@emotion/react`', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const theme = createTheme({
+        palette: {
+          primary: {
+            main: 'rgb(0, 191, 165)',
+          },
+        },
+      });
+      const { getByRole } = render(
+        <ThemeProvider theme={theme}>
+          <TextField focused label="Your email" />
+        </ThemeProvider>,
+      );
+      const fieldset = getByRole('textbox').nextSibling;
+      expect(fieldset).toHaveComputedStyle({ borderColor: 'rgb(0, 191, 165)' });
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/29126

As a solution to this issue "**[TextField] Using `ThemeProvider` of `@emotion/react` doesn't apply custom theme to border**", this PR removes the unnecessary/wrong act of applying default mui theme in `InputBase`.

Before:
- [codesandbox](https://codesandbox.io/s/charming-violet-kbs5i?file=/src/Demo.tsx)

After:
- [codesandbox](https://codesandbox.io/s/rough-night-2cp4x?file=/src/Demo.tsx)