### PR TITLE
[CardMedia] Apply specified `img` role instead of custom `image` role

### DIFF
--- a/packages/mui-material/src/CardMedia/CardMedia.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.js
@@ -64,7 +64,7 @@ const CardMedia = React.forwardRef(function CardMedia(inProps, ref) {
     <CardMediaRoot
       className={clsx(classes.root, className)}
       as={component}
-      role={!isMediaComponent && image ? 'image' : undefined}
+      role={!isMediaComponent && image ? 'img' : undefined}
       ref={ref}
       style={composedStyle}
       ownerState={ownerState}

--- a/packages/mui-material/src/CardMedia/CardMedia.test.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.test.js
@@ -18,11 +18,11 @@ describe('<CardMedia />', () => {
     skip: ['componentsProp'],
   }));
 
-  it('has the image role if `image` is defined', () => {
+  it('has the img role if `image` is defined', () => {
     const { container } = render(<CardMedia image="/fake.png" />);
 
     const cardMedia = container.firstChild;
-    expect(cardMedia).to.have.attribute('role', 'image');
+    expect(cardMedia).to.have.attribute('role', 'img');
   });
 
   it('should have the backgroundImage specified', () => {


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/pull/27676#issuecomment-947051165
See https://www.w3.org/TR/wai-aria-1.2/#img