### PR TITLE
[docs] Fix typo in CSP policy

### DIFF
--- a/docs/src/pages/guides/content-security-policy/content-security-policy.md
+++ b/docs/src/pages/guides/content-security-policy/content-security-policy.md
@@ -36,7 +36,7 @@ You then apply this nonce to the CSP header. A CSP header might look like this w
 
 ```js
 header('Content-Security-Policy').set(
-  `default-src 'self'; style-src: 'self' 'nonce-${nonce}';`,
+  `default-src 'self'; style-src 'self' 'nonce-${nonce}';`,
 );
 ```
 


### PR DESCRIPTION
I noticed when copy-pasting the example that there should be no colon (didn't work for me, at least, until I removed the colon and MDN documentation seems to agree: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
