### PR TITLE
[NProgressBar] Use GlobalStyles instead of withStyles

### DIFF
--- a/packages/mui-docs/src/NProgressBar/NProgressBar.js
+++ b/packages/mui-docs/src/NProgressBar/NProgressBar.js
@@ -8,6 +8,8 @@ import { exactProp } from '@mui/utils';
 
 NProgress.configure({
   barSelector: '.nprogress-bar',
+  // `(first|last)-child` classes are used instead of `:(first|last)-child` selectors.
+  // `:(first|last)-child` are not safe for SSR since Emotion may insert <style> elements: https://github.com/emotion-js/emotion/issues/1059#issuecomment-444566635
   template: `
     <div class="nprogress-bar">
       <div class="nprogress-bar-first-child"></div>


### PR DESCRIPTION
Review by commit advised.

1. Was using undeclared dependency `@mui/styles` (now uses `@mui/material/styles`)
2. Was using JSS instead of used styled-engine (now uses `@mui/material/styles`)