### PR TITLE
[codemod] Support new package name in `link-underline-hover` transformer

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/link-underline-hover.js
+++ b/packages/mui-codemod/src/v5.0.0/link-underline-hover.js
@@ -16,6 +16,7 @@ export default function transformer(file, api, options) {
       node.specifiers.forEach((s) => {
         if (s.type === 'ImportDefaultSpecifier') {
           jsxLinkNames.push(s.local.name);
+          node.source.value = node.source.value.replace('@material-ui/core', '@mui/material');
         }
       });
     });
@@ -27,6 +28,7 @@ export default function transformer(file, api, options) {
       node.specifiers.forEach((s) => {
         if (s.imported.name === 'Link') {
           jsxLinkNames.push(s.local.name);
+          node.source.value = node.source.value.replace('@material-ui/core', '@mui/material');
         }
       });
     });

--- a/packages/mui-codemod/src/v5.0.0/link-underline-hover.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/link-underline-hover.test/actual.js
@@ -1,13 +1,9 @@
 import Link from 'next/Link';
 import MaterialLink from '@material-ui/core/Link';
 import { Link as MuiLink } from '@material-ui/core';
-import MaterialLink2 from '@mui/material/Link';
-import { Link as MuiLink2 } from '@mui/material';
 
 <>
   <Link />
   <MaterialLink />
   <MuiLink />
-  <MaterialLink2 />
-  <MuiLink2 />
 </>;

--- a/packages/mui-codemod/src/v5.0.0/link-underline-hover.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/link-underline-hover.test/expected.js
@@ -1,13 +1,9 @@
 import Link from 'next/Link';
-import MaterialLink from '@material-ui/core/Link';
-import { Link as MuiLink } from '@material-ui/core';
-import MaterialLink2 from '@mui/material/Link';
-import { Link as MuiLink2 } from '@mui/material';
+import MaterialLink from "@mui/material/Link";
+import { Link as MuiLink } from "@mui/material";
 
 <>
   <Link />
   <MaterialLink underline="hover" />
   <MuiLink underline="hover" />
-  <MaterialLink2 underline="hover" />
-  <MuiLink2 underline="hover" />
 </>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This codemod is not a part of the `preset-safe` transformer, so it should be able to transform import from both `@material-ui/core` and `@mui/material`.

close #29163

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
