### PR TITLE
[Rating] Don't generate a random `name` on the client

### DIFF
--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -310,7 +310,7 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
     icon = defaultIcon,
     IconContainerComponent = IconContainer,
     max = 5,
-    name: nameProp,
+    name,
     onChange,
     onChangeActive,
     onMouseLeave,
@@ -321,8 +321,6 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
     value: valueProp,
     ...other
   } = props;
-
-  const name = useId(nameProp);
 
   const [valueDerived, setValueState] = useControlled({
     controlled: valueProp,

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -144,6 +144,10 @@ describe('<Rating />', () => {
 
     [
       {
+        ratingProps: { defaultValue: 2 },
+        formData: [],
+      },
+      {
         ratingProps: { name: 'rating', defaultValue: 2 },
         formData: [['rating', '2']],
       },


### PR DESCRIPTION
On hold until https://github.com/mui-org/material-ui/issues/19870 is considered

Considering that `React.useId` may only work with a hardcoded list of attributes (https://github.com/reactwg/react-18/discussions/111#discussioncomment-1517180), I looked at our usage of `useId`. I don't think it makes sense to generate a random `name` for an `input`. The name is only relevant when submitting the corresponding form. But if you have a random name you can't know which input it corresponds to. Right now you could assume that these randomly named elements are `Rating`. But there's no guarantee this remains that way i.e. new inputs may start to contain random names (with our previous thinking).

It might also be desired that unnamed `Rating` is not submitted. But that's not achievable with the previous behavior of `Rating`.

Did some manual testing with keyboard navigation and could not find any regressions. So if the previous  random `name` implemented some behavior, it was neither tested nor documented.