### PR TITLE
[styled-engine] Revert changes to peer dependencies

### DIFF
--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -41,8 +41,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@types/styled-components": "^5.1.15",
-    "styled-components": "^5.3.3"
+    "@types/styled-components": "^5.1.14",
+    "styled-components": "^5.3.1"
   },
   "peerDependenciesMeta": {
     "@types/styled-components": {

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -43,7 +43,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@emotion/react": "^11.5.0",
+    "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
     "react": "^17.0.2"
   },


### PR DESCRIPTION
These would've been breaking changes. Need to teach Renovate to not do this.