### PR TITLE
[system] Support `sx` prop of function type in extendSxProp()

### DIFF
--- a/packages/mui-system/src/styleFunctionSx/extendSxProp.js
+++ b/packages/mui-system/src/styleFunctionSx/extendSxProp.js
@@ -21,8 +21,13 @@ export default function extendSxProp(props) {
   const { sx: inSx, ...other } = props;
   const { systemProps, otherProps } = splitProps(other);
 
+  let inSxStyles = inSx;
+  if (inSx && typeof inSx === 'function') {
+    inSxStyles = inSx();
+  }
+
   return {
     ...otherProps,
-    sx: { ...systemProps, ...inSx },
+    sx: { ...systemProps, ...inSxStyles },
   };
 }

--- a/packages/mui-system/src/styleFunctionSx/extendSxProp.test.js
+++ b/packages/mui-system/src/styleFunctionSx/extendSxProp.test.js
@@ -11,7 +11,7 @@ describe('extendSxProp', () => {
     });
   });
 
-  it('should merge system props with the sx prop', () => {
+  it('should merge system props with the sx prop of object type', () => {
     expect(extendSxProp({ mb: 2, mt: [1, 2, 3], sx: { mr: 2, mb: 1 } })).to.deep.equal({
       sx: {
         mb: 1,
@@ -21,8 +21,28 @@ describe('extendSxProp', () => {
     });
   });
 
-  it('should not process non system props', () => {
+  it('should not process non system props with the sx prop of object type', () => {
     expect(extendSxProp({ ariaLabel: 'label', sx: { mr: 2, mb: 1 } })).to.deep.equal({
+      sx: {
+        mr: 2,
+        mb: 1,
+      },
+      ariaLabel: 'label',
+    });
+  });
+
+  it('should merge system props with the sx prop of function type', () => {
+    expect(extendSxProp({ mb: 2, mt: [1, 2, 3], sx: () => ({ mr: 2, mb: 1 }) })).to.deep.equal({
+      sx: {
+        mb: 1,
+        mt: [1, 2, 3],
+        mr: 2,
+      },
+    });
+  });
+
+  it('should not process non system props with the sx prop of function type', () => {
+    expect(extendSxProp({ ariaLabel: 'label', sx: () => ({ mr: 2, mb: 1 }) })).to.deep.equal({
       sx: {
         mr: 2,
         mb: 1,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Continuation of https://github.com/mui-org/material-ui/pull/29198