### PR TITLE
[website] Fix typo on the About Page

### DIFF
--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -678,7 +678,7 @@ function AboutContent() {
           <Grid item xs={12} sm={6} md={4}>
             <Widget
               icon={<LocalAtmRoundedIcon fontSize="small" color="primary" />}
-              title="Suport us financially"
+              title="Support us financially"
             >
               <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                 If you use MUI in a commercial project and would like to support its continued


### PR DESCRIPTION
 I've fixed a small typo that I noticed on the About Page of the MUI Website.
 Please let me know if I can make any more changes.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
