### PR TITLE
[system] Fix executing server-side Emotion component as function interpolation

### DIFF
--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -112,6 +112,9 @@ export default function createStyled(input = {}) {
     const muiStyledResolver = (styleArg, ...expressions) => {
       const expressionsWithDefaultTheme = expressions
         ? expressions.map((stylesArg) => {
+            // On the server emotion doesn't use React.forwardRef for creating components, so the created
+            // component stays as a function. This condition makes sure that we do not interpolate functions
+            // which are basically components used as a selectors.
             // eslint-disable-next-line no-underscore-dangle
             return typeof stylesArg === 'function' && stylesArg.__emotion_real !== stylesArg
               ? ({ theme: themeInput, ...other }) => {


### PR DESCRIPTION
fixes https://github.com/mui-org/material-ui/issues/29078

On the server we don't use `React.forwardRef` so the created component stays as a function (when it is a `forwardRef` object on the client-side). This made you to execute this function as an interpolation when the user has been using a component as a selector (so they interpolated a component into the template string):
https://github.com/emotion-js/emotion/blob/4be3391914878fd41279701bc23332b75903ec43/packages/react/src/context.js#L44-L67

