### PR TITLE
[IconButton] remove on hover effect when disableRipple is set

### DIFF
--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -71,20 +71,21 @@ const IconButtonRoot = styled(ButtonBase, {
     ...(ownerState.color === 'inherit' && {
       color: 'inherit',
     }),
-    ...(!ownerState.disableRipple &&
-      ownerState.color !== 'inherit' &&
+    ...(ownerState.color !== 'inherit' &&
       ownerState.color !== 'default' && {
         color: theme.palette[ownerState.color].main,
-        '&:hover': {
-          backgroundColor: alpha(
-            theme.palette[ownerState.color].main,
-            theme.palette.action.hoverOpacity,
-          ),
-          // Reset on touch devices, it doesn't add specificity
-          '@media (hover: none)': {
-            backgroundColor: 'transparent',
+        ...(!ownerState.disableRipple && {
+          '&:hover': {
+            backgroundColor: alpha(
+              theme.palette[ownerState.color].main,
+              theme.palette.action.hoverOpacity,
+            ),
+            // Reset on touch devices, it doesn't add specificity
+            '@media (hover: none)': {
+              backgroundColor: 'transparent',
+            },
           },
-        },
+        }),
       }),
     ...(ownerState.size === 'small' && {
       padding: 5,

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -51,13 +51,15 @@ const IconButtonRoot = styled(ButtonBase, {
     transition: theme.transitions.create('background-color', {
       duration: theme.transitions.duration.shortest,
     }),
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.action.active, theme.palette.action.hoverOpacity),
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: 'transparent',
+    ...(!ownerState.disableRipple && {
+      '&:hover': {
+        backgroundColor: alpha(theme.palette.action.active, theme.palette.action.hoverOpacity),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: 'transparent',
+        },
       },
-    },
+    }),
     ...(ownerState.edge === 'start' && {
       marginLeft: ownerState.size === 'small' ? -3 : -12,
     }),

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -71,7 +71,8 @@ const IconButtonRoot = styled(ButtonBase, {
     ...(ownerState.color === 'inherit' && {
       color: 'inherit',
     }),
-    ...(ownerState.color !== 'inherit' &&
+    ...(!ownerState.disableRipple &&
+      ownerState.color !== 'inherit' &&
       ownerState.color !== 'default' && {
         color: theme.palette[ownerState.color].main,
         '&:hover': {

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -34,13 +34,14 @@ describe('<IconButton />', () => {
     expect(container.querySelector('.touch-ripple')).not.to.equal(null);
   });
 
-  it('can disable the ripple', () => {
-    const { container } = render(
+  it('can disable the ripple and hover effect', () => {
+    const { container, getByRole } = render(
       <IconButton disableRipple TouchRippleProps={{ className: 'touch-ripple' }}>
         book
       </IconButton>,
     );
     expect(container.querySelector('.touch-ripple')).to.equal(null);
+    expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.equal('transparent');
   });
 
   describe('prop: size', () => {

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -41,8 +41,8 @@ describe('<IconButton />', () => {
       </IconButton>,
     );
     expect(container.querySelector('.touch-ripple')).to.equal(null);
-    expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.not.equal(
-      'rgba(156, 39, 176, 0.04)',
+    expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.equal(
+      getComputedStyle(getByRole('button')).backgroundColor,
     );
   });
 

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -34,16 +34,18 @@ describe('<IconButton />', () => {
     expect(container.querySelector('.touch-ripple')).not.to.equal(null);
   });
 
-  it('can disable the ripple and hover effect', () => {
-    const { container, getByRole } = render(
-      <IconButton disableRipple TouchRippleProps={{ className: 'touch-ripple' }}>
-        book
-      </IconButton>,
-    );
-    expect(container.querySelector('.touch-ripple')).to.equal(null);
-    expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.equal(
-      getComputedStyle(getByRole('button')).backgroundColor,
-    );
+  ['default', 'primary'].forEach((color) => {
+    it(`can disable the ripple and hover effect for color ${color}`, () => {
+      const { container, getByRole } = render(
+        <IconButton disableRipple color={color} TouchRippleProps={{ className: 'touch-ripple' }}>
+          book
+        </IconButton>,
+      );
+      expect(container.querySelector('.touch-ripple')).to.equal(null);
+      expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.equal(
+        getComputedStyle(getByRole('button')).backgroundColor,
+      );
+    });
   });
 
   describe('prop: size', () => {

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -41,7 +41,9 @@ describe('<IconButton />', () => {
       </IconButton>,
     );
     expect(container.querySelector('.touch-ripple')).to.equal(null);
-    expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.equal('transparent');
+    expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.not.equal(
+      'rgba(156, 39, 176, 0.04)',
+    );
   });
 
   describe('prop: size', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Added a check for the `disableRipple` prop before adding the on-hover background color styling.

Addresses #11108 
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
