### PR TITLE
[internal] Don't bump peer dependency ranges on dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,10 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
       "groupName": "babel",
       "matchPackagePatterns": "@babel/*"
     },


### PR DESCRIPTION
Follow-up to https://github.com/mui-org/material-ui/pull/29283.

