### PR TITLE
[system] Add `not` operator to `breakpoints`

### DIFF
--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -31,6 +31,7 @@ The theme provides four styles helpers to do so:
 - [theme.breakpoints.up(key)](#theme-breakpoints-up-key-media-query)
 - [theme.breakpoints.down(key)](#theme-breakpoints-down-key-media-query)
 - [theme.breakpoints.only(key)](#theme-breakpoints-only-key-media-query)
+- [theme.breakpoints.not(key)](#theme-breakpoints-not-key-media-query)
 - [theme.breakpoints.between(start, end)](#theme-breakpoints-between-start-end-media-query)
 
 In the following demo, we change the background color (red, blue & green) based on the screen width.
@@ -227,9 +228,9 @@ const styles = (theme) => ({
 const styles = (theme) => ({
   root: {
     backgroundColor: 'blue',
-    // Match md)[md + 1
-    //       md)[lg
-    //       900px)[1200px
+    // Match [xs, md) and [md + 1, ∞)
+    //       [xs, md) and [lg, ∞)
+    //       [0px, 900px) and [1200px, ∞)
     [theme.breakpoints.not('md')]: {
       backgroundColor: 'red',
     },

--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -209,6 +209,34 @@ const styles = (theme) => ({
 });
 ```
 
+### `theme.breakpoints.not(key) => media query`
+
+<!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
+
+#### Arguments
+
+1. `key` (_string_): A breakpoint key (`xs`, `sm`, etc.).
+
+#### Returns
+
+`media query`: A media query string ready to be used with most styling solutions, which matches screen widths stopping at the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive).
+
+#### Examples
+
+```js
+const styles = (theme) => ({
+  root: {
+    backgroundColor: 'blue',
+    // Match md)[md + 1
+    //       md)[lg
+    //       900px)[1200px
+    [theme.breakpoints.not('md')]: {
+      backgroundColor: 'red',
+    },
+  },
+});
+```
+
 ### `theme.breakpoints.between(start, end) => media query`
 
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->

--- a/packages/mui-system/src/createTheme/createBreakpoints.d.ts
+++ b/packages/mui-system/src/createTheme/createBreakpoints.d.ts
@@ -55,6 +55,12 @@ export interface Breakpoints {
    * @see [API documentation](https://mui.com/customization/breakpoints/#theme-breakpoints-only-key-media-query)
    */
   only: (key: Breakpoint) => string;
+  /**
+   * @param key - A breakpoint key (`xs`, `sm`, etc.).
+   * @returns A media query string ready to be used with most styling solutions, which matches screen widths stopping at
+   *          the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive).
+   */
+  not: (key: Breakpoint) => string;
 }
 
 export interface BreakpointsOptions extends Partial<Breakpoints> {

--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -55,6 +55,21 @@ export default function createBreakpoints(breakpoints) {
     return up(key);
   }
 
+  function not(key) {
+    const keyIndex = keys.indexOf(key);
+    if (keyIndex === 0) {
+      return up(keys[1]);
+    }
+    if (keyIndex === keys.length - 1) {
+      return down(keys[keyIndex]);
+    }
+
+    return (
+      `@media not all and (min-width:${values[key]}${unit}) and ` +
+      `(max-width:${values[keys[keyIndex + 1]] - step / 100}${unit})`
+    );
+  }
+
   return {
     keys,
     values,
@@ -62,6 +77,7 @@ export default function createBreakpoints(breakpoints) {
     down,
     between,
     only,
+    not,
     unit,
     ...other,
   };

--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -56,7 +56,16 @@ export default function createBreakpoints(breakpoints) {
   }
 
   function not(key) {
-    return only(key).replace('@media', '@media not all and');
+    // handle first and last key separately, for better readability
+    const keyIndex = keys.indexOf(key);
+    if (keyIndex === 0) {
+      return up(keys[1]);
+    }
+    if (keyIndex === keys.length - 1) {
+      return down(keys[keyIndex]);
+    }
+
+    return between(key, keys[keys.indexOf(key) + 1]).replace('@media', '@media not all and');
   }
 
   return {

--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -56,18 +56,7 @@ export default function createBreakpoints(breakpoints) {
   }
 
   function not(key) {
-    const keyIndex = keys.indexOf(key);
-    if (keyIndex === 0) {
-      return up(keys[1]);
-    }
-    if (keyIndex === keys.length - 1) {
-      return down(keys[keyIndex]);
-    }
-
-    return (
-      `@media not all and (min-width:${values[key]}${unit}) and ` +
-      `(max-width:${values[keys[keyIndex + 1]] - step / 100}${unit})`
-    );
+    return only(key).replace('@media', '@media not all and');
   }
 
   return {

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -105,12 +105,14 @@ describe('createBreakpoints', () => {
       );
     });
 
-    it('on xl should call down', () => {
-      expect(breakpoints.not('xl')).to.equal('@media (max-width:1535.95px)');
+    it('should invert up for xl', () => {
+      expect(breakpoints.not('xl')).to.equal('@media not all and (min-width:1536px)');
     });
 
-    it('on xs should call up', () => {
-      expect(breakpoints.not('xs')).to.equal('@media (min-width:600px)');
+    it('should invert down for xs', () => {
+      expect(breakpoints.not('xs')).to.equal(
+        '@media not all and (min-width:0px) and (max-width:599.95px)',
+      );
     });
 
     it('should work for custom breakpoints', () => {

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -106,13 +106,11 @@ describe('createBreakpoints', () => {
     });
 
     it('should invert up for xl', () => {
-      expect(breakpoints.not('xl')).to.equal('@media not all and (min-width:1536px)');
+      expect(breakpoints.not('xl')).to.equal('@media (max-width:1535.95px)');
     });
 
     it('should invert down for xs', () => {
-      expect(breakpoints.not('xs')).to.equal(
-        '@media not all and (min-width:0px) and (max-width:599.95px)',
-      );
+      expect(breakpoints.not('xs')).to.equal('@media (min-width:600px)');
     });
 
     it('should work for custom breakpoints', () => {

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -97,4 +97,26 @@ describe('createBreakpoints', () => {
       );
     });
   });
+
+  describe('not', () => {
+    it('should work', () => {
+      expect(breakpoints.not('md')).to.equal(
+        '@media not all and (min-width:900px) and (max-width:1199.95px)',
+      );
+    });
+
+    it('on xl should call down', () => {
+      expect(breakpoints.not('xl')).to.equal('@media (max-width:1535.95px)');
+    });
+
+    it('on xs should call up', () => {
+      expect(breakpoints.not('xs')).to.equal('@media (min-width:600px)');
+    });
+
+    it('should work for custom breakpoints', () => {
+      expect(customBreakpoints.not('tablet')).to.equal(
+        '@media not all and (min-width:640px) and (max-width:1023.95px)',
+      );
+    });
+  });
 });


### PR DESCRIPTION
Allow to easily create styles, which are the inverted version of the only operator
Updated the documentation and included tests

This change is related to issue #29228 


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
