### PR TITLE
[system] Add a "not" breakpoint helper

### DIFF
--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -26,11 +26,12 @@ These values can be [customized](#custom-breakpoints).
 ## CSS Media Queries
 
 CSS media queries are the idiomatic approach to make your UI responsive.
-The theme provides four styles helpers to do so:
+The theme provides five styles helpers to do so:
 
 - [theme.breakpoints.up(key)](#theme-breakpoints-up-key-media-query)
 - [theme.breakpoints.down(key)](#theme-breakpoints-down-key-media-query)
 - [theme.breakpoints.only(key)](#theme-breakpoints-only-key-media-query)
+- [theme.breakpoints.not(key)](#theme-breakpoints-not-key-media-query)
 - [theme.breakpoints.between(start, end)](#theme-breakpoints-between-start-end-media-query)
 
 In the following demo, we change the background color (red, blue & green) based on the screen width.
@@ -203,6 +204,34 @@ const styles = (theme) => ({
     //       [md, lg)
     //       [900px, 1200px)
     [theme.breakpoints.only('md')]: {
+      backgroundColor: 'red',
+    },
+  },
+});
+```
+
+### `theme.breakpoints.not(key) => media query`
+
+<!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
+
+#### Arguments
+
+1. `key` (_string_): A breakpoint key (`xs`, `sm`, etc.).
+
+#### Returns
+
+`media query`: A media query string ready to be used with most styling solutions, which matches all screen widths except the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive).
+
+#### Examples
+
+```js
+const styles = (theme) => ({
+  root: {
+    backgroundColor: 'blue',
+    // Match [xs, md) and [md + 1, ∞)
+    //       [xs, md) and [lg, ∞)
+    //       [0px, 900px) and [1200, ∞)
+    [theme.breakpoints.not('md')]: {
       backgroundColor: 'red',
     },
   },

--- a/packages/mui-system/src/createTheme/createBreakpoints.d.ts
+++ b/packages/mui-system/src/createTheme/createBreakpoints.d.ts
@@ -55,6 +55,13 @@ export interface Breakpoints {
    * @see [API documentation](https://mui.com/customization/breakpoints/#theme-breakpoints-only-key-media-query)
    */
   only: (key: Breakpoint) => string;
+  /**
+   * @param key - A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+   * @returns A media query string ready to be used with most styling solutions, which matches all screen widths except
+   *          the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive).
+   * @see [API documentation](https://mui.com/customization/breakpoints/#theme-breakpoints-not-key-media-query)
+   */
+  not: (key: Breakpoint) => string;
 }
 
 export interface BreakpointsOptions extends Partial<Breakpoints> {

--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -55,6 +55,10 @@ export default function createBreakpoints(breakpoints) {
     return up(key);
   }
 
+  function not(key) {
+    return only(key).replace('@media', '@media not all and');
+  }
+
   return {
     keys,
     values,
@@ -62,6 +66,7 @@ export default function createBreakpoints(breakpoints) {
     down,
     between,
     only,
+    not,
     unit,
     ...other,
   };

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -97,4 +97,15 @@ describe('createBreakpoints', () => {
       );
     });
   });
+
+  describe('not', () => {
+    it('should work', () => {
+      expect(breakpoints.not('md')).to.equal(
+        '@media not all and (min-width:900px) and (max-width:1199.95px)',
+      );
+    });
+    it('should invert up for xl', () => {
+      expect(breakpoints.not('xl')).to.equal('@media not all and (min-width:1536px)');
+    });
+  });
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adds a new theme breakpoint helper called `not` which is simply a negated `only` media query.
Updates the docs and adds a few tests. As the implementation internally uses `only`, any more tests will simply test `only`.

See the related issue for a motivation and example use case.

Closes #29228