### PR TITLE
[FormControlLabel] Narrow the label type

### DIFF
--- a/docs/pages/api-docs/form-control-label.json
+++ b/docs/pages/api-docs/form-control-label.json
@@ -1,13 +1,19 @@
 {
   "props": {
     "control": { "type": { "name": "element" }, "required": true },
+    "label": {
+      "type": {
+        "name": "union",
+        "description": "element<br>&#124;&nbsp;number<br>&#124;&nbsp;string"
+      },
+      "required": true
+    },
     "checked": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
     "componentsProps": { "type": { "name": "object" }, "default": "{}" },
     "disabled": { "type": { "name": "bool" } },
     "disableTypography": { "type": { "name": "bool" } },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
-    "label": { "type": { "name": "node" } },
     "labelPlacement": {
       "type": {
         "name": "enum",

--- a/docs/translations/api-docs/form-control-label/form-control-label.json
+++ b/docs/translations/api-docs/form-control-label/form-control-label.json
@@ -8,7 +8,7 @@
     "disabled": "If <code>true</code>, the control is disabled.",
     "disableTypography": "If <code>true</code>, the label is rendered as it is passed without an additional typography node.",
     "inputRef": "Pass a ref to the <code>input</code> element.",
-    "label": "The text to be used in an enclosing label element.",
+    "label": "A text or an element to be used in an enclosing label element.",
     "labelPlacement": "The position of the label.",
     "onChange": "Callback fired when the state is changed.<br><br><strong>Signature:</strong><br><code>function(event: React.SyntheticEvent) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new checked state by accessing <code>event.target.checked</code> (boolean).",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.d.ts
@@ -43,9 +43,9 @@ export interface FormControlLabelProps
    */
   inputRef?: React.Ref<any>;
   /**
-   * The text to be used in an enclosing label element.
+   * A text or an element to be used in an enclosing label element.
    */
-  label: React.ReactNode;
+  label: string | number | React.ReactElement;
   /**
    * The position of the label.
    * @default 'end'

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -175,9 +175,9 @@ FormControlLabel.propTypes /* remove-proptypes */ = {
    */
   inputRef: refType,
   /**
-   * The text to be used in an enclosing label element.
+   * A text or an element to be used in an enclosing label element.
    */
-  label: PropTypes.node,
+  label: PropTypes.oneOfType([PropTypes.element, PropTypes.number, PropTypes.string]).isRequired,
   /**
    * The position of the label.
    * @default 'end'


### PR DESCRIPTION
Do not accept `null` or `undefined` as a value for the FormControlLabel's `label` prop. The change affects just the types (the implementation breaks anyway if nullish is provided).

Fixes #29301