### PR TITLE
[test] Add internal test for uniqe `name` in `Rating`

### DIFF
--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -124,9 +124,9 @@ describe('<Rating />', () => {
   it('should ensure a `name`', () => {
     render(<Rating value={null} />);
 
-    const [arbirtraryRadio, ...radios] = document.querySelectorAll('input[type="radio"]');
+    const [arbitraryRadio, ...radios] = document.querySelectorAll('input[type="radio"]');
     // `name` **property** will always be a string even if the **attribute** is omitted
-    expect(arbirtraryRadio.name).not.to.equal('');
+    expect(arbitraryRadio.name).not.to.equal('');
     // all input[type="radio"] have the same name
     expect(new Set(radios.map((radio) => radio.name))).to.have.length(1);
   });


### PR DESCRIPTION
We need to ensure `name` when using radio inputs. See https://github.com/mui-org/material-ui/issues/19870