### PR TITLE
[internal] Remove unecessary destructuration

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -425,9 +425,8 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
       onClick(event);
     }
   };
-  const { className: inputPropsPropClassName, ...inputPropsPropOthers } = inputPropsProp;
   let InputComponent = inputComponent;
-  let inputProps = inputPropsPropOthers;
+  let inputProps = inputPropsProp;
 
   if (multiline && InputComponent === 'input') {
     if (rows) {
@@ -531,7 +530,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
               ownerState: { ...ownerState, ...inputProps.ownerState },
             })}
             ref={handleInputRef}
-            className={clsx(classes.input, inputPropsPropClassName)}
+            className={clsx(classes.input, inputProps.className)}
             onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}


### PR DESCRIPTION
A follow-up on #29353, it seems that all we needed in the first place is:

```diff
-className={clsx(classes.input, inputProps.className, inputPropsProp.className)}
+className={clsx(classes.input, inputProps.className)}
```

The tests are still green. Fewer LOCs.