### PR TITLE
[Masonry] Fix crash on unmount when using React 18

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -240,7 +240,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
     // IE and old browsers are not supported
     if (typeof ResizeObserver === 'undefined') {
-      return null;
+      return undefined;
     }
     const resizeObserver = new ResizeObserver(handleResize);
 


### PR DESCRIPTION
Same issue as https://github.com/mui-org/material-ui/pull/28202. Probably copied code from `MasonryItem` in https://github.com/mui-org/material-ui/pull/28059 before https://github.com/mui-org/material-ui/pull/28202 landed