### PR TITLE
[test] Expose `AbortController` on global

### DIFF
--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -2,6 +2,9 @@ const { JSDOM } = require('jsdom');
 
 // We can use jsdom-global at some point if maintaining these lists is a burden.
 const whitelist = [
+  // used by React's experimental cache API
+  // Always including it to reduce churn when switching between React builds
+  'AbortController',
   // required for fake getComputedStyle
   'CSSStyleDeclaration',
   'Element',


### PR DESCRIPTION
Used by `react@experimental`. Permanently including it to reduce code churn when switching React builds.