### PR TITLE
NOT FOR MERGE [test] Check runtime performance of testing-library/dom-testing-library#1068

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "**/@babel/preset-react": "^7.14.5",
     "**/@babel/preset-typescript": "^7.15.0",
     "**/@babel/runtime": "^7.15.4",
+    "**/@testing-library/dom": "https://pkg.csb.dev/testing-library/dom-testing-library/commit/f7ffeac9/@testing-library/dom",
     "**/@types/react": "^17.0.33",
     "**/@types/react-dom": "^17.0.10",
     "**/cross-fetch": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,10 +2824,9 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.10.1":
-  version "8.10.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.10.1.tgz#e24fed92ad51c619cf304c6f1410b4c76b1000c0"
-  integrity sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==
+"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.10.1", "@testing-library/dom@https://pkg.csb.dev/testing-library/dom-testing-library/commit/f7ffeac9/@testing-library/dom":
+  version "0.0.0-semantically-released"
+  resolved "https://pkg.csb.dev/testing-library/dom-testing-library/commit/f7ffeac9/@testing-library/dom#29d432ff52ea308477aee233f0df9f1f0d5ed582"
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"


### PR DESCRIPTION
Testing https://github.com/testing-library/dom-testing-library/pull/1068

Results analyzed with https://www.calculatorsoup.com/calculators/statistics/mean-median-mode.php

## test:unit
### master
#### Sampled runs
- https://app.circleci.com/pipelines/github/mui-org/material-ui/54271/workflows/70b3a264-c9ff-43e4-a47e-cbdb21306595/jobs/309914
- https://app.circleci.com/pipelines/github/mui-org/material-ui/54267/workflows/977289f6-9d4b-4453-b8f8-782867aa6442/jobs/309876
- https://app.circleci.com/pipelines/github/mui-org/material-ui/54261/workflows/2bdcd6c3-1366-4db5-86c0-2dfd8a309f50/jobs/309853
- https://app.circleci.com/pipelines/github/mui-org/material-ui/54250/workflows/75e2d5d1-a336-47f4-a367-18ec312aaae3/jobs/309790
- https://app.circleci.com/pipelines/github/mui-org/material-ui/54247/workflows/d88e8629-dcf6-4291-a1f3-2004223f3488/jobs/309761

#### Results

`test:unit` runtime:
1. 454.99s
1. 459.60s
1. 489.28s
1. 358.27s
1. 346.96s


Mean x¯¯¯	421.82
Median x˜	454.99
Mode	454.99, 459.60, 489.28, 358.27, 346.96
Range	142.32
Minimum	346.96
Maximum	489.28
Count n	5
Sum	2109.1
Quartiles	Quartiles:
Q1 --> 352.615
Q2 --> 454.99
Q3 --> 474.44
Interquartile
Range IQR	121.825
Outliers	none

### PR
#### Sampled runs
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/bdc731be-158f-4529-81de-370ee0d742f3/jobs/309905
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/e5a5a49c-340d-40d7-aa0c-97aba6fbb7fa/jobs/309953
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/05b02e36-d084-46b5-bf96-8037ac583a74/jobs/309960
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/7789df15-414a-47af-9165-5af05b8c07ec/jobs/309964


#### Results

1. 308.45s
1. 314.55s
1. 276.73s
1. 387.27s

Mean x¯¯¯	321.75
Median x˜	311.5
Mode	308.45, 314.55, 276.73, 387.27
Range	110.54
Minimum	276.73
Maximum	387.27
Count n	4
Sum	1287
Quartiles	Quartiles:
Q1 --> 292.59
Q2 --> 311.5
Q3 --> 350.91
Interquartile
Range IQR	58.32
Outliers	none

## test:karma

### master

#### Sampled runs

1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54271/workflows/70b3a264-c9ff-43e4-a47e-cbdb21306595/jobs/309908
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54267/workflows/977289f6-9d4b-4453-b8f8-782867aa6442/jobs/309878
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54261/workflows/2bdcd6c3-1366-4db5-86c0-2dfd8a309f50/jobs/309852
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54250/workflows/75e2d5d1-a336-47f4-a367-18ec312aaae3/jobs/309786
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54247/workflows/d88e8629-dcf6-4291-a1f3-2004223f3488/jobs/309765

#### Results

1. 89s
1. 49s
1. 60s
1. 61s
1. 52s

Mean x¯¯¯	62.2
Median x˜	60
Mode	89, 49, 60, 61, 52
Range	40
Minimum	49
Maximum	89
Count n	5
Sum	311
Quartiles	Quartiles:
Q1 --> 50.5
Q2 --> 60
Q3 --> 75
Interquartile
Range IQR	24.5
Outliers	none

### PR

#### Sampled runs

1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/bdc731be-158f-4529-81de-370ee0d742f3/jobs/309906
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/e5a5a49c-340d-40d7-aa0c-97aba6fbb7fa/jobs/309952
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/05b02e36-d084-46b5-bf96-8037ac583a74/jobs/309962
1. https://app.circleci.com/pipelines/github/mui-org/material-ui/54270/workflows/7789df15-414a-47af-9165-5af05b8c07ec/jobs/309968

#### Results

1. 61s
1. 53s
1. 84s
1. 63s

Mean x¯¯¯	65.25
Median x˜	62
Mode	61, 53, 84, 63
Range	31
Minimum	53
Maximum	84
Count n	4
Sum	261
Quartiles	Quartiles:
Q1 --> 57
Q2 --> 62
Q3 --> 73.5
Interquartile
Range IQR	16.5
Outliers	none

## Conclusion

While it's hard to tell if this change does in fact speed things up (ressource classes are flaky; wide spread to begin with) it seems safe to say that this didn't result in a significant slowdown.

Looks safe to land.

