### PR TITLE
[Tooltip] `open` prop in `componentsProps.popper` can be optional

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.d.ts
+++ b/packages/mui-material/src/Tooltip/Tooltip.d.ts
@@ -39,7 +39,7 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
    * @default {}
    */
   componentsProps?: {
-    popper?: PopperProps & TooltipComponentsPropsOverrides;
+    popper?: Partial<PopperProps> & TooltipComponentsPropsOverrides;
     transition?: TransitionProps & TooltipComponentsPropsOverrides;
     tooltip?: React.HTMLProps<HTMLDivElement> &
       MUIStyledCommonProps &


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Addresses point 4 from https://github.com/mui-org/material-ui/pull/29023#issuecomment-948425123

Before: https://codesandbox.io/s/popperprops-issue-o0wkg?file=/src/App.tsx
After: https://codesandbox.io/s/popperprops-issue-sru1s?file=/src/App.tsx