### PR TITLE
[InputBase] Remove WebkitAppearance from search type

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -210,7 +210,6 @@ export const InputBaseComponent = styled('input', {
     ...(ownerState.type === 'search' && {
       // Improve type search style.
       MozAppearance: 'textfield',
-      WebkitAppearance: 'textfield',
     }),
   };
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

On Safari for iOS 15.1, the appearance of text fields has a background color which is being shown on the search input type. This removes the appearance from the base styles so it no longer attempts to display a background.

Closes #29365