### PR TITLE
feat: remove Edge password reveal button

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -168,6 +168,10 @@ export const InputBaseComponent = styled('input', {
     '&::-moz-placeholder': placeholder, // Firefox 19+
     '&:-ms-input-placeholder': placeholder, // IE11
     '&::-ms-input-placeholder': placeholder, // Edge
+    // Remove Edge password reveal button
+    '&::-ms-reveal': {
+      display: 'none',
+    },
     '&:focus': {
       outline: 0,
     },


### PR DESCRIPTION
Edge display password reveal button by default
ref: https://docs.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal

Edge displays 2 reveal buttons in InputAdornment password type with suffix.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
