### PR TITLE
[docs] Track usage of dark mode in Google Analytics

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -16,15 +16,10 @@ import { useRouter } from 'next/router';
 import pages from 'docs/src/pages';
 import PageContext from 'docs/src/modules/components/PageContext';
 import GoogleAnalytics from 'docs/src/modules/components/GoogleAnalytics';
-import loadScript from 'docs/src/modules/utils/loadScript';
 import { ThemeProvider } from 'docs/src/modules/components/ThemeContext';
 import { pathnameToLanguage, getCookie } from 'docs/src/modules/utils/helpers';
-import { CODE_VARIANTS, LANGUAGES } from 'docs/src/modules/constants';
-import {
-  CodeVariantProvider,
-  useCodeVariant,
-  useSetCodeVariant,
-} from 'docs/src/modules/utils/codeVariant';
+import { LANGUAGES } from 'docs/src/modules/constants';
+import { CodeVariantProvider } from 'docs/src/modules/utils/codeVariant';
 import {
   UserLanguageProvider,
   useSetUserLanguage,
@@ -35,15 +30,6 @@ import createEmotionCache from 'docs/src/createEmotionCache';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
-
-function useFirstRender() {
-  const firstRenderRef = React.useRef(true);
-  React.useEffect(() => {
-    firstRenderRef.current = false;
-  }, []);
-
-  return firstRenderRef.current;
-}
 
 // Set the locales that the documentation automatically redirects to.
 acceptLanguage.languages(LANGUAGES);
@@ -66,107 +52,6 @@ function LanguageNegotiation() {
       setUserLanguage(userLanguageUrl);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return null;
-}
-
-/**
- * Priority: on first render: navigated value, persisted value; otherwise initial value, 'JS'
- * @returns {string} - The persisted variant if the initial value is undefined
- */
-function usePersistCodeVariant() {
-  const initialCodeVariant = useCodeVariant();
-  const setCodeVariant = useSetCodeVariant();
-
-  const isFirstRender = useFirstRender();
-
-  const navigatedCodeVariant = React.useMemo(() => {
-    const navigatedCodeVariantMatch =
-      typeof window !== 'undefined' ? window.location.hash.match(/\.(js|tsx)$/) : null;
-
-    if (navigatedCodeVariantMatch === null) {
-      return undefined;
-    }
-
-    return navigatedCodeVariantMatch[1] === 'tsx' ? CODE_VARIANTS.TS : CODE_VARIANTS.JS;
-  }, []);
-
-  const persistedCodeVariant = React.useMemo(() => {
-    if (typeof window === 'undefined') {
-      return undefined;
-    }
-    return getCookie('codeVariant');
-  }, []);
-
-  /**
-   * we initialize from navigation or cookies. on subsequent renders the store is the
-   * truth
-   */
-  const codeVariant =
-    isFirstRender === true
-      ? navigatedCodeVariant || persistedCodeVariant || initialCodeVariant
-      : initialCodeVariant;
-
-  React.useEffect(() => {
-    if (codeVariant !== initialCodeVariant) {
-      setCodeVariant(codeVariant);
-    }
-  });
-
-  React.useEffect(() => {
-    document.cookie = `codeVariant=${codeVariant};path=/;max-age=31536000`;
-  }, [codeVariant]);
-
-  return codeVariant;
-}
-
-/**
- * basically just a `useAnalytics` hook.
- * However, it needs the redux store which is created
- * in the same component this "hook" is used.
- */
-function Analytics() {
-  React.useEffect(() => {
-    loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
-  }, []);
-
-  const userLanguage = useUserLanguage();
-
-  const codeVariant = usePersistCodeVariant();
-  React.useEffect(() => {
-    window.ga('set', 'dimension1', codeVariant);
-  }, [codeVariant]);
-
-  React.useEffect(() => {
-    window.ga('set', 'dimension2', userLanguage);
-  }, [userLanguage]);
-
-  React.useEffect(() => {
-    /**
-     * @type {null | MediaQueryList}
-     */
-    let matchMedia = null;
-
-    /**
-     * Based on https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#Monitoring_screen_resolution_or_zoom_level_changes
-     * Adjusted to track 3 or more different ratios
-     */
-    function trackDevicePixelRation() {
-      window.ga('set', 'dimension3', Math.round(window.devicePixelRatio * 10) / 10);
-
-      matchMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
-      // Need to setup again.
-      // Otherwise we track only changes from the initial ratio to another.
-      // It would not track 3 or more different monitors/zoom stages
-      matchMedia.addListener(trackDevicePixelRation);
-    }
-
-    trackDevicePixelRation();
-
-    return () => {
-      matchMedia = null;
-    };
-  }, []);
 
   return null;
 }
@@ -334,14 +219,13 @@ function AppWrapper(props) {
             <ThemeProvider>
               <DocsStyledEngineProvider cacheLtr={emotionCache}>
                 {children}
+                <GoogleAnalytics />
               </DocsStyledEngineProvider>
             </ThemeProvider>
           </PageContext.Provider>
           <LanguageNegotiation />
-          <Analytics />
         </CodeVariantProvider>
       </UserLanguageProvider>
-      <GoogleAnalytics key={router.route} />
     </React.Fragment>
   );
 }

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -7,7 +7,7 @@ import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import { getMetaThemeColor } from 'docs/src/modules/brandingTheme';
-import { GlobalStyles } from '@mui/styled-engine';
+import GlobalStyles from '@mui/material/GlobalStyles';
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -115,20 +115,22 @@ export default class MyDocument extends Document {
             }}
           />
           <GlobalStyles
-            styles={`
-              .only-light-mode {
-                display: none;
-              }
-              .mode-light .only-light-mode {
-                display: block;
-              }
-              .only-dark-mode {
-                display: none;
-              }
-              .mode-dark .only-dark-mode {
-                display: block;
-              }
-            `}
+            styles={{
+              // First SSR paint
+              '.only-light-mode': {
+                display: 'block',
+              },
+              '.only-dark-mode': {
+                display: 'none',
+              },
+              // Post SSR Hyration
+              '.mode-dark .only-light-mode': {
+                display: 'none',
+              },
+              '.mode-dark .only-dark-mode': {
+                display: 'block',
+              },
+            }}
           />
         </Head>
         <body>

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -123,7 +123,7 @@ export default class MyDocument extends Document {
               '.only-dark-mode': {
                 display: 'none',
               },
-              // Post SSR Hyration
+              // Post SSR Hydration
               '.mode-dark .only-light-mode': {
                 display: 'none',
               },

--- a/docs/src/components/header/ThemeModeToggle.tsx
+++ b/docs/src/components/header/ThemeModeToggle.tsx
@@ -4,7 +4,12 @@ import Tooltip from '@mui/material/Tooltip';
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
 import LightModeOutlined from '@mui/icons-material/LightModeOutlined';
 
-const ThemeModeToggle = (props: { checked: boolean; onChange: (checked: boolean) => void }) => {
+interface ThemeModeToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export default function ThemeModeToggle(props: ThemeModeToggleProps) {
   return (
     <Tooltip title={props.checked ? 'Turn on the light' : 'Turn off the light'}>
       <IconButton
@@ -30,6 +35,4 @@ const ThemeModeToggle = (props: { checked: boolean; onChange: (checked: boolean)
       </IconButton>
     </Tooltip>
   );
-};
-
-export default ThemeModeToggle;
+}

--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -32,29 +32,20 @@ export default function AppHeader() {
   const changeTheme = useChangeTheme();
   const [mode, setMode] = React.useState<string | null>(null);
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const preferredMode = prefersDarkMode ? 'dark' : 'light';
 
   React.useEffect(() => {
-    setMode(getCookie('paletteMode') || 'system');
-  }, [setMode]);
+    const initialMode = getCookie('paletteMode') || 'system';
+    setMode(initialMode);
+  }, []);
 
   const handleChangeThemeMode = (checked: boolean) => {
-    let paletteMode = 'system';
-    paletteMode = checked ? 'dark' : 'light';
-    if (paletteMode === null) {
-      return;
-    }
-
+    const paletteMode = checked ? 'dark' : 'light';
     setMode(paletteMode);
 
-    if (paletteMode === 'system') {
-      document.cookie = `paletteMode=;path=/;max-age=31536000`;
-      changeTheme({ paletteMode: preferredMode });
-    } else {
-      document.cookie = `paletteMode=${paletteMode};path=/;max-age=31536000`;
-      changeTheme({ paletteMode });
-    }
+    document.cookie = `paletteMode=${paletteMode};path=/;max-age=31536000`;
+    changeTheme({ paletteMode });
   };
+
   return (
     <Header>
       <Container sx={{ display: 'flex', alignItems: 'center', minHeight: 64 }}>

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -42,21 +42,10 @@ function AppSettingsDrawer(props) {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
 
-  const updateBodyClass = (currentMode) => {
-    if (currentMode === 'dark') {
-      document.body.classList.remove('mode-light');
-      document.body.classList.add('mode-dark');
-    } else {
-      document.body.classList.remove('mode-dark');
-      document.body.classList.add('mode-light');
-    }
-  };
-
   React.useEffect(() => {
     const initialMode = getCookie('paletteMode') || 'system';
     setMode(initialMode);
-    updateBodyClass(initialMode === 'system' ? preferredMode : initialMode);
-  }, [setMode, preferredMode]);
+  }, [preferredMode]);
 
   const handleChangeThemeMode = (event, paletteMode) => {
     if (paletteMode === null) {
@@ -68,11 +57,9 @@ function AppSettingsDrawer(props) {
     if (paletteMode === 'system') {
       document.cookie = `paletteMode=;path=/;max-age=31536000`;
       changeTheme({ paletteMode: preferredMode });
-      updateBodyClass(preferredMode);
     } else {
       document.cookie = `paletteMode=${paletteMode};path=/;max-age=31536000`;
       changeTheme({ paletteMode });
-      updateBodyClass(paletteMode);
     }
   };
 

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -128,6 +128,7 @@ export function ThemeProvider(props) {
   const { children } = props;
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const preferredMode = prefersDarkMode ? 'dark' : 'light';
+
   const [themeOptions, dispatch] = React.useReducer(
     (state, action) => {
       switch (action.type) {
@@ -253,6 +254,16 @@ export function ThemeProvider(props) {
       window.createTheme = createTheme;
     }
   }, [theme]);
+
+  useEnhancedEffect(() => {
+    if (theme.palette.mode === 'dark') {
+      document.body.classList.remove('mode-light');
+      document.body.classList.add('mode-dark');
+    } else {
+      document.body.classList.remove('mode-dark');
+      document.body.classList.add('mode-light');
+    }
+  }, [theme.palette.mode]);
 
   return (
     <MuiThemeProvider theme={theme}>

--- a/docs/src/modules/utils/codeVariant.js
+++ b/docs/src/modules/utils/codeVariant.js
@@ -1,5 +1,6 @@
-import PropTypes from 'prop-types';
 import * as React from 'react';
+import PropTypes from 'prop-types';
+import { getCookie } from 'docs/src/modules/utils/helpers';
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
 
 const CodeVariantContext = React.createContext({
@@ -10,14 +11,58 @@ if (process.env.NODE_ENV !== 'production') {
   CodeVariantContext.displayName = 'CodeVariant';
 }
 
+function useFirstRender() {
+  const firstRenderRef = React.useRef(true);
+  React.useEffect(() => {
+    firstRenderRef.current = false;
+  }, []);
+
+  return firstRenderRef.current;
+}
+
 export function CodeVariantProvider(props) {
   const { children } = props;
 
   const [codeVariant, setCodeVariant] = React.useState('JS');
 
-  const contextValue = React.useMemo(() => {
-    return { codeVariant, setCodeVariant };
+  const navigatedCodeVariant = React.useMemo(() => {
+    const navigatedCodeVariantMatch =
+      typeof window !== 'undefined' ? window.location.hash.match(/\.(js|tsx)$/) : null;
+
+    if (navigatedCodeVariantMatch === null) {
+      return undefined;
+    }
+
+    return navigatedCodeVariantMatch[1] === 'tsx' ? CODE_VARIANTS.TS : CODE_VARIANTS.JS;
+  }, []);
+
+  const persistedCodeVariant = React.useMemo(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    return getCookie('codeVariant');
+  }, []);
+  const isFirstRender = useFirstRender();
+
+  // We initialize from navigation or cookies. on subsequent renders the store is the truth
+  const noSsrCodeVariant =
+    isFirstRender === true
+      ? navigatedCodeVariant || persistedCodeVariant || codeVariant
+      : codeVariant;
+
+  React.useEffect(() => {
+    if (codeVariant !== noSsrCodeVariant) {
+      setCodeVariant(noSsrCodeVariant);
+    }
+  }, [codeVariant, noSsrCodeVariant]);
+
+  React.useEffect(() => {
+    document.cookie = `codeVariant=${codeVariant};path=/;max-age=31536000`;
   }, [codeVariant]);
+
+  const contextValue = React.useMemo(() => {
+    return { codeVariant, noSsrCodeVariant, setCodeVariant };
+  }, [codeVariant, noSsrCodeVariant]);
 
   return <CodeVariantContext.Provider value={contextValue}>{children}</CodeVariantContext.Provider>;
 }
@@ -28,6 +73,10 @@ CodeVariantProvider.propTypes = {
 
 export function useCodeVariant() {
   return React.useContext(CodeVariantContext).codeVariant;
+}
+
+export function useNoSsrCodeVariant() {
+  return React.useContext(CodeVariantContext).noSsrCodeVariant;
 }
 
 export function useSetCodeVariant() {

--- a/docs/src/pages/customization/typography/typography.md
+++ b/docs/src/pages/customization/typography/typography.md
@@ -106,10 +106,10 @@ const theme = createTheme({
 The computed font size by the browser follows this mathematical equation:
 
 <div class="only-light-mode">
-  <img src="/static/images/font-size.svg" alt="font size calculation" style="width: 458px;" />
+  <img alt="font size calculation" style="width: 458px;" src="/static/images/font-size.svg" />
 </div>
 <div class="only-dark-mode">
-  <img src="/static/images/font-size-dark.svg" alt="font size calculation" style="width: 458px;" />
+  <img alt="font size calculation" style="width: 458px;" src="/static/images/font-size-dark.svg" />
 </div>
 
 <!-- https://latex.codecogs.com/svg.latex?\dpi{200}&space;\text{computed}&space;=&space;\text{specification}\cdot\frac{\text{typography.fontSize}}{14}\cdot\frac{\text{html&space;fontsize}}{\text{typography.htmlFontSize}} -->


### PR DESCRIPTION
The main objective of this PR is to add the last two Google Analytics custom dimensions:

<img width="272" alt="Screenshot 2021-10-31 at 11 04 49" src="https://user-images.githubusercontent.com/3165635/139577499-39357744-46fd-4d47-a588-f6ffe258761b.png">

[source of the screneshot](https://analytics.google.com/analytics/web/#/a106598593w159022482p160376982/admin/custom-dimensions/m-content-dimensionsContent.rowShow=10&m-content-dimensionsContent.rowStart=0&m-content-dimensionsContent.sortColumnId=index&m-content-dimensionsContent.sortDescending=false&m-content.mode=LIST)

- `colorSchemeOS`: The color scheme used by the OS of the developer. 
- `colorScheme`: The color scheme used on the documentation.

Maintainers will be able to access the data the same way we have an example of [the pixel density](https://www.notion.so/mui-org/Analytics-f2e2576203564e6c8dc3429cf305a36f).

Why work on this? I have seen a growing trend toward dark mode, but I have no idea if a real thing, or simply a short-lived fashion. I'm looking for gathering more data. How much of the audience is using dark mode? Is it 10%, 20%, 40%, or even more? What should be the default mode? I bet on 15%.

At the same time, I'm also fixing a couple of side issues:

- Fix a number of polish negligences in #28665.
- Isolate the purpose of GoogleAnalytics.js better, it should only be about analytics. Before it also had logic backed into it, changing the code language, not ideal.
- Fix a deprecated match media addListener API