### PR TITLE
[core] Add playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /coverage
 /docs/.env.local
 /docs/export
+/docs/pages/playground.tsx
 /examples/**/.cache
 /packages/mui-codemod/lib
 /packages/mui-envinfo/*.tgz

--- a/docs/pages/playground.example.tsx
+++ b/docs/pages/playground.example.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export default function Playground() {
+  return (
+    <div>
+      A playground for a fast iteration development cycle. You can copy this file and name it{' '}
+      <code>playground.tsx</code>
+    </div>
+  );
+}


### PR DESCRIPTION
This is a continuation of https://github.com/mui-org/material-ui-x/pull/3057. I have been using the following workflow for as long as I can remember since we have the Next.js documentation (for 3 years?):

1. There is a change I want to try
2. Got to `/docs/pages/index.tsx`, copy and paste the component I need to work on
3. Try changes

Since then, I haven't found anything better. For instance, editing demos in the documentation was feeling slower. However, this approach has one important downside, I had to make sure I wasn't committing `/docs/pages/index.tsx`. This was painful.

This PR is about improving this and sharing the pattern with this possible workflow with the rest of the team. Now, we can copy the `/docs/pages/playground.example.tsx` file into `/docs/pages/playground.tsx` and make all the changes we want in http://0.0.0.0:3000/playground without having to care about git.