### PR TITLE
[docs] Fix layout-shift on id='main-content'

### DIFF
--- a/docs/src/modules/components/AppContainer.js
+++ b/docs/src/modules/components/AppContainer.js
@@ -5,12 +5,10 @@ import Container from '@mui/material/Container';
 const StyledContainer = styled(Container)(({ theme }) => {
   return {
     paddingTop: 80 + 20,
-    [theme.breakpoints.up('md')]: {
-      // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
-      // 94ch ≈ 902px (theme.breakpoints.values.md) using 16px IBM Plex Sans
-      // TODO Does it make sense to create breakpoints based on `ch`?
-      maxWidth: '94ch',
-    },
+    // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
+    // 105ch ≈ 930px
+    fontFamily: 'Arial',
+    maxWidth: '105ch',
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(8),
       paddingRight: theme.spacing(8),


### PR DESCRIPTION
Since #24531, we use the ch unit for setting the max-width of the container, but the ch px value depends on the font family used. The font family is not stable. IBM Plex is loaded with `font-display:swap`, which is a very short block period, not long enough:

For instance, when loading https://mui.com/components/alert/, you can observe the following:

![loading-font](https://user-images.githubusercontent.com/3165635/139584605-11f032b2-8bf4-4f98-a73e-6e075a221d34.gif)

It was driving me nuts.

In this PR:

1. I have made the layout stable, by forcing the font family. I believe we still get the main benefit: width changing with the default font size.
2. I have increased the max-width in the default configuration by +30px as @mui-org/x was complaining about not having enough space in the demo. This is still -50px less compared to the docs layout of v4.

Preview: https://deploy-preview-29425--material-ui.netlify.app/components/alert/