### PR TITLE
[core] Add mui as a npm keyword

### DIFF
--- a/packages/mui-codemod/package.json
+++ b/packages/mui-codemod/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "codemod",
     "jscodeshift"
   ],

--- a/packages/mui-core/package.json
+++ b/packages/mui-core/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "unstyled",
     "a11y"
   ],

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -8,6 +8,7 @@
   "keywords": [
     "react",
     "react-component",
+    "mui",
     "material-ui",
     "material design",
     "icons"

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -8,6 +8,7 @@
   "keywords": [
     "react",
     "react-component",
+    "mui",
     "material-ui",
     "material design",
     "lab"

--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -8,6 +8,7 @@
   "keywords": [
     "react",
     "react-component",
+    "mui",
     "material-ui",
     "material design"
   ],

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -8,6 +8,7 @@
   "keywords": [
     "react",
     "react-component",
+    "mui",
     "material-ui",
     "material design"
   ],

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "theme"
   ],
   "repository": {

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "styled-components"
   ],
   "repository": {

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -8,7 +8,6 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
     "mui",
     "emotion"
   ],

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -9,6 +9,7 @@
     "react",
     "react-component",
     "material-ui",
+    "mui",
     "emotion"
   ],
   "repository": {

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "styles"
   ],
   "repository": {

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "system"
   ],
   "repository": {

--- a/packages/mui-types/package.json
+++ b/packages/mui-types/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "types"
   ],
   "repository": {

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "react",
     "react-component",
-    "material-ui",
+    "mui",
     "utils"
   ],
   "repository": {


### PR DESCRIPTION
React and its ecosystem uses "react" a keyboard for its packages, e.g. https://unpkg.com/prop-types@15.7.2/package.json. 

In this PR, I have 1. replaced "material-ui" with "mui", and 2. added "material-ui" where it's relevant as a synonymous of "Material Design".

What's the use case? Here is one https://unpkg.com/browse/@mui/material@5.0.4/package.json, https://xpvrpr7r4o.codesandbox.io/: to make it easier for developers to find packages that are compatible with our ecosystem.