### PR TITLE
[core] Fix issue template redirection

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -38,7 +38,7 @@ https://mui.com/store/* https://material-ui.com/store/:splat 302!
 /r/pseudo-classes-guide /customization/components/#state-classes 302
 /r/state-classes-guide /customization/components/#state-classes 302
 /r/input-component-ref-interface /components/text-fields/#integration-with-3rd-party-input-libraries 302
-/r/issue-template https://codesandbox.io/s/material-ui-issue-next-o7xkt
+/r/issue-template https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/issue-template-next https://codesandbox.io/s/material-ui-issue-next-o7xkt
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/ts-issue-template https://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEMhhYowZABsAtHOCdhlMnToE5o-MAii4AESwgIACgBKVnYuHgBNeSghCBUsDSA 302


### PR DESCRIPTION
This is outdated. I believe we should be able to always ask to provide a reproduction using https://mui.com/r/issue-template, without maintainers having to care about what's the underlying codesandbox used. No, it should no point to a codesandbox using next.