### PR TITLE
[docs] Link to the new public roadmap for the design kits

### DIFF
--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -290,7 +290,7 @@ export default function HeaderNavBar() {
                           role="menuitem"
                           href={ROUTES.productDesignKits}
                           icon={<IconImage name="product-designkits" />}
-                          name="Design Kits"
+                          name="Design kits"
                           description="Our components available in your favorite design tool."
                           onKeyDown={handleKeyDown}
                         />

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -60,7 +60,7 @@ const PRODUCTS = [
     href: ROUTES.productTemplates,
   },
   {
-    name: 'Design Kits',
+    name: 'Design kits',
     description: 'Our components available in your favorite design tool.',
     href: ROUTES.productDesignKits,
   },

--- a/docs/src/components/home/ProductsSwitcher.tsx
+++ b/docs/src/components/home/ProductsSwitcher.tsx
@@ -124,7 +124,7 @@ const ProductsSwitcher = ({
     <ProductItem
       aria-label="Go to design-kits page"
       icon={<IconImage name="product-designkits" />}
-      name="Design Kits"
+      name="Design kits"
       description="Our components available in your favorite design tool."
       href={ROUTES.productDesignKits}
     />,

--- a/docs/src/components/productDesignKit/DesignKitHero.tsx
+++ b/docs/src/components/productDesignKit/DesignKitHero.tsx
@@ -31,7 +31,7 @@ export default function TemplateHero() {
               '& > *': { mr: 1, width: 28, height: 28 },
             }}
           >
-            <IconImage name="product-designkits" /> Design Kits
+            <IconImage name="product-designkits" /> Design kits
           </Typography>
           <Typography variant="h1" sx={{ my: 2, maxWidth: 500 }}>
             MUI in your favorite

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -65,7 +65,7 @@ export default function AppFooter() {
               <Link href={ROUTES.productCore}>MUI Core</Link>
               <Link href={ROUTES.productAdvanced}>MUI X</Link>
               <Link href={ROUTES.productTemplates}>Templates</Link>
-              <Link href={ROUTES.productDesignKits}>Design Kits</Link>
+              <Link href={ROUTES.productDesignKits}>Design kits</Link>
             </Box>
           ) : (
             <Box sx={{ display: { xs: 'none', md: 'block' } }} />

--- a/docs/src/pages/discover-more/roadmap/roadmap.md
+++ b/docs/src/pages/discover-more/roadmap/roadmap.md
@@ -34,6 +34,8 @@ Our GitHub project's roadmap is where you can learn about what features we're wo
 - [MUI X](https://github.com/mui-org/material-ui-x/projects/1).
   This repository focuses on providing advanced React components.
   Some of the features are MIT licensed, others are available under a commercial license.
+- [MUI Design kits](https://github.com/mui-org/mui-design-kits/projects/1)
+  This repository focuses on providing the components for designers on Figma and more.
 
 ## New components
 

--- a/docs/src/pages/discover-more/roadmap/roadmap.md
+++ b/docs/src/pages/discover-more/roadmap/roadmap.md
@@ -35,7 +35,7 @@ Our GitHub project's roadmap is where you can learn about what features we're wo
   This repository focuses on providing advanced React components.
   Some of the features are MIT licensed, others are available under a commercial license.
 - [MUI Design kits](https://github.com/mui-org/mui-design-kits/projects/1)
-  This repository focuses on providing the components for designers on Figma and more.
+  This repository focuses on providing the components for designers on Figma, Sketch, and Adobe XD.
 
 ## New components
 

--- a/docs/src/pages/discover-more/roadmap/roadmap.md
+++ b/docs/src/pages/discover-more/roadmap/roadmap.md
@@ -35,7 +35,8 @@ Our GitHub project's roadmap is where you can learn about what features we're wo
   This repository focuses on providing advanced React components.
   Some of the features are MIT licensed, others are available under a commercial license.
 - [MUI Design kits](https://github.com/mui-org/mui-design-kits/projects/1)
-  This repository focuses on gathering feedback and requests for the components available on Figma, Sketch, and Adobe XD.
+  This repository focuses on providing the components for designers on Figma and other design tools.
+  It's a great place to leave feedback, feature requests, and ask questions.
 
 ## New components
 

--- a/docs/src/pages/discover-more/roadmap/roadmap.md
+++ b/docs/src/pages/discover-more/roadmap/roadmap.md
@@ -35,7 +35,7 @@ Our GitHub project's roadmap is where you can learn about what features we're wo
   This repository focuses on providing advanced React components.
   Some of the features are MIT licensed, others are available under a commercial license.
 - [MUI Design kits](https://github.com/mui-org/mui-design-kits/projects/1)
-  This repository focuses on providing the components for designers on Figma, Sketch, and Adobe XD.
+  This repository focuses on gathering feedback and requests for the components available on Figma, Sketch, and Adobe XD.
 
 ## New components
 


### PR DESCRIPTION
This [roadmap](https://github.com/mui-org/mui-design-kits/projects/1) is owned by @adrianmanea.

https://deploy-preview-29433--material-ui.netlify.app/discover-more/roadmap/#quarterly-roadmap