### PR TITLE
[docs] Fix TOC highlighting logic

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -101,7 +101,7 @@ function AppLayoutDocs(props) {
               <AppLayoutDocsFooter />
             </NoSsr>
           </StyledAppContainer>
-          {disableToc ? null : <AppTableOfContents items={toc} />}
+          {disableToc ? null : <AppTableOfContents toc={toc} />}
         </Main>
       </AdManager>
     </AppFrame>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -97,9 +97,26 @@ function useThrottledOnScroll(callback, delay) {
   }, [throttledCallback]);
 }
 
+function flatten(headings) {
+  const itemsWithNode = [];
+
+  headings.forEach((item) => {
+    itemsWithNode.push(item);
+
+    if (item.children.length > 0) {
+      item.children.forEach((subitem) => {
+        itemsWithNode.push(subitem);
+      });
+    }
+  });
+  return itemsWithNode;
+}
+
 export default function AppTableOfContents(props) {
-  const { items } = props;
+  const { toc } = props;
   const t = useTranslate();
+
+  const items = React.useMemo(() => flatten(toc), [toc]);
 
   const { activePage } = React.useContext(PageContext);
   const [activeState, setActiveState] = React.useState(null);
@@ -192,11 +209,11 @@ export default function AppTableOfContents(props) {
 
   return (
     <Nav aria-label={t('pageTOC')}>
-      {items.length > 0 ? (
+      {toc.length > 0 ? (
         <React.Fragment>
           <NavLabel gutterBottom>{t('tableOfContents')}</NavLabel>
           <NavList component="ul">
-            {items.map((item) => (
+            {toc.map((item) => (
               <li key={item.text}>
                 {itemLink(item)}
                 {item.children.length > 0 ? (
@@ -216,5 +233,5 @@ export default function AppTableOfContents(props) {
 }
 
 AppTableOfContents.propTypes = {
-  items: PropTypes.array.isRequired,
+  toc: PropTypes.array.isRequired,
 };

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -76,6 +76,28 @@ const NavItem = styled(Link, {
   };
 });
 
+// TODO: these nodes are mutable sources. Use createMutableSource once it's stable
+function getItemsClient(headings) {
+  const itemsWithNode = [];
+
+  headings.forEach((item) => {
+    itemsWithNode.push({
+      ...item,
+      node: document.getElementById(item.hash),
+    });
+
+    if (item.children.length > 0) {
+      item.children.forEach((subitem) => {
+        itemsWithNode.push({
+          ...subitem,
+          node: document.getElementById(subitem.hash),
+        });
+      });
+    }
+  });
+  return itemsWithNode;
+}
+
 const noop = () => {};
 
 function useThrottledOnScroll(callback, delay) {
@@ -101,6 +123,11 @@ export default function AppTableOfContents(props) {
   const { items } = props;
   const t = useTranslate();
 
+  const itemsWithNodeRef = React.useRef([]);
+  React.useEffect(() => {
+    itemsWithNodeRef.current = getItemsClient(items);
+  }, [items]);
+
   const { activePage } = React.useContext(PageContext);
   const [activeState, setActiveState] = React.useState(null);
   const clickedRef = React.useRef(false);
@@ -112,25 +139,24 @@ export default function AppTableOfContents(props) {
     }
 
     let active;
-    for (let i = items.length - 1; i >= 0; i -= 1) {
+    for (let i = itemsWithNodeRef.current.length - 1; i >= 0; i -= 1) {
       // No hash if we're near the top of the page
       if (document.documentElement.scrollTop < 200) {
         active = { hash: null };
         break;
       }
 
-      const item = items[i];
-      const node = document.getElementById(item.hash);
+      const item = itemsWithNodeRef.current[i];
 
       if (process.env.NODE_ENV !== 'production') {
-        if (!node) {
+        if (!item.node) {
           console.error(`Missing node on the item ${JSON.stringify(item, null, 2)}`);
         }
       }
 
       if (
-        node &&
-        node.offsetTop <
+        item.node &&
+        item.node.offsetTop <
           document.documentElement.scrollTop + document.documentElement.clientHeight / 8
       ) {
         active = item;
@@ -141,7 +167,7 @@ export default function AppTableOfContents(props) {
     if (active && activeState !== active.hash) {
       setActiveState(active.hash);
     }
-  }, [activeState, items]);
+  }, [activeState]);
 
   // Corresponds to 10 frames at 60 Hz
   useThrottledOnScroll(items.length > 0 ? findActiveIndex : null, 166);


### PR DESCRIPTION
Since #29204, it's no longer possible to reach this highlight state by scrolling;

<img width="228" alt="Screenshot 2021-10-31 at 18 02 29" src="https://user-images.githubusercontent.com/3165635/139594308-7daaa15a-4c3e-41e4-a88b-309a6e251102.png">

https://master--material-ui.netlify.app/components/autocomplete/#customized-hook

~This reverts commit 6b12d46a24dad402178f2152708c0c965f5042bb, to fix the regression it introduces. I propose we either ignore the case (we don't use the React streaming feature, and we might never do) or have a deeper look into how to fix the issue.~

