### PR TITLE
[docs] Fix layout shift when scrolling

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -31,7 +31,7 @@ const NavLabel = styled(Typography)(({ theme }) => {
     marginTop: theme.spacing(2),
     paddingLeft: theme.spacing(1.5),
     fontSize: theme.typography.pxToRem(12),
-    fontWeight: 700,
+    fontWeight: theme.typography.fontWeightBold,
     color:
       theme.palette.mode === 'dark' ? alpha(theme.palette.grey[500], 0.5) : theme.palette.grey[500],
   };
@@ -50,7 +50,6 @@ const NavItem = styled(Link, {
     borderLeftColor:
       theme.palette.mode === 'light' ? theme.palette.primary[200] : theme.palette.primary[600],
     color: theme.palette.mode === 'dark' ? theme.palette.primary[300] : theme.palette.primary[500],
-    fontWeight: 700,
   };
 
   return {


### PR DESCRIPTION
I have first noticed the issue on X: https://deploy-preview-3006--material-ui-x.netlify.app/components/data-grid/editing/#server-side-validation with @m4theushw's PR. But it can also be reproduced on the Core. As you scroll, the font weight of the highlighted item increases, making it sometimes wrap, and shifting the rest of the table of content.

![wrap](https://user-images.githubusercontent.com/3165635/139594612-78dc2728-fe8e-4e0a-b373-51deda3d68e2.gif)

https://mui.com/components/links/#security

Compare with how it feels smoother on https://stripe.com/docs/terminal/overview. I went on reproducing the same behavior: no change of font-weight. I believe there is already enough contrast, more is taking the risk to catch the attention of the user away from what matters: the body of the page.

Preview: https://deploy-preview-29436--material-ui.netlify.app/components/links/