### PR TITLE
[docs] Remove usage of `process.browser`

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -253,7 +253,7 @@ function loadDependencies() {
   );
 }
 
-if (process.browser && process.env.NODE_ENV === 'production') {
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production') {
   // eslint-disable-next-line no-console
   console.log(
     `%c

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -150,7 +150,7 @@ async function submitFeedback(page, rating, comment, language) {
 
 function getCurrentRating(pathname) {
   let userFeedback;
-  if (process.browser) {
+  if (typeof window !== 'undefined') {
     userFeedback = getCookie('feedback');
     userFeedback = userFeedback && JSON.parse(userFeedback);
   }

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -145,7 +145,8 @@ const getTheme = (outerTheme) => {
 // TODO: Let demos decide whether they need JSS
 const jss = create({
   plugins: [...jssPreset().plugins, rtl()],
-  insertionPoint: process.browser ? document.querySelector('#insertion-point-jss') : null,
+  insertionPoint:
+    typeof window !== 'undefined' ? document.querySelector('#insertion-point-jss') : null,
 });
 
 /**

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -184,7 +184,7 @@ export function ThemeProvider(props) {
   useLazyCSS('/static/styles/prism-okaidia.css', '#prismjs');
 
   React.useEffect(() => {
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       const nextPaletteColors = JSON.parse(getCookie('paletteColors') || 'null');
       const nextPaletteMode = getCookie('paletteMode') || preferredMode;
 
@@ -248,7 +248,7 @@ export function ThemeProvider(props) {
 
   React.useEffect(() => {
     // Expose the theme as a global variable so people can play with it.
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       window.theme = theme;
       window.createTheme = createTheme;
     }

--- a/docs/src/modules/components/bootstrap.js
+++ b/docs/src/modules/components/bootstrap.js
@@ -1,6 +1,6 @@
 // Disable auto highlighting
 // https://github.com/PrismJS/prism/issues/765
-if (process.browser) {
+if (typeof window !== 'undefined') {
   window.Prism = window.Prism || {};
   window.Prism.manual = true;
 }

--- a/test/utils/setup.js
+++ b/test/utils/setup.js
@@ -1,8 +1,6 @@
 const testingLibrary = require('@testing-library/dom');
 const createDOM = require('./createDOM');
 
-process.browser = true;
-
 createDOM();
 require('./init');
 


### PR DESCRIPTION
This is a continuation of #24122. It's the encouraged path in https://github.com/vercel/next.js/pull/7651.