### PR TITLE
[Masonry] Check if container or child exists to prevent error

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -255,21 +255,21 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     // IE and old browsers are not supported
-    if (!observer) {
+    if (observer.current === undefined) {
       return undefined;
     }
 
     const container = masonryRef.current;
-    if (container) {
+    const resizeObserver = observer.current;
+    if (container && resizeObserver) {
       // only the masonry container and its first child are observed for resizing;
       // this might cause unforeseen problems in some use cases;
-      observer.current.observe(container);
+      resizeObserver.observe(container);
       if (container.firstChild) {
-        observer.current.observe(container.firstChild);
+        resizeObserver.observe(container.firstChild);
       }
     }
-    if (observer) {
-      const resizeObserver = observer.current;
+    if (resizeObserver) {
       return () => {
         resizeObserver.disconnect();
       };

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -184,6 +184,9 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     const handleResize = () => {
+      if (!masonryRef.current.firstChild) {
+        return;
+      }
       const parentWidth = masonryRef.current.clientWidth;
       const childWidth = masonryRef.current.firstChild.clientWidth;
       const firstChildComputedStyle = window.getComputedStyle(masonryRef.current.firstChild);

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -194,7 +194,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
           const parentWidth = masonry.contentRect.width;
           const childWidth = masonryFirstChild.contentRect.width;
-          const firstChildComputedStyle = window.getComputedStyle(masonryRef.current.firstChild);
+          const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild.target);
           const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
           const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
 
@@ -233,6 +233,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
             for (let i = 0; i < child.childNodes.length; i += 1) {
               const nestedChild = child.childNodes[i];
               if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
+                observer.current.observe(nestedChild);
                 skip = true;
                 break;
               }
@@ -254,13 +255,13 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
   );
 
   React.useEffect(() => {
+    const resizeObserver = observer.current;
     // IE and old browsers are not supported
-    if (observer.current === undefined) {
+    if (resizeObserver === undefined) {
       return undefined;
     }
 
     const container = masonryRef.current;
-    const resizeObserver = observer.current;
     if (container && resizeObserver) {
       // only the masonry container and its first child are observed for resizing;
       // this might cause unforeseen problems in some use cases;
@@ -269,12 +270,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
         resizeObserver.observe(container.firstChild);
       }
     }
-    if (resizeObserver) {
-      return () => {
-        resizeObserver.disconnect();
-      };
-    }
-    return () => {};
+    return () => (resizeObserver ? resizeObserver.disconnect() : {});
   }, [columns, spacing, children]);
 
   const handleRef = useForkRef(ref, masonryRef);

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -192,8 +192,8 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
             return;
           }
 
-          const parentWidth = masonryRef.current.clientWidth;
-          const childWidth = masonryRef.current.firstChild.clientWidth;
+          const parentWidth = masonry.contentRect.width;
+          const childWidth = masonryFirstChild.contentRect.width;
           const firstChildComputedStyle = window.getComputedStyle(masonryRef.current.firstChild);
           const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
           const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
@@ -208,7 +208,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
           const columnHeights = new Array(currentNumberOfColumns).fill(0);
           let skip = false;
-          masonryRef.current.childNodes.forEach((child) => {
+          masonry.target.childNodes.forEach((child) => {
             if (
               child.nodeType !== Node.ELEMENT_NODE ||
               child.dataset.class === 'line-break' ||

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -182,87 +182,80 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  const handleResize = (elements) => {
+    if (!elements) {
+      return;
+    }
+    let masonry;
+    let masonryFirstChild;
+    let parentWidth;
+    let childWidth;
+    if (elements[0].target.className.includes(classes.root)) {
+      masonry = elements[0].target;
+      parentWidth = elements[0].contentRect.width;
+      masonryFirstChild = elements[1]?.target || masonry.firstChild;
+      childWidth = masonryFirstChild?.contentRect?.width || masonryFirstChild?.clientWidth || 0;
+    } else {
+      masonryFirstChild = elements[0].target;
+      childWidth = elements[0].contentRect.width;
+      masonry = elements[1]?.target || masonryFirstChild.parentElement;
+      parentWidth = masonry.contentRect?.width || masonry.clientWidth;
+    }
+
+    if (parentWidth === 0 || childWidth === 0 || !masonry || !masonryFirstChild) {
+      return;
+    }
+
+    const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild);
+    const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
+    const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
+
+    const currentNumberOfColumns = Math.round(
+      parentWidth / (childWidth + firstChildMarginLeft + firstChildMarginRight),
+    );
+
+    const columnHeights = new Array(currentNumberOfColumns).fill(0);
+    let skip = false;
+    masonry.childNodes.forEach((child) => {
+      if (child.nodeType !== Node.ELEMENT_NODE || child.dataset.class === 'line-break' || skip) {
+        return;
+      }
+      const childComputedStyle = window.getComputedStyle(child);
+      const childMarginTop = parseToNumber(childComputedStyle.marginTop);
+      const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
+      // if any one of children isn't rendered yet, masonry's height shouldn't be computed yet
+      const childHeight = parseToNumber(childComputedStyle.height)
+        ? Math.ceil(parseToNumber(childComputedStyle.height)) + childMarginTop + childMarginBottom
+        : 0;
+      if (childHeight === 0) {
+        skip = true;
+        return;
+      }
+      // if there is a nested image that isn't rendered yet, masonry's height shouldn't be computed yet
+      for (let i = 0; i < child.childNodes.length; i += 1) {
+        const nestedChild = child.childNodes[i];
+        if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
+          skip = true;
+          break;
+        }
+      }
+      if (!skip) {
+        // find the current shortest column (where the current item will be placed)
+        const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
+        columnHeights[currentMinColumnIndex] += childHeight;
+        const order = currentMinColumnIndex + 1;
+        child.style.order = order;
+      }
+    });
+    if (!skip) {
+      setMaxColumnHeight(Math.max(...columnHeights));
+      const numOfLineBreaks = currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0;
+      setNumberOfLineBreaks(numOfLineBreaks);
+    }
+  };
+
   const observer = React.useRef(
-    typeof ResizeObserver === 'undefined'
-      ? undefined
-      : new ResizeObserver((elements) => {
-          if (!elements) {
-            return;
-          }
-          let masonry;
-          let masonryFirstChild;
-          let parentWidth;
-          let childWidth;
-          if (elements[0].target.className.includes(classes.root)) {
-            masonry = elements[0].target;
-            parentWidth = elements[0].contentRect.width;
-            masonryFirstChild = elements[1]?.target || masonryRef.current.firstChild;
-            childWidth =
-              masonryFirstChild?.contentRect?.width || masonryFirstChild?.clientWidth || 0;
-          } else {
-            masonryFirstChild = elements[0].target;
-            childWidth = elements[0].contentRect.width;
-            masonry = elements[1]?.target || masonryRef.current;
-            parentWidth = masonry.contentRect?.width || masonry.clientWidth;
-          }
-
-          if (parentWidth === 0 || childWidth === 0 || !masonry || !masonryFirstChild) {
-            return;
-          }
-
-          const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild);
-          const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
-          const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
-
-          const currentNumberOfColumns = Math.round(
-            parentWidth / (childWidth + firstChildMarginLeft + firstChildMarginRight),
-          );
-
-          const columnHeights = new Array(currentNumberOfColumns).fill(0);
-          let skip = false;
-          masonry.childNodes.forEach((child) => {
-            if (
-              child.nodeType !== Node.ELEMENT_NODE ||
-              child.dataset.class === 'line-break' ||
-              skip
-            ) {
-              return;
-            }
-            const childComputedStyle = window.getComputedStyle(child);
-            const childMarginTop = parseToNumber(childComputedStyle.marginTop);
-            const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
-            // if any one of children isn't rendered yet, masonry's height shouldn't be computed yet
-            const childHeight = parseToNumber(childComputedStyle.height)
-              ? Math.ceil(parseToNumber(childComputedStyle.height)) +
-                childMarginTop +
-                childMarginBottom
-              : 0;
-            if (childHeight === 0) {
-              skip = true;
-              return;
-            }
-            // if there is a nested image that isn't rendered yet, masonry's height shouldn't be computed yet
-            for (let i = 0; i < child.childNodes.length; i += 1) {
-              const nestedChild = child.childNodes[i];
-              if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
-                skip = true;
-                break;
-              }
-            }
-            if (!skip) {
-              // find the current shortest column (where the current item will be placed)
-              const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
-              columnHeights[currentMinColumnIndex] += childHeight;
-              const order = currentMinColumnIndex + 1;
-              child.style.order = order;
-            }
-          });
-          if (!skip) {
-            setMaxColumnHeight(Math.max(...columnHeights));
-            const numOfLineBreaks = currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0;
-            setNumberOfLineBreaks(numOfLineBreaks);
-          }
-        }),
+    typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(handleResize),
   );
 
   React.useEffect(() => {

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -255,7 +255,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     // IE and old browsers are not supported
-    if (typeof ResizeObserver === 'undefined') {
+    if (!observer) {
       return undefined;
     }
 

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -184,7 +184,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     const handleResize = () => {
-      if (!masonryRef.current.firstChild) {
+      if (!masonryRef.current || !masonryRef.current.firstChild) {
         return;
       }
       const parentWidth = masonryRef.current.clientWidth;

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -52,6 +52,25 @@ describe('<Masonry />', () => {
         width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing)})`,
       });
     });
+
+    it('should throw console error when children are empty', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
+        'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
+      );
+    });
+
+    it('should not throw type error when children are empty', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
+        'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
+      );
+      expect(() => render(<Masonry columns={3} spacing={1} />)).not.to.throw(new TypeError());
+    });
   });
 
   describe('style attribute:', () => {

--- a/test/regressions/fixtures/Masonry/EmptyMasonry.js
+++ b/test/regressions/fixtures/Masonry/EmptyMasonry.js
@@ -1,6 +1,0 @@
-import * as React from 'react';
-import Masonry from '@mui/lab/Masonry';
-
-export default function EmptyMasonry() {
-  return <Masonry columns={3} spacing={1} />;
-}

--- a/test/regressions/fixtures/Masonry/EmptyMasonry.js
+++ b/test/regressions/fixtures/Masonry/EmptyMasonry.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Masonry from '@mui/lab/Masonry';
+
+export default function EmptyMasonry() {
+  return <Masonry columns={3} spacing={1} />;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/29362
Closes https://github.com/mui-org/material-ui/issues/29446

Problem:
- `Uncaught TypeError: Cannot read properties of null (reading 'clientWidth') at ResizeObserver.handleResize`
- [code sandbox](https://codesandbox.io/s/basicmasonry-material-demo-forked-dgbyn)

Solution:
- Make the following change at the start of `handleResize()` in order to prevent `Cannot read properties of null` error.
```diff
diff --git a/packages/mui-lab/src/Masonry/Masonry.js b/packages/mui-lab/src/Masonry/Masonry.js
index 73bc1e166d..e127668cd7 100644
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -184,6 +184,9 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     const handleResize = () => {
+      if (!masonryRef.current || !masonryRef.current.firstChild) {
+        return;
+      }
       const parentWidth = masonryRef.current.clientWidth;
       const childWidth = masonryRef.current.firstChild.clientWidth;
       const firstChildComputedStyle = window.getComputedStyle(masonryRef.current.firstChild);
```
- [code sandbox](https://codesandbox.io/s/basicmasonry-material-demo-forked-v8fyi?file=/demo.js)