### PR TITLE
[docs] Remove create-mui-theme no longer working

### DIFF
--- a/docs/src/pages/customization/color/color.md
+++ b/docs/src/pages/customization/color/color.md
@@ -71,7 +71,6 @@ If you are using the default primary and / or secondary shades then by providing
 
 ### Tools by the community
 
-- [create-mui-theme](https://react-theming.github.io/create-mui-theme/): Is an online tool for creating MUI themes via Material Design Color Tool.
 - [mui-theme-creator](https://bareynol.github.io/mui-theme-creator/): A tool to help design and customize themes for the MUI component library. Includes basic site templates to show various components and how they are affected by the theme
 - [Material palette generator](https://material.io/inline-tools/color/): The Material palette generator can be used to generate a palette for any color you input.
 

--- a/docs/src/pages/customization/theming/theming.md
+++ b/docs/src/pages/customization/theming/theming.md
@@ -73,7 +73,6 @@ declare module '@mui/material/styles' {
 The community has built great tools to build a theme:
 
 - [mui-theme-creator](https://bareynol.github.io/mui-theme-creator/): A tool to help design and customize themes for the MUI component library. Includes basic site templates to show various components and how they are affected by the theme
-- [create-mui-theme](https://react-theming.github.io/create-mui-theme/): Is an online tool for creating MUI themes via Material Design Color Tool.
 - [Material palette generator](https://material.io/inline-tools/color/): The Material palette generator can be used to generate a palette for any color you input.
 
 ## Accessing the theme in a component

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -94,6 +94,5 @@ This is a collection of third-party projects that extend MUI.
 
 ## Theming
 
-- [create-mui-theme](https://react-theming.github.io/create-mui-theme/): An online tool for creating MUI themes via Material Design Color Tool.
 - [material-ui-theme-editor](https://in-your-saas.github.io/material-ui-theme-editor/): A tool to generate themes for your MUI applications by just selecting the colors and having a live preview.
 - [Material palette generator](https://material.io/inline-tools/color/): The Material palette generator can be used to generate a palette for any color you input.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The create-mui-theme project is no longer maintained. The service hasn't been functional since at least May 2020. This PR removes the 3 references in the MUI docs to the project.
