### PR TITLE
fix(templates-hero): perspective box scroll overflow

### DIFF
--- a/docs/src/components/productTemplate/TemplateHero.tsx
+++ b/docs/src/components/productTemplate/TemplateHero.tsx
@@ -54,7 +54,7 @@ export default function TemplateHero() {
         </Box>
       }
       right={
-        <Box sx={{ position: 'relative', height: '100%', perspective: '1000px' }}>
+        <Box sx={{ position: 'relative', height: '100%', perspective: '1000px', overflow: "hidden" }}>
           <Box
             sx={{
               left: '40%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

for some reason there's a scrollbar showing up inside of this animated perspective box. This PR should remove that

![image](https://user-images.githubusercontent.com/14989804/139912444-c43f2917-0fa8-45ab-bd82-6c76a10de96f.png)
