### PR TITLE
[docs] Do not repeat language snippet in url in Algolia search

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -277,7 +277,6 @@ function AppFrame(props) {
                 {LANGUAGES_LABEL.map((language) => (
                   <MenuItem
                     component="a"
-                    data-no-link="true"
                     href={language.code === 'en' ? canonical : `/${language.code}${canonical}`}
                     key={language.code}
                     selected={userLanguage === language.code}
@@ -293,7 +292,6 @@ function AppFrame(props) {
                 </Box>
                 <MenuItem
                   component="a"
-                  data-no-link="true"
                   href={
                     userLanguage === 'en'
                       ? `${CROWDIN_ROOT_URL}`

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -277,6 +277,7 @@ function AppFrame(props) {
                 {LANGUAGES_LABEL.map((language) => (
                   <MenuItem
                     component="a"
+                    data-no-markdown-link="true"
                     href={language.code === 'en' ? canonical : `/${language.code}${canonical}`}
                     key={language.code}
                     selected={userLanguage === language.code}

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
 import NextLink from 'next/link';
@@ -16,6 +17,7 @@ import { LANGUAGES_SSR } from 'docs/src/modules/constants';
 import Link from 'docs/src/modules/components/Link';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
+import { useRouter } from 'next/router';
 
 const SearchButton = styled('button')(({ theme }) => {
   return {
@@ -148,13 +150,7 @@ const NewStartScreen = () => {
 
 function DocSearcHit(props) {
   const { children, hit } = props;
-
-  const parseUrl = document.createElement('a');
-  parseUrl.href = hit.url;
-
-  // `url` contains the domain.
-  // But we want to link to the current domain e.g. deploy-preview-1--material-ui.netlify.app
-  return <Link href={`${parseUrl.pathname}${parseUrl.hash}`}>{children}</Link>;
+  return <Link href={hit.url}>{children}</Link>;
 }
 
 DocSearcHit.propTypes = {
@@ -179,6 +175,13 @@ export default function AppSearch() {
   const onOpen = React.useCallback(() => {
     setIsOpen(true);
   }, [setIsOpen]);
+  const router = useRouter();
+  const keyboardNavigator = {
+    navigate({ itemUrl }) {
+      const url = userLanguage !== 'en' ? `/${userLanguage}${itemUrl}` : itemUrl;
+      router.push(url);
+    },
+  };
 
   const onClose = React.useCallback(() => {
     const modal = document.querySelector('.DocSearch-Container');
@@ -280,21 +283,19 @@ export default function AppSearch() {
                 } else {
                   parseUrl.href = item.url;
                 }
-                const pathName = userLanguage
-                  ? parseUrl.pathname.replace(`/${userLanguage}`, '')
-                  : parseUrl.pathname;
-
+                const { canonical } = pathnameToLanguage(parseUrl.pathname);
                 return {
                   ...item,
                   // `url` contains the domain.
                   // But we want to link to the current domain e.g. deploy-preview-1--material-ui.netlify.app
-                  url: `${pathName}${parseUrl.hash}`,
+                  url: `${canonical}${parseUrl.hash}`,
                 };
               });
             }}
             hitComponent={DocSearcHit}
             initialScrollY={typeof window !== 'undefined' ? window.scrollY : undefined}
             onClose={onClose}
+            navigator={keyboardNavigator}
           />,
           document.body,
         )}

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -280,11 +280,15 @@ export default function AppSearch() {
                 } else {
                   parseUrl.href = item.url;
                 }
+                const pathName = userLanguage
+                  ? parseUrl.pathname.replace(`/${userLanguage}`, '')
+                  : parseUrl.pathname;
+
                 return {
                   ...item,
                   // `url` contains the domain.
                   // But we want to link to the current domain e.g. deploy-preview-1--material-ui.netlify.app
-                  url: `${parseUrl.pathname}${parseUrl.hash}`,
+                  url: `${pathName}${parseUrl.hash}`,
                 };
               });
             }}

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -230,10 +230,10 @@ export default function AppSearch() {
         addStartScreen();
       }
       if (searchInput) {
-        const handleInput = (e) => {
+        const handleInput = (event) => {
           const newStartScreen = document.querySelector('.DocSearch-NewStartScreen');
           if (newStartScreen) {
-            newStartScreen.style.display = e.target.value !== '' ? 'none' : 'grid';
+            newStartScreen.style.display = event.target.value !== '' ? 'none' : 'grid';
           }
         };
         searchInput.addEventListener('input', handleInput);

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -41,7 +41,7 @@ const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedPro
         passHref
         locale={locale}
       >
-        <Anchor ref={ref} {...other} />
+        <Anchor data-no-markdown-link="true" ref={ref} {...other} />
       </NextLink>
     );
   },

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -42,7 +42,7 @@ function handleClick(event) {
     activeElement === null ||
     activeElement.nodeName !== 'A' ||
     activeElement.getAttribute('target') === '_blank' ||
-    activeElement.getAttribute('data-no-link') === 'true' ||
+    activeElement.getAttribute('data-no-markdown-link') === 'true' ||
     activeElement.getAttribute('href').indexOf('/') !== 0
   ) {
     return;

--- a/docs/src/pages/discover-more/languages/Languages.js
+++ b/docs/src/pages/discover-more/languages/Languages.js
@@ -22,7 +22,7 @@ export default function Languages() {
                 <Link
                   variant="body2"
                   color="secondary"
-                  data-no-link="true"
+                  data-no-markdown-link="true"
                   href={language.code === 'en' ? '/' : `/${language.code}/`}
                 >
                   Documentation


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/29332
Closes https://github.com/mui-org/material-ui/issues/29461

Problem:
- When user is using a language other than English, links in Algolia search contain the language snippet (zh or pt). This results in repetition of the language snippet in url; e.g., `https://mui.com/zh/zh/components/buttons/#main-content`
- This is because `mui.com` already changes to `mui.com/${language}` if language other than English is set.
- To reproduce, follow these steps:
(1) Go to https://mui.com/getting-started/usage/
(2) Change language setting to Portuguese
(3) Open algolia searchbox and enter "mig"
(4) Click the first link
(4) You will be directed to `https://mui.com/pt/pt/guides/migration-v4/#main-content`

Solution:
- When user is using language other than English, remove the language snippet (zh or pt) from urls used in algolia search.