### PR TITLE
[ButtonGroup] Fix variant outlined always has primary color borders on hover

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -149,16 +149,18 @@ const ButtonGroupRoot = styled('div', {
         ownerState.color !== 'inherit' && {
           borderColor: theme.palette[ownerState.color].dark,
         }),
+      '&:hover': {
+        ...(ownerState.variant === 'outlined' &&
+          ownerState.orientation === 'horizontal' && {
+            borderRightColor: 'currentColor',
+          }),
+        ...(ownerState.variant === 'outlined' &&
+          ownerState.orientation === 'vertical' && {
+            borderBottomColor: 'currentColor',
+          }),
+      },
     },
     '&:hover': {
-      ...(ownerState.variant === 'outlined' &&
-        ownerState.orientation === 'horizontal' && {
-          borderRightColor: 'currentColor',
-        }),
-      ...(ownerState.variant === 'outlined' &&
-        ownerState.orientation === 'vertical' && {
-          borderBottomColor: 'currentColor',
-        }),
       ...(ownerState.variant === 'contained' && {
         boxShadow: 'none',
       }),

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -152,8 +152,12 @@ const ButtonGroupRoot = styled('div', {
     },
     '&:hover': {
       ...(ownerState.variant === 'outlined' &&
-        ownerState.color !== 'inherit' && {
-          borderColor: theme.palette[ownerState.color].main,
+        ownerState.orientation === 'horizontal' && {
+          borderRightColor: 'currentColor',
+        }),
+      ...(ownerState.variant === 'outlined' &&
+        ownerState.orientation === 'vertical' && {
+          borderBottomColor: 'currentColor',
         }),
       ...(ownerState.variant === 'contained' && {
         boxShadow: 'none',
@@ -223,7 +227,6 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
       classes.grouped,
     ],
   );
-
   return (
     <ButtonGroupRoot
       as={component}

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -227,6 +227,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
       classes.grouped,
     ],
   );
+
   return (
     <ButtonGroupRoot
       as={component}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29219 

The border-color style is applied in the `Button` component and we don't need to have it in `ButtonGroup`. Since the hovering behaviour is such that it is not on the _complete_ ButtonGroup but instead on individual buttons within button group.

Since in `ButtonGroup` the `border-right-color` and `border-bottom-color` for `horizontal` and `vertical` orientation respectively is `transparent`, while hovering we take the current color value. 

I think this is a regression from `v5.0.0-alpha.25 ` from PR #24775.

In v4, we had border color styles while hovering on both `ButtonGroup` and `Button` but the `Button `ones had high specificity. In v5, with the new styling solution, the `grouped`  selector within `root` (`$ .grouped`) in `ButtonGroup` got the high specificity. But anyway I think we need not have border color styles in `ButtonGroup`.

-----

Before `v5.0.0-alpha.25 `:  https://codesandbox.io/s/mui-buttongroup-color-bug-forked-xw8ke?file=/src/Demo.tsx (in v5.0.0-alpha.24)

Before fix: https://codesandbox.io/s/mui-buttongroup-color-bug-t37rv?file=/src/Demo.tsx
After fix: https://codesandbox.io/s/mui-buttongroup-color-bug-63351?file=/src/Demo.tsx