### PR TITLE
[DatePicker][TimePicker] Add missing component declarations

### DIFF
--- a/packages/mui-lab/src/themeAugmentation/components.d.ts
+++ b/packages/mui-lab/src/themeAugmentation/components.d.ts
@@ -21,15 +21,15 @@ export interface LabComponents {
     styleOverrides?: ComponentsOverrides['MuiDatePicker'];
     variants?: ComponentsVariants['MuiDatePicker'];
   };
-  MuiDateTimePicker?: {
-    defaultProps?: ComponentsProps['MuiDateTimePicker'];
-    styleOverrides?: ComponentsOverrides['MuiDateTimePicker'];
-    variants?: ComponentsVariants['MuiDateTimePicker'];
-  };
   MuiDateRangePickerDay?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
     styleOverrides?: ComponentsOverrides['MuiDateRangePickerDay'];
     variants?: ComponentsVariants['MuiDateRangePickerDay'];
+  };
+  MuiDateTimePicker?: {
+    defaultProps?: ComponentsProps['MuiDateTimePicker'];
+    styleOverrides?: ComponentsOverrides['MuiDateTimePicker'];
+    variants?: ComponentsVariants['MuiDateTimePicker'];
   };
   MuiLoadingButton?: {
     defaultProps?: ComponentsProps['MuiLoadingButton'];

--- a/packages/mui-lab/src/themeAugmentation/components.d.ts
+++ b/packages/mui-lab/src/themeAugmentation/components.d.ts
@@ -16,6 +16,16 @@ export interface LabComponents {
     styleOverrides?: ComponentsOverrides['MuiClockPicker'];
     variants?: ComponentsVariants['MuiClockPicker'];
   };
+  MuiDatePicker?: {
+    defaultProps?: ComponentsProps['MuiDatePicker'];
+    styleOverrides?: ComponentsOverrides['MuiDatePicker'];
+    variants?: ComponentsVariants['MuiDatePicker'];
+  };
+  MuiDateTimePicker?: {
+    defaultProps?: ComponentsProps['MuiDateTimePicker'];
+    styleOverrides?: ComponentsOverrides['MuiDateTimePicker'];
+    variants?: ComponentsVariants['MuiDateTimePicker'];
+  };
   MuiDateRangePickerDay?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
     styleOverrides?: ComponentsOverrides['MuiDateRangePickerDay'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `@mui/lab/themeAugmentation` declarations were missing the `MuiDatePicker` and `MuiDateTimePicker` components. This made it not possible to override the props and styles for those components in a custom theme.

It appears these components were at one point part of the declarations file https://github.com/mui-org/material-ui/pull/24092/files but not sure how it was dropped or lost.