### PR TITLE
[Breadcrumbs][Divider] Replace decimal spacing values with integers and css calc

### DIFF
--- a/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.js
+++ b/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.js
@@ -7,8 +7,8 @@ import ButtonBase from '../ButtonBase';
 
 const BreadcrumbCollapsedButton = styled(ButtonBase, { skipSx: true })(({ theme }) => ({
   display: 'flex',
-  marginLeft: theme.spacing(0.5),
-  marginRight: theme.spacing(0.5),
+  marginLeft: `calc(${theme.spacing(1)} * 0.5)`,
+  marginRight: `calc(${theme.spacing(1)} * 0.5)`,
   ...(theme.palette.mode === 'light'
     ? { backgroundColor: theme.palette.grey[100], color: theme.palette.grey[700] }
     : { backgroundColor: theme.palette.grey[700], color: theme.palette.grey[100] }),

--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -155,11 +155,11 @@ const DividerWrapper = styled('span', {
   },
 })(({ theme, ownerState }) => ({
   display: 'inline-block',
-  paddingLeft: theme.spacing(1.2),
-  paddingRight: theme.spacing(1.2),
+  paddingLeft: `calc(${theme.spacing(1)} * 1.2)`,
+  paddingRight: `calc(${theme.spacing(1)} * 1.2)`,
   ...(ownerState.orientation === 'vertical' && {
-    paddingTop: theme.spacing(1.2),
-    paddingBottom: theme.spacing(1.2),
+    paddingTop: `calc(${theme.spacing(1)} * 1.2)`,
+    paddingBottom: `calc(${theme.spacing(1)} * 1.2)`,
   }),
 }));
 


### PR DESCRIPTION
Replace decimal values passed to `theme.spacing()` with integers

* use combination of `theme.spacing()` and css `calc()` arithmetic to obtain final value
* components affected: `BreadcrumbCollapsed`, `DividerWrapper` 
* close #29479 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).



