### PR TITLE
[ListItemButton]: Fix ts(4023) by adding missing export

### DIFF
--- a/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
@@ -5,7 +5,7 @@ import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { ListItemButtonClasses } from './listItemButtonClasses';
 
-interface ListItemButtonBaseProps {
+export interface ListItemButtonBaseProps {
   /**
    * Defines the `align-items` style property.
    * @default 'center'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I get the following error message when using ListItemButton, ListItemButtonProps in my custom component lib:

_Exported variable 'ListItemButton' has or is using name 'ListItemButtonBaseProps' from external module ".../node_modules/@mui/material/ListItemButton/ListItemButton" but cannot be named. ts(4023)_