### PR TITLE
[ImageList] Verify a quilted variant is created as test title suggests

### DIFF
--- a/packages/mui-material/src/ImageList/ImageList.test.js
+++ b/packages/mui-material/src/ImageList/ImageList.test.js
@@ -73,13 +73,13 @@ describe('<ImageList />', () => {
 
     it('should render with the quilted class', () => {
       const { getByTestId } = render(
-        <ImageList data-testid="test-root" variant="woven">
+        <ImageList data-testid="test-root" variant="quilted">
           {children}
         </ImageList>,
       );
 
       expect(getByTestId('test-root')).to.have.class(classes.root);
-      expect(getByTestId('test-root')).to.have.class(classes.woven);
+      expect(getByTestId('test-root')).to.have.class(classes.quilted);
     });
 
     it('should render with the woven class', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This test's title says it is testing the `quilted` variant of the `ImageList` component, but it actually creates a `woven` variant.

This is my first contribution here, so please let me know if there's anything I missed. I hope to contribute more in the future!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
