### PR TITLE
[ListItem] Add missing exports

### DIFF
--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -7,7 +7,7 @@ import { ListItemClasses } from './listItemClasses';
 
 export interface ListItemComponentsPropsOverrides {}
 
-interface ListItemBaseProps {
+export interface ListItemBaseProps {
   /**
    * Defines the `align-items` style property.
    * @default 'center'

--- a/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
@@ -5,7 +5,7 @@ import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { ListItemButtonClasses } from './listItemButtonClasses';
 
-interface ListItemButtonBaseProps {
+export interface ListItemButtonBaseProps {
   /**
    * Defines the `align-items` style property.
    * @default 'center'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR exports `ListItemBaseProps` and `ListItemButtonBaseProps` to fix a TS4023 error.

Fixes #29291
