### PR TITLE
[core] Add `experiments` index page

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -181,6 +181,9 @@ module.exports = {
       const prefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
 
       pages2.forEach((page) => {
+        if (process.env.PULL_REQUEST !== 'true' && page.pathname.startsWith('/playgrounds')) {
+          return;
+        }
         if (!page.children) {
           map[`${prefix}${page.pathname.replace(/^\/api-docs\/(.*)/, '/api/$1')}`] = {
             page: page.pathname,

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -181,7 +181,7 @@ module.exports = {
       const prefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
 
       pages2.forEach((page) => {
-        if (process.env.PULL_REQUEST !== 'true' && page.pathname.startsWith('/playgrounds')) {
+        if (process.env.PULL_REQUEST !== 'true' && page.pathname.startsWith('/experiments')) {
           return;
         }
         if (!page.children) {

--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -58,6 +58,9 @@ export default function Experiments({ experiments }) {
               <Typography component="li">
                 URLs start with <code>/experiments/*</code> are deployed only on the pull request.
               </Typography>
+              <Typography component="li">
+                <code>/experiments/*</code> are not included in docsearch indexing.
+              </Typography>
             </ul>
           </Box>
         </Box>

--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -11,10 +11,10 @@ import GradientText from 'docs/src/components/typography/GradientText';
 import Link from 'docs/src/modules/components/Link';
 import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
 
-export default function Playgrounds({ playgrounds }) {
+export default function Experiments({ experiments }) {
   const categories = {};
 
-  playgrounds.forEach((name) => {
+  experiments.forEach((name) => {
     const paths = name.split('/');
     const categoryName = paths.length === 1 ? 'Uncategorized' : capitalize(paths[0] || '');
 
@@ -23,7 +23,7 @@ export default function Playgrounds({ playgrounds }) {
     }
     categories[categoryName].push({
       name: capitalize(paths[1] || paths[0]),
-      pathname: `/playgrounds/${name}`,
+      pathname: `/experiments/${name}`,
     });
   });
 
@@ -47,16 +47,16 @@ export default function Playgrounds({ playgrounds }) {
             Welcome to
           </Typography>
           <Typography component="h1" variant="h2" sx={{ my: 1 }}>
-            MUI <GradientText>Playgrounds</GradientText>
+            MUI <GradientText>Experiments</GradientText>
           </Typography>
 
           <Box sx={{ textAlign: 'left' }}>
             <ul>
               <Typography component="li">
-                All the files under <code>/playgrounds</code> are committed to git.
+                All the files under <code>/experiments</code> are committed to git.
               </Typography>
               <Typography component="li">
-                URLs start with <code>/playgrounds/*</code> are deployed only on the pull request.
+                URLs start with <code>/experiments/*</code> are deployed only on the pull request.
               </Typography>
             </ul>
           </Box>
@@ -73,9 +73,9 @@ export default function Playgrounds({ playgrounds }) {
             textAlign="center"
             sx={{ mb: 2 }}
           >
-            All Playgrounds ({playgrounds.length})
+            All Experiments ({experiments.length})
           </Typography>
-          {playgrounds.length > 0 && (
+          {experiments.length > 0 && (
             <Box
               sx={{
                 display: 'grid',
@@ -136,15 +136,15 @@ export default function Playgrounds({ playgrounds }) {
   );
 }
 
-Playgrounds.getInitialProps = () => {
-  const playgrounds = [];
+Experiments.getInitialProps = () => {
+  const experiments = [];
   const req = require.context('./', true, /^\.\/.*(?<!index)\.(js|tsx)$/);
 
   req.keys().forEach((k) => {
-    playgrounds.push(k.replace(/^\.\/(.*)\.(js|tsx)$/, '$1'));
+    experiments.push(k.replace(/^\.\/(.*)\.(js|tsx)$/, '$1'));
   });
 
   return {
-    playgrounds,
+    experiments,
   };
 };

--- a/docs/pages/playgrounds/index.js
+++ b/docs/pages/playgrounds/index.js
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { capitalize } from '@mui/material/utils';
+import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import GradientText from 'docs/src/components/typography/GradientText';
+import Link from 'docs/src/modules/components/Link';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+
+export default function Playgrounds({ playgrounds }) {
+  const categories = {};
+
+  playgrounds.forEach((name) => {
+    const paths = name.split('/');
+    const categoryName = paths.length === 1 ? 'Uncategorized' : capitalize(paths[0] || '');
+
+    if (!categories[categoryName]) {
+      categories[categoryName] = [];
+    }
+    categories[categoryName].push({
+      name: capitalize(paths[1] || paths[0]),
+      pathname: `/playgrounds/${name}`,
+    });
+  });
+
+  return (
+    <React.Fragment>
+      <CssBaseline />
+      <Container>
+        <Box
+          sx={{
+            minHeight: 300,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            maxWidth: 600,
+            mx: 'auto',
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="body2" color="primary.600" fontWeight="bold">
+            Welcome to
+          </Typography>
+          <Typography component="h1" variant="h2" sx={{ my: 1 }}>
+            MUI <GradientText>Playgrounds</GradientText>
+          </Typography>
+
+          <Box sx={{ textAlign: 'left' }}>
+            <ul>
+              <Typography component="li">
+                All the files under <code>/playgrounds</code> are committed to git.
+              </Typography>
+              <Typography component="li">
+                URLs start with <code>/playgrounds/*</code> are deployed only on the pull request.
+              </Typography>
+            </ul>
+          </Box>
+        </Box>
+      </Container>
+      <Box
+        sx={{ bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.900' : 'grey.50') }}
+      >
+        <Container sx={{ py: { xs: 4, md: 8 } }}>
+          <Typography
+            variant="body2"
+            color="grey.600"
+            fontWeight="bold"
+            textAlign="center"
+            sx={{ mb: 2 }}
+          >
+            All Playgrounds ({playgrounds.length})
+          </Typography>
+          {playgrounds.length > 0 && (
+            <Box
+              sx={{
+                display: 'grid',
+                gap: 2,
+                gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+              }}
+            >
+              {Object.entries(categories).map(([categoryName, children]) => (
+                <Box key={categoryName} sx={{ pb: 2 }}>
+                  <Typography
+                    component="h2"
+                    variant="body2"
+                    sx={{
+                      fontWeight: 500,
+                      color: 'grey.600',
+                      px: 1,
+                    }}
+                  >
+                    {categoryName}
+                  </Typography>
+                  <List>
+                    {(children || []).map((aPage) => {
+                      return (
+                        <ListItem key={aPage.pathname} disablePadding>
+                          <ListItemButton
+                            component={Link}
+                            noLinkStyle
+                            href={aPage.pathname}
+                            sx={{
+                              px: 1,
+                              py: 0.5,
+                              fontSize: '0.84375rem',
+                              fontWeight: 500,
+                              '&:hover, &:focus': { '& svg': { opacity: 1 } },
+                            }}
+                          >
+                            {aPage.name}
+                            <KeyboardArrowRightRounded
+                              sx={{
+                                ml: 'auto',
+                                fontSize: '1.125rem',
+                                opacity: 0,
+                                color: 'primary.main',
+                              }}
+                            />
+                          </ListItemButton>
+                        </ListItem>
+                      );
+                    })}
+                  </List>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Container>
+      </Box>
+    </React.Fragment>
+  );
+}
+
+Playgrounds.getInitialProps = () => {
+  const playgrounds = [];
+  const req = require.context('./', true, /^\.\/.*(?<!index)\.(js|tsx)$/);
+
+  req.keys().forEach((k) => {
+    playgrounds.push(k.replace(/^\.\/(.*)\.(js|tsx)$/, '$1'));
+  });
+
+  return {
+    playgrounds,
+  };
+};


### PR DESCRIPTION
Preview: https://deploy-preview-29582--material-ui.netlify.app/experiments/

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The purpose of `experiments/*` pages is for us to share ideas with POCs/demos locally and in PR. These experiments will not be deployed to the production site.

Follow up from:

- https://github.com/mui-org/material-ui/pull/29423#issuecomment-957349252
- https://github.com/oliviertassinari/material-ui/pull/18

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
