### PR TITLE
[Select] Make it clear that `Select` is not a root component

### DIFF
--- a/docs/pages/api-docs/select.json
+++ b/docs/pages/api-docs/select.json
@@ -38,7 +38,6 @@
   "name": "Select",
   "styles": {
     "classes": [
-      "root",
       "select",
       "filled",
       "outlined",

--- a/docs/translations/api-docs/select/select.json
+++ b/docs/translations/api-docs/select/select.json
@@ -26,7 +26,6 @@
     "variant": "The variant to use."
   },
   "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
     "select": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the select component `select` class"

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { deepmerge } from '@mui/utils';
-import { unstable_composeClasses as composeClasses } from '@mui/base';
 import SelectInput from './SelectInput';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
@@ -13,16 +12,10 @@ import FilledInput from '../FilledInput';
 import OutlinedInput from '../OutlinedInput';
 import useThemeProps from '../styles/useThemeProps';
 import useForkRef from '../utils/useForkRef';
-import { getSelectUtilityClasses } from './selectClasses';
 
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
-
-  const slots = {
-    root: ['root'],
-  };
-
-  return composeClasses(slots, getSelectUtilityClasses, classes);
+  return classes;
 };
 
 const Select = React.forwardRef(function Select(inProps, ref) {
@@ -72,7 +65,6 @@ const Select = React.forwardRef(function Select(inProps, ref) {
 
   const ownerState = { ...props, classes: classesProp };
   const classes = useUtilityClasses(ownerState);
-  const { root, ...otherClasses } = classesProp;
 
   const inputComponentRef = useForkRef(ref, InputComponent.ref);
 
@@ -100,12 +92,12 @@ const Select = React.forwardRef(function Select(inProps, ref) {
             SelectDisplayProps: { id, ...SelectDisplayProps },
           }),
       ...inputProps,
-      classes: inputProps ? deepmerge(otherClasses, inputProps.classes) : otherClasses,
+      classes: inputProps ? deepmerge(classes, inputProps.classes) : classes,
       ...(input ? input.props.inputProps : {}),
     },
     ...(multiple && native && variant === 'outlined' ? { notched: true } : {}),
     ref: inputComponentRef,
-    className: clsx(classes.root, InputComponent.props.className, className),
+    className: clsx(InputComponent.props.className, className),
     ...other,
   });
 });

--- a/packages/mui-material/src/Select/selectClasses.ts
+++ b/packages/mui-material/src/Select/selectClasses.ts
@@ -1,8 +1,6 @@
 import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 
 export interface SelectClasses {
-  /** Styles applied to the root element. */
-  root: string;
   /** Styles applied to the select component `select` class. */
   select: string;
   /** Styles applied to the select component if `variant="filled"`. */
@@ -34,7 +32,6 @@ export function getSelectUtilityClasses(slot: string): string {
 }
 
 const selectClasses: SelectClasses = generateUtilityClasses('MuiSelect', [
-  'root',
   'select',
   'filled',
   'outlined',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/29342
Closes https://github.com/mui-org/material-ui/pull/29384

`Select` component is implemented as a custom input of `Input` component. However, this is not clear in code and in docs API. 

e.g.,
![Screenshot 2021-11-09 at 11 36 54](https://user-images.githubusercontent.com/32841130/140917358-8a72f79a-d546-4e34-b066-c8e912abc1cc.png)

Due to the lack of clarity, some developers expect such theme to take effect:
```javascript
const theme = createTheme({
  components: {
    MuiSelect: {
      styleOverrides: {
        root: {
          background: "red"
        }
      }
    }
  }
});
```

Before:
- [codesandbox](https://codesandbox.io/s/lingering-violet-7rixw)
- if you inspect `Select` component, you will see `MuiSelect-root` in classname.

After:
- [codesandbox](https://codesandbox.io/s/quiet-microservice-td4lx?file=/package.json)
- if you inspect `Select` component, you won't see `MuiSelect-root` in classname.
