### PR TITLE
[core] Move s3 bucket ownership to mui-org

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,15 +77,15 @@ jobs:
       - task: S3Upload@1
         inputs:
           regionName: 'eu-central-1'
-          bucketName: 'eps1lon-material-ui'
+          bucketName: 'mui-org-material-ui'
           globExpressions: '*.tgz'
           targetFolder: $(S3_ARTIFACTS_PATH_PERMA)
           filesAcl: 'public-read'
         displayName: 'Upload distributables to S3'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         env:
-          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID_SIZE_SNAPSHOT)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY_SIZE_SNAPSHOT)
 
       - task: PublishPipelineArtifact@1
         inputs:
@@ -106,9 +106,9 @@ jobs:
         displayName: 'persist size snapshot on S3'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
-          awsCredentials: 's3 artifacts'
+          awsCredentials: 's3 artifacts v2'
           regionName: 'eu-central-1'
-          bucketName: 'eps1lon-material-ui'
+          bucketName: 'mui-org-material-ui'
           sourceFolder: '$(System.DefaultWorkingDirectory)'
           globExpressions: 'size-snapshot.json'
           targetFolder: $(S3_ARTIFACTS_PATH_PERMA)
@@ -121,9 +121,9 @@ jobs:
         displayName: 'symlink size-snapshot to latest'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Reason'], 'Schedule'))
         inputs:
-          awsCredentials: 's3 artifacts'
+          awsCredentials: 's3 artifacts v2'
           regionName: 'eu-central-1'
-          bucketName: 'eps1lon-material-ui'
+          bucketName: 'mui-org-material-ui'
           sourceFolder: '$(System.DefaultWorkingDirectory)'
           globExpressions: 'size-snapshot.json'
           targetFolder: 'artifacts/$(Build.SourceBranchName)/latest/'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,6 @@ trigger:
     include:
       - 'master'
       - 'next'
-      # REVERT LATER
-      - 'core/size-snapshot-handoff'
 
 schedules:
   - cron: '0 0 * * *'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@ trigger:
     include:
       - 'master'
       - 'next'
+      # REVERT LATER
+      - 'core/size-snapshot-handoff'
 
 schedules:
   - cron: '0 0 * * *'

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -4,7 +4,7 @@
 /trash / 301
 /spam / 301
 
-/size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/master/latest/size-snapshot.json 200
+/size-snapshot https://s3.eu-central-1.amazonaws.com/mui-org-material-ui/artifacts/master/latest/size-snapshot.json 200
 
 # To add when we finish work on v6
 # https://next.mui.com/* https://mui.com/:splat 301!

--- a/scripts/sizeSnapshot/loadComparison.js
+++ b/scripts/sizeSnapshot/loadComparison.js
@@ -28,11 +28,14 @@ async function loadSnapshot(commitId, ref) {
 
 const nullSnapshot = { parsed: 0, gzip: 0 };
 
-module.exports = async function loadComparison(parrentId, ref) {
+module.exports = async function loadComparison(parentId, ref) {
   const [currentSnapshot, previousSnapshot] = await Promise.all([
     loadCurrentSnapshot(),
-    // silence non existing snapshots
-    loadSnapshot(parrentId, ref).catch(() => ({})),
+    // continue non existing snapshots
+    loadSnapshot(parentId, ref).catch((reason) => {
+      console.warn(`Failed to load snapshot for ref '${ref}' and commit '${parentId}': `, reason);
+      return {};
+    }),
   ]);
 
   const bundleKeys = Object.keys({ ...currentSnapshot, ...previousSnapshot });
@@ -65,7 +68,7 @@ module.exports = async function loadComparison(parrentId, ref) {
   );
 
   return {
-    previous: parrentId,
+    previous: parentId,
     current: 'HEAD',
     bundles,
   };

--- a/scripts/sizeSnapshot/loadComparison.js
+++ b/scripts/sizeSnapshot/loadComparison.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fetch = require('node-fetch');
 const lodash = require('lodash');
 
-const artifactServer = 'https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui';
+const artifactServer = 'https://s3.eu-central-1.amazonaws.com/mui-org-material-ui';
 
 async function loadCurrentSnapshot() {
   return fse.readJSON(path.join(__dirname, '../../size-snapshot.json'));


### PR DESCRIPTION
s3 bucket was previously owned by me. Created a new bucket under our org. Copied all existing objects via `aws --profile Administrator s3 cp s3://eps1lon-material-ui/ s3://mui-org-material-ui/ --recursive --acl bucket-owner-full-control`

Pushed to upstream so that I get full coverage of the azure pipeline. 

Same as https://github.com/mui-org/material-ui/pull/29608 but from upstream to test behavior on `master`