### PR TITLE
[material] Fix types for `variants.style` to accept callbacks

### DIFF
--- a/packages/mui-material/src/styles/createTheme.spec.ts
+++ b/packages/mui-material/src/styles/createTheme.spec.ts
@@ -1,4 +1,4 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, ThemeOptions } from '@mui/material/styles';
 
 const theme = createTheme();
 
@@ -77,6 +77,44 @@ const theme = createTheme();
             color: 'black',
           },
         },
+      },
+    },
+  });
+}
+
+{
+  createTheme(theme, {
+    components: {
+      MuiButton: {
+        variants: [
+          {
+            props: {}, // match any props combination
+            style: ({ theme: t }) => {
+              return {
+                fontFamily: t.typography.fontFamily,
+              };
+            },
+          },
+        ],
+      },
+    },
+  } as ThemeOptions);
+}
+
+{
+  createTheme({
+    components: {
+      MuiButton: {
+        variants: [
+          {
+            props: {}, // match any props combination
+            style: ({ theme: t }) => {
+              return {
+                fontFamily: t.typography.fontFamily,
+              };
+            },
+          },
+        ],
       },
     },
   });

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -1,8 +1,13 @@
 import { expect } from 'chai';
 import createTheme from './createTheme';
+import { createRenderer } from 'test/utils';
+import Button from '@mui/material/Button';
+import { ThemeProvider } from '@mui/material/styles';
 import { deepOrange, green } from '../colors';
 
 describe('createTheme', () => {
+  const { render } = createRenderer();
+
   it('should have a palette', () => {
     const theme = createTheme();
     expect(typeof createTheme).to.equal('function');
@@ -126,5 +131,34 @@ describe('createTheme', () => {
     const theme = createTheme({ custom: { foo: 'I am foo' } }, { custom: { bar: 'I am bar' } });
     expect(theme.custom.foo).to.equal('I am foo');
     expect(theme.custom.bar).to.equal('I am bar');
+  });
+
+  it('allows callbacks using theme in variants', () => {
+    const theme = createTheme({
+      typography: {
+        fontFamily: 'cursive',
+      },
+      components: {
+        MuiButton: {
+          variants: [
+            {
+              props: {}, // match any props combination
+              style: ({ theme: t }) => {
+                return {
+                  fontFamily: t.typography.fontFamily,
+                };
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Button />
+      </ThemeProvider>,
+    );
+    expect(container.firstChild).toHaveComputedStyle({ fontFamily: 'cursive' });
   });
 });

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -1,9 +1,9 @@
+import * as React from 'react';
 import { expect } from 'chai';
-import createTheme from './createTheme';
 import { createRenderer } from 'test/utils';
 import Button from '@mui/material/Button';
-import { ThemeProvider } from '@mui/material/styles';
-import { deepOrange, green } from '../colors';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { deepOrange, green } from '@mui/material/colors';
 
 describe('createTheme', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/styles/variants.d.ts
+++ b/packages/mui-material/src/styles/variants.d.ts
@@ -1,9 +1,10 @@
-import { CSSInterpolation } from '@mui/system';
+import { Interpolation } from '@mui/system';
+import { Theme } from './createTheme';
 import { ComponentsPropsList } from './props';
 
 export type ComponentsVariants = {
   [Name in keyof ComponentsPropsList]?: Array<{
     props: Partial<ComponentsPropsList[Name]>;
-    style: CSSInterpolation;
+    style: Interpolation<{ theme: Theme }>;
   }>;
 };


### PR DESCRIPTION
The PR fixes the types for the `variants` by changing the `CSSInterpolation` with `Interpolation` which accepts function callbacks. Added tests for types as well as run time behavior.