### PR TITLE
[website] Fix dark mode on brand pages

### DIFF
--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -515,6 +515,11 @@ export function getThemedComponents(theme: Theme) {
           },
         },
       },
+      MuiCssBaseline: {
+        defaultProps: {
+          enableColorScheme: true,
+        },
+      },
     },
   };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

It appears that the theme of the doc pages and the brand pages are different. That cause the dark mode migration to fail on branding pages

### Now
![image](https://user-images.githubusercontent.com/45398769/141099162-ddd7aa98-aec8-4ffd-90fc-cfb5a423b4d8.png)

### After modification

![image](https://user-images.githubusercontent.com/45398769/141099240-49efe2e4-1988-46c5-97dc-0d37ffcb1385.png)

Preview: https://deploy-preview-29611--material-ui.netlify.app/