### PR TITLE
[Button] Fix disableRipple getting ignored in MuiButtonBase defaultProps

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -318,7 +318,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   const fullWidth = fullWidthProp || fullWidthContext || false;
   const size = sizeProp || sizeContext || 'medium';
   const variant = variantProp || variantContext || 'text';
-  const disableRipple = disableRippleProp || disableRippleContext || false;
+  const disableRipple = disableRippleContext || disableRippleProp;
 
   const ownerState = {
     ...props,

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describeConformance, act, createRenderer, fireEvent } from 'test/utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button, { buttonClasses as classes } from '@mui/material/Button';
-import ButtonBase, {touchRippleClasses} from '@mui/material/ButtonBase';
+import ButtonBase, { touchRippleClasses } from '@mui/material/ButtonBase';
 
 describe('<Button />', () => {
   const { render, renderToString } = createRenderer();

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { describeConformance, act, createRenderer, fireEvent } from 'test/utils';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button, { buttonClasses as classes } from '@mui/material/Button';
-import ButtonBase from '@mui/material/ButtonBase';
+import ButtonBase, {touchRippleClasses} from '@mui/material/ButtonBase';
 
 describe('<Button />', () => {
   const { render, renderToString } = createRenderer();
@@ -371,5 +372,43 @@ describe('<Button />', () => {
     const { container } = render(<Button disabled classes={{ disabled: disabledClassName }} />);
 
     expect(container.querySelector('button')).to.have.class(disabledClassName);
+  });
+
+  it("should disable ripple when MuiButtonBase has disableRipple in theme's defaultProps", () => {
+    const theme = createTheme({
+      components: {
+        MuiButtonBase: {
+          defaultProps: {
+            disableRipple: true,
+          },
+        },
+      },
+    });
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Button>Disabled ripple</Button>
+      </ThemeProvider>,
+    );
+    expect(container.firstChild.querySelector(`.${touchRippleClasses.root}`)).to.equal(null);
+  });
+
+  it("should disable ripple when MuiButtonBase has disableRipple in theme's defaultProps but override on the individual Buttons if provided", () => {
+    const theme = createTheme({
+      components: {
+        MuiButtonBase: {
+          defaultProps: {
+            disableRipple: true,
+          },
+        },
+      },
+    });
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Button disableRipple={false}>Enabled ripple</Button>
+        <Button>Disabled ripple 1</Button>
+        <Button>Disabled ripple 2</Button>
+      </ThemeProvider>,
+    );
+    expect(container.querySelectorAll(`.${touchRippleClasses.root}`)).to.have.length(1);
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29598 

Fixes a regression from #28645 wherein before it there was no default prop for `disableRipple` in `Button` but got mistakenly added in #28645. This caused the inner `ButtonBase` component to get the default prop as `false` and the `theme.components.ButtonBase.defaultProps.disableRipple` did not get applied.
https://github.com/mui-org/material-ui/blob/aac3631f8fdf5a404dff6d71365fd509f70fa847/packages/mui-system/src/useThemeProps/getThemeProps.js#L21-L25

`output['disableRipple']` was `false`, not `undefined`. 

After fix : [CodeSandbox](https://codesandbox.io/s/muibuttonbase-defaultprops-issue-8660q?file=/src/theme.ts)

----

On a side note, I noticed we say `You can change the default of every prop of a MUI component.` at https://mui.com/customization/theme-components/#default-props. But some default props don't get changed like `disabled: true` in `MuiButtonBase`. https://codesandbox.io/s/muibuttonbase-defaultprops-issue-forked-bo2i6?file=/src/App.tsx