### PR TITLE
[core] Improve support request message

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -19,7 +19,7 @@ jobs:
           support-label: 'support'
           # Comment to post on issues marked as support requests. Add a link
           # to a support page, or set to `false` to disable
-          issue-comment: >
+          issue-comment: |
             👋 Thanks for using MUI Core!
 
             We use GitHub issues exclusively as a bug and feature requests tracker, however,


### PR DESCRIPTION
Follow up on https://github.com/mui-org/material-ui/pull/29594 (@oliviertassinari it's not one commit after all :\)

When working on the same on the X team I noticed that the new lines are not working. The PR should fix this issue.

Previously:
![image](https://user-images.githubusercontent.com/4512430/141105572-fa0a75db-f3f3-4f1f-9334-a84f16eb9abc.png)

Now:
![image](https://user-images.githubusercontent.com/4512430/141105534-dcd99e71-eb32-44a9-b941-fd5ab8d9265d.png)
