### PR TITLE
[docs] Do not render CSS section in API docs navbar if there are no CSS classes

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -229,7 +229,7 @@ function ApiDocs(props) {
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
     createTocEntry('props'),
-    componentStyles.classes && createTocEntry('css'),
+    componentStyles.classes.length > 0 && createTocEntry('css'),
     createTocEntry('demos'),
   ].filter(Boolean);
 

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -229,7 +229,7 @@ function ApiDocs(props) {
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
     createTocEntry('props'),
-    componentStyles.classes.length > 0 && createTocEntry('css'),
+    componentStyles.classes?.length > 0 && createTocEntry('css'),
     createTocEntry('demos'),
   ].filter(Boolean);
 

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -229,7 +229,7 @@ function ApiDocs(props) {
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
     createTocEntry('props'),
-    componentStyles.classes?.length > 0 && createTocEntry('css'),
+    componentStyles.classes.length > 0 && createTocEntry('css'),
     createTocEntry('demos'),
   ].filter(Boolean);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29559 

Some components do not have CSS classes, so not rendering it in the top-right navbar in the API docs. It was not checking for empty array. 

[Preview](https://deploy-preview-29622--material-ui.netlify.app/api/date-picker/#props)