### PR TITLE
[docs] Fix link locale handling

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -256,6 +256,7 @@ export default function AppLayoutDocsFooter() {
                   component={Link}
                   noLinkStyle
                   href={prevPage.pathname}
+                  {...prevPage.linkProps}
                   size="medium"
                   startIcon={<ChevronLeftIcon />}
                 >
@@ -297,6 +298,7 @@ export default function AppLayoutDocsFooter() {
                   component={Link}
                   noLinkStyle
                   href={nextPage.pathname}
+                  {...nextPage.linkProps}
                   size="medium"
                   endIcon={<ChevronRightIcon />}
                 >

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -86,10 +86,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     return <MuiLink className={className} href={href} ref={ref} {...other} />;
   }
 
-  if (noLinkStyle) {
-    return <NextLinkComposed className={className} ref={ref} to={href} {...other} />;
-  }
-
   let linkAs = linkAsProp || (href as string);
   if (
     userLanguage !== 'en' &&
@@ -98,6 +94,12 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     href.indexOf('/blog') !== 0
   ) {
     linkAs = `/${userLanguage}${linkAs}`;
+  }
+
+  if (noLinkStyle) {
+    return (
+      <NextLinkComposed className={className} ref={ref} to={href} linkAs={linkAs} {...other} />
+    );
   }
 
   return (


### PR DESCRIPTION
Two bugs:

1. Open https://mui.com/api/alert-title/#demos
2. Click on

<img width="152" alt="Screenshot 2021-11-11 at 11 43 59" src="https://user-images.githubusercontent.com/3165635/141284731-131b2146-651c-42e7-8fb9-d4556e016e8c.png">

3. See how the URL is wrong https://mui.com/api-docs/alert/

---

1. Open https://mui.com/zh/components/autocomplete/#api
2. Click on 

<img width="144" alt="Screenshot 2021-11-11 at 11 45 14" src="https://user-images.githubusercontent.com/3165635/141284872-1e65879a-da98-4bea-8d82-e522b7b3eac0.png">

3. See how the URL is wrong https://mui.com/getting-started/support/