### PR TITLE
[TextField] Fix missing space before asterisk in `OutlinedInput`'s label

### DIFF
--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -143,7 +143,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
             label && fcs.required ? (
               <React.Fragment>
                 {label}
-                {'\u00a0*'}
+                &nbsp;{'*'}
               </React.Fragment>
             ) : (
               label

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -119,6 +119,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
     multiline = false,
     notched,
     type = 'text',
+    required,
     ...other
   } = props;
 
@@ -130,7 +131,16 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
       renderSuffix={(state) => (
         <NotchedOutlineRoot
           className={classes.notchedOutline}
-          label={label}
+          label={
+            label && required ? (
+              <React.Fragment>
+                {label}
+                {'\u00a0*'}
+              </React.Fragment>
+            ) : (
+              label
+            )
+          }
           notched={
             typeof notched !== 'undefined'
               ? notched

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { refType } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import NotchedOutline from './NotchedOutline';
+import useFormControl from '../FormControl/useFormControl';
+import formControlState from '../FormControl/formControlState';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 import outlinedInputClasses, { getOutlinedInputUtilityClass } from './outlinedInputClasses';
 import InputBase, {
@@ -119,11 +121,17 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
     multiline = false,
     notched,
     type = 'text',
-    required,
     ...other
   } = props;
 
   const classes = useUtilityClasses(props);
+
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['required'],
+  });
 
   return (
     <InputBase
@@ -132,7 +140,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
         <NotchedOutlineRoot
           className={classes.notchedOutline}
           label={
-            label && required ? (
+            label && fcs.required ? (
               <React.Fragment>
                 {label}
                 {'\u00a0*'}

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -36,7 +36,7 @@ describe('<OutlinedInput />', () => {
       />,
     );
     const notchOutlined = container.querySelector('.notched-outlined legend');
-    expect(notchOutlined).to.have.text('label\u00a0*');
+    expect(notchOutlined).to.have.text('label\xa0*');
   });
 
   it('should forward classes to InputBase', () => {

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -27,6 +27,18 @@ describe('<OutlinedInput />', () => {
     expect(container.querySelector('.notched-outlined')).not.to.equal(null);
   });
 
+  it('should set correct label prop on outline', () => {
+    const { container } = render(
+      <OutlinedInput
+        classes={{ notchedOutline: 'notched-outlined' }}
+        label={<div data-testid="label">label</div>}
+        required
+      />,
+    );
+    const notchOutlined = container.querySelector('.notched-outlined legend');
+    expect(notchOutlined).to.have.text('label\u00a0*');
+  });
+
   it('should forward classes to InputBase', () => {
     render(<OutlinedInput error classes={{ error: 'error' }} />);
     expect(document.querySelector('.error')).not.to.equal(null);

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -135,15 +135,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     if (InputLabelProps && typeof InputLabelProps.shrink !== 'undefined') {
       InputMore.notched = InputLabelProps.shrink;
     }
-    if (label) {
-      const displayRequired = InputLabelProps?.required ?? required;
-      InputMore.label = (
-        <React.Fragment>
-          {label}
-          {displayRequired && '\u00a0*'}
-        </React.Fragment>
-      );
-    }
+    InputMore.label = label;
   }
   if (select) {
     // unset defaults from textbox inputs


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29206


**Problem:**

- When the required is being set in the Formcontrol component , the border of input touches the end of the label, and it does not add a non-breaking space between border and asterik. Meanwhile, this non-breaking space is being considered when the input is created by Textfield component.

**Solution:**

- Adding `'\u00a0*'` to the OutlinedInput's label when required is set.