### PR TITLE
[test] Allow experimental CLI to run exact test

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -21,11 +21,15 @@ async function run(argv) {
       }
       return line;
     });
-  const globPattern = `**/*${argv.testFilePattern}*.test.{js,ts,tsx}`;
-  const spec = glob.sync(globPattern, {
-    cwd: workspaceRoot,
-    ignore,
-  });
+  const globPattern = `**/*${argv.testFilePattern}*`;
+  const spec = glob
+    .sync(globPattern, {
+      cwd: workspaceRoot,
+      ignore,
+    })
+    .filter((relativeFile) => {
+      return /\.test\.(js|ts|tsx)$/.test(relativeFile);
+    });
 
   if (spec.length === 0) {
     throw new Error(`Could not find any file test files matching '${globPattern}'`);


### PR DESCRIPTION
Enables running more focused tests e.g. `yarn t Autocomplete/Autocomplete.test`. Previously you only had access to `yarn t Autocomplete` which would also run `useAutocomplete.test`.

This also enables custom VSCode tasks for using the integrated debugger via
`.vscode/launch.json`
```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "launch",
      "name": "Test Current File",
      "program": "test/cli.js",
      "args": ["${relativeFile}"],
      "console": "integratedTerminal",
      "internalConsoleOptions": "neverOpen",
      "disableOptimisticBPs": true,
    }
  ]
}
```