### PR TITLE
[test] Accept backslashes as path separators in test CLI

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -21,7 +21,7 @@ async function run(argv) {
       }
       return line;
     });
-  const globPattern = `**/*${argv.testFilePattern}*`;
+  const globPattern = `**/*${argv.testFilePattern.replace(/\\/g, '/')}*`;
   const spec = glob
     .sync(globPattern, {
       cwd: workspaceRoot,


### PR DESCRIPTION
A follow-up to #29685.
Allows to provide the test path with forward slashes, e.g. `yarn t Autocomplete/Autocomplete.test`.

This enables integrating with VSCode tasks on Windows

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "launch",
      "name": "Test Current File",
      "program": "test/cli.js",
      "args": ["${relativeFile}"],
      "console": "integratedTerminal",
      "internalConsoleOptions": "neverOpen",
      "disableOptimisticBPs": true,
    }
  ]
}
```