### PR TITLE
[Select] Include aria-selected=false when option not selected

### DIFF
--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -372,7 +372,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     }
 
     return React.cloneElement(child, {
-      'aria-selected': selected ? 'true' : undefined,
+      'aria-selected': selected ? 'true' : 'false',
       onClick: handleItemClick(child),
       onKeyUp: (event) => {
         if (event.key === ' ') {


### PR DESCRIPTION
Include `aria-selected=false` attribute for not selected options. This makes screen readers announce the change of state when an option is selected.

Fixes #26964.

Preview: http://deploy-preview-29695--material-ui.netlify.app/components/selects/#multiple-select
