### PR TITLE
[docs] Fix broken Next and Previous links

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -256,7 +256,7 @@ export default function AppLayoutDocsFooter() {
                   component={Link}
                   noLinkStyle
                   href={prevPage.pathname}
-                  {...prevPage.linkProps}
+                  linkAs={prevPage.linkProps.as}
                   size="medium"
                   startIcon={<ChevronLeftIcon />}
                 >
@@ -298,7 +298,7 @@ export default function AppLayoutDocsFooter() {
                   component={Link}
                   noLinkStyle
                   href={nextPage.pathname}
-                  {...nextPage.linkProps}
+                  linkAs={nextPage.linkProps.as}
                   size="medium"
                   endIcon={<ChevronRightIcon />}
                 >

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -256,7 +256,7 @@ export default function AppLayoutDocsFooter() {
                   component={Link}
                   noLinkStyle
                   href={prevPage.pathname}
-                  linkAs={prevPage.linkProps.as}
+                  {...prevPage.linkProps}
                   size="medium"
                   startIcon={<ChevronLeftIcon />}
                 >
@@ -298,7 +298,7 @@ export default function AppLayoutDocsFooter() {
                   component={Link}
                   noLinkStyle
                   href={nextPage.pathname}
-                  linkAs={nextPage.linkProps.as}
+                  {...nextPage.linkProps}
                   size="medium"
                   endIcon={<ChevronRightIcon />}
                 >

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -31,15 +31,9 @@ const iconsMap = {
   ReaderIcon: ChromeReaderModeOutlined,
 };
 
-const Item = styled(
-  function Item({ component: Component = 'div', ...props }) {
-    return <Component {...props} />;
-  },
-  {
-    // disable `as` prop
-    shouldForwardProp: () => true,
-  },
-)(({ theme }) => ({
+const Item = styled(function Item({ component: Component = 'div', ...props }) {
+  return <Component {...props} />;
+})(({ theme }) => ({
   ...theme.typography.body2,
   display: 'flex',
   borderRadius: 5,

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -196,7 +196,7 @@ export default function AppTableOfContents(props) {
   const itemLink = (item, secondary) => (
     <NavItem
       display="block"
-      href={`${activePage.linkProps?.as ?? activePage.pathname}#${item.hash}`}
+      href={`${activePage.linkProps?.linkAs ?? activePage.pathname}#${item.hash}`}
       underline="none"
       onClick={handleClick(item.hash)}
       active={activeState === item.hash}

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -51,6 +51,7 @@ export type LinkProps = {
   activeClassName?: string;
   as?: NextLinkProps['as'];
   href: NextLinkProps['href'];
+  linkAs?: NextLinkProps['as']; // Useful when the as prop is shallow by styled().
   noLinkStyle?: boolean;
 } & Omit<NextLinkComposedProps, 'to' | 'linkAs' | 'href'> &
   Omit<MuiLinkProps, 'href'>;
@@ -60,9 +61,10 @@ export type LinkProps = {
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
   const {
     activeClassName = 'active',
-    as: linkAsProp,
+    as: asProp,
     className: classNameProps,
     href,
+    linkAs: linkAsProp,
     noLinkStyle,
     role, // Link don't have roles.
     ...other
@@ -86,12 +88,12 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     return <MuiLink className={className} href={href} ref={ref} {...other} />;
   }
 
-  let linkAs = linkAsProp || (href as string);
+  let linkAs = linkAsProp || asProp || (href as string);
   if (
     userLanguage !== 'en' &&
-    typeof href === 'string' &&
-    href.indexOf('/') === 0 &&
-    href.indexOf('/blog') !== 0
+    pathname &&
+    pathname.indexOf('/') === 0 &&
+    pathname.indexOf('/blog') !== 0
   ) {
     linkAs = `/${userLanguage}${linkAs}`;
   }

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -226,7 +226,10 @@ const pages: readonly MuiPage[] = [
             title: 'GridPrintExportOptions',
           },
         ].map((page) => {
-          return { ...page, linkProps: { as: `${page.pathname.replace(/^\/api-docs/, '/api')}/` } };
+          return {
+            ...page,
+            linkProps: { linkAs: `${page.pathname.replace(/^\/api-docs/, '/api')}/` },
+          };
         }),
       },
     ]
@@ -234,7 +237,10 @@ const pages: readonly MuiPage[] = [
         a.pathname.replace('/api-docs/', '').localeCompare(b.pathname.replace('/api-docs/', '')),
       )
       .map((page) => {
-        return { ...page, linkProps: { as: `${page.pathname.replace(/^\/api-docs/, '/api')}/` } };
+        return {
+          ...page,
+          linkProps: { linkAs: `${page.pathname.replace(/^\/api-docs/, '/api')}/` },
+        };
       }),
   },
   {

--- a/examples/nextjs-with-styled-components-typescript/src/Link.tsx
+++ b/examples/nextjs-with-styled-components-typescript/src/Link.tsx
@@ -41,6 +41,7 @@ export type LinkProps = {
   activeClassName?: string;
   as?: NextLinkProps['as'];
   href: NextLinkProps['href'];
+  linkAs?: NextLinkProps['as']; // Useful when the as prop is shallow by styled().
   noLinkStyle?: boolean;
 } & Omit<NextLinkComposedProps, 'to' | 'linkAs' | 'href'> &
   Omit<MuiLinkProps, 'href'>;

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -41,6 +41,7 @@ export type LinkProps = {
   activeClassName?: string;
   as?: NextLinkProps['as'];
   href: NextLinkProps['href'];
+  linkAs?: NextLinkProps['as']; // Useful when the as prop is shallow by styled().
   noLinkStyle?: boolean;
 } & Omit<NextLinkComposedProps, 'to' | 'linkAs' | 'href'> &
   Omit<MuiLinkProps, 'href'>;

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -91,6 +91,7 @@ Link.propTypes = {
   as: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.string,
   href: PropTypes.any,
+  linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   noLinkStyle: PropTypes.bool,
   role: PropTypes.string,
 };


### PR DESCRIPTION
I still don't quite understand why this was caused, since the changes have been in master for a few days and I've been able to access the MUI docs in the interim (I think, although can't be fully sure since we haven't migrated from 4 to 5 yet), but I guess it's due to the way that you guys do releases?

I also have a feeling that the typing for the props expected to be passed to the `Link` component in `docs/src/modules/components/Link.tsx` are slightly wrong since we should be `Omit`ing the `linkAs` prop as specified in the typing.

Happy to have more of a look at this in the future, but this at least un-blocks the prod website from being completely broken.

Fixes https://github.com/mui-org/material-ui/issues/29704
Fixes #29708

https://deploy-preview-29711--material-ui.netlify.app/api/form-control-label/