### PR TITLE
[docs] Update tooltip doc to better define touch action

### DIFF
--- a/docs/src/pages/components/tooltips/tooltips.md
+++ b/docs/src/pages/components/tooltips/tooltips.md
@@ -62,6 +62,8 @@ You can find a similar concept in the [wrapping components](/guides/composition/
 
 You can define the types of events that cause a tooltip to show.
 
+The touch action requires a long press due to the `enterTouchDelay` prop being set to `700`ms by default.
+
 {{"demo": "pages/components/tooltips/TriggersTooltips.js"}}
 
 ## Controlled tooltips


### PR DESCRIPTION
Added note about touch event requiring long-press to tooltip trigger documentation, per issue #29716.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29716