### PR TITLE
[FormControlUnstyled] `focused` is always false unless explicitly set to `true`

### DIFF
--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -70,7 +70,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
     componentsProps = {},
     disabled = false,
     error = false,
-    focused: visuallyFocused = false,
+    focused: visuallyFocused,
     onChange,
     required = false,
     value: incomingValue,


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/29636 with the solution proposed by @hbjORbj

Source of error:

```javascript
@@ -70,7 +70,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
     componentsProps = {},
     disabled = false,
     error = false,
     focused: visuallyFocused = false, <------------ here
     onChange,
     required = false,
     value: incomingValue,
```
Hence, `focused` is always set to `false` unless explicitly set to true as a prop.
```javascript
const focused = visuallyFocused !== undefined && !disabled ? visuallyFocused : focusedState;
```

Fix:
```diff
diff --git a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
index 164161c030..593e18c047 100644
--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -70,7 +70,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
     componentsProps = {},
     disabled = false,
     error = false,
-    focused: visuallyFocused = false,
+    focused: visuallyFocused,
     onChange,
     required = false,
     value: incomingValue,
```