### PR TITLE
[POC] Add resolveDemoImports

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -99,7 +99,7 @@ module.exports = {
             oneOf: [
               {
                 resourceQuery: /@mui\/markdown/,
-                use: require.resolve('@mui/markdown/loader'),
+                use: [options.defaultLoaders.babel, require.resolve('@mui/markdown/loader')],
               },
               {
                 // used in some /getting-started/templates

--- a/docs/packages/markdown/loader.js
+++ b/docs/packages/markdown/loader.js
@@ -183,12 +183,18 @@ module.exports = async function demoLoader() {
       })
       .join('\n')}};
 
-    export async function resolveDemoImports() {
-      return Object.fromEntries(await Promise.all([
+    export async function resolveDemoImports(requests) {
+      const modules = await Object.fromEntries(await Promise.all([
         ${Array.from(demoImportedModuleIDs, (importModuleID) => {
           return `import('${importModuleID}').then(module => ['${importModuleID}', module])`;
         }).join(',\n')}
-      ]))
+      ]));
+      return requests.map(request => {
+        if (modules[request]) {
+          return modules[request]
+        }
+        throw new Error(\`Cannot find module '\${request}'\`)
+      });
     }
   `;
 


### PR DESCRIPTION
Alternative strategy to handle demo imports from https://github.com/mui-org/material-ui/pull/24640
We could generate a `resolveImports` function that can be directly consumed by `jarle`. It's probably good enough to have one function for the whole docs page. alternatively we could generate one per demo, but I'm not sure how much that would confuse `webpack`.
