### PR TITLE
[styled-engine] Fix props inference in styled-engine

### DIFF
--- a/packages/mui-material/src/styles/styled.spec.tsx
+++ b/packages/mui-material/src/styles/styled.spec.tsx
@@ -39,8 +39,12 @@ const Container = styled('div')<{ $heightLimit: boolean }>`
 `;
 
 // https://github.com/mui-org/material-ui/issues/28844
-type PropsFooVariant = { variant: 'foo' };
-type PropsBarVariant = { variant: 'bar' };
+interface PropsFooVariant {
+  variant: 'foo';
+}
+interface PropsBarVariant {
+  variant: 'bar';
+}
 const Component = (props: PropsFooVariant | PropsBarVariant) => <div />;
 const StyledComponent = styled(Component)(({ theme }) => ({}));
 const rendered = (

--- a/packages/mui-material/src/styles/styled.spec.tsx
+++ b/packages/mui-material/src/styles/styled.spec.tsx
@@ -37,3 +37,15 @@ const Container = styled('div')<{ $heightLimit: boolean }>`
       height: 10vh;
     `}
 `;
+
+// https://github.com/mui-org/material-ui/issues/28844
+type PropsFooVariant = { variant: 'foo' };
+type PropsBarVariant = { variant: 'bar' };
+const Component = (props: PropsFooVariant | PropsBarVariant) => <div />;
+const StyledComponent = styled(Component)(({ theme }) => ({}));
+const rendered = (
+  <React.Fragment>
+    <StyledComponent variant="foo" />
+    <StyledComponent variant="bar" />
+  </React.Fragment>
+);

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -93,6 +93,10 @@ export interface CreateStyledComponent<
   JSXProps extends {} = {},
   T extends object = {},
 > {
+  (
+    ...styles: Array<Interpolation<ComponentProps & SpecificComponentProps & { theme: T }>>
+  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
+
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
    */

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -100,7 +100,7 @@ export interface CreateStyledComponent<
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
    */
-  <AdditionalProps extends {} = {}>(
+  <AdditionalProps extends {}>(
     ...styles: Array<
       Interpolation<ComponentProps & SpecificComponentProps & AdditionalProps & { theme: T }>
     >


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/28844

Explanation: https://github.com/emotion-js/emotion/pull/1664/files#r353487626