### PR TITLE
[test] Disable nightly integration tests on `next` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -691,7 +691,6 @@ workflows:
             branches:
               only:
                 - master
-                - next
     jobs:
       - test_unit:
           react-dist-tag: next
@@ -709,6 +708,5 @@ workflows:
             branches:
               only:
                 - master
-                - next
     jobs:
       - test_types_next


### PR DESCRIPTION
Branch is stale. Failures won't be worked on anyway.