### PR TITLE
Masonry export in packages/mui-lab/src/index.(js|d.ts)

### DIFF
--- a/packages/mui-lab/src/index.d.ts
+++ b/packages/mui-lab/src/index.d.ts
@@ -150,3 +150,6 @@ export * from './YearPicker';
 
 export { default as useAutocomplete } from './useAutocomplete';
 export * from './useAutocomplete';
+
+export { default as Masonry } from './Masonry';
+export * from './Masonry';

--- a/packages/mui-lab/src/index.js
+++ b/packages/mui-lab/src/index.js
@@ -151,3 +151,6 @@ export * from './YearPicker';
 
 // createFilterOptions is exported from Autocomplete
 export { default as useAutocomplete } from './useAutocomplete';
+
+export { default as Masonry } from './Masonry';
+export * from './Masonry';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29705 with the solution proposed by @siriwatknp

#### Source of error:
When attempting to use Masonry like so:
`import {Masonry} from '@mui/lab';`

the component cannot be found.

![image](https://user-images.githubusercontent.com/66718489/142486654-7b054d3a-efc7-4e18-8492-a0814f620e1d.png)

#### Fix:
By export Masonry in packages/mui-lab/src/index.(js|d.ts)

![image](https://user-images.githubusercontent.com/66718489/142486945-fbe5ad8a-d756-4ff7-9e73-57b05157b0e4.png)
