### PR TITLE
[system] Fix `sx` throw error when value is `null` or `undefined`

### DIFF
--- a/packages/mui-system/src/breakpoints.js
+++ b/packages/mui-system/src/breakpoints.js
@@ -96,7 +96,7 @@ export function createEmptyBreakpointObject(breakpointsInput = {}) {
 export function removeUnusedBreakpoints(breakpointKeys, style) {
   return breakpointKeys.reduce((acc, key) => {
     const breakpointOutput = acc[key];
-    const isBreakpointUnused = Object.keys(breakpointOutput).length === 0;
+    const isBreakpointUnused = !breakpointOutput || Object.keys(breakpointOutput).length === 0;
     if (isBreakpointUnused) {
       delete acc[key];
     }

--- a/packages/mui-system/src/breakpoints.test.js
+++ b/packages/mui-system/src/breakpoints.test.js
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import breakpoints, { computeBreakpointsBase, resolveBreakpointValues } from './breakpoints';
+import breakpoints, {
+  computeBreakpointsBase,
+  resolveBreakpointValues,
+  removeUnusedBreakpoints,
+} from './breakpoints';
 import style from './style';
 
 const textColor = style({
@@ -207,6 +211,34 @@ describe('breakpoints', () => {
         const customBase = { extraSmall: true, small: true, medium: true, large: true };
         const values = resolveBreakpointValues({ values: columns, base: customBase });
         expect(values).to.deep.equal({ extraSmall: 1, small: 2, medium: 3, large: 3 });
+      });
+    });
+  });
+
+  describe('function: removeUnusedBreakpoints', () => {
+    it('allow value to be null', () => {
+      const result = removeUnusedBreakpoints(
+        ['@media (min-width:0px)', '@media (min-width:600px)', '@media (min-width:960px)'],
+        {
+          '@media (min-width:0px)': {
+            fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+            fontSize: '0.875rem',
+            letterSpacing: '0.01071em',
+            fontWeight: 400,
+            lineHeight: 1.43,
+          },
+          '@media (min-width:600px)': null,
+          '@media (min-width:960px)': {},
+        },
+      );
+      expect(result).to.deep.equal({
+        '@media (min-width:0px)': {
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontSize: '0.875rem',
+          letterSpacing: '0.01071em',
+          fontWeight: 400,
+          lineHeight: 1.43,
+        },
       });
     });
   });

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
@@ -42,22 +42,24 @@ function styleFunctionSx(props) {
 
     Object.keys(sxObject).forEach((styleKey) => {
       const value = callIfFn(sxObject[styleKey], theme);
-      if (typeof value === 'object') {
-        if (propToStyleFunction[styleKey]) {
-          css = merge(css, getThemeValue(styleKey, value, theme));
-        } else {
-          const breakpointsValues = handleBreakpoints({ theme }, value, (x) => ({
-            [styleKey]: x,
-          }));
-
-          if (objectsHaveSameKeys(breakpointsValues, value)) {
-            css[styleKey] = styleFunctionSx({ sx: value, theme });
+      if (value) {
+        if (typeof value === 'object') {
+          if (propToStyleFunction[styleKey]) {
+            css = merge(css, getThemeValue(styleKey, value, theme));
           } else {
-            css = merge(css, breakpointsValues);
+            const breakpointsValues = handleBreakpoints({ theme }, value, (x) => ({
+              [styleKey]: x,
+            }));
+
+            if (objectsHaveSameKeys(breakpointsValues, value)) {
+              css[styleKey] = styleFunctionSx({ sx: value, theme });
+            } else {
+              css = merge(css, breakpointsValues);
+            }
           }
+        } else {
+          css = merge(css, getThemeValue(styleKey, value, theme));
         }
-      } else {
-        css = merge(css, getThemeValue(styleKey, value, theme));
       }
     });
 

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
@@ -42,7 +42,7 @@ function styleFunctionSx(props) {
 
     Object.keys(sxObject).forEach((styleKey) => {
       const value = callIfFn(sxObject[styleKey], theme);
-      if (value) {
+      if (value !== null && value !== undefined) {
         if (typeof value === 'object') {
           if (propToStyleFunction[styleKey]) {
             css = merge(css, getThemeValue(styleKey, value, theme));

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
@@ -15,3 +15,6 @@ const Text = (props: { sx?: SxProps<Theme> }) => null;
 
 // array
 <Text sx={[(theme) => ({ color: theme.color }), { m: 2 }]} />;
+
+// null
+<Text sx={{ m: null, transform: null, typography: undefined }} />;

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -112,6 +112,21 @@ describe('styleFunctionSx', () => {
         },
       });
     });
+
+    it('allow values to be `null` or `undefined`', () => {
+      expect(() =>
+        styleFunctionSx({
+          theme,
+          sx: { transform: null },
+        }),
+      ).not.to.throw();
+
+      const result = styleFunctionSx({
+        theme,
+        sx: { typography: null, m: null },
+      });
+      expect(result).to.deep.equal({});
+    });
   });
 
   it('resolves non system CSS properties if specified', () => {

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -114,18 +114,13 @@ describe('styleFunctionSx', () => {
     });
 
     it('allow values to be `null` or `undefined`', () => {
-      expect(() =>
-        styleFunctionSx({
-          theme,
-          sx: { transform: null },
-        }),
-      ).not.to.throw();
-
       const result = styleFunctionSx({
         theme,
-        sx: { typography: null, m: null },
+        sx: { typography: null, m: 0, p: null, transform: null },
       });
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        margin: '0px',
+      });
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #29710

`sx` types allow to do this:

```js
<Text sx={{ m: null, transform: null, typography: undefined }} />;
```

But it throws an error. This PR fixes the behavior by neglecting the null or undefined values.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
