### PR TITLE
[pickers] Widen accepted `luxon` version range

### DIFF
--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -83,7 +83,7 @@
     "@types/luxon": "^1.27.1",
     "date-fns": "^2.25.0",
     "dayjs": "^1.10.7",
-    "luxon": "^1.28.0",
+    "luxon": "^1.21.3 || ^2.x",
     "moment": "^2.29.1"
   },
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10958,10 +10958,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-luxon@^1.28.0:
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"
-  integrity sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==
+"luxon@^1.21.3 || ^2.x":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.1.1.tgz#34052f7a33a7989767637be7cf80b47db264ff88"
+  integrity sha512-6VQVNw7+kQu3hL1ZH5GyOhnk8uZm21xS7XJ/6vDZaFNcb62dpFDKcH8TI5NkoZOdMRxr7af7aYGrJlE/Wv0i1w==
 
 lz-string@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
Closes #29580 

Luxon v2 is supported as of `@date-io/luxon@2.11.1` which is ensured due to our `dependencies`.