### PR TITLE
[test] Only mock Date in regression tests

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -29,9 +29,10 @@ function TestViewer(props) {
 
     // Use a "real timestamp" so that we see a useful date instead of "00:00"
     // eslint-disable-next-line react-hooks/rules-of-hooks -- not a React hook
-    const clock = useFakeTimers(new Date('Mon Aug 18 14:11:54 2014 -0500'));
-    // and wait `load-css` timeouts to be flushed
-    clock.runToLast();
+    const clock = useFakeTimers({
+      now: new Date('Mon Aug 18 14:11:54 2014 -0500'),
+      toFake: ['Date'],
+    });
     // In case the child triggered font fetching we're not ready yet.
     // The fonts event handler will mark the test as ready on `loadingdone`
     if (document.fonts.status === 'loaded') {


### PR DESCRIPTION
This caused React devtools to sometimes fail element inspection because the backend runs with the same clock as the React component depending on when its hook is injected.

Since we don't actually need to mock a ticking clock and just the current time for stable screenshots of Date, we can reduce the mocked APIs.

Note that this can potentially be confusing since `new Date()` never changes. But neither broken devtools nor unstable screenshots are an alternative so hopefully this works.
