### PR TITLE
[useMediaQuery] Fix crash in Safari < 14 and IE 11

### DIFF
--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
@@ -22,10 +22,11 @@ function createMatchMedia(width, ref) {
       matches: mediaQuery.match(query, {
         width,
       }),
-      addEventListener: (type, listener) => {
+      // Mocking matchMedia in Safari < 14 where MediaQueryList doesn't inherit from EventTarget
+      addListener: (listener) => {
         listeners.push(listener);
       },
-      removeEventListener: (type, listener) => {
+      removeListener: (listener) => {
         const index = listeners.indexOf(listener);
         if (index > -1) {
           listeners.splice(index, 1);

--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.ts
@@ -75,10 +75,11 @@ function useMediaQueryOld(
       }
     };
     updateMatch();
-    queryList.addEventListener('change', updateMatch);
+    // TODO: Use `addEventListener` once support for Safari < 14 is dropped
+    queryList.addListener(updateMatch);
     return () => {
       active = false;
-      queryList.removeEventListener('change', updateMatch);
+      queryList.removeListener(updateMatch);
     };
   }, [query, matchMedia, supportMatchMedia]);
 
@@ -109,9 +110,10 @@ function useMediaQueryNew(
     return [
       () => mediaQueryList.matches,
       (notify: () => void) => {
-        mediaQueryList.addEventListener('change', notify);
+        // TODO: Use `addEventListener` once support for Safari < 14 is dropped
+        mediaQueryList.addListener(notify);
         return () => {
-          mediaQueryList.removeEventListener('change', notify);
+          mediaQueryList.removeListener(notify);
         };
       },
     ];


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/mui-org/material-ui/56494/workflows/3531a490-8a12-4234-a7e6-f07aad6eb414/jobs/317457

While `addListener`/`removeListener` are deprecate, they're required to use in Safari < 14 and IE 11.

Full browser run: https://app.circleci.com/pipelines/github/mui-org/material-ui/56529/workflows/87e04b92-c6ea-4afd-bd11-197d8024ac6b