### PR TITLE
[useIsFocusVisible] Restore focus-visible polyfill if tab was hidden for a long time

### DIFF
--- a/packages/mui-utils/src/useIsFocusVisible.d.ts
+++ b/packages/mui-utils/src/useIsFocusVisible.d.ts
@@ -1,8 +1,0 @@
-import * as React from 'react';
-
-export default function useIsFocusVisible(): {
-  isFocusVisibleRef: React.MutableRefObject<boolean>;
-  onBlur: (event: React.FocusEvent<any>) => void;
-  onFocus: (event: React.FocusEvent<any>) => void;
-  ref: React.Ref<unknown>;
-};


### PR DESCRIPTION
Tested https://codesandbox.io/s/detect-blur-due-to-tab-out-vt5qr?file=/src/App.js in IE 11, Firefox 78, Edge 91 and Chrome 95 (deploy: https://codesandbox.io/s/detect-blur-due-to-tab-out-vt5qr?file=/src/App.js).

Will confirm with https://codesandbox.io/s/interesting-breeze-xy5qh?file=/src/Demo.tsx