### PR TITLE
[core] Update latest issue template for codesandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -35,7 +35,7 @@
     "@mui/joy": "packages/mui-joy/build"
   },
   "sandboxes": [
-    "material-ui-issue-dh2yh",
+    "material-ui-issue-latest-s2dsx",
     "github/mui-org/material-ui/tree/HEAD/examples/create-react-app",
     "github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-typescript",
     "github/mui-org/material-ui/tree/HEAD/examples/joy-cra-typescript"


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/29707

Was moved when the template was renamed. Unclear why it as renamed and why the change in URL was not considered.