### PR TITLE
[docs] Add responsive AppBar demo

### DIFF
--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -7,13 +7,9 @@ import Typography from "@mui/material/Typography";
 import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
 import MenuIcon from "@mui/icons-material/Menu";
-import { NavLink } from "react-router-dom";
 import Container from "@mui/material/Container";
-import useAuth from "../../../hooks/useAuth";
-import { Avatar } from "@mui/material";
 
-const Navbar = () => {
-  const { user, logout } = useAuth();
+export default function ButtonAppBar() {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const handleMenu = (event) => {
@@ -23,44 +19,20 @@ const Navbar = () => {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const [anchorElp, setAnchorElp] = React.useState(null);
-
-  const handleMenup = (event) => {
-    setAnchorElp(event.currentTarget);
-  };
-
-  const handleClosep = () => {
-    setAnchorElp(null);
-  };
 
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
         <Container maxWidth="xl">
           <Toolbar>
-            <Typography
-              variant="h6"
-              noWrap
-              component="div"
-              sx={{ display: { xs: "none", sm: "block" } }}
-            >
-              RAKIB-JEWELLERS
+            <Typography variant="h6" noWrap component="div">
+              News
             </Typography>
 
-            {/* for mobile version */}
+            {/* responsive AppBar for mobile  start */}
 
             <Box sx={{ display: { xs: "flex", md: "none" } }}>
               <div>
-                <IconButton
-                  size="large"
-                  aria-label="account of current user"
-                  aria-controls="menu-appbar"
-                  aria-haspopup="true"
-                  onClick={handleMenu}
-                  color="inherit"
-                >
-                  <MenuIcon />
-                </IconButton>
                 <Menu
                   id="menu-appbar"
                   anchorEl={anchorEl}
@@ -81,359 +53,106 @@ const Navbar = () => {
                     px: "20px",
                   }}
                 >
-                  {/* NAVBAR FOR DESKTOP */}
-                  <NavLink
-                    style={{ textDecoration: "none", color: "black" }}
-                    to="/home"
-                  >
-                    <MenuItem>
-                      <Typography
-                        onClick={handleClose}
-                        variant="h6"
-                        noWrap
-                        component="div"
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          m: 1,
-                        }}
-                      >
-                        Home
-                      </Typography>
-                    </MenuItem>
-                  </NavLink>
-                  <NavLink
-                    style={{ textDecoration: "none", color: "black" }}
-                    to="/shops"
-                  >
-                    <MenuItem>
-                      <Typography
-                        onClick={handleClose}
-                        variant="h6"
-                        noWrap
-                        component="div"
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          m: 1,
-                        }}
-                      >
-                        Shops
-                      </Typography>
-                    </MenuItem>
-                  </NavLink>
-                  <NavLink
-                    style={{ textDecoration: "none", color: "black" }}
-                    to="/blogs"
-                  >
-                    <MenuItem>
-                      <Typography
-                        onClick={handleClose}
-                        variant="h6"
-                        noWrap
-                        component="div"
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          m: 1,
-                        }}
-                      >
-                        Blogs
-                      </Typography>
-                    </MenuItem>
-                  </NavLink>
-                  {!(user?.displayName || user?.email) && (
-                    <Box>
-                      {/* NAVBAR FOR DESKTOP */}
+                  <MenuItem>
+                    <Typography
+                      onClick={handleClose}
+                      variant="h6"
+                      noWrap
+                      component="div"
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        m: 1,
+                      }}
+                    >
+                      Home
+                    </Typography>
+                  </MenuItem>
+                  <Box>
+                    {/* NAVBAR FOR DESKTOP */}
 
-                      <NavLink
-                        style={{ textDecoration: "none", color: "black" }}
-                        to="/login"
+                    <MenuItem>
+                      <Typography
+                        onClick={handleClose}
+                        variant="h6"
+                        noWrap
+                        component="div"
+                        // onClick={}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          m: 1,
+                        }}
                       >
-                        <MenuItem>
-                          <Typography
-                            variant="h6"
-                            noWrap
-                            component="div"
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              p: 1,
-                              m: 1,
-                            }}
-                          >
-                            Login
-                          </Typography>
-                        </MenuItem>
-                      </NavLink>
-                      <NavLink
-                        style={{ textDecoration: "none", color: "black" }}
-                        to="/signup"
-                      >
-                        <MenuItem>
-                          <Typography
-                            variant="h6"
-                            noWrap
-                            component="div"
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              p: 1,
-                              m: 1,
-                            }}
-                          >
-                            SignUp
-                          </Typography>
-                        </MenuItem>
-                      </NavLink>
-                    </Box>
-                  )}
-                  {(user?.displayName || user?.email) && (
-                    <Box>
-                      {/* NAVBAR FOR DESKTOP */}
-                      <NavLink
-                        style={{ textDecoration: "none", color: "black" }}
-                        to="/dashboard"
-                      >
-                        <MenuItem>
-                          <Typography
-                            variant="h6"
-                            noWrap
-                            component="div"
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              m: 1,
-                            }}
-                          >
-                            Dashboard
-                          </Typography>
-                        </MenuItem>
-                      </NavLink>
-                      <NavLink
-                        style={{ textDecoration: "none", color: "black" }}
-                        to="/dashboard"
-                      >
-                        <MenuItem>
-                          <Typography
-                            variant="h6"
-                            noWrap
-                            component="div"
-                            onClick={logout}
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              m: 1,
-                            }}
-                          >
-                            Logout
-                          </Typography>
-                        </MenuItem>
-                      </NavLink>
-                    </Box>
-                  )}
+                        login
+                      </Typography>
+                    </MenuItem>
+                  </Box>
                 </Menu>
               </div>
             </Box>
 
-            {/* for mobile version end here */}
+            {/*  */}
+            {/* for mobile responsive APPbar end here */}
+            {/*  */}
+            {/*  */}
+            {/* NAVBAR FOR DESKTOP START HERE */}
+            {/*  */}
 
             <Box sx={{ display: { xs: "none", md: "flex" } }}>
-              {/* NAVBAR FOR DESKTOP */}
-
-              <NavLink
-                style={{ textDecoration: "none", color: "white" }}
-                to="/home"
-              >
-                <MenuItem>
-                  <Typography
-                    variant="h6"
-                    noWrap
-                    component="div"
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      p: 1,
-                      m: 1,
-                    }}
-                  >
-                    Home
-                  </Typography>
-                </MenuItem>
-              </NavLink>
-              <NavLink
-                style={{ textDecoration: "none", color: "white" }}
-                to="/shops"
-              >
-                <MenuItem>
-                  <Typography
-                    variant="h6"
-                    noWrap
-                    component="div"
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      p: 1,
-                      m: 1,
-                    }}
-                  >
-                    Shops
-                  </Typography>
-                </MenuItem>
-              </NavLink>
-              <NavLink
-                style={{ textDecoration: "none", color: "white" }}
-                to="/blogs"
-              >
-                <MenuItem>
-                  <Typography
-                    variant="h6"
-                    noWrap
-                    component="div"
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      p: 1,
-                      m: 1,
-                    }}
-                  >
-                    Blogs
-                  </Typography>
-                </MenuItem>
-              </NavLink>
+              <MenuItem>
+                <Typography
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    p: 1,
+                    m: 1,
+                  }}
+                >
+                  Home
+                </Typography>
+              </MenuItem>
             </Box>
-
-            <Box sx={{ flexGrow: 1 }}></Box>
-
-            {/* if login the all button show in desktop */}
-            {(user?.displayName || user?.email) && (
+            <Box sx={{ flexGrow: 1 }}>
               <Box sx={{ display: { xs: "none", md: "flex" } }}>
-                {/* NAVBAR FOR DESKTOP */}
-                <NavLink
-                  style={{ textDecoration: "none", color: "white" }}
-                  to="/dashboard"
-                >
-                  <MenuItem>
-                    <Typography
-                      variant="h6"
-                      noWrap
-                      component="div"
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        p: 1,
-                        m: 1,
-                      }}
-                    >
-                      Dashboard
-                    </Typography>
-                  </MenuItem>
-                </NavLink>
-                <NavLink
-                  style={{ textDecoration: "none", color: "white" }}
-                  to="/dashboard"
-                >
-                  <MenuItem>
-                    <Typography
-                      variant="h6"
-                      noWrap
-                      component="div"
-                      onClick={logout}
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        p: 1,
-                        m: 1,
-                      }}
-                    >
-                      Logout
-                    </Typography>
-                  </MenuItem>
-                </NavLink>
+                <MenuItem>
+                  <Typography
+                    variant="h6"
+                    noWrap
+                    component="div"
+                    // onClick={}
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      p: 1,
+                      m: 1,
+                    }}
+                  >
+                    Login
+                  </Typography>
+                </MenuItem>
               </Box>
-            )}
-            {/* if not login then login singup show in desktop */}
-            {!(user?.displayName || user?.email) && (
-              <Box sx={{ display: { xs: "none", md: "flex" } }}>
-                {/* NAVBAR FOR DESKTOP */}
-
-                <NavLink
-                  style={{ textDecoration: "none", color: "white" }}
-                  to="/login"
-                >
-                  <MenuItem>
-                    <Typography
-                      variant="h6"
-                      noWrap
-                      component="div"
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        p: 1,
-                        m: 1,
-                      }}
-                    >
-                      Login
-                    </Typography>
-                  </MenuItem>
-                </NavLink>
-                <NavLink
-                  style={{ textDecoration: "none", color: "white" }}
-                  to="/signup"
-                >
-                  <MenuItem>
-                    <Typography
-                      variant="h6"
-                      noWrap
-                      component="div"
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        p: 1,
-                        m: 1,
-                      }}
-                    >
-                      SignUp
-                    </Typography>
-                  </MenuItem>
-                </NavLink>
-              </Box>
-            )}
-            {/* if login the picture and details show in desktop */}
-            {(user?.displayName || user?.email) && (
-              <Box>
-                <Avatar
-                  alt="Remy Sharp"
-                  src={user?.photoURL}
-                  onClick={handleMenup}
-                />
-                <Menu
-                  sx={{ mt: "45px" }}
-                  id="menu-appbar"
-                  anchorEl={anchorElp}
-                  anchorOrigin={{
-                    vertical: "top",
-                    horizontal: "right",
-                  }}
-                  keepMounted
-                  transformOrigin={{
-                    vertical: "top",
-                    horizontal: "right",
-                  }}
-                  open={Boolean(anchorElp)}
-                  onClose={handleClosep}
-                >
-                  <MenuItem onClick={handleClosep}>
-                    {user?.displayName}
-                  </MenuItem>
-                  <MenuItem onClick={handleClosep}>{user?.email}</MenuItem>
-                </Menu>
-              </Box>
-            )}
+              {/* NAVBAR FOR DESKTOP  end*/}
+            </Box>
+            <Box>
+              <IconButton
+                size="large"
+                aria-label="account of current user"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleMenu}
+                color="inherit"
+                sx={{ display: { xs: "block", sm: "none" } }}
+              >
+                <MenuIcon />
+              </IconButton>
+            </Box>
           </Toolbar>
         </Container>
       </AppBar>
     </Box>
   );
-};
-export default Navbar;
+}

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -1,13 +1,13 @@
-import * as React from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import Menu from '@mui/material/Menu';
+import * as React from "react";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import MenuIcon from "@mui/icons-material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Menu from "@mui/material/Menu";
 
 export default function ButtonAppBar() {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -22,22 +22,16 @@ export default function ButtonAppBar() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            sx={{ mr: 2 }}
-          >
+        <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
+          <IconButton size="large" edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
             News
           </Typography>
           <Button color="inherit">Login</Button>
         </Box>
-        <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+        <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
             News
           </Typography>
@@ -52,25 +46,25 @@ export default function ButtonAppBar() {
             <MenuIcon />
           </IconButton>
 
-          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+          <Box sx={{ display: { xs: "flex", md: "none" } }}>
             <Menu
               id="menu-appbar"
               anchorEl={anchorEl}
               anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
+                vertical: "top",
+                horizontal: "right",
               }}
               keepMounted
               transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
+                vertical: "top",
+                horizontal: "right",
               }}
               open={Boolean(anchorEl)}
               onClose={handleClose}
               sx={{
-                display: { xs: 'block', sm: 'none' },
-                mt: '32px',
-                px: '20px',
+                display: { xs: "block", sm: "none" },
+                mt: "32px",
+                px: "20px",
               }}
             >
               <MenuItem>
@@ -80,8 +74,8 @@ export default function ButtonAppBar() {
                   noWrap
                   component="div"
                   sx={{
-                    display: 'flex',
-                    alignItems: 'center',
+                    display: "flex",
+                    alignItems: "center",
                   }}
                 >
                   login

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -20,83 +20,77 @@ export default function ButtonAppBar() {
     setAnchorEl(null);
   };
   return (
-    <Box>
-      <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-        <AppBar position="static">
-          <Toolbar>
-            <IconButton
-              size="large"
-              edge="start"
-              color="inherit"
-              aria-label="menu"
-              sx={{ mr: 2 }}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-              News
-            </Typography>
-            <Button color="inherit">Login</Button>
-          </Toolbar>
-        </AppBar>
-      </Box>
-      <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-              News
-            </Typography>
-            <IconButton
-              size="large"
-              edge="start"
-              color="inherit"
-              aria-label="menu"
-              onClick={handleMenu}
-              sx={{ mr: 2 }}
-            >
-              <MenuIcon />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-        <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-          <Menu
-            id="menu-appbar"
-            anchorEl={anchorEl}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            keepMounted
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
-            sx={{
-              display: { xs: 'block', sm: 'none' },
-              mt: '32px',
-              px: '20px',
-            }}
+    <AppBar position="static">
+      <Toolbar>
+        <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
           >
-            <MenuItem>
-              <Typography
-                onClick={handleClose}
-                variant="h6"
-                noWrap
-                component="div"
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  m: 1,
-                }}
-              >
-                login
-              </Typography>
-            </MenuItem>
-          </Menu>
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            News
+          </Typography>
+          <Button color="inherit">Login</Button>
         </Box>
-      </Box>
-    </Box>
+        <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
+            News
+          </Typography>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            onClick={handleMenu}
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+
+          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+              sx={{
+                display: { xs: 'block', sm: 'none' },
+                mt: '32px',
+                px: '20px',
+              }}
+            >
+              <MenuItem>
+                <Typography
+                  onClick={handleClose}
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                >
+                  login
+                </Typography>
+              </MenuItem>
+            </Menu>
+          </Box>
+        </Box>
+      </Toolbar>
+    </AppBar>
   );
 }

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -29,7 +29,7 @@ export default function ButtonAppBar() {
               News
             </Typography>
 
-            {/* responsive AppBar for mobile  start */}
+                {/* responsive AppBar for mobile  start */}
 
             <Box sx={{ display: { xs: "flex", md: "none" } }}>
               <div>
@@ -68,8 +68,6 @@ export default function ButtonAppBar() {
                       Home
                     </Typography>
                   </MenuItem>
-
-                  <Box></Box>
                   <Box>
                     {/* NAVBAR FOR DESKTOP */}
 
@@ -118,28 +116,27 @@ export default function ButtonAppBar() {
                 </Typography>
               </MenuItem>
             </Box>
-            <Box sx={{ flexGrow: 1 }}></Box>
-            <Box sx={{ display: { xs: "none", md: "flex" } }}>
-              <MenuItem>
-                <Typography
-                  variant="h6"
-                  noWrap
-                  component="div"
-                  // onClick={}
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    p: 1,
-                    m: 1
-                  }}
-                >
-                  Login
-                </Typography>
-              </MenuItem>
+            <Box sx={{ flexGrow: 1 }}>
+              <Box sx={{ display: { xs: "none", md: "flex" } }}>
+                <MenuItem>
+                  <Typography
+                    variant="h6"
+                    noWrap
+                    component="div"
+                    // onClick={}
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      p: 1,
+                      m: 1
+                    }}
+                  >
+                    Login
+                  </Typography>
+                </MenuItem>
+              </Box>
+              {/* NAVBAR FOR DESKTOP  end*/}
             </Box>
- {/* NAVBAR FOR DESKTOP  END*/}
-
- {/* Menu dropdown icon*/}
             <Box>
               <IconButton
                 size="large"

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -7,9 +7,13 @@ import Typography from "@mui/material/Typography";
 import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
 import MenuIcon from "@mui/icons-material/Menu";
+import { NavLink } from "react-router-dom";
 import Container from "@mui/material/Container";
+import useAuth from "../../../hooks/useAuth";
+import { Avatar } from "@mui/material";
 
-export default function ButtonAppBar() {
+const Navbar = () => {
+  const { user, logout } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const handleMenu = (event) => {
@@ -19,140 +23,417 @@ export default function ButtonAppBar() {
   const handleClose = () => {
     setAnchorEl(null);
   };
+  const [anchorElp, setAnchorElp] = React.useState(null);
+
+  const handleMenup = (event) => {
+    setAnchorElp(event.currentTarget);
+  };
+
+  const handleClosep = () => {
+    setAnchorElp(null);
+  };
 
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
         <Container maxWidth="xl">
           <Toolbar>
-            <Typography variant="h6" noWrap component="div">
-              News
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              sx={{ display: { xs: "none", sm: "block" } }}
+            >
+              RAKIB-JEWELLERS
             </Typography>
 
-                {/* responsive AppBar for mobile  start */}
+            {/* for mobile version */}
 
             <Box sx={{ display: { xs: "flex", md: "none" } }}>
               <div>
+                <IconButton
+                  size="large"
+                  aria-label="account of current user"
+                  aria-controls="menu-appbar"
+                  aria-haspopup="true"
+                  onClick={handleMenu}
+                  color="inherit"
+                >
+                  <MenuIcon />
+                </IconButton>
                 <Menu
                   id="menu-appbar"
                   anchorEl={anchorEl}
                   anchorOrigin={{
                     vertical: "top",
-                    horizontal: "right"
+                    horizontal: "right",
                   }}
                   keepMounted
                   transformOrigin={{
                     vertical: "top",
-                    horizontal: "right"
+                    horizontal: "right",
                   }}
                   open={Boolean(anchorEl)}
                   onClose={handleClose}
                   sx={{
                     display: { xs: "block", sm: "none" },
                     mt: "32px",
-                    px: "20px"
+                    px: "20px",
                   }}
                 >
-                  <MenuItem>
-                    <Typography
-                      onClick={handleClose}
-                      variant="h6"
-                      noWrap
-                      component="div"
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        m: 1
-                      }}
-                    >
-                      Home
-                    </Typography>
-                  </MenuItem>
-                  <Box>
-                    {/* NAVBAR FOR DESKTOP */}
-
+                  {/* NAVBAR FOR DESKTOP */}
+                  <NavLink
+                    style={{ textDecoration: "none", color: "black" }}
+                    to="/home"
+                  >
                     <MenuItem>
                       <Typography
                         onClick={handleClose}
                         variant="h6"
                         noWrap
                         component="div"
-                        // onClick={}
                         sx={{
                           display: "flex",
                           alignItems: "center",
-                          m: 1
+                          m: 1,
                         }}
                       >
-                        login
+                        Home
                       </Typography>
                     </MenuItem>
-                  </Box>
+                  </NavLink>
+                  <NavLink
+                    style={{ textDecoration: "none", color: "black" }}
+                    to="/shops"
+                  >
+                    <MenuItem>
+                      <Typography
+                        onClick={handleClose}
+                        variant="h6"
+                        noWrap
+                        component="div"
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          m: 1,
+                        }}
+                      >
+                        Shops
+                      </Typography>
+                    </MenuItem>
+                  </NavLink>
+                  <NavLink
+                    style={{ textDecoration: "none", color: "black" }}
+                    to="/blogs"
+                  >
+                    <MenuItem>
+                      <Typography
+                        onClick={handleClose}
+                        variant="h6"
+                        noWrap
+                        component="div"
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          m: 1,
+                        }}
+                      >
+                        Blogs
+                      </Typography>
+                    </MenuItem>
+                  </NavLink>
+                  {!(user?.displayName || user?.email) && (
+                    <Box>
+                      {/* NAVBAR FOR DESKTOP */}
+
+                      <NavLink
+                        style={{ textDecoration: "none", color: "black" }}
+                        to="/login"
+                      >
+                        <MenuItem>
+                          <Typography
+                            variant="h6"
+                            noWrap
+                            component="div"
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              p: 1,
+                              m: 1,
+                            }}
+                          >
+                            Login
+                          </Typography>
+                        </MenuItem>
+                      </NavLink>
+                      <NavLink
+                        style={{ textDecoration: "none", color: "black" }}
+                        to="/signup"
+                      >
+                        <MenuItem>
+                          <Typography
+                            variant="h6"
+                            noWrap
+                            component="div"
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              p: 1,
+                              m: 1,
+                            }}
+                          >
+                            SignUp
+                          </Typography>
+                        </MenuItem>
+                      </NavLink>
+                    </Box>
+                  )}
+                  {(user?.displayName || user?.email) && (
+                    <Box>
+                      {/* NAVBAR FOR DESKTOP */}
+                      <NavLink
+                        style={{ textDecoration: "none", color: "black" }}
+                        to="/dashboard"
+                      >
+                        <MenuItem>
+                          <Typography
+                            variant="h6"
+                            noWrap
+                            component="div"
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              m: 1,
+                            }}
+                          >
+                            Dashboard
+                          </Typography>
+                        </MenuItem>
+                      </NavLink>
+                      <NavLink
+                        style={{ textDecoration: "none", color: "black" }}
+                        to="/dashboard"
+                      >
+                        <MenuItem>
+                          <Typography
+                            variant="h6"
+                            noWrap
+                            component="div"
+                            onClick={logout}
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              m: 1,
+                            }}
+                          >
+                            Logout
+                          </Typography>
+                        </MenuItem>
+                      </NavLink>
+                    </Box>
+                  )}
                 </Menu>
               </div>
             </Box>
 
-            {/*  */}
-            {/* for mobile responsive APPbar end here */}
-            {/*  */}
-            {/*  */}
-            {/* NAVBAR FOR DESKTOP START HERE */}
-            {/*  */}
+            {/* for mobile version end here */}
 
             <Box sx={{ display: { xs: "none", md: "flex" } }}>
-              <MenuItem>
-                <Typography
-                  variant="h6"
-                  noWrap
-                  component="div"
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    p: 1,
-                    m: 1
-                  }}
-                >
-                  Home
-                </Typography>
-              </MenuItem>
-            </Box>
-            <Box sx={{ flexGrow: 1 }}>
-              <Box sx={{ display: { xs: "none", md: "flex" } }}>
+              {/* NAVBAR FOR DESKTOP */}
+
+              <NavLink
+                style={{ textDecoration: "none", color: "white" }}
+                to="/home"
+              >
                 <MenuItem>
                   <Typography
                     variant="h6"
                     noWrap
                     component="div"
-                    // onClick={}
                     sx={{
                       display: "flex",
                       alignItems: "center",
                       p: 1,
-                      m: 1
+                      m: 1,
                     }}
                   >
-                    Login
+                    Home
                   </Typography>
                 </MenuItem>
-              </Box>
-              {/* NAVBAR FOR DESKTOP  end*/}
-            </Box>
-            <Box>
-              <IconButton
-                size="large"
-                aria-label="account of current user"
-                aria-controls="menu-appbar"
-                aria-haspopup="true"
-                onClick={handleMenu}
-                color="inherit"
-                sx={{ display: { xs: "block", sm: "none" } }}
+              </NavLink>
+              <NavLink
+                style={{ textDecoration: "none", color: "white" }}
+                to="/shops"
               >
-                <MenuIcon />
-              </IconButton>
+                <MenuItem>
+                  <Typography
+                    variant="h6"
+                    noWrap
+                    component="div"
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      p: 1,
+                      m: 1,
+                    }}
+                  >
+                    Shops
+                  </Typography>
+                </MenuItem>
+              </NavLink>
+              <NavLink
+                style={{ textDecoration: "none", color: "white" }}
+                to="/blogs"
+              >
+                <MenuItem>
+                  <Typography
+                    variant="h6"
+                    noWrap
+                    component="div"
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      p: 1,
+                      m: 1,
+                    }}
+                  >
+                    Blogs
+                  </Typography>
+                </MenuItem>
+              </NavLink>
             </Box>
+
+            <Box sx={{ flexGrow: 1 }}></Box>
+
+            {/* if login the all button show in desktop */}
+            {(user?.displayName || user?.email) && (
+              <Box sx={{ display: { xs: "none", md: "flex" } }}>
+                {/* NAVBAR FOR DESKTOP */}
+                <NavLink
+                  style={{ textDecoration: "none", color: "white" }}
+                  to="/dashboard"
+                >
+                  <MenuItem>
+                    <Typography
+                      variant="h6"
+                      noWrap
+                      component="div"
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        p: 1,
+                        m: 1,
+                      }}
+                    >
+                      Dashboard
+                    </Typography>
+                  </MenuItem>
+                </NavLink>
+                <NavLink
+                  style={{ textDecoration: "none", color: "white" }}
+                  to="/dashboard"
+                >
+                  <MenuItem>
+                    <Typography
+                      variant="h6"
+                      noWrap
+                      component="div"
+                      onClick={logout}
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        p: 1,
+                        m: 1,
+                      }}
+                    >
+                      Logout
+                    </Typography>
+                  </MenuItem>
+                </NavLink>
+              </Box>
+            )}
+            {/* if not login then login singup show in desktop */}
+            {!(user?.displayName || user?.email) && (
+              <Box sx={{ display: { xs: "none", md: "flex" } }}>
+                {/* NAVBAR FOR DESKTOP */}
+
+                <NavLink
+                  style={{ textDecoration: "none", color: "white" }}
+                  to="/login"
+                >
+                  <MenuItem>
+                    <Typography
+                      variant="h6"
+                      noWrap
+                      component="div"
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        p: 1,
+                        m: 1,
+                      }}
+                    >
+                      Login
+                    </Typography>
+                  </MenuItem>
+                </NavLink>
+                <NavLink
+                  style={{ textDecoration: "none", color: "white" }}
+                  to="/signup"
+                >
+                  <MenuItem>
+                    <Typography
+                      variant="h6"
+                      noWrap
+                      component="div"
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        p: 1,
+                        m: 1,
+                      }}
+                    >
+                      SignUp
+                    </Typography>
+                  </MenuItem>
+                </NavLink>
+              </Box>
+            )}
+            {/* if login the picture and details show in desktop */}
+            {(user?.displayName || user?.email) && (
+              <Box>
+                <Avatar
+                  alt="Remy Sharp"
+                  src={user?.photoURL}
+                  onClick={handleMenup}
+                />
+                <Menu
+                  sx={{ mt: "45px" }}
+                  id="menu-appbar"
+                  anchorEl={anchorElp}
+                  anchorOrigin={{
+                    vertical: "top",
+                    horizontal: "right",
+                  }}
+                  keepMounted
+                  transformOrigin={{
+                    vertical: "top",
+                    horizontal: "right",
+                  }}
+                  open={Boolean(anchorElp)}
+                  onClose={handleClosep}
+                >
+                  <MenuItem onClick={handleClosep}>
+                    {user?.displayName}
+                  </MenuItem>
+                  <MenuItem onClick={handleClosep}>{user?.email}</MenuItem>
+                </Menu>
+              </Box>
+            )}
           </Toolbar>
         </Container>
       </AppBar>
     </Box>
   );
-}
+};
+export default Navbar;

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -1,31 +1,160 @@
-import * as React from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
+import * as React from "react";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import MenuItem from "@mui/material/MenuItem";
+import Menu from "@mui/material/Menu";
+import MenuIcon from "@mui/icons-material/Menu";
+import Container from "@mui/material/Container";
 
 export default function ButtonAppBar() {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
-        <Toolbar>
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            News
-          </Typography>
-          <Button color="inherit">Login</Button>
-        </Toolbar>
+        <Container maxWidth="xl">
+          <Toolbar>
+            <Typography variant="h6" noWrap component="div">
+              LOGO
+            </Typography>
+
+            {/* responsive AppBar for mobile  start */}
+
+            <Box sx={{ display: { xs: "flex", md: "none" } }}>
+              <div>
+                <Menu
+                  id="menu-appbar"
+                  anchorEl={anchorEl}
+                  anchorOrigin={{
+                    vertical: "top",
+                    horizontal: "right"
+                  }}
+                  keepMounted
+                  transformOrigin={{
+                    vertical: "top",
+                    horizontal: "right"
+                  }}
+                  open={Boolean(anchorEl)}
+                  onClose={handleClose}
+                  sx={{
+                    display: { xs: "block", sm: "none" },
+                    mt: "32px",
+                    px: "20px"
+                  }}
+                >
+                  <MenuItem>
+                    <Typography
+                      onClick={handleClose}
+                      variant="h6"
+                      noWrap
+                      component="div"
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        m: 1
+                      }}
+                    >
+                      Home
+                    </Typography>
+                  </MenuItem>
+
+                  <Box></Box>
+                  <Box>
+                    {/* NAVBAR FOR DESKTOP */}
+
+                    <MenuItem>
+                      <Typography
+                        onClick={handleClose}
+                        variant="h6"
+                        noWrap
+                        component="div"
+                        // onClick={}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          m: 1
+                        }}
+                      >
+                        login
+                      </Typography>
+                    </MenuItem>
+                  </Box>
+                </Menu>
+              </div>
+            </Box>
+
+            {/*  */}
+            {/* for mobile responsive APPbar end here */}
+            {/*  */}
+            {/*  */}
+            {/* NAVBAR FOR DESKTOP START HERE */}
+            {/*  */}
+
+            <Box sx={{ display: { xs: "none", md: "flex" } }}>
+              <MenuItem>
+                <Typography
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    p: 1,
+                    m: 1
+                  }}
+                >
+                  Home
+                </Typography>
+              </MenuItem>
+            </Box>
+            <Box sx={{ flexGrow: 1 }}></Box>
+            <Box sx={{ display: { xs: "none", md: "flex" } }}>
+              <MenuItem>
+                <Typography
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  // onClick={}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    p: 1,
+                    m: 1
+                  }}
+                >
+                  Login
+                </Typography>
+              </MenuItem>
+            </Box>
+ {/* NAVBAR FOR DESKTOP  END*/}
+
+ {/* Menu dropdown icon*/}
+            <Box>
+              <IconButton
+                size="large"
+                aria-label="account of current user"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleMenu}
+                color="inherit"
+                sx={{ display: { xs: "block", sm: "none" } }}
+              >
+                <MenuIcon />
+              </IconButton>
+            </Box>
+          </Toolbar>
+        </Container>
       </AppBar>
     </Box>
   );

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -59,44 +59,42 @@ export default function ButtonAppBar() {
           </Toolbar>
         </AppBar>
         <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-          <div>
-            <Menu
-              id="menu-appbar"
-              anchorEl={anchorEl}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              open={Boolean(anchorEl)}
-              onClose={handleClose}
-              sx={{
-                display: { xs: 'block', sm: 'none' },
-                mt: '32px',
-                px: '20px',
-              }}
-            >
-              <MenuItem>
-                <Typography
-                  onClick={handleClose}
-                  variant="h6"
-                  noWrap
-                  component="div"
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    m: 1,
-                  }}
-                >
-                  login
-                </Typography>
-              </MenuItem>
-            </Menu>
-          </div>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+            sx={{
+              display: { xs: 'block', sm: 'none' },
+              mt: '32px',
+              px: '20px',
+            }}
+          >
+            <MenuItem>
+              <Typography
+                onClick={handleClose}
+                variant="h6"
+                noWrap
+                component="div"
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  m: 1,
+                }}
+              >
+                login
+              </Typography>
+            </MenuItem>
+          </Menu>
         </Box>
       </Box>
     </Box>

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -1,13 +1,13 @@
-import * as React from "react";
-import AppBar from "@mui/material/AppBar";
-import Box from "@mui/material/Box";
-import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
-import IconButton from "@mui/material/IconButton";
-import MenuIcon from "@mui/icons-material/Menu";
-import MenuItem from "@mui/material/MenuItem";
-import Menu from "@mui/material/Menu";
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Menu from '@mui/material/Menu';
 
 export default function ButtonAppBar() {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -22,8 +22,14 @@ export default function ButtonAppBar() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
-          <IconButton size="large" edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+        <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
@@ -31,7 +37,7 @@ export default function ButtonAppBar() {
           </Typography>
           <Button color="inherit">Login</Button>
         </Box>
-        <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
+        <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
             News
           </Typography>
@@ -46,25 +52,25 @@ export default function ButtonAppBar() {
             <MenuIcon />
           </IconButton>
 
-          <Box sx={{ display: { xs: "flex", md: "none" } }}>
+          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
             <Menu
               id="menu-appbar"
               anchorEl={anchorEl}
               anchorOrigin={{
-                vertical: "top",
-                horizontal: "right",
+                vertical: 'top',
+                horizontal: 'right',
               }}
               keepMounted
               transformOrigin={{
-                vertical: "top",
-                horizontal: "right",
+                vertical: 'top',
+                horizontal: 'right',
               }}
               open={Boolean(anchorEl)}
               onClose={handleClose}
               sx={{
-                display: { xs: "block", sm: "none" },
-                mt: "32px",
-                px: "20px",
+                display: { xs: 'block', sm: 'none' },
+                mt: '32px',
+                px: '20px',
               }}
             >
               <MenuItem>
@@ -74,8 +80,8 @@ export default function ButtonAppBar() {
                   noWrap
                   component="div"
                   sx={{
-                    display: "flex",
-                    alignItems: "center",
+                    display: 'flex',
+                    alignItems: 'center',
                   }}
                 >
                   login

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -26,7 +26,7 @@ export default function ButtonAppBar() {
         <Container maxWidth="xl">
           <Toolbar>
             <Typography variant="h6" noWrap component="div">
-              LOGO
+              MUI
             </Typography>
 
             {/* responsive AppBar for mobile  start */}

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -1,13 +1,13 @@
-import * as React from "react";
-import AppBar from "@mui/material/AppBar";
-import Box from "@mui/material/Box";
-import Toolbar from "@mui/material/Toolbar";
-import IconButton from "@mui/material/IconButton";
-import Typography from "@mui/material/Typography";
-import MenuItem from "@mui/material/MenuItem";
-import Menu from "@mui/material/Menu";
-import MenuIcon from "@mui/icons-material/Menu";
-import Container from "@mui/material/Container";
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Menu from '@mui/material/Menu';
+import Container from '@mui/material/Container';
 
 export default function ButtonAppBar() {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -28,29 +28,26 @@ export default function ButtonAppBar() {
             <Typography variant="h6" noWrap component="div">
               News
             </Typography>
-
-            {/* responsive AppBar for mobile  start */}
-
-            <Box sx={{ display: { xs: "flex", md: "none" } }}>
+            <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
               <div>
                 <Menu
                   id="menu-appbar"
                   anchorEl={anchorEl}
                   anchorOrigin={{
-                    vertical: "top",
-                    horizontal: "right",
+                    vertical: 'top',
+                    horizontal: 'right',
                   }}
                   keepMounted
                   transformOrigin={{
-                    vertical: "top",
-                    horizontal: "right",
+                    vertical: 'top',
+                    horizontal: 'right',
                   }}
                   open={Boolean(anchorEl)}
                   onClose={handleClose}
                   sx={{
-                    display: { xs: "block", sm: "none" },
-                    mt: "32px",
-                    px: "20px",
+                    display: { xs: 'block', sm: 'none' },
+                    mt: '32px',
+                    px: '20px',
                   }}
                 >
                   <MenuItem>
@@ -60,8 +57,8 @@ export default function ButtonAppBar() {
                       noWrap
                       component="div"
                       sx={{
-                        display: "flex",
-                        alignItems: "center",
+                        display: 'flex',
+                        alignItems: 'center',
                         m: 1,
                       }}
                     >
@@ -69,18 +66,15 @@ export default function ButtonAppBar() {
                     </Typography>
                   </MenuItem>
                   <Box>
-                    {/* NAVBAR FOR DESKTOP */}
-
                     <MenuItem>
                       <Typography
                         onClick={handleClose}
                         variant="h6"
                         noWrap
                         component="div"
-                        // onClick={}
                         sx={{
-                          display: "flex",
-                          alignItems: "center",
+                          display: 'flex',
+                          alignItems: 'center',
                           m: 1,
                         }}
                       >
@@ -92,22 +86,15 @@ export default function ButtonAppBar() {
               </div>
             </Box>
 
-            {/*  */}
-            {/* for mobile responsive APPbar end here */}
-            {/*  */}
-            {/*  */}
-            {/* NAVBAR FOR DESKTOP START HERE */}
-            {/*  */}
-
-            <Box sx={{ display: { xs: "none", md: "flex" } }}>
+            <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
               <MenuItem>
                 <Typography
                   variant="h6"
                   noWrap
                   component="div"
                   sx={{
-                    display: "flex",
-                    alignItems: "center",
+                    display: 'flex',
+                    alignItems: 'center',
                     p: 1,
                     m: 1,
                   }}
@@ -117,16 +104,15 @@ export default function ButtonAppBar() {
               </MenuItem>
             </Box>
             <Box sx={{ flexGrow: 1 }}>
-              <Box sx={{ display: { xs: "none", md: "flex" } }}>
+              <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
                 <MenuItem>
                   <Typography
                     variant="h6"
                     noWrap
                     component="div"
-                    // onClick={}
                     sx={{
-                      display: "flex",
-                      alignItems: "center",
+                      display: 'flex',
+                      alignItems: 'center',
                       p: 1,
                       m: 1,
                     }}
@@ -135,7 +121,6 @@ export default function ButtonAppBar() {
                   </Typography>
                 </MenuItem>
               </Box>
-              {/* NAVBAR FOR DESKTOP  end*/}
             </Box>
             <Box>
               <IconButton
@@ -145,7 +130,7 @@ export default function ButtonAppBar() {
                 aria-haspopup="true"
                 onClick={handleMenu}
                 color="inherit"
-                sx={{ display: { xs: "block", sm: "none" } }}
+                sx={{ display: { xs: 'block', sm: 'none' } }}
               >
                 <MenuIcon />
               </IconButton>

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -26,7 +26,7 @@ export default function ButtonAppBar() {
         <Container maxWidth="xl">
           <Toolbar>
             <Typography variant="h6" noWrap component="div">
-              MUI
+              News
             </Typography>
 
             {/* responsive AppBar for mobile  start */}

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -3,11 +3,11 @@ import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
-import Container from '@mui/material/Container';
 
 export default function ButtonAppBar() {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -19,125 +19,86 @@ export default function ButtonAppBar() {
   const handleClose = () => {
     setAnchorEl(null);
   };
-
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static">
-        <Container maxWidth="xl">
+    <Box>
+      <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+        <AppBar position="static">
           <Toolbar>
-            <Typography variant="h6" noWrap component="div">
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
               News
             </Typography>
-            <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-              <div>
-                <Menu
-                  id="menu-appbar"
-                  anchorEl={anchorEl}
-                  anchorOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                  }}
-                  keepMounted
-                  transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                  }}
-                  open={Boolean(anchorEl)}
-                  onClose={handleClose}
-                  sx={{
-                    display: { xs: 'block', sm: 'none' },
-                    mt: '32px',
-                    px: '20px',
-                  }}
-                >
-                  <MenuItem>
-                    <Typography
-                      onClick={handleClose}
-                      variant="h6"
-                      noWrap
-                      component="div"
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        m: 1,
-                      }}
-                    >
-                      Home
-                    </Typography>
-                  </MenuItem>
-                  <Box>
-                    <MenuItem>
-                      <Typography
-                        onClick={handleClose}
-                        variant="h6"
-                        noWrap
-                        component="div"
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          m: 1,
-                        }}
-                      >
-                        login
-                      </Typography>
-                    </MenuItem>
-                  </Box>
-                </Menu>
-              </div>
-            </Box>
-
-            <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+            <Button color="inherit">Login</Button>
+          </Toolbar>
+        </AppBar>
+      </Box>
+      <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+        <AppBar position="static">
+          <Toolbar>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              News
+            </Typography>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              onClick={handleMenu}
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+        <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+          <div>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+              sx={{
+                display: { xs: 'block', sm: 'none' },
+                mt: '32px',
+                px: '20px',
+              }}
+            >
               <MenuItem>
                 <Typography
+                  onClick={handleClose}
                   variant="h6"
                   noWrap
                   component="div"
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
-                    p: 1,
                     m: 1,
                   }}
                 >
-                  Home
+                  login
                 </Typography>
               </MenuItem>
-            </Box>
-            <Box sx={{ flexGrow: 1 }}>
-              <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
-                <MenuItem>
-                  <Typography
-                    variant="h6"
-                    noWrap
-                    component="div"
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      p: 1,
-                      m: 1,
-                    }}
-                  >
-                    Login
-                  </Typography>
-                </MenuItem>
-              </Box>
-            </Box>
-            <Box>
-              <IconButton
-                size="large"
-                aria-label="account of current user"
-                aria-controls="menu-appbar"
-                aria-haspopup="true"
-                onClick={handleMenu}
-                color="inherit"
-                sx={{ display: { xs: 'block', sm: 'none' } }}
-              >
-                <MenuIcon />
-              </IconButton>
-            </Box>
-          </Toolbar>
-        </Container>
-      </AppBar>
+            </Menu>
+          </div>
+        </Box>
+      </Box>
     </Box>
   );
 }

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -59,47 +59,44 @@ export default function ButtonAppBar() {
           </Toolbar>
         </AppBar>
         <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-          <div>
-            <Menu
-              id="menu-appbar"
-              anchorEl={anchorEl}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              open={Boolean(anchorEl)}
-              onClose={handleClose}
-              sx={{
-                display: { xs: 'block', sm: 'none' },
-                mt: '32px',
-                px: '20px',
-              }}
-            >
-              <MenuItem>
-                <Typography
-                  onClick={handleClose}
-                  variant="h6"
-                  noWrap
-                  component="div"
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    m: 1,
-                  }}
-                >
-                  login
-                </Typography>
-              </MenuItem>
-            </Menu>
-          </div>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+            sx={{
+              display: { xs: 'block', sm: 'none' },
+              mt: '32px',
+              px: '20px',
+            }}
+          >
+            <MenuItem>
+              <Typography
+                onClick={handleClose}
+                variant="h6"
+                noWrap
+                component="div"
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  m: 1,
+                }}
+              >
+                login
+              </Typography>
+            </MenuItem>
+          </Menu>
         </Box>
       </Box>
     </Box>
   );
 }
-

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import Menu from '@mui/material/Menu';
+import * as React from "react";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import MenuIcon from "@mui/icons-material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Menu from "@mui/material/Menu";
 
 export default function ButtonAppBar() {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -22,22 +22,16 @@ export default function ButtonAppBar() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            sx={{ mr: 2 }}
-          >
+        <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
+          <IconButton size="large" edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
             News
           </Typography>
           <Button color="inherit">Login</Button>
         </Box>
-        <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+        <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
             News
           </Typography>
@@ -52,25 +46,25 @@ export default function ButtonAppBar() {
             <MenuIcon />
           </IconButton>
 
-          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+          <Box sx={{ display: { xs: "flex", md: "none" } }}>
             <Menu
               id="menu-appbar"
               anchorEl={anchorEl}
               anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
+                vertical: "top",
+                horizontal: "right",
               }}
               keepMounted
               transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
+                vertical: "top",
+                horizontal: "right",
               }}
               open={Boolean(anchorEl)}
               onClose={handleClose}
               sx={{
-                display: { xs: 'block', sm: 'none' },
-                mt: '32px',
-                px: '20px',
+                display: { xs: "block", sm: "none" },
+                mt: "32px",
+                px: "20px",
               }}
             >
               <MenuItem>
@@ -80,8 +74,8 @@ export default function ButtonAppBar() {
                   noWrap
                   component="div"
                   sx={{
-                    display: 'flex',
-                    alignItems: 'center',
+                    display: "flex",
+                    alignItems: "center",
                   }}
                 >
                   login

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -20,83 +20,77 @@ export default function ButtonAppBar() {
     setAnchorEl(null);
   };
   return (
-    <Box>
-      <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-        <AppBar position="static">
-          <Toolbar>
-            <IconButton
-              size="large"
-              edge="start"
-              color="inherit"
-              aria-label="menu"
-              sx={{ mr: 2 }}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-              News
-            </Typography>
-            <Button color="inherit">Login</Button>
-          </Toolbar>
-        </AppBar>
-      </Box>
-      <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-              News
-            </Typography>
-            <IconButton
-              size="large"
-              edge="start"
-              color="inherit"
-              aria-label="menu"
-              onClick={handleMenu}
-              sx={{ mr: 2 }}
-            >
-              <MenuIcon />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-        <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-          <Menu
-            id="menu-appbar"
-            anchorEl={anchorEl}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            keepMounted
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
-            sx={{
-              display: { xs: 'block', sm: 'none' },
-              mt: '32px',
-              px: '20px',
-            }}
+    <AppBar position="static">
+      <Toolbar>
+        <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
           >
-            <MenuItem>
-              <Typography
-                onClick={handleClose}
-                variant="h6"
-                noWrap
-                component="div"
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  m: 1,
-                }}
-              >
-                login
-              </Typography>
-            </MenuItem>
-          </Menu>
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            News
+          </Typography>
+          <Button color="inherit">Login</Button>
         </Box>
-      </Box>
-    </Box>
+        <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
+            News
+          </Typography>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            onClick={handleMenu}
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+
+          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+              sx={{
+                display: { xs: 'block', sm: 'none' },
+                mt: '32px',
+                px: '20px',
+              }}
+            >
+              <MenuItem>
+                <Typography
+                  onClick={handleClose}
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                >
+                  login
+                </Typography>
+              </MenuItem>
+            </Menu>
+          </Box>
+        </Box>
+      </Toolbar>
+    </AppBar>
   );
 }

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -6,27 +6,100 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Menu from '@mui/material/Menu';
 
 export default function ButtonAppBar() {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static">
-        <Toolbar>
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            News
-          </Typography>
-          <Button color="inherit">Login</Button>
-        </Toolbar>
-      </AppBar>
+    <Box>
+      <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+        <AppBar position="static">
+          <Toolbar>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              News
+            </Typography>
+            <Button color="inherit">Login</Button>
+          </Toolbar>
+        </AppBar>
+      </Box>
+      <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+        <AppBar position="static">
+          <Toolbar>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              News
+            </Typography>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              onClick={handleMenu}
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+        <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+          <div>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+              sx={{
+                display: { xs: 'block', sm: 'none' },
+                mt: '32px',
+                px: '20px',
+              }}
+            >
+              <MenuItem>
+                <Typography
+                  onClick={handleClose}
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    m: 1,
+                  }}
+                >
+                  login
+                </Typography>
+              </MenuItem>
+            </Menu>
+          </div>
+        </Box>
+      </Box>
     </Box>
   );
 }
+

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
-import AppBar from "@mui/material/AppBar";
-import Box from "@mui/material/Box";
-import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
-import IconButton from "@mui/material/IconButton";
-import MenuIcon from "@mui/icons-material/Menu";
-import MenuItem from "@mui/material/MenuItem";
-import Menu from "@mui/material/Menu";
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Menu from '@mui/material/Menu';
 
 export default function ButtonAppBar() {
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-  const handleMenu = (event) => {
+  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
@@ -22,8 +22,14 @@ export default function ButtonAppBar() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
-          <IconButton size="large" edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+        <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
@@ -31,7 +37,7 @@ export default function ButtonAppBar() {
           </Typography>
           <Button color="inherit">Login</Button>
         </Box>
-        <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
+        <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, mt: 1 }}>
             News
           </Typography>
@@ -46,25 +52,25 @@ export default function ButtonAppBar() {
             <MenuIcon />
           </IconButton>
 
-          <Box sx={{ display: { xs: "flex", md: "none" } }}>
+          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
             <Menu
               id="menu-appbar"
               anchorEl={anchorEl}
               anchorOrigin={{
-                vertical: "top",
-                horizontal: "right",
+                vertical: 'top',
+                horizontal: 'right',
               }}
               keepMounted
               transformOrigin={{
-                vertical: "top",
-                horizontal: "right",
+                vertical: 'top',
+                horizontal: 'right',
               }}
               open={Boolean(anchorEl)}
               onClose={handleClose}
               sx={{
-                display: { xs: "block", sm: "none" },
-                mt: "32px",
-                px: "20px",
+                display: { xs: 'block', sm: 'none' },
+                mt: '32px',
+                px: '20px',
               }}
             >
               <MenuItem>
@@ -74,8 +80,8 @@ export default function ButtonAppBar() {
                   noWrap
                   component="div"
                   sx={{
-                    display: "flex",
-                    alignItems: "center",
+                    display: 'flex',
+                    alignItems: 'center',
                   }}
                 >
                   login

--- a/docs/src/pages/components/app-bar/app-bar.md
+++ b/docs/src/pages/components/app-bar/app-bar.md
@@ -15,7 +15,7 @@ It can transform into a contextual action bar or be used as a navbar.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-## Basic App Bar
+## Basic Responsive App Bar
 
 {{"demo": "pages/components/app-bar/ButtonAppBar.js", "bg": true}}
 


### PR DESCRIPTION
I created a responsive AppBar for all devices. It's so useful for beginners to create a responsive AppBar easily.

### **Basic App Bar**
Preview: [https://deploy-preview-29811--material-ui.netlify.app/components/app-bar/#basic-app-bar](https://deploy-preview-29811--material-ui.netlify.app/components/app-bar/#basic-app-bar)

### Demo:
[https://u3xus.csb.app/](https://u3xus.csb.app/)

### Desktop view:
![image](https://user-images.githubusercontent.com/57065763/142769101-19a1f075-db7b-4e48-a692-5afe08642844.png)

### Mobile View:
![image](https://user-images.githubusercontent.com/57065763/142769151-8d6a5804-a78f-4131-af4a-8dc1abfb45d4.png)



<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
