### PR TITLE
[docs] Add a note that ToggleButton exclusive does not enforce selection

### DIFF
--- a/docs/src/pages/components/toggle-button/toggle-button.md
+++ b/docs/src/pages/components/toggle-button/toggle-button.md
@@ -21,7 +21,7 @@ With exclusive selection, selecting one option deselects any other.
 
 In this example, text justification toggle buttons present options for left, center, right, and fully justified text (disabled), with only one item available for selection at a time.
 
-**Note**: Exclusive selection does not enforce that at least one button must be active. For that effect see [enforce value set](#enforce-value-set).
+**Note**: Exclusive selection does not enforce that a button must be active. For that effect see [enforce value set](#enforce-value-set).
 
 {{"demo": "pages/components/toggle-button/ToggleButtons.js"}}
 

--- a/docs/src/pages/components/toggle-button/toggle-button.md
+++ b/docs/src/pages/components/toggle-button/toggle-button.md
@@ -21,6 +21,8 @@ With exclusive selection, selecting one option deselects any other.
 
 In this example, text justification toggle buttons present options for left, center, right, and fully justified text (disabled), with only one item available for selection at a time.
 
+Note that exclusive selection does not enforce that at least one button must be active. For that effect see [enforce value set](#enforce-value-set).
+
 {{"demo": "pages/components/toggle-button/ToggleButtons.js"}}
 
 ## Multiple selection

--- a/docs/src/pages/components/toggle-button/toggle-button.md
+++ b/docs/src/pages/components/toggle-button/toggle-button.md
@@ -21,7 +21,7 @@ With exclusive selection, selecting one option deselects any other.
 
 In this example, text justification toggle buttons present options for left, center, right, and fully justified text (disabled), with only one item available for selection at a time.
 
-Note that exclusive selection does not enforce that at least one button must be active. For that effect see [enforce value set](#enforce-value-set).
+**Note**: Exclusive selection does not enforce that at least one button must be active. For that effect see [enforce value set](#enforce-value-set).
 
 {{"demo": "pages/components/toggle-button/ToggleButtons.js"}}
 


### PR DESCRIPTION
Exclusive selection for `ToggleButtonGroup` does not enforce value at the moment. Since the most common use scenario for the exclusive selection is using `ToggleButtonGroup` in a similar manner to `RadioGroup` it would be worth noting that `exclusive` flag does not enforce value in documentation for exclusive selection. 

Closes https://github.com/mui-org/material-ui/issues/29784

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
