### PR TITLE
[SelectInput] `multiple` does not handle React node properly (instead prints [object Object])

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -805,6 +805,20 @@ describe('<Select />', () => {
       expect(options[2]).to.have.attribute('aria-selected', 'true');
     });
 
+    it('should serialize multiple select display value', () => {
+      const { getByRole } = render(
+        <Select multiple value={[10, 20, 30]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>
+            <strong>Twenty</strong>
+          </MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('button')).to.have.text('Ten, Twenty, Thirty');
+    });
+
     it('selects value based on their stringified equality when theyre not objects', () => {
       const { getAllByRole } = render(
         <Select multiple open value={['10', '20']}>

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -417,7 +417,11 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   }
 
   if (computeDisplay) {
-    display = multiple ? displayMultiple.join(', ') : displaySingle;
+    if (multiple) {
+      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr]);
+    } else {
+      display = displaySingle;
+    }
   }
 
   // Avoid performing a layout computation in the render method.


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/29832

React Nodes are preserved in an array instead of being converted into string (to avoid printing [object Object] when MenuItem contains React Nodes)

![image](https://user-images.githubusercontent.com/6678421/142898701-c718483e-2005-47cc-a2fe-44fd9e097671.png)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
