### PR TITLE
[icons] Move xlink replace above svgo.optimize calls

### DIFF
--- a/packages/mui-icons-material/builder.js
+++ b/packages/mui-icons-material/builder.js
@@ -99,7 +99,8 @@ export function cleanPaths({ svgPath, data }) {
   const input = data
     .replace(/ fill="#010101"/g, '')
     .replace(/<rect fill="none" width="24" height="24"\/>/g, '')
-    .replace(/<rect id="SVGID_1_" width="24" height="24"\/>/g, '');
+    .replace(/<rect id="SVGID_1_" width="24" height="24"\/>/g, '')
+    .replace(/xlink:href=/g, 'xlinkHref=');
 
   const result = svgo.optimize(input, {
     floatPrecision: 4,
@@ -197,7 +198,6 @@ export function cleanPaths({ svgPath, data }) {
   let paths = jsxResult.data
     .replace(/"\/>/g, '" />')
     .replace(/fill-opacity=/g, 'fillOpacity=')
-    .replace(/xlink:href=/g, 'xlinkHref=')
     .replace(/clip-rule=/g, 'clipRule=')
     .replace(/fill-rule=/g, 'fillRule=')
     .replace(/ clip-path=".+?"/g, '') // Fix visibility issue and save some bytes.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

While trying to run `yarn src:icons` I was getting the following error:

```
TypeError: Cannot read property 'replace' of undefined
    at cleanPaths (/Users/tylergoelz/www/redshelf/material-ui/packages/mui-icons-material/builder.js:198:6)
    at _callee2$ (/Users/tylergoelz/www/redshelf/material-ui/packages/mui-icons-material/builder.js:245:17)
    at tryCatch (/Users/tylergoelz/www/redshelf/material-ui/node_modules/regenerator-runtime/runtime.js:63:40)
    at Generator.invoke [as _invoke] (/Users/tylergoelz/www/redshelf/material-ui/node_modules/regenerator-runtime/runtime.js:294:22)
    at Generator.next (/Users/tylergoelz/www/redshelf/material-ui/node_modules/regenerator-runtime/runtime.js:119:21)
    at asyncGeneratorStep (/Users/tylergoelz/www/redshelf/material-ui/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/Users/tylergoelz/www/redshelf/material-ui/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
```

This is happening because `svgo.optimize(input ...` is failing due to the following error:

```
error: 'SvgoParserError: <input>:1:140: Unbound namespace prefix: "xlink"\n' +
    '\n' +
    '> 1 | …".3"/></defs><use xlink:href="#a" overflow="visible"/><clipPath id="b"><us…\n' +
    '    |                                                       ^\n',
  modernError: SvgoParserError: <input>:1:140: Unbound namespace prefix: "xlink"
  ... {
    reason: 'Unbound namespace prefix: "xlink"',
    line: 1,
    column: 140,
    source: '<svg viewBox="0 0 24 24"><g opacity=".3"><defs><path id="a" d="M4 8H14V19H4z" opacity=".3"/></defs><use xlink:href="#a" overflow="visible"/><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path d="M4 19h10V8H4v11zm1-7h2.5V9.5h3V12H13v3h-2.5v2.5h-3V15H5v-3z" clip-path="url(#b)"/></g><path d="M3 3H15V5H3z"/><path d="M14 6H4c-1.1 0-2 .9-2 2v11c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2m0 13H4V8h10v11z"/><path d="M7.5 17.5 10.5 17.5 10.5 15 13 15 13 12 10.5 12 10.5 9.5 7.5 9.5 7.5 12 5 12 5 15 7.5 15z"/><ellipse cx="20" cy="10" opacity=".3" rx="1" ry="2"/><path d="M20 6c-1.68 0-3 1.76-3 4 0 1.77.83 3.22 2 3.76V20c0 .55.45 1 1 1s1-.45 1-1v-6.24c1.17-.54 2-1.99 2-3.76 0-2.24-1.32-4-3-4zm0 6c-.41 0-1-.78-1-2s.59-2 1-2 1 .78 1 2-.59 2-1 2z"/></svg>'
  }
```
(the only icon with xlink in it is `medication_liquid_two_tone_24px.svg`, btw)

I tried adding `reusePath` as a plugin, [as suggested by svgo](https://github.com/svg/svgo/issues/1200), but to no avail.

Moving the replacement of xlist to _before_ svgo optimize calls seems to fix the problem.