### PR TITLE
[system] Add support for `enableColorScheme` in `createCssVarsProvider`

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -71,6 +71,11 @@ export default function createCssVarsProvider<
    */
   defaultMode?: Mode;
   /**
+   * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
+   * @default true
+   */
+  enableColorScheme?: boolean;
+  /**
    * CSS variable prefix
    * @default ''
    */

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -62,14 +62,21 @@ export default function createCssVarsProvider(options) {
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.light;
     const defaultDarkColorScheme =
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.dark;
-    const { mode, setMode, lightColorScheme, darkColorScheme, colorScheme, setColorScheme } =
-      useCurrentColorScheme({
-        supportedColorSchemes: allColorSchemes,
-        defaultLightColorScheme,
-        defaultDarkColorScheme,
-        modeStorageKey,
-        defaultMode,
-      });
+    const {
+      mode,
+      setMode,
+      systemMode,
+      lightColorScheme,
+      darkColorScheme,
+      colorScheme,
+      setColorScheme,
+    } = useCurrentColorScheme({
+      supportedColorSchemes: allColorSchemes,
+      defaultLightColorScheme,
+      defaultDarkColorScheme,
+      modeStorageKey,
+      defaultMode,
+    });
     const resolvedColorScheme = (() => {
       if (!colorScheme) {
         // This scope occurs on the server
@@ -125,6 +132,18 @@ export default function createCssVarsProvider(options) {
         document.body.setAttribute(attribute, colorScheme);
       }
     }, [colorScheme, attribute]);
+
+    React.useEffect(() => {
+      if (!mode) {
+        return;
+      }
+      // `color-scheme` tells browser to render built-in elements according to its value: `light` or `dark`
+      if (mode === 'system') {
+        document.body.style.setProperty('color-scheme', systemMode);
+      } else {
+        document.body.style.setProperty('color-scheme', mode);
+      }
+    }, [mode, systemMode]);
 
     return (
       <ColorSchemeContext.Provider

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -16,6 +16,7 @@ export default function createCssVarsProvider(options) {
     theme: baseTheme = {},
     defaultMode: desisgnSystemMode = 'light',
     defaultColorScheme: designSystemColorScheme,
+    enableColorScheme = true,
     prefix: designSystemPrefix = '',
     shouldSkipGeneratingVar,
   } = options;
@@ -134,7 +135,7 @@ export default function createCssVarsProvider(options) {
     }, [colorScheme, attribute]);
 
     React.useEffect(() => {
-      if (!mode) {
+      if (!mode || !enableColorScheme) {
         return;
       }
       // `color-scheme` tells browser to render built-in elements according to its value: `light` or `dark`

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -140,9 +140,9 @@ export default function createCssVarsProvider(options) {
       }
       // `color-scheme` tells browser to render built-in elements according to its value: `light` or `dark`
       if (mode === 'system') {
-        document.body.style.setProperty('color-scheme', systemMode);
+        document.documentElement.style.setProperty('color-scheme', systemMode);
       } else {
-        document.body.style.setProperty('color-scheme', mode);
+        document.documentElement.style.setProperty('color-scheme', mode);
       }
     }, [mode, systemMode]);
 

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -237,6 +237,62 @@ describe('createCssVarsProvider', () => {
       expect(screen.getByText('var(--palette-primary)')).not.to.equal(null);
       expect(screen.getByText('var(--palette-grey)')).not.to.equal(null);
     });
+
+    it('set `color-scheme` property to body with correct mode, given `mode` is `light` or `dark`', () => {
+      const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
+        theme: {
+          colorSchemes: { light: {}, dark: {} },
+        },
+        defaultColorScheme: 'light',
+      });
+      const Consumer = () => {
+        const { setMode } = useColorScheme();
+        return <button onClick={() => setMode('dark')}>change to dark</button>;
+      };
+      render(
+        <CssVarsProvider>
+          <Consumer />
+        </CssVarsProvider>,
+      );
+      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
+        'light',
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'change to dark' }));
+
+      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
+        'dark',
+      );
+    });
+
+    it('set `color-scheme` property to body with correct mode, given mode is `system`', () => {
+      window.matchMedia = createMatchMedia(true); // system matches 'prefers-color-scheme: dark'
+
+      const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
+        theme: {
+          colorSchemes: { light: {}, dark: {} },
+        },
+        defaultColorScheme: 'light',
+      });
+      const Consumer = () => {
+        const { setMode } = useColorScheme();
+        return <button onClick={() => setMode('system')}>change to system</button>;
+      };
+      render(
+        <CssVarsProvider>
+          <Consumer />
+        </CssVarsProvider>,
+      );
+      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
+        'light',
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'change to system' }));
+
+      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
+        'dark',
+      );
+    });
   });
 
   describe('DOM', () => {

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -238,12 +238,13 @@ describe('createCssVarsProvider', () => {
       expect(screen.getByText('var(--palette-grey)')).not.to.equal(null);
     });
 
-    it('set `color-scheme` property to body with correct mode, given `mode` is `light` or `dark`', () => {
+    it('set `color-scheme` property to body with correct mode, given `enableColorScheme` is true and `mode` is `light` or `dark`', () => {
       const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
         theme: {
           colorSchemes: { light: {}, dark: {} },
         },
         defaultColorScheme: 'light',
+        enableColorScheme: true,
       });
       const Consumer = () => {
         const { setMode } = useColorScheme();
@@ -265,7 +266,7 @@ describe('createCssVarsProvider', () => {
       );
     });
 
-    it('set `color-scheme` property to body with correct mode, given mode is `system`', () => {
+    it('set `color-scheme` property to body with correct mode, given `enableColorScheme` is true and mode is `system`', () => {
       window.matchMedia = createMatchMedia(true); // system matches 'prefers-color-scheme: dark'
 
       const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
@@ -273,6 +274,7 @@ describe('createCssVarsProvider', () => {
           colorSchemes: { light: {}, dark: {} },
         },
         defaultColorScheme: 'light',
+        enableColorScheme: true,
       });
       const Consumer = () => {
         const { setMode } = useColorScheme();
@@ -291,6 +293,26 @@ describe('createCssVarsProvider', () => {
 
       expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
         'dark',
+      );
+    });
+
+    it('does not set `color-scheme` property to body with correct mode, given`enableColorScheme` is false', () => {
+      const { CssVarsProvider } = createCssVarsProvider({
+        theme: {
+          colorSchemes: { light: {}, dark: {} },
+        },
+        defaultColorScheme: 'light',
+        enableColorScheme: false,
+      });
+      const Consumer = () => <div />;
+
+      render(
+        <CssVarsProvider>
+          <Consumer />
+        </CssVarsProvider>,
+      );
+      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).not.to.equal(
+        'light',
       );
     });
   });

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -255,15 +255,15 @@ describe('createCssVarsProvider', () => {
           <Consumer />
         </CssVarsProvider>,
       );
-      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
-        'light',
-      );
+      expect(
+        window.getComputedStyle(document.documentElement).getPropertyValue('color-scheme'),
+      ).to.equal('light');
 
       fireEvent.click(screen.getByRole('button', { name: 'change to dark' }));
 
-      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
-        'dark',
-      );
+      expect(
+        window.getComputedStyle(document.documentElement).getPropertyValue('color-scheme'),
+      ).to.equal('dark');
     });
 
     it('set `color-scheme` property to body with correct mode, given `enableColorScheme` is true and mode is `system`', () => {
@@ -285,15 +285,15 @@ describe('createCssVarsProvider', () => {
           <Consumer />
         </CssVarsProvider>,
       );
-      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
-        'light',
-      );
+      expect(
+        window.getComputedStyle(document.documentElement).getPropertyValue('color-scheme'),
+      ).to.equal('light');
 
       fireEvent.click(screen.getByRole('button', { name: 'change to system' }));
 
-      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).to.equal(
-        'dark',
-      );
+      expect(
+        window.getComputedStyle(document.documentElement).getPropertyValue('color-scheme'),
+      ).to.equal('dark');
     });
 
     it('does not set `color-scheme` property to body with correct mode, given`enableColorScheme` is false', () => {
@@ -311,9 +311,9 @@ describe('createCssVarsProvider', () => {
           <Consumer />
         </CssVarsProvider>,
       );
-      expect(window.getComputedStyle(document.body).getPropertyValue('color-scheme')).not.to.equal(
-        'light',
-      );
+      expect(
+        window.getComputedStyle(document.documentElement).getPropertyValue('color-scheme'),
+      ).not.to.equal('light');
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of https://github.com/mui-org/material-ui/issues/27651

- Support for `enableColorScheme` in `createCssVarsProvider` (when true, we indicate to the browser which `color-scheme` to use when rendering built-in UI)
- Set `color-scheme` property to `body` with correct `mode` value (light or dark) inside `createCssVarsProvider`