### PR TITLE
[DatePicker] Add customizable weekday labels

### DIFF
--- a/docs/pages/api-docs/date-picker.json
+++ b/docs/pages/api-docs/date-picker.json
@@ -79,6 +79,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/date-range-picker.json
+++ b/docs/pages/api-docs/date-range-picker.json
@@ -85,6 +85,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -93,6 +93,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/desktop-date-picker.json
+++ b/docs/pages/api-docs/desktop-date-picker.json
@@ -70,6 +70,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/desktop-date-range-picker.json
+++ b/docs/pages/api-docs/desktop-date-range-picker.json
@@ -76,6 +76,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -84,6 +84,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/mobile-date-picker.json
+++ b/docs/pages/api-docs/mobile-date-picker.json
@@ -73,6 +73,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/mobile-date-range-picker.json
+++ b/docs/pages/api-docs/mobile-date-range-picker.json
@@ -79,6 +79,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -87,6 +87,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/static-date-picker.json
+++ b/docs/pages/api-docs/static-date-picker.json
@@ -72,6 +72,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/static-date-range-picker.json
+++ b/docs/pages/api-docs/static-date-range-picker.json
@@ -78,6 +78,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -86,6 +86,7 @@
       "type": { "name": "func" },
       "default": "() => <span data-mui-test=\"loading-progress\">...</span>"
     },
+    "renderWeekdayLabel": { "type": { "name": "func" } },
     "rifmFormatter": { "type": { "name": "func" } },
     "rightArrowButtonText": { "type": { "name": "string" } },
     "shouldDisableDate": { "type": { "name": "func" } },

--- a/docs/src/pages/components/date-picker/CustomWeekdayLabel.js
+++ b/docs/src/pages/components/date-picker/CustomWeekdayLabel.js
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import StaticDatePicker from '@mui/lab/StaticDatePicker';
+
+const PickersCalendarWeekDayLabel = styled(Typography, { skipSx: true })(
+  ({ theme }) => ({
+    width: 36,
+    height: 40,
+    margin: '0 2px',
+    textAlign: 'center',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: theme.palette.text.secondary,
+  }),
+);
+
+export default function CustomWeekdayLabel() {
+  const [value, setValue] = React.useState(new Date());
+
+  const renderWeekdayLabel = (weekday, i) => (
+    <PickersCalendarWeekDayLabel
+      aria-hidden
+      key={weekday + i.toString()}
+      variant="caption"
+    >
+      {weekday}
+    </PickersCalendarWeekDayLabel>
+  );
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <StaticDatePicker
+        displayStaticWrapperAs="desktop"
+        label="Week picker"
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        renderWeekdayLabel={renderWeekdayLabel}
+        renderInput={(params) => <TextField {...params} />}
+        inputFormat="'Week of' MMM d"
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/src/pages/components/date-picker/CustomWeekdayLabel.tsx
+++ b/docs/src/pages/components/date-picker/CustomWeekdayLabel.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import StaticDatePicker from '@mui/lab/StaticDatePicker';
+
+const PickersCalendarWeekDayLabel = styled(Typography, { skipSx: true })(
+  ({ theme }) => ({
+    width: 36,
+    height: 40,
+    margin: '0 2px',
+    textAlign: 'center',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: theme.palette.text.secondary,
+  }),
+);
+
+export default function CustomWeekdayLabel() {
+  const [value, setValue] = React.useState<Date | null>(new Date());
+
+  const renderWeekdayLabel = (weekday: string, i: number) => (
+    <PickersCalendarWeekDayLabel
+      aria-hidden
+      key={weekday + i.toString()}
+      variant="caption"
+    >
+      {weekday}
+    </PickersCalendarWeekDayLabel>
+  );
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <StaticDatePicker
+        displayStaticWrapperAs="desktop"
+        label="Week picker"
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        renderWeekdayLabel={renderWeekdayLabel}
+        renderInput={(params) => <TextField {...params} />}
+        inputFormat="'Week of' MMM d"
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/src/pages/components/date-picker/CustomWeekdayLabel.tsx.preview
+++ b/docs/src/pages/components/date-picker/CustomWeekdayLabel.tsx.preview
@@ -1,0 +1,13 @@
+<LocalizationProvider dateAdapter={AdapterDateFns}>
+  <StaticDatePicker
+    displayStaticWrapperAs="desktop"
+    label="Week picker"
+    value={value}
+    onChange={(newValue) => {
+      setValue(newValue);
+    }}
+    renderWeekdayLabel={renderWeekdayLabel}
+    renderInput={(params) => <TextField {...params} />}
+    inputFormat="'Week of' MMM d"
+  />
+</LocalizationProvider>

--- a/docs/src/pages/components/date-picker/date-picker.md
+++ b/docs/src/pages/components/date-picker/date-picker.md
@@ -108,6 +108,12 @@ You can take advantage of the [PickersDay](/api/pickers-day/) component.
 
 {{"demo": "pages/components/date-picker/CustomDay.js"}}
 
+## Customized weekday label rendering
+
+The displayed weekday labels are customizable with the `renderWeekdayLabel` function prop.
+
+{{"demo": "pages/components/date-picker/CustomWeekdayLabel.js"}}
+
 ## Dynamic data
 
 Sometimes it may be necessary to display additional info right in the calendar. Here's an example of prefetching and displaying server-side data using the `onMonthChange`, `loading`, and `renderDay` props.

--- a/docs/translations/api-docs/date-picker/date-picker.json
+++ b/docs/translations/api-docs/date-picker/date-picker.json
@@ -47,6 +47,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/date-range-picker/date-range-picker.json
+++ b/docs/translations/api-docs/date-range-picker/date-range-picker.json
@@ -48,6 +48,7 @@
     "renderDay": "Custom renderer for <code>&lt;DateRangePicker /&gt;</code> days. @DateIOType",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>startProps</code> and <code>endProps</code> arguments of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a>, that you need to forward to the range start/end inputs respectively. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/date-time-picker/date-time-picker.json
+++ b/docs/translations/api-docs/date-time-picker/date-time-picker.json
@@ -58,6 +58,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/desktop-date-picker/desktop-date-picker.json
+++ b/docs/translations/api-docs/desktop-date-picker/desktop-date-picker.json
@@ -41,6 +41,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/desktop-date-range-picker/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/desktop-date-range-picker/desktop-date-range-picker.json
@@ -42,6 +42,7 @@
     "renderDay": "Custom renderer for <code>&lt;DateRangePicker /&gt;</code> days. @DateIOType",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>startProps</code> and <code>endProps</code> arguments of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a>, that you need to forward to the range start/end inputs respectively. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/desktop-date-time-picker/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/desktop-date-time-picker/desktop-date-time-picker.json
@@ -52,6 +52,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/mobile-date-picker/mobile-date-picker.json
+++ b/docs/translations/api-docs/mobile-date-picker/mobile-date-picker.json
@@ -44,6 +44,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/mobile-date-range-picker/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/mobile-date-range-picker/mobile-date-range-picker.json
@@ -45,6 +45,7 @@
     "renderDay": "Custom renderer for <code>&lt;DateRangePicker /&gt;</code> days. @DateIOType",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>startProps</code> and <code>endProps</code> arguments of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a>, that you need to forward to the range start/end inputs respectively. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/mobile-date-time-picker/mobile-date-time-picker.json
+++ b/docs/translations/api-docs/mobile-date-time-picker/mobile-date-time-picker.json
@@ -55,6 +55,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/static-date-picker/static-date-picker.json
+++ b/docs/translations/api-docs/static-date-picker/static-date-picker.json
@@ -40,6 +40,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/static-date-range-picker/static-date-range-picker.json
+++ b/docs/translations/api-docs/static-date-range-picker/static-date-range-picker.json
@@ -41,6 +41,7 @@
     "renderDay": "Custom renderer for <code>&lt;DateRangePicker /&gt;</code> days. @DateIOType",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>startProps</code> and <code>endProps</code> arguments of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a>, that you need to forward to the range start/end inputs respectively. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/docs/translations/api-docs/static-date-time-picker/static-date-time-picker.json
+++ b/docs/translations/api-docs/static-date-time-picker/static-date-time-picker.json
@@ -51,6 +51,7 @@
     "renderDay": "Custom renderer for day. Check the <a href=\"https://mui.com/api/pickers-day/\">PickersDay</a> component.",
     "renderInput": "The <code>renderInput</code> prop allows you to customize the rendered input. The <code>props</code> argument of this render prop contains props of <a href=\"https://mui.com/api/text-field/#textfield-api\">TextField</a> that you need to forward. Pay specific attention to the <code>ref</code> and <code>inputProps</code> keys.",
     "renderLoading": "Component displaying when passed <code>loading</code> true.",
+    "renderWeekdayLabel": "Custom renderer for the week day label.",
     "rifmFormatter": "Custom formatter to be passed into Rifm component.",
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableDate": "Disable specific date. @DateIOType",

--- a/packages/mui-lab/src/CalendarPicker/PickersCalendar.tsx
+++ b/packages/mui-lab/src/CalendarPicker/PickersCalendar.tsx
@@ -33,6 +33,10 @@ export interface ExportedCalendarProps<TDate>
     pickersDayProps: PickersDayProps<TDate>,
   ) => JSX.Element;
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel?: (weekday: string, index: number) => JSX.Element;
+  /**
    * Component displaying when passed `loading` true.
    * @default () => "..."
    */
@@ -116,6 +120,11 @@ function PickersCalendar<TDate>(props: PickersCalendarProps<TDate>) {
     readOnly,
     reduceAnimations,
     renderDay,
+    renderWeekdayLabel = (weekday, i) => (
+      <PickersCalendarWeekDayLabel aria-hidden key={weekday + i.toString()} variant="caption">
+        {weekday.charAt(0).toUpperCase()}
+      </PickersCalendarWeekDayLabel>
+    ),
     renderLoading = () => <span data-mui-test="loading-progress">...</span>,
     showDaysOutsideCurrentMonth,
     slideDirection,
@@ -150,11 +159,7 @@ function PickersCalendar<TDate>(props: PickersCalendarProps<TDate>) {
   return (
     <React.Fragment>
       <PickersCalendarDayHeader>
-        {utils.getWeekdays().map((day, i) => (
-          <PickersCalendarWeekDayLabel aria-hidden key={day + i.toString()} variant="caption">
-            {day.charAt(0).toUpperCase()}
-          </PickersCalendarWeekDayLabel>
-        ))}
+        {utils.getWeekdays().map(renderWeekdayLabel)}
       </PickersCalendarDayHeader>
 
       {loading ? (

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -343,6 +343,10 @@ DatePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -459,6 +459,10 @@ DateRangePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -401,6 +401,10 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -318,6 +318,10 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -437,6 +437,10 @@ DesktopDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -377,6 +377,10 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -326,6 +326,10 @@ MobileDatePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -449,6 +449,10 @@ MobileDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -387,6 +387,10 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -306,6 +306,10 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -418,6 +418,10 @@ StaticDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -367,6 +367,10 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
    */
   renderLoading: PropTypes.func,
   /**
+   * Custom renderer for the week day label.
+   */
+  renderWeekdayLabel: PropTypes.func,
+  /**
    * Custom formatter to be passed into Rifm component.
    */
   rifmFormatter: PropTypes.func,


### PR DESCRIPTION
This PR adds the possibility to customize the weekday labels on the `PickersCalendar` by introducing the new function prop `renderWeekdayLabel`. When this prop is not set, the `PickersCalendar` renders as before.

Deploy preview: https://deploy-preview-29849--material-ui.netlify.app/components/date-picker/#customized-weekday-label-rendering

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).