### PR TITLE
[system] Add support for `disableTransitionOnChange` in `createCssVarsProvider`

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -71,7 +71,7 @@ export default function createCssVarsProvider<
    */
   defaultMode?: Mode;
   /**
-   * Disable CSS transitions when switching between modes
+   * Disable CSS transitions when switching between modes or color schemes
    * @default false
    */
   disableTransitionOnChange?: boolean;

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Result, Mode } from './useCurrentColorScheme';
+import { Mode, Result } from './useCurrentColorScheme';
 
 type RequiredDeep<T> = {
   [K in keyof T]-?: RequiredDeep<T[K]>;
@@ -70,6 +70,11 @@ export default function createCssVarsProvider<
    * @default 'light'
    */
   defaultMode?: Mode;
+  /**
+   * Disable CSS transitions when switching between modes
+   * @default false
+   */
+  disableTransitionOnChange?: boolean;
   /**
    * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
    * @default true


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of https://github.com/mui-org/material-ui/issues/27651

- Support for `disableTransitionOnChange` in `createCssVarsProvider` (when true, we disable all css transitions momentarily when switching between modes; this allows the switch to be smooth; ref: https://paco.me/writing/disable-theme-transitions)