### PR TITLE
[docs] Smoother image loading UX

### DIFF
--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -104,6 +104,7 @@ const Person = (props: Profile & { sx?: PaperProps['sx'] }) => {
                 width: 24,
                 height: 24,
                 border: '2px solid #fff',
+                backgroundColor: '#fff',
                 borderRadius: 40,
                 overflow: 'hidden',
                 display: 'flex',


### PR DESCRIPTION
A small detail, but that has annoyed me for some time when loading the page:

**Before**

https://user-images.githubusercontent.com/3165635/143063485-d553072c-7a2b-4fb6-9d3d-cf72a51dcc30.mp4

**After**

https://user-images.githubusercontent.com/3165635/143063137-5469f350-1c6e-48c2-9173-dff0bfd66660.mp4


