### PR TITLE
[MenuList] Add component prop

### DIFF
--- a/packages/mui-material/src/List/List.d.ts
+++ b/packages/mui-material/src/List/List.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { Theme } from '..';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { OverridableComponent, OverridableTypeMap, OverrideProps } from '../OverridableComponent';
 import { ListClasses } from './listClasses';
 
 export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
@@ -39,6 +39,16 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
 }
 
 /**
+ * utility to create component types that inherit props from List.
+ */
+export interface ExtendListTypeMap<M extends OverridableTypeMap> {
+  props: M['props'] & ListTypeMap['props'];
+  defaultComponent: M['defaultComponent'];
+}
+
+export type ExtendList<M extends OverridableTypeMap> = OverridableComponent<ExtendListTypeMap<M>>;
+
+/**
  *
  * Demos:
  *
@@ -49,7 +59,7 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
  *
  * - [List API](https://mui.com/api/list/)
  */
-declare const List: OverridableComponent<ListTypeMap>;
+declare const List: ExtendList<ListTypeMap>;
 
 export type ListProps<
   D extends React.ElementType = ListTypeMap['defaultComponent'],

--- a/packages/mui-material/src/MenuList/MenuList.d.ts
+++ b/packages/mui-material/src/MenuList/MenuList.d.ts
@@ -1,41 +1,45 @@
 import * as React from 'react';
-import { ListProps } from '../List';
+import { ExtendList, ExtendListTypeMap } from '../List';
+import { OverrideProps } from '../OverridableComponent';
 
-export interface MenuListProps extends ListProps {
-  /**
-   * If `true`, will focus the `[role="menu"]` container and move into tab order.
-   * @default false
-   */
-  autoFocus?: boolean;
-  /**
-   * If `true`, will focus the first menuitem if `variant="menu"` or selected item
-   * if `variant="selectedMenu"`.
-   * @default false
-   */
-  autoFocusItem?: boolean;
-  /**
-   * MenuList contents, normally `MenuItem`s.
-   */
-  children?: React.ReactNode;
-  /**
-   * If `true`, will allow focus on disabled items.
-   * @default false
-   */
-  disabledItemsFocusable?: boolean;
-  /**
-   * If `true`, the menu items will not wrap focus.
-   * @default false
-   */
-  disableListWrap?: boolean;
-  /**
-   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus
-   * and the vertical alignment relative to the anchor element.
-   * @default 'selectedMenu'
-   */
-  variant?: 'menu' | 'selectedMenu';
-}
+export type MenuListTypeMap<P = {}, D extends React.ElementType = 'ul'> = ExtendListTypeMap<{
+  props: P & {
+    /**
+     * If `true`, will focus the `[role="menu"]` container and move into tab order.
+     * @default false
+     */
+    autoFocus?: boolean;
+    /**
+     * If `true`, will focus the first menuitem if `variant="menu"` or selected item
+     * if `variant="selectedMenu"`.
+     * @default false
+     */
+    autoFocusItem?: boolean;
+    /**
+     * MenuList contents, normally `MenuItem`s.
+     */
+    children?: React.ReactNode;
+    /**
+     * If `true`, will allow focus on disabled items.
+     * @default false
+     */
+    disabledItemsFocusable?: boolean;
+    /**
+     * If `true`, the menu items will not wrap focus.
+     * @default false
+     */
+    disableListWrap?: boolean;
+    /**
+     * The variant to use. Use `menu` to prevent selected items from impacting the initial focus
+     * and the vertical alignment relative to the anchor element.
+     * @default 'selectedMenu'
+     */
+    variant?: 'menu' | 'selectedMenu';
+  };
+  defaultComponent: D;
+}>;
 
-export type MenuListClassKey = keyof NonNullable<MenuListProps['classes']>;
+export type MenuListClassKey = keyof NonNullable<MenuListTypeMap['props']['classes']>;
 
 /**
  * A permanently displayed menu following https://www.w3.org/TR/wai-aria-practices/#menubutton.
@@ -52,4 +56,11 @@ export type MenuListClassKey = keyof NonNullable<MenuListProps['classes']>;
  * - [MenuList API](https://mui.com/api/menu-list/)
  * - inherits [List API](https://mui.com/api/list/)
  */
-export default function MenuList(props: MenuListProps): JSX.Element;
+declare const MenuList: ExtendList<MenuListTypeMap>;
+
+export type MenuListProps<
+  D extends React.ElementType = MenuListTypeMap['defaultComponent'],
+  P = {},
+> = OverrideProps<MenuListTypeMap<P, D>, D>;
+
+export default MenuList;

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -289,11 +289,6 @@ MenuList.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
-   * The component used for the root node.
-   * Either a string to use a HTML element or a component.
-   */
-  component: PropTypes.elementType,
-  /**
    * If `true`, will allow focus on disabled items.
    * @default false
    */

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -289,6 +289,11 @@ MenuList.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
    * If `true`, will allow focus on disabled items.
    * @default false
    */

--- a/packages/mui-material/src/MenuList/MenuList.spec.tsx
+++ b/packages/mui-material/src/MenuList/MenuList.spec.tsx
@@ -1,0 +1,5 @@
+import MenuList from '@mui/material/MenuList';
+import * as React from 'react';
+
+// component prop works as expected
+<MenuList component="div" />;


### PR DESCRIPTION
Adding a new prop named `component` for the MenuList component. The underlying component List already accepts this prop.

Closes https://github.com/mui-org/material-ui/issues/29628

Before:
- code sandbox: https://codesandbox.io/s/unruffled-shamir-o6323?file=/src/Demo.tsx

After:
- code sandbox: https://codesandbox.io/s/cocky-cdn-z0b5r?file=/src/Demo.tsx