### PR TITLE
[pickers] Fix missing key on PickerCalendar custom renderDay

### DIFF
--- a/packages/mui-lab/src/CalendarPicker/PickersCalendar.tsx
+++ b/packages/mui-lab/src/CalendarPicker/PickersCalendar.tsx
@@ -196,7 +196,9 @@ function PickersCalendar<TDate>(props: PickersCalendarProps<TDate>) {
                   };
 
                   return renderDay ? (
-                    renderDay(day, selectedDates, pickersDayProps)
+                    <React.Fragment key={pickersDayProps.key}>{
+                      renderDay(day, selectedDates, pickersDayProps)
+                    }</React.Fragment>
                   ) : (
                     <div role="cell" key={pickersDayProps.key}>
                       <PickersDay {...pickersDayProps} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

React complains about missing keys when using `renderDay` custom renderer on `PickersCalendar`:

```error
Warning: Each child in a list should have a unique "key" prop.

Check the render method of PickersCalendar
```

All keys must be directly on the JSX array, so it won't work if we add any keys inside the custom `renderDay` function, so, we add a fragment with the key and call `renderDay` inside it will solve the issue.

I didn't create an issue for this, because it's something very small and very obvious.