### PR TITLE
[test] Reject shorthand properties in style matchers

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -44,7 +44,8 @@ describe('<Masonry />', () => {
       expect(getByTestId('container')).toHaveComputedStyle({
         width: `${width}px`,
         display: 'flex',
-        flexFlow: 'column wrap',
+        flexDirection: 'column',
+        flexWrap: 'wrap',
         alignContent: 'space-between',
         boxSizing: 'border-box',
         marginTop: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -28,28 +28,37 @@ describe('<Masonry />', () => {
 
   describe('render', () => {
     it('should render with correct default styles', function test() {
-      if (!/jsdom/.test(window.navigator.userAgent)) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
+      const width = 400;
       const columns = 4;
       const spacing = 1;
       const { getByTestId } = render(
-        <Masonry data-testid="container">
-          <div data-testid="child" />
-        </Masonry>,
+        <div style={{ width: `${width}px` }}>
+          <Masonry data-testid="container">
+            <div data-testid="child" />
+          </Masonry>
+        </div>,
       );
       expect(getByTestId('container')).toHaveComputedStyle({
-        width: '100%',
+        width: `${width}px`,
         display: 'flex',
         flexFlow: 'column wrap',
         alignContent: 'space-between',
         boxSizing: 'border-box',
-        margin: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
+        marginTop: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
+        marginRight: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
+        marginBottom: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
+        marginLeft: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
       });
       expect(getByTestId('child')).toHaveComputedStyle({
         boxSizing: 'border-box',
-        margin: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
-        width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing)})`,
+        marginTop: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
+        marginRight: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
+        marginBottom: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
+        marginLeft: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
+        width: `${width / columns - parseToNumber(theme.spacing(spacing))}px`,
       });
     });
 

--- a/packages/mui-system/src/sx/sx.test.js
+++ b/packages/mui-system/src/sx/sx.test.js
@@ -80,8 +80,14 @@ describe('sx', () => {
       expect(container.firstChild).toHaveComputedStyle({
         color: 'rgb(0, 0, 255)',
         backgroundColor: 'rgb(0, 255, 0)',
-        margin: '20px',
-        padding: '10px',
+        marginTop: '20px',
+        marginRight: '20px',
+        marginBottom: '20px',
+        marginLeft: '20px',
+        paddingTop: '10px',
+        paddingRight: '10px',
+        paddingBottom: '10px',
+        paddingLeft: '10px',
         fontSize: '14px',
         maxWidth: '600px',
       });
@@ -133,8 +139,14 @@ describe('sx', () => {
       expect(container.firstChild).toHaveComputedStyle({
         color: 'rgb(0, 0, 255)',
         backgroundColor: 'rgb(0, 255, 0)',
-        margin: '20px',
-        padding: '10px',
+        marginTop: '20px',
+        marginRight: '20px',
+        marginBottom: '20px',
+        marginLeft: '20px',
+        paddingTop: '10px',
+        paddingRight: '10px',
+        paddingBottom: '10px',
+        paddingLeft: '10px',
         fontSize: '14px',
         maxWidth: '600px',
       });

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -330,6 +330,69 @@ chai.use((chaiAPI, utils) => {
     options: { styleTypeHint: string },
   ): void {
     const { styleTypeHint } = options;
+
+    const shorthandProperties = new Set([
+      'all',
+      'animation',
+      'background',
+      'border',
+      'border-block-end',
+      'border-block-start',
+      'border-bottom',
+      'border-color',
+      'border-image',
+      'border-inline-end',
+      'border-inline-start',
+      'border-left',
+      'border-radius',
+      'border-right',
+      'border-style',
+      'border-top',
+      'border-width',
+      'column-rule',
+      'columns',
+      'flex',
+      'flex-flow',
+      'font',
+      'gap',
+      'grid',
+      'grid-area',
+      'grid-column',
+      'grid-row',
+      'grid-template',
+      'list-style',
+      'margin',
+      'mask',
+      'offset',
+      'outline',
+      'overflow',
+      'padding',
+      'place-content',
+      'place-items',
+      'place-self',
+      'scroll-margin',
+      'scroll-padding',
+      'text-decoration',
+      'text-emphasis',
+      'transition',
+    ]);
+    const usedShorthandProperties = Object.keys(expectedStyleUnnormalized).filter((cssProperty) => {
+      return shorthandProperties.has(cssProperty);
+    });
+    if (usedShorthandProperties.length > 0) {
+      throw new Error(
+        [
+          `Shorthand properties are not supported in ${styleTypeHint} styles matchers since browser can compute them differently. `,
+          'Use longhand properties instead for the follow shorthand properties:\n',
+          usedShorthandProperties
+            .map((cssProperty) => {
+              return `- https://developer.mozilla.org/en-US/docs/Web/CSS/${cssProperty}#constituent_properties`;
+            })
+            .join('\n'),
+        ].join(''),
+      );
+    }
+
     // Compare objects using hyphen case.
     // This is closer to actual CSS and required for getPropertyValue anyway.
     const expectedStyle: Record<string, string> = {};

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -394,7 +394,7 @@ chai.use((chaiAPI, utils) => {
     if (usedShorthandProperties.length > 0) {
       throw new Error(
         [
-          `Shorthand properties are not supported in ${styleTypeHint} styles matchers since browser can compute them differently. `,
+          `Shorthand properties are not supported in ${styleTypeHint} styles matchers since browsers can compute them differently. `,
           'Use longhand properties instead for the follow shorthand properties:\n',
           usedShorthandProperties
             .map((cssProperty) => {

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -331,6 +331,18 @@ chai.use((chaiAPI, utils) => {
   ): void {
     const { styleTypeHint } = options;
 
+    // Compare objects using hyphen case.
+    // This is closer to actual CSS and required for getPropertyValue anyway.
+    const expectedStyle: Record<string, string> = {};
+    Object.keys(expectedStyleUnnormalized).forEach((cssProperty) => {
+      const hyphenCasedPropertyName = _.kebabCase(cssProperty);
+      const isVendorPrefixed = /^(moz|ms|o|webkit)-/.test(hyphenCasedPropertyName);
+      const propertyName = isVendorPrefixed
+        ? `-${hyphenCasedPropertyName}`
+        : hyphenCasedPropertyName;
+      expectedStyle[propertyName] = expectedStyleUnnormalized[cssProperty];
+    });
+
     const shorthandProperties = new Set([
       'all',
       'animation',
@@ -376,7 +388,7 @@ chai.use((chaiAPI, utils) => {
       'text-emphasis',
       'transition',
     ]);
-    const usedShorthandProperties = Object.keys(expectedStyleUnnormalized).filter((cssProperty) => {
+    const usedShorthandProperties = Object.keys(expectedStyle).filter((cssProperty) => {
       return shorthandProperties.has(cssProperty);
     });
     if (usedShorthandProperties.length > 0) {
@@ -392,18 +404,6 @@ chai.use((chaiAPI, utils) => {
         ].join(''),
       );
     }
-
-    // Compare objects using hyphen case.
-    // This is closer to actual CSS and required for getPropertyValue anyway.
-    const expectedStyle: Record<string, string> = {};
-    Object.keys(expectedStyleUnnormalized).forEach((cssProperty) => {
-      const hyphenCasedPropertyName = _.kebabCase(cssProperty);
-      const isVendorPrefixed = /^(moz|ms|o|webkit)-/.test(hyphenCasedPropertyName);
-      const propertyName = isVendorPrefixed
-        ? `-${hyphenCasedPropertyName}`
-        : hyphenCasedPropertyName;
-      expectedStyle[propertyName] = expectedStyleUnnormalized[cssProperty];
-    });
 
     const actualStyle: Record<string, string> = {};
     Object.keys(expectedStyle).forEach((cssProperty) => {


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/mui-org/material-ui/57061/workflows/607c4168-b6ad-4152-9806-5a03a9a6bfb8/jobs/320116
Browser run: https://app.circleci.com/pipelines/github/mui-org/material-ui/57084/workflows/57e049e7-1ecf-46f4-9249-f8f516995609

Since these types of failures are easy to make and frequent, we just reject shorthand properties outright.

Example failure (notice the link to constituent properties making it easier to find what you should write instead):
```bash
Chrome Headless 97.0.4666.0 (Linux x86_64) sx system resolves system when used inside styled() FAILED
        Error: Shorthand properties are not supported in computed styles matchers since browser can compute them differently. Use longhand properties instead for the follow shorthand properties:
        - https://developer.mozilla.org/en-US/docs/Web/CSS/margin#constituent_properties
        - https://developer.mozilla.org/en-US/docs/Web/CSS/padding#constituent_properties
            at Proxy.assertMatchingStyles (webpack-internal:///./test/utils/initMatchers.ts:13:69718)
            at Proxy.toHaveComputedStyle (webpack-internal:///./test/utils/initMatchers.ts:13:73847)
            at Proxy.methodWrapper (webpack-internal:///./node_modules/chai/lib/chai/utils/addMethod.js:57:25)
            at Context.test (webpack-internal:///./packages/mui-system/src/sx/sx.test.js:9:14969)
Chrome Headless 97.0.4666.0 (Linux x86_64) sx system resolves system when used inside variants FAILED
        Error: Shorthand properties are not supported in computed styles matchers since browser can compute them differently. Use longhand properties instead for the follow shorthand properties:
        - https://developer.mozilla.org/en-US/docs/Web/CSS/margin#constituent_properties
        - https://developer.mozilla.org/en-US/docs/Web/CSS/padding#constituent_properties
            at Proxy.assertMatchingStyles (webpack-internal:///./test/utils/initMatchers.ts:13:69718)
            at Proxy.toHaveComputedStyle (webpack-internal:///./test/utils/initMatchers.ts:13:73847)
            at Proxy.methodWrapper (webpack-internal:///./node_modules/chai/lib/chai/utils/addMethod.js:57:25)
            at Context.test (webpack-internal:///./packages/mui-system/src/sx/sx.test.js:9:16237)
```

List of shorthand properties from https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#see_also

