### PR TITLE
[core] Fix PR detection pattern in test_bundle_size_monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,6 +650,7 @@ jobs:
             matches:
               # "^pull/\d+" is not valid YAML
               # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+              # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
               pattern: "^pull/.+$"
               value: << pipeline.git.branch >>
           steps:
@@ -678,6 +679,7 @@ jobs:
               matches:
                 # "^pull/\d+" is not valid YAML
                 # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+                # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
                 pattern: "^pull/.+$"
                 value: << pipeline.git.branch >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,12 +647,13 @@ jobs:
       - when:
           # don't run on PRs
           condition:
-            matches:
-              # "^pull/\d+" is not valid YAML
-              # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-              # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-              pattern: "^pull/.+$"
-              value: << pipeline.git.branch >>
+            not:
+              matches:
+                # "^pull/\d+" is not valid YAML
+                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+                # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
+                pattern: "^pull/.+$"
+                value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
             - aws-s3/copy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,9 @@ jobs:
           condition:
             not:
               matches:
-                pattern: "^pull/\\d+"
+                # "^pull/\d+" is not valid YAML
+                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+                pattern: "^pull/"
                 value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
@@ -675,7 +677,9 @@ jobs:
           condition:
             not:
               matches:
-                pattern: "^pull/\\d+"
+                # "^pull/\d+" is not valid YAML
+                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+                pattern: "^pull/"
                 value: << pipeline.git.branch >>
           steps:
             # persist size snapshot on S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,7 +650,7 @@ jobs:
             matches:
               # "^pull/\d+" is not valid YAML
               # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-              pattern: "^pull/"
+              pattern: "^pull/.+$"
               value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
@@ -678,7 +678,7 @@ jobs:
               matches:
                 # "^pull/\d+" is not valid YAML
                 # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-                pattern: "^pull/"
+                pattern: "^pull/.+$"
                 value: << pipeline.git.branch >>
           steps:
             # persist size snapshot on S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,12 +647,11 @@ jobs:
       - when:
           # don't run on PRs
           condition:
-            not:
-              matches:
-                # "^pull/\d+" is not valid YAML
-                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-                pattern: "^pull/"
-                value: << pipeline.git.branch >>
+            matches:
+              # "^pull/\d+" is not valid YAML
+              # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+              pattern: "^pull/"
+              value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
             - aws-s3/copy:


### PR DESCRIPTION
Another attempt at https://github.com/mui-org/material-ui/pull/29879

I tested both true and false in https://github.com/mui-org/material-ui/pull/29879 but I didn't actually check which branch was hit in the PR run so let's focus now.

- FAIL With 8fbae13cf351ebe899011d1720b015c84c949d83 mui-material.tgz should be uploaded on PRs but not size-snapshot.json: https://app.circleci.com/pipelines/github/mui-org/material-ui/57086/workflows/5c032d03-80ff-4683-9369-27b5b18a63e5/jobs/320317
- PASS: With 55edd01f57053d3558b8a397d114700c5930d72d mui-material.tgz should be uploaded on PRs but not size-snapshot.json: https://app.circleci.com/pipelines/github/mui-org/material-ui/57088/workflows/93f6f261-0706-4cc4-873c-c914c7049139/jobs/320333