### PR TITLE
[TextField] Generate id automatically

### DIFF
--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -285,7 +285,7 @@ In order for the text field to be accessible, **the input should be linked to th
 </div>
 ```
 
-- If you are using the `TextField` component, you just have to provide a unique `id`.
+- If you are using the `TextField` component, you can provide an optional `id`, otherwise one will be generated for you.
 - If you are composing the component:
 
 ```jsx

--- a/docs/translations/api-docs/text-field/text-field.json
+++ b/docs/translations/api-docs/text-field/text-field.json
@@ -11,7 +11,7 @@
     "FormHelperTextProps": "Props applied to the <a href=\"/api/form-helper-text/\"><code>FormHelperText</code></a> element.",
     "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
     "helperText": "The helper text content.",
-    "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
+    "id": "The id of the <code>input</code> element. If not provided one will be generated for accessibility purposes.",
     "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
     "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
     "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",

--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -77,8 +77,7 @@ export interface BaseTextFieldProps
    */
   helperText?: React.ReactNode;
   /**
-   * The id of the `input` element.
-   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   * The id of the `input` element. If not provided one will be generated for accessibility purposes.
    */
   id?: string;
   /**

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { refType } from '@mui/utils';
+import { refType, unstable_useId as useId } from '@mui/utils';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import Input from '../Input';
@@ -82,7 +82,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     FormHelperTextProps,
     fullWidth = false,
     helperText,
-    id,
+    id: providedId,
     InputLabelProps,
     inputProps,
     InputProps,
@@ -119,6 +119,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     variant,
   };
 
+  const id = useId(providedId);
   const classes = useUtilityClasses(ownerState);
 
   if (process.env.NODE_ENV !== 'production') {
@@ -289,8 +290,7 @@ TextField.propTypes /* remove-proptypes */ = {
    */
   helperText: PropTypes.node,
   /**
-   * The id of the `input` element.
-   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   * The id of the `input` element. If not provided one will be generated for accessibility purposes.
    */
   id: PropTypes.string,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

It's been a while! 👋 

I remember proposing this change a few years back and think it was generally well received? Unfortunately it never went anywhere, and I don't remember why. Anyways I thought i'd try again as i think it's a good usability improvement for everyone!

The change here is to generate an `id` using `useId` for the TextField component if one wasn't provided in the props. An `id` is required to link up the label, input, and helper text elements all together for a11y purposes.

Benefits:
- Accessible out-of-the-box 🎉
- Developers don't have to worry about generating unique ids to keep their TextField's a11y. They can still provide one if they choose though!

Drawbacks:
- I can't think of any. Can you folks?