### PR TITLE
[system] Support boolean values in typescript for the `sx` prop when used as array

### DIFF
--- a/docs/pages/api-docs/accordion-actions.json
+++ b/docs/pages/api-docs/accordion-actions.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/accordion-details.json
+++ b/docs/pages/api-docs/accordion-details.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/accordion-summary.json
+++ b/docs/pages/api-docs/accordion-summary.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/accordion.json
+++ b/docs/pages/api-docs/accordion.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Collapse" },

--- a/docs/pages/api-docs/alert-title.json
+++ b/docs/pages/api-docs/alert-title.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/alert.json
+++ b/docs/pages/api-docs/alert.json
@@ -29,7 +29,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/app-bar.json
+++ b/docs/pages/api-docs/app-bar.json
@@ -20,7 +20,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -82,7 +82,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "custom", "description": "any" } }

--- a/docs/pages/api-docs/avatar-group.json
+++ b/docs/pages/api-docs/avatar-group.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/avatar.json
+++ b/docs/pages/api-docs/avatar.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/backdrop.json
+++ b/docs/pages/api-docs/backdrop.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "transitionDuration": {

--- a/docs/pages/api-docs/badge.json
+++ b/docs/pages/api-docs/badge.json
@@ -33,7 +33,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/bottom-navigation-action.json
+++ b/docs/pages/api-docs/bottom-navigation-action.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/bottom-navigation.json
+++ b/docs/pages/api-docs/bottom-navigation.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/breadcrumbs.json
+++ b/docs/pages/api-docs/breadcrumbs.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/button-base.json
+++ b/docs/pages/api-docs/button-base.json
@@ -15,7 +15,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TouchRippleProps": { "type": { "name": "object" } }

--- a/docs/pages/api-docs/button-group.json
+++ b/docs/pages/api-docs/button-group.json
@@ -29,7 +29,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/button.json
+++ b/docs/pages/api-docs/button.json
@@ -28,7 +28,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/calendar-picker-skeleton.json
+++ b/docs/pages/api-docs/calendar-picker-skeleton.json
@@ -4,7 +4,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/card-action-area.json
+++ b/docs/pages/api-docs/card-action-area.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/card-actions.json
+++ b/docs/pages/api-docs/card-actions.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/card-content.json
+++ b/docs/pages/api-docs/card-content.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/card-header.json
+++ b/docs/pages/api-docs/card-header.json
@@ -10,7 +10,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "title": { "type": { "name": "node" } },

--- a/docs/pages/api-docs/card-media.json
+++ b/docs/pages/api-docs/card-media.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/card.json
+++ b/docs/pages/api-docs/card.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/checkbox.json
+++ b/docs/pages/api-docs/checkbox.json
@@ -31,7 +31,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/chip.json
+++ b/docs/pages/api-docs/chip.json
@@ -27,7 +27,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/circular-progress.json
+++ b/docs/pages/api-docs/circular-progress.json
@@ -16,7 +16,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "thickness": { "type": { "name": "number" }, "default": "3.6" },

--- a/docs/pages/api-docs/collapse.json
+++ b/docs/pages/api-docs/collapse.json
@@ -22,7 +22,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "timeout": {

--- a/docs/pages/api-docs/container.json
+++ b/docs/pages/api-docs/container.json
@@ -14,7 +14,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/date-range-picker-day.json
+++ b/docs/pages/api-docs/date-range-picker-day.json
@@ -14,7 +14,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/dialog-actions.json
+++ b/docs/pages/api-docs/dialog-actions.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/dialog-content-text.json
+++ b/docs/pages/api-docs/dialog-content-text.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/dialog-content.json
+++ b/docs/pages/api-docs/dialog-content.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/dialog-title.json
+++ b/docs/pages/api-docs/dialog-title.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/dialog.json
+++ b/docs/pages/api-docs/dialog.json
@@ -30,7 +30,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Fade" },

--- a/docs/pages/api-docs/divider.json
+++ b/docs/pages/api-docs/divider.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "textAlign": {

--- a/docs/pages/api-docs/drawer.json
+++ b/docs/pages/api-docs/drawer.json
@@ -19,7 +19,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "transitionDuration": {

--- a/docs/pages/api-docs/fab.json
+++ b/docs/pages/api-docs/fab.json
@@ -24,7 +24,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/filled-input.json
+++ b/docs/pages/api-docs/filled-input.json
@@ -39,7 +39,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "type": { "type": { "name": "string" }, "default": "'text'" },

--- a/docs/pages/api-docs/form-control-label.json
+++ b/docs/pages/api-docs/form-control-label.json
@@ -25,7 +25,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/form-control.json
+++ b/docs/pages/api-docs/form-control.json
@@ -33,7 +33,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/form-group.json
+++ b/docs/pages/api-docs/form-group.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/form-helper-text.json
+++ b/docs/pages/api-docs/form-helper-text.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/form-label.json
+++ b/docs/pages/api-docs/form-label.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/grid.json
+++ b/docs/pages/api-docs/grid.json
@@ -62,7 +62,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "wrap": {

--- a/docs/pages/api-docs/icon-button.json
+++ b/docs/pages/api-docs/icon-button.json
@@ -29,7 +29,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/icon.json
+++ b/docs/pages/api-docs/icon.json
@@ -21,7 +21,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/image-list-item-bar.json
+++ b/docs/pages/api-docs/image-list-item-bar.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "title": { "type": { "name": "node" } }

--- a/docs/pages/api-docs/image-list-item.json
+++ b/docs/pages/api-docs/image-list-item.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/image-list.json
+++ b/docs/pages/api-docs/image-list.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/input-adornment.json
+++ b/docs/pages/api-docs/input-adornment.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/input-base.json
+++ b/docs/pages/api-docs/input-base.json
@@ -47,7 +47,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "type": { "type": { "name": "string" }, "default": "'text'" },

--- a/docs/pages/api-docs/input-label.json
+++ b/docs/pages/api-docs/input-label.json
@@ -18,7 +18,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/input.json
+++ b/docs/pages/api-docs/input.json
@@ -38,7 +38,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "type": { "type": { "name": "string" }, "default": "'text'" },

--- a/docs/pages/api-docs/linear-progress.json
+++ b/docs/pages/api-docs/linear-progress.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "number" } },

--- a/docs/pages/api-docs/link.json
+++ b/docs/pages/api-docs/link.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TypographyClasses": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/list-item-avatar.json
+++ b/docs/pages/api-docs/list-item-avatar.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list-item-button.json
+++ b/docs/pages/api-docs/list-item-button.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list-item-icon.json
+++ b/docs/pages/api-docs/list-item-icon.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list-item-secondary-action.json
+++ b/docs/pages/api-docs/list-item-secondary-action.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list-item-text.json
+++ b/docs/pages/api-docs/list-item-text.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list-item.json
+++ b/docs/pages/api-docs/list-item.json
@@ -46,7 +46,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list-subheader.json
+++ b/docs/pages/api-docs/list-subheader.json
@@ -16,7 +16,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/list.json
+++ b/docs/pages/api-docs/list.json
@@ -9,7 +9,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/loading-button.json
+++ b/docs/pages/api-docs/loading-button.json
@@ -18,7 +18,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/masonry.json
+++ b/docs/pages/api-docs/masonry.json
@@ -23,7 +23,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/menu-item.json
+++ b/docs/pages/api-docs/menu-item.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/menu.json
+++ b/docs/pages/api-docs/menu.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "transitionDuration": {

--- a/docs/pages/api-docs/mobile-stepper.json
+++ b/docs/pages/api-docs/mobile-stepper.json
@@ -16,7 +16,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/modal.json
+++ b/docs/pages/api-docs/modal.json
@@ -29,7 +29,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/month-picker.json
+++ b/docs/pages/api-docs/month-picker.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/native-select.json
+++ b/docs/pages/api-docs/native-select.json
@@ -9,7 +9,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } },

--- a/docs/pages/api-docs/outlined-input.json
+++ b/docs/pages/api-docs/outlined-input.json
@@ -38,7 +38,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "type": { "type": { "name": "string" }, "default": "'text'" },

--- a/docs/pages/api-docs/pagination-item.json
+++ b/docs/pages/api-docs/pagination-item.json
@@ -33,7 +33,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "type": {

--- a/docs/pages/api-docs/pagination.json
+++ b/docs/pages/api-docs/pagination.json
@@ -38,7 +38,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/paper.json
+++ b/docs/pages/api-docs/paper.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/pickers-day.json
+++ b/docs/pages/api-docs/pickers-day.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "today": { "type": { "name": "bool" } }

--- a/docs/pages/api-docs/popover.json
+++ b/docs/pages/api-docs/popover.json
@@ -33,7 +33,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "transformOrigin": {

--- a/docs/pages/api-docs/radio.json
+++ b/docs/pages/api-docs/radio.json
@@ -29,7 +29,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/rating.json
+++ b/docs/pages/api-docs/rating.json
@@ -31,7 +31,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "number" } }

--- a/docs/pages/api-docs/select.json
+++ b/docs/pages/api-docs/select.json
@@ -23,7 +23,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } },

--- a/docs/pages/api-docs/skeleton.json
+++ b/docs/pages/api-docs/skeleton.json
@@ -14,7 +14,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -53,7 +53,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "tabIndex": { "type": { "name": "number" } },

--- a/docs/pages/api-docs/snackbar-content.json
+++ b/docs/pages/api-docs/snackbar-content.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/snackbar.json
+++ b/docs/pages/api-docs/snackbar.json
@@ -22,7 +22,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Grow" },

--- a/docs/pages/api-docs/speed-dial-action.json
+++ b/docs/pages/api-docs/speed-dial-action.json
@@ -9,7 +9,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TooltipClasses": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/speed-dial-icon.json
+++ b/docs/pages/api-docs/speed-dial-icon.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/speed-dial.json
+++ b/docs/pages/api-docs/speed-dial.json
@@ -20,7 +20,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Zoom" },

--- a/docs/pages/api-docs/stack.json
+++ b/docs/pages/api-docs/stack.json
@@ -20,7 +20,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/step-button.json
+++ b/docs/pages/api-docs/step-button.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/step-connector.json
+++ b/docs/pages/api-docs/step-connector.json
@@ -4,7 +4,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/step-content.json
+++ b/docs/pages/api-docs/step-content.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Collapse" },

--- a/docs/pages/api-docs/step-icon.json
+++ b/docs/pages/api-docs/step-icon.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/step-label.json
+++ b/docs/pages/api-docs/step-label.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/step.json
+++ b/docs/pages/api-docs/step.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/stepper.json
+++ b/docs/pages/api-docs/stepper.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/svg-icon.json
+++ b/docs/pages/api-docs/svg-icon.json
@@ -22,7 +22,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "titleAccess": { "type": { "name": "string" } },

--- a/docs/pages/api-docs/switch.json
+++ b/docs/pages/api-docs/switch.json
@@ -36,7 +36,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/tab-panel.json
+++ b/docs/pages/api-docs/tab-panel.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/tab-scroll-button.json
+++ b/docs/pages/api-docs/tab-scroll-button.json
@@ -14,7 +14,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/tab.json
+++ b/docs/pages/api-docs/tab.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } },

--- a/docs/pages/api-docs/table-body.json
+++ b/docs/pages/api-docs/table-body.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table-cell.json
+++ b/docs/pages/api-docs/table-cell.json
@@ -24,7 +24,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/table-container.json
+++ b/docs/pages/api-docs/table-container.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table-footer.json
+++ b/docs/pages/api-docs/table-footer.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table-head.json
+++ b/docs/pages/api-docs/table-head.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table-pagination.json
+++ b/docs/pages/api-docs/table-pagination.json
@@ -32,7 +32,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table-row.json
+++ b/docs/pages/api-docs/table-row.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table-sort-label.json
+++ b/docs/pages/api-docs/table-sort-label.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/table.json
+++ b/docs/pages/api-docs/table.json
@@ -21,7 +21,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/tabs.json
+++ b/docs/pages/api-docs/tabs.json
@@ -26,7 +26,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TabIndicatorProps": { "type": { "name": "object" }, "default": "{}" },

--- a/docs/pages/api-docs/text-field.json
+++ b/docs/pages/api-docs/text-field.json
@@ -48,7 +48,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "type": { "type": { "name": "string" } },

--- a/docs/pages/api-docs/timeline-connector.json
+++ b/docs/pages/api-docs/timeline-connector.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/timeline-content.json
+++ b/docs/pages/api-docs/timeline-content.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/timeline-dot.json
+++ b/docs/pages/api-docs/timeline-dot.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/timeline-item.json
+++ b/docs/pages/api-docs/timeline-item.json
@@ -6,7 +6,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/timeline-opposite-content.json
+++ b/docs/pages/api-docs/timeline-opposite-content.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/timeline-separator.json
+++ b/docs/pages/api-docs/timeline-separator.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/timeline.json
+++ b/docs/pages/api-docs/timeline.json
@@ -13,7 +13,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/toggle-button-group.json
+++ b/docs/pages/api-docs/toggle-button-group.json
@@ -27,7 +27,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/api-docs/toggle-button.json
+++ b/docs/pages/api-docs/toggle-button.json
@@ -25,7 +25,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/toolbar.json
+++ b/docs/pages/api-docs/toolbar.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/pages/api-docs/tooltip.json
+++ b/docs/pages/api-docs/tooltip.json
@@ -39,7 +39,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Grow" },

--- a/docs/pages/api-docs/tree-item.json
+++ b/docs/pages/api-docs/tree-item.json
@@ -18,7 +18,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "TransitionComponent": { "type": { "name": "elementType" }, "default": "Collapse" },

--- a/docs/pages/api-docs/tree-view.json
+++ b/docs/pages/api-docs/tree-view.json
@@ -28,7 +28,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/api-docs/typography.json
+++ b/docs/pages/api-docs/typography.json
@@ -16,7 +16,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
     "variant": {

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductHeroLayout.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductHeroLayout.js
@@ -78,7 +78,9 @@ function ProductHeroLayout(props) {
 ProductHeroLayout.propTypes = {
   children: PropTypes.node,
   sxBackground: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/AlignContent.js
+++ b/docs/src/pages/system/flexbox/AlignContent.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/AlignItems.js
+++ b/docs/src/pages/system/flexbox/AlignItems.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/AlignSelf.js
+++ b/docs/src/pages/system/flexbox/AlignSelf.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/FlexDirection.js
+++ b/docs/src/pages/system/flexbox/FlexDirection.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/FlexGrow.js
+++ b/docs/src/pages/system/flexbox/FlexGrow.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/FlexShrink.js
+++ b/docs/src/pages/system/flexbox/FlexShrink.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/FlexWrap.js
+++ b/docs/src/pages/system/flexbox/FlexWrap.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/JustifyContent.js
+++ b/docs/src/pages/system/flexbox/JustifyContent.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/flexbox/Order.js
+++ b/docs/src/pages/system/flexbox/Order.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/Gap.js
+++ b/docs/src/pages/system/grid/Gap.js
@@ -23,7 +23,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/GridAutoColumns.js
+++ b/docs/src/pages/system/grid/GridAutoColumns.js
@@ -23,7 +23,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/GridAutoFlow.js
+++ b/docs/src/pages/system/grid/GridAutoFlow.js
@@ -23,7 +23,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/GridAutoRows.js
+++ b/docs/src/pages/system/grid/GridAutoRows.js
@@ -23,7 +23,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/GridTemplateColumns.js
+++ b/docs/src/pages/system/grid/GridTemplateColumns.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/GridTemplateRows.js
+++ b/docs/src/pages/system/grid/GridTemplateRows.js
@@ -24,7 +24,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/grid/RowAndColumnGap.js
+++ b/docs/src/pages/system/grid/RowAndColumnGap.js
@@ -23,7 +23,9 @@ function Item(props) {
 
 Item.propTypes = {
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/docs/src/pages/system/the-sx-prop/PassingSxProp.js
+++ b/docs/src/pages/system/the-sx-prop/PassingSxProp.js
@@ -21,7 +21,9 @@ const ListHeader = ({ sx = [], children }) => (
 ListHeader.propTypes = {
   children: PropTypes.node,
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),
+    ),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -178,7 +178,7 @@ CalendarPickerSkeleton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -350,7 +350,7 @@ DateRangePickerDay.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -247,7 +247,7 @@ LoadingButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -365,7 +365,7 @@ Masonry.propTypes /* remove-proptypes */ = {
    * Allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -217,7 +217,7 @@ MonthPicker.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -483,7 +483,7 @@ PickersDay.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TabPanel/TabPanel.js
+++ b/packages/mui-lab/src/TabPanel/TabPanel.js
@@ -79,7 +79,7 @@ TabPanel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -130,7 +130,7 @@ Timeline.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
@@ -70,7 +70,7 @@ TimelineConnector.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.js
@@ -79,7 +79,7 @@ TimelineContent.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.js
@@ -125,7 +125,7 @@ TimelineDot.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -117,7 +117,7 @@ TimelineItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -80,7 +80,7 @@ TimelineOppositeContent.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js
@@ -69,7 +69,7 @@ TimelineSeparator.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TreeItem/TreeItem.js
+++ b/packages/mui-lab/src/TreeItem/TreeItem.js
@@ -403,7 +403,7 @@ TreeItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-lab/src/TreeView/TreeView.js
+++ b/packages/mui-lab/src/TreeView/TreeView.js
@@ -943,7 +943,7 @@ TreeView.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material-next/src/Button/Button.js
+++ b/packages/mui-material-next/src/Button/Button.js
@@ -629,7 +629,7 @@ Button.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material-next/src/Input/Input.js
+++ b/packages/mui-material-next/src/Input/Input.js
@@ -496,7 +496,7 @@ Input.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material-next/src/Tab/Tab.js
+++ b/packages/mui-material-next/src/Tab/Tab.js
@@ -241,7 +241,7 @@ Tab.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material-next/src/TabScrollButton/TabScrollButton.js
+++ b/packages/mui-material-next/src/TabScrollButton/TabScrollButton.js
@@ -107,7 +107,7 @@ TabScrollButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material-next/src/Tabs/Tabs.js
+++ b/packages/mui-material-next/src/Tabs/Tabs.js
@@ -715,7 +715,7 @@ Tabs.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -254,7 +254,7 @@ Accordion.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/AccordionActions/AccordionActions.js
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.js
@@ -79,7 +79,7 @@ AccordionActions.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.js
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.js
@@ -61,7 +61,7 @@ AccordionDetails.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.js
@@ -178,7 +178,7 @@ AccordionSummary.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Alert/Alert.js
+++ b/packages/mui-material/src/Alert/Alert.js
@@ -253,7 +253,7 @@ Alert.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/AlertTitle/AlertTitle.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.js
@@ -72,7 +72,7 @@ AlertTitle.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/AppBar/AppBar.js
+++ b/packages/mui-material/src/AppBar/AppBar.js
@@ -180,7 +180,7 @@ AppBar.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -1020,7 +1020,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -236,7 +236,7 @@ Avatar.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -180,7 +180,7 @@ AvatarGroup.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -129,7 +129,7 @@ Backdrop.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -329,7 +329,7 @@ Badge.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.js
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.js
@@ -124,7 +124,7 @@ BottomNavigation.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
@@ -160,7 +160,7 @@ BottomNavigationAction.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -241,7 +241,7 @@ Breadcrumbs.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -456,7 +456,7 @@ Button.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -504,7 +504,7 @@ ButtonBase.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -317,7 +317,7 @@ ButtonGroup.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Card/Card.js
+++ b/packages/mui-material/src/Card/Card.js
@@ -83,7 +83,7 @@ Card.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -103,7 +103,7 @@ CardActionArea.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/CardActions/CardActions.js
+++ b/packages/mui-material/src/CardActions/CardActions.js
@@ -83,7 +83,7 @@ CardActions.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/CardContent/CardContent.js
+++ b/packages/mui-material/src/CardContent/CardContent.js
@@ -78,7 +78,7 @@ CardContent.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/CardHeader/CardHeader.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.js
@@ -198,7 +198,7 @@ CardHeader.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/CardMedia/CardMedia.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.js
@@ -125,7 +125,7 @@ CardMedia.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -208,7 +208,7 @@ Checkbox.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -539,7 +539,7 @@ Chip.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.js
@@ -247,7 +247,7 @@ CircularProgress.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Collapse/Collapse.js
+++ b/packages/mui-material/src/Collapse/Collapse.js
@@ -398,7 +398,7 @@ Collapse.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Container/Container.js
+++ b/packages/mui-material/src/Container/Container.js
@@ -159,7 +159,7 @@ Container.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -378,7 +378,7 @@ Dialog.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/DialogActions/DialogActions.js
+++ b/packages/mui-material/src/DialogActions/DialogActions.js
@@ -83,7 +83,7 @@ DialogActions.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/DialogContent/DialogContent.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.js
@@ -90,7 +90,7 @@ DialogContent.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/DialogContentText/DialogContentText.js
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.js
@@ -63,7 +63,7 @@ DialogContentText.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/DialogTitle/DialogTitle.js
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.js
@@ -77,7 +77,7 @@ DialogTitle.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -262,7 +262,7 @@ Divider.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -327,7 +327,7 @@ Drawer.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -245,7 +245,7 @@ Fab.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -367,7 +367,7 @@ FilledInput.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/FormControl/FormControl.js
+++ b/packages/mui-material/src/FormControl/FormControl.js
@@ -305,7 +305,7 @@ FormControl.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -198,7 +198,7 @@ FormControlLabel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/FormGroup/FormGroup.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.js
@@ -84,7 +84,7 @@ FormGroup.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -173,7 +173,7 @@ FormHelperText.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -170,7 +170,7 @@ FormLabel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -446,7 +446,7 @@ Grid.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Icon/Icon.js
+++ b/packages/mui-material/src/Icon/Icon.js
@@ -161,7 +161,7 @@ Icon.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -234,7 +234,7 @@ IconButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ImageList/ImageList.js
+++ b/packages/mui-material/src/ImageList/ImageList.js
@@ -145,7 +145,7 @@ ImageList.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ImageListItem/ImageListItem.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.js
@@ -173,7 +173,7 @@ ImageListItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js
@@ -220,7 +220,7 @@ ImageListItemBar.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -287,7 +287,7 @@ Input.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/InputAdornment/InputAdornment.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.js
@@ -179,7 +179,7 @@ InputAdornment.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -727,7 +727,7 @@ InputBase.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -204,7 +204,7 @@ InputLabel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/LinearProgress/LinearProgress.js
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.js
@@ -364,7 +364,7 @@ LinearProgress.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -208,7 +208,7 @@ Link.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/List/List.js
+++ b/packages/mui-material/src/List/List.js
@@ -125,7 +125,7 @@ List.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -443,7 +443,7 @@ ListItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js
@@ -78,7 +78,7 @@ ListItemAvatar.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -248,7 +248,7 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.js
@@ -81,7 +81,7 @@ ListItemIcon.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -76,7 +76,7 @@ ListItemSecondaryAction.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListItemText/ListItemText.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.js
@@ -173,7 +173,7 @@ ListItemText.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ListSubheader/ListSubheader.js
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.js
@@ -146,7 +146,7 @@ ListSubheader.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Menu/Menu.js
+++ b/packages/mui-material/src/Menu/Menu.js
@@ -261,7 +261,7 @@ Menu.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -267,7 +267,7 @@ MenuItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -212,7 +212,7 @@ MobileStepper.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -255,7 +255,7 @@ Modal.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/NativeSelect/NativeSelect.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.js
@@ -111,7 +111,7 @@ NativeSelect.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -295,7 +295,7 @@ OutlinedInput.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Pagination/Pagination.js
+++ b/packages/mui-material/src/Pagination/Pagination.js
@@ -237,7 +237,7 @@ Pagination.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/PaginationItem/PaginationItem.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.js
@@ -392,7 +392,7 @@ PaginationItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Paper/Paper.js
+++ b/packages/mui-material/src/Paper/Paper.js
@@ -161,7 +161,7 @@ Paper.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -518,7 +518,7 @@ Popover.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -202,7 +202,7 @@ Radio.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -730,7 +730,7 @@ Rating.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -229,7 +229,7 @@ Select.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -221,7 +221,7 @@ Skeleton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -668,7 +668,7 @@ Slider.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Snackbar/Snackbar.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.js
@@ -375,7 +375,7 @@ Snackbar.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.js
@@ -123,7 +123,7 @@ SnackbarContent.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -503,7 +503,7 @@ SpeedDial.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
@@ -240,7 +240,7 @@ SpeedDialAction.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js
@@ -122,7 +122,7 @@ SpeedDialIcon.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -165,7 +165,7 @@ Stack.propTypes /* remove-proptypes */ = {
    * The system prop, which allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -166,7 +166,7 @@ Step.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -115,7 +115,7 @@ StepButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/StepConnector/StepConnector.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.js
@@ -114,7 +114,7 @@ StepConnector.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/StepContent/StepContent.js
+++ b/packages/mui-material/src/StepContent/StepContent.js
@@ -115,7 +115,7 @@ StepContent.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/StepIcon/StepIcon.js
+++ b/packages/mui-material/src/StepIcon/StepIcon.js
@@ -147,7 +147,7 @@ StepIcon.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -224,7 +224,7 @@ StepLabel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -141,7 +141,7 @@ Stepper.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -165,7 +165,7 @@ SvgIcon.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -309,7 +309,7 @@ Switch.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -280,7 +280,7 @@ Tab.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.js
@@ -108,7 +108,7 @@ TabScrollButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Table/Table.js
+++ b/packages/mui-material/src/Table/Table.js
@@ -130,7 +130,7 @@ Table.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableBody/TableBody.js
+++ b/packages/mui-material/src/TableBody/TableBody.js
@@ -82,7 +82,7 @@ TableBody.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -227,7 +227,7 @@ TableCell.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableContainer/TableContainer.js
+++ b/packages/mui-material/src/TableContainer/TableContainer.js
@@ -73,7 +73,7 @@ TableContainer.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableFooter/TableFooter.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.js
@@ -82,7 +82,7 @@ TableFooter.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableHead/TableHead.js
+++ b/packages/mui-material/src/TableHead/TableHead.js
@@ -82,7 +82,7 @@ TableHead.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -397,7 +397,7 @@ TablePagination.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableRow/TableRow.js
+++ b/packages/mui-material/src/TableRow/TableRow.js
@@ -121,7 +121,7 @@ TableRow.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -164,7 +164,7 @@ TableSortLabel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -842,7 +842,7 @@ Tabs.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -387,7 +387,7 @@ TextField.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -218,7 +218,7 @@ ToggleButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -238,7 +238,7 @@ ToggleButtonGroup.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Toolbar/Toolbar.js
+++ b/packages/mui-material/src/Toolbar/Toolbar.js
@@ -106,7 +106,7 @@ Toolbar.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -860,7 +860,7 @@ Tooltip.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -183,7 +183,7 @@ Typography.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
   ]),

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -57,7 +57,7 @@ export type SystemStyleObject<Theme extends object = {}> =
 export type SxProps<Theme extends object = {}> =
   | SystemStyleObject<Theme>
   | ((theme: Theme) => SystemStyleObject<Theme>)
-  | Array<SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)>;
+  | Array<SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>) | boolean>;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function unstable_styleFunctionSx(props: object): object;

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -57,7 +57,7 @@ export type SystemStyleObject<Theme extends object = {}> =
 export type SxProps<Theme extends object = {}> =
   | SystemStyleObject<Theme>
   | ((theme: Theme) => SystemStyleObject<Theme>)
-  | Array<SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>) | boolean>;
+  | Array<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)>;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function unstable_styleFunctionSx(props: object): object;

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
@@ -18,3 +18,6 @@ const Text = (props: { sx?: SxProps<Theme> }) => null;
 
 // null
 <Text sx={{ m: null, transform: null, typography: undefined }} />;
+
+// array
+<Text sx={[false && { p: 2 }, { m: 2 }]} />;

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
@@ -19,5 +19,5 @@ const Text = (props: { sx?: SxProps<Theme> }) => null;
 // null
 <Text sx={{ m: null, transform: null, typography: undefined }} />;
 
-// array
+// array contains boolean
 <Text sx={[false && { p: 2 }, { m: 2 }]} />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #29941

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I found type check errors if an array containing boolean value is given as sx props.
For examples, typescript compiler raises error on sx against the sample code introduced in the official docs(https://mui.com/system/the-sx-prop/#array-values).

```
<Box
  sx={[
    {
      '&:hover': {
        color: 'red',
        backgroundColor: 'white',
      },
    },
    // errors on the next line!
    foo && {
      '&:hover': { backgroundColor: 'grey' },
    },
    bar && {
      '&:hover': { backgroundColor: 'yellow' },
    },
  ]}
/>
```

I think my fix will resolve this problem.