### PR TITLE
[docs] Clarify the difference between React and UI components

### DIFF
--- a/docs/packages/markdown/parseMarkdown.test.js
+++ b/docs/packages/markdown/parseMarkdown.test.js
@@ -61,7 +61,7 @@ describe('parseMarkdown', () => {
 ---
 title: React Alert component
 components: Alert, AlertTitle
-githubLabel: 'component: Alert'
+githubLabel: 'component: alert'
 packageName: '@mui/lab'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 authors: ['foo', 'bar']
@@ -69,7 +69,7 @@ authors: ['foo', 'bar']
 `),
       ).to.deep.equal({
         components: ['Alert', 'AlertTitle'],
-        githubLabel: 'component: Alert',
+        githubLabel: 'component: alert',
         packageName: '@mui/lab',
         title: 'React Alert component',
         waiAria: 'https://www.w3.org/TR/wai-aria-practices/#alert',
@@ -83,7 +83,7 @@ authors: ['foo', 'bar']
 ---
 title: React Alert component
 components: Alert, AlertTitle
-githubLabel: 'component: Alert'
+githubLabel: 'component: alert'
 packageName: '@mui/lab'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 authors:
@@ -92,7 +92,7 @@ authors:
 `),
       ).to.deep.equal({
         components: ['Alert', 'AlertTitle'],
-        githubLabel: 'component: Alert',
+        githubLabel: 'component: alert',
         packageName: '@mui/lab',
         title: 'React Alert component',
         waiAria: 'https://www.w3.org/TR/wai-aria-practices/#alert',
@@ -106,7 +106,7 @@ authors:
 ---
 title: React Alert component
 components: Alert, AlertTitle
-githubLabel: 'component: Alert'
+githubLabel: 'component: alert'
 packageName: '@mui/lab'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 authors:
@@ -118,7 +118,7 @@ authors:
     `),
       ).to.deep.equal({
         components: ['Alert', 'AlertTitle'],
-        githubLabel: 'component: Alert',
+        githubLabel: 'component: alert',
         packageName: '@mui/lab',
         title: 'React Alert component',
         waiAria: 'https://www.w3.org/TR/wai-aria-practices/#alert',

--- a/docs/src/pages/components/accordion/accordion.md
+++ b/docs/src/pages/components/accordion/accordion.md
@@ -1,7 +1,7 @@
 ---
 title: React Accordion component
 components: Accordion, AccordionActions, AccordionDetails, AccordionSummary
-githubLabel: 'component: Accordion'
+githubLabel: 'component: accordion'
 materialDesign: https://material.io/archive/guidelines/components/expansion-panels.html
 waiAria: https://www.w3.org/TR/wai-aria-practices/#accordion
 ---

--- a/docs/src/pages/components/alert/alert.md
+++ b/docs/src/pages/components/alert/alert.md
@@ -1,7 +1,7 @@
 ---
 title: React Alert component
 components: Alert, AlertTitle
-githubLabel: 'component: Alert'
+githubLabel: 'component: alert'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
 ---
 

--- a/docs/src/pages/components/app-bar/app-bar-pt.md
+++ b/docs/src/pages/components/app-bar/app-bar-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente Barra de Aplicativos para React
 components: AppBar, Toolbar, Menu
-githubLabel: 'component: AppBar'
+githubLabel: 'component: app bar'
 materialDesign: https://material.io/components/app-bars-top
 ---
 

--- a/docs/src/pages/components/app-bar/app-bar-zh.md
+++ b/docs/src/pages/components/app-bar/app-bar-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React App Bar（应用栏）组件
 components: AppBar, Toolbar, Menu
-githubLabel: 'component: AppBar'
+githubLabel: 'component: app bar'
 materialDesign: https://material.io/components/app-bars-top
 ---
 

--- a/docs/src/pages/components/app-bar/app-bar.md
+++ b/docs/src/pages/components/app-bar/app-bar.md
@@ -1,7 +1,7 @@
 ---
 title: App Bar React component
 components: AppBar, Toolbar, Menu
-githubLabel: 'component: AppBar'
+githubLabel: 'component: app bar'
 materialDesign: https://material.io/components/app-bars-top
 ---
 

--- a/docs/src/pages/components/autocomplete/autocomplete-pt.md
+++ b/docs/src/pages/components/autocomplete/autocomplete-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Autocompletar
 components: TextField, Popper, Autocomplete
-githubLabel: 'component: Autocomplete'
+githubLabel: 'component: autocomplete'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#combobox'
 ---
 

--- a/docs/src/pages/components/autocomplete/autocomplete-zh.md
+++ b/docs/src/pages/components/autocomplete/autocomplete-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Autocomplete（自动补全）组件
 components: TextField, Popper, Autocomplete
-githubLabel: 'component: Autocomplete'
+githubLabel: 'component: autocomplete'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#combobox'
 ---
 

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -1,7 +1,7 @@
 ---
 title: React Autocomplete component
 components: TextField, Popper, Autocomplete
-githubLabel: 'component: Autocomplete'
+githubLabel: 'component: autocomplete'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#combobox
 ---
 

--- a/docs/src/pages/components/avatars/avatars-pt.md
+++ b/docs/src/pages/components/avatars/avatars-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente para Avatares
 components: Avatar, AvatarGroup, Badge
-githubLabel: 'component: Avatar'
+githubLabel: 'component: avatar'
 ---
 
 # Avatar

--- a/docs/src/pages/components/avatars/avatars-zh.md
+++ b/docs/src/pages/components/avatars/avatars-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Avatar（头像）组件
 components: Avatar, AvatarGroup, Badge
-githubLabel: 'component: Avatar'
+githubLabel: 'component: avatar'
 ---
 
 # Avatar 头像组件

--- a/docs/src/pages/components/avatars/avatars.md
+++ b/docs/src/pages/components/avatars/avatars.md
@@ -1,7 +1,7 @@
 ---
 title: React Avatar component
 components: Avatar, AvatarGroup, Badge
-githubLabel: 'component: Avatar'
+githubLabel: 'component: avatar'
 ---
 
 # Avatar

--- a/docs/src/pages/components/backdrop/backdrop-pt.md
+++ b/docs/src/pages/components/backdrop/backdrop-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Pano de Fundo
 components: Backdrop, BackdropUnstyled
-githubLabel: 'component: Backdrop'
+githubLabel: 'component: backdrop'
 ---
 
 # Backdrop

--- a/docs/src/pages/components/backdrop/backdrop.md
+++ b/docs/src/pages/components/backdrop/backdrop.md
@@ -1,7 +1,7 @@
 ---
 title: Backdrop React Component
 components: Backdrop, BackdropUnstyled
-githubLabel: 'component: Backdrop'
+githubLabel: 'component: backdrop'
 ---
 
 # Backdrop

--- a/docs/src/pages/components/badges/badges-pt.md
+++ b/docs/src/pages/components/badges/badges-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para emblemas
 components: Badge, BadgeUnstyled
-githubLabel: 'component: Badge'
+githubLabel: 'component: badge'
 ---
 
 # Emblema

--- a/docs/src/pages/components/badges/badges-zh.md
+++ b/docs/src/pages/components/badges/badges-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Badge（徽章）组件
 components: Badge, BadgeUnstyled
-githubLabel: 'component: Badge'
+githubLabel: 'component: badge'
 ---
 
 # Badge 徽章

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -1,7 +1,7 @@
 ---
 title: React Badge component
 components: Badge, BadgeUnstyled
-githubLabel: 'component: Badge'
+githubLabel: 'component: badge'
 ---
 
 # Badge

--- a/docs/src/pages/components/bottom-navigation/bottom-navigation-pt.md
+++ b/docs/src/pages/components/bottom-navigation/bottom-navigation-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Navegação inferior
 components: BottomNavigation, BottomNavigationAction
-githubLabel: 'component: BottomNavigation'
+githubLabel: 'component: bottom navigation'
 materialDesign: https://material.io/components/bottom-navigation
 ---
 

--- a/docs/src/pages/components/bottom-navigation/bottom-navigation-zh.md
+++ b/docs/src/pages/components/bottom-navigation/bottom-navigation-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Bottom Navigation（底部导航栏）组件
 components: BottomNavigation, BottomNavigationAction
-githubLabel: 'component: BottomNavigation'
+githubLabel: 'component: bottom navigation'
 materialDesign: https://material.io/components/bottom-navigation
 ---
 

--- a/docs/src/pages/components/bottom-navigation/bottom-navigation.md
+++ b/docs/src/pages/components/bottom-navigation/bottom-navigation.md
@@ -1,7 +1,7 @@
 ---
 title: Bottom Navigation React component
 components: BottomNavigation, BottomNavigationAction
-githubLabel: 'component: BottomNavigation'
+githubLabel: 'component: bottom navigation'
 materialDesign: https://material.io/components/bottom-navigation
 ---
 

--- a/docs/src/pages/components/breadcrumbs/breadcrumbs-pt.md
+++ b/docs/src/pages/components/breadcrumbs/breadcrumbs-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Navegação estrutural
 components: Breadcrumbs, Link, Typography
-githubLabel: 'component: Breadcrumbs'
+githubLabel: 'component: breadcrumbs'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#breadcrumb'
 ---
 

--- a/docs/src/pages/components/breadcrumbs/breadcrumbs-zh.md
+++ b/docs/src/pages/components/breadcrumbs/breadcrumbs-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Breadcrumbs（面包屑导航）组件
 components: Breadcrumbs, Link, Typography
-githubLabel: 'component: Breadcrumbs'
+githubLabel: 'component: breadcrumbs'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#breadcrumb'
 ---
 

--- a/docs/src/pages/components/breadcrumbs/breadcrumbs.md
+++ b/docs/src/pages/components/breadcrumbs/breadcrumbs.md
@@ -1,7 +1,7 @@
 ---
 title: React Breadcrumbs component
 components: Breadcrumbs, Link, Typography
-githubLabel: 'component: Breadcrumbs'
+githubLabel: 'component: breadcrumbs'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#breadcrumb
 ---
 

--- a/docs/src/pages/components/buttons/buttons-pt.md
+++ b/docs/src/pages/components/buttons/buttons-pt.md
@@ -2,7 +2,7 @@
 title: Componente React para Botão
 components: Button, IconButton, ButtonBase
 materialDesign: https://material.io/components/buttons
-githubLabel: 'component: Button'
+githubLabel: 'component: button'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#button'
 ---
 

--- a/docs/src/pages/components/buttons/buttons-zh.md
+++ b/docs/src/pages/components/buttons/buttons-zh.md
@@ -2,7 +2,7 @@
 title: React Button（按钮）组件
 components: Button, IconButton, ButtonBase, LoadingButton
 materialDesign: https://material.io/components/buttons
-githubLabel: 'component: Button'
+githubLabel: 'component: button'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#button'
 ---
 

--- a/docs/src/pages/components/buttons/buttons.md
+++ b/docs/src/pages/components/buttons/buttons.md
@@ -2,7 +2,7 @@
 title: React Button component
 components: Button, IconButton, ButtonBase, LoadingButton, ButtonUnstyled
 materialDesign: https://material.io/components/buttons
-githubLabel: 'component: Button'
+githubLabel: 'component: button'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#button
 ---
 

--- a/docs/src/pages/components/cards/cards-pt.md
+++ b/docs/src/pages/components/cards/cards-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Cartão
 components: Card, CardActionArea, CardActions, CardContent, CardHeader, CardMedia, Collapse, Paper
-githubLabel: 'component: Card'
+githubLabel: 'component: card'
 materialDesign: https://material.io/components/cards
 ---
 

--- a/docs/src/pages/components/cards/cards-zh.md
+++ b/docs/src/pages/components/cards/cards-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Card（卡片）组件
 components: Card, CardActionArea, CardActions, CardContent, CardHeader, CardMedia, Collapse, Paper
-githubLabel: 'component: Card'
+githubLabel: 'component: card'
 materialDesign: https://material.io/components/cards
 ---
 

--- a/docs/src/pages/components/cards/cards.md
+++ b/docs/src/pages/components/cards/cards.md
@@ -1,7 +1,7 @@
 ---
 title: React Card component
 components: Card, CardActionArea, CardActions, CardContent, CardHeader, CardMedia, Collapse, Paper
-githubLabel: 'component: Card'
+githubLabel: 'component: card'
 materialDesign: https://material.io/components/cards
 ---
 

--- a/docs/src/pages/components/checkboxes/checkboxes-pt.md
+++ b/docs/src/pages/components/checkboxes/checkboxes-pt.md
@@ -2,7 +2,7 @@
 title: Componente React para Caixa de seleção
 components: Checkbox, FormControl, FormGroup, FormLabel, FormControlLabel
 materialDesign: 'https://material.io/components/selection-controls#checkboxes'
-githubLabel: 'component: Checkbox'
+githubLabel: 'component: checkbox'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#checkbox'
 ---
 

--- a/docs/src/pages/components/checkboxes/checkboxes-zh.md
+++ b/docs/src/pages/components/checkboxes/checkboxes-zh.md
@@ -2,7 +2,7 @@
 title: React Checkbox（选择框）组件
 components: Checkbox, FormControl, FormGroup, FormLabel, FormControlLabel
 materialDesign: 'https://material.io/components/selection-controls#checkboxes'
-githubLabel: 'component: Checkbox'
+githubLabel: 'component: checkbox'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#checkbox'
 ---
 

--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -2,7 +2,7 @@
 title: React Checkbox component
 components: Checkbox, FormControl, FormGroup, FormLabel, FormControlLabel
 materialDesign: https://material.io/components/selection-controls#checkboxes
-githubLabel: 'component: Checkbox'
+githubLabel: 'component: checkbox'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#checkbox
 ---
 

--- a/docs/src/pages/components/chips/chips-pt.md
+++ b/docs/src/pages/components/chips/chips-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Chip
 components: Chip
-githubLabel: 'component: Chip'
+githubLabel: 'component: chip'
 materialDesign: https://material.io/components/chips
 ---
 

--- a/docs/src/pages/components/chips/chips-zh.md
+++ b/docs/src/pages/components/chips/chips-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Chip（纸片）组件
 components: Chip
-githubLabel: 'component: Chip'
+githubLabel: 'component: chip'
 materialDesign: https://material.io/components/chips
 ---
 

--- a/docs/src/pages/components/chips/chips.md
+++ b/docs/src/pages/components/chips/chips.md
@@ -1,7 +1,7 @@
 ---
 title: React Chip component
 components: Chip
-githubLabel: 'component: Chip'
+githubLabel: 'component: chip'
 materialDesign: https://material.io/components/chips
 ---
 

--- a/docs/src/pages/components/date-picker/date-picker-pt.md
+++ b/docs/src/pages/components/date-picker/date-picker-pt.md
@@ -1,8 +1,8 @@
 ---
 title: Componente React Seletor de data
 components: CalendarPicker, CalendarPickerSkeleton, DatePicker, DesktopDatePicker, MobileDatePicker, MonthPicker, PickersDay, StaticDatePicker, YearPicker
-githubLabel: 'component: DatePicker'
-packageName: '@material-ui/lab'
+githubLabel: 'component: date picker'
+packageName: '@mui/lab'
 materialDesign: https://material.io/components/date-pickers
 ---
 

--- a/docs/src/pages/components/date-picker/date-picker-zh.md
+++ b/docs/src/pages/components/date-picker/date-picker-zh.md
@@ -1,8 +1,8 @@
 ---
 title: React Date Picker（日期选择器）组件
 components: CalendarPicker, CalendarPickerSkeleton, DatePicker, DesktopDatePicker, MobileDatePicker, MonthPicker, PickersDay, StaticDatePicker, YearPicker
-githubLabel: 'component: DatePicker'
-packageName: '@material-ui/lab'
+githubLabel: 'component: date picker'
+packageName: '@mui/lab'
 materialDesign: https://material.io/components/date-pickers
 ---
 

--- a/docs/src/pages/components/date-picker/date-picker.md
+++ b/docs/src/pages/components/date-picker/date-picker.md
@@ -1,7 +1,7 @@
 ---
 title: React Date Picker component
 components: CalendarPicker, CalendarPickerSkeleton, DatePicker, DesktopDatePicker, MobileDatePicker, MonthPicker, PickersDay, StaticDatePicker, YearPicker
-githubLabel: 'component: DatePicker'
+githubLabel: 'component: date picker'
 packageName: '@mui/lab'
 materialDesign: https://material.io/components/date-pickers
 ---

--- a/docs/src/pages/components/date-range-picker/date-range-picker-pt.md
+++ b/docs/src/pages/components/date-range-picker/date-range-picker-pt.md
@@ -1,8 +1,8 @@
 ---
 title: Componente React Seletor intervalo de data
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
-githubLabel: 'component: DateRangePicker'
-packageName: '@material-ui/lab'
+githubLabel: 'component: date range picker'
+packageName: '@mui/lab'
 materialDesign: https://material.io/components/date-pickers
 ---
 

--- a/docs/src/pages/components/date-range-picker/date-range-picker-zh.md
+++ b/docs/src/pages/components/date-range-picker/date-range-picker-zh.md
@@ -1,8 +1,13 @@
 ---
 title: React Date Range Picker（日期范围选择器）组件
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
+<<<<<<< HEAD
 githubLabel: 'component: DateRangePicker'
 packageName: '@material-ui/lab'
+=======
+githubLabel: 'component: date range picker'
+packageName: '@mui/lab'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/date-pickers
 ---
 

--- a/docs/src/pages/components/date-range-picker/date-range-picker.md
+++ b/docs/src/pages/components/date-range-picker/date-range-picker.md
@@ -1,7 +1,7 @@
 ---
 title: React Date Range Picker component
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
-githubLabel: 'component: DateRangePicker'
+githubLabel: 'component: date range picker'
 packageName: '@mui/lab'
 materialDesign: https://material.io/components/date-pickers
 ---

--- a/docs/src/pages/components/date-time-picker/date-time-picker-pt.md
+++ b/docs/src/pages/components/date-time-picker/date-time-picker-pt.md
@@ -1,8 +1,13 @@
 ---
 title: Componente React Seletor de data e hora
 components: DateTimePicker,DesktopDateTimePicker,MobileDateTimePicker,StaticDateTimePicker
+<<<<<<< HEAD
 githubLabel: 'component: DateTimePicker'
 packageName: '@material-ui/lab'
+=======
+githubLabel: 'component: date time picker'
+packageName: '@mui/lab'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/date-pickers
 ---
 

--- a/docs/src/pages/components/date-time-picker/date-time-picker-zh.md
+++ b/docs/src/pages/components/date-time-picker/date-time-picker-zh.md
@@ -1,8 +1,13 @@
 ---
 title: React Date Time Picker（日期时间选择器） 组件
 components: DateTimePicker,DesktopDateTimePicker,MobileDateTimePicker,StaticDateTimePicker
+<<<<<<< HEAD
 githubLabel: 'component: DateTimePicker'
 packageName: '@material-ui/lab'
+=======
+githubLabel: 'component: date time picker'
+packageName: '@mui/lab'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/date-pickers
 ---
 

--- a/docs/src/pages/components/date-time-picker/date-time-picker.md
+++ b/docs/src/pages/components/date-time-picker/date-time-picker.md
@@ -1,7 +1,7 @@
 ---
 title: React Date Time Picker component
 components: DateTimePicker,DesktopDateTimePicker,MobileDateTimePicker,StaticDateTimePicker
-githubLabel: 'component: DateTimePicker'
+githubLabel: 'component: date time picker'
 packageName: '@mui/lab'
 materialDesign: https://material.io/components/date-pickers
 ---

--- a/docs/src/pages/components/dialogs/dialogs-pt.md
+++ b/docs/src/pages/components/dialogs/dialogs-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente Diálogo para React
 components: Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Slide
-githubLabel: 'component: Dialog'
+githubLabel: 'component: dialog'
 materialDesign: https://material.io/components/dialogs
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#dialog_modal'
 ---

--- a/docs/src/pages/components/dialogs/dialogs-zh.md
+++ b/docs/src/pages/components/dialogs/dialogs-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Dialog（对话框）组件
 components: Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Slide
-githubLabel: 'component: Dialog'
+githubLabel: 'component: dialog'
 materialDesign: https://material.io/components/dialogs
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#dialog_modal'
 ---

--- a/docs/src/pages/components/dialogs/dialogs.md
+++ b/docs/src/pages/components/dialogs/dialogs.md
@@ -1,7 +1,7 @@
 ---
 title: React Dialog component
 components: Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Slide
-githubLabel: 'component: Dialog'
+githubLabel: 'component: dialog'
 materialDesign: https://material.io/components/dialogs
 waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
 ---

--- a/docs/src/pages/components/dividers/dividers-pt.md
+++ b/docs/src/pages/components/dividers/dividers-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Divisor
 components: Divider
-githubLabel: 'component: Divider'
+githubLabel: 'component: divider'
 materialDesign: https://material.io/components/dividers
 ---
 

--- a/docs/src/pages/components/dividers/dividers-zh.md
+++ b/docs/src/pages/components/dividers/dividers-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Divider（分隔线）组件
 components: Divider
-githubLabel: 'component: Divider'
+githubLabel: 'component: divider'
 materialDesign: https://material.io/components/dividers
 ---
 

--- a/docs/src/pages/components/dividers/dividers.md
+++ b/docs/src/pages/components/dividers/dividers.md
@@ -1,7 +1,7 @@
 ---
 title: React Divider component
 components: Divider
-githubLabel: 'component: Divider'
+githubLabel: 'component: divider'
 materialDesign: https://material.io/components/dividers
 ---
 

--- a/docs/src/pages/components/drawers/drawers-pt.md
+++ b/docs/src/pages/components/drawers/drawers-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente Drawer para React
 components: Drawer, SwipeableDrawer
-githubLabel: 'component: Drawer'
+githubLabel: 'component: drawer'
 materialDesign: https://material.io/components/navigation-drawer
 ---
 

--- a/docs/src/pages/components/drawers/drawers-zh.md
+++ b/docs/src/pages/components/drawers/drawers-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Drawer（抽屉）组件
 components: Drawer, SwipeableDrawer
-githubLabel: 'component: Drawer'
+githubLabel: 'component: drawer'
 materialDesign: https://material.io/components/navigation-drawer
 ---
 

--- a/docs/src/pages/components/drawers/drawers.md
+++ b/docs/src/pages/components/drawers/drawers.md
@@ -1,7 +1,7 @@
 ---
 title: React Drawer component
 components: Drawer, SwipeableDrawer
-githubLabel: 'component: Drawer'
+githubLabel: 'component: drawer'
 materialDesign: https://material.io/components/navigation-drawer
 ---
 

--- a/docs/src/pages/components/image-list/image-list-pt.md
+++ b/docs/src/pages/components/image-list/image-list-pt.md
@@ -2,7 +2,7 @@
 title: Componente React para Lista de Imagem
 components: ImageList, ImageListItem, ImageListItemBar
 materialDesign: https://material.io/components/image-lists
-githubLabel: 'component: ImageList'
+githubLabel: 'component: image list'
 ---
 
 # Lista de imagem

--- a/docs/src/pages/components/image-list/image-list-zh.md
+++ b/docs/src/pages/components/image-list/image-list-zh.md
@@ -2,7 +2,7 @@
 title: React Image list（图像列表）组件
 components: ImageList, ImageListItem, ImageListItemBar
 materialDesign: https://material.io/components/image-lists
-githubLabel: 'component: ImageList'
+githubLabel: 'component: image list'
 ---
 
 # Image list 图像列表

--- a/docs/src/pages/components/image-list/image-list.md
+++ b/docs/src/pages/components/image-list/image-list.md
@@ -2,7 +2,7 @@
 title: Image list React component
 components: ImageList, ImageListItem, ImageListItemBar
 materialDesign: https://material.io/components/image-lists
-githubLabel: 'component: ImageList'
+githubLabel: 'component: image list'
 ---
 
 # Image list

--- a/docs/src/pages/components/links/links-pt.md
+++ b/docs/src/pages/components/links/links-pt.md
@@ -1,6 +1,6 @@
 ---
 components: Link
-githubLabel: 'component: Link'
+githubLabel: 'component: link'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#link'
 ---
 

--- a/docs/src/pages/components/links/links-zh.md
+++ b/docs/src/pages/components/links/links-zh.md
@@ -1,6 +1,6 @@
 ---
 components: Link
-githubLabel: 'component: Link'
+githubLabel: 'component: link'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#link'
 ---
 

--- a/docs/src/pages/components/links/links.md
+++ b/docs/src/pages/components/links/links.md
@@ -1,6 +1,6 @@
 ---
 components: Link
-githubLabel: 'component: Link'
+githubLabel: 'component: link'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#link
 ---
 

--- a/docs/src/pages/components/lists/lists-pt.md
+++ b/docs/src/pages/components/lists/lists-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Lista
 components: Collapse, Divider, List, ListItem, ListItemButton, ListItemAvatar, ListItemIcon, ListItemSecondaryAction, ListItemText, ListSubheader
-githubLabel: 'component: List'
+githubLabel: 'component: list'
 materialDesign: https://material.io/components/lists
 ---
 

--- a/docs/src/pages/components/lists/lists-zh.md
+++ b/docs/src/pages/components/lists/lists-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React List（列表）组件
 components: Collapse, Divider, List, ListItem, ListItemButton, ListItemAvatar, ListItemIcon, ListItemSecondaryAction, ListItemText, ListSubheader
-githubLabel: 'component: List'
+githubLabel: 'component: list'
 materialDesign: https://material.io/components/lists
 ---
 

--- a/docs/src/pages/components/lists/lists.md
+++ b/docs/src/pages/components/lists/lists.md
@@ -1,7 +1,7 @@
 ---
 title: React List component
 components: Collapse, Divider, List, ListItem, ListItemButton, ListItemAvatar, ListItemIcon, ListItemSecondaryAction, ListItemText, ListSubheader
-githubLabel: 'component: List'
+githubLabel: 'component: list'
 materialDesign: https://material.io/components/lists
 ---
 

--- a/docs/src/pages/components/masonry/masonry.md
+++ b/docs/src/pages/components/masonry/masonry.md
@@ -1,7 +1,7 @@
 ---
 title: React Masonry component
 components: Masonry
-githubLabel: 'component: Masonry'
+githubLabel: 'component: masonry'
 ---
 
 # Masonry

--- a/docs/src/pages/components/menus/menus-pt.md
+++ b/docs/src/pages/components/menus/menus-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Menu
 components: Menu, MenuItem, MenuList, ClickAwayListener, Popover, Popper
-githubLabel: 'component: Menu'
+githubLabel: 'component: menu'
 materialDesign: https://material.io/components/menus
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#menubutton'
 ---

--- a/docs/src/pages/components/menus/menus-zh.md
+++ b/docs/src/pages/components/menus/menus-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Menu（菜单）组件
 components: Menu, MenuItem, MenuList, ClickAwayListener, Popover, Popper
-githubLabel: 'component: Menu'
+githubLabel: 'component: menu'
 materialDesign: https://material.io/components/menus
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#menubutton'
 ---

--- a/docs/src/pages/components/menus/menus.md
+++ b/docs/src/pages/components/menus/menus.md
@@ -1,7 +1,7 @@
 ---
 title: React Menu component
 components: Menu, MenuItem, MenuList, ClickAwayListener, Popover, Popper
-githubLabel: 'component: Menu'
+githubLabel: 'component: menu'
 materialDesign: https://material.io/components/menus
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
 ---

--- a/docs/src/pages/components/modal/modal-pt.md
+++ b/docs/src/pages/components/modal/modal-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Modal
 components: Modal, ModalUnstyled
-githubLabel: 'component: Modal'
+githubLabel: 'component: modal'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#dialog_modal'
 ---
 

--- a/docs/src/pages/components/modal/modal-zh.md
+++ b/docs/src/pages/components/modal/modal-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Modal（模态框）组件
 components: Modal, ModalUnstyled
-githubLabel: 'component: Modal'
+githubLabel: 'component: modal'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#dialog_modal'
 ---
 

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -1,7 +1,7 @@
 ---
 title: React Modal component
 components: Modal, ModalUnstyled
-githubLabel: 'component: Modal'
+githubLabel: 'component: modal'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
 ---
 

--- a/docs/src/pages/components/pagination/pagination-pt.md
+++ b/docs/src/pages/components/pagination/pagination-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Paginação
 components: Pagination, PaginationItem
-githubLabel: 'component: Pagination'
+githubLabel: 'component: pagination'
 ---
 
 # Paginação

--- a/docs/src/pages/components/pagination/pagination-zh.md
+++ b/docs/src/pages/components/pagination/pagination-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Pagination（分页）组件
 components: Pagination, PaginationItem
-githubLabel: 'component: Pagination'
+githubLabel: 'component: pagination'
 ---
 
 # Pagination 分页

--- a/docs/src/pages/components/pagination/pagination.md
+++ b/docs/src/pages/components/pagination/pagination.md
@@ -1,7 +1,7 @@
 ---
 title: React Pagination component
 components: Pagination, PaginationItem
-githubLabel: 'component: Pagination'
+githubLabel: 'component: pagination'
 ---
 
 # Pagination

--- a/docs/src/pages/components/pickers/pickers-pt.md
+++ b/docs/src/pages/components/pickers/pickers-pt.md
@@ -1,7 +1,12 @@
 ---
 title: Componente React para Data e Hora
+<<<<<<< HEAD
 components: TextField
 githubLabel: 'component: DatePicker'
+=======
+components: DatePicker,DateTimePicker,TimePicker,TextField
+githubLabel: 'component: date picker'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/date-pickers
 waiAria: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
 packageName: '@material-ui/lab'

--- a/docs/src/pages/components/pickers/pickers-zh.md
+++ b/docs/src/pages/components/pickers/pickers-zh.md
@@ -1,7 +1,12 @@
 ---
 title: React Date Picker（日期选择器）和 Time Picker（时间选择器）组件
+<<<<<<< HEAD
 components: TextField
 githubLabel: 'component: DatePicker'
+=======
+components: DatePicker,DateTimePicker,TimePicker,TextField
+githubLabel: 'component: date picker'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/date-pickers
 waiAria: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
 packageName: '@material-ui/lab'

--- a/docs/src/pages/components/pickers/pickers.md
+++ b/docs/src/pages/components/pickers/pickers.md
@@ -1,7 +1,7 @@
 ---
 title: Date picker, Time picker React components
 components: DatePicker,DateTimePicker,TimePicker,TextField
-githubLabel: 'component: DatePicker'
+githubLabel: 'component: date picker'
 materialDesign: https://material.io/components/date-pickers
 waiAria: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
 packageName: '@mui/lab'

--- a/docs/src/pages/components/progress/progress.md
+++ b/docs/src/pages/components/progress/progress.md
@@ -1,7 +1,7 @@
 ---
 title: Circular, Linear progress React components
 components: CircularProgress, LinearProgress
-githubLabel: 'component: CircularProgress'
+githubLabel: 'component: progress'
 materialDesign: https://material.io/components/progress-indicators
 ---
 

--- a/docs/src/pages/components/radio-buttons/radio-buttons-pt.md
+++ b/docs/src/pages/components/radio-buttons/radio-buttons-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Botões de opção
 components: Radio, RadioGroup, FormControl, FormLabel, FormControlLabel
-githubLabel: 'component: Radio'
+githubLabel: 'component: radio'
 materialDesign: 'https://material.io/components/selection-controls#radio-buttons'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#radiobutton'
 ---

--- a/docs/src/pages/components/radio-buttons/radio-buttons-zh.md
+++ b/docs/src/pages/components/radio-buttons/radio-buttons-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Radio buttons（单选按钮）组件
 components: Radio, RadioGroup, FormControl, FormLabel, FormControlLabel
-githubLabel: 'component: Radio'
+githubLabel: 'component: radio'
 materialDesign: 'https://material.io/components/selection-controls#radio-buttons'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#radiobutton'
 ---

--- a/docs/src/pages/components/radio-buttons/radio-buttons.md
+++ b/docs/src/pages/components/radio-buttons/radio-buttons.md
@@ -1,7 +1,7 @@
 ---
 title: Radio buttons React component
 components: Radio, RadioGroup, FormControl, FormLabel, FormControlLabel
-githubLabel: 'component: Radio'
+githubLabel: 'component: radio'
 materialDesign: https://material.io/components/selection-controls#radio-buttons
 waiAria: https://www.w3.org/TR/wai-aria-practices/#radiobutton
 ---

--- a/docs/src/pages/components/rating/rating-pt.md
+++ b/docs/src/pages/components/rating/rating-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Avaliação
 components: Rating
-githubLabel: 'component: Rating'
+githubLabel: 'component: rating'
 waiAria: 'https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rating'
 ---
 

--- a/docs/src/pages/components/rating/rating-zh.md
+++ b/docs/src/pages/components/rating/rating-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Rating（评分）组件
 components: Rating
-githubLabel: 'component: Rating'
+githubLabel: 'component: rating'
 waiAria: 'https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rating'
 ---
 

--- a/docs/src/pages/components/rating/rating.md
+++ b/docs/src/pages/components/rating/rating.md
@@ -1,7 +1,7 @@
 ---
 title: React Rating component
 components: Rating
-githubLabel: 'component: Rating'
+githubLabel: 'component: rating'
 waiAria: https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rating
 ---
 

--- a/docs/src/pages/components/selects/selects-pt.md
+++ b/docs/src/pages/components/selects/selects-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Seleção
 components: Select, NativeSelect
-githubLabel: 'component: Select'
+githubLabel: 'component: select'
 ---
 
 # Seleção

--- a/docs/src/pages/components/selects/selects-zh.md
+++ b/docs/src/pages/components/selects/selects-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Select（选择器）组件
 components: Select, NativeSelect
-githubLabel: 'component: Select'
+githubLabel: 'component: select'
 ---
 
 # Select 选择属性

--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -1,7 +1,7 @@
 ---
 title: React Select component
 components: Select, NativeSelect
-githubLabel: 'component: Select'
+githubLabel: 'component: select'
 ---
 
 # Select

--- a/docs/src/pages/components/skeleton/skeleton-pt.md
+++ b/docs/src/pages/components/skeleton/skeleton-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Skeleton
 components: Skeleton
-githubLabel: 'component: Skeleton'
+githubLabel: 'component: skeleton'
 ---
 
 # Skeleton

--- a/docs/src/pages/components/skeleton/skeleton-zh.md
+++ b/docs/src/pages/components/skeleton/skeleton-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Skeleton（骨架屏）组件
 components: Skeleton
-githubLabel: 'component: Skeleton'
+githubLabel: 'component: skeleton'
 ---
 
 # Skeleton 骨架屏

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: React Skeleton component
 components: Skeleton
-githubLabel: 'component: Skeleton'
+githubLabel: 'component: skeleton'
 ---
 
 # Skeleton

--- a/docs/src/pages/components/slider/slider-pt.md
+++ b/docs/src/pages/components/slider/slider-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Slider
 components: Slider, SliderUnstyled
-githubLabel: 'component: Slider'
+githubLabel: 'component: slider'
 materialDesign: https://material.io/components/sliders
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#slider'
 ---

--- a/docs/src/pages/components/slider/slider-zh.md
+++ b/docs/src/pages/components/slider/slider-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Slider（滑块）组件
 components: Slider, SliderUnstyled
-githubLabel: 'component: Slider'
+githubLabel: 'component: slider'
 materialDesign: https://material.io/components/sliders
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#slider'
 ---

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -1,7 +1,7 @@
 ---
 title: React Slider component
 components: Slider, SliderUnstyled
-githubLabel: 'component: Slider'
+githubLabel: 'component: slider'
 materialDesign: https://material.io/components/sliders
 waiAria: https://www.w3.org/TR/wai-aria-practices/#slider
 ---

--- a/docs/src/pages/components/snackbars/snackbars-pt.md
+++ b/docs/src/pages/components/snackbars/snackbars-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Snackbar
 components: Snackbar, SnackbarContent
-githubLabel: 'component: Snackbar'
+githubLabel: 'component: snackbar'
 materialDesign: https://material.io/components/snackbars
 waiAria: 'https://www.w3.org/TR/wai-aria-1.1/#alert'
 ---

--- a/docs/src/pages/components/snackbars/snackbars-zh.md
+++ b/docs/src/pages/components/snackbars/snackbars-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Snackbar（消息条）组件
 components: Snackbar, SnackbarContent
-githubLabel: 'component: Snackbar'
+githubLabel: 'component: snackbar'
 materialDesign: https://material.io/components/snackbars
 waiAria: 'https://www.w3.org/TR/wai-aria-1.1/#alert'
 ---

--- a/docs/src/pages/components/snackbars/snackbars.md
+++ b/docs/src/pages/components/snackbars/snackbars.md
@@ -1,7 +1,7 @@
 ---
 title: React Snackbar component
 components: Snackbar, SnackbarContent
-githubLabel: 'component: Snackbar'
+githubLabel: 'component: snackbar'
 materialDesign: https://material.io/components/snackbars
 waiAria: https://www.w3.org/TR/wai-aria-1.1/#alert
 ---

--- a/docs/src/pages/components/speed-dial/speed-dial-pt.md
+++ b/docs/src/pages/components/speed-dial/speed-dial-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Acesso Rápido
 components: SpeedDial, SpeedDialAction, SpeedDialIcon
-githubLabel: 'component: SpeedDial'
+githubLabel: 'component: speed dial'
 materialDesign: 'https://material.io/components/buttons-floating-action-button#types-of-transitions'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#menubutton'
 ---

--- a/docs/src/pages/components/speed-dial/speed-dial-zh.md
+++ b/docs/src/pages/components/speed-dial/speed-dial-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Speed Dial（快速拨号）组件
 components: SpeedDial, SpeedDialAction, SpeedDialIcon
-githubLabel: 'component: SpeedDial'
+githubLabel: 'component: speed dial'
 materialDesign: 'https://material.io/components/buttons-floating-action-button#types-of-transitions'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#menubutton'
 ---

--- a/docs/src/pages/components/speed-dial/speed-dial.md
+++ b/docs/src/pages/components/speed-dial/speed-dial.md
@@ -1,7 +1,7 @@
 ---
 title: React Speed Dial component
 components: SpeedDial, SpeedDialAction, SpeedDialIcon
-githubLabel: 'component: SpeedDial'
+githubLabel: 'component: speed dial'
 materialDesign: https://material.io/components/buttons-floating-action-button#types-of-transitions
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
 ---

--- a/docs/src/pages/components/steppers/steppers-pt.md
+++ b/docs/src/pages/components/steppers/steppers-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Assistente
 components: MobileStepper, Step, StepButton, StepConnector, StepContent, StepIcon, StepLabel, Stepper
-githubLabel: 'component: Stepper'
+githubLabel: 'component: stepper'
 materialDesign: https://material.io/archive/guidelines/components/steppers.html
 ---
 

--- a/docs/src/pages/components/steppers/steppers-zh.md
+++ b/docs/src/pages/components/steppers/steppers-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Stepper（步骤条）组件
 components: MobileStepper, Step, StepButton, StepConnector, StepContent, StepIcon, StepLabel, Stepper
-githubLabel: 'component: Stepper'
+githubLabel: 'component: stepper'
 materialDesign: https://material.io/archive/guidelines/components/steppers.html
 ---
 

--- a/docs/src/pages/components/steppers/steppers.md
+++ b/docs/src/pages/components/steppers/steppers.md
@@ -1,7 +1,7 @@
 ---
 title: React Stepper component
 components: MobileStepper, Step, StepButton, StepConnector, StepContent, StepIcon, StepLabel, Stepper
-githubLabel: 'component: Stepper'
+githubLabel: 'component: stepper'
 materialDesign: https://material.io/archive/guidelines/components/steppers.html
 ---
 

--- a/docs/src/pages/components/switches/switches-pt.md
+++ b/docs/src/pages/components/switches/switches-pt.md
@@ -1,7 +1,12 @@
 ---
 title: Componente React Interruptor
+<<<<<<< HEAD
 components: Switch, FormControl, FormGroup, FormLabel, FormControlLabel
 githubLabel: 'component: Switch'
+=======
+components: Switch, FormControl, FormGroup, FormLabel, FormControlLabel, SwitchUnstyled
+githubLabel: 'component: switch'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: 'https://material.io/components/selection-controls#switches'
 ---
 

--- a/docs/src/pages/components/switches/switches-zh.md
+++ b/docs/src/pages/components/switches/switches-zh.md
@@ -1,7 +1,12 @@
 ---
 title: React Switch（开关）组件
+<<<<<<< HEAD
 components: Switch, FormControl, FormGroup, FormLabel, FormControlLabel
 githubLabel: 'component: Switch'
+=======
+components: Switch, FormControl, FormGroup, FormLabel, FormControlLabel, SwitchUnstyled
+githubLabel: 'component: switch'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: 'https://material.io/components/selection-controls#switches'
 ---
 

--- a/docs/src/pages/components/switches/switches.md
+++ b/docs/src/pages/components/switches/switches.md
@@ -1,7 +1,7 @@
 ---
 title: React Switch component
 components: Switch, FormControl, FormGroup, FormLabel, FormControlLabel, SwitchUnstyled
-githubLabel: 'component: Switch'
+githubLabel: 'component: switch'
 materialDesign: https://material.io/components/selection-controls#switches
 ---
 

--- a/docs/src/pages/components/tables/tables-pt.md
+++ b/docs/src/pages/components/tables/tables-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Tabela
 components: Table, TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel, TablePaginationUnstyled
-githubLabel: 'component: Table'
+githubLabel: 'component: table'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#table'
 materialDesign: https://material.io/components/data-tables
 ---

--- a/docs/src/pages/components/tables/tables-zh.md
+++ b/docs/src/pages/components/tables/tables-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Table（表格）组件
 components: Table, TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel, TablePaginationUnstyled
-githubLabel: 'component: Table'
+githubLabel: 'component: table'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#table'
 materialDesign: https://material.io/components/data-tables
 ---

--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -1,7 +1,7 @@
 ---
 title: React Table component
 components: Table, TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel, TablePaginationUnstyled
-githubLabel: 'component: Table'
+githubLabel: 'component: table'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#table
 materialDesign: https://material.io/components/data-tables
 ---

--- a/docs/src/pages/components/tabs/tabs-pt.md
+++ b/docs/src/pages/components/tabs/tabs-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React Abas
 components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
-githubLabel: 'component: Tabs'
+githubLabel: 'component: tabs'
 materialDesign: https://material.io/components/tabs
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#tabpanel'
 ---

--- a/docs/src/pages/components/tabs/tabs-zh.md
+++ b/docs/src/pages/components/tabs/tabs-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Tabs（选项卡）组件
 components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
-githubLabel: 'component: Tabs'
+githubLabel: 'component: tabs'
 materialDesign: https://material.io/components/tabs
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#tabpanel'
 ---

--- a/docs/src/pages/components/tabs/tabs.md
+++ b/docs/src/pages/components/tabs/tabs.md
@@ -1,7 +1,7 @@
 ---
 title: React Tabs component
 components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
-githubLabel: 'component: Tabs'
+githubLabel: 'component: tabs'
 materialDesign: https://material.io/components/tabs
 waiAria: https://www.w3.org/TR/wai-aria-practices/#tabpanel
 ---

--- a/docs/src/pages/components/text-fields/text-fields-pt.md
+++ b/docs/src/pages/components/text-fields/text-fields-pt.md
@@ -1,7 +1,12 @@
 ---
 title: Componente React para Campo de Texto
+<<<<<<< HEAD
 components: FilledInput, FormControl, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField
 githubLabel: 'component: TextField'
+=======
+components: FilledInput, FormControl, FormControlUnstyled, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField, InputUnstyled
+githubLabel: 'component: text field'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/text-fields
 ---
 

--- a/docs/src/pages/components/text-fields/text-fields-zh.md
+++ b/docs/src/pages/components/text-fields/text-fields-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Text Field（文本框）组件
 components: FilledInput, FormControl, FormControlUnstyled, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField, InputUnstyled
-githubLabel: 'component: TextField'
+githubLabel: 'component: text field'
 materialDesign: https://material.io/components/text-fields
 ---
 

--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -1,7 +1,7 @@
 ---
 title: Text Field React component
 components: FilledInput, FormControl, FormControlUnstyled, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField, InputUnstyled
-githubLabel: 'component: TextField'
+githubLabel: 'component: text field'
 materialDesign: https://material.io/components/text-fields
 ---
 

--- a/docs/src/pages/components/time-picker/time-picker-pt.md
+++ b/docs/src/pages/components/time-picker/time-picker-pt.md
@@ -1,8 +1,13 @@
 ---
 title: Componente React Seletor de hora
 components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
+<<<<<<< HEAD
 githubLabel: 'component: TimePicker'
 packageName: '@material-ui/lab'
+=======
+githubLabel: 'component: time picker'
+packageName: '@mui/lab'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/time-pickers
 ---
 

--- a/docs/src/pages/components/time-picker/time-picker-zh.md
+++ b/docs/src/pages/components/time-picker/time-picker-zh.md
@@ -1,8 +1,13 @@
 ---
 title: React Time Picker（时间选择器）组件
 components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
+<<<<<<< HEAD
 githubLabel: 'component: TimePicker'
 packageName: '@material-ui/lab'
+=======
+githubLabel: 'component: time picker'
+packageName: '@mui/lab'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 materialDesign: https://material.io/components/time-pickers
 ---
 

--- a/docs/src/pages/components/time-picker/time-picker.md
+++ b/docs/src/pages/components/time-picker/time-picker.md
@@ -1,7 +1,7 @@
 ---
 title: React Time Picker component
 components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
-githubLabel: 'component: TimePicker'
+githubLabel: 'component: time picker'
 packageName: '@mui/lab'
 materialDesign: https://material.io/components/time-pickers
 ---

--- a/docs/src/pages/components/timeline/timeline-pt.md
+++ b/docs/src/pages/components/timeline/timeline-pt.md
@@ -1,8 +1,13 @@
 ---
 title: Componente React para Linha do tempo
 components: Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent, TimelineOppositeContent
+<<<<<<< HEAD
 githubLabel: 'component: Timeline'
 packageName: '@material-ui/lab'
+=======
+githubLabel: 'component: timeline'
+packageName: '@mui/lab'
+>>>>>>> 0f996c1ce5 ([docs] Clear the difference between UI and React components)
 ---
 
 # Linha do tempo

--- a/docs/src/pages/components/timeline/timeline-zh.md
+++ b/docs/src/pages/components/timeline/timeline-zh.md
@@ -1,8 +1,8 @@
 ---
 title: React Timeline（时间轴）组件
 components: Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent, TimelineOppositeContent
-githubLabel: 'component: Timeline'
-packageName: '@material-ui/lab'
+githubLabel: 'component: timeline'
+packageName: '@mui/lab'
 ---
 
 # Timeline 时间轴

--- a/docs/src/pages/components/timeline/timeline.md
+++ b/docs/src/pages/components/timeline/timeline.md
@@ -1,7 +1,7 @@
 ---
 title: React Timeline component
 components: Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent, TimelineOppositeContent
-githubLabel: 'component: Timeline'
+githubLabel: 'component: timeline'
 packageName: '@mui/lab'
 ---
 

--- a/docs/src/pages/components/toggle-button/toggle-button-pt.md
+++ b/docs/src/pages/components/toggle-button/toggle-button-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Botões de Alternância
 components: ToggleButton, ToggleButtonGroup
-githubLabel: 'component: ToggleButton'
+githubLabel: 'component: toggle button'
 materialDesign: 'https://material.io/components/buttons#toggle-button'
 ---
 

--- a/docs/src/pages/components/toggle-button/toggle-button-zh.md
+++ b/docs/src/pages/components/toggle-button/toggle-button-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Toggle Button（切换按钮）组件
 components: ToggleButton, ToggleButtonGroup
-githubLabel: 'component: ToggleButton'
+githubLabel: 'component: toggle button'
 materialDesign: 'https://material.io/components/buttons#toggle-button'
 ---
 

--- a/docs/src/pages/components/toggle-button/toggle-button.md
+++ b/docs/src/pages/components/toggle-button/toggle-button.md
@@ -1,7 +1,7 @@
 ---
 title: Toggle Button React component
 components: ToggleButton, ToggleButtonGroup
-githubLabel: 'component: ToggleButton'
+githubLabel: 'component: toggle button'
 materialDesign: https://material.io/components/buttons#toggle-button
 ---
 

--- a/docs/src/pages/components/tooltips/tooltips-pt.md
+++ b/docs/src/pages/components/tooltips/tooltips-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React para Dicas
 components: Tooltip
-githubLabel: 'component: Tooltip'
+githubLabel: 'component: tooltip'
 materialDesign: https://material.io/components/tooltips
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#tooltip'
 ---

--- a/docs/src/pages/components/tooltips/tooltips-zh.md
+++ b/docs/src/pages/components/tooltips/tooltips-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Tooltip（工具提示）组件
 components: Tooltip
-githubLabel: 'component: Tooltip'
+githubLabel: 'component: tooltip'
 materialDesign: https://material.io/components/tooltips
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#tooltip'
 ---

--- a/docs/src/pages/components/tooltips/tooltips.md
+++ b/docs/src/pages/components/tooltips/tooltips.md
@@ -1,7 +1,7 @@
 ---
 title: React Tooltip component
 components: Tooltip
-githubLabel: 'component: Tooltip'
+githubLabel: 'component: tooltip'
 materialDesign: https://material.io/components/tooltips
 waiAria: https://www.w3.org/TR/wai-aria-practices/#tooltip
 ---

--- a/docs/src/pages/components/transfer-list/transfer-list.md
+++ b/docs/src/pages/components/transfer-list/transfer-list.md
@@ -1,7 +1,7 @@
 ---
 title: Transfer List React component
 components: List, ListItem, Checkbox, Switch
-githubLabel: 'component: TransferList'
+githubLabel: 'component: transfer list'
 ---
 
 # Transfer List

--- a/docs/src/pages/components/transitions/transitions.md
+++ b/docs/src/pages/components/transitions/transitions.md
@@ -1,7 +1,7 @@
 ---
 title: React Transition component
 components: Collapse, Fade, Grow, Slide, Zoom
-githubLabel: 'component: Transition'
+githubLabel: 'component: transitions'
 ---
 
 # Transitions

--- a/docs/src/pages/components/tree-view/tree-view-pt.md
+++ b/docs/src/pages/components/tree-view/tree-view-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Componente React de Visualização em Árvore
 components: TreeView, TreeItem
-githubLabel: 'component: TreeView'
+githubLabel: 'component: tree view'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#TreeView'
 packageName: '@material-ui/lab'
 ---

--- a/docs/src/pages/components/tree-view/tree-view-zh.md
+++ b/docs/src/pages/components/tree-view/tree-view-zh.md
@@ -1,7 +1,7 @@
 ---
 title: React Tree View（树视图）组件
 components: TreeView, TreeItem
-githubLabel: 'component: TreeView'
+githubLabel: 'component: tree view'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#TreeView'
 packageName: '@material-ui/lab'
 ---

--- a/docs/src/pages/components/tree-view/tree-view.md
+++ b/docs/src/pages/components/tree-view/tree-view.md
@@ -1,7 +1,7 @@
 ---
 title: Tree View React component
 components: TreeView, TreeItem
-githubLabel: 'component: TreeView'
+githubLabel: 'component: tree view'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#TreeView
 packageName: '@mui/lab'
 ---


### PR DESCRIPTION
Should an issue/PR that touches on the `<TreeItem>` React component have the `component: TreeView` GitHub label?

While I believe the answer should be yes, so we can have [sub-product owners](https://www.notion.so/mui-org/Product-ownership-836c72feffcc4cb2b735b51527e6991a) that can monitor the labels they care about, I believe the label casing, colors, descriptions were not making it clear. This change is meant to solve this confusion. Now, we have:

- GitHub labels that are about UI components. They *could* include Joy, Material Design, Unstyled, etc. The important part here is that no matter how it's implemented, the end-user experience is what ultimately matters the most (see the survey where people ranked "look & feel" as the number one criteria for picking a UI library). Therefore, I think that we should organize ourselves around it.

  **Before**
  <img width="661" alt="Screenshot 2021-11-28 at 20 02 01" src="https://user-images.githubusercontent.com/3165635/143782123-a5ecba7e-fe6d-4eeb-b3c2-ffb662283a3f.png">

  **After**
  <img width="662" alt="Screenshot 2021-11-28 at 20 01 32" src="https://user-images.githubusercontent.com/3165635/143782106-e20982bb-bec7-464d-a75f-4903703b26d2.png">

- GitHub labels that are about technical components (React) now have a slightly different description:

  **Before**
  <img width="565" alt="Screenshot 2021-11-28 at 20 23 20" src="https://user-images.githubusercontent.com/3165635/143782799-be7b115e-45e3-490f-bfa6-46bca1e25165.png">

  **After**
  <img width="584" alt="Screenshot 2021-11-28 at 20 23 36" src="https://user-images.githubusercontent.com/3165635/143782800-a24fec47-c2d3-4f63-9f58-a70e27e4265b.png">

I hope this proposal makes it clearer.