### PR TITLE
[docs] Fix v5-beta confusing example description

### DIFF
--- a/examples/cdn/README.md
+++ b/examples/cdn/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/next | tar -xz --strip=2  material-ui-next/examples/cdn
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/cdn
 cd cdn
 ```
 

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -82,7 +82,7 @@ function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          CDN v5 example
+          CDN example
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/create-react-app-with-styled-components-typescript/src/App.tsx
+++ b/examples/create-react-app-with-styled-components-typescript/src/App.tsx
@@ -22,7 +22,7 @@ export default function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Create React App v5 example with styled-components and TypeScript
+          Create React App example with styled-components and TypeScript
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/create-react-app-with-styled-components/src/App.js
+++ b/examples/create-react-app-with-styled-components/src/App.js
@@ -22,7 +22,7 @@ export default function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Create React App v5 example with styled-components
+          Create React App example with styled-components
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/create-react-app-with-typescript/src/App.tsx
+++ b/examples/create-react-app-with-typescript/src/App.tsx
@@ -22,7 +22,7 @@ export default function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Create React App v5 example with TypeScript
+          Create React App example with TypeScript
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -23,7 +23,7 @@ export default function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Create React App v5 example
+          Create React App example
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/gatsby/src/pages/about.js
+++ b/examples/gatsby/src/pages/about.js
@@ -11,7 +11,7 @@ export default function About() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Gatsby v5 example
+          Gatsby example
         </Typography>
         <Link to="/">Go to the main page</Link>
         <ProTip />

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -11,7 +11,7 @@ export default function Index() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Gatsby v5 example
+          Gatsby example
         </Typography>
         <Link to="/about" color="secondary">
           Go to the about page

--- a/examples/nextjs-with-styled-components-typescript/pages/about.tsx
+++ b/examples/nextjs-with-styled-components-typescript/pages/about.tsx
@@ -12,7 +12,7 @@ export default function About() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Next.js v5-beta with TypeScript example
+          Next.js with TypeScript example
         </Typography>
         <Button variant="contained" component={Link} noLinkStyle href="/">
           Go to the main page

--- a/examples/nextjs-with-styled-components-typescript/pages/index.tsx
+++ b/examples/nextjs-with-styled-components-typescript/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Index() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Next.js v5-beta with TypeScript example
+          Next.js with TypeScript example
         </Typography>
         <Link href="/about" color="secondary">
           Go to the about page

--- a/examples/nextjs-with-typescript/pages/about.tsx
+++ b/examples/nextjs-with-typescript/pages/about.tsx
@@ -12,7 +12,7 @@ export default function About() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Next.js v5-beta with TypeScript example
+          Next.js with TypeScript example
         </Typography>
         <Button variant="contained" component={Link} noLinkStyle href="/">
           Go to the main page

--- a/examples/nextjs-with-typescript/pages/index.tsx
+++ b/examples/nextjs-with-typescript/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Index() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Next.js v5-beta with TypeScript example
+          Next.js with TypeScript example
         </Typography>
         <Link href="/about" color="secondary">
           Go to the about page

--- a/examples/nextjs/pages/about.js
+++ b/examples/nextjs/pages/about.js
@@ -12,7 +12,7 @@ export default function About() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Next.js v5 example
+          Next.js example
         </Typography>
         <Button variant="contained" component={Link} noLinkStyle href="/">
           Go to the main page

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -11,7 +11,7 @@ export default function Index() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Next.js v5 example
+          Next.js example
         </Typography>
         <Link href="/about" color="secondary">
           Go to the about page

--- a/examples/preact/src/App.js
+++ b/examples/preact/src/App.js
@@ -10,7 +10,7 @@ export default function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Preact v5 example
+          Preact example
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/ssr/App.js
+++ b/examples/ssr/App.js
@@ -23,7 +23,7 @@ export default function App() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Server Rendering v5 example
+          Server-side rendering example
         </Typography>
         <ProTip />
         <Copyright />

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -1,4 +1,4 @@
-# Server Rendering example
+# Server-side rendering example
 
 ## How to use
 


### PR DESCRIPTION
I believe that people could read "Create React App v5 example" as CRA is on v5, while we mean MUI. Also, as you can see, we forgot to update one of the examples, it was on "Next.js v5-beta with TypeScript example". So, I propose we remove the mention of the version in the headers, people can check what's installed on the yarn/npm lock or the version https://github.com/mui-org/material-ui/blob/4241561c4b81dfca750ff3fb9c3e74097a8334f9/examples/nextjs/package.json#L3