### PR TITLE
[docs] Apply the z-index on the right DOM element

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -62,14 +62,24 @@ const Root = styled('div')(({ theme }) => ({
   },
 }));
 
-const DemoTooltip = styled(Tooltip)(({ theme }) => ({
-  zIndex: theme.zIndex.appBar - 1,
-}));
+function DemoTooltip(props) {
+  return (
+    <Tooltip
+      componentsProps={{
+        popper: {
+          sx: {
+            zIndex: (theme) => theme.zIndex.appBar - 1,
+          },
+        },
+      }}
+      {...props}
+    />
+  );
+}
 
 function ToggleCodeTooltip(props) {
   const { showSourceHint, ...other } = props;
   const atLeastSmallViewport = useMediaQuery((theme) => theme.breakpoints.up('sm'));
-
   const [open, setOpen] = React.useState(false);
 
   return (


### PR DESCRIPTION
In #27184, we have introduced a regression, we started to apply a z-index on the toolbar buttons, instead of the tooltip's popper. To reproduce the issue, you can do one of these three, same root cause:

1. https://mui.com/components/autocomplete/#customized-hook. See the icon above the autocomplete's popup (this is initially what got me to look into what was wrong):

<img width="275" alt="Screenshot 2021-11-28 at 21 31 13" src="https://user-images.githubusercontent.com/3165635/143784840-14f1ba26-435d-4032-a1ce-76d2c70317bc.png">

2. https://mui.com/components/autocomplete/#customized-hook. See the tooltip above the header:

<img width="222" alt="Screenshot 2021-11-28 at 21 31 47" src="https://user-images.githubusercontent.com/3165635/143784848-164e70db-3809-4fef-a579-444425b552d5.png">
 
3. https://mui.com/components/autocomplete/#customized-hook. See the rogue z-index:

<img width="525" alt="Screenshot 2021-11-28 at 21 32 33" src="https://user-images.githubusercontent.com/3165635/143784879-ce0142c5-2123-4655-aca1-2663f29e0b0c.png">

This reminds me a bit of #28679. It could be interesting to move this file to TypeScript in the future, to see if our typings are working.