### PR TITLE
[docs] Remove Black Friday sale notification

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -13,10 +13,5 @@
     "id": 55,
     "title": "2021 MUI developer survey",
     "text": "Help shape the future of MUI! 🚀<br />Please take a few minutes to complete the <a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://mui-org.typeform.com/2021-dev-survey\">2021 MUI developer survey</a>."
-  },
-  {
-    "id": 56,
-    "title": "Black Friday special offers!",
-    "text": "Get a special discount on a range of templates in the <a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://mui.com/store/\">MUI Store</a>.<br />Limited time only – don't miss out!"
   }
 ]


### PR DESCRIPTION
To be merged around 2021-11-29T21:00Z.

It might be useful to have start and end dates on notifications in the future.